### PR TITLE
ISPN-1140 Fix transient mortal cache entry's setValue

### DIFF
--- a/core/src/main/java/org/infinispan/container/entries/TransientMortalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/TransientMortalCacheEntry.java
@@ -118,7 +118,7 @@ public class TransientMortalCacheEntry extends AbstractInternalCacheEntry {
    }
 
    public Object setValue(Object value) {
-      return cacheValue.maxIdle;
+      return cacheValue.setValue(value);
    }
 
    @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1140

Master only.
