### PR TITLE
ISPN-1114 Sleep calls from timed tests to rethrow InterrutedException

### DIFF
--- a/core/src/test/java/org/infinispan/loaders/decorators/AsyncTest.java
+++ b/core/src/test/java/org/infinispan/loaders/decorators/AsyncTest.java
@@ -390,7 +390,7 @@ public class AsyncTest extends AbstractInfinispanTest {
                if (entry != null) {
                   assert entry.getValue().equals(value + i);
                } else {
-                  TestingUtil.sleepThread(20, "still waiting for key to appear: " + key + i);
+                  TestingUtil.sleepThreadInt(20, "still waiting for key to appear: " + key + i);
                }
             }
          }
@@ -407,7 +407,7 @@ public class AsyncTest extends AbstractInfinispanTest {
       InternalCacheEntry entry;
       boolean success = false;
       for (int i = 0; i < 120; i++) {
-         TestingUtil.sleepThread(20);
+         TestingUtil.sleepThreadInt(20, null);
          entry = store.load(key);
          success = entry.getValue().equals(value + (number - 1));
          if (success) break;
@@ -429,7 +429,7 @@ public class AsyncTest extends AbstractInfinispanTest {
       for (int i = 0; i < number; i++) {
          InternalCacheEntry entry = entries[i];
          while (entry != null) {
-            TestingUtil.sleepThread(20, "still waiting for key to be removed: " + key + i);
+            TestingUtil.sleepThreadInt(20, "still waiting for key to be removed: " + key + i);
             entry = store.load(key + i);
          }
       }
@@ -439,7 +439,7 @@ public class AsyncTest extends AbstractInfinispanTest {
       store.remove(key);
       InternalCacheEntry entry;
       do {
-         TestingUtil.sleepThread(20, "still waiting for key to be removed: " + key);
+         TestingUtil.sleepThreadInt(20, "still waiting for key to be removed: " + key);
          entry = store.load(key);
       } while (entry != null);
    }
@@ -457,7 +457,7 @@ public class AsyncTest extends AbstractInfinispanTest {
       for (int i = 0; i < number; i++) {
          InternalCacheEntry entry = entries[i];
          while (entry != null) {
-            TestingUtil.sleepThread(20, "still waiting for key to be removed: " + key + i);
+            TestingUtil.sleepThreadInt(20, "still waiting for key to be removed: " + key + i);
             entry = store.load(key + i);
          }
       }

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferFunctionalTest.java
@@ -371,7 +371,8 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
       cache2 = createCacheManager().getCache(cacheName);
 
       // Pause to give caches time to see each other
-      TestingUtil.blockUntilViewsReceived(60000, cache1, cache2);
+      // Make sure any interruption for test timing out is propagated
+      TestingUtil.blockUntilViewsReceivedInt(60000, cache1, cache2);
 
       writerThread.stopThread();
       writerThread.join();

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2009 Red Hat Inc. and/or its affiliates and other
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other
  * contributors as indicated by the @author tags. All rights reserved.
  * See the copyright.txt in the distribution for a full listing of
  * individual contributors.
@@ -164,11 +164,32 @@ public class TestingUtil {
       throw new RuntimeException("timed out before caches had complete views");
    }
 
+   public static void blockUntilViewsReceivedInt(Cache[] caches, long timeout) throws InterruptedException {
+      long failTime = System.currentTimeMillis() + timeout;
+
+      while (System.currentTimeMillis() < failTime) {
+         sleepThreadInt(100, null);
+         if (areCacheViewsComplete(caches)) {
+            return;
+         }
+      }
+
+      throw new RuntimeException("timed out before caches had complete views");
+   }
+
+
    /**
     * Version of blockUntilViewsReceived that uses varargs
     */
    public static void blockUntilViewsReceived(long timeout, Cache... caches) {
       blockUntilViewsReceived(caches, timeout);
+   }
+
+   /**
+    * Version of blockUntilViewsReceived that throws back any interruption
+    */
+   public static void blockUntilViewsReceivedInt(long timeout, Cache... caches) throws InterruptedException {
+      blockUntilViewsReceivedInt(caches, timeout);
    }
 
    /**
@@ -403,6 +424,17 @@ public class TestingUtil {
       catch (InterruptedException ie) {
          if (messageOnInterrupt != null)
             log.error(messageOnInterrupt);
+      }
+   }
+
+   public static void sleepThreadInt(long sleeptime, String messageOnInterrupt) throws InterruptedException {
+      try {
+         Thread.sleep(sleeptime);
+      }
+      catch (InterruptedException ie) {
+         if (messageOnInterrupt != null)
+            log.error(messageOnInterrupt);
+         throw ie;
       }
    }
 


### PR DESCRIPTION
Otherwise, there's a risk that interrupted exceptions as a result of
timeout are lost forever and the test does not finish.

https://issues.jboss.org/browse/ISPN-1114

Master only.
