### PR TITLE
ISPN-1075 - Configuration.getName does not work for programmatically defi

### DIFF
--- a/core/src/main/java/org/infinispan/config/Configuration.java
+++ b/core/src/main/java/org/infinispan/config/Configuration.java
@@ -186,6 +186,9 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
       this.globalConfiguration = gc;
    }
 
+   /**
+     * Returns the name of the cache associated with this configuration.
+   */
    public String getName() {
       return name;
    }

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -396,8 +396,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
       Configuration configuration = defaultConfigIfNotPresent.clone();
       configuration.applyOverrides(configOverride.clone());
       configurationOverrides.put(cacheName, configuration);
-      //use reflection for this as we don't want to expose setName on Configuration.
-      ReflectionUtil.setValue(configuration, "name", cacheName);
+      setConfigurationName(cacheName, configuration);
       return configuration;
    }
 
@@ -533,6 +532,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
          return existingCache.getCache();
 
       Configuration c = getConfiguration(cacheName);
+      setConfigurationName(cacheName, c);
 
       c.setGlobalConfiguration(globalConfiguration);
       c.assertValid();
@@ -765,6 +765,13 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
    @Override
    public String toString() {
       return super.toString() + "@Address:" + getAddress();
+   }
+
+   /**
+    * Use reflection for this as we don't want to expose setName on Configuration.
+    */
+   private void setConfigurationName(String cacheName, Configuration configuration) {
+      ReflectionUtil.setValue(configuration, "name", cacheName);
    }
 }
 

--- a/core/src/test/java/org/infinispan/config/ProgrammaticNameSetConfig.java
+++ b/core/src/test/java/org/infinispan/config/ProgrammaticNameSetConfig.java
@@ -24,6 +24,7 @@
 package org.infinispan.config;
 
 import org.infinispan.Cache;
+import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -43,7 +44,7 @@ public class ProgrammaticNameSetConfig extends SingleCacheManagerTest {
       return TestCacheManagerFactory.createCacheManager(getDefaultStandaloneConfig(true));
    }
 
-   public void testGetSetName() {
+   public void testGetNotDefaultCache() {
       Configuration configurationOverride = new Configuration();
       configurationOverride.fluent().mode(Configuration.CacheMode.LOCAL);
       String aName = "aName";
@@ -51,5 +52,15 @@ public class ProgrammaticNameSetConfig extends SingleCacheManagerTest {
       Cache c = cacheManager.getCache(aName);
       assertEquals(c.getConfiguration().getName(), aName);
       assertEquals(configuration.getName(), aName);
+   }
+
+   public void testGetNameForDefaultCache() {
+      String name = cacheManager.getCache().getConfiguration().getName();
+      assertEquals(name, CacheContainer.DEFAULT_CACHE_NAME);
+   }
+
+   public void getNameForUndefinedCache() {
+      Configuration configuration = cacheManager.getCache("undefinedCache").getConfiguration();
+      assertEquals(configuration.getName(), "undefinedCache");
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1075
ISPN-1075 - Configuration.getName does not work for programmatically defined caches
t_ISPN-1075_4 for 4.2.x
