### PR TITLE
ISPN-930  race condition in Lock reordering could cause Lucene Index corruption when a CacheLoader is enabled

### DIFF
--- a/lucene-directory/src/main/java/org/infinispan/lucene/FileMetadata.java
+++ b/lucene-directory/src/main/java/org/infinispan/lucene/FileMetadata.java
@@ -36,12 +36,11 @@ public final class FileMetadata implements Serializable {
    /** The serialVersionUID */
    private static final long serialVersionUID = -7150923427362644166L;
    
-   private long lastModified;
+   private long lastModified = 0;
    private long size = 0;
    private int bufferSize;
 
    public FileMetadata() {
-      touch();
    }
 
    public void touch() {

--- a/lucene-directory/src/main/java/org/infinispan/lucene/InfinispanIndexInput.java
+++ b/lucene-directory/src/main/java/org/infinispan/lucene/InfinispanIndexInput.java
@@ -44,12 +44,12 @@ import org.infinispan.util.logging.LogFactory;
 public class InfinispanIndexInput extends IndexInput {
 
    private static final Log log = LogFactory.getLog(InfinispanIndexInput.class);
+   private final boolean trace = log.isTraceEnabled();
 
    private final AdvancedCache chunksCache;
    private final FileCacheKey fileKey;
    private final int chunkSize;
    private final SegmentReadLocker readLocks;
-   private final boolean trace;
    private final String filename;
    private final long fileLength;
 
@@ -67,7 +67,6 @@ public class InfinispanIndexInput extends IndexInput {
       this.fileLength = fileMetadata.getSize();
       this.readLocks = readLocks;
       this.filename = fileKey.getFileName();
-      trace = log.isTraceEnabled();
       if (trace) {
          log.trace("Opened new IndexInput for file:%s in index: %s", filename, fileKey.getIndexName());
       }

--- a/lucene-directory/src/test/java/org/infinispan/lucene/InfinispanDirectoryIOTest.java
+++ b/lucene-directory/src/test/java/org/infinispan/lucene/InfinispanDirectoryIOTest.java
@@ -91,8 +91,6 @@ public class InfinispanDirectoryIOTest {
       }
       io.flush();
       assert io.length() == REPEATABLE_BUFFER_SIZE;
-      long deepCountFileSize = DirectoryIntegrityCheck.deepCountFileSize(new FileCacheKey(INDEXNAME,fileName), cache);
-      assert io.length() == deepCountFileSize;
       
       //Text to write on file with repeatable text
       final String someText = "This is some text";
@@ -100,7 +98,6 @@ public class InfinispanDirectoryIOTest {
       //4 points in random order where writing someText: at begin of file, at end of file, within a single chunk,
       //between 2 chunks
       final int[] pointers = {0, 635, REPEATABLE_BUFFER_SIZE, 135};
-      
       for(int i=0; i < pointers.length; i++) {
          io.seek(pointers[i]);
          io.writeBytes(someTextAsBytes, someTextAsBytes.length);
@@ -648,6 +645,7 @@ public class InfinispanDirectoryIOTest {
          indexOutput.writeBytes(manyBytes, bufferSize);
          indexOutput.flush();
       }
+      indexOutput.close();
       IndexInput input = dir.openInput(filename);
       final int finalSize = (10 * bufferSize);
       assert input.length() == finalSize;
@@ -658,7 +656,6 @@ public class InfinispanDirectoryIOTest {
          for (int j = 0; j < bufferSize; j++)
             assert resultingBuffer[index++] == manyBytes[j];
       }
-      indexOutput.close();
    }
 
    private byte[] fillBytes(int size) {


### PR DESCRIPTION
Please merge in both master and 4.2.x branch.
This one is for 4.2.x
My branch for master is ISPN-930-master

Explanation from commit message follows:

The workaround is to avoid writing two different values under the same key.
With Lucene, the first bytes are rewritten at file close time to add checksum
information to the head of the file.
Previously we where writing each file chunk as soon as possible to be
memory friendly, getting the first chunk back as needed to edit it and putting
it into the cache modified - apparently if these operations are close enough in
time, the value without the checksum might end up to be the value stored (ISPN-575).
What we do with this patch is hold the writing of the first chunk up to the file
close operation, so that each chunk is written only once.

As a side effect, we can simplify the batch operations and the intermediate flush
operations, as they don't need to detect if we are in closing phase.
