### PR TITLE
ISPN-1178 Failing to start a cache hides the error as the logging message

### DIFF
--- a/core/src/main/java/org/infinispan/util/Proxies.java
+++ b/core/src/main/java/org/infinispan/util/Proxies.java
@@ -87,7 +87,7 @@ public class Proxies {
             try {
                 result = m.invoke(obj, args);
             } catch (Throwable t) {
-                log.ignoringException(m.getName(), t.getCause());
+                log.ignoringException(m.getName(), t.getMessage(), t.getCause());
             } finally {
             }
             return result;

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -595,7 +595,7 @@ public interface Log extends BasicLogger {
 
    @LogMessage(level = WARN)
    @Message(value = "Invocation of %s threw an exception %s. Exception is ignored.", id = 120)
-   void ignoringException(String name, @Cause Throwable t);
+   void ignoringException(String methodName, String exceptionName, @Cause Throwable t);
 
    @LogMessage(level = ERROR)
    @Message(value = "Unable to set value!", id = 121)


### PR DESCRIPTION
ISPN-1178 Failing to start a cache hides the error as the logging message is wrong
https://issues.jboss.org/browse/ISPN-1178
