### PR TITLE
ISPN-1096: Mostly replace use of TCCL with configured classloader

### DIFF
--- a/cachestore/jdbc/src/test/java/org/infinispan/config/parsing/JdbcConfigurationTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/config/parsing/JdbcConfigurationTest.java
@@ -44,7 +44,7 @@ import java.util.Map;
 public class JdbcConfigurationTest {
    
    public void testParseCacheLoaders() throws Exception {
-      InfinispanConfiguration configuration = InfinispanConfiguration.newInfinispanConfiguration("configs/jdbc-parsing-test.xml");
+      InfinispanConfiguration configuration = InfinispanConfiguration.newInfinispanConfiguration("configs/jdbc-parsing-test.xml", Thread.currentThread().getContextClassLoader());
       Map<String, Configuration> namedConfigurations = configuration.parseNamedConfigurations();
       Configuration c = namedConfigurations.get("withJDBCLoader");
       CacheLoaderManagerConfig clc = c.getCacheLoaderManagerConfig();

--- a/core/src/main/java/org/infinispan/AdvancedCache.java
+++ b/core/src/main/java/org/infinispan/AdvancedCache.java
@@ -168,4 +168,6 @@ public interface AdvancedCache<K, V> extends Cache<K, V> {
     * reference to Infinispan's XAResource implementation.
     */
    XAResource getXAResource();
+   
+   ClassLoader getClassLoader();
 }

--- a/core/src/main/java/org/infinispan/CacheDelegate.java
+++ b/core/src/main/java/org/infinispan/CacheDelegate.java
@@ -728,4 +728,12 @@ public class CacheDelegate<K, V> extends CacheSupport<K,V> implements AdvancedCa
          }
       }
    }
+
+   @Override
+   public ClassLoader getClassLoader() {
+      // TODO Make this overriable
+      return config.getClassLoader();
+   }
+   
+   
 }

--- a/core/src/main/java/org/infinispan/config/Configuration.java
+++ b/core/src/main/java/org/infinispan/config/Configuration.java
@@ -97,6 +97,9 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
 
    @XmlTransient
    FluentConfiguration fluentConfig = new FluentConfiguration(this);
+   
+   @XmlTransient
+   private ClassLoader cl;
 
    @XmlElement
    LockingType locking = new LockingType().setConfiguration(this);
