### PR TITLE
ISPN-1159: Cassandra Cache Store tests are failing

### DIFF
--- a/cachestore/cassandra/pom.xml
+++ b/cachestore/cassandra/pom.xml
@@ -50,6 +50,12 @@
 			<artifactId>cassandra-all</artifactId>
 			<version>${version.cassandra}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>${version.slf4j}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/cachestore/cassandra/src/test/java/org/infinispan/loaders/cassandra/CassandraCacheStoreTest.java
+++ b/cachestore/cassandra/src/test/java/org/infinispan/loaders/cassandra/CassandraCacheStoreTest.java
@@ -60,7 +60,7 @@ public class CassandraCacheStoreTest extends BaseCacheStoreTest {
 	protected CacheStore createCacheStore() throws Exception {
 		CassandraCacheStore cs = new CassandraCacheStore();
 		CassandraCacheStoreConfig clc = new CassandraCacheStoreConfig();
-		clc.setHost("localhost");
+		clc.setHost("127.0.0.1");
 		clc.setKeySpace("Infinispan");
 		cs.init(clc, getCache(), getMarshaller());
 		cs.start();

--- a/cachestore/cassandra/src/test/resources/cassandra.yaml
+++ b/cachestore/cassandra/src/test/resources/cassandra.yaml
@@ -69,6 +69,7 @@ reduce_cache_sizes_at: 1.0
 rpc_keepalive: true
 rpc_max_threads: 2147483647
 rpc_min_threads: 16
+rpc_address: 127.0.0.1
 rpc_port: 9160
 rpc_timeout_in_ms: 10000
 saved_caches_directory: ${java.io.tmpdir}/infinispan-cassandra-cachestore/savedcaches

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -148,6 +148,7 @@
       <version.rhq.plugingen>3.0.1</version.rhq.plugingen>
       <version.rhq>3.0.0</version.rhq>
       <version.scala>2.8.1</version.scala>
+      <version.slf4j>1.6.1</version.slf4j>
       <version.spymemcached>2.5</version.spymemcached>
       <version.testng>5.11</version.testng>
       <version.webdav.servlet>2.0.1</version.webdav.servlet>


### PR DESCRIPTION
Fix the execution of tests by using a specific IP address (127.0.0.1) both in the client and the server
