### PR TITLE
ISPN-1051 - Potential concurrency issues when retrieving a cache concurre

### DIFF
--- a/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
@@ -98,16 +98,16 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
     */
    private Map<Class, Class<? extends AbstractComponentFactory>> defaultFactories = null;
 
-   protected static final Object NULL_COMPONENT = new Object();
+   private static final Object NULL_COMPONENT = new Object();
 
    // component and method containers
-   final Map<String, Component> componentLookup = new HashMap<String, Component>();
+   private final Map<String, Component> componentLookup = new HashMap<String, Component>(1);
 
    protected static List<ModuleLifecycle> moduleLifecycles = ModuleProperties.resolveModuleLifecycles();
 
-   volatile ComponentStatus state = ComponentStatus.INSTANTIATED;
+   protected volatile ComponentStatus state = ComponentStatus.INSTANTIATED;
 
-   final ReflectionCache reflectionCache;
+   private final ReflectionCache reflectionCache;
 
    public AbstractComponentRegistry(ReflectionCache reflectionCache) {
       this.reflectionCache = reflectionCache;
@@ -186,21 +186,24 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
     * @param component component to register
     * @param type      type of component
     */
-   public void registerComponent(Object component, Class type) {
+   public final void registerComponent(Object component, Class type) {
       registerComponent(component, type.getName());
    }
 
-   protected void registerNonVolatileComponent(Object component, String name) {
-      registerComponent(component, name);
-      Component c = componentLookup.get(name);
-      c.nonVolatile = true;
+   public final void registerComponent(Object component, String name) {
+      boolean nonVolatile = ReflectionUtil.isAnnotationPresent(component.getClass(), SurvivesRestarts.class);
+      registerComponentInternal(component, name, nonVolatile);
    }
 
-   protected void registerNonVolatileComponent(Object component, Class type) {
+   protected final void registerNonVolatileComponent(Object component, String name) {
+      registerComponentInternal(component, name, true);
+   }
+
+   protected final void registerNonVolatileComponent(Object component, Class type) {
       registerNonVolatileComponent(component, type.getName());
    }
 
-   public void registerComponent(Object component, String name) {
+   protected void registerComponentInternal(Object component, String name, boolean nonVolatile) {
       if (component == null)
          throw new NullPointerException("Cannot register a null component under name [" + name + "]");
       Component old = componentLookup.get(name);
@@ -219,17 +222,17 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
          old.instance = component;
          old.methodsScanned = false;
          c = old;
-
-         if (state == ComponentStatus.RUNNING) populateLifecycleMethods();
       } else {
          c = new Component();
          c.name = name;
          c.instance = component;
          componentLookup.put(name, c);
       }
-      c.nonVolatile = ReflectionUtil.isAnnotationPresent(component.getClass(), SurvivesRestarts.class);
+      c.nonVolatile = nonVolatile;
+
       addComponentDependencies(c);
       // inject dependencies for this component
+      // we inject dependencies only after the component is already in the map to support cyclical dependencies
       c.injectDependencies();
 
       if (old == null) getLog().trace("Registering component %s under name %s", c, name);
@@ -310,12 +313,13 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
    protected <T> T getOrCreateComponent(Class<T> componentClass, String name) {
       if (DEBUG_DEPENDENCIES) debugStack.push(name);
 
-      T component = getComponent(componentClass, name);
-
-      if (component == null) {
-         // first see if this has been injected externally.
+      T component;
+      Component oldWrapper = lookupComponent(componentClass, name);
+      if (oldWrapper != null) {
+         component = unwrapComponent(oldWrapper);
+      } else {
+         // see if this has been injected externally.
          component = getFromConfiguration(componentClass);
-         boolean attemptedFactoryConstruction = false;
 
          if (component == null) {
             // create this component and add it to the registry
@@ -323,16 +327,13 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
             component = factory instanceof NamedComponentFactory ?
                     ((NamedComponentFactory) factory).construct(componentClass, name)
                     : factory.construct(componentClass);
-            attemptedFactoryConstruction = true;
-
          }
 
          if (component != null) {
-            registerComponent(component, componentClass);
-         } else if (attemptedFactoryConstruction) {
-            if (getLog().isTraceEnabled())
-               getLog().trace("Registering a null for component %s", componentClass.getSimpleName());
-            registerNullComponent(componentClass);
+            registerComponent(component, name);
+         } else {
+             getLog().trace("Registering a null for component %s", name);
+            registerNullComponent(name);
          }
       }
 
@@ -437,10 +438,10 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
    /**
     * registers a special "null" component that has no dependencies.
     *
-    * @param type type of component to register as a null
+    * @param name name of component to register as a null
     */
-   void registerNullComponent(Class type) {
-      registerComponent(NULL_COMPONENT, type);
+   protected final void registerNullComponent(String name) {
+      registerComponent(NULL_COMPONENT, name);
    }
 
    /**
@@ -493,6 +494,13 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
       Component wrapper = lookupComponent(type, name);
       if (wrapper == null) return null;
 
+      return unwrapComponent(wrapper);
+   }
+
+   /**
+    * Get the component from a wrapper, properly handling <code>null</code> components.
+    */
+   private <T> T unwrapComponent(Component wrapper) {
       return (T) (wrapper.instance == NULL_COMPONENT ? null : wrapper.instance);
    }
 

--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -31,7 +31,7 @@ import static org.infinispan.factories.KnownComponentNames.MODULE_COMMAND_INITIA
 public class ComponentRegistry extends AbstractComponentRegistry {
 
    // cached component scopes
-   private static final Map<Class, Scopes> componentScopeLookup = new ConcurrentHashMap<Class, Scopes>();
+   private static final Map<Class, Scopes> componentScopeLookup = new ConcurrentHashMap<Class, Scopes>(1);
 
    private final GlobalComponentRegistry globalComponents;
    private final String cacheName;
@@ -92,10 +92,7 @@ public class ComponentRegistry extends AbstractComponentRegistry {
 
    @SuppressWarnings("unchecked")
    public final <T> T getLocalComponent(Class<T> componentType, String name) {
-      Component wrapper = lookupLocalComponent(componentType, name);
-      if (wrapper == null) return null;
-
-      return (T) (wrapper.instance == NULL_COMPONENT ? null : wrapper.instance);
+      return super.getComponent(componentType, name);
    }
 
    public final <T> T getLocalComponent(Class<T> componentType) {
@@ -126,11 +123,11 @@ public class ComponentRegistry extends AbstractComponentRegistry {
    }
 
    @Override
-   public final void registerComponent(Object component, String name) {
+   protected void registerComponentInternal(Object component, String name, boolean nonVolatile) {
       if (isGlobal(component.getClass())) {
-         globalComponents.registerComponent(component, name);
+         globalComponents.registerComponentInternal(component, name, nonVolatile);
       } else {
-         super.registerComponent(component, name);
+         super.registerComponentInternal(component, name, nonVolatile);
       }
    }
 
@@ -148,9 +145,7 @@ public class ComponentRegistry extends AbstractComponentRegistry {
 
    @Override
    public void start() {
-      if (globalComponents.getStatus() != ComponentStatus.RUNNING || globalComponents.getStatus() != ComponentStatus.INITIALIZING) {
-         globalComponents.start();
-      }
+      globalComponents.start();
       boolean needToNotify = state != ComponentStatus.RUNNING && state != ComponentStatus.INITIALIZING;
 
       // set this up *before* starting the components since some components - specifically state transfer - needs to be

--- a/core/src/test/java/org/infinispan/manager/ConcurrentCacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/ConcurrentCacheManagerTest.java
@@ -1,8 +1,10 @@
 package org.infinispan.manager;
 
-import org.infinispan.manager.DefaultCacheManager;
-import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.AbstractCacheTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -16,29 +18,44 @@ import java.util.concurrent.Future;
 /**
  * Test that verifies that CacheContainer.getCache() can be called concurrently.
  *
- * @author Galder Zamarre�o
+ * @author Galder Zamarreño
  * @since 4.2
  */
 @Test(groups = "functional", testName = "ConcurrentCacheManagerTest")
-public class ConcurrentCacheManagerTest extends SingleCacheManagerTest {
-   @Override
-   protected EmbeddedCacheManager createCacheManager() throws Exception {
-      return new DefaultCacheManager();
+public class ConcurrentCacheManagerTest extends AbstractCacheTest {
+   static final int NUM_CACHES = 4;
+   static final int NUM_THREADS = 25;
+
+   private EmbeddedCacheManager cacheManager;
+
+   @BeforeMethod
+   protected void setup() throws Exception {
+      DefaultCacheManager manager = new DefaultCacheManager();
+      for (int i = 0; i < NUM_CACHES; i++) {
+         manager.defineConfiguration("cache" + i, TestCacheManagerFactory.getDefaultConfiguration(true));
+      }
+      cacheManager = manager;
+   }
+
+   @AfterMethod
+   protected void teardown() {
+      TestingUtil.killCacheManagers(cacheManager);
    }
 
    public void testConcurrentGetCacheCalls() throws Exception {
-      int numThreads = 25;
-      final CyclicBarrier barrier = new CyclicBarrier(numThreads +1);
-      List<Future<Void>> futures = new ArrayList<Future<Void>>(numThreads);
-      ExecutorService executorService = Executors.newCachedThreadPool();
-      for (int i = 0; i < numThreads; i++) {
+      final CyclicBarrier barrier = new CyclicBarrier(NUM_THREADS + 1);
+      List<Future<Void>> futures = new ArrayList<Future<Void>>(NUM_THREADS);
+      ExecutorService executorService = Executors.newFixedThreadPool(NUM_THREADS);
+      for (int i = 0; i < NUM_THREADS; i++) {
          log.debug("Schedule execution");
+         final String name = "cache" + (i % NUM_CACHES);
+
          Future<Void> future = executorService.submit(new Callable<Void>(){
             @Override
             public Void call() throws Exception {
                try {
                   barrier.await();
-                  cacheManager.getCache("blahblah").put("a", "b");
+                  cacheManager.getCache(name).put("a", "b");
                   return null;
                } finally {
                   log.debug("Wait for all execution paths to finish");


### PR DESCRIPTION
ISPN-1051 - Potential concurrency issues when retrieving a cache concurrently (for the first time)
https://issues.jboss.org/browse/ISPN-1051

The issue is that multiple caches were starting at the same time and were
all trying to register the same components in the global component registry.
I updated ConcurrentCacheManagerTest to reproduce the issue.

To fix the issue I modified DefaultCacheManager to create just one cache at a time.
Since the component registry is only modified during cache initialization,
the synchronization in DCM allows us to not use synchronization at all in
AbstractComponentRegistry and its subclasses.

I also fixed some small issues in AbstractComponentRegistry:
- Named components created by factories were registered under the class name key
  instead of using their name.
- If a factory returned a null object, it would be registered as null but
  the next call would try to create it again.
