### PR TITLE
ISPN-1105 - infinispan-tools fails to build with JDK 7 early access (4.2)

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -86,10 +86,9 @@
       <profile>
          <id>default-tools.jar</id>
          <activation>
-            <property>
-               <name>java.vendor</name>
-               <value>Sun Microsystems Inc.</value>
-            </property>
+            <file>
+              <exists>${java.home}/../lib/tools.jar</exists>
+            </file>
          </activation>
          <dependencies>
             <dependency>


### PR DESCRIPTION
- default-tools.jar profile is now activated when tools.jar exists in
  the file system to support any JDK vendors with tools.jar.
