### PR TITLE
ISPN-1183 Global config should be injected when starting a DCM from XML

### DIFF
--- a/core/src/main/java/org/infinispan/config/FluentGlobalConfiguration.java
+++ b/core/src/main/java/org/infinispan/config/FluentGlobalConfiguration.java
@@ -33,6 +33,7 @@ import org.infinispan.marshall.AdvancedExternalizer;
 import org.infinispan.marshall.Marshaller;
 import org.infinispan.remoting.transport.Transport;
 
+import javax.sound.midi.SysexMessage;
 import java.util.Properties;
 
 /**
@@ -330,8 +331,9 @@ abstract class AbstractConfigurationBeanWithGCR extends AbstractConfigurationBea
    GlobalConfiguration globalConfig;
 
    @Inject
-   public void inject(GlobalComponentRegistry gcr) {
+   public void inject(GlobalComponentRegistry gcr, GlobalConfiguration globalConfig) {
       this.gcr = gcr;
+      this.globalConfig = globalConfig;
    }
 
    @Override

--- a/server/rest/src/test/scala/org/infinispan/rest/ServerInstance.scala
+++ b/server/rest/src/test/scala/org/infinispan/rest/ServerInstance.scala
@@ -45,6 +45,7 @@ object ServerInstance {
     
     val sh = new ServletHolder(classOf[StartupListener])
     sh setInitOrder 1
+    sh.setInitParameter("infinispan.config", "config-samples/sample.xml")
     
     ctx.addServlet(sh, "/listener/*")
   }


### PR DESCRIPTION
Since testing startup of sample.xml in core/ module could cause JMX or
other JGroups issues with tests running in paralell, the easiest to
verify this is to make REST server which has only one test class test
with the XML configuration that the .war archive is configured with.
