### PR TITLE
ISPN-1069 Return values for put, putIfAbsent and remove not available if 

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/DistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/DistributionInterceptor.java
@@ -186,7 +186,7 @@ public class DistributionInterceptor extends BaseRpcInterceptor {
                invokeNextInterceptor(ctx, put);
             } else {
                CacheEntry ce = ctx.lookupEntry(key);
-               if (ce == null || ce.isNull() || ce.isLockPlaceholder()) {
+               if (ce == null || ce.isNull() || ce.isLockPlaceholder() || ce.getValue() == null) {
                   if (ce != null && ce.isChanged()) {
                      ce.setValue(ice.getValue());
                   } else {

--- a/core/src/test/java/org/infinispan/distribution/DisabledL1WithRetValsTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DisabledL1WithRetValsTest.java
@@ -24,24 +24,13 @@
 package org.infinispan.distribution;
 
 import org.infinispan.Cache;
-import org.infinispan.config.Configuration;
-import org.infinispan.test.MultipleCacheManagersTest;
-import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.annotations.Test;
-
-import java.io.Serializable;
-import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Random;
-
-import static org.infinispan.test.TestingUtil.k;
-import static org.infinispan.test.TestingUtil.v;
 
 /**
  * Test distribution when L1 is disabled and return values are needed.
  *
  * @author Galder Zamarreño
- * @since 4.2
+ * @author Manik Surtani
  * @since 5.0
  */
 @Test(groups = "functional", testName = "distribution.DisabledL1WithRetValsTest")
@@ -54,13 +43,79 @@ public class DisabledL1WithRetValsTest extends BaseDistFunctionalTest {
       INIT_CLUSTER_SIZE = 2;
    }
 
-   public void testReplaceFromNonOwner(Method m) {
-      final String k = k(m);
-      final String v = v(m);
-      Cache<Object, String> ownerCache = getOwners(k, 1)[0];
-      ownerCache.put(k, v);
-      Cache<Object, String> nonOwnerCache = getNonOwners(k, 1)[0];
-      nonOwnerCache.replace(k, v(m, 1));
+   public void testReplaceFromNonOwner() {
+      initAndTest();
+      Cache<Object, String> nonOwner = getFirstNonOwner("k1");
+
+      Object retval = nonOwner.replace("k1", "value2");
+
+      assert "value".equals(retval);
+      assertOnAllCachesAndOwnership("k1", "value2");
    }
 
+   public void testConditionalReplaceFromNonOwner() {
+      initAndTest();
+      Cache<Object, String> nonOwner = getFirstNonOwner("k1");
+
+      boolean success = nonOwner.replace("k1", "blah", "value2");
+      assert !success;
+
+      assertOnAllCachesAndOwnership("k1", "value");
+
+      success = nonOwner.replace("k1", "value", "value2");
+      assert success;
+
+      assertOnAllCachesAndOwnership("k1", "value2");
+   }
+
+   public void testPutFromNonOwner() {
+      initAndTest();
+      Cache<Object, String> nonOwner = getFirstNonOwner("k1");
+
+      Object retval = nonOwner.put("k1", "value2");
+
+      assert "value".equals(retval);
+      assertOnAllCachesAndOwnership("k1", "value2");
+   }
+
+   public void testRemoveFromNonOwner() {
+      initAndTest();
+      Cache<Object, String> nonOwner = getFirstNonOwner("k1");
+
+      Object retval = nonOwner.remove("k1");
+
+      assert "value".equals(retval);
+      assertOnAllCachesAndOwnership("k1", null);
+   }
+
+   public void testConditionalRemoveFromNonOwner() {
+      initAndTest();
+      Cache<Object, String> nonOwner = getFirstNonOwner("k1");
+
+      boolean removed = nonOwner.remove("k1", "blah");
+      assert !removed;
+
+      assertOnAllCachesAndOwnership("k1", "value");
+
+      removed = nonOwner.remove("k1", "value");
+      assert removed;
+
+      assertOnAllCachesAndOwnership("k1", null);
+   }
+
+   public void testPutIfAbsentFromNonOwner() {
+      initAndTest();
+      Object retval = getFirstNonOwner("k1").putIfAbsent("k1", "value2");
+
+      assert "value".equals(retval);
+
+      assertOnAllCachesAndOwnership("k1", "value");
+
+      c1.clear();
+
+      retval = getFirstNonOwner("k1").putIfAbsent("k1", "value2");
+      assert null == retval;
+
+      assertOnAllCachesAndOwnership("k1", "value2");
+   }
 }


### PR DESCRIPTION
ISPN-1069 Return values for put, putIfAbsent and remove not available if invoked from a non-owner and L1 is disabled
- Add test
- Fix issue with not storing return values of a remote GET in the context when L1 isn't available

Sanne to review and handle, since he raised the bug.
