### PR TITLE
ISPN-1171 - State transfer should not write anything to the shared cache store or clear any cache store

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -66,6 +66,7 @@ import java.util.Set;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.infinispan.context.Flag.CACHE_MODE_LOCAL;
+import static org.infinispan.context.Flag.SKIP_SHARED_CACHE_STORE;
 
 public class StateTransferManagerImpl implements StateTransferManager {
 
@@ -313,8 +314,6 @@ public class StateTransferManagerImpl implements StateTransferManager {
             boolean canProvideState = (Boolean) marshaller.objectFromObjectStream(oi);
             if (canProvideState) {
                assertDelimited(oi);
-               // First clear the cache store!!
-               if (cs != null) cs.clear();
                if (transientState) applyInMemoryState(oi);
                assertDelimited(oi);
                if (persistentState) applyPersistentState(oi);
@@ -343,7 +342,7 @@ public class StateTransferManagerImpl implements StateTransferManager {
       try {
          Set<InternalCacheEntry> set = (Set<InternalCacheEntry>) marshaller.objectFromObjectStream(i);
          for (InternalCacheEntry se : set)
-            cache.withFlags(CACHE_MODE_LOCAL).put(se.getKey(), se.getValue(), se.getLifespan(), MILLISECONDS, se.getMaxIdle(), MILLISECONDS);
+            cache.withFlags(CACHE_MODE_LOCAL, SKIP_SHARED_CACHE_STORE).put(se.getKey(), se.getValue(), se.getLifespan(), MILLISECONDS, se.getMaxIdle(), MILLISECONDS);
       } catch (Exception e) {
          dataContainer.clear();
          throw new StateTransferException(e);

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -709,9 +709,12 @@ public interface Log extends BasicLogger {
    @LogMessage(level = ERROR)
    @Message(value = "Error invalidating keys from L1 after rehash", id = 147)
    void failedToInvalidateKeys(@Cause Throwable t);
-   
+
    @LogMessage(level = WARN)
    @Message(value = "Invalid %s value of %s. It can not be higher than %s which is %s", id = 148)
    void invalidTimeoutValue(Object configName1, Object value1, Object configName2, Object value2);
-   
+
+   @LogMessage(level = WARN)
+   @Message(value = "Fetch persistent state and purge on startup are both disabled, cache may contain stale entries on startup")
+   void staleEntriesWithoutFetchPersistentStateOrPurgeOnStartup();
 }


### PR DESCRIPTION
ISPN-1171 - State transfer should not write anything to the shared cache store or clear any cache store
https://issues.jboss.org/browse/ISPN-1171
- Don't clear the cache store before state transfer, use purgeOnStartup for that.
- Don't write to a shared cache store during state transfer.
- Warning about stale entries when fetch persistent state and purge on startup are both disabled.
