### PR TITLE
Fix for ISPN-787

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/DistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/DistributionInterceptor.java
@@ -100,7 +100,7 @@ public class DistributionInterceptor extends BaseRpcInterceptor {
 
    private boolean needsRemoteGet(InvocationContext ctx, Object key, boolean retvalCheck) {
       CacheEntry entry;
-      return retvalCheck && !ctx.hasFlag(Flag.SKIP_REMOTE_LOOKUP) && ((entry = ctx.lookupEntry(key)) == null || entry.isLockPlaceholder());
+      return retvalCheck && !ctx.hasFlag(Flag.SKIP_REMOTE_LOOKUP) && ((entry = ctx.lookupEntry(key)) == null || entry.isNull() || entry.isLockPlaceholder());
    }
 
 


### PR DESCRIPTION
Adds entry.isNull() to criteria for determining whether remote get is necessary.  Not entirely sure if this is a correct fix but it does allow the unit test attached to ISPN-787 to pass.
