### PR TITLE
ISPN-1067 Initial support for Spring namespace

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -472,6 +472,10 @@
             <updatePolicy>never</updatePolicy>
          </snapshots>
       </repository>
+      <repository>
+         <id>spring-milestone</id>
+         <url>http://maven.springsource.org/milestone</url>
+      </repository>
    </repositories>
 
    <pluginRepositories>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -49,6 +49,15 @@
          </roles>
          <timezone>0</timezone>
       </developer>
+      <developer>
+         <id>marius.bogoevici</id>
+         <name>Marius Bogoevici</name>
+         <email>marius.bogoevici AT gmail.com</email>
+         <roles>
+             <role>Developer</role>
+         </roles>
+         <timezone>-5</timezone>
+       </developer>
    </developers>
 
 	<!-- =================================================== -->

--- a/spring/src/main/java/org/infinispan/spring/AbstractEmbeddedCacheManagerFactory.java
+++ b/spring/src/main/java/org/infinispan/spring/AbstractEmbeddedCacheManagerFactory.java
@@ -1,6 +1,6 @@
 /**
  * JBoss, Home of Professional Open Source
- * Copyright 2009 Red Hat Inc. and/or its affiliates and other
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other
  * contributors as indicated by the @author tags. All rights reserved.
  * See the copyright.txt in the distribution for a full listing of
  * individual contributors.
@@ -9,7 +9,7 @@
  * under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation; either version 2.1 of
  * the License, or (at your option) any later version.
- *   ~
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU

--- a/spring/src/main/java/org/infinispan/spring/config/ContainerCacheManagerFactoryBean.java
+++ b/spring/src/main/java/org/infinispan/spring/config/ContainerCacheManagerFactoryBean.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *    ~
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.spring.config;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.manager.CacheContainer;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.spring.provider.SpringEmbeddedCacheManager;
+import org.infinispan.spring.provider.SpringRemoteCacheManager;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.util.Assert;
+
+/**
+ * {@link FactoryBean} for creating a {@link CacheManager} for a pre-defined {@link org.infinispan.manager.CacheContainer}.
+ * <p/>
+ * Useful when the cache container is defined outside the application (e.g. provided by the application server)
+ *
+ * @author Marius Bogoevici
+ */
+public class ContainerCacheManagerFactoryBean implements FactoryBean<CacheManager> {
+
+    private CacheContainer cacheContainer;
+
+    public ContainerCacheManagerFactoryBean(CacheContainer cacheContainer) {
+        Assert.notNull(cacheContainer, "CacheContainer cannot be null");
+        if (!(cacheContainer instanceof EmbeddedCacheManager ||
+                cacheContainer instanceof RemoteCacheManager)) {
+            throw new IllegalArgumentException("CacheContainer must be either an EmbeddedCacheManager or a RemoteCacheManager ");
+        }
+        this.cacheContainer = cacheContainer;
+    }
+
+    @Override
+    public CacheManager getObject() throws Exception {
+        if (this.cacheContainer instanceof EmbeddedCacheManager) {
+            return new SpringEmbeddedCacheManager((EmbeddedCacheManager) this.cacheContainer);
+        } else if (this.cacheContainer instanceof RemoteCacheManager) {
+            return new SpringRemoteCacheManager((RemoteCacheManager) this.cacheContainer);
+        } else {
+            throw new IllegalArgumentException("CacheContainer must be either an EmbeddedCacheManager or a RemoteCacheManager ");
+        }
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return CacheManager.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+
+}

--- a/spring/src/main/java/org/infinispan/spring/config/InfinispanContainerCacheManagerBeanDefinitionParser.java
+++ b/spring/src/main/java/org/infinispan/spring/config/InfinispanContainerCacheManagerBeanDefinitionParser.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *    ~
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.spring.config;
+
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.parsing.BeanComponentDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class InfinispanContainerCacheManagerBeanDefinitionParser extends AbstractBeanDefinitionParser {
+
+    private static final String DEFAULT_CACHE_MANAGER_BEAN_NAME = "cacheManager";
+
+    private static final String FACTORY_BEAN_CLASS = "org.infinispan.spring.config.ContainerCacheManagerFactoryBean";
+
+    @Override
+    protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
+      BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(FACTORY_BEAN_CLASS);
+      String cacheContainerRef = element.getAttribute("cache-container-ref");
+      BeanComponentDefinition innerBean = InfinispanNamespaceUtils.parseInnerBeanDefinition(element, parserContext);
+      if (innerBean != null) {
+         parserContext.registerBeanComponent(innerBean);
+      }
+      if ((!StringUtils.hasText(cacheContainerRef) && innerBean == null)
+              ||(StringUtils.hasText(cacheContainerRef) && innerBean != null) ) {
+          parserContext.getReaderContext().error("Exactly one of the 'cache-container-ref' attribute " +
+                  "or an inner bean definition is required for a 'container-cache-manager' element", element);
+      }
+      beanDefinitionBuilder.addConstructorArgReference(innerBean!=null?innerBean.getBeanName():cacheContainerRef);
+      return beanDefinitionBuilder.getBeanDefinition();
+    }
+
+    @Override
+   protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext) throws BeanDefinitionStoreException
+   {
+      String id = element.getAttribute("id");
+      if (!StringUtils.hasText(id))
+      {
+         id = DEFAULT_CACHE_MANAGER_BEAN_NAME;
+      }
+      return id;
+   }
+}

