### PR TITLE
ISPN-720 CacheEntryEvicted and CacheEntryPassivated made plural

### DIFF
--- a/core/src/main/java/org/infinispan/commands/write/EvictCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/EvictCommand.java
@@ -27,6 +27,9 @@ import org.infinispan.commands.Visitor;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * @author Mircea.Markus@jboss.com
  * @since 4.0
@@ -58,7 +61,8 @@ public class EvictCommand extends RemoveCommand implements LocalCommand {
 
    @Override
    public void notify(InvocationContext ctx, Object value, boolean isPre) {
-      notifier.notifyCacheEntryEvicted(key, value, isPre, ctx);
+      Map<Object,Object> entries = Collections.singletonMap(key, value);
+      notifier.notifyCacheEntriesEvicted(entries, isPre, ctx);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/eviction/PassivationManager.java
+++ b/core/src/main/java/org/infinispan/eviction/PassivationManager.java
@@ -29,6 +29,8 @@ import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.loaders.CacheLoaderException;
 
+import java.util.Map;
+
 /**
  * A passivation manager
  *
@@ -41,7 +43,8 @@ public interface PassivationManager {
    
    boolean isEnabled();
 
-   void passivate(Object key, InternalCacheEntry entry, InvocationContext ctx) throws CacheLoaderException;
+   void passivate(Map<Object, InternalCacheEntry> entries,
+                  Map<Object, Object> nakedEntries, InvocationContext ctx);
 
    void passivateAll() throws CacheLoaderException;
 

--- a/core/src/main/java/org/infinispan/eviction/PassivationManagerImpl.java
+++ b/core/src/main/java/org/infinispan/eviction/PassivationManagerImpl.java
@@ -27,17 +27,22 @@ import org.infinispan.config.ConfigurationException;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.context.impl.ImmutableContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.loaders.CacheLoaderManager;
 import org.infinispan.loaders.CacheStore;
+import org.infinispan.marshall.MarshalledValue;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.util.Util;
+import org.infinispan.util.concurrent.TimeoutException;
+import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class PassivationManagerImpl implements PassivationManager {
@@ -53,13 +58,15 @@ public class PassivationManagerImpl implements PassivationManager {
    private final AtomicLong passivations = new AtomicLong(0);
    private DataContainer container;
    private static final boolean trace = log.isTraceEnabled();
+   private LockManager lockManager;
 
    @Inject
-   public void inject(CacheLoaderManager cacheLoaderManager, CacheNotifier notifier, Configuration cfg, DataContainer container) {
+   public void inject(CacheLoaderManager cacheLoaderManager, CacheNotifier notifier, Configuration cfg, DataContainer container, LockManager lockManager) {
       this.cacheLoaderManager = cacheLoaderManager;
       this.notifier = notifier;
       this.cfg = cfg;
       this.container = container;
+      this.lockManager = lockManager;
    }
 
    @Start(priority = 11)
@@ -82,17 +89,35 @@ public class PassivationManagerImpl implements PassivationManager {
    }
 
    @Override
-   public void passivate(Object key, InternalCacheEntry entry, InvocationContext ctx) throws CacheLoaderException {
+   public void passivate(Map<Object, InternalCacheEntry> entries,
+                         Map<Object, Object> nakedEntries, InvocationContext ctx) {
       if (enabled) {
-         final Object value = entry != null ? entry.getValue() : null;
-         // notify listeners that this entry is about to be passivated
-         notifier.notifyCacheEntryPassivated(key, value, true, ctx);
-         if (trace) log.tracef("Passivating entry %s", key);
-         cacheStore.store(entry);
-         notifier.notifyCacheEntryPassivated(key, value, false, ctx);
-         if (statsEnabled && entry != null) {
-            passivations.getAndIncrement();
+         notifier.notifyCacheEntriesPassivated(nakedEntries, true, ctx);
+         for (Map.Entry<Object, InternalCacheEntry> entry : entries.entrySet()) {
+            Object key = entry.getKey();
+            boolean locked = false;
+            try {
+               locked = acquireLock(ctx, key);
+            } catch (Exception e) {
+               log.couldNotAcquireLockForEviction(key, e);
+            }
+            try {
+               // notify listeners that this entry is about to be passivated
+               if (trace) log.tracef("Passivating entry %s", key);
+               cacheStore.store(entry.getValue());
+               if (statsEnabled && entry.getValue() != null) {
+                  passivations.getAndIncrement();
+               }
+            } catch (CacheLoaderException e) {
+               log.unableToPassivateEntry(key, e);
+            }
+            finally {
+               if (locked) {
+                  lockManager.unlock(key);
+               }
+            }
          }
+         notifier.notifyCacheEntriesPassivated(nakedEntries, false, ctx);
       }
    }
 
@@ -115,5 +140,37 @@ public class PassivationManagerImpl implements PassivationManager {
 
    public void resetPassivationCount() {
       passivations.set(0L);
+   }
+
+      /**
+    * Attempts to lock an entry if the lock isn't already held in the current scope, and records the lock in the
+    * context.
+    *
+    * @param ctx context
+    * @param key Key to lock
+    * @return true if a lock was needed and acquired, false if it didn't need to acquire the lock (i.e., lock was
+    *         already held)
+    * @throws InterruptedException if interrupted
+    * @throws org.infinispan.util.concurrent.TimeoutException
+    *                              if we are unable to acquire the lock after a specified timeout.
+    */
+   private boolean acquireLock(InvocationContext ctx, Object key) throws InterruptedException, TimeoutException {
+      // don't EVER use lockManager.isLocked() since with lock striping it may be the case that we hold the relevant
+      // lock which may be shared with another key that we have a lock for already.
+      // nothing wrong, just means that we fail to record the lock.  And that is a problem.
+      // Better to check our records and lock again if necessary.
+
+      if (lockManager.lockAndRecord(key, ctx)) {
+         return true;
+      } else {
+         Object owner = lockManager.getOwner(key);
+         // if lock cannot be acquired, expose the key itself, not the marshalled value
+         if (key instanceof MarshalledValue) {
+            key = ((MarshalledValue) key).get();
+         }
+         throw new TimeoutException(String.format(
+            "Unable to acquire lock after [%d] on key [%s] for requestor [%s]! Lock held by [%s]",
+            cfg.getLockAcquisitionTimeout(), key, ctx.getLockOwner(), owner));
+      }
    }
 }

--- a/core/src/main/java/org/infinispan/notifications/Listener.java
+++ b/core/src/main/java/org/infinispan/notifications/Listener.java
@@ -76,13 +76,13 @@ import java.lang.annotation.Target;
  * <td valign="top">{@link org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent}</td> <td valign="top">A
  * cache entry was visited</td> </tr> <tr> <td valign="top">{@link org.infinispan.notifications.cachelistener.annotation.CacheEntryLoaded}</td>
  * <td valign="top">{@link org.infinispan.notifications.cachelistener.event.CacheEntryLoadedEvent}</td> <td valign="top">A
- * cache entry was loaded</td> </tr> <tr> <td valign="top">{@link org.infinispan.notifications.cachelistener.annotation.CacheEntryEvicted}</td>
- * <td valign="top">{@link org.infinispan.notifications.cachelistener.event.CacheEntryEvictedEvent}</td> <td valign="top">A
- * cache entry was evicted</td> </tr> <tr> <td valign="top">{@link org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated}</td>
+ * cache entry was loaded</td> </tr> <tr> <td valign="top">{@link org.infinispan.notifications.cachelistener.annotation.CacheEntriesEvicted}</td>
+ * <td valign="top">{@link org.infinispan.notifications.cachelistener.event.CacheEntriesEvictedEvent}</td> <td valign="top">A
+ * cache entries were evicted</td> </tr> <tr> <td valign="top">{@link org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated}</td>
  * <td valign="top">{@link org.infinispan.notifications.cachelistener.event.CacheEntryActivatedEvent}</td> <td
  * valign="top">A cache entry was activated</td> </tr> <tr> <td valign="top">{@link
- * org.infinispan.notifications.cachelistener.annotation.CacheEntryPassivated}</td> <td valign="top">{@link
- * org.infinispan.notifications.cachelistener.event.CacheEntryPassivatedEvent}</td> <td valign="top">A cache entry was
+ * org.infinispan.notifications.cachelistener.annotation.CacheEntriesPassivated}</td> <td valign="top">{@link
+ * org.infinispan.notifications.cachelistener.event.CacheEntriesPassivatedEvent}</td> <td valign="top">One or more cache entries were
  * passivated</td> </tr> <tr> <td valign="top">{@link org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged}</td>
  * <td valign="top">{@link org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent}</td> <td
  * valign="top">A view change event was detected</td> </tr> <tr> <td valign="top">{@link
@@ -201,9 +201,9 @@ import java.lang.annotation.Target;
  * @see org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved
  * @see org.infinispan.notifications.cachelistener.annotation.CacheEntryVisited
  * @see org.infinispan.notifications.cachelistener.annotation.CacheEntryLoaded
- * @see org.infinispan.notifications.cachelistener.annotation.CacheEntryEvicted
+ * @see org.infinispan.notifications.cachelistener.annotation.CacheEntriesEvicted
  * @see org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated
- * @see org.infinispan.notifications.cachelistener.annotation.CacheEntryPassivated
+ * @see org.infinispan.notifications.cachelistener.annotation.CacheEntriesPassivated
  * @see org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged
  * @see org.infinispan.notifications.cachelistener.annotation.TransactionCompleted
  * @see org.infinispan.notifications.cachelistener.annotation.TransactionRegistered

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifier.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifier.java
@@ -31,6 +31,7 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.transaction.xa.GlobalTransaction;
 
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Public interface with all allowed notifications.
@@ -61,9 +62,9 @@ public interface CacheNotifier extends Listenable {
    void notifyCacheEntryVisited(Object key, Object value, boolean pre, InvocationContext ctx);
 
    /**
-    * Notifies all registered listeners of a CacheEntryEvicted event.
+    * Notifies all registered listeners of a CacheEntriesEvicted event.
     */
-   void notifyCacheEntryEvicted(Object key, Object value, boolean pre, InvocationContext ctx);
+   void notifyCacheEntriesEvicted(Map<Object, Object> entries, boolean pre, InvocationContext ctx);
 
    /**
     * Notifies all registered listeners of a CacheEntryInvalidated event.
@@ -81,9 +82,9 @@ public interface CacheNotifier extends Listenable {
    void notifyCacheEntryActivated(Object key, Object value, boolean pre, InvocationContext ctx);
 
    /**
-    * Notifies all registered listeners of a CacheEntryPassivated event.
+    * Notifies all registered listeners of a CacheEntriesPassivated event.
     */
-   void notifyCacheEntryPassivated(Object key, Object value, boolean pre, InvocationContext ctx);
+   void notifyCacheEntriesPassivated(Map<Object, Object> entries, boolean pre, InvocationContext ctx);
 
    /**
     * Notifies all registered listeners of a transaction completion event.

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
@@ -63,9 +63,9 @@ public class CacheNotifierImpl extends AbstractListenerImpl implements CacheNoti
       allowedListeners.put(CacheEntryVisited.class, CacheEntryVisitedEvent.class);
       allowedListeners.put(CacheEntryModified.class, CacheEntryModifiedEvent.class);
       allowedListeners.put(CacheEntryActivated.class, CacheEntryActivatedEvent.class);
-      allowedListeners.put(CacheEntryPassivated.class, CacheEntryPassivatedEvent.class);
+      allowedListeners.put(CacheEntriesPassivated.class, CacheEntriesPassivatedEvent.class);
       allowedListeners.put(CacheEntryLoaded.class, CacheEntryLoadedEvent.class);
-      allowedListeners.put(CacheEntryEvicted.class, CacheEntryEvictedEvent.class);
+      allowedListeners.put(CacheEntriesEvicted.class, CacheEntriesEvictedEvent.class);
       allowedListeners.put(TransactionRegistered.class, TransactionRegisteredEvent.class);
       allowedListeners.put(TransactionCompleted.class, TransactionCompletedEvent.class);
       allowedListeners.put(CacheEntryInvalidated.class, CacheEntryInvalidatedEvent.class);
@@ -97,9 +97,9 @@ public class CacheNotifierImpl extends AbstractListenerImpl implements CacheNoti
       listenersMap.put(CacheEntryVisited.class, cacheEntryVisitedListeners);
       listenersMap.put(CacheEntryModified.class, cacheEntryModifiedListeners);
       listenersMap.put(CacheEntryActivated.class, cacheEntryActivatedListeners);
-      listenersMap.put(CacheEntryPassivated.class, cacheEntryPassivatedListeners);
+      listenersMap.put(CacheEntriesPassivated.class, cacheEntryPassivatedListeners);
       listenersMap.put(CacheEntryLoaded.class, cacheEntryLoadedListeners);
-      listenersMap.put(CacheEntryEvicted.class, cacheEntryEvictedListeners);
+      listenersMap.put(CacheEntriesEvicted.class, cacheEntryEvictedListeners);
       listenersMap.put(TransactionRegistered.class, transactionRegisteredListeners);
       listenersMap.put(TransactionCompleted.class, transactionCompletedListeners);
       listenersMap.put(CacheEntryInvalidated.class, cacheEntryInvalidatedListeners);
@@ -198,17 +198,13 @@ public class CacheNotifierImpl extends AbstractListenerImpl implements CacheNoti
    }
 
    @Override
-   public void notifyCacheEntryEvicted(final Object key, Object value, final boolean pre, InvocationContext ctx) {
+   public void notifyCacheEntriesEvicted(Map<Object, Object> entries, final boolean pre, InvocationContext ctx) {
       if (!cacheEntryEvictedListeners.isEmpty()) {
-         final boolean originLocal = ctx.isOriginLocal();
          InvocationContext contexts = icc.suspend();
          try {
             EventImpl<Object, Object> e = EventImpl.createEvent(cache, CACHE_ENTRY_EVICTED);
-            e.setOriginLocal(originLocal);
             e.setPre(pre);
-            e.setKey(key);
-            e.setValue(value);
-            setTx(ctx, e);
+            e.setEntries(entries);
             for (ListenerInvocation listener : cacheEntryEvictedListeners) listener.invoke(e);
          } finally {
             icc.resume(contexts);
@@ -281,15 +277,13 @@ public class CacheNotifierImpl extends AbstractListenerImpl implements CacheNoti
    }
 
    @Override
-   public void notifyCacheEntryPassivated(Object key, Object value, boolean pre, InvocationContext ctx) {
+   public void notifyCacheEntriesPassivated(Map<Object, Object> entries, boolean pre, InvocationContext ctx) {
       if (!cacheEntryPassivatedListeners.isEmpty()) {
          InvocationContext contexts = icc.suspend();
          try {
             EventImpl<Object, Object> e = EventImpl.createEvent(cache, CACHE_ENTRY_PASSIVATED);
             e.setPre(pre);
-            e.setKey(key);
-            e.setValue(value);
-            setTx(ctx, e);
+            e.setEntries(entries);
             for (ListenerInvocation listener : cacheEntryPassivatedListeners) listener.invoke(e);
          } finally {
             icc.resume(contexts);

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntriesEvicted.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntriesEvicted.java
@@ -20,19 +20,29 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.infinispan.notifications.cachelistener.event;
+package org.infinispan.notifications.cachelistener.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * This event subtype is passed in to any method annotated with {@link org.infinispan.notifications.cachelistener.annotation.CacheEntryPassivated}.
+ * This annotation should be used on methods that need to be notified when cache entries are evicted.
+ * <p/>
+ * Methods annotated with this annotation should be public and take in a single parameter, a {@link
+ * org.infinispan.notifications.cachelistener.event.CacheEntriesEvictedEvent} otherwise an {@link
+ * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your cache listener.
+ * <p/>
+ *  Locking: notification is performed WITH locks on the given key.
  *
  * @author Manik Surtani
- * @since 4.0
+ * @author Galder Zamarreño
+ * @see org.infinispan.notifications.Listener
+ * @see CacheEntryLoaded
+ * @since 5.0
  */
-public interface CacheEntryPassivatedEvent<K, V> extends CacheEntryEvent<K, V> {
-   /**
-    * Retrieves the value of the entry being passivated.
-    *
-    * @return the value of the passivated entry
-    */
-   V getValue();
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CacheEntriesEvicted {
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntriesPassivated.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntriesPassivated.java
@@ -20,19 +20,30 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.infinispan.notifications.cachelistener.event;
+package org.infinispan.notifications.cachelistener.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * This event subtype is passed in to any method annotated with {@link org.infinispan.notifications.cachelistener.annotation.CacheEntryEvicted}.
+ * This annotation should be used on methods that need to be notified when cache entries are passivated.
+ * <p/>
+ * Methods annotated with this annotation should accept a single parameter, a {@link
+ * org.infinispan.notifications.cachelistener.event.CacheEntriesPassivatedEvent} otherwise a {@link
+ * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your listener.
+ *  <p/>
+ *  Locking: notification is performed WITH locks on the given key.
  *
  * @author Manik Surtani
- * @since 4.0
+ * @author Galder Zamarreño
+ * @see org.infinispan.notifications.Listener
+ * @since 5.0
  */
-public interface CacheEntryEvictedEvent<K, V> extends CacheEntryEvent<K, V> {
-   /**
-    * Retrieves the value of the entry being evicted.
-    *
-    * @return the value of the evicted entry
-    */
-   V getValue();
+// ensure this annotation is available at runtime.
+@Retention(RetentionPolicy.RUNTIME)
+// ensure that this annotation is applied to classes.
+@Target(ElementType.METHOD)
+public @interface CacheEntriesPassivated {
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryActivated.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntryActivated.java
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:manik@jboss.org">Manik Surtani</a>
  * @see org.infinispan.notifications.Listener
- * @see CacheEntryPassivated
+ * @see CacheEntriesPassivated
  * @since 4.0
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/event/CacheEntriesEvictedEvent.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/event/CacheEntriesEvictedEvent.java
@@ -20,28 +20,26 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.infinispan.notifications.cachelistener.annotation;
+package org.infinispan.notifications.cachelistener.event;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.util.Map;
 
 /**
- * This annotation should be used on methods that need to be notified when a cache entry is evicted.
- * <p/>
- * Methods annotated with this annotation should be public and take in a single parameter, a {@link
- * org.infinispan.notifications.cachelistener.event.CacheEntryEvictedEvent} otherwise an {@link
- * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your cache listener.
- * <p/>
- *  Locking: notification is performed WITH locks on the given key.
+ * This event subtype is passed in to any method annotated with
+ * {@link org.infinispan.notifications.cachelistener.annotation.CacheEntriesEvicted}.
  *
- * @author <a href="mailto:manik@jboss.org">Manik Surtani</a>
- * @see org.infinispan.notifications.Listener
- * @see CacheEntryLoaded
- * @since 4.0
+ * @author Manik Surtani
+ * @author Galder Zamarreño
+ * @since 5.0
  */
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-public @interface CacheEntryEvicted {
+public interface CacheEntriesEvictedEvent<K, V> extends Event<K, V> {
+
+   /**
+    * Retrieves entries being evicted.
+    *
+    * @return A map containing the key/value pairs of the
+    *         cache entries being evicted.
+    */
+   Map<K, V> getEntries();
+
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/event/CacheEntriesPassivatedEvent.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/event/CacheEntriesPassivatedEvent.java
@@ -20,29 +20,26 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.infinispan.notifications.cachelistener.annotation;
+package org.infinispan.notifications.cachelistener.event;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.util.Map;
 
 /**
- * This annotation should be used on methods that need to be notified when a cache entry is passivated.
- * <p/>
- * Methods annotated with this annotation should accept a single parameter, a {@link
- * org.infinispan.notifications.cachelistener.event.CacheEntryPassivatedEvent} otherwise a {@link
- * org.infinispan.notifications.IncorrectListenerException} will be thrown when registering your listener.
- *  <p/>
- *  Locking: notification is performed WITH locks on the given key.
+ * This event subtype is passed in to any method annotated with
+ * {@link org.infinispan.notifications.cachelistener.annotation.CacheEntriesPassivated}.
  *
- * @author <a href="mailto:manik@jboss.org">Manik Surtani</a>
- * @see org.infinispan.notifications.Listener
- * @since 4.0
+ * @author Manik Surtani
+ * @author Galder Zamarreño
+ * @since 5.0
  */
-// ensure this annotation is available at runtime.
-@Retention(RetentionPolicy.RUNTIME)
-// ensure that this annotation is applied to classes.
-@Target(ElementType.METHOD)
-public @interface CacheEntryPassivated {
+public interface CacheEntriesPassivatedEvent<K, V> extends Event<K, V> {
+
+   /**
+    * Retrieves entries being passivated.
+    *
+    * @return A map containing the key/value pairs of the
+    *         cache entries being passivated.
+    */
+   Map<K, V> getEntries();
+
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/event/EventImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/event/EventImpl.java
@@ -31,7 +31,7 @@ import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.Util;
 
 import java.util.Collection;
-import java.util.List;
+import java.util.Map;
 
 /**
  * Basic implementation of an event that covers all event types.
@@ -40,8 +40,8 @@ import java.util.List;
  * @since 4.0
  */
 @NotThreadSafe
-public class EventImpl<K, V> implements CacheEntryActivatedEvent, CacheEntryCreatedEvent, CacheEntryEvictedEvent, CacheEntryLoadedEvent, CacheEntryModifiedEvent,
-                                  CacheEntryPassivatedEvent, CacheEntryRemovedEvent, CacheEntryVisitedEvent, TransactionCompletedEvent, TransactionRegisteredEvent,
+public class EventImpl<K, V> implements CacheEntryActivatedEvent, CacheEntryCreatedEvent, CacheEntriesEvictedEvent, CacheEntryLoadedEvent, CacheEntryModifiedEvent,
+                                        CacheEntriesPassivatedEvent, CacheEntryRemovedEvent, CacheEntryVisitedEvent, TransactionCompletedEvent, TransactionRegisteredEvent,
                                   CacheEntryInvalidatedEvent, DataRehashedEvent, TopologyChangedEvent {
    private boolean pre = false; // by default events are after the fact
    private Cache<K, V> cache;
@@ -54,6 +54,7 @@ public class EventImpl<K, V> implements CacheEntryActivatedEvent, CacheEntryCrea
    private Collection<Address> membersAtStart, membersAtEnd;
    private ConsistentHash consistentHashAtStart, consistentHashAtEnd;
    private long newViewId;
+   private Map<Object, Object> entries;
 
    public EventImpl() {
    }
@@ -157,6 +158,10 @@ public class EventImpl<K, V> implements CacheEntryActivatedEvent, CacheEntryCrea
       this.value = value;
    }
 
+   public void setEntries(Map<Object, Object> entries) {
+      this.entries = entries;
+   }
+
    @Override
    public boolean equals(Object o) {
       if (this == o) return true;
@@ -235,5 +240,10 @@ public class EventImpl<K, V> implements CacheEntryActivatedEvent, CacheEntryCrea
    @Override
    public ConsistentHash getConsistentHashAtEnd() {
       return consistentHashAtEnd;
+   }
+
+   @Override
+   public Map getEntries() {
+      return entries;
    }
 }

--- a/core/src/test/java/org/infinispan/eviction/BaseEvictionFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/eviction/BaseEvictionFunctionalTest.java
@@ -30,8 +30,8 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.config.Configuration;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.notifications.Listener;
-import org.infinispan.notifications.cachelistener.annotation.CacheEntryEvicted;
-import org.infinispan.notifications.cachelistener.event.CacheEntryEvictedEvent;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntriesEvicted;
+import org.infinispan.notifications.cachelistener.event.CacheEntriesEvictedEvent;
 import org.infinispan.notifications.cachelistener.event.Event;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -155,10 +155,11 @@ public abstract class BaseEvictionFunctionalTest extends SingleCacheManagerTest 
    @Listener
    public class EvictionListener {
       
-      @CacheEntryEvicted
-      public void nodeEvicted(CacheEntryEvictedEvent e){
+      @CacheEntriesEvicted
+      public void nodeEvicted(CacheEntriesEvictedEvent e){
          assert e.isPre() || !e.isPre();
-         assert e.getKey() != null;
+         Object key = e.getEntries().keySet().iterator().next();
+         assert key != null;
          assert e.getCache() != null;
          assert e.getType() == Event.Type.CACHE_ENTRY_EVICTED;         
       }

--- a/core/src/test/java/org/infinispan/jmx/ActivationAndPassivationInterceptorMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/ActivationAndPassivationInterceptorMBeanTest.java
@@ -46,6 +46,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.infinispan.test.TestingUtil.getCacheObjectName;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Tester class for ActivationInterceptor and PassivationInterceptor.
@@ -175,7 +176,8 @@ public class ActivationAndPassivationInterceptorMBeanTest extends SingleCacheMan
    }
 
    private void assertPassivationCount(int activationCount) throws Exception {
-      assert Integer.valueOf(threadMBeanServer.getAttribute(passivationInterceptorObjName, "Passivations").toString()).equals(activationCount);
+      Object passivations = threadMBeanServer.getAttribute(passivationInterceptorObjName, "Passivations");
+      assertEquals(activationCount, Integer.valueOf(passivations.toString()).intValue());
    }
 
 }

--- a/core/src/test/java/org/infinispan/notifications/CacheListenerCacheLoaderTest.java
+++ b/core/src/test/java/org/infinispan/notifications/CacheListenerCacheLoaderTest.java
@@ -29,7 +29,8 @@ import org.infinispan.loaders.dummy.DummyInMemoryCacheStore;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryLoaded;
-import org.infinispan.notifications.cachelistener.annotation.CacheEntryPassivated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntriesPassivated;
+import org.infinispan.notifications.cachelistener.event.CacheEntriesPassivatedEvent;
 import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
@@ -177,9 +178,11 @@ public class CacheListenerCacheLoaderTest extends AbstractInfinispanTest {
          if (e.isPre()) activated.add(e.getKey());
       }
 
-      @CacheEntryPassivated
-      public void handlePassivated(CacheEntryEvent e) {
-         if (e.isPre()) passivated.add(e.getKey());
+      @CacheEntriesPassivated
+      public void handlePassivated(CacheEntriesPassivatedEvent e) {
+         if (e.isPre()) {
+            passivated.add(e.getEntries().keySet().iterator().next());
+         }
       }
 
       void reset() {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheListener.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheListener.java
@@ -70,11 +70,11 @@ public class CacheListener {
 
    @CacheEntryActivated
    @CacheEntryCreated
-   @CacheEntryEvicted
+   @CacheEntriesEvicted
    @CacheEntryInvalidated
    @CacheEntryLoaded
    @CacheEntryModified
-   @CacheEntryPassivated
+   @CacheEntriesPassivated
    @CacheEntryRemoved
    @CacheEntryVisited
    @TransactionCompleted

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
@@ -30,22 +30,16 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.InvocationContextContainer;
 import org.infinispan.context.InvocationContextContainerImpl;
 import org.infinispan.context.impl.NonTxInvocationContext;
-import org.infinispan.notifications.cachelistener.event.CacheEntryActivatedEvent;
-import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
-import org.infinispan.notifications.cachelistener.event.CacheEntryEvictedEvent;
-import org.infinispan.notifications.cachelistener.event.CacheEntryInvalidatedEvent;
-import org.infinispan.notifications.cachelistener.event.CacheEntryLoadedEvent;
-import org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent;
-import org.infinispan.notifications.cachelistener.event.CacheEntryPassivatedEvent;
-import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
-import org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent;
-import org.infinispan.notifications.cachelistener.event.Event;
-import org.infinispan.notifications.cachelistener.event.TransactionCompletedEvent;
-import org.infinispan.notifications.cachelistener.event.TransactionRegisteredEvent;
+import org.infinispan.notifications.cachelistener.event.*;
+import org.infinispan.notifications.cachelistener.event.CacheEntriesPassivatedEvent;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 @Test(groups = "unit", testName = "notifications.cachelistener.CacheNotifierImplTest")
 public class CacheNotifierImplTest extends AbstractInfinispanTest {
@@ -134,20 +128,25 @@ public class CacheNotifierImplTest extends AbstractInfinispanTest {
    }
 
    public void testNotifyCacheEntryEvicted() {
-      n.notifyCacheEntryEvicted("k", "v", true, ctx);
-      n.notifyCacheEntryEvicted("k", "v", false, ctx);
+      Map<Object, Object> entries = Collections.<Object, Object>singletonMap("k", "v");
+      n.notifyCacheEntriesEvicted(entries, false, null);
+      n.notifyCacheEntriesEvicted(entries, true, null);
 
       assert cl.isReceivedPost();
       assert cl.isReceivedPre();
       assert cl.getInvocationCount() == 2;
       assert cl.getEvents().get(0).getCache() == mockCache;
       assert cl.getEvents().get(0).getType() == Event.Type.CACHE_ENTRY_EVICTED;
-      assert ((CacheEntryEvent) cl.getEvents().get(0)).getKey().equals("k");
-      assert ((CacheEntryEvictedEvent) cl.getEvents().get(0)).getValue().equals("v");
+      entries = ((CacheEntriesEvictedEvent) cl.getEvents().get(0)).getEntries();
+      Map.Entry<Object, Object> entry = entries.entrySet().iterator().next();
+      assert entry.getKey().equals("k");
+      assert entry.getValue().equals("v");
       assert cl.getEvents().get(1).getCache() == mockCache;
       assert cl.getEvents().get(1).getType() == Event.Type.CACHE_ENTRY_EVICTED;
-      assert ((CacheEntryEvent) cl.getEvents().get(1)).getKey().equals("k");
-      assert ((CacheEntryEvictedEvent) cl.getEvents().get(1)).getValue().equals("v");
+      entries = ((CacheEntriesEvictedEvent) cl.getEvents().get(1)).getEntries();
+      entry = entries.entrySet().iterator().next();
+      assert entry.getKey().equals("k");
+      assert entry.getValue().equals("v");
    }
 
    public void testNotifyCacheEntryInvalidated() {
@@ -202,20 +201,25 @@ public class CacheNotifierImplTest extends AbstractInfinispanTest {
    }
 
    public void testNotifyCacheEntryPassivated() {
-      n.notifyCacheEntryPassivated("k", "v", true, ctx);
-      n.notifyCacheEntryPassivated("k", "v", false, ctx);
+      Map<Object, Object> entries = Collections.<Object, Object>singletonMap("k", "v");
+      n.notifyCacheEntriesPassivated(entries, true, null);
+      n.notifyCacheEntriesPassivated(entries, false, null);
 
       assert cl.isReceivedPost();
       assert cl.isReceivedPre();
       assert cl.getInvocationCount() == 2;
       assert cl.getEvents().get(0).getCache() == mockCache;
       assert cl.getEvents().get(0).getType() == Event.Type.CACHE_ENTRY_PASSIVATED;
-      assert ((CacheEntryEvent) cl.getEvents().get(0)).getKey().equals("k");
-      assert ((CacheEntryPassivatedEvent) cl.getEvents().get(0)).getValue().equals("v");
+      entries = ((CacheEntriesEvictedEvent) cl.getEvents().get(0)).getEntries();
+      Map.Entry<Object, Object> entry = entries.entrySet().iterator().next();
+      assert entry.getKey().equals("k");
+      assert entry.getValue().equals("v");
       assert cl.getEvents().get(1).getCache() == mockCache;
       assert cl.getEvents().get(1).getType() == Event.Type.CACHE_ENTRY_PASSIVATED;
-      assert ((CacheEntryEvent) cl.getEvents().get(1)).getKey().equals("k");
-      assert ((CacheEntryPassivatedEvent) cl.getEvents().get(1)).getValue().equals("v");
+      entries = ((CacheEntriesEvictedEvent) cl.getEvents().get(1)).getEntries();
+      entry = entries.entrySet().iterator().next();
+      assert entry.getKey().equals("k");
+      assert entry.getValue().equals("v");
    }
 
    public void testNotifyTransactionCompleted() {

--- a/demos/gui/src/main/java/org/infinispan/demo/InfinispanDemo.java
+++ b/demos/gui/src/main/java/org/infinispan/demo/InfinispanDemo.java
@@ -494,7 +494,7 @@ public class InfinispanDemo {
 
       @CacheEntryModified
       @CacheEntryRemoved
-      @CacheEntryEvicted
+      @CacheEntriesEvicted
       public void removed(Event e) {
          if (!e.isPre()) updateCachedDataTable();
       }


### PR DESCRIPTION
- Notifications refactored to take multiple entries.
- getKey/getValue dissapear and become getEntries returning a key/value
  pair map of these entries.
- Passivator interface changes slightly to accomodate both notification
  and passivation objects.

I'm not completely happy on how the passivator interface has finished, but it's at least the most efficient way I could think of (iow, without having to recalculate the notification entries map) if we want to keep the passivation notification within the passivator classes. Any other ideas are welcomed :)
