### PR TITLE
ISPN-1046 Disable annotation scanning to get around issue

### DIFF
--- a/server/rest/src/main/webapp/WEB-INF/jboss-scanning.xml
+++ b/server/rest/src/main/webapp/WEB-INF/jboss-scanning.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2011 Red Hat Inc. and/or its affiliates and other
+  ~ contributors as indicated by the @author tags. All rights reserved.
+  ~ See the copyright.txt in the distribution for a full listing of
+  ~ individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<scanning xmlns="urn:jboss:scanning:1.0">
+<!-- Purpose:  Disable scanning for annotations in contained deployment. -->
+</scanning>


### PR DESCRIPTION
Note that disabling annotation scanning at this level has no impact
in the RESTEasy annotations used by the REST servers since these
are managed in a different way.

Master and 4.2.x

4.2.x branch: t_1046_4
