### PR TITLE
ISPN-1020 - HotRod client test suite hangs in ClientConnectionPoolingTest

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/PropsKeyedObjectPoolFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/PropsKeyedObjectPoolFactory.java
@@ -27,6 +27,7 @@ public class PropsKeyedObjectPoolFactory extends GenericKeyedObjectPoolFactory {
       _testOnReturn = booleanProp(props, "testOnReturn", false);
       _timeBetweenEvictionRunsMillis = intProp(props, "timeBetweenEvictionRunsMillis", 2 * 60 * 1000);
       _minEvictableIdleTimeMillis = longProp(props, "minEvictableIdleTimeMillis", 5 * 60 * 1000);
+      _numTestsPerEvictionRun = intProp(props, "numTestsPerEvictionRun", 3);
       _testWhileIdle = booleanProp(props, "testWhileIdle", true);
       _minIdle = intProp(props, "minIdle", 1);
       _lifo = booleanProp(props, "lifo", true);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientConnectionPoolingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientConnectionPoolingTest.java
@@ -106,12 +106,21 @@ public class ClientConnectionPoolingTest extends MultipleCacheManagersTest {
    public void tearDown() throws ExecutionException, InterruptedException {
       hotRodServer1.stop();
       hotRodServer2.stop();
+
       workerThread1.stop();
       workerThread2.stop();
       workerThread3.stop();
       workerThread4.stop();
       workerThread5.stop();
       workerThread6.stop();
+
+      workerThread1.awaitTermination();
+      workerThread2.awaitTermination();
+      workerThread3.awaitTermination();
+      workerThread4.awaitTermination();
+      workerThread5.awaitTermination();
+      workerThread6.awaitTermination();
+
       remoteCacheManager.stop();
    }
 
@@ -193,6 +202,13 @@ public class ClientConnectionPoolingTest extends MultipleCacheManagersTest {
          dt1.allow();
          dt2.allow();
       }
+
+      // give the servers some time to process the operations
+      eventually(new Condition() {
+         public boolean isSatisfied() throws Exception {
+            return connectionPool.getNumActive() == 0;
+         }
+      }, 1000);
 
       assertExistKeyValue("k3", "v3");
       assertExistKeyValue("k4", "v4");

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/DroppedConnectionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/DroppedConnectionsTest.java
@@ -55,7 +55,7 @@ public class DroppedConnectionsTest extends SingleCacheManagerTest {
       GenericKeyedObjectPool keyedObjectPool = transportFactory.getConnectionPool();
       InetSocketAddress address = new InetSocketAddress("127.0.0.1", hotRodServer.getPort());
 
-      assertEquals(1, keyedObjectPool.getNumActive(address));
+      assertEquals(0, keyedObjectPool.getNumActive(address));
       assertEquals(1, keyedObjectPool.getNumIdle(address));
 
       TcpTransport tcpConnection = (TcpTransport) keyedObjectPool.borrowObject(address);
@@ -64,7 +64,7 @@ public class DroppedConnectionsTest extends SingleCacheManagerTest {
       tcpConnection.destroy();
 
       assertEquals("v", rc.get("k"));
-      assertEquals(1, keyedObjectPool.getNumActive(address));
+      assertEquals(0, keyedObjectPool.getNumActive(address));
       assertEquals(1, keyedObjectPool.getNumIdle(address));
 
       TcpTransport tcpConnection2 = (TcpTransport) keyedObjectPool.borrowObject(address);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HeavyLoadConnectionPoolingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HeavyLoadConnectionPoolingTest.java
@@ -2,6 +2,9 @@ package org.infinispan.client.hotrod;
 
 import org.apache.commons.pool.impl.GenericKeyedObjectPool;
 import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory;
+import org.infinispan.commands.VisitableCommand;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -39,12 +42,16 @@ public class HeavyLoadConnectionPoolingTest extends SingleCacheManagerTest {
       cacheManager = TestCacheManagerFactory.createLocalCacheManager();
       cache = cacheManager.getCache();
 
+      // make sure all operations take at least 100 msecs
+      cache.getAdvancedCache().addInterceptor(new ConstantDelayTransportInterceptor(100), 0);
+
       hotRodServer = TestHelper.startHotRodServer(cacheManager);
 
       Properties hotrodClientConf = new Properties();
       hotrodClientConf.put("infinispan.client.hotrod.server_list", "localhost:"+hotRodServer.getPort());
-      hotrodClientConf.put("timeBetweenEvictionRunsMillis", "3000");
-      hotrodClientConf.put("minEvictableIdleTimeMillis", "1000");
+      hotrodClientConf.put("timeBetweenEvictionRunsMillis", "500");
+      hotrodClientConf.put("minEvictableIdleTimeMillis", "100");
+      hotrodClientConf.put("numTestsPerEvictionRun", "10");
       hotrodClientConf.put("infinispan.client.hotrod.ping_on_startup", "true");
       remoteCacheManager = new RemoteCacheManager(hotrodClientConf);
       remoteCache = remoteCacheManager.getCache();
@@ -72,20 +79,38 @@ public class HeavyLoadConnectionPoolingTest extends SingleCacheManagerTest {
          workers.add(workerThread);
          workerThread.stress();
       }
-      while (!(connectionPool.getNumActive() > 15)) {
+      while (connectionPool.getNumActive() <= 15) {
          Thread.sleep(10);
       }
 
       for (WorkerThread wt: workers) {
          wt.stop();
       }
-      //now wait for the idle thread to wake up and clean them
-      for (int i = 0; i < 50; i++) {
-//         System.out.println("connectionPool = " + connectionPool.getNumActive());
-         if (connectionPool.getNumIdle() == 1) break;
-         Thread.sleep(1000);
+
+      for (WorkerThread wt: workers) {
+         wt.awaitTermination();
       }
+
+      //now wait for the idle thread to wake up and clean them
+      // the eviction thread cleans up at most 10 connections at a time, so we need to let it run at least 2 times
+      Thread.sleep(500 * 3);
+
       assertEquals(1, connectionPool.getNumIdle());
-      assertEquals(1, connectionPool.getNumActive());
+      assertEquals(0, connectionPool.getNumActive());
+   }
+
+   public static class ConstantDelayTransportInterceptor extends CommandInterceptor {
+
+      private int millis;
+
+      public ConstantDelayTransportInterceptor(int millis) {
+         this.millis = millis;
+      }
+
+      @Override
+      protected Object handleDefault(InvocationContext ctx, VisitableCommand command) throws Throwable {
+         Thread.sleep(millis);
+         return super.handleDefault(ctx, command);
+      }
    }
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/WorkerThread.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/WorkerThread.java
@@ -91,10 +91,17 @@ public class WorkerThread {
    }
 
    /**
+    * Returns without waiting for the threads to finish.
+    */
+   public void stop() {
+      executor.shutdown();
+   }
+
+   /**
     * Only returns when the last operation on this thread has finished.
     */
-   public void stop() throws InterruptedException, ExecutionException {
-      executor.shutdown();
+   public void awaitTermination() throws InterruptedException, ExecutionException {
+      executor.awaitTermination(1, TimeUnit.SECONDS);
       if (future != null) {
          future.get();
       }


### PR DESCRIPTION
ISPN-1020 - HotRod client test suite hangs in ClientConnectionPoolingTest.tearDown
https://issues.jboss.org/browse/ISPN-1020

ClientConnectionPoolingTest and HeavyLoadConnectionPoolingTest were still failing from time to time after my fix.
I added some guards to make sure that the servers have time to process the operations and that the eviction thread has time to clean up idle connections.
