### PR TITLE
ISPN-856  Fix compatibility issues of Query module with Lucene 3 and Hibernate Search 3.3.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -91,7 +91,7 @@
       <version.gnu.getopt>1.0.13</version.gnu.getopt>
       <version.guava>r03</version.guava>
       <version.h2.driver>1.1.117</version.h2.driver>
-      <version.hibernate.search>3.3.0.Beta1</version.hibernate.search>
+      <version.hibernate.search>3.4.0-SNAPSHOT</version.hibernate.search>
       <version.jackson>1.6.1</version.jackson>
       <version.javax.persistence>1.0</version.javax.persistence>
       <version.javax.servlet>2.5</version.javax.servlet>

--- a/query/src/main/java/org/infinispan/query/QueryFactory.java
+++ b/query/src/main/java/org/infinispan/query/QueryFactory.java
@@ -24,6 +24,7 @@ package org.infinispan.query;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.queryParser.QueryParser;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.Version;
 import org.hibernate.search.engine.SearchFactoryImplementor;
 import org.infinispan.Cache;
 import org.infinispan.query.backend.QueryHelper;
@@ -75,11 +76,15 @@ public class QueryFactory {
     * @param search - the String that you want to be using to search
     * @return {@link org.infinispan.query.CacheQuery} result
     */
-   public CacheQuery getBasicQuery(String field, String search) throws org.apache.lucene.queryParser.ParseException {
-      QueryParser parser = new QueryParser(field, new StandardAnalyzer());
+   public CacheQuery getBasicQuery(String field, String search, Version luceneVersion) throws org.apache.lucene.queryParser.ParseException {
+      QueryParser parser = new QueryParser(luceneVersion, field, new StandardAnalyzer(luceneVersion));
       org.apache.lucene.search.Query luceneQuery = parser.parse(search);
       return new CacheQueryImpl(luceneQuery, searchFactory, cache);
-
+   }
+   
+   @Deprecated
+   public CacheQuery getBasicQuery(String field, String search) throws org.apache.lucene.queryParser.ParseException {
+      return getBasicQuery(field, search, Version.LUCENE_CURRENT);
    }
    
 }

--- a/query/src/main/java/org/infinispan/query/backend/QueryHelper.java
+++ b/query/src/main/java/org/infinispan/query/backend/QueryHelper.java
@@ -23,7 +23,7 @@ package org.infinispan.query.backend;
 
 import org.hibernate.search.cfg.SearchConfiguration;
 import org.hibernate.search.engine.SearchFactoryImplementor;
-import org.hibernate.search.impl.SearchFactoryBuilder;
+import org.hibernate.search.spi.SearchFactoryBuilder;
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.CacheException;
@@ -50,19 +50,19 @@ import java.util.Properties;
  * <p/>
  * This class must be instantiated only once however.
  * <p/>
- * However, only one instan This class WILL be removed once other hooks come into Infinispan for versions 4.1 etc.
+ * This class WILL be removed once other hooks come into Infinispan for versions 4.1 etc.
  *
  * @author Navin Surtani
  * @since 4.0
  */
 public class QueryHelper {
 
+   private static final Log log = LogFactory.getLog(QueryHelper.class);
+
    private Cache cache;
    private Properties properties;
    private Class[] classes;
    private SearchFactoryImplementor searchFactory;
-
-   private static final Log log = LogFactory.getLog(QueryHelper.class);
 
    /**
     * Constructor that will take in 3 params and build the searchFactory for Hibernate Search.
@@ -109,23 +109,15 @@ public class QueryHelper {
    /**
     * This method MUST be called if running the query module and you want to index objects in the cache.
     * <p/>
-    * <p/>
-    * <p/>
     * e.g.:- QueryHelper.applyQueryProperties(); has to be used BEFORE any objects are put in the cache so that they can
     * be indexed.
-    * <p/>
-    * <p/>
-    * <p/>
     * <p/>
     * Anything put before calling this method will NOT not be picked up by the {@link QueryInterceptor} and hence not be
     * indexed.
     */
-
    private void applyProperties(Configuration cfg) {
       log.debug("Entered QueryHelper.applyProperties()");
-
       if (cfg.isIndexingEnabled()) {
-
          try {
             if (cfg.isIndexLocalOnly()) {
                // Add a LocalQueryInterceptor to the chain
@@ -141,41 +133,19 @@ public class QueryHelper {
       }
    }
 
-   /**
-    * Simple getter.
-    *
-    * @return the {@link org.hibernate.search.engine.SearchFactoryImplementor} instance being used.
-    */
-
    public SearchFactoryImplementor getSearchFactory() {
       return searchFactory;
    }
-
-   /**
-    * Simple getter.
-    *
-    * @return the class[].
-    */
-
 
    public Class[] getClasses() {
       return classes;
    }
 
-   /**
-    * Simple getter.
-    *
-    * @return {@link java.util.Properties}
-    */
-
    public Properties getProperties() {
       return properties;
    }
 
-
    // Private method that adds the interceptor from the classname parameter.
-
-
    private void initComponents(Configuration cfg, Class<? extends QueryInterceptor> interceptorClass)
          throws IllegalAccessException, InstantiationException {
 
@@ -219,21 +189,15 @@ public class QueryHelper {
       }
    }
 
-
    private void checkInterceptorChain(Cache cache) {
       // Check if there are any QueryInterceptors already added onto the chain.
       // If there already is one then throw a CacheException
-
       AdvancedCache advanced = cache.getAdvancedCache();
-
       List<CommandInterceptor> interceptorList = advanced.getInterceptorChain();
-
       for (CommandInterceptor inter : interceptorList) {
-
          if (inter.getClass().equals(QueryInterceptor.class) || inter.getClass().equals(LocalQueryInterceptor.class)) {
             throw new CacheException("There is already an instance of the QueryInterceptor running");
          }
-
       }
    }
 }

--- a/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
+++ b/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
@@ -53,7 +53,6 @@ import static org.infinispan.query.backend.KeyTransformationHandler.keyToString;
  * @author Navin Surtani
  * @since 4.0
  */
-
 public class QueryInterceptor extends CommandInterceptor {
 
    protected SearchFactoryImplementor searchFactory;
@@ -109,7 +108,6 @@ public class QueryInterceptor extends CommandInterceptor {
       return valueRemoved;
    }
 
-
    @Override
    public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) throws Throwable {
       Object valueReplaced = invokeNextInterceptor(ctx, command);
@@ -161,9 +159,7 @@ public class QueryInterceptor extends CommandInterceptor {
       return returnValue;
    }
 
-
    // Method that will be called when data needs to be added into Lucene.
-
    protected void addToIndexes(Object value, Object key) {
       if (trace) log.trace("Adding to indexes for key [%s] and value [%s]", key, value);
 
@@ -175,9 +171,7 @@ public class QueryInterceptor extends CommandInterceptor {
       searchFactory.getWorker().performWork(new Work<Object>(value, keyToString(key), WorkType.ADD), transactionContext);
    }
 
-
    // Method that will be called when data needs to be removed from Lucene.
-
    protected void removeFromIndexes(Object value, Object key) {
 
       // The key here is the String representation of the key that is stored in the cache.
@@ -195,7 +189,6 @@ public class QueryInterceptor extends CommandInterceptor {
       if (value == null) throw new NullPointerException("Cannot handle a null value!");
       TransactionContext transactionContext = new TransactionalEventTransactionContext(transactionManager);
       searchFactory.getWorker().performWork(new Work<Object>(value, keyToString(key), WorkType.UPDATE), transactionContext);
-
    }
 
    private Object extractValue(Object wrappedValue) {

--- a/query/src/main/java/org/infinispan/query/backend/SearchableCacheConfiguration.java
+++ b/query/src/main/java/org/infinispan/query/backend/SearchableCacheConfiguration.java
@@ -25,7 +25,9 @@ package org.infinispan.query.backend;
 import org.hibernate.annotations.common.reflection.ReflectionManager;
 import org.hibernate.search.cfg.SearchConfiguration;
 import org.hibernate.search.cfg.SearchMapping;
+import org.hibernate.search.spi.ServiceProvider;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -82,5 +84,10 @@ public class SearchableCacheConfiguration implements SearchConfiguration {
    public SearchMapping getProgrammaticMapping() {
       // TODO What does Hibernate Search expect here?
       return null;
+   }
+
+   @Override
+   public Map<Class<? extends ServiceProvider<?>>, Object> getProvidedServices() {
+      return Collections.emptyMap();
    }
 }

--- a/query/src/test/java/org/infinispan/query/backend/QueryHelperTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/QueryHelperTest.java
@@ -24,7 +24,6 @@ package org.infinispan.query.backend;
 import org.infinispan.Cache;
 import org.infinispan.CacheException;
 import org.infinispan.config.Configuration;
-import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.test.Person;
 import org.infinispan.test.TestingUtil;
@@ -53,7 +52,6 @@ public class QueryHelperTest {
       cfg = new Configuration();
       cfg.setIndexingEnabled(true);
       cfg.setIndexLocalOnly(true);
-
       cacheContainers = new LinkedList<EmbeddedCacheManager>();
    }
 
@@ -93,8 +91,8 @@ public class QueryHelperTest {
    public void testTwoQueryHelpersWithTwoCaches() {
       Cache c1 = createCache(cfg);
       Cache c2 = createCache(cfg);
-
       QueryHelper qh1 = new QueryHelper(c1, null, Person.class);
       QueryHelper qh2 = new QueryHelper(c2, null, Person.class);
    }
+
 }

--- a/query/src/test/java/org/infinispan/query/blackbox/AbstractLocalQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/AbstractLocalQueryTest.java
@@ -21,7 +21,6 @@
  */
 package org.infinispan.query.blackbox;
 
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryParser.ParseException;
 import org.apache.lucene.queryParser.QueryParser;
@@ -29,6 +28,7 @@ import org.apache.lucene.search.Filter;
 import org.apache.lucene.search.PrefixFilter;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
 import org.infinispan.Cache;
 import org.infinispan.query.CacheQuery;
@@ -43,6 +43,7 @@ import org.testng.annotations.AfterMethod;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static org.infinispan.query.helper.TestQueryHelperFactory.*;
 
 public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
    protected Person person1;
@@ -70,7 +71,7 @@ public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
    }
 
    public void testSimple() throws ParseException {
-      cacheQuery = new QueryFactory(cache, qh).getBasicQuery("blurb", "playing");
+      cacheQuery = createCacheQuery(cache, qh, "blurb", "playing" );
 
       found = cacheQuery.list();
 
@@ -83,8 +84,7 @@ public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
 
    public void testEagerIterator() throws ParseException {
 
-      cacheQuery = new QueryFactory(cache, qh).
-            getBasicQuery("blurb", "playing");
+      cacheQuery = createCacheQuery(cache, qh, "blurb", "playing" );
 
       QueryIterator found = cacheQuery.iterator();
 
@@ -94,7 +94,7 @@ public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
 
    public void testMultipleResults() throws ParseException {
 
-      queryParser = new QueryParser("name", new StandardAnalyzer());
+      queryParser = createQueryParser("name");
 
       luceneQuery = queryParser.parse("goat");
       cacheQuery = new QueryFactory(cache, qh).getQuery(luceneQuery);
@@ -107,7 +107,7 @@ public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
    }
 
    public void testModified() throws ParseException {
-      queryParser = new QueryParser("blurb", new StandardAnalyzer());
+      queryParser = createQueryParser("blurb");
       luceneQuery = queryParser.parse("playing");
       cacheQuery = new QueryFactory(cache, qh).getQuery(luceneQuery);
 
@@ -119,7 +119,7 @@ public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
       person1.setBlurb("Likes pizza");
       cache.put(key1, person1);
 
-      queryParser = new QueryParser("blurb", new StandardAnalyzer());
+      queryParser = createQueryParser("blurb");
       luceneQuery = queryParser.parse("pizza");
       cacheQuery = new QueryFactory(cache, qh).getQuery(luceneQuery);
 
@@ -131,7 +131,7 @@ public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
    }
 
    public void testAdded() throws ParseException {
-      queryParser = new QueryParser("name", new StandardAnalyzer());
+      queryParser = createQueryParser("name");
 
       luceneQuery = queryParser.parse("Goat");
       cacheQuery = new QueryFactory(cache, qh).getQuery(luceneQuery);
@@ -159,7 +159,7 @@ public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
    }
 
    public void testRemoved() throws ParseException {
-      queryParser = new QueryParser("name", new StandardAnalyzer());
+      queryParser = createQueryParser("name");
 
       luceneQuery = queryParser.parse("Goat");
       cacheQuery = new QueryFactory(cache, qh).getQuery(luceneQuery);
@@ -181,7 +181,7 @@ public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
    }
 
    public void testUpdated() throws ParseException{
-      queryParser = new QueryParser("name", new StandardAnalyzer());
+      queryParser = createQueryParser("name");
 
       luceneQuery = queryParser.parse("Goat");
       cacheQuery = new QueryFactory(cache, qh).getQuery(luceneQuery);
@@ -199,17 +199,15 @@ public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
       assert found.size() == 1 : "Size of list should be 1";
       assert !found.contains(person2) : "Person 2 should not be found now";
       assert !found.contains(person1) : "Person 1 should not be found because it does not meet the search criteria";
-
    }
-
 
    public void testSetSort() throws ParseException {
       person2.setAge(35);
       person3.setAge(12);
 
-      Sort sort = new Sort("age");
+      Sort sort = new Sort( new SortField("age", SortField.STRING));
 
-      queryParser = new QueryParser("name", new StandardAnalyzer());
+      queryParser = createQueryParser("name");
 
       luceneQuery = queryParser.parse("Goat");
       cacheQuery = new QueryFactory(cache, qh).getQuery(luceneQuery);
@@ -227,7 +225,7 @@ public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
    }
 
    public void testSetFilter() throws ParseException {
-      queryParser = new QueryParser("name", new StandardAnalyzer());
+      queryParser = createQueryParser("name");
 
       luceneQuery = queryParser.parse("goat");
       cacheQuery = new QueryFactory(cache, qh).getQuery(luceneQuery);
@@ -242,11 +240,10 @@ public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
       found = cacheQuery.list();
 
       assert found.size() == 1;
-
    }
 
    public void testLazyIterator() throws ParseException {
-      queryParser = new QueryParser("blurb", new StandardAnalyzer());
+      queryParser = createQueryParser("blurb");
       luceneQuery = queryParser.parse("playing");
       cacheQuery = new QueryFactory(cache, qh).getQuery(luceneQuery);
 
@@ -254,12 +251,11 @@ public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
 
       assert found.isFirst();
       assert found.isLast();
-
    }
 
    public void testGetResultSize() throws ParseException {
 
-      queryParser = new QueryParser("blurb", new StandardAnalyzer());
+      queryParser = createQueryParser("blurb");
       luceneQuery = queryParser.parse("playing");
       cacheQuery = new QueryFactory(cache, qh).getQuery(luceneQuery);
 
@@ -294,7 +290,7 @@ public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
    }
 
    public void testTypeFiltering() throws ParseException {
-      queryParser = new QueryParser("blurb", new StandardAnalyzer());
+      queryParser = createQueryParser("blurb");
       luceneQuery = queryParser.parse("grass");
       cacheQuery = new QueryFactory(cache, qh).getQuery(luceneQuery);
 
@@ -303,7 +299,7 @@ public abstract class AbstractLocalQueryTest extends SingleCacheManagerTest {
       assert found.size() == 2;
       assert found.containsAll(asList(person2, anotherGrassEater));
 
-      queryParser = new QueryParser("blurb", new StandardAnalyzer());
+      queryParser = createQueryParser("blurb");
       luceneQuery = queryParser.parse("grass");
       cacheQuery = new QueryFactory(cache, qh).getQuery(luceneQuery, AnotherGrassEater.class);
 

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
@@ -21,7 +21,6 @@
  */
 package org.infinispan.query.blackbox;
 
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.queryParser.ParseException;
 import org.apache.lucene.queryParser.QueryParser;
 import org.apache.lucene.search.Query;
@@ -45,6 +44,7 @@ import org.testng.annotations.Test;
 import java.util.List;
 
 import static org.infinispan.config.Configuration.CacheMode.REPL_SYNC;
+import static org.infinispan.query.helper.TestQueryHelperFactory.*;
 
 /**
  * @author Navin Surtani
@@ -63,10 +63,9 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
    Query luceneQuery;
    CacheQuery cacheQuery;
    QueryHelper qh;
-   List found;
-   String key1 = "Navin";
-   String key2 = "BigGoat";
-   String key3 = "MiniGoat";
+   final String key1 = "Navin";
+   final String key2 = "BigGoat";
+   final String key3 = "MiniGoat";
 
    public ClusteredCacheTest() {
       cleanup = CleanupPhase.AFTER_METHOD;
@@ -120,10 +119,9 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
 
 
    public void testSimple() throws ParseException {
-      cacheQuery = new QueryFactory(cache2, qh)
-            .getBasicQuery("blurb", "playing");
+      cacheQuery = createCacheQuery(cache2, qh, "blurb", "playing");
 
-      found = cacheQuery.list();
+      List<Object> found = cacheQuery.list();
 
       assert found.size() == 1;
 
@@ -139,7 +137,6 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       }
 
       assert found.get(0).equals(person1);
-
    }
 
    private void assertQueryInterceptorPresent(Cache<?, ?> c) {
@@ -150,11 +147,11 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
    public void testModified() throws ParseException {
       assertQueryInterceptorPresent(cache2);
 
-      queryParser = new QueryParser("blurb", new StandardAnalyzer());
+      queryParser = createQueryParser("blurb");
       luceneQuery = queryParser.parse("playing");
       cacheQuery = new QueryFactory(cache2, qh).getQuery(luceneQuery);
 
-      found = cacheQuery.list();
+      List<Object> found = cacheQuery.list();
 
       assert found.size() == 1 : "Expected list of size 1, was of size " + found.size();
       assert found.get(0).equals(person1);
@@ -163,7 +160,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       cache1.put("Navin", person1);
 
 
-      queryParser = new QueryParser("blurb", new StandardAnalyzer());
+      queryParser = createQueryParser("blurb");
       luceneQuery = queryParser.parse("pizza");
       cacheQuery = new QueryFactory(cache2, qh).getQuery(luceneQuery);
 
@@ -174,11 +171,11 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
    }
 
    public void testAdded() throws ParseException {
-      queryParser = new QueryParser("blurb", new StandardAnalyzer());
+      queryParser = createQueryParser("blurb");
 
       luceneQuery = queryParser.parse("eats");
       cacheQuery = new QueryFactory(cache2, qh).getQuery(luceneQuery);
-      found = cacheQuery.list();
+      List<Object> found = cacheQuery.list();
 
 
       assert found.size() == 2 : "Size of list should be 2";
@@ -203,10 +200,10 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
    }
 
    public void testRemoved() throws ParseException {
-      queryParser = new QueryParser("blurb", new StandardAnalyzer());
+      queryParser = createQueryParser("blurb");
       luceneQuery = queryParser.parse("eats");
       cacheQuery = new QueryFactory(cache2, qh).getQuery(luceneQuery);
-      found = cacheQuery.list();
+      List<Object> found = cacheQuery.list();
 
       assert found.size() == 2;
       assert found.contains(person2);
@@ -214,31 +211,26 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
 
       cache1.remove(key3);
 
-      queryParser = new QueryParser("blurb", new StandardAnalyzer());
+      queryParser = createQueryParser("blurb");
       luceneQuery = queryParser.parse("eats");
       cacheQuery = new QueryFactory(cache2, qh).getQuery(luceneQuery);
       found = cacheQuery.list();
-
    }
 
    public void testGetResultSize() throws ParseException {
 
-      queryParser = new QueryParser("blurb", new StandardAnalyzer());
+      queryParser = createQueryParser("blurb");
       luceneQuery = queryParser.parse("playing");
       cacheQuery = new QueryFactory(cache2, qh).getQuery(luceneQuery);
-      found = cacheQuery.list();
+      List<Object> found = cacheQuery.list();
 
       assert found.size() == 1;
-
    }
 
    public void testClear() throws ParseException {
-
-      queryParser = new QueryParser("blurb", new StandardAnalyzer());
+      queryParser = createQueryParser("blurb");
       luceneQuery = queryParser.parse("eats");
       cacheQuery = new QueryFactory(cache1, qh).getQuery(luceneQuery);
-      found = cacheQuery.list();
-
 
       Query[] queries = new Query[2];
       queries[0] = luceneQuery;
@@ -262,10 +254,6 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       // run the same query on cache 2
       cacheQuery = new QueryFactory(cache2, qh).getQuery(luceneQuery);
       assert cacheQuery.getResultSize() == 0;
-
    }
 
-
 }
-
-

--- a/query/src/test/java/org/infinispan/query/blackbox/MarshalledValueQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/MarshalledValueQueryTest.java
@@ -31,8 +31,6 @@ import org.testng.annotations.Test;
  * @author Navin Surtani
  * @since 4.0
  */
-
-
 @Test(groups="functional", testName = "query.blackbox.MarshalledValueQueryTest")
 public class MarshalledValueQueryTest extends LocalCacheTest {
    @Override

--- a/query/src/test/java/org/infinispan/query/blackbox/SearchFactoryShutdownTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/SearchFactoryShutdownTest.java
@@ -6,7 +6,6 @@ import org.hibernate.search.impl.MutableSearchFactory;
 import org.infinispan.Cache;
 import org.infinispan.config.Configuration;
 import org.infinispan.manager.CacheContainer;
-import org.infinispan.query.backend.QueryHelper;
 import org.infinispan.query.helper.TestQueryHelperFactory;
 import org.infinispan.query.test.AnotherGrassEater;
 import org.infinispan.query.test.Person;
@@ -29,6 +28,7 @@ import static org.infinispan.config.Configuration.CacheMode.LOCAL;
  */
 @Test(testName = "query.blackbox.SearchFactoryShutdownTest", groups = "functional")
 public class SearchFactoryShutdownTest extends AbstractInfinispanTest {
+   
    public void testCorrectShutdown() throws NoSuchFieldException, IllegalAccessException {
       CacheContainer cc = null;
 
@@ -38,7 +38,7 @@ public class SearchFactoryShutdownTest extends AbstractInfinispanTest {
          c.setIndexLocalOnly(false);
          cc = TestCacheManagerFactory.createCacheManager(c, true);
          Cache<?, ?> cache = cc.getCache();
-         QueryHelper qh = TestQueryHelperFactory.createTestQueryHelperInstance(cache, Person.class, AnotherGrassEater.class);
+         TestQueryHelperFactory.createTestQueryHelperInstance(cache, Person.class, AnotherGrassEater.class);
          SearchFactoryImplementor sfi = TestingUtil.extractComponent(cache, SearchFactoryImplementor.class);
 
          assert !isStopped(sfi);

--- a/query/src/test/java/org/infinispan/query/config/CacheModeTest.java
+++ b/query/src/test/java/org/infinispan/query/config/CacheModeTest.java
@@ -33,10 +33,9 @@ public class CacheModeTest extends AbstractInfinispanTest {
 
    private void doTest(Configuration.CacheMode m) {
       CacheContainer cc = null;
-
       try {
          cc = TestCacheManagerFactory.createCacheManager(m, true);
-         QueryHelper qh = new QueryHelper(cc.getCache(), new Properties(), Person.class);
+         new QueryHelper(cc.getCache(), new Properties(), Person.class);
          boolean found = false;
          for (CommandInterceptor i : cc.getCache().getAdvancedCache().getInterceptorChain()) {
             System.out.println("  Testing " + i.getClass().getSimpleName());
@@ -45,6 +44,6 @@ public class CacheModeTest extends AbstractInfinispanTest {
          assert found : "Didn't find a query interceptor in the chain!!";
       } finally {
          TestingUtil.killCacheManagers(cc);
-      }      
+      }
    }
 }

--- a/query/src/test/java/org/infinispan/query/config/DeclarativeConfigTest.java
+++ b/query/src/test/java/org/infinispan/query/config/DeclarativeConfigTest.java
@@ -24,7 +24,6 @@ package org.infinispan.query.config;
 import org.apache.lucene.queryParser.ParseException;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.CacheQuery;
-import org.infinispan.query.QueryFactory;
 import org.infinispan.query.backend.QueryHelper;
 import org.infinispan.query.helper.TestQueryHelperFactory;
 import org.infinispan.query.test.Person;
@@ -40,8 +39,6 @@ import java.util.List;
 @Test(testName = "query.config.DeclarativeConfigTest", groups = "functional")
 public class DeclarativeConfigTest extends SingleCacheManagerTest {
 
-   QueryFactory qf;
-
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       String config = TestingUtil.INFINISPAN_START_TAG +
@@ -52,14 +49,13 @@ public class DeclarativeConfigTest extends SingleCacheManagerTest {
       InputStream is = new ByteArrayInputStream(config.getBytes());
       cacheManager = TestCacheManagerFactory.fromStream(is);
       cache = cacheManager.getCache();
-      QueryHelper qh = TestQueryHelperFactory.createTestQueryHelperInstance(cache, Person.class);
-      qf = new QueryFactory(cache, qh);
       return cacheManager;
    }
 
    public void simpleIndexTest() throws ParseException {
+      QueryHelper qh = TestQueryHelperFactory.createTestQueryHelperInstance(cache, Person.class);
       cache.put("1", new Person("A Person's Name", "A paragraph containing some text", 75));
-      CacheQuery cq = qf.getBasicQuery("name", "Person");
+      CacheQuery cq = TestQueryHelperFactory.createCacheQuery(cache, qh, "name", "Person");
       assert cq.getResultSize() == 1;
       List<Object> l =  cq.list();
       assert l.size() == 1;

--- a/query/src/test/java/org/infinispan/query/helper/TestQueryHelperFactory.java
+++ b/query/src/test/java/org/infinispan/query/helper/TestQueryHelperFactory.java
@@ -21,7 +21,14 @@
  */
 package org.infinispan.query.helper;
 
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.queryParser.ParseException;
+import org.apache.lucene.queryParser.QueryParser;
+import org.apache.lucene.util.Version;
 import org.infinispan.Cache;
+import org.infinispan.query.CacheQuery;
+import org.infinispan.query.QueryFactory;
 import org.infinispan.query.backend.QueryHelper;
 
 import java.util.Properties;
@@ -30,13 +37,32 @@ import java.util.Properties;
  * Creates a test query helper
  *
  * @author Manik Surtani
+ * @author Sanne Grinovero
  * @since 4.0
  */
 public class TestQueryHelperFactory {
+   
+   public static final Analyzer STANDARD_ANALYZER = new StandardAnalyzer(getLuceneVersion());
+   
    public static QueryHelper createTestQueryHelperInstance(Cache<?, ?> cache, Class... classes) {
       if (cache == null) throw new NullPointerException("Cache should not be null!");
       Properties p = new Properties();
       p.setProperty("hibernate.search.default.directory_provider", "org.hibernate.search.store.RAMDirectoryProvider");
       return new QueryHelper(cache, p, classes);
    }
+   
+   public static QueryParser createQueryParser(String defaultFieldName) {
+      return new QueryParser(getLuceneVersion(), defaultFieldName, STANDARD_ANALYZER);
+   }
+   
+   public static Version getLuceneVersion() {
+      return Version.LUCENE_30; //Change as needed
+   }
+
+   public static CacheQuery createCacheQuery(Cache m_cache, QueryHelper m_queryHelper, String fieldName, String searchString) throws ParseException {
+      QueryFactory queryFactory = new QueryFactory(m_cache, m_queryHelper);
+      CacheQuery cacheQuery = queryFactory.getBasicQuery(fieldName, searchString, getLuceneVersion());
+      return cacheQuery;
+   }
+   
 }

--- a/query/src/test/java/org/infinispan/query/impl/LazyIteratorTest.java
+++ b/query/src/test/java/org/infinispan/query/impl/LazyIteratorTest.java
@@ -110,12 +110,10 @@ public class LazyIteratorTest {
       keyList.add("S:key8");
       keyList.add("S:key9");
       keyList.add("S:key10");
-
-
    }
 
    @BeforeMethod
-   public void setUp() throws ParseException {
+   public void setUp() throws ParseException, IOException {
 
       // Setting up the cache mock instance
       cache = createMock(Cache.class);
@@ -128,37 +126,28 @@ public class LazyIteratorTest {
          }
       }).anyTimes();
 
-
       // Create mock instances of other things required to create a lazy iterator.
 
       SearchFactoryImplementor searchFactory = createMock(SearchFactoryImplementor.class);
 
       DocumentExtractor extractor = org.easymock.classextension.EasyMock.createMock(DocumentExtractor.class);
 
-
-      try {
          org.easymock.classextension.EasyMock.expect(extractor.extract(anyInt())).andAnswer(new IAnswer<EntityInfo>() {
 
             public EntityInfo answer() throws Throwable {
                int index = (Integer) getCurrentArguments()[0];
                String keyString = keyList.get(index);
-               return new EntityInfo(Person.class, keyString, null);
+               return new EntityInfo(Person.class, keyString, keyString, new String[0]);
             }
          }).anyTimes();
 
-
-      } catch (IOException e) {
-         e.printStackTrace();
-      }
       IndexSearcher searcher = org.easymock.classextension.EasyMock.createMock(IndexSearcher.class);
 
       EasyMock.replay(cache, searchFactory);
       org.easymock.classextension.EasyMock.replay(searcher, extractor);
 
       iterator = new LazyIterator(extractor, cache, searcher, searchFactory, 0, 9, fetchSize);
-
    }
-
 
    @AfterMethod (alwaysRun = true)
    public void tearDown() {
@@ -179,7 +168,6 @@ public class LazyIteratorTest {
       assert iterator.isBeforeLast();
    }
 
-
    @Test(expectedExceptions = IndexOutOfBoundsException.class)
    public void testOutOfBoundsBelow() {
       iterator.jumpToResult(-1);
@@ -189,7 +177,6 @@ public class LazyIteratorTest {
    public void testOutOfBoundsAbove() {
       iterator.jumpToResult(keyList.size() + 1);
    }
-
 
    public void testFirst() {
       assert iterator.isFirst() : "We should be pointing at the first element";
@@ -205,7 +192,6 @@ public class LazyIteratorTest {
       next = iterator.next();
       assert next == person1;
       assert !iterator.isFirst();
-
    }
 
    public void testLast() {

--- a/query/src/test/java/org/infinispan/query/test/BrokenProvided.java
+++ b/query/src/test/java/org/infinispan/query/test/BrokenProvided.java
@@ -38,7 +38,6 @@ public class BrokenProvided {
    public void setBoth(String name, int age) {
       this.name = name;
       this.age = age;
-
    }
 
 }


### PR DESCRIPTION
For master only. Contains the needed fixes and some whitespace/style cleanup.

To run the tests successfully, make sure to download latest snapshots of Search (avoid maven offline) to get the downstream fixes I just deployed to Nexus.
