### PR TITLE
ISPN-1127 Preparing transaction now removed when tx commits fine too

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/CacheStoreInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheStoreInterceptor.java
@@ -133,8 +133,10 @@ public class CacheStoreInterceptor extends JmxStatsCommandInterceptor {
             try {
                store.commit(tx);
             } catch (Throwable t) {
-               preparingTxs.remove(tx);
                throw t;
+            } finally {
+               // Regardless of outcome, remove from preparing txs
+               preparingTxs.remove(tx);
             }
             if (getStatisticsEnabled()) {
                Integer puts = txStores.get(tx);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1127

Preparing transactions were only removed if an exception was thrown
during commit. The fix guarantees that the preparing tx is removed
regardless of the store commit outcome.

Master only.
