### PR TITLE
ISPN-985 Update Lucene 3.x version to 3.0.3, and switch from default target of Lucene 2

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -110,6 +110,7 @@
       <version.jstl>1.2</version.jstl>
       <version.jta>1.0.1.GA</version.jta>
       <version.log4j>1.2.16</version.log4j>
+      <version.lucene>3.0.3</version.lucene>
       <version.mysql.driver>5.1.9</version.mysql.driver>
       <version.netty>3.2.3.Final</version.netty>
       <version.org.jboss.naming>5.0.3.GA</version.org.jboss.naming>
@@ -484,24 +485,13 @@
          </properties>
       </profile>
       <profile>
-         <!-- Used to start the tests using the latest stable version of Lucene, use: -->
-         <!-- mvn clean test -P useLatestLuceneVersion,test-functional -->
-         <id>useLatestLuceneVersion</id>
+         <!-- we are still likely compatible with the 2.9.x Lucene version: test for that -->
+         <id>useOlderLuceneVersion</id>
          <activation>
             <activeByDefault>false</activeByDefault>
          </activation>
          <properties>
-            <version.lucene>3.0.2</version.lucene>
-         </properties>
-      </profile>
-      <profile>
-         <!-- define the Lucene version used in release package, and as reference target -->
-         <id>useReferenceLuceneVersion</id>
-         <activation>
-            <activeByDefault>true</activeByDefault>
-         </activation>
-         <properties>
-            <version.lucene>2.9.3</version.lucene>
+            <version.lucene>2.9.4</version.lucene>
          </properties>
       </profile>
       <profile>


### PR DESCRIPTION
For master only, trivial changes:
- fix undefined property when enabling other profiles
- bump minor versions of Lucene
- set default tests to run on latest mayor version of Lucene
