### PR TITLE
ISPN-1121 Concurrent access and removal of an AtomicMap should result in 

### DIFF
--- a/core/src/main/java/org/infinispan/atomic/AtomicHashMap.java
+++ b/core/src/main/java/org/infinispan/atomic/AtomicHashMap.java
@@ -64,6 +64,7 @@ public class AtomicHashMap<K, V> implements AtomicMap<K, V>, DeltaAware, Cloneab
    private AtomicHashMapDelta delta = null;
    private volatile AtomicHashMapProxy<K, V> proxy;
    volatile boolean copied = false;
+   volatile boolean removed = false;
 
    /**
     * Construction only allowed through this factory method.  This factory is intended for use internally by the
@@ -172,6 +173,10 @@ public class AtomicHashMap<K, V> implements AtomicMap<K, V>, DeltaAware, Cloneab
       return proxy;
    }
 
+   public void markRemoved() {
+      removed = true;
+   }
+
    public Delta delta() {
       Delta toReturn = delta == null ? NullDelta.INSTANCE : delta;
       delta = null; // reset
@@ -211,6 +216,8 @@ public class AtomicHashMap<K, V> implements AtomicMap<K, V>, DeltaAware, Cloneab
       if (delta == null) delta = new AtomicHashMapDelta();
       return delta;
    }
+
+
 
    public static class Externalizer extends AbstractExternalizer<AtomicHashMap> {
       @Override

--- a/core/src/main/java/org/infinispan/atomic/AtomicHashMapProxy.java
+++ b/core/src/main/java/org/infinispan/atomic/AtomicHashMapProxy.java
@@ -78,7 +78,9 @@ public class AtomicHashMapProxy<K, V> extends AutoBatchSupport implements Atomic
 
    // internal helper, reduces lots of casts.
    private AtomicHashMap<K, V> getDeltaMapForRead() {
-      return toMap(cache.get(deltaMapKey));
+      AtomicHashMap<K, V> ahm = toMap(cache.get(deltaMapKey));
+      assertValid(ahm);
+      return ahm;
    }
 
    @SuppressWarnings("unchecked")
@@ -113,6 +115,10 @@ public class AtomicHashMapProxy<K, V> extends AutoBatchSupport implements Atomic
    }
 
    // readers
+
+   private void assertValid(AtomicHashMap<?, ?> map) {
+      if (map == null || map.removed) throw new IllegalStateException("AtomicMap stored under key " + deltaMapKey + " has been concurrently removed!");
+   }
 
    public Set<K> keySet() {
       AtomicHashMap<K, V> map = getDeltaMapForRead();

--- a/core/src/main/java/org/infinispan/atomic/AtomicMapLookup.java
+++ b/core/src/main/java/org/infinispan/atomic/AtomicMapLookup.java
@@ -23,6 +23,7 @@
 package org.infinispan.atomic;
 
 import org.infinispan.Cache;
+import org.infinispan.context.Flag;
 
 import java.util.Collections;
 import java.util.Map;
@@ -106,7 +107,6 @@ public class AtomicMapLookup {
     * @param <MK> key param of the cache
     */
    public static <MK> void removeAtomicMap(Cache<MK, ?> cache, MK key) {
-      cache.remove(key);
+      cache.getAdvancedCache().withFlags(Flag.SKIP_REMOTE_LOOKUP, Flag.SKIP_CACHE_LOAD).remove(key);
    }
-
 }

--- a/core/src/main/java/org/infinispan/commands/write/RemoveCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/RemoveCommand.java
@@ -22,9 +22,7 @@
  */
 package org.infinispan.commands.write;
 
-import java.util.Collections;
-import java.util.Set;
-
+import org.infinispan.atomic.AtomicHashMap;
 import org.infinispan.commands.Visitor;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.MVCCEntry;
@@ -33,6 +31,9 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+
+import java.util.Collections;
+import java.util.Set;
 
 
 /**
@@ -92,6 +93,8 @@ public class RemoveCommand extends AbstractDataWriteCommand {
       }
 
       final Object removedValue = e.getValue();
+      // If this is an AtomicMap, mark it as removed
+      if (removedValue != null && removedValue instanceof AtomicHashMap) ((AtomicHashMap) removedValue).markRemoved();
       notify(ctx, removedValue, true);
       e.setRemoved(true);
       e.setValid(false);


### PR DESCRIPTION
ISPN-1121 Concurrent access and removal of an AtomicMap should result in an IllegalStateException
- Add checks for concurrent deletion
- Add test

Only on master
