### PR TITLE
ISPN-870 Virtual Nodes

### DIFF
--- a/core/src/main/java/org/infinispan/config/Configuration.java
+++ b/core/src/main/java/org/infinispan/config/Configuration.java
@@ -1226,6 +1226,10 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
    public int getNumOwners() {
       return clustering.hash.numOwners;
    }
+   
+   public int getNumVirtualNodes() {
+      return clustering.hash.numVirtualNodes;
+   }
 
    public boolean isRehashEnabled() {
       return clustering.hash.rehashEnabled;
@@ -3044,6 +3048,9 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
 
       @ConfigurationDocRef(bean = Configuration.class, targetElement = "setRehashEnabled")
       protected Boolean rehashEnabled = true;
+      
+      @ConfigurationDocRef(bean = Configuration.class, targetElement = "numVirtualNodes")
+      protected Integer numVirtualNodes = 0;
 
       public void accept(ConfigurationBeanVisitor v) {
          v.visitHashType(this);
@@ -3095,6 +3102,26 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
       public Integer getNumOwners() {
          return numOwners;
       }
+      
+      @XmlAttribute
+      public Integer getNumVirtualNodes() {
+         return numVirtualNodes;
+      }
+      
+      public HashConfig numVirtualNodes(Integer numVirtualNodes) {
+         setNumVirtualNodes(numVirtualNodes);
+         return this;
+      }
+      
+      /**
+       * @deprecated The visibility of this will be reduced, use {@link #numVirtualNodes(Integer)}
+       */
+      @Deprecated
+      public void setNumVirtualNodes(Integer numVirtualNodes) {
+         testImmutability("numVirtualNodes");
+         this.numVirtualNodes = numVirtualNodes;
+      }
+
 
       /**
        * @deprecated The visibility of this will be reduced, use {@link #numOwners(Integer)}
@@ -3186,6 +3213,7 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
          if (hashFunctionClass != null ? !hashFunctionClass.equals(hashType.hashFunctionClass) : hashType.hashFunctionClass != null)
             return false;
          if (numOwners != null ? !numOwners.equals(hashType.numOwners) : hashType.numOwners != null) return false;
+         if (numVirtualNodes != null ? !numVirtualNodes.equals(hashType.numVirtualNodes) : hashType.numVirtualNodes != null) return false;
          if (rehashRpcTimeout != null ? !rehashRpcTimeout.equals(hashType.rehashRpcTimeout) : hashType.rehashRpcTimeout != null)
             return false;
          if (rehashWait != null ? !rehashWait.equals(hashType.rehashWait) : hashType.rehashWait != null) return false;
@@ -3199,6 +3227,7 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
          int result = consistentHashClass != null ? consistentHashClass.hashCode() : 0;
          result = 31 * result + (hashFunctionClass != null ? hashFunctionClass.hashCode() : 0);
          result = 31 * result + (numOwners != null ? numOwners.hashCode() : 0);
+         result = 31 * result + (numVirtualNodes != null ? numVirtualNodes.hashCode() : 0);
          result = 31 * result + (rehashWait != null ? rehashWait.hashCode() : 0);
          result = 31 * result + (rehashRpcTimeout != null ? rehashRpcTimeout.hashCode() : 0);
          result = 31 * result + (rehashEnabled ? 0 : 1);

--- a/core/src/main/java/org/infinispan/config/FluentConfiguration.java
+++ b/core/src/main/java/org/infinispan/config/FluentConfiguration.java
@@ -625,6 +625,21 @@ public class FluentConfiguration extends AbstractFluentConfigurationBean {
        * @param rehashEnabled
        */
       HashConfig rehashEnabled(Boolean rehashEnabled);
+      
+      /**
+       * Controls the number of virtual nodes per "real" node. You can read more about virtual nodes
+       * at ...
+       * 
+       * If numVirtualNodes is 1, then virtual nodes are disabled. The topology aware consistent hash
+       * must be used if you wish to take advnatage of virtual nodes.
+       * 
+       * A default of 1 is used.
+       * 
+       * @param numVirtualNodes the number of virtual nodes. Must be >0.
+       * @throws IllegalArgumentException if numVirtualNodes <0
+       * 
+       */
+      HashConfig numVirtualNodes(Integer numVirtualNodes);
    }
 
    /**

--- a/core/src/main/java/org/infinispan/distribution/ch/AbstractWheelConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/AbstractWheelConsistentHash.java
@@ -1,16 +1,15 @@
 package org.infinispan.distribution.ch;
 
-import org.infinispan.marshall.AbstractExternalizer;
-import org.infinispan.remoting.transport.Address;
-import org.infinispan.util.Util;
-import org.infinispan.util.hash.Hash;
-import org.infinispan.util.logging.Log;
-import org.infinispan.util.logging.LogFactory;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -18,10 +17,45 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.Util;
+import org.infinispan.util.hash.Hash;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
 /**
+ * <p>
  * Abstract class for the wheel-based CH implementations.
+ * </p>
+ * 
+ * <p>
+ * This base class supports consistent hashses which wish to enable virtual nodes. To do this
+ * the implementation should override {@link #isVirtualNodesEnabled()} and return true when
+ * virtual nodes should be enabled (we recommend at least that {@link #numVirtualNodes} should be
+ * > 1 for virtual nodes to be enabled!). It is assumed that implementations of a consistent hash
+ * in which virtual nodes are enabled will take responsibility for ensuring that the fact virtual
+ * nodes are in use does not escape the consistent hash implementation.
+ * </p> 
+ * 
+ * <p>
+ * The only consistent hash in Inifinispan to provide virtual node support is the topology aware
+ * consistent hash,
+ * </p>
+ * 
+ * <p>
+ * In order to do this, the
+ * implementation can use {@link #getRealAddress(Address)}, {@link #getRealAddresses(List)} and 
+ * {@link #getRealAddresses(Set)} to convert the virtual addresses obtained from {@link #positions},
+ * {@link #addressToHashIds} and {@link AbstractConsistentHash#caches} to real addresses. In particular an 
+ * implementation should ensure that {@link #locate(Object, int)}, {@link #getStateProvidersOnLeave(Address, int)}
+ * and {@link #getStateProvidersOnJoin(Address, int)} do not return virtual addresses (as implementations of
+ * these methods are not provided by this abstract super class). The behavior of Infinispan if 
+ * virtual addresses leak from the consistent hash implementation is not tested.
+ * </p>
  *
  * @author Mircea.Markus@jboss.com
+ * @author Pete Muir
  * @since 4.2
  */
 public abstract class AbstractWheelConsistentHash extends AbstractConsistentHash {
@@ -32,6 +66,7 @@ public abstract class AbstractWheelConsistentHash extends AbstractConsistentHash
    // TODO: Maybe address and addressToHashIds can be combined in a LinkedHashMap?
    protected Map<Address, Integer> addressToHashIds;
    protected Hash hashFunction;
+   protected int numVirtualNodes;
 
    final static int HASH_SPACE = 10240; // no more than 10k nodes?
 
@@ -43,6 +78,10 @@ public abstract class AbstractWheelConsistentHash extends AbstractConsistentHash
    public void setHashFunction(Hash h) {
       hashFunction = h;
    }
+   
+   public void setNumVirtualNodes(Integer numVirtualNodes) {
+      this.numVirtualNodes = numVirtualNodes;
+   }
 
    @Override
    public void setCaches(Set<Address> newCaches) {
@@ -51,20 +90,93 @@ public abstract class AbstractWheelConsistentHash extends AbstractConsistentHash
       positions = new TreeMap<Integer, Address>();
       addressToHashIds = new HashMap<Address, Integer>();
 
+      if (trace) log.trace("Adding %s nodes to cluster", newCaches.size());
+      
       for (Address a : newCaches) {
-         int positionIndex = Math.abs(hashFunction.hash(a)) % HASH_SPACE;
-         // this is deterministic since the address list is ordered and the order is consistent across the grid
-         while (positions.containsKey(positionIndex)) positionIndex = positionIndex + 1 % HASH_SPACE;
-         positions.put(positionIndex, a);
-         // If address appears several times, take the lowest value to guarantee that
-         // at least the initial value and subsequent +1 values would end up in the same node
-         // TODO: Remove this check since https://jira.jboss.org/jira/browse/ISPN-428 contains a proper fix for this
-         if (!addressToHashIds.containsKey(a))
-            addressToHashIds.put(a, positionIndex);
+         if (isVirtualNodesEnabled()) {
+            if (trace) log.trace("Adding %s virtual nodes for real node %s", numVirtualNodes, a);
+            for (int i = 0; i < numVirtualNodes; i++) {
+               Address va = new VirtualAddress(a, i);
+               if (trace) log.trace("Adding virtual node %s", va);
+               addNode(va);
+            }
+         } else {
+            if (trace) log.trace("Adding node %s", a);
+            addNode(a);
+         }
       }
 
       // reorder addresses as per the positions.
       caches.addAll(positions.values());
+   }
+   
+   @Override
+   public Set<Address> getCaches() {
+      return getRealAddresses(caches);
+   }
+   
+   protected void addNode(Address a) {
+      int positionIndex = Math.abs(hashFunction.hash(a)) % HASH_SPACE;
+      // this is deterministic since the address list is ordered and the order is consistent across the grid
+      while (positions.containsKey(positionIndex)) positionIndex = positionIndex + 1 % HASH_SPACE;
+      positions.put(positionIndex, a);
+      // If address appears several times, take the lowest value to guarantee that
+      // at least the initial value and subsequent +1 values would end up in the same node
+      // TODO: Remove this check since https://jira.jboss.org/jira/browse/ISPN-428 contains a proper fix for this
+      if (!addressToHashIds.containsKey(a))
+         addressToHashIds.put(a, positionIndex);
+      if (trace) log.trace("Added node %s", a);
+   }
+   
+   protected Address getRealAddress(Address a) {
+      if (isVirtualNodesEnabled())
+         return ((VirtualAddress) a).getRealAddress();
+      else
+         return a;
+   }
+   
+   protected List<Address> getRealAddresses(List<Address> virtualAddresses) {
+      if (virtualAddresses.isEmpty())
+         return emptyList();
+      else if (virtualAddresses.size() == 1) {
+         if (isVirtualNodesEnabled()) {
+            VirtualAddress a = (VirtualAddress) virtualAddresses.iterator().next();
+            return singletonList(a.getRealAddress());
+         } else
+            return virtualAddresses;
+      } else {
+         if (isVirtualNodesEnabled()) {
+            List<Address> addresses = new ArrayList<Address>();
+            for (Address a : virtualAddresses) {
+               VirtualAddress va = (VirtualAddress) a;
+               addresses.add(va.getRealAddress());
+            }
+            return addresses;
+         } else
+            return virtualAddresses;
+      }
+   }
+   
+   protected Set<Address> getRealAddresses(Set<Address> virtualAddresses) {
+      if (virtualAddresses.isEmpty())
+         return Collections.emptySet();
+      else if (virtualAddresses.size() == 1) {
+         if (isVirtualNodesEnabled()) {
+            VirtualAddress a = (VirtualAddress) virtualAddresses.iterator().next();
+            return Collections.singleton(a.getRealAddress());
+         } else
+            return virtualAddresses;
+      } else {
+         if (isVirtualNodesEnabled()) {
+            Set<Address> addresses = new HashSet<Address>();
+            for (Address a : virtualAddresses) {
+               VirtualAddress va = (VirtualAddress) a;
+               addresses.add(va.getRealAddress());
+            }
+            return addresses;
+         } else
+            return virtualAddresses;
+      }
    }
 
    @Override
@@ -102,6 +214,10 @@ public abstract class AbstractWheelConsistentHash extends AbstractConsistentHash
             ", addressToHashIds=" + addressToHashIds +
             "}";
    }
+   
+   protected boolean isVirtualNodesEnabled() {
+      return false;
+   }
 
    public static abstract class Externalizer<T extends AbstractWheelConsistentHash> extends AbstractExternalizer<T> {
 
@@ -113,6 +229,7 @@ public abstract class AbstractWheelConsistentHash extends AbstractConsistentHash
          output.writeObject(abstractWheelConsistentHash.caches);
          output.writeObject(abstractWheelConsistentHash.positions);
          output.writeObject(abstractWheelConsistentHash.addressToHashIds);
+         output.writeInt(abstractWheelConsistentHash.numVirtualNodes);
       }
 
       @Override
@@ -124,6 +241,7 @@ public abstract class AbstractWheelConsistentHash extends AbstractConsistentHash
          abstractWheelConsistentHash.caches = (Set<Address>) unmarshaller.readObject();
          abstractWheelConsistentHash.positions = (SortedMap<Integer, Address>) unmarshaller.readObject();
          abstractWheelConsistentHash.addressToHashIds = (Map<Address, Integer>) unmarshaller.readObject();
+         abstractWheelConsistentHash.numVirtualNodes = unmarshaller.readInt();
          return abstractWheelConsistentHash;
       }
    }

