### PR TITLE
ISPN-1123 more tests fixed

### DIFF
--- a/core/src/test/java/org/infinispan/test/SingleCacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/test/SingleCacheManagerTest.java
@@ -64,16 +64,18 @@ public abstract class SingleCacheManagerTest extends AbstractCacheTest {
    protected void createBeforeClass() throws Exception {
       try {
          if (cleanupAfterTest()) setup();
+         else assert cleanupAfterMethod() : "you must either cleanup after test or after method";
       } catch (Exception e) {
          log.error("Unexpected!", e);
          throw e;
       }
    }
 
-   @BeforeMethod
+   @BeforeMethod(alwaysRun = true)
    protected void createBeforeMethod() throws Exception {
       try {
          if (cleanupAfterMethod()) setup();
+         else assert cleanupAfterTest() : "you must either cleanup after test or after method";
       } catch (Exception e) {
          log.error("Unexpected!", e);
          throw e;

--- a/query/src/test/java/org/infinispan/query/blackbox/KeyTypeTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/KeyTypeTest.java
@@ -24,7 +24,6 @@ package org.infinispan.query.blackbox;
 
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
-import org.infinispan.Cache;
 import org.infinispan.config.Configuration;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.CacheQuery;
@@ -45,11 +44,9 @@ import static org.infinispan.config.Configuration.CacheMode.LOCAL;
  *
  * @author Navin Surtani
  */
-
 @Test(groups = "functional")
-public class KeyTypeTest extends SingleCacheManagerTest{
+public class KeyTypeTest extends SingleCacheManagerTest {
 
-   Cache<Object, Person> cache;
    Person person1;
 
    public KeyTypeTest() {
@@ -64,7 +61,6 @@ public class KeyTypeTest extends SingleCacheManagerTest{
          .indexLocalOnly(false)
          .addProperty("hibernate.search.default.directory_provider", "ram");
       cacheManager = TestCacheManagerFactory.createCacheManager(c, true);
-      cache = cacheManager.getCache();
 
       person1 = new Person();
       person1.setName("Navin");


### PR DESCRIPTION
With these changes the Query module is totally stable, on core it reduced failures sensibly:

Failed tests:
  testTaskCancellation(org.infinispan.distexec.DistributedExecutorTest)
  testRemoveFromNonOwner(org.infinispan.distribution.DisabledL1Test)

Tests run: 1233, Failures: 2, Errors: 0, Skipped: 0

Don't close the issue, it's still work in progress.
https://issues.jboss.org/browse/ISPN-1123