--- a/spring/src/main/java/org/infinispan/spring/config/InfinispanEmbeddedCacheManagerBeanDefinitionParser.java
+++ b/spring/src/main/java/org/infinispan/spring/config/InfinispanEmbeddedCacheManagerBeanDefinitionParser.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *    ~
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.spring.config;
+
+import org.infinispan.spring.provider.SpringEmbeddedCacheManager;
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class InfinispanEmbeddedCacheManagerBeanDefinitionParser extends AbstractBeanDefinitionParser {
+
+    private static final String DEFAULT_CACHE_MANAGER_BEAN_NAME = "cacheManager";
+
+    private static final String CACHE_MANAGER_CLASS = "org.infinispan.spring.provider.SpringEmbeddedCacheManagerFactoryBean";
+
+    @Override
+    protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
+      BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(CACHE_MANAGER_CLASS);
+      String configFileLocation = element.getAttribute("configuration");
+      if (StringUtils.hasText(configFileLocation)) {
+         beanDefinitionBuilder.addPropertyValue("configurationFileLocation", configFileLocation);
+      }
+      return beanDefinitionBuilder.getBeanDefinition();
+    }
+
+    @Override
+   protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext) throws BeanDefinitionStoreException
+   {
+      String id = element.getAttribute("id");
+      if (!StringUtils.hasText(id))
+      {
+         id = DEFAULT_CACHE_MANAGER_BEAN_NAME;
+      }
+      return id;
+   }
+}

--- a/spring/src/main/java/org/infinispan/spring/config/InfinispanNamespaceHandler.java
+++ b/spring/src/main/java/org/infinispan/spring/config/InfinispanNamespaceHandler.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *    ~
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.spring.config;
+
+import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
+
+/**
+ * {@link org.springframework.beans.factory.xml.NamespaceHandler} for Infinispan-based caches.
+ *
+ * @author Marius Bogoevici
+ */
+public class InfinispanNamespaceHandler extends NamespaceHandlerSupport {
+
+    @Override
+    public void init() {
+        registerBeanDefinitionParser("embedded-cache-manager", new InfinispanEmbeddedCacheManagerBeanDefinitionParser());
+        registerBeanDefinitionParser("remote-cache-manager", new InfinispanRemoteCacheManagerBeanDefinitionParser());
+        registerBeanDefinitionParser("container-cache-manager", new InfinispanContainerCacheManagerBeanDefinitionParser());
+    }
+
+}

--- a/spring/src/main/java/org/infinispan/spring/config/InfinispanNamespaceUtils.java
+++ b/spring/src/main/java/org/infinispan/spring/config/InfinispanNamespaceUtils.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *    ~
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.spring.config;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinitionHolder;
+import org.springframework.beans.factory.config.TypedStringValue;
+import org.springframework.beans.factory.parsing.BeanComponentDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.BeanDefinitionParserDelegate;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.core.Conventions;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.util.xml.DomUtils;
+import org.w3c.dom.Element;
+
+import java.util.List;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class InfinispanNamespaceUtils {
+
+    public static BeanComponentDefinition parseInnerBeanDefinition(Element element, ParserContext parserContext) {
+		List<Element> childElements = DomUtils.getChildElementsByTagName(element, "bean");
+		BeanComponentDefinition innerComponentDefinition = null;
+		if (childElements != null && childElements.size() == 1) {
+			Element beanElement = childElements.get(0);
+            if (!"http://www.springframework.org/schema/beans".equals(beanElement.getNamespaceURI())) {
+                throw new IllegalStateException ("Illegal inner child element");
+            }
+			BeanDefinitionParserDelegate delegate = parserContext.getDelegate();
+			BeanDefinitionHolder beanDefinitionHolder = delegate.parseBeanDefinitionElement(beanElement);
+			beanDefinitionHolder = delegate.decorateBeanDefinitionIfRequired(beanElement, beanDefinitionHolder);
+			BeanDefinition beanDefinition = beanDefinitionHolder.getBeanDefinition();
+			innerComponentDefinition = new BeanComponentDefinition(beanDefinition, beanDefinitionHolder.getBeanName());
+		}
+		return innerComponentDefinition;
+	}
+
+    public static void setPropertyIfAttributePresent(BeanDefinitionBuilder builder, Element element, String attributeName) {
+		String attributeValue = element.getAttribute(attributeName);
+		if (StringUtils.hasText(attributeValue)) {
+			builder.addPropertyValue(Conventions.attributeNameToPropertyName(attributeName), new TypedStringValue(attributeValue));
+		}
+	}
+}

