### PR TITLE
ISPN-982 - Testsuite is leaking threads

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -361,6 +361,7 @@ public class RemoteCacheManager implements CacheContainer {
       if (isStarted()) {
          transportFactory.destroy();
       }
+      asyncExecutorService.shutdownNow();
       started = false;
    }
 

--- a/core/src/main/java/org/infinispan/notifications/AbstractListenerImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/AbstractListenerImpl.java
@@ -74,10 +74,13 @@ public abstract class AbstractListenerImpl {
     * Removes all listeners from the notifier
     */
    @Stop(priority = 99)
-   public void removeAllCacheListeners() {
+   void stop() {
       for (List<ListenerInvocation> list : listenersMap.values()) {
          if (list != null) list.clear();
       }
+
+      if (syncProcessor != null) syncProcessor.shutdownNow();
+      if (asyncProcessor != null) asyncProcessor.shutdownNow();
    }
 
    protected abstract Log getLog();

--- a/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/CacheManagerNotifierImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/CacheManagerNotifierImpl.java
@@ -135,12 +135,6 @@ public class CacheManagerNotifierImpl extends AbstractListenerImpl implements Ca
       }
    }
 
-   @Stop
-   void stop() {
-      if (syncProcessor != null) syncProcessor.shutdownNow();
-      if (asyncProcessor != null) asyncProcessor.shutdownNow();
-   }
-
    protected Log getLog() {
       return log;
    }

--- a/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
@@ -33,6 +33,7 @@ import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.manager.CacheContainer;
@@ -111,6 +112,13 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
    public void start() {
       distributedSync = transport.getDistributedSync();
       distributedSyncTimeout = globalConfiguration.getDistributedSyncTimeout();
+   }
+
+   @Stop
+   public void stop() {
+      for (Map.Entry<String, RetryQueue> retryThread : retryThreadMap.entrySet()) {
+         retryThread.getValue().interrupt();
+      }
    }
 
    private boolean isDefined(String cacheName) {
@@ -375,8 +383,7 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
 
       @Override
       public void run() {
-         boolean running = true;
-         while (running) {
+         while (!interrupted()) {
             CacheRpcCommand c = null;
             boolean unlock = false;
             try {
@@ -395,7 +402,8 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
             } catch (InterruptedException e) {
                enqueueing = false;
                enqueuedBlocker.open();
-               running = false;
+               // set the interrupted flag
+               interrupt();
             } catch (Throwable throwable) {
                log.exceptionHandlingCommand(c, throwable);
             } finally {

--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
@@ -31,6 +31,7 @@ import org.infinispan.factories.KnownComponentNames;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.Stop;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
@@ -106,6 +107,11 @@ public class RpcManagerImpl implements RpcManager {
    private void start() {
       stateTransferEnabled = configuration.isStateTransferEnabled();
       statisticsEnabled = configuration.isExposeJmxStatistics();
+   }
+
+   @Stop(priority = 9)
+   private void stop() {
+      asyncExecutor.shutdown();
    }
 
    private boolean useReplicationQueue(boolean sync) {

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -187,6 +187,8 @@ public class JGroupsTransport extends AbstractTransport implements ExtendedMembe
          dispatcher.stop();
       }
 
+      asyncExecutor.shutdown();
+
       members = Collections.emptyList();
       coordinator = false;
       dispatcher = null;

--- a/core/src/test/java/org/infinispan/api/mvcc/repeatable_read/WriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/api/mvcc/repeatable_read/WriteSkewTest.java
@@ -142,6 +142,7 @@ public class WriteSkewTest extends AbstractInfinispanTest {
 
       log.debug("All threads finished, let's shutdown the executor and check whether any exceptions were reported");
       for (Future<Void> future : futures) future.get();
+      executorService.shutdownNow();
    }
 
 

--- a/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
@@ -184,8 +184,7 @@ public abstract class BaseDistFunctionalTest extends MultipleCacheManagersTest {
    // so this function orders things such that the test can predict where keys get mapped to.
    private void reorderBasedOnCHPositions() {
       // wait for all joiners to join
-      List<Cache> clist = new ArrayList<Cache>(cacheManagers.size());
-      for (CacheContainer cm : cacheManagers) clist.add(cm.getCache(cacheName));
+      List<Cache> clist = new ArrayList<Cache>(caches);
       assert clist.size() == INIT_CLUSTER_SIZE;
       waitForJoinTasksToComplete(SECONDS.toMillis(480), clist.toArray(new Cache[clist.size()]));
 

--- a/core/src/test/java/org/infinispan/distribution/ConcurrentStartWithReplTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ConcurrentStartWithReplTest.java
@@ -171,7 +171,9 @@ public class ConcurrentStartWithReplTest extends AbstractInfinispanTest {
       };
       if (nonBlockingStartup) {
          final ExecutorService e = Executors.newFixedThreadPool(1);
-         return e.submit(cacheCreator);
+         Future<Cache<String, String>> future = e.submit(cacheCreator);
+         e.shutdown();
+         return future;
       } else {
          return new AbstractInProcessFuture<Cache<String, String>>() {
             @Override

--- a/core/src/test/java/org/infinispan/distribution/rehash/ConsistencyStressTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/ConsistencyStressTest.java
@@ -165,6 +165,8 @@ public class ConsistencyStressTest extends MultipleCacheManagersTest {
             }
          }
       }
+
+      executorService.shutdownNow();
    }
 
    private static String keyFor(int nodeId, int workerId, int iterationId) {

--- a/core/src/test/java/org/infinispan/loaders/ConcurrentLoadAndEvictTest.java
+++ b/core/src/test/java/org/infinispan/loaders/ConcurrentLoadAndEvictTest.java
@@ -109,6 +109,8 @@ public class ConcurrentLoadAndEvictTest extends SingleCacheManagerTest {
 
       // and check that the key actually has been evicted
       assert !TestingUtil.extractComponent(cache, DataContainer.class).containsKey("a");
+
+      e.shutdownNow();
    }
 
    public static class SlowDownInterceptor extends CommandInterceptor implements CloneableConfigurationComponent{

--- a/core/src/test/java/org/infinispan/loaders/decorators/SingletonStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/decorators/SingletonStoreTest.java
@@ -249,6 +249,7 @@ public class SingletonStoreTest extends MultipleCacheManagersTest {
       f2.get();
 
       assertEquals(1, mscl.getNumberCreatedTasks());
+      executor.shutdownNow();
    }
 
    public void testPushStateTimedOut() throws Throwable {

--- a/core/src/test/java/org/infinispan/manager/ConcurrentCacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/ConcurrentCacheManagerTest.java
@@ -92,5 +92,6 @@ public class ConcurrentCacheManagerTest extends AbstractCacheTest {
 
       log.debug("All threads finished, let's shutdown the executor and check whether any exceptions were reported");
       for (Future<Void> future : futures) future.get();
+      executorService.shutdownNow();
    }
 }

--- a/core/src/test/java/org/infinispan/tx/TerminatedCacheWhileInTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/TerminatedCacheWhileInTxTest.java
@@ -124,5 +124,7 @@ public class TerminatedCacheWhileInTxTest extends SingleCacheManagerTest {
             throw e.getCause();
          }
       }
+
+      executorService.shutdownNow();
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-982

Also t_ispn982_4.2.x for 4.2.x.

Added Executor.shutdown()/shutdownNow() calls for executors used in Infinispan components and in tests.