--- a/core/src/main/java/org/infinispan/distribution/ch/ConsistentHashHelper.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/ConsistentHashHelper.java
@@ -45,15 +45,19 @@ public class ConsistentHashHelper {
       ConsistentHash ch = (ConsistentHash) Util.getInstance(c.getConsistentHashClass());
       if (ch instanceof AbstractWheelConsistentHash) {
          Hash h = (Hash) Util.getInstance(c.getHashFunctionClass());
-         ((AbstractWheelConsistentHash) ch).setHashFunction(h);
+         AbstractWheelConsistentHash wch = (AbstractWheelConsistentHash) ch;
+         wch.setHashFunction(h);
+         wch.setNumVirtualNodes(c.getNumVirtualNodes());
       }
       return ch;
    }
 
-   private static ConsistentHash constructConsistentHashInstance(Class<? extends ConsistentHash> clazz, Hash hash) {
+   private static ConsistentHash constructConsistentHashInstance(Class<? extends ConsistentHash> clazz, Hash hash, int numVirtualNodes) {
       ConsistentHash ch = Util.getInstance(clazz);
       if (ch instanceof AbstractWheelConsistentHash) {
-         ((AbstractWheelConsistentHash) ch).setHashFunction(hash);
+         AbstractWheelConsistentHash wch = (AbstractWheelConsistentHash) ch;
+         wch.setHashFunction(hash);
+         wch.setNumVirtualNodes(numVirtualNodes);
       }
       return ch;
    }
@@ -132,10 +136,13 @@ public class ConsistentHashHelper {
     */
    public static ConsistentHash createConsistentHash(ConsistentHash template, Collection<Address> addresses, TopologyInfo topologyInfo) {
       Hash hf = null;
+      int numVirtualNodes = 1;
       if (template instanceof AbstractWheelConsistentHash) {
-         hf = ((AbstractWheelConsistentHash) template).hashFunction;
+         AbstractWheelConsistentHash wTemplate = (AbstractWheelConsistentHash) template;
+         hf = wTemplate.hashFunction;
+         numVirtualNodes = wTemplate.numVirtualNodes;
       }
-      ConsistentHash ch = constructConsistentHashInstance(template.getClass(), hf);
+      ConsistentHash ch = constructConsistentHashInstance(template.getClass(), hf, numVirtualNodes);
       if (addresses != null && !addresses.isEmpty())  ch.setCaches(toSet(addresses));
       ch.setTopologyInfo(topologyInfo);
       return ch;

--- a/core/src/main/java/org/infinispan/distribution/ch/DefaultConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/DefaultConsistentHash.java
@@ -39,7 +39,7 @@ public class DefaultConsistentHash extends AbstractWheelConsistentHash {
 
       for (Address a : candidates.values()) {
          if (numOwnersFound < numCopiesToFind) {
-            owners.add(a);
+            owners.add(getRealAddress(a));
             numOwnersFound++;
          } else {
             break;
@@ -49,7 +49,7 @@ public class DefaultConsistentHash extends AbstractWheelConsistentHash {
       if (numOwnersFound < numCopiesToFind) {
          for (Address a : positions.values()) {
             if (numOwnersFound < numCopiesToFind) {
-               owners.add(a);
+               owners.add(getRealAddress(a));
                numOwnersFound++;
             } else {
                break;
@@ -69,7 +69,7 @@ public class DefaultConsistentHash extends AbstractWheelConsistentHash {
       int nodesTested = 0;
       for (Address a : candidates.values()) {
          if (nodesTested < numCopiesToFind) {
-            if (a.equals(target)) return true;
+            if (getRealAddress(a).equals(target)) return true;
             nodesTested++;
          } else {
             break;
@@ -80,7 +80,7 @@ public class DefaultConsistentHash extends AbstractWheelConsistentHash {
       if (nodesTested < numCopiesToFind) {
          for (Address a : positions.values()) {
             if (nodesTested < numCopiesToFind) {
-               if (a.equals(target)) return true;
+               if (getRealAddress(a).equals(target)) return true;
                nodesTested++;
             } else {
                break;
@@ -171,7 +171,7 @@ public class DefaultConsistentHash extends AbstractWheelConsistentHash {
 
    public List<Address> getStateProvidersOnJoin(Address self, int replCount) {
       List<Address> l = new LinkedList<Address>();
-      List<Address> cachesList = new LinkedList<Address>(this.caches);
+      List<Address> cachesList = new LinkedList<Address>(getRealAddresses(this.caches));
       int selfIdx = cachesList.indexOf(self);
       if (selfIdx >= replCount - 1) {
          l.addAll(cachesList.subList(selfIdx - replCount + 1, selfIdx));
@@ -194,7 +194,7 @@ public class DefaultConsistentHash extends AbstractWheelConsistentHash {
    public List<Address> getStateProvidersOnLeave(Address leaver, int replCount) {
       if (trace) log.trace("List of addresses is: %s. leaver is: %s", caches, leaver);
       Set<Address> holders = new HashSet<Address>();
-      for (Address address : caches) {
+      for (Address address : getRealAddresses(caches)) {
          if (isAdjacent(leaver, address)) {
             holders.add(address);
             if (trace) log.trace("%s is state holder", address);

--- a/core/src/main/java/org/infinispan/marshall/Ids.java
+++ b/core/src/main/java/org/infinispan/marshall/Ids.java
@@ -88,4 +88,6 @@ public interface Ids {
    int XID = 66;
    int XID_DEADLOCK_DETECTING_GLOBAL_TRANSACTION = 67;
    int XID_GLOBAL_TRANSACTION = 68;
+   
+   int VIRTUAL_ADDRESS = 69;
 }

--- a/core/src/main/java/org/infinispan/marshall/jboss/ExternalizerTable.java
+++ b/core/src/main/java/org/infinispan/marshall/jboss/ExternalizerTable.java
@@ -46,6 +46,7 @@ import org.infinispan.distribution.ch.DefaultConsistentHash;
 import org.infinispan.distribution.ch.NodeTopologyInfo;
 import org.infinispan.distribution.ch.TopologyAwareConsistentHash;
 import org.infinispan.distribution.ch.UnionConsistentHash;
+import org.infinispan.distribution.ch.VirtualAddress;
 import org.infinispan.io.UnsignedNumeric;
 import org.infinispan.loaders.bucket.Bucket;
 import org.infinispan.marshall.Externalizer;
@@ -169,6 +170,8 @@ class ExternalizerTable implements ObjectTable {
 
       internalExternalizers.add(new RemoteTransactionLogDetails.Externalizer());
       internalExternalizers.add(new SerializableXid.XidExternalizer());
+      
+      internalExternalizers.add(new VirtualAddress.Externalizer());
    }
 
    void addInternalExternalizer(Externalizer ext) {

--- a/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
@@ -52,6 +52,7 @@ public abstract class BaseDistFunctionalTest extends MultipleCacheManagersTest {
    protected boolean batchingEnabled = false;
    protected int numOwners = 2;
    protected int lockTimeout = 45;
+   protected int numVirtualNodes = 1;
 
    protected void createCacheManagers() throws Throwable {
       cacheName = "dist";
@@ -68,6 +69,7 @@ public abstract class BaseDistFunctionalTest extends MultipleCacheManagersTest {
       configuration.setSyncReplTimeout(60, TimeUnit.SECONDS);
       configuration.setLockAcquisitionTimeout(lockTimeout, TimeUnit.SECONDS);
       configuration.setL1CacheEnabled(l1CacheEnabled);
+      configuration.fluent().clustering().hash().numVirtualNodes(numVirtualNodes);
       if (l1CacheEnabled) configuration.setL1OnRehash(l1OnRehash);
       if (l1CacheEnabled) configuration.setL1InvalidationThreshold(l1Threshold);
       caches = createClusteredCaches(INIT_CLUSTER_SIZE, cacheName, configuration);

--- a/core/src/test/java/org/infinispan/distribution/virtualnodes/VNodesChFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/virtualnodes/VNodesChFunctionalTest.java
@@ -1,0 +1,79 @@
+package org.infinispan.distribution.virtualnodes;
+
+import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.distribution.DistSyncFuncTest;
+import org.infinispan.distribution.ch.TopologyAwareConsistentHash;
+import org.infinispan.distribution.ch.TopologyInfo;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * @author Mircea.Markus@jboss.com
+ * @since 4.2
+ */
+@Test (groups = "functional", testName = "distribution.VNodesChFunctionalTest")
+public class VNodesChFunctionalTest extends DistSyncFuncTest {
+   
+   public VNodesChFunctionalTest() {
+      numVirtualNodes = 10;
+   }
+
+   @Override
+   protected EmbeddedCacheManager addClusterEnabledCacheManager() {
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager();
+      int index = cacheManagers.size();
+      String rack;
+      String machine;
+      switch (index) {
+         case 0 : {
+            rack = "r0";
+            machine = "m0";
+            break;
+         }
+         case 1 : {
+            rack = "r0";
+            machine = "m1";
+            break;
+         }
+         case 2 : {
+            rack = "r1";
+            machine = "m0";
+            break;
+         }
+         case 3 : {
+            rack = "r2";
+            machine = "m0";
+            break;
+         }
+         default : {
+            throw new RuntimeException("Bad!");
+         }
+      }
+      GlobalConfiguration globalConfiguration = cm.getGlobalConfiguration();      
+      globalConfiguration.setRackId(rack);
+      globalConfiguration.setMachineId(machine);
+      cacheManagers.add(cm);
+      return cm;
+   }
+
+   public void testHashesInitiated() {
+      TopologyAwareConsistentHash hash = (TopologyAwareConsistentHash) advancedCache(0, cacheName).getDistributionManager().getConsistentHash();
+      containsAllHashes(hash);
+      containsAllHashes((TopologyAwareConsistentHash) advancedCache(1, cacheName).getDistributionManager().getConsistentHash());
+      containsAllHashes((TopologyAwareConsistentHash) advancedCache(2, cacheName).getDistributionManager().getConsistentHash());
+      containsAllHashes((TopologyAwareConsistentHash) advancedCache(3, cacheName).getDistributionManager().getConsistentHash());
+   }
+
+   private void containsAllHashes(TopologyAwareConsistentHash ch) {
+      assert ch.getCaches().contains(address(0));
+      assert ch.getCaches().contains(address(1));
+      assert ch.getCaches().contains(address(2));
+      assert ch.getCaches().contains(address(3));
+      TopologyInfo topologyInfo = ch.getTopologyInfo();
+      assert topologyInfo.containsInfoForNode(address(0)) : topologyInfo;
+      assert topologyInfo.containsInfoForNode(address(1)) : topologyInfo;
+      assert topologyInfo.containsInfoForNode(address(2)) : topologyInfo;
+      assert topologyInfo.containsInfoForNode(address(3)) : topologyInfo;
+   }
+}

--- a/core/src/test/java/org/infinispan/distribution/virtualnodes/VNodesDistAsyncFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/virtualnodes/VNodesDistAsyncFuncTest.java
@@ -1,0 +1,57 @@
+package org.infinispan.distribution.virtualnodes;
+
+import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.distribution.DistAsyncFuncTest;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * @author Mircea.Markus@jboss.com
+ * @since 4.2
+ */
+@Test (groups = "functional", testName = "topologyaware.VNodesDistAsyncFuncTest")
+public class VNodesDistAsyncFuncTest extends DistAsyncFuncTest {
+
+   public VNodesDistAsyncFuncTest() {
+      numVirtualNodes = 10;
+   }
+   
+   @Override
+   protected EmbeddedCacheManager addClusterEnabledCacheManager() {
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager();
+      int index = cacheManagers.size();
+      String rack;
+      String machine;
+      switch (index) {
+         case 0 : {
+            rack = "r0";
+            machine = "m0";
+            break;
+         }
+         case 1 : {
+            rack = "r1";
+            machine = "m0";
+            break;
+         }
+         case 2 : {
+            rack = "r1";
+            machine = "m0";
+            break;
+         }
+         case 3 : {
+            rack = "r1";
+            machine = "m1";
+            break;
+         }
+         default : {
+            throw new RuntimeException("Bad!");
+         }
+      }
+      GlobalConfiguration globalConfiguration = cm.getGlobalConfiguration();
+      globalConfiguration.setRackId(rack);
+      globalConfiguration.setMachineId(machine);
+      cacheManagers.add(cm);
+      return cm;
+   }
+}

--- a/core/src/test/java/org/infinispan/distribution/virtualnodes/VNodesDistSyncUnsafeFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/virtualnodes/VNodesDistSyncUnsafeFuncTest.java
@@ -1,0 +1,59 @@
+package org.infinispan.distribution.virtualnodes;
+
+import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.distribution.DistSyncUnsafeFuncTest;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * @author Mircea.Markus@jboss.com
+ * @since 4.2
+ */
+@Test(testName="topologyaware.VNodesDistSyncUnsafeFuncTest", groups = "functional")
+public class VNodesDistSyncUnsafeFuncTest extends DistSyncUnsafeFuncTest {
+
+   
+   public VNodesDistSyncUnsafeFuncTest() {
+      numVirtualNodes = 10;
+   }
+   
+   @Override
+   protected EmbeddedCacheManager addClusterEnabledCacheManager() {
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager();
+      int index = cacheManagers.size();
+      String rack;
+      String machine;
+      switch (index) {
+         case 0 : {
+            rack = "r0";
+            machine = "m0";
+            break;
+         }
+         case 1 : {
+            rack = "r0";
+            machine = "m0";
+            break;
+         }
+         case 2 : {
+            rack = "r1";
+            machine = "m0";
+            break;
+         }
+         case 3 : {
+            rack = "r1";
+            machine = "m0";
+            break;
+         }
+         default : {
+            throw new RuntimeException("Bad!");
+         }
+      }
+      GlobalConfiguration globalConfiguration = cm.getGlobalConfiguration();
+      globalConfiguration.setRackId(rack);
+      globalConfiguration.setMachineId(machine);
+      cacheManagers.add(cm);
+      return cm;
+   }
+
+}


### PR DESCRIPTION
Possibly slightly too late pull request for the initial work on virtual nodes, as described in the commit this is still wip, and I concentrated on the core functionality, and ensuring it does not break hashing. I still want to add specific tests for virtual nodes.

Please review :-)

---

Initial implementation of virtual nodes implemented
on top of the topology aware consistent hash. It
can be enabled by setting the numVirtualNodes
configuration parameter on clustering.hash

The implementation of virtual nodes passes existing
tests verifying that the hash function is working
however no tests have been introduced to test the
correctness of the virtual node distribution.

The implementation is entirely self contained in
the consistent hash function, and the bulk of it 
is provided in AbstractWheelConsistentHash, which
contains instructions for implementations of a
wheel consistent hash to enable virtual nodes.