--- a/spring/src/main/java/org/infinispan/spring/config/InfinispanRemoteCacheManagerBeanDefinitionParser.java
+++ b/spring/src/main/java/org/infinispan/spring/config/InfinispanRemoteCacheManagerBeanDefinitionParser.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *    ~
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.spring.config;
+
+import org.infinispan.spring.provider.SpringRemoteCacheManager;
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class InfinispanRemoteCacheManagerBeanDefinitionParser extends AbstractBeanDefinitionParser {
+
+    private static final String DEFAULT_CACHE_MANAGER_BEAN_NAME = "cacheManager";
+
+    private static final String CACHE_MANAGER_CLASS = "org.infinispan.spring.provider.SpringRemoteCacheManagerFactoryBean";
+
+    @Override
+    protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
+      BeanDefinitionBuilder beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(CACHE_MANAGER_CLASS);
+      String configFileLocation = element.getAttribute("configuration");
+      if (StringUtils.hasText(configFileLocation)) {
+         beanDefinitionBuilder.addPropertyValue("configurationPropertiesFileLocation", configFileLocation);
+      }
+      return beanDefinitionBuilder.getBeanDefinition();
+    }
+
+    @Override
+   protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext) throws BeanDefinitionStoreException
+   {
+      String id = element.getAttribute("id");
+      if (!StringUtils.hasText(id))
+      {
+         id = DEFAULT_CACHE_MANAGER_BEAN_NAME;
+      }
+      return id;
+   }
+}

--- a/spring/src/main/resources/META-INF/spring.handlers
+++ b/spring/src/main/resources/META-INF/spring.handlers
@@ -1,0 +1,1 @@
+http\://www.jboss.org/schema/infinispan/spring=org.infinispan.spring.config.InfinispanNamespaceHandler

--- a/spring/src/main/resources/META-INF/spring.schemas
+++ b/spring/src/main/resources/META-INF/spring.schemas
@@ -1,0 +1,2 @@
+http\://www.jboss.org/schema/infinispan/spring/infinispan-spring.xsd=org/infinispan/spring/config/infinispan-spring.xsd
+http\://www.jboss.org/schema/infinispan/spring/infinispan-spring-5.0.xsd=org/infinispan/spring/config/infinispan-spring.xsd

--- a/spring/src/main/resources/org/infinispan/spring/config/infinispan-spring.xsd
+++ b/spring/src/main/resources/org/infinispan/spring/config/infinispan-spring.xsd
@@ -1,0 +1,70 @@
+<!--
+
+    JBoss, Home of Professional Open Source
+    Copyright 2009 Red Hat Inc. and/or its affiliates and other
+    contributors as indicated by the @author tags. All rights reserved.
+    See the copyright.txt in the distribution for a full listing of
+    individual contributors.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 2.1 of
+    the License, or (at your option) any later version.
+      ~
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+
+<xsd:schema xmlns="http://www.jboss.org/schema/infinispan/spring"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:beans="http://www.springframework.org/schema/beans"
+		    xmlns:tool="http://www.springframework.org/schema/tool"
+            targetNamespace="http://www.jboss.org/schema/infinispan/spring"
+        elementFormDefault="qualified"
+		attributeFormDefault="unqualified">
+
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://www.springframework.org/schema/beans" schemaLocation="http://www.springframework.org/schema/beans/spring-beans-3.1.xsd"/>
+    <!--<xsd:import namespace="http://www.springframework.org/schema/tool" schemaLocation="http://www.springframework.org/schema/tool/spring-tool-3.1.xsd"/>-->
+
+    <xsd:annotation>
+		<xsd:documentation><![CDATA[
+	    Defines the elements used in Infinispan's Spring Namespace support
+	    Author: Marius Bogoevici
+		]]></xsd:documentation>
+	</xsd:annotation>
+
+    <xsd:element name="embedded-cache-manager">
+        <xsd:complexType>
+            <xsd:attribute name="id" type="xsd:string" use="optional"/>
+            <xsd:attribute name="configuration" type="xsd:string" use="optional"/>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:element name="remote-cache-manager">
+        <xsd:complexType>
+            <xsd:attribute name="id" type="xsd:string" use="optional"/>
+            <xsd:attribute name="configuration" type="xsd:string" use="optional"/>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:element name="container-cache-manager">
+        <xsd:complexType>
+            <xsd:choice>
+                <xsd:any namespace="##other" processContents="strict" minOccurs="0" maxOccurs="1" />
+            </xsd:choice>
+            <xsd:attribute name="id" type="xsd:string" use="optional"/>
+            <xsd:attribute name="cache-container-ref" type="xsd:string" use="optional"/>
+        </xsd:complexType>
+    </xsd:element>
+
+
+</xsd:schema>

