### PR TITLE
ISPN-749 Added several interesting stats or info for servers

### DIFF
--- a/core/src/main/java/org/infinispan/jmx/AbstractJmxRegistration.java
+++ b/core/src/main/java/org/infinispan/jmx/AbstractJmxRegistration.java
@@ -47,7 +47,7 @@ public abstract class AbstractJmxRegistration {
    protected abstract ComponentsJmxRegistration buildRegistrar(Set<AbstractComponentRegistry.Component> components);
 
    protected void registerMBeans(Set<AbstractComponentRegistry.Component> components, GlobalConfiguration globalConfig) {
-      mBeanServer = getMBeanServer(globalConfig);
+      mBeanServer = JmxUtil.lookupMBeanServer(globalConfig);
       ComponentsJmxRegistration registrar = buildRegistrar(components);
       registrar.registerMBeans();
    }
@@ -59,28 +59,4 @@ public abstract class AbstractJmxRegistration {
       }
    }
 
-   protected MBeanServer getMBeanServer(GlobalConfiguration configuration) {
-      MBeanServerLookup lookup = configuration.getMBeanServerLookupInstance();
-      return lookup.getMBeanServer(configuration.getMBeanServerProperties());
-   }
-
-   protected String getJmxDomain(String jmxDomain, MBeanServer mBeanServer, String groupName) {
-      int index = 2;
-      String finalName = jmxDomain;
-      boolean done = false;
-      while (!done) {
-         done = true;
-         try {
-            ObjectName targetName = new ObjectName(finalName + ':' + groupName + ",*");
-            if (mBeanServer.queryNames(targetName, null).size() > 0) {
-               finalName = jmxDomain + index++;
-               done = false;
-            }
-         } catch (MalformedObjectNameException e) {
-            throw new CacheException("Unable to check for duplicate names", e);
-         }
-      }
-
-      return finalName;
-   }
 }

