### PR TITLE
ISPN-1025 - CommandAwareRpcDispatcher.FutureCollator.getResponseList() ha

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
@@ -365,9 +365,10 @@ public class CommandAwareRpcDispatcher extends RpcDispatcher {
          long giveupTime = System.currentTimeMillis() + timeout;
          boolean notTimedOut = true;
          synchronized (this) {
-            notTimedOut = giveupTime > System.currentTimeMillis();
-            while (notTimedOut && expectedResponses > 0 && retval == null)
+            while (notTimedOut && expectedResponses > 0 && retval == null) {
+               notTimedOut = giveupTime > System.currentTimeMillis();
                this.wait(timeout);
+            }
          }
 
          // if we've got here, we either have the response we need or aren't expecting any more responses - or have run out of time.


### PR DESCRIPTION
Also t_ispn1025_4.2.x for the 4.2.x branch.

ISPN-1025 - CommandAwareRpcDispatcher.FutureCollator.getResponseList() hangs instead of reporting timeout

I moved the timeout check inside the wait loop.