--- a/spring/src/test/java/org/infinispan/spring/config/InfinispanContainerCacheManagerDefinitionTest.java
+++ b/spring/src/test/java/org/infinispan/spring/config/InfinispanContainerCacheManagerDefinitionTest.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *    ~
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.spring.config;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Marius Bogoevici
+ */
+
+@ContextConfiguration
+public class InfinispanContainerCacheManagerDefinitionTest extends AbstractTestNGSpringContextTests {
+
+    @Autowired @Qualifier("cacheManager")
+    private CacheManager containerCacheManager;
+
+    @Autowired @Qualifier("cacheManager2")
+    private CacheManager containerCacheManager2;
+
+    @Test
+    public void testContainerCacheManagerExists() {
+       Assert.assertNotNull(containerCacheManager);
+       Assert.assertNotNull(containerCacheManager2);
+    }
+
+}

--- a/spring/src/test/java/org/infinispan/spring/config/InfinispanEmbeddedCacheManagerDefinitionTest.java
+++ b/spring/src/test/java/org/infinispan/spring/config/InfinispanEmbeddedCacheManagerDefinitionTest.java
@@ -1,0 +1,53 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *   ~
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.spring.config;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Marius Bogoevici
+ */
+
+@ContextConfiguration
+public class InfinispanEmbeddedCacheManagerDefinitionTest extends AbstractTestNGSpringContextTests {
+
+    @Autowired @Qualifier("cacheManager")
+    private CacheManager embeddedCacheManager;
+
+    @Autowired @Qualifier("withConfigFile")
+    private CacheManager embeddedCacheManagerWithConfigFile;
+
+    @Test
+    public void testEmbeddedCacheManagerExists() {
+       Assert.assertNotNull(embeddedCacheManager);
+       Assert.assertNotNull(embeddedCacheManagerWithConfigFile);
+    }
+}

--- a/spring/src/test/java/org/infinispan/spring/config/InfinispanRemoteCacheManagerDefinitionTest.java
+++ b/spring/src/test/java/org/infinispan/spring/config/InfinispanRemoteCacheManagerDefinitionTest.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *    ~
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.spring.config;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @author Marius Bogoevici
+ */
+
+@ContextConfiguration
+public class InfinispanRemoteCacheManagerDefinitionTest extends AbstractTestNGSpringContextTests {
+
+    @Autowired @Qualifier("cacheManager")
+    private CacheManager remoteCacheManager;
+
+    @Autowired @Qualifier("withConfigFile")
+    private CacheManager remoteCacheManagerWithConfigFile;
+
+    @Test
+    public void testRemoteCacheManagerExists() {
+       Assert.assertNotNull(remoteCacheManager);
+       Assert.assertNotNull(remoteCacheManagerWithConfigFile);
+    }
+}

