### PR TITLE
ISPN-1133 Enable faster builds

### DIFF
--- a/cachestore/bdbje/pom.xml
+++ b/cachestore/bdbje/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-cachestore-bdbje</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan BDBJE CacheStore</name>
    <description>Infinispan BerkeleyDB JavaEdition CacheStore module</description>
    <dependencies>

--- a/cachestore/cassandra/pom.xml
+++ b/cachestore/cassandra/pom.xml
@@ -31,7 +31,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>infinispan-cachestore-cassandra</artifactId>
-	<packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
 	<name>Infinispan CassandraCacheStore</name>
 	<description>Infinispan CassandraCacheStore module</description>
 

--- a/cachestore/cloud/pom.xml
+++ b/cachestore/cloud/pom.xml
@@ -32,7 +32,7 @@
       <relativePath>../pom.xml</relativePath>
    </parent>
    <artifactId>infinispan-cachestore-cloud</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan CloudCacheStore</name>
    <description>Infinispan CloudCacheStore module</description>
 

--- a/cachestore/jdbc/pom.xml
+++ b/cachestore/jdbc/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-cachestore-jdbc</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan JDBC CacheStore</name>
    <description>Infinispan JDBC CacheStore module</description>
 

--- a/cachestore/jdbm/pom.xml
+++ b/cachestore/jdbm/pom.xml
@@ -32,7 +32,7 @@
       <relativePath>../pom.xml</relativePath>
    </parent>
    <artifactId>infinispan-cachestore-jdbm</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan JDBM CacheStore</name>
    <description>Infinispan JDBM CacheStore module</description>
    <properties>

--- a/cachestore/remote/pom.xml
+++ b/cachestore/remote/pom.xml
@@ -32,7 +32,7 @@
       <relativePath>../pom.xml</relativePath>
    </parent>
    <artifactId>infinispan-cachestore-remote</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan remote CacheStore</name>
    <description>Infinispan remote CacheStore based on Hotrod protocol</description>
    <properties>

--- a/client/hotrod-client/pom.xml
+++ b/client/hotrod-client/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-client-hotrod</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan Client Hotrod Module</name>
    <description>Infinispan client hotrod module</description>
    <properties>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,7 +34,7 @@
    </parent>
 
    <artifactId>infinispan-core</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan Core</name>
    <description>Infinispan core module</description>
 

--- a/lucene-directory/pom.xml
+++ b/lucene-directory/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-lucene-directory</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan Lucene Directory Implementation</name>
    <description>A Lucene directory implementation based on Infinispan</description>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -231,30 +231,6 @@
       <directory>${buildDirectory}</directory>
 
       <plugins>
-         <!-- enforce java 1.6 and maven 2.1.0 -->
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-enforcer-plugin</artifactId>
-            <version>1.0-beta-1</version>
-            <executions>
-               <execution>
-                  <id>enforce-java</id>
-                  <goals>
-                     <goal>enforce</goal>
-                  </goals>
-                  <configuration>
-                     <rules>
-                        <requireJavaVersion>
-                           <version>[1.6,)</version>
-                        </requireJavaVersion>
-                        <requireMavenVersion>
-                           <version>[2.1.0,)</version>
-                        </requireMavenVersion>
-                     </rules>
-                  </configuration>
-               </execution>
-            </executions>
-         </plugin>
          <!-- by default, compile to JDK 1.6 compatibility (individual modules and/or user can override) -->
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -279,21 +255,6 @@
             <version>2.4.3</version>
             <configuration>
                <encoding>UTF-8</encoding>
-            </configuration>
-         </plugin>
-
-         <plugin>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>maven-bundle-plugin</artifactId>
-            <version>2.0.1</version>
-            <extensions>true</extensions>
-            <configuration>
-               <instructions>
-                  <Bundle-DocURL>http://www.infinispan.org/</Bundle-DocURL>
-                  <Export-Package>
-                     ${project.groupId}.*;version=${project.version};-split-package:=error
-                  </Export-Package>
-               </instructions>
             </configuration>
          </plugin>
 