@@ -199,6 +202,22 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
    @Inject
    private void injectGlobalConfiguration(GlobalConfiguration globalConfiguration) {
       this.globalConfiguration = globalConfiguration;
+   }
+   
+   public ClassLoader getClassLoader() {
+      if (cl != null)
+         // The classloader has been set for this configuration
+         return cl;
+      else if (cl == null && globalConfiguration != null)
+         // The classloader is not set for this configuration, and we have a global config
+         return globalConfiguration.getClassLoader();
+      else 
+         // Return the default CL 
+         return Thread.currentThread().getContextClassLoader();
+   }
+   
+   public void setClassLoader(ClassLoader cl) {
+      this.cl = cl;
    }
 
    public boolean isStateTransferEnabled() {

--- a/core/src/main/java/org/infinispan/config/GlobalConfiguration.java
+++ b/core/src/main/java/org/infinispan/config/GlobalConfiguration.java
@@ -119,10 +119,35 @@ public class GlobalConfiguration extends AbstractConfigurationBean {
 
    @XmlTransient
    GlobalComponentRegistry gcr;
+   
+   @XmlTransient
+   private final ClassLoader cl;
 
+   /**
+    * Create a new GlobalConfiguration, using the Thread Context ClassLoader to load any
+    * classes or resources required by this configuration. The TCCL will also be used as
+    * default classloader for the CacheManager and any caches created.
+    * 
+    */
    public GlobalConfiguration() {
-      super();
+      this(Thread.currentThread().getContextClassLoader());
    }
+   
+   /**
+    * Create a new GlobalConfiguration, specifying the classloader to use. This classloader will
+    * be used to load resources or classes required by configuration, and used as the default
+    * classloader for the CacheManager and any caches created.
+    * 
+    * @param cl
+    */
+   public GlobalConfiguration(ClassLoader cl) {
+      super();
+      if (cl == null)
+         throw new IllegalArgumentException("cl must not be null");
+      this.cl = cl;
+   }
+
+
 
    public FluentGlobalConfiguration fluent() {
       return fluentGlobalConfig;
@@ -819,6 +844,15 @@ public class GlobalConfiguration extends AbstractConfigurationBean {
       gc.setTransportClass(null);
       gc.setTransportProperties((Properties) null);
       return gc;
+   }
+   
+   /**
+    * Get the classloader in use by this configuration.
+    * 
+    * @return
+    */
+   public ClassLoader getClassLoader() {
+      return cl;
    }
 
    public abstract static class FactoryClassWithPropertiesType extends AbstractConfigurationBeanWithGCR {
@@ -1608,7 +1642,7 @@ public class GlobalConfiguration extends AbstractConfigurationBean {
       @XmlTransient
       public MBeanServerLookup getMBeanServerLookupInstance() {
          if (mBeanServerLookupInstance == null)
-            mBeanServerLookupInstance = (MBeanServerLookup) Util.getInstance(mBeanServerLookup, Thread.currentThread().getContextClassLoader());
+            mBeanServerLookupInstance = (MBeanServerLookup) Util.getInstance(mBeanServerLookup, globalConfig.getClassLoader());
 
          return mBeanServerLookupInstance;
       }

--- a/core/src/main/java/org/infinispan/config/InfinispanConfiguration.java
+++ b/core/src/main/java/org/infinispan/config/InfinispanConfiguration.java
@@ -95,7 +95,7 @@ public class InfinispanConfiguration implements XmlConfigurationParser, JAXBUnma
     * <p/>
     * Both configuration file and schema file are looked up in following order:
     * <p/>
-    * <ol> <li> using current thread's context ClassLoader</li> <li> if fails, the system ClassLoader</li> <li> if
+    * <ol> <li> using the specified ClassLoader</li> <li> if fails, the system ClassLoader</li> <li> if
     * fails, attempt is made to load it as a file from the disk </li> </ol>
     *
     * @param configFileName configuration file name
@@ -104,8 +104,8 @@ public class InfinispanConfiguration implements XmlConfigurationParser, JAXBUnma
     * @throws IOException if there are any issues creating InfinispanConfiguration object
     */
    public static InfinispanConfiguration newInfinispanConfiguration(String configFileName,
-                                                                    String schemaFileName) throws IOException {
-      return newInfinispanConfiguration(configFileName, schemaFileName, null);
+                                                                    String schemaFileName, ClassLoader cl) throws IOException {
+      return newInfinispanConfiguration(configFileName, schemaFileName, null, cl);
    }
 
    /**
@@ -114,7 +114,7 @@ public class InfinispanConfiguration implements XmlConfigurationParser, JAXBUnma
     * <p/>
     * Both configuration file and schema file are looked up in following order:
     * <p/>
-    * <ol> <li> using current thread's context ClassLoader</li> <li> if fails, the system ClassLoader</li> <li> if
+    * <ol> <li> using specified ClassLoader</li> <li> if fails, the system ClassLoader</li> <li> if
     * fails, attempt is made to load it as a file from the disk </li> </ol>
     *
     * @param configFileName configuration file name
@@ -124,9 +124,9 @@ public class InfinispanConfiguration implements XmlConfigurationParser, JAXBUnma
     * @throws IOException if there are any issues creating InfinispanConfiguration object
     */
    public static InfinispanConfiguration newInfinispanConfiguration(String configFileName,
-                                                                    String schemaFileName, ConfigurationBeanVisitor cbv) throws IOException {
+                                                                    String schemaFileName, ConfigurationBeanVisitor cbv, ClassLoader cl) throws IOException {
 
-      InputStream inputStream = configFileName != null ? findInputStream(configFileName, Thread.currentThread().getContextClassLoader()) : null;
+      InputStream inputStream = configFileName != null ? findInputStream(configFileName, cl) : null;
       InputStream schemaIS = schemaFileName != null ? findSchemaInputStream(schemaFileName) : null;
       try {
          return newInfinispanConfiguration(inputStream, schemaIS, cbv);
@@ -140,16 +140,16 @@ public class InfinispanConfiguration implements XmlConfigurationParser, JAXBUnma
     * <p/>
     * Configuration file is looked up in following order:
     * <p/>
-    * <ol> <li> using current thread's context ClassLoader</li> <li> if fails, the system ClassLoader</li> <li> if
+    * <ol> <li> using the specified ClassLoader</li> <li> if fails, the system ClassLoader</li> <li> if
     * fails, attempt is made to load it as a file from the disk </li> </ol>
     *
     * @param configFileName configuration file name
     * @return returns infinispan configuration
     * @throws IOException if there are any issues creating InfinispanConfiguration object
     */
-   public static InfinispanConfiguration newInfinispanConfiguration(String configFileName)
+   public static InfinispanConfiguration newInfinispanConfiguration(String configFileName, ClassLoader cl)
            throws IOException {
-      return newInfinispanConfiguration(configFileName, null);
+      return newInfinispanConfiguration(configFileName, null, cl);
    }
 
    /**
@@ -363,7 +363,8 @@ public class InfinispanConfiguration implements XmlConfigurationParser, JAXBUnma
       FileLookup fileLookup = new FileLookup();
       InputStream is = null;
       if (localPathToSchema != null) {
-         is = fileLookup.lookupFile(localPathToSchema, Thread.currentThread().getContextClassLoader());
+         // Schema's are always stored in Infinispan
+         is = fileLookup.lookupFile(localPathToSchema, null);
          if (is != null) {
             log.debugf("Using schema %s", localPathToSchema);
             return is;
@@ -375,7 +376,7 @@ public class InfinispanConfiguration implements XmlConfigurationParser, JAXBUnma
       }
 
       //2. resolve local schema path in infinispan distro
-      is = fileLookup.lookupFile(schemaPath(), Thread.currentThread().getContextClassLoader());
+      is = fileLookup.lookupFile(schemaPath(), null);
       if (is != null) {
          log.debugf("Using schema %s", schemaPath());
          return is;

--- a/core/src/main/java/org/infinispan/distribution/ch/ConsistentHashHelper.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/ConsistentHashHelper.java
@@ -69,9 +69,9 @@ public class ConsistentHashHelper {
    }
 
    private static ConsistentHash constructConsistentHashInstance(Configuration c) {
-      ConsistentHash ch = (ConsistentHash) Util.getInstance(c.getConsistentHashClass(), Thread.currentThread().getContextClassLoader());
+      ConsistentHash ch = (ConsistentHash) Util.getInstance(c.getConsistentHashClass(), c.getClassLoader());
       if (ch instanceof AbstractWheelConsistentHash) {
-         Hash h = (Hash) Util.getInstance(c.getHashFunctionClass(), Thread.currentThread().getContextClassLoader());
+         Hash h = (Hash) Util.getInstance(c.getHashFunctionClass(), c.getClassLoader());
          AbstractWheelConsistentHash wch = (AbstractWheelConsistentHash) ch;
          wch.setHashFunction(h);
          wch.setNumVirtualNodes(c.getNumVirtualNodes());

--- a/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
@@ -104,7 +104,9 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
    // component and method containers
    private final Map<String, Component> componentLookup = new HashMap<String, Component>(1);
 
-   protected static List<ModuleLifecycle> moduleLifecycles = ModuleProperties.resolveModuleLifecycles();
+   // Modules must be on the same classloader as Infinispan 
+   // TODO revise this assumption
+   protected static List<ModuleLifecycle> moduleLifecycles = ModuleProperties.resolveModuleLifecycles(null);
 
    protected volatile ComponentStatus state = ComponentStatus.INSTANTIATED;
 

--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -87,7 +87,8 @@ public class ComponentRegistry extends AbstractComponentRegistry {
          registerComponent(new BootstrapFactory(cache, configuration, this), BootstrapFactory.class);
 
          // register any module-specific commmand initializers
-         Map<Byte, ModuleCommandInitializer> initializers = ModuleProperties.moduleCommandInitializers();
+         // Moduiles are on the same classloader as Infinispan
+         Map<Byte, ModuleCommandInitializer> initializers = ModuleProperties.moduleCommandInitializers(null);
          if (initializers != null && !initializers.isEmpty()) {
             registerNonVolatileComponent(initializers, MODULE_COMMAND_INITIALIZERS);
             for (ModuleCommandInitializer mci: initializers.values()) registerNonVolatileComponent(mci, mci.getClass());

--- a/core/src/main/java/org/infinispan/factories/DataContainerFactory.java
+++ b/core/src/main/java/org/infinispan/factories/DataContainerFactory.java
@@ -69,7 +69,7 @@ public class DataContainerFactory extends AbstractNamedCacheComponentFactory imp
                         + configuration.getEvictionStrategy());
          }
       } else {
-         DataContainer dataContainer = DataContainer.class.cast(Util.getInstance(configuration.getDataContainerClass(), Thread.currentThread().getContextClassLoader()));
+         DataContainer dataContainer = DataContainer.class.cast(Util.getInstance(configuration.getDataContainerClass(), configuration.getClassLoader()));
          XmlConfigHelper.setValues(dataContainer, configuration.getDataContainerProperties(), false, true);
          return (T) dataContainer;
       }

--- a/core/src/main/java/org/infinispan/factories/EmptyConstructorFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EmptyConstructorFactory.java
@@ -44,7 +44,7 @@ import org.infinispan.util.Util;
 public class EmptyConstructorFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
    public <T> T construct(Class<T> componentType) {
       if (componentType.isInterface()) {
-         return componentType.cast(Util.getInstance(componentType.getName() + "Impl", Thread.currentThread().getContextClassLoader()));
+         return componentType.cast(Util.getInstance(componentType.getName() + "Impl", globalConfiguration.getClassLoader()));
       } else {
          return Util.getInstance(componentType);
       }

--- a/core/src/main/java/org/infinispan/factories/EmptyConstructorNamedCacheFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EmptyConstructorNamedCacheFactory.java
@@ -63,7 +63,7 @@ public class EmptyConstructorNamedCacheFactory extends AbstractNamedCacheCompone
             return componentType.cast(versionAwareMarshaller);
          } else {
             // add an "Impl" to the end of the class name and try again
-            componentImpl = loadClass(componentType.getName() + "Impl", Thread.currentThread().getContextClassLoader());
+            componentImpl = loadClass(componentType.getName() + "Impl", configuration.getClassLoader());
          }
          return componentType.cast(getInstance(componentImpl));
       } else {

--- a/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
@@ -98,7 +98,7 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
          registerComponent(new CacheManagerJmxRegistration(), CacheManagerJmxRegistration.class);
          registerComponent(new CacheManagerNotifierImpl(), CacheManagerNotifier.class);
 
-         Map<Byte, ModuleCommandFactory> factories = ModuleProperties.moduleCommandFactories();
+         Map<Byte, ModuleCommandFactory> factories = ModuleProperties.moduleCommandFactories(configuration.getClassLoader());
          if (factories != null && !factories.isEmpty())
             registerNonVolatileComponent(factories, KnownComponentNames.MODULE_COMMAND_FACTORIES);
          else

--- a/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
@@ -160,12 +160,12 @@ public class InterceptorChainFactory extends AbstractNamedCacheComponentFactory 
    @SuppressWarnings("unchecked")
    private Class<? extends CommandInterceptor> getCustomInterceptorType(CustomInterceptorConfig cfg) {
       if (cfg.getInterceptor() != null) return cfg.getInterceptor().getClass();
-      return Util.loadClass(cfg.getClassName(), Thread.currentThread().getContextClassLoader());
+      return Util.loadClass(cfg.getClassName(), configuration.getClassLoader());
    }
 
    private CommandInterceptor getOrCreateCustomInterceptor(CustomInterceptorConfig cfg) {
       if (cfg.getInterceptor() != null) return cfg.getInterceptor();
-      return (CommandInterceptor) Util.getInstance(cfg.getClassName(), Thread.currentThread().getContextClassLoader());
+      return (CommandInterceptor) Util.getInstance(cfg.getClassName(), configuration.getClassLoader());
    }
 
    private void buildCustomInterceptors(InterceptorChain interceptorChain, List<CustomInterceptorConfig> customInterceptors) {

--- a/core/src/main/java/org/infinispan/factories/MarshallerFactory.java
+++ b/core/src/main/java/org/infinispan/factories/MarshallerFactory.java
@@ -36,6 +36,6 @@ import org.infinispan.util.Util;
 public class MarshallerFactory extends EmptyConstructorFactory implements AutoInstantiableFactory {
    @Override
    public <T> T construct(Class<T> componentType) {
-      return componentType.cast(Util.getInstance(globalConfiguration.getMarshallerClass(), Thread.currentThread().getContextClassLoader()));
+      return componentType.cast(Util.getInstance(globalConfiguration.getMarshallerClass(), globalConfiguration.getClassLoader()));
    }
 }

--- a/core/src/main/java/org/infinispan/factories/NamedExecutorsFactory.java
+++ b/core/src/main/java/org/infinispan/factories/NamedExecutorsFactory.java
@@ -103,7 +103,7 @@ public class NamedExecutorsFactory extends NamedComponentFactory implements Auto
    private ExecutorService buildAndConfigureExecutorService(String factoryName, Properties p, String componentName) throws Exception {
       Properties props = new Properties(p); // defensive copy
       if (p != null && !p.isEmpty()) props.putAll(p);
-      ExecutorFactory f = (ExecutorFactory) Util.getInstance(factoryName, Thread.currentThread().getContextClassLoader());
+      ExecutorFactory f = (ExecutorFactory) Util.getInstance(factoryName, globalConfiguration.getClassLoader());
       setComponentName(componentName, props);
       setDefaultThreads(KnownComponentNames.getDefaultThreads(componentName), props);
       setDefaultThreadPrio(KnownComponentNames.getDefaultThreadPrio(componentName), props);
@@ -113,7 +113,7 @@ public class NamedExecutorsFactory extends NamedComponentFactory implements Auto
    private ScheduledExecutorService buildAndConfigureScheduledExecutorService(String factoryName, Properties p, String componentName) throws Exception {
       Properties props = new Properties(); // defensive copy
       if (p != null && !p.isEmpty()) props.putAll(p);
-      ScheduledExecutorFactory f = (ScheduledExecutorFactory) Util.getInstance(factoryName, Thread.currentThread().getContextClassLoader());
+      ScheduledExecutorFactory f = (ScheduledExecutorFactory) Util.getInstance(factoryName, globalConfiguration.getClassLoader());
       setComponentName(componentName, props);
       setDefaultThreadPrio(KnownComponentNames.getDefaultThreadPrio(componentName), props);
       return f.getScheduledExecutor(props);

--- a/core/src/main/java/org/infinispan/factories/ReplicationQueueFactory.java
+++ b/core/src/main/java/org/infinispan/factories/ReplicationQueueFactory.java
@@ -42,7 +42,7 @@ public class ReplicationQueueFactory extends EmptyConstructorNamedCacheFactory i
          if (type == null)
             return super.construct(componentType);
          else
-            return (T) super.construct(Util.loadClass(type, Thread.currentThread().getContextClassLoader()));
+            return (T) super.construct(Util.loadClass(type, configuration.getClassLoader()));
       } else {
          return null;
       }

--- a/core/src/main/java/org/infinispan/factories/TransactionManagerFactory.java
+++ b/core/src/main/java/org/infinispan/factories/TransactionManagerFactory.java
@@ -22,12 +22,15 @@
  */
 package org.infinispan.factories;
 
-import org.infinispan.factories.annotations.DefaultFactoryFor;
-import org.infinispan.transaction.tm.BatchModeTransactionManager;
-import org.infinispan.transaction.lookup.TransactionManagerLookup;
-import org.infinispan.util.Util;
+import java.lang.reflect.InvocationTargetException;
 
 import javax.transaction.TransactionManager;
+
+import org.infinispan.config.Configuration;
+import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.transaction.lookup.TransactionManagerLookup;
+import org.infinispan.transaction.tm.BatchModeTransactionManager;
+import org.infinispan.util.Util;
 
 /**
  * Uses a number of mechanisms to retrieve a transaction manager.
@@ -46,12 +49,13 @@ public class TransactionManagerFactory extends AbstractNamedCacheComponentFactor
       if (lookup == null) {
          // Nope. See if we can look it up from JNDI
          if (configuration.getTransactionManagerLookupClass() != null) {
-            lookup = (TransactionManagerLookup) Util.getInstance(configuration.getTransactionManagerLookupClass(), Thread.currentThread().getContextClassLoader());
+            lookup = (TransactionManagerLookup) Util.getInstance(configuration.getTransactionManagerLookupClass(), configuration.getClassLoader());
          }
       }
 
       try {
          if (lookup != null) {
+            componentRegistry.wireDependencies(lookup);
             transactionManager = lookup.getTransactionManager();
          }
       }

--- a/core/src/main/java/org/infinispan/factories/TransportFactory.java
+++ b/core/src/main/java/org/infinispan/factories/TransportFactory.java
@@ -39,6 +39,6 @@ public class TransportFactory extends AbstractComponentFactory implements AutoIn
    public <T> T construct(Class<T> componentType) {
       String transportClass = globalConfiguration.getTransportClass();
       if (transportClass == null) return null;
-      return (T) Util.getInstance(transportClass, Thread.currentThread().getContextClassLoader());
+      return (T) Util.getInstance(transportClass, globalConfiguration.getClassLoader());
    }
 }

--- a/core/src/main/java/org/infinispan/loaders/CacheLoaderConfig.java
+++ b/core/src/main/java/org/infinispan/loaders/CacheLoaderConfig.java
@@ -83,7 +83,7 @@ class CacheLoaderConfigAdapter extends XmlAdapter<AbstractCacheStoreConfig, Cach
 
       CacheLoaderConfig clc;
       try {
-         clc = instantiateCacheLoaderConfig(clClass);
+         clc = instantiateCacheLoaderConfig(clClass, Thread.currentThread().getContextClassLoader());
       } catch (Exception e) {
          throw new ConfigurationException("Unable to instantiate cache loader or configuration", e);
       }
@@ -106,9 +106,9 @@ class CacheLoaderConfigAdapter extends XmlAdapter<AbstractCacheStoreConfig, Cach
       return clc;
    }
 
-   private CacheLoaderConfig instantiateCacheLoaderConfig(String cacheLoaderImpl) throws Exception {
+   private CacheLoaderConfig instantiateCacheLoaderConfig(String cacheLoaderImpl, ClassLoader classLoader) throws Exception {
       // first see if the type is annotated
-      Class<? extends CacheLoaderConfig> clazz = Util.loadClass(cacheLoaderImpl, Thread.currentThread().getContextClassLoader());
+      Class<? extends CacheLoaderConfig> clazz = Util.loadClass(cacheLoaderImpl, classLoader);
       Class<? extends CacheLoaderConfig> cacheLoaderConfigType;
       CacheLoaderMetadata metadata = clazz.getAnnotation(CacheLoaderMetadata.class);
       if (metadata == null) {

--- a/core/src/main/java/org/infinispan/loaders/CacheLoaderManagerImpl.java
+++ b/core/src/main/java/org/infinispan/loaders/CacheLoaderManagerImpl.java
@@ -256,7 +256,7 @@ public class CacheLoaderManagerImpl implements CacheLoaderManager {
    }
 
    CacheLoader createCacheLoader(CacheLoaderConfig cfg, AdvancedCache<Object, Object> cache) throws Exception {
-      CacheLoader tmpLoader = (CacheLoader) Util.getInstance(cfg.getCacheLoaderClassName(), Thread.currentThread().getContextClassLoader());
+      CacheLoader tmpLoader = (CacheLoader) Util.getInstance(cfg.getCacheLoaderClassName(), cache.getClassLoader());
 
       if (tmpLoader != null) {
          if (cfg instanceof CacheStoreConfig) {

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -251,7 +251,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
       try {
          InfinispanConfiguration configuration = InfinispanConfiguration.newInfinispanConfiguration(
                  configurationFile, InfinispanConfiguration.resolveSchemaPath(),
-                getConfigurationVisitors());
+                getConfigurationVisitors(), Thread.currentThread().getContextClassLoader());
 
          globalConfiguration = configuration.parseGlobalConfiguration();
          defaultConfiguration = configuration.parseDefaultConfiguration();
@@ -336,20 +336,20 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
       try {
          InfinispanConfiguration gconfiguration = InfinispanConfiguration.newInfinispanConfiguration(
                  globalConfigurationFile, InfinispanConfiguration.resolveSchemaPath(),
-                 getConfigurationVisitors());
+                 getConfigurationVisitors(), Thread.currentThread().getContextClassLoader());
 
          globalConfiguration = gconfiguration.parseGlobalConfiguration();
 
          InfinispanConfiguration dconfiguration = InfinispanConfiguration.newInfinispanConfiguration(
                  defaultConfigurationFile, InfinispanConfiguration.resolveSchemaPath(),
-                 getConfigurationVisitors());
+                 getConfigurationVisitors(), Thread.currentThread().getContextClassLoader());
 
          defaultConfiguration = dconfiguration.parseDefaultConfiguration();
 
          if (namedCacheFile != null) {
             InfinispanConfiguration NCconfiguration = InfinispanConfiguration.newInfinispanConfiguration(
                     namedCacheFile, InfinispanConfiguration.resolveSchemaPath(),
-                    getConfigurationVisitors());
+                    getConfigurationVisitors(), Thread.currentThread().getContextClassLoader());
 
             for (Map.Entry<String, Configuration> entry : NCconfiguration.parseNamedConfigurations().entrySet()) {
                Configuration c = defaultConfiguration.clone();
@@ -801,7 +801,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
    protected ConfigurationBeanVisitor getConfigurationVisitors(){
       return new DelegatingConfigurationVisitor(new ConfigurationBeanVisitor[] {
                new ConfigurationValidatingVisitor(), new TimeoutConfigurationValidatingVisitor() });
-   }   
+   }
 }
 
 class CacheWrapper {

--- a/core/src/main/java/org/infinispan/marshall/exts/ReplicableCommandExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/ReplicableCommandExternalizer.java
@@ -129,7 +129,7 @@ public class ReplicableCommandExternalizer extends AbstractExternalizer<Replicab
             RemoveCommand.class, ReplaceCommand.class,
             RemoveCacheCommand.class, RemoveRecoveryInfoCommand.class, GetInDoubtTransactionsCommand.class,
             GetInDoubtTxInfoCommand.class, CompleteTransactionCommand.class);
-      Collection<Class<? extends ReplicableCommand>> moduleCommands = ModuleProperties.moduleCommands();
+      Collection<Class<? extends ReplicableCommand>> moduleCommands = ModuleProperties.moduleCommands(null);
       if (moduleCommands != null && !moduleCommands.isEmpty()) coreCommands.addAll(moduleCommands);
       return coreCommands;
    }

--- a/core/src/main/java/org/infinispan/marshall/exts/SingletonListExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/SingletonListExternalizer.java
@@ -61,7 +61,8 @@ public class SingletonListExternalizer extends AbstractExternalizer<List<?>> {
 
    @Override
    public Set<Class<? extends List<?>>> getTypeClasses() {
-      return Util.<Class<? extends List<?>>>asSet(Util.<List<?>>loadClass("java.util.Collections$SingletonList", Thread.currentThread().getContextClassLoader()));
+      // This is loadable from any classloader
+      return Util.<Class<? extends List<?>>>asSet(Util.<List<?>>loadClass("java.util.Collections$SingletonList", null));
    }
 
 }

--- a/core/src/main/java/org/infinispan/marshall/jboss/ExternalizerTable.java
+++ b/core/src/main/java/org/infinispan/marshall/jboss/ExternalizerTable.java
@@ -288,7 +288,7 @@ class ExternalizerTable implements ObjectTable {
       List<AdvancedExternalizerConfig> configs = globalCfg.getExternalizers();
       for (AdvancedExternalizerConfig config : configs) {
          AdvancedExternalizer ext = config.getAdvancedExternalizer() != null ? config.getAdvancedExternalizer()
-               : (AdvancedExternalizer) Util.getInstance(config.getExternalizerClass(), Thread.currentThread().getContextClassLoader());
+               : (AdvancedExternalizer) Util.getInstance(config.getExternalizerClass(), globalCfg.getClassLoader());
 
          // If no XML or programmatic config, id in annotation is used
          // as long as it's not default one (meaning, user did not set it).

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -259,6 +259,7 @@ public class JGroupsTransport extends AbstractTransport implements ExtendedMembe
       dispatcher.setResponseMarshaller(adapter);
    }
 
+   // This is per CM, so the CL in use should be the CM CL
    private void buildChannel() {
       // in order of preference - we first look for an external JGroups file, then a set of XML properties, and
       // finally the legacy JGroups String properties.
@@ -268,7 +269,7 @@ public class JGroupsTransport extends AbstractTransport implements ExtendedMembe
             String channelLookupClassName = props.getProperty(CHANNEL_LOOKUP);
 
             try {
-               JGroupsChannelLookup lookup = (JGroupsChannelLookup) Util.getInstance(channelLookupClassName, Thread.currentThread().getContextClassLoader());
+               JGroupsChannelLookup lookup = (JGroupsChannelLookup) Util.getInstance(channelLookupClassName, configuration.getClassLoader());
                channel = lookup.getJGroupsChannel(props);
                startChannel = lookup.shouldStartAndConnect();
                stopChannel = lookup.shouldStopAndDisconnect();
@@ -282,7 +283,7 @@ public class JGroupsTransport extends AbstractTransport implements ExtendedMembe
          if (channel == null && props.containsKey(CONFIGURATION_FILE)) {
             cfg = props.getProperty(CONFIGURATION_FILE);
             try {
-               channel = new JChannel(new FileLookup().lookupFileLocation(cfg, Thread.currentThread().getContextClassLoader()));
+               channel = new JChannel(new FileLookup().lookupFileLocation(cfg, configuration.getClassLoader()));
             } catch (Exception e) {
                log.errorCreatingChannelFromConfigFile(cfg);
                throw new CacheException(e);
@@ -313,7 +314,7 @@ public class JGroupsTransport extends AbstractTransport implements ExtendedMembe
       if (channel == null) {
          log.unableToUseJGroupsPropertiesProvided(props);
          try {
-            channel = new JChannel(new FileLookup().lookupFileLocation(DEFAULT_JGROUPS_CONFIGURATION_FILE, Thread.currentThread().getContextClassLoader()));
+            channel = new JChannel(new FileLookup().lookupFileLocation(DEFAULT_JGROUPS_CONFIGURATION_FILE, configuration.getClassLoader()));
          } catch (ChannelException e) {
             throw new CacheException("Unable to start JGroups channel", e);
          }

--- a/core/src/main/java/org/infinispan/util/EnumerationList.java
+++ b/core/src/main/java/org/infinispan/util/EnumerationList.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2008, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.infinispan.util;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+
+/**
+ * An Enumeration -> List adaptor
+ *  
+ * @author Pete Muir
+ */
+public class EnumerationList<T> extends ForwardingList<T>
+{
+   // The enumeration as a list
+   private final List<T> list = new ArrayList<T>();
+   
+   /**
+    * Constructor
+    * 
+    * @param enumeration The enumeration
+    */
+   public EnumerationList(Enumeration<T> enumeration)
+   {
+      while (enumeration.hasMoreElements())
+      {
+         list.add(enumeration.nextElement());
+      }
+   }
+
+   @Override
+   protected List<T> delegate()
+   {
+      return list;
+   }
+}

--- a/core/src/main/java/org/infinispan/util/ForwardingList.java
+++ b/core/src/main/java/org/infinispan/util/ForwardingList.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2007 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.infinispan.util;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+/**
+ * A list which forwards all its method calls to another list. Subclasses should override one or more methods to modify the
+ * behavior of the backing list as desired per the <a href="http://en.wikipedia.org/wiki/Decorator_pattern">decorator
+ * pattern</a>.
+ * 
+ * <p>
+ * This class does not implement {@link java.util.RandomAccess}. If the delegate supports random access, the
+ * {@code ForwardingList} subclass should implement the {@code RandomAccess} interface.
+ * 
+ * @author Mike Bostock
+ * @since 2 (imported from Google Collections Library)
+ */
+public abstract class ForwardingList<E> implements List<E> {
+
+   /** Constructor for use by subclasses. */
+   protected ForwardingList() {
+   }
+
+   protected abstract List<E> delegate();
+
+   public void add(int index, E element) {
+      delegate().add(index, element);
+   }
+
+   public boolean addAll(int index, Collection<? extends E> elements) {
+      return delegate().addAll(index, elements);
+   }
+
+   public E get(int index) {
+      return delegate().get(index);
+   }
+
+   public int indexOf(Object element) {
+      return delegate().indexOf(element);
+   }
+
+   public int lastIndexOf(Object element) {
+      return delegate().lastIndexOf(element);
+   }
+
+   public ListIterator<E> listIterator() {
+      return delegate().listIterator();
+   }
+
+   public ListIterator<E> listIterator(int index) {
+      return delegate().listIterator(index);
+   }
+
+   public E remove(int index) {
+      return delegate().remove(index);
+   }
+
+   public E set(int index, E element) {
+      return delegate().set(index, element);
+   }
+
+   public List<E> subList(int fromIndex, int toIndex) {
+      return delegate().subList(fromIndex, toIndex);
+   }
+
+   @Override
+   public boolean equals(Object object) {
+      return object == this || delegate().equals(object);
+   }
+
+   @Override
+   public int hashCode() {
+      return delegate().hashCode();
+   }
+
+   public Iterator<E> iterator() {
+      return delegate().iterator();
+   }
+
+   public int size() {
+      return delegate().size();
+   }
+
+   public boolean removeAll(Collection<?> collection) {
+      return delegate().removeAll(collection);
+   }
+
+   public boolean isEmpty() {
+      return delegate().isEmpty();
+   }
+
+   public boolean contains(Object object) {
+      return delegate().contains(object);
+   }
+
+   public Object[] toArray() {
+      return delegate().toArray();
+   }
+
+   public <T> T[] toArray(T[] array) {
+      return delegate().toArray(array);
+   }
+
+   public boolean add(E element) {
+      return delegate().add(element);
+   }
+
+   public boolean remove(Object object) {
+      return delegate().remove(object);
+   }
+
+   public boolean containsAll(Collection<?> collection) {
+      return delegate().containsAll(collection);
+   }
+
+   public boolean addAll(Collection<? extends E> collection) {
+      return delegate().addAll(collection);
+   }
+
+   public boolean retainAll(Collection<?> collection) {
+      return delegate().retainAll(collection);
+   }
+
+   public void clear() {
+      delegate().clear();
+   }
+
+}

--- a/core/src/main/java/org/infinispan/util/Util.java
+++ b/core/src/main/java/org/infinispan/util/Util.java
@@ -265,16 +265,6 @@ public final class Util {
       return (a == b) || (a != null && a.equals(b));
    }
 
-   public static InputStream loadResourceAsStream(String resource) {
-      ClassLoader cl = Thread.currentThread().getContextClassLoader();
-      InputStream s = cl.getResourceAsStream(resource);
-      if (s == null) {
-         cl = Util.class.getClassLoader();
-         s = cl.getResourceAsStream(resource);
-      }
-      return s;
-   }
-
    /**
     * Static inner class that holds 3 maps - for data added, removed and modified.
     */

--- a/core/src/main/java/org/infinispan/util/logging/LogFactory.java
+++ b/core/src/main/java/org/infinispan/util/logging/LogFactory.java
@@ -22,7 +22,6 @@
  */
 package org.infinispan.util.logging;
 
-import org.infinispan.util.Util;
 import org.jboss.logging.Logger;
 import org.jboss.logging.NDC;
 
@@ -34,25 +33,11 @@ import org.jboss.logging.NDC;
  */
 public class LogFactory {
 
-   public static final boolean IS_LOG4J_AVAILABLE;
-
-   static {
-      boolean available;
-      try {
-         Util.loadClassStrict("org.apache.log4j.Logger", Thread.currentThread().getContextClassLoader());
-         available = true;
-      }
-      catch (ClassNotFoundException cnfe) {
-         available = false;
-      }
-      IS_LOG4J_AVAILABLE = available;
-   }
-
-   public static Log getLog(Class clazz) {
+   public static Log getLog(Class<?> clazz) {
       return Logger.getMessageLogger(Log.class, clazz.getName());
    }
 
-   public static <T> T getLog(Class clazz, Class<T> logClass) {
+   public static <T> T getLog(Class<?> clazz, Class<T> logClass) {
       return Logger.getMessageLogger(logClass, clazz.getName());
    }
 

--- a/core/src/test/java/org/infinispan/config/parsing/XmlFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/config/parsing/XmlFileParsingTest.java
@@ -60,7 +60,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
    public void testNamedCacheFileJaxb() throws Exception {
       String schemaFileName = String.format("infinispan-config-%s.xsd", Version.MAJOR_MINOR);
       testNamedCacheFile(InfinispanConfiguration.newInfinispanConfiguration(
-            "configs/named-cache-test.xml", "schema/" + schemaFileName, new ConfigurationValidatingVisitor()));
+            "configs/named-cache-test.xml", "schema/" + schemaFileName, new ConfigurationValidatingVisitor(), Thread.currentThread().getContextClassLoader()));
    }
    
    public void testNamedCacheFileWithAllValidators() throws Exception {
@@ -69,17 +69,17 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
                "configs/named-cache-test.xml", "schema/" + schemaFileName,
                new DelegatingConfigurationVisitor(new ConfigurationBeanVisitor[] {
                         new ConfigurationValidatingVisitor(),
-                        new TimeoutConfigurationValidatingVisitor()})));
+                        new TimeoutConfigurationValidatingVisitor()}), Thread.currentThread().getContextClassLoader()));
    }
 
    public void testConfigurationMergingJaxb() throws Exception {
       testConfigurationMerging(InfinispanConfiguration
-            .newInfinispanConfiguration("configs/named-cache-test.xml"));
+            .newInfinispanConfiguration("configs/named-cache-test.xml", Thread.currentThread().getContextClassLoader()));
    }
 
    public void testConfigSampleAllValidation() throws Exception {
       String schemaFileName = String.format("infinispan-config-%s.xsd", Version.MAJOR_MINOR);
-      InfinispanConfiguration.newInfinispanConfiguration("config-samples/sample.xml", "schema/" + schemaFileName, new ConfigurationValidatingVisitor());
+      InfinispanConfiguration.newInfinispanConfiguration("config-samples/sample.xml", "schema/" + schemaFileName, new ConfigurationValidatingVisitor(), Thread.currentThread().getContextClassLoader());
    }
 
    public void testNoNamedCaches() throws Exception {

--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -75,7 +75,8 @@ public class TestCacheManagerFactory {
       InfinispanConfiguration parser = InfinispanConfiguration.newInfinispanConfiguration(
             xmlFile,
             InfinispanConfiguration.resolveSchemaPath(),
-            new ConfigurationValidatingVisitor());
+            new ConfigurationValidatingVisitor(),
+            Thread.currentThread().getContextClassLoader());
       return fromConfigFileParser(parser, allowDupeDomains);
    }
 

--- a/core/src/test/java/org/infinispan/tx/TransactionManagerLookupTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionManagerLookupTest.java
@@ -22,6 +22,7 @@
  */
 package org.infinispan.tx;
 
+import org.infinispan.config.Configuration;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
 import org.infinispan.transaction.lookup.GenericTransactionManagerLookup;
@@ -39,9 +40,13 @@ import javax.transaction.TransactionManager;
  */
 @Test(testName = "tx.TransactionManagerLookupTest", groups = "unit")
 public class TransactionManagerLookupTest extends AbstractInfinispanTest {
+   
+   Configuration configuration = new Configuration();
 
    public void testGenericTransactionManagerLookup() throws Exception {
-      doTest(new GenericTransactionManagerLookup());
+      GenericTransactionManagerLookup lookup = new GenericTransactionManagerLookup();
+      lookup.setConfiguration(configuration);
+      doTest(lookup);
    }
 
    public void testDummyTransactionManagerLookup() throws Exception {
@@ -49,7 +54,9 @@ public class TransactionManagerLookupTest extends AbstractInfinispanTest {
    }
 
    public void testJBossStandaloneJTAManagerLookup() throws Exception {
-      doTest(new JBossStandaloneJTAManagerLookup());
+      JBossStandaloneJTAManagerLookup lookup = new JBossStandaloneJTAManagerLookup();
+      lookup.init(configuration);
+      doTest(lookup);
    }
    
    protected void doTest(TransactionManagerLookup lookup) throws Exception {


### PR DESCRIPTION
- Introduces a CacheManager scoped configured classloader. This
  can be configured via GlobalConfiguration. It is not overridable
  once the CacheManager has been configured. This is mostly used
  for loading configuration files and CM scoped pluggable
  implementations
- Introduces a Named Cache scoped configured classloader. This
  can be configured via Configuration. It is currently not overridable
  but will be overidable per cache usage for certain uses in a future
  commit for this issue
- There are also some decisions to explicitly use the TCCL (eg. in
  DefaultCacheManager where we explicitly document that a file is
  loaded from the classpath for a given name. Passing a classloader
  in here is redundent, simpler to just pass in an InputStream).
- Various cleanup which can remove TCCL use

This issue still needs:
- Override of Named Cache scoped classloader
- Replacement outside of core (requires discussion with appropriate developers)
- Removal of TCCL in a couple more cases I couldn't figure out yet
- TESTS!!!!