--- a/spring/src/test/resources/org/infinispan/spring/config/InfinispanContainerCacheManagerDefinitionTest-context.xml
+++ b/spring/src/test/resources/org/infinispan/spring/config/InfinispanContainerCacheManagerDefinitionTest-context.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2011 Red Hat Inc. and/or its affiliates and other
+  ~ contributors as indicated by the @author tags. All rights reserved.
+  ~ See the copyright.txt in the distribution for a full listing of
+  ~ individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~    ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:jee="http://www.springframework.org/schema/jee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:infinispan="http://www.jboss.org/schema/infinispan/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee.xsd
+       http://www.jboss.org/schema/infinispan/spring http://www.jboss.org/schema/infinispan/spring/infinispan-spring.xsd">
+
+    <infinispan:container-cache-manager cache-container-ref="cacheContainer"/>
+
+    <!-- We just want to validate that when a valid container exists, wrapping in a Spring CacheManager is possible -->
+    <bean id="cacheContainer" class="org.infinispan.manager.DefaultCacheManager"/>
+
+    <infinispan:container-cache-manager id="cacheManager2">
+        <bean class="org.infinispan.manager.DefaultCacheManager"/>
+    </infinispan:container-cache-manager>
+
+</beans>

--- a/spring/src/test/resources/org/infinispan/spring/config/InfinispanEmbeddedCacheManagerDefinitionTest-context.xml
+++ b/spring/src/test/resources/org/infinispan/spring/config/InfinispanEmbeddedCacheManagerDefinitionTest-context.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source
+    Copyright 2009 Red Hat Inc. and/or its affiliates and other
+    contributors as indicated by the @author tags. All rights reserved.
+    See the copyright.txt in the distribution for a full listing of
+    individual contributors.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 2.1 of
+    the License, or (at your option) any later version.
+      ~
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:infinispan="http://www.jboss.org/schema/infinispan/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.jboss.org/schema/infinispan/spring http://www.jboss.org/schema/infinispan/spring/infinispan-spring.xsd">
+
+    <infinispan:embedded-cache-manager/>
+
+    <infinispan:embedded-cache-manager id="withConfigFile"
+            configuration="classpath:org/infinispan/spring/support/embedded/named-async-cache.xml"/>
+
+</beans>

--- a/spring/src/test/resources/org/infinispan/spring/config/InfinispanRemoteCacheManagerDefinitionTest-context.xml
+++ b/spring/src/test/resources/org/infinispan/spring/config/InfinispanRemoteCacheManagerDefinitionTest-context.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2011 Red Hat Inc. and/or its affiliates and other
+  ~ contributors as indicated by the @author tags. All rights reserved.
+  ~ See the copyright.txt in the distribution for a full listing of
+  ~ individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~    ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:infinispan="http://www.jboss.org/schema/infinispan/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://www.jboss.org/schema/infinispan/spring http://www.jboss.org/schema/infinispan/spring/infinispan-spring.xsd">
+
+    <infinispan:remote-cache-manager/>
+
+    <infinispan:remote-cache-manager id="withConfigFile"
+          configuration="classpath:org/infinispan/spring/support/remote/hotrod-client.properties"/>
+
+</beans>

--- a/spring/src/test/resources/org/infinispan/spring/provider/sample/CachingBookDaoContextTest.xml
+++ b/spring/src/test/resources/org/infinispan/spring/provider/sample/CachingBookDaoContextTest.xml
@@ -1,15 +1,17 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cache="http://www.springframework.org/schema/cache"
    xmlns:p="http://www.springframework.org/schema/p" xmlns:jdbc="http://www.springframework.org/schema/jdbc" xmlns:context="http://www.springframework.org/schema/context"
+   xmlns:infinispan="http://www.jboss.org/schema/infinispan/spring"
    xmlns:tx="http://www.springframework.org/schema/tx"
    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/cache http://www.springframework.org/schema/cache/spring-cache.xsd
         http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
         http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-                  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+                  http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+         http://www.jboss.org/schema/infinispan/spring http://www.jboss.org/schema/infinispan/spring/infinispan-spring.xsd">
 
-   <cache:annotation-driven cache-manager="booksCache" />
+   <cache:annotation-driven/>
 
-   <bean id="booksCache" class="org.infinispan.spring.provider.SpringEmbeddedCacheManagerFactoryBean" p:configurationFileLocation="classpath:/org/infinispan/spring/provider/sample/books-infinispan-config.xml" />
+   <infinispan:embedded-cache-manager configuration="classpath:/org/infinispan/spring/provider/sample/books-infinispan-config.xml"/>
 
    <context:component-scan base-package="org.infinispan.spring.provider.sample" />
 


### PR DESCRIPTION
- Added an additional type of FactoryBean for creating Spring
  CacheManagers using an existing CacheContainer reference
  (Currently supporting only EmbeddedCacheManager and
  RemoteCacheManager references)
- Added namespace elements for:
  - <embedded-cache-manager> with optional configuration file reference
  - <remote-cache-manager> with optional configuration file reference
  - <container-cache-manager> with a mandatory cache container reference
- Modified the example to use the namespace element