--- a/core/src/main/java/org/infinispan/jmx/CacheJmxRegistration.java
+++ b/core/src/main/java/org/infinispan/jmx/CacheJmxRegistration.java
@@ -142,7 +142,7 @@ public class CacheJmxRegistration extends AbstractJmxRegistration {
       GlobalConfiguration gc = componentRegistry.getComponent(GlobalConfiguration.class);
       CacheManagerJmxRegistration managerJmxReg = componentRegistry.getComponent(CacheManagerJmxRegistration.class);
       if (!gc.isExposeGlobalJmxStatistics() && jmxDomain == null) {
-         String tmpJmxDomain = getJmxDomain(gc.getJmxDomain(), mBeanServer, groupName);
+         String tmpJmxDomain = JmxUtil.buildJmxDomain(gc, mBeanServer, groupName);
          synchronized (managerJmxReg) {
             if (managerJmxReg.jmxDomain == null) {
                if (!tmpJmxDomain.equals(gc.getJmxDomain()) && !gc.isAllowDuplicateDomains()) {

--- a/core/src/main/java/org/infinispan/jmx/CacheManagerJmxRegistration.java
+++ b/core/src/main/java/org/infinispan/jmx/CacheManagerJmxRegistration.java
@@ -89,7 +89,7 @@ public class CacheManagerJmxRegistration extends AbstractJmxRegistration {
 
    protected void updateDomain(ComponentsJmxRegistration registrar, MBeanServer mBeanServer, String groupName) {
       if (jmxDomain == null) {
-         jmxDomain = getJmxDomain(globalConfig.getJmxDomain(), mBeanServer, groupName);
+         jmxDomain = JmxUtil.buildJmxDomain(globalConfig, mBeanServer, groupName);
          String configJmxDomain = globalConfig.getJmxDomain();
          if (!jmxDomain.equals(configJmxDomain) && !globalConfig.isAllowDuplicateDomains()) {
             log.cacheManagerAlreadyRegistered(configJmxDomain);

--- a/core/src/main/java/org/infinispan/jmx/ComponentsJmxRegistration.java
+++ b/core/src/main/java/org/infinispan/jmx/ComponentsJmxRegistration.java
@@ -82,22 +82,8 @@ public class ComponentsJmxRegistration {
    public void registerMBeans() throws CacheException {
       try {
          List<ResourceDMBean> resourceDMBeans = getResourceDMBeansFromComponents();
-         boolean trace = log.isTraceEnabled();
-         for (ResourceDMBean resource : resourceDMBeans) {
-            ObjectName objectName = getObjectName(resource);
-            if (!mBeanServer.isRegistered(objectName)) {
-               try {
-                  mBeanServer.registerMBean(resource, objectName);
-                  if (trace) log.tracef("Registered %s under %s", resource, objectName);
-               } catch (InstanceAlreadyExistsException e) {
-                  //this might happen if multiple instances are trying to concurrently register same objectName
-                  log.couldNotRegisterObjectName(objectName, e);
-               }
-            } else {
-               if (log.isDebugEnabled())
-                  log.debugf("Object name %s already registered", objectName);
-            }
-         }
+         for (ResourceDMBean resource : resourceDMBeans)
+            JmxUtil.registerMBean(resource, getObjectName(resource), mBeanServer);
       }
       catch (Exception e) {
          throw new CacheException("Failure while registering mbeans", e);
@@ -113,11 +99,7 @@ public class ComponentsJmxRegistration {
          List<ResourceDMBean> resourceDMBeans = getResourceDMBeansFromComponents();
          boolean trace = log.isTraceEnabled();
          for (ResourceDMBean resource : resourceDMBeans) {
-            ObjectName objectName = getObjectName(resource);
-            if (mBeanServer.isRegistered(objectName)) {
-               mBeanServer.unregisterMBean(objectName);
-               if (trace) log.tracef("Unregistered %s", objectName);
-            }
+            JmxUtil.unregisterMBean(getObjectName(resource), mBeanServer);
          }
       }
       catch (Exception e) {

--- a/core/src/main/java/org/infinispan/jmx/JmxUtil.java
+++ b/core/src/main/java/org/infinispan/jmx/JmxUtil.java
@@ -1,0 +1,103 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.jmx;
+
+import org.infinispan.CacheException;
+import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+/**
+ * Class containing JMX related utility methods.
+ *
+ * @author Galder Zamarreño
+ * @since 5.0
+ */
+public class JmxUtil {
+
+   private static final Log log = LogFactory.getLog(JmxUtil.class);
+
+   public static MBeanServer lookupMBeanServer(GlobalConfiguration cfg) {
+      MBeanServerLookup lookup = cfg.getMBeanServerLookupInstance();
+      return lookup.getMBeanServer(cfg.getMBeanServerProperties());
+   }
+
+   public static String buildJmxDomain(GlobalConfiguration cfg, MBeanServer mBeanServer, String groupName) {
+      String jmxDomain = findJmxDomain(cfg.getJmxDomain(), mBeanServer, groupName);
+      String configJmxDomain = cfg.getJmxDomain();
+      if (!jmxDomain.equals(configJmxDomain) && !cfg.isAllowDuplicateDomains()) {
+         log.cacheManagerAlreadyRegistered(configJmxDomain);
+         throw new JmxDomainConflictException(String.format("Domain already registered %s", configJmxDomain));
+      }
+      return jmxDomain;
+   }
+
+   public static void registerMBean(ResourceDMBean dynamicMBean, ObjectName objectName, MBeanServer mBeanServer) throws Exception {
+      if (!mBeanServer.isRegistered(objectName)) {
+         try {
+            mBeanServer.registerMBean(dynamicMBean, objectName);
+            if (log.isTraceEnabled()) log.tracef("Registered %s under %s", dynamicMBean, objectName);
+         } catch (InstanceAlreadyExistsException e) {
+            //this might happen if multiple instances are trying to concurrently register same objectName
+            log.couldNotRegisterObjectName(objectName, e);
+         }
+      } else {
+         if (log.isDebugEnabled())
+            log.debugf("Object name %s already registered", objectName);
+      }
+   }
+
+   public static void unregisterMBean(ObjectName objectName, MBeanServer mBeanServer) throws Exception {
+      if (mBeanServer.isRegistered(objectName)) {
+         mBeanServer.unregisterMBean(objectName);
+         if (log.isTraceEnabled()) log.tracef("Unregistered %s", objectName);
+      }
+   }
+
+   private static String findJmxDomain(String jmxDomain, MBeanServer mBeanServer, String groupName) {
+      int index = 2;
+      String finalName = jmxDomain;
+      boolean done = false;
+      while (!done) {
+         done = true;
+         try {
+            ObjectName targetName = new ObjectName(finalName + ':' + groupName + ",*");
+            if (mBeanServer.queryNames(targetName, null).size() > 0) {
+               finalName = jmxDomain + index++;
+               done = false;
+            }
+         } catch (MalformedObjectNameException e) {
+            throw new CacheException("Unable to check for duplicate names", e);
+         }
+      }
+
+      return finalName;
+   }
+
+}

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -21,13 +21,6 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-/*
- * JBoss, the OpenSource J2EE webOS
- *
- * Distributable under LGPL license.
- * See terms of license at gnu.org.
- */
-
 package org.infinispan.test;
 
 import org.infinispan.AdvancedCache;

--- a/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolDecoder.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolDecoder.scala
@@ -336,6 +336,15 @@ abstract class AbstractProtocolDecoder[K, V <: CacheValue](transport: NettyTrans
       }
    }
 
+   override def writeComplete(ctx: ChannelHandlerContext, e: WriteCompletionEvent) {
+      transport.updateTotalBytesWritten(e)
+      ctx.sendUpstream(e)
+   }
+
+   override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) = {
+      transport.updateTotalBytesRead(e)
+      super.messageReceived(ctx, e)
+   }
 }
 
 object AbstractProtocolDecoder extends Log {

--- a/server/core/src/test/scala/org/infinispan/server/core/AbstractProtocolServerTest.scala
+++ b/server/core/src/test/scala/org/infinispan/server/core/AbstractProtocolServerTest.scala
@@ -204,8 +204,8 @@ class AbstractProtocolServerTest {
 
       override def getDecoder = null
 
-      override def startTransport(idleTimeout: Int, tcpNoDelay: Boolean, sendBufSize: Int, recvBufSize: Int,
-                                  typedProps: TypedProperties) {
+      override def startTransport(idleTimeout: Int, tcpNoDelay: Boolean,
+            sendBufSize: Int, recvBufSize: Int, typedProps: TypedProperties) {
          this.tcpNoDelay = tcpNoDelay
       }
    }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/AbstractVersionedDecoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/AbstractVersionedDecoder.scala
@@ -27,6 +27,7 @@ import org.infinispan.stats.Stats
 import org.infinispan.util.ByteArrayKey
 import org.jboss.netty.buffer.ChannelBuffer
 import org.infinispan.server.core.{RequestParameters, CacheValue}
+import org.infinispan.server.core.transport.NettyTransport
 
 /**
  * This class represents the work to be done by a decoder of a particular Hot Rod protocol version.
@@ -94,7 +95,7 @@ abstract class AbstractVersionedDecoder {
    /**
     * Create a response for the stats command.
     */
-   def createStatsResponse(header: HotRodHeader, stats: Stats): AnyRef
+   def createStatsResponse(header: HotRodHeader, stats: Stats, t: NettyTransport): AnyRef
 
    /**
     * Create an error response based on the Throwable instance received.

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder10.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder10.scala
@@ -38,6 +38,7 @@ import org.infinispan.context.Flag.SKIP_CACHE_LOAD
 import org.infinispan.util.ByteArrayKey
 import org.jboss.netty.buffer.ChannelBuffer
 import org.infinispan.server.core.transport.ExtendedChannelBuffer._
+import transport.NettyTransport
 
 /**
  * HotRod protocol decoder specific for specification version 1.0.
@@ -201,7 +202,7 @@ object Decoder10 extends AbstractVersionedDecoder with Log {
 
    override def customReadValue(header: HotRodHeader, buffer: ChannelBuffer, cache: Cache[ByteArrayKey, CacheValue]): AnyRef = null
 
-   override def createStatsResponse(h: HotRodHeader, cacheStats: Stats): AnyRef = {
+   override def createStatsResponse(h: HotRodHeader, cacheStats: Stats, t: NettyTransport): AnyRef = {
       val stats = mutable.Map.empty[String, String]
       stats += ("timeSinceStart" -> cacheStats.getTimeSinceStart.toString)
       stats += ("currentNumberOfEntries" -> cacheStats.getCurrentNumberOfEntries.toString)
@@ -212,6 +213,8 @@ object Decoder10 extends AbstractVersionedDecoder with Log {
       stats += ("misses" -> cacheStats.getMisses.toString)
       stats += ("removeHits" -> cacheStats.getRemoveHits.toString)
       stats += ("removeMisses" -> cacheStats.getRemoveMisses.toString)
+      stats += ("totalBytesRead" -> t.getTotalBytesRead)
+      stats += ("totalBytesWritten" -> t.getTotalBytesWritten)
       new StatsResponse(h.messageId, h.cacheName, h.clientIntel, immutable.Map[String, String]() ++ stats, h.topologyId)
    }
 

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
@@ -154,7 +154,7 @@ class HotRodDecoder(cacheManager: EmbeddedCacheManager, transport: NettyTranspor
       writeResponse(ch, header.decoder.customReadValue(header, buffer, cache))
 
    override def createStatsResponse: AnyRef =
-      header.decoder.createStatsResponse(header, cache.getAdvancedCache.getStats)
+      header.decoder.createStatsResponse(header, cache.getAdvancedCache.getStats, transport)
 
    override def createErrorResponse(t: Throwable): AnyRef = {
       t match {

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
@@ -76,7 +76,8 @@ class HotRodServer extends AbstractProtocolServer("HotRod") with Log {
       super.start(properties, cacheManager, 11222)
    }
 
-   override def startTransport(idleTimeout: Int, tcpNoDelay: Boolean, sendBufSize: Int, recvBufSize: Int, typedProps: TypedProperties) {
+   override def startTransport(idleTimeout: Int, tcpNoDelay: Boolean,
+         sendBufSize: Int, recvBufSize: Int, typedProps: TypedProperties) {
       // Start rest of the caches and self to view once we know for sure that we need to start
       // and we know that the rank calculator listener is registered
 

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodStatsTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodStatsTest.scala
@@ -41,6 +41,9 @@ class HotRodStatsTest extends HotRodSingleNodeTest {
    override def createTestCacheManager: EmbeddedCacheManager = TestCacheManagerFactory.createCacheManagerEnforceJmxDomain(jmxDomain)
 
    def testStats(m: Method) {
+      var bytesRead = 0
+      var bytesWritten = 0
+
       var s = client.stats
       assertTrue(s.get("timeSinceStart") != 0)
       assertEquals(s.get("currentNumberOfEntries").get, "0")
@@ -51,17 +54,33 @@ class HotRodStatsTest extends HotRodSingleNodeTest {
       assertEquals(s.get("misses").get, "0")
       assertEquals(s.get("removeHits").get, "0")
       assertEquals(s.get("removeMisses").get, "0")
+      bytesRead = assertHigherBytes(bytesRead, s.get("totalBytesRead"))
+      // At time of request, no data had been written yet
+      assertEquals(s.get("totalBytesWritten").get, "0")
 
       client.assertPut(m)
       s = client.stats
       assertEquals(s.get("currentNumberOfEntries").get, "1")
       assertEquals(s.get("totalNumberOfEntries").get, "1")
       assertEquals(s.get("stores").get, "1")
+      bytesRead = assertHigherBytes(bytesRead, s.get("totalBytesRead"))
+      bytesWritten = assertHigherBytes(bytesWritten, s.get("totalBytesWritten"))
+
+      assertEquals(s.get("totalBytesRead").get, "86")
+      assertEquals(s.get("totalBytesWritten").get, "180")
+
       assertSuccess(client.assertGet(m), v(m))
       s = client.stats
       assertEquals(s.get("hits").get, "1")
       assertEquals(s.get("misses").get, "0")
       assertEquals(s.get("retrievals").get, "1")
+      bytesRead = assertHigherBytes(bytesRead, s.get("totalBytesRead"))
+      bytesWritten = assertHigherBytes(bytesWritten, s.get("totalBytesWritten"))
    }
 
+   private def assertHigherBytes(currentBytesRead: Int, bytesStr: Option[String]): Int = {
+      val bytesRead = bytesStr.get.toInt
+      assertTrue(bytesRead > currentBytesRead)
+      bytesRead
+   }
 }

--- a/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedDecoder.scala
+++ b/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedDecoder.scala
@@ -484,8 +484,8 @@ class MemcachedDecoder(memcachedCache: Cache[String, MemcachedValue], scheduler:
          buildStat("auth_errors", 0, sb), // Unsupported
          //TODO: Evictions are measure by evict calls, but not by nodes are that are expired after the entry's lifespan has expired.
          buildStat("evictions", stats.getEvictions, sb),
-         buildStat("bytes_read", 0, sb), // TODO: Through netty?
-         buildStat("bytes_written", 0, sb), // TODO: Through netty?
+         buildStat("bytes_read", transport.getTotalBytesRead, sb),
+         buildStat("bytes_written", transport.getTotalBytesWritten, sb),
          buildStat("limit_maxbytes", 0, sb), // Unsupported
          buildStat("threads", 0, sb), // TODO: Through netty?
          buildStat("conn_yields", 0, sb), // Unsupported

--- a/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedStatsTest.scala
+++ b/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedStatsTest.scala
@@ -30,6 +30,8 @@ import java.util.concurrent.TimeUnit
 import org.infinispan.Version
 import org.infinispan.test.TestingUtil
 import org.infinispan.manager.EmbeddedCacheManager
+import org.infinispan.jmx.PerThreadMBeanServerLookup
+import javax.management.ObjectName
 
 /**
  * Tests stats command for Infinispan Memcached server.
@@ -45,60 +47,57 @@ class MemcachedStatsTest extends MemcachedSingleNodeTest {
       TestCacheManagerFactory.createCacheManagerEnforceJmxDomain(jmxDomain)
 
    def testUnsupportedStats(m: Method) {
-      val stats = getStats
-      assertEquals(stats.get("pid"), "0")
-      assertEquals(stats.get("pointer_size"), "0")
-      assertEquals(stats.get("rusage_user"), "0")
-      assertEquals(stats.get("rusage_system"), "0")
-      assertEquals(stats.get("bytes"), "0")
-      assertEquals(stats.get("connection_structures"), "0")
-      assertEquals(stats.get("auth_cmds"), "0")
-      assertEquals(stats.get("auth_errors"), "0")
-      assertEquals(stats.get("limit_maxbytes"), "0")
-      assertEquals(stats.get("conn_yields"), "0")
-      assertEquals(stats.get("reclaimed"), "0")
+      val stats = getStats(-1, -1)
+      assertEquals(stats._1.get("pid"), "0")
+      assertEquals(stats._1.get("pointer_size"), "0")
+      assertEquals(stats._1.get("rusage_user"), "0")
+      assertEquals(stats._1.get("rusage_system"), "0")
+      assertEquals(stats._1.get("bytes"), "0")
+      assertEquals(stats._1.get("connection_structures"), "0")
+      assertEquals(stats._1.get("auth_cmds"), "0")
+      assertEquals(stats._1.get("auth_errors"), "0")
+      assertEquals(stats._1.get("limit_maxbytes"), "0")
+      assertEquals(stats._1.get("conn_yields"), "0")
+      assertEquals(stats._1.get("reclaimed"), "0")
    }
 
    def testUncomparableStats(m: Method) {
       TestingUtil.sleepThread(TimeUnit.SECONDS.toMillis(1))
-      val stats = getStats
-      assertNotSame(stats.get("uptime"), "0")
-      assertNotSame(stats.get("time"), "0")
-      assertNotSame(stats.get("uptime"), stats.get("time"))
+      val stats = getStats(-1, -1)
+      assertNotSame(stats._1.get("uptime"), "0")
+      assertNotSame(stats._1.get("time"), "0")
+      assertNotSame(stats._1.get("uptime"), stats._1.get("time"))
    }
 
    def testStaticStats(m: Method) {
-       val stats = getStats
-       assertEquals(stats.get("version"), Version.VERSION)
+       val stats = getStats(-1, -1)
+       assertEquals(stats._1.get("version"), Version.VERSION)
     }
 
    def testTodoStats {
-      val stats = getStats
-      assertEquals(stats.get("curr_connections"), "0")
-      assertEquals(stats.get("total_connections"), "0")
-      assertEquals(stats.get("bytes_read"), "0")
-      assertEquals(stats.get("bytes_written"), "0")
-      assertEquals(stats.get("threads"), "0")
+      val stats = getStats(-1, -1)
+      assertEquals(stats._1.get("curr_connections"), "0")
+      assertEquals(stats._1.get("total_connections"), "0")
+      assertEquals(stats._1.get("threads"), "0")
    }
 
-
    def testStats(m: Method) {
-      var stats = getStats
-      assertEquals(stats.get("cmd_set"), "0")
-      assertEquals(stats.get("cmd_get"), "0")
-      assertEquals(stats.get("get_hits"), "0")
-      assertEquals(stats.get("get_misses"), "0")
-      assertEquals(stats.get("delete_hits"), "0")
-      assertEquals(stats.get("delete_misses"), "0")
-      assertEquals(stats.get("curr_items"), "0")
-      assertEquals(stats.get("total_items"), "0")
-      assertEquals(stats.get("incr_misses"), "0")
-      assertEquals(stats.get("incr_hits"), "0")
-      assertEquals(stats.get("decr_misses"), "0")
-      assertEquals(stats.get("decr_hits"), "0")
-      assertEquals(stats.get("cas_misses"), "0")
-      assertEquals(stats.get("cas_hits"), "0")
-      assertEquals(stats.get("cas_badval"), "0")
+      var stats = getStats(-1, -1)
+      assertEquals(stats._1.get("cmd_set"), "0")
+      assertEquals(stats._1.get("cmd_get"), "0")
+      assertEquals(stats._1.get("get_hits"), "0")
+      assertEquals(stats._1.get("get_misses"), "0")
+      assertEquals(stats._1.get("delete_hits"), "0")
+      assertEquals(stats._1.get("delete_misses"), "0")
+      assertEquals(stats._1.get("curr_items"), "0")
+      assertEquals(stats._1.get("total_items"), "0")
+      assertEquals(stats._1.get("incr_misses"), "0")
+      assertEquals(stats._1.get("incr_hits"), "0")
+      assertEquals(stats._1.get("decr_misses"), "0")
+      assertEquals(stats._1.get("decr_hits"), "0")
+      assertEquals(stats._1.get("cas_misses"), "0")
+      assertEquals(stats._1.get("cas_hits"), "0")
+      assertEquals(stats._1.get("cas_badval"), "0")
 
       var f = client.set(k(m), 0, v(m))
       assertTrue(f.get(timeout, TimeUnit.SECONDS).booleanValue)
@@ -106,92 +105,102 @@ class MemcachedStatsTest extends MemcachedSingleNodeTest {
       f = client.set(k(m, "k1-"), 0, v(m, "v1-"))
       assertTrue(f.get(timeout, TimeUnit.SECONDS).booleanValue)
       assertEquals(client.get(k(m, "k1-")), v(m, "v1-"))
-      stats = getStats
-      assertEquals(stats.get("cmd_set"), "2")
-      assertEquals(stats.get("cmd_get"), "2")
-      assertEquals(stats.get("get_hits"), "2")
-      assertEquals(stats.get("get_misses"), "0")
-      assertEquals(stats.get("delete_hits"), "0")
-      assertEquals(stats.get("delete_misses"), "0")
-      assertEquals(stats.get("curr_items"), "2")
-      assertEquals(stats.get("total_items"), "2")
+      stats = getStats(stats._2, stats._3)
+      assertEquals(stats._1.get("cmd_set"), "2")
+      assertEquals(stats._1.get("cmd_get"), "2")
+      assertEquals(stats._1.get("get_hits"), "2")
+      assertEquals(stats._1.get("get_misses"), "0")
+      assertEquals(stats._1.get("delete_hits"), "0")
+      assertEquals(stats._1.get("delete_misses"), "0")
+      assertEquals(stats._1.get("curr_items"), "2")
+      assertEquals(stats._1.get("total_items"), "2")
 
       f = client.delete(k(m, "k1-"))
       assertTrue(f.get(timeout, TimeUnit.SECONDS).booleanValue)
-      stats = getStats
-      assertEquals(stats.get("curr_items"), "1")
-      assertEquals(stats.get("total_items"), "2")
-      assertEquals(stats.get("delete_hits"), "1")
-      assertEquals(stats.get("delete_misses"), "0")
+      stats = getStats(stats._2, stats._3)
+      assertEquals(stats._1.get("curr_items"), "1")
+      assertEquals(stats._1.get("total_items"), "2")
+      assertEquals(stats._1.get("delete_hits"), "1")
+      assertEquals(stats._1.get("delete_misses"), "0")
 
       assertNull(client.get(k(m, "k99-")))
-      stats = getStats
-      assertEquals(stats.get("get_hits"), "2")
-      assertEquals(stats.get("get_misses"), "1")
+      stats = getStats(stats._2, stats._3)
+      assertEquals(stats._1.get("get_hits"), "2")
+      assertEquals(stats._1.get("get_misses"), "1")
 
       f = client.delete(k(m, "k99-"))
       assertFalse(f.get(timeout, TimeUnit.SECONDS).booleanValue)
-      stats = getStats
-      assertEquals(stats.get("delete_hits"), "1")
-      assertEquals(stats.get("delete_misses"), "1")
+      stats = getStats(stats._2, stats._3)
+      assertEquals(stats._1.get("delete_hits"), "1")
+      assertEquals(stats._1.get("delete_misses"), "1")
 
       val future = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis + 1000).asInstanceOf[Int]
       f = client.set(k(m, "k3-"), future, v(m, "v3-"))
       assertTrue(f.get(timeout, TimeUnit.SECONDS).booleanValue)
       TestingUtil.sleepThread(1100)
       assertNull(client.get(k(m, "k3-")))
-      stats = getStats
-      assertEquals(stats.get("curr_items"), "1")
-      assertEquals(stats.get("total_items"), "3")
+      stats = getStats(stats._2, stats._3)
+      assertEquals(stats._1.get("curr_items"), "1")
+      assertEquals(stats._1.get("total_items"), "3")
 
       client.incr(k(m, "k4-"), 1)
-      stats = getStats
-      assertEquals(stats.get("incr_misses"), "1")
-      assertEquals(stats.get("incr_hits"), "0")
+      stats = getStats(stats._2, stats._3)
+      assertEquals(stats._1.get("incr_misses"), "1")
+      assertEquals(stats._1.get("incr_hits"), "0")
 
       f = client.set(k(m, "k4-"), 0, "1")
       assertTrue(f.get(timeout, TimeUnit.SECONDS).booleanValue)
       client.incr(k(m, "k4-"), 1)
       client.incr(k(m, "k4-"), 2)
       client.incr(k(m, "k4-"), 4)
-      stats = getStats
-      assertEquals(stats.get("incr_misses"), "1")
-      assertEquals(stats.get("incr_hits"), "3")
+      stats = getStats(stats._2, stats._3)
+      assertEquals(stats._1.get("incr_misses"), "1")
+      assertEquals(stats._1.get("incr_hits"), "3")
 
       client.decr(k(m, "k5-"), 1)
-      stats = getStats
-      assertEquals(stats.get("decr_misses"), "1")
-      assertEquals(stats.get("decr_hits"), "0")
+      stats = getStats(stats._2, stats._3)
+      assertEquals(stats._1.get("decr_misses"), "1")
+      assertEquals(stats._1.get("decr_hits"), "0")
 
       f = client.set(k(m, "k5-"), 0, "8")
       assertTrue(f.get(timeout, TimeUnit.SECONDS).booleanValue)
       client.decr(k(m, "k5-"), 1)
       client.decr(k(m, "k5-"), 2)
       client.decr(k(m, "k5-"), 4)
-      stats = getStats
-      assertEquals(stats.get("decr_misses"), "1")
-      assertEquals(stats.get("decr_hits"), "3")
+      stats = getStats(stats._2, stats._3)
+      assertEquals(stats._1.get("decr_misses"), "1")
+      assertEquals(stats._1.get("decr_hits"), "3")
 
       client.cas(k(m, "k6-"), 1234, v(m, "v6-"))
-      stats = getStats
-      assertEquals(stats.get("cas_misses"), "1")
-      assertEquals(stats.get("cas_hits"), "0")
-      assertEquals(stats.get("cas_badval"), "0")
+      stats = getStats(stats._2, stats._3)
+      assertEquals(stats._1.get("cas_misses"), "1")
+      assertEquals(stats._1.get("cas_hits"), "0")
+      assertEquals(stats._1.get("cas_badval"), "0")
 
       f = client.set(k(m, "k6-"), 0, v(m, "v6-"))
       assertTrue(f.get(timeout, TimeUnit.SECONDS).booleanValue)
-      var value = client.gets(k(m, "k6-"))
-      var old: Long = value.getCas
+      val value = client.gets(k(m, "k6-"))
+      val old: Long = value.getCas
       client.cas(k(m, "k6-"), value.getCas, v(m, "v66-"))
-      stats = getStats
-      assertEquals(stats.get("cas_misses"), "1")
-      assertEquals(stats.get("cas_hits"), "1")
-      assertEquals(stats.get("cas_badval"), "0")
+      stats = getStats(stats._2, stats._3)
+      assertEquals(stats._1.get("cas_misses"), "1")
+      assertEquals(stats._1.get("cas_hits"), "1")
+      assertEquals(stats._1.get("cas_badval"), "0")
       client.cas(k(m, "k6-"), old, v(m, "v66-"))
-      stats = getStats
-      assertEquals(stats.get("cas_misses"), "1")
-      assertEquals(stats.get("cas_hits"), "1")
-      assertEquals(stats.get("cas_badval"), "1")
+      stats = getStats(stats._2, stats._3)
+      assertEquals(stats._1.get("cas_misses"), "1")
+      assertEquals(stats._1.get("cas_hits"), "1")
+      assertEquals(stats._1.get("cas_badval"), "1")
+   }
+
+   def testStatsSpecificToMemcachedViaJmx {
+      // Send any command
+      getStats(-1, -1)
+      val server = PerThreadMBeanServerLookup.getThreadMBeanServer()
+      val on = new ObjectName("%s:type=Server,name=Memcached,component=Transport".format(jmxDomain))
+      // Now verify that via JMX as well, these stats are also as expected
+      assertTrue(server.getAttribute(on, "TotalBytesRead").toString.toInt > 0)
+      assertTrue(server.getAttribute(on, "TotalBytesWritten").toString.toInt > 0)
    }
 
    def testStatsWithArgs {
@@ -205,10 +214,18 @@ class MemcachedStatsTest extends MemcachedSingleNodeTest {
       assertClientError(resp)
    }
    
-   private def getStats() = {
-      val stats = client.getStats()
-      assertEquals(stats.size(), 1)
-      stats.values.iterator.next
+   private def getStats(currentBytesRead: Int, currentBytesWritten: Int) = {
+      val globalStats = client.getStats()
+      assertEquals(globalStats.size(), 1)
+      val stats = globalStats.values.iterator.next
+      val bytesRead = assertHigherBytes(currentBytesRead, stats.get("bytes_read"))
+      val bytesWritten = assertHigherBytes(currentBytesRead, stats.get("bytes_written"))
+      (stats, bytesRead, bytesWritten)
    }
 
+   private def assertHigherBytes(currentBytesRead: Int, bytesStr: String): Int = {
+      val bytesRead = bytesStr.toInt
+      assertTrue(bytesRead > currentBytesRead)
+      bytesRead
+   }
 }


### PR DESCRIPTION
- Such as total bytes read/written stats for servers, host/port info,
  send and receive buffer sizes...etc.
- Total bytes counts are exposed both via the response to the stats
  command in both HotRod and Memcacached but also JMX/RHQ. The latter
  required some reworking in order to enable other modules to register
  MBeans.

Master only.
