### PR TITLE
ISPN-850 RemoteCache.replaceWithVersion javadoc is incorrect

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCache.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCache.java
@@ -99,10 +99,10 @@ public interface RemoteCache<K, V> extends Cache<K, V> {
    NotifyingFuture<Boolean> removeWithVersionAsync(K key, long version);
 
    /**
-    * Removes the given value only if its version matches the supplied version. See {@link #removeWithVersion(Object,
-    * long)} for a sample usage.
+    * Replaces the given value only if its version matches the supplied version. See {@link #removeWithVersion(Object,
+    * long)} for a sample usage of the version-based methods.
     *
-    * @return true if the method has been replaced
+    * @return true if the value has been replaced
     * @see #getVersioned(Object)
     * @see VersionedValue
     */


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-850
t_ISPN-850_4 for 4.2.x
