### PR TITLE
ISPN-1157 - StartupListener overwrites ManagerInstance.instance even if it's set already by container.

### DIFF
--- a/server/rest/src/main/scala/org/infinispan/rest/StartupListener.scala
+++ b/server/rest/src/main/scala/org/infinispan/rest/StartupListener.scala
@@ -46,7 +46,9 @@ class StartupListener extends HttpServlet with Log {
       //    setting ManagerInstance.instance
       // 2. Doing it here makes it a lot easier rather than needing to have a separate module
       //    within app server build system
-      ManagerInstance.instance = getMcInjectedCacheManager(cfg)
+      if (ManagerInstance.instance == null) {
+         ManagerInstance.instance = getMcInjectedCacheManager(cfg)
+      }
 
       // If cache manager is still null, create one for REST server's own usage
       if (ManagerInstance.instance == null) {


### PR DESCRIPTION
Please apply this fix to both 4.2.x and master.
- Do not call getMcInjectedCacheManager() if ManagerInstance.instance is set already.
