### PR TITLE
ISPN-1161 Separate JAXB method from programmatic config method

### DIFF
--- a/core/src/main/java/org/infinispan/config/CacheLoaderManagerConfig.java
+++ b/core/src/main/java/org/infinispan/config/CacheLoaderManagerConfig.java
@@ -192,11 +192,24 @@ public class CacheLoaderManagerConfig extends AbstractFluentConfigurationBean im
       return cacheLoaderConfigs;
    }
 
+   // JAXB method
+   private List<CacheLoaderConfig> getCacheLoaders() {
+      testImmutability("cacheLoaderConfigs");
+      return cacheLoaderConfigs;
+   }
+
+   // JAXB method
+   @XmlElement(name = "loader")
+   private LoadersConfig setCacheLoaders(List<CacheLoaderConfig> configs) {
+      testImmutability("cacheLoaderConfigs");
+      this.cacheLoaderConfigs = configs == null ? new LinkedList<CacheLoaderConfig>() : configs;
+      return this;
+   }
+
    /**
     * @deprecated The visibility of this method will be reduced and
     * XMLElement definition is likely to move to the getCacheLoaderConfigs().
     */
-   @XmlElement(name = "loader")
    @Deprecated
    public LoadersConfig setCacheLoaderConfigs(List<CacheLoaderConfig> configs) {
       testImmutability("cacheLoaderConfigs");


### PR DESCRIPTION
It's one of the annoying things of having methods that are both used for JAXB and programmatic configuration. Concerns get mixed and you end up with silly errors like that. I've now separated JAXB and programmatic config methods marking it clear which are JAXB, generally these should all be private.

As we all know, this will all be revised for https://issues.jboss.org/browse/ISPN-1065
