### PR TITLE
ISPN-1142 - reference to a non existing Maven repository

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -462,7 +462,7 @@
       </repository>
       <repository>
          <id>jboss</id>
-         <url>http://repository.jboss.org/maven2</url>
+         <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
       </repository>
       <repository>
          <id>scala-tools.org</id>
@@ -473,12 +473,17 @@
             <updatePolicy>never</updatePolicy>
          </snapshots>
       </repository>
+      <!-- needed for the scala-tools build plugins -->
+      <repository>
+         <id>glassfish.java.net</id>
+         <url>http://download.java.net/maven/glassfish</url>
+      </repository>
    </repositories>
 
    <pluginRepositories>
       <pluginRepository>
          <id>jboss</id>
-         <url>http://repository.jboss.org/maven2</url>
+         <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
       </pluginRepository>
 
       <pluginRepository>


### PR DESCRIPTION
Fixed the Maven repositories URLs for the time being, as this is critical.
The change is small but it took me ages to verify.
