### PR TITLE
Ispn 935

### DIFF
--- a/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
@@ -432,24 +432,26 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
       }
       
    }
+
+   static class PojoWhichFailsOnUnmarshalling extends Pojo {
+      private static final long serialVersionUID = -5109779096242560884L;
+
+      @Override
+      public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+         throw new IOException("Injected failue!");
+      }
+      
+   };
    
    public void testErrorUnmarshalling() throws Exception {
-      Pojo pojo = new Pojo() {
-         private static final long serialVersionUID = -5109779096242560884L;
-
-         @Override
-         public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-            throw new IOException("Injected failue!");
-         }
-         
-      };
+      Pojo pojo = new PojoWhichFailsOnUnmarshalling();
       byte[] bytes = marshaller.objectToByteBuffer(pojo);
       try {
          marshaller.objectFromByteBuffer(bytes);
       } catch (IOException e) {
          log.info("Log exception for output format verification", e);
          TraceInformation inf = (TraceInformation) e.getCause();
-         assert inf.toString().contains("in object of type org.infinispan.marshall.VersionAwareMarshallerTest$1");
+         assert inf.toString().contains("in object of type org.infinispan.marshall.VersionAwareMarshallerTest$PojoWhichFailsOnUnmarshalling");
       }
       
    }


### PR DESCRIPTION
Can be applied to master and to 4.2 branch, just make this test less prone to failing when someone alters the class structure of the test.
