### PR TITLE
ISPN-1113 Async store shutdown timeout is now much lower

### DIFF
--- a/core/src/main/java/org/infinispan/loaders/decorators/AsyncStoreConfig.java
+++ b/core/src/main/java/org/infinispan/loaders/decorators/AsyncStoreConfig.java
@@ -62,9 +62,10 @@ public class AsyncStoreConfig extends AbstractDecoratorConfigurationBean {
    @ConfigurationDocRef(bean=AsyncStoreConfig.class,targetElement="setFlushLockTimeout")
    protected Long flushLockTimeout = 5000L;
 
+   // By default a bit under the default cache stop timeout
    @Dynamic
    @ConfigurationDocRef(bean=AsyncStoreConfig.class,targetElement="setShutdownTimeout")
-   protected Long shutdownTimeout = 7200L;
+   protected Long shutdownTimeout = 25000L;
 
    @XmlAttribute
    public Boolean isEnabled() {

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -683,4 +683,10 @@ public interface Log extends BasicLogger {
    @LogMessage(level = WARN)
    @Message(value = "Could not rollback prepared 1PC transaction. This transaction will be rolled back by the recovery process, if enabled. Transaction: %s", id = 141)
    void couldNotRollbackPrepared1PcTransaction(LocalXaTransaction localTransaction, @Cause XAException e1);
+
+   @LogMessage(level = WARN)
+   @Message(value = "The async store shutdown timeout (%d ms) is too high compared" +
+         " to cache stop timeout (%d ms), so instead using %d ms for async store stop wait", id = 142)
+   void asyncStoreShutdownTimeoutTooHigh(long configuredAsyncStopTimeout,
+      long cacheStopTimeout, long asyncStopTimeout);
 }


### PR DESCRIPTION
Apart from lowering the timeout, we make sure that is never bigger than
the cache stop timeout and if it is, lower it and log a warn message.

Master and 4.2.x (branch = t_1113_4)
