### PR TITLE
ISPN-1075 - Configuration.getName does not work for programmatically defi

### DIFF
--- a/core/src/main/java/org/infinispan/config/Configuration.java
+++ b/core/src/main/java/org/infinispan/config/Configuration.java
@@ -1313,8 +1313,20 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
       v.visitConfiguration(this);
    }
 
+   /**
+    * Also see {@link #equalsIgnoreName(Object)} for equality that does not consider the name of the configuration.
+    */
    @Override
    public boolean equals(Object o) {
+      if (!equalsIgnoreName(o)) return false;
+      Configuration that = (Configuration) o;
+      return !(name != null ? !name.equals(that.name) : that.name != null);
+   }
+
+   /**
+    * Same as {@link #equals(Object)} but it ignores the {@link #getName()} attribute in the comparison.
+    */
+   public boolean equalsIgnoreName(Object o) {
       if (this == o) return true;
       if (!(o instanceof Configuration)) return false;
 
@@ -1339,7 +1351,6 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
          return false;
       if (loaders != null ? !loaders.equals(that.loaders) : that.loaders != null) return false;
       if (locking != null ? !locking.equals(that.locking) : that.locking != null) return false;
-      if (name != null ? !name.equals(that.name) : that.name != null) return false;
       if (transaction != null ? !transaction.equals(that.transaction) : that.transaction != null) return false;
       if (unsafe != null ? !unsafe.equals(that.unsafe) : that.unsafe != null) return false;
 

--- a/core/src/test/java/org/infinispan/config/ProgrammaticConfigurationTest.java
+++ b/core/src/test/java/org/infinispan/config/ProgrammaticConfigurationTest.java
@@ -70,7 +70,7 @@ public class ProgrammaticConfigurationTest extends AbstractInfinispanTest {
       Configuration c = new Configuration();
       c.setConsistentHashClass("org.infinispan.distribution.DefaultConsistentHash");
       Configuration oneCacheConfiguration = cm.defineConfiguration("oneCache", c);
-      assert oneCacheConfiguration.equals(c);
+      assert oneCacheConfiguration.equalsIgnoreName(c);
    }
 
    public void testGlobalConfiguration() {

--- a/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
@@ -133,10 +133,10 @@ public class CacheManagerTest extends AbstractInfinispanTest {
       }
       
       Configuration c = cm.defineConfiguration("cache1", null, new Configuration());
-      assert c.equals(cm.getDefaultConfiguration());
+      assert c.equalsIgnoreName(cm.getDefaultConfiguration()) ;
       
       c = cm.defineConfiguration("cache1", "does-not-exist-cache", new Configuration());
-      assert c.equals(cm.getDefaultConfiguration());
+      assert c.equalsIgnoreName(cm.getDefaultConfiguration());
    }
 
    public void testDefiningConfigurationWithTemplateName() {
@@ -145,12 +145,12 @@ public class CacheManagerTest extends AbstractInfinispanTest {
       Configuration c = new Configuration();
       c.setIsolationLevel(IsolationLevel.NONE);
       Configuration oneCacheConfiguration = cm.defineConfiguration("oneCache", c);
-      assert oneCacheConfiguration.equals(c);
+      assert oneCacheConfiguration.equalsIgnoreName(c) ;
       assert oneCacheConfiguration.getIsolationLevel().equals(IsolationLevel.NONE);
       
       c = new Configuration();
       Configuration secondCacheConfiguration = cm.defineConfiguration("secondCache", "oneCache", c);
-      assert oneCacheConfiguration.equals(secondCacheConfiguration);
+      assert oneCacheConfiguration.equalsIgnoreName(secondCacheConfiguration) ;
       assert secondCacheConfiguration.getIsolationLevel().equals(IsolationLevel.NONE);
       
       c = new Configuration();


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1075
t_ISPN-1075_4 for 4.2.x