@@ -353,21 +314,6 @@
             <configuration>
                <downloadSources>true</downloadSources>
             </configuration>
-         </plugin>
-         <!-- Make sure we generate src jars too -->
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>2.1.1</version>
-            <inherited>true</inherited>
-            <executions>
-               <execution>
-                  <id>attach-sources</id>
-                  <goals>
-                     <goal>jar</goal>
-                  </goals>
-               </execution>
-            </executions>
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -493,6 +439,74 @@
    </pluginRepositories>
 
    <profiles>
+      <profile>
+         <id>extras</id>
+         <activation>
+            <activeByDefault>true</activeByDefault>
+         </activation>
+         <properties>
+            <!-- By default create OSGI bundles -->
+            <packaging>bundle</packaging>
+         </properties>
+         <build>
+            <plugins>
+               <!-- enforce java 1.6 and maven 2.1.0 -->
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-enforcer-plugin</artifactId>
+                  <version>1.0-beta-1</version>
+                  <executions>
+                     <execution>
+                        <id>enforce-java</id>
+                        <goals>
+                           <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                           <rules>
+                              <requireJavaVersion>
+                                 <version>[1.6,)</version>
+                              </requireJavaVersion>
+                              <requireMavenVersion>
+                                 <version>[2.1.0,)</version>
+                              </requireMavenVersion>
+                           </rules>
+                        </configuration>
+                     </execution>
+                  </executions>
+               </plugin>
+               <!-- Make sure we generate src jars too -->
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-source-plugin</artifactId>
+                  <version>2.1.1</version>
+                  <inherited>true</inherited>
+                  <executions>
+                     <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                           <goal>jar</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.felix</groupId>
+                  <artifactId>maven-bundle-plugin</artifactId>
+                  <version>2.0.1</version>
+                  <extensions>true</extensions>
+                  <configuration>
+                     <instructions>
+                        <Bundle-DocURL>http://www.infinispan.org/</Bundle-DocURL>
+                        <Export-Package>
+                           ${project.groupId}.*;version=${project.version};-split-package:=error
+                        </Export-Package>
+                     </instructions>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+
       <profile>
          <id>test-hudson</id>
          <activation>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-query</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan Query API</name>
    <description>Infinispan Query API module</description>
    <dependencies>

--- a/server/core/pom.xml
+++ b/server/core/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-server-core</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan Server Core Module</name>
    <description>Infinispan server core module</description>
 

--- a/server/hotrod/pom.xml
+++ b/server/hotrod/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-server-hotrod</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan Server Hotrod Module</name>
    <description>Infinispan server hotrod  module</description>
 

--- a/server/memcached/pom.xml
+++ b/server/memcached/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-server-memcached</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan Server Memcached Module</name>
    <description>Infinispan server memcached module</description>
 

--- a/server/websocket/pom.xml
+++ b/server/websocket/pom.xml
@@ -32,7 +32,7 @@
    </parent>
 
    <artifactId>infinispan-server-websocket</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan WebSocket Server</name>
    <description>WebSocket interface for Infinispan</description>
 

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -9,7 +9,7 @@
    </parent>
 
    <artifactId>infinispan-spring</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
 
    <name>Infinispan Spring Integration</name>
    <description>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -34,7 +34,7 @@
    </parent>
 
    <artifactId>infinispan-tools</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan Tools</name>
    <description>Infinispan - Tools for project</description>
 

--- a/tree/pom.xml
+++ b/tree/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-tree</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>${packaging}</packaging>
    <name>Infinispan Tree API</name>
    <description>Infinispan tree API module</description>
    <dependencies>


### PR DESCRIPTION
Below is a summary but you can find more detailed information in https://issues.jboss.org/browse/ISPN-1133
- All non-essential build plugins have been moved to a separate profile
  which can easily be disabled at build time.
- On top of that, created a packaging property to able to switch between
  default 'bundle' packaging and 'jar' packaging which is faster.

Master only.
