### PR TITLE
ISPN-1182 Timeout updating topology should lead to retry and not fail

### DIFF
--- a/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
@@ -39,6 +39,8 @@ trait Log {
 
    def debug(msg: => String, param1: Any) = log.debugf(msg, param1)
 
+   def debug(t: Throwable, msg: => String, param1: Any) = log.debugf(t, msg, param1)
+
    def debug(msg: => String, param1: Any, param2: Any) =
       log.debugf(msg, param1, param2)
 

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDistributionTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDistributionTest.scala
@@ -51,32 +51,32 @@ class HotRodDistributionTest extends HotRodMultiNodeTest {
 
    def testDistributedPutWithTopologyChanges(m: Method) {
       var resp = clients.head.ping(3, 0)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       var expectedHashIds = generateExpectedHashIds
       assertHashTopologyReceived(resp.topologyResponse.get, servers, expectedHashIds)
 
       resp = clients.head.put(k(m) , 0, 0, v(m), 1, 0)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
       assertSuccess(clients.tail.head.get(k(m), 0), v(m))
       resp = clients.head.put(k(m) , 0, 0, v(m, "v1-"), 2, 0)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertTopologyReceived(resp.topologyResponse.get, servers)
       resp = clients.tail.head.put(k(m) , 0, 0, v(m, "v2-"), 2, 1)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertTopologyReceived(resp.topologyResponse.get, servers)
       resp = clients.head.put(k(m) , 0, 0, v(m, "v3-"), 2, 2)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
       assertSuccess(clients.tail.head.get(k(m), 0), v(m, "v3-"))
 
       resp = clients.head.put(k(m) , 0, 0, v(m, "v4-"), 3, 0)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       expectedHashIds = generateExpectedHashIds
       assertHashTopologyReceived(resp.topologyResponse.get, servers, expectedHashIds)
       assertSuccess(clients.tail.head.get(k(m), 0), v(m, "v4-"))
       resp = clients.tail.head.put(k(m) , 0, 0, v(m, "v5-"), 3, 1)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       expectedHashIds = generateExpectedHashIds
       assertHashTopologyReceived(resp.topologyResponse.get, servers, expectedHashIds)
       assertSuccess(clients.tail.head.get(k(m), 0), v(m, "v5-"))
@@ -89,7 +89,7 @@ class HotRodDistributionTest extends HotRodMultiNodeTest {
          log.trace("New client started, modify key to be v6-*")
          resp = newClient.put(k(m) , 0, 0, v(m, "v6-"), 3, 2)
          // resp = clients.tail.head.put(k(m) , 0, 0, v(m, "v6-"), 3, 2)
-         assertStatus(resp.status, Success)
+         assertStatus(resp, Success)
          val hashTopologyResp = resp.topologyResponse.get.asInstanceOf[HashDistAwareResponse]
          assertEquals(hashTopologyResp.view.topologyId, 3)
          assertEquals(hashTopologyResp.view.members.size, 3)
@@ -112,7 +112,7 @@ class HotRodDistributionTest extends HotRodMultiNodeTest {
       }
 
       resp = clients.tail.head.put(k(m) , 0, 0, v(m, "v7-"), 3, 3)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       val hashTopologyResp = resp.topologyResponse.get.asInstanceOf[HashDistAwareResponse]
       assertEquals(hashTopologyResp.view.topologyId, 4)
       assertEquals(hashTopologyResp.view.members.size, 2)

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodFunctionalTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodFunctionalTest.scala
@@ -64,15 +64,15 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
    }
 
    def testPutOnDefaultCache(m: Method) {
-      val status = client.execute(0xA0, 0x01, "", k(m), 0, 0, v(m), 0, 1, 0).status
-      assertStatus(status, Success)
+      val resp = client.execute(0xA0, 0x01, "", k(m), 0, 0, v(m), 0, 1, 0)
+      assertStatus(resp, Success)
       val cache = cacheManager.getCache[ByteArrayKey, CacheValue]()
       val value = cache.get(new ByteArrayKey(k(m)))
       assertTrue(Arrays.equals(value.data, v(m)));
    }
 
    def testPutOnUndefinedCache(m: Method) {
-      var resp = client.execute(0xA0, 0x01, "boomooo", k(m), 0, 0, v(m), 0, 1, 0).asInstanceOf[TestErrorResponse]
+      val resp = client.execute(0xA0, 0x01, "boomooo", k(m), 0, 0, v(m), 0, 1, 0).asInstanceOf[TestErrorResponse]
       assertTrue(resp.msg.contains("CacheNotFoundException"))
       assertEquals(resp.status, ParseError, "Status should have been 'ParseError' but instead was: " + resp.status)
       client.assertPut(m)
@@ -99,7 +99,7 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
 
    def testPutWithPreviousValue(m: Method) {
       var resp = client.put(k(m) , 0, 0, v(m), 1).asInstanceOf[TestResponseWithPrevious]
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.previous, None)
       resp = client.put(k(m) , 0, 0, v(m, "v2-"), 1).asInstanceOf[TestResponseWithPrevious]
       assertSuccess(resp, v(m))
@@ -115,73 +115,73 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
    }
 
    def testPutIfAbsentNotExist(m: Method) {
-      val status = client.putIfAbsent(k(m) , 0, 0, v(m)).status
-      assertStatus(status, Success)
+      val resp = client.putIfAbsent(k(m) , 0, 0, v(m))
+      assertStatus(resp, Success)
    }
 
    def testPutIfAbsentExist(m: Method) {
       client.assertPut(m)
-      val status = client.putIfAbsent(k(m) , 0, 0, v(m, "v2-")).status
-      assertStatus(status, OperationNotExecuted)
+      val resp = client.putIfAbsent(k(m) , 0, 0, v(m, "v2-"))
+      assertStatus(resp, OperationNotExecuted)
    }
 
    def testPutIfAbsentWithLifespan(m: Method) {
-      val status = client.putIfAbsent(k(m) , 1, 0, v(m)).status
-      assertStatus(status, Success)
+      val resp = client.putIfAbsent(k(m) , 1, 0, v(m))
+      assertStatus(resp, Success)
       Thread.sleep(1100)
       assertKeyDoesNotExist(client.assertGet(m))
    }
 
    def testPutIfAbsentWithMaxIdle(m: Method) {
-      val status = client.putIfAbsent(k(m) , 0, 1, v(m)).status
-      assertStatus(status, Success)
+      val resp = client.putIfAbsent(k(m) , 0, 1, v(m))
+      assertStatus(resp, Success)
       Thread.sleep(1100)
       assertKeyDoesNotExist(client.assertGet(m))
    }
 
    def testPutIfAbsentWithPreviousValue(m: Method) {
       var resp = client.putIfAbsent(k(m) , 0, 0, v(m), 1).asInstanceOf[TestResponseWithPrevious]
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.previous, None)
       resp = client.putIfAbsent(k(m) , 0, 0, v(m, "v2-"), 1).asInstanceOf[TestResponseWithPrevious]
-      assertStatus(resp.status, OperationNotExecuted)
+      assertStatus(resp, OperationNotExecuted)
       assertTrue(Arrays.equals(v(m), resp.previous.get))
    }
 
    def testReplaceBasic(m: Method) {
       client.assertPut(m)
-      val status = client.replace(k(m), 0, 0, v(m, "v1-")).status
-      assertStatus(status, Success)
+      val resp = client.replace(k(m), 0, 0, v(m, "v1-"))
+      assertStatus(resp, Success)
       assertSuccess(client.assertGet(m), v(m, "v1-"))
    }
 
    def testNotReplaceIfNotPresent(m: Method) {
-      val status = client.replace(k(m), 0, 0, v(m)).status
-      assertStatus(status, OperationNotExecuted)
+      val resp = client.replace(k(m), 0, 0, v(m))
+      assertStatus(resp, OperationNotExecuted)
    }
 
    def testReplaceWithLifespan(m: Method) {
       client.assertPut(m)
-      val status = client.replace(k(m), 1, 0, v(m, "v1-")).status
-      assertStatus(status, Success)
+      val resp = client.replace(k(m), 1, 0, v(m, "v1-"))
+      assertStatus(resp, Success)
       Thread.sleep(1100)
       assertKeyDoesNotExist(client.assertGet(m))
    }
 
    def testReplaceWithMaxIdle(m: Method) {
       client.assertPut(m)
-      val status = client.replace(k(m), 0, 1, v(m, "v1-")).status
-      assertStatus(status, Success)
+      val resp = client.replace(k(m), 0, 1, v(m, "v1-"))
+      assertStatus(resp, Success)
       Thread.sleep(1100)
       assertKeyDoesNotExist(client.assertGet(m))
    }
 
    def testReplaceWithPreviousValue(m: Method) {
       var resp = client.replace(k(m) , 0, 0, v(m), 1).asInstanceOf[TestResponseWithPrevious]
-      assertStatus(resp.status, OperationNotExecuted)
+      assertStatus(resp, OperationNotExecuted)
       assertEquals(resp.previous, None)
       resp = client.put(k(m) , 0, 0, v(m, "v2-"), 1).asInstanceOf[TestResponseWithPrevious]
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.previous, None)
       resp = client.replace(k(m) , 0, 0, v(m, "v3-"), 1).asInstanceOf[TestResponseWithPrevious]
       assertSuccess(resp, v(m, "v2-"))
@@ -202,63 +202,62 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
       client.assertPut(m)
       val resp = client.getWithVersion(k(m), 0)
       assertSuccess(resp, v(m), 0)
-      val status = client.replaceIfUnmodified(k(m), 0, 0, v(m, "v1-"), resp.version).status
-      assertStatus(status, Success)
+      val resp2 = client.replaceIfUnmodified(k(m), 0, 0, v(m, "v1-"), resp.version)
+      assertStatus(resp2, Success)
    }
 
    def testReplaceIfUnmodifiedNotFound(m: Method) {
       client.assertPut(m)
       val resp = client.getWithVersion(k(m), 0)
       assertSuccess(resp, v(m), 0)
-      val status = client.replaceIfUnmodified(k(m, "k1-"), 0, 0, v(m, "v1-"), resp.version).status
-      assertStatus(status, KeyDoesNotExist)
+      val resp2 = client.replaceIfUnmodified(k(m, "k1-"), 0, 0, v(m, "v1-"), resp.version)
+      assertStatus(resp2, KeyDoesNotExist)
    }
 
    def testReplaceIfUnmodifiedNotExecuted(m: Method) {
       client.assertPut(m)
-      var resp = client.getWithVersion(k(m), 0)
+      val resp = client.getWithVersion(k(m), 0)
       assertSuccess(resp, v(m), 0)
-      var status = client.replaceIfUnmodified(k(m), 0, 0, v(m, "v1-"), resp.version).status
-      assertStatus(status, Success)
-      val resp2 = client.getWithVersion(k(m), 0)
-      assertSuccess(resp2, v(m, "v1-"), 0)
-      assertTrue(resp.version != resp2.version)
-      status = client.replaceIfUnmodified(k(m), 0, 0, v(m, "v2-"), resp.version).status
-      assertStatus(status, OperationNotExecuted)
-      status = client.replaceIfUnmodified(k(m), 0, 0, v(m, "v2-"), resp2.version).status
-      assertStatus(status, Success)
+      val resp2 = client.replaceIfUnmodified(k(m), 0, 0, v(m, "v1-"), resp.version)
+      assertStatus(resp2, Success)
+      val resp3 = client.getWithVersion(k(m), 0)
+      assertSuccess(resp3, v(m, "v1-"), 0)
+      assertTrue(resp.version != resp3.version)
+      val resp4 = client.replaceIfUnmodified(k(m), 0, 0, v(m, "v2-"), resp.version)
+      assertStatus(resp4, OperationNotExecuted)
+      val resp5 = client.replaceIfUnmodified(k(m), 0, 0, v(m, "v2-"), resp3.version)
+      assertStatus(resp5, Success)
    }
 
    def testReplaceIfUnmodifiedWithPreviousValue(m: Method) {
       var resp = client.replaceIfUnmodified(k(m) , 0, 0, v(m), 999, 1).asInstanceOf[TestResponseWithPrevious]
-      assertStatus(resp.status, KeyDoesNotExist)
+      assertStatus(resp, KeyDoesNotExist)
       assertEquals(resp.previous, None)
       client.assertPut(m)
       val getResp = client.getWithVersion(k(m), 0)
       assertSuccess(getResp, v(m), 0)
       resp  = client.replaceIfUnmodified(k(m), 0, 0, v(m, "v2-"), 888, 1).asInstanceOf[TestResponseWithPrevious]
-      assertStatus(resp.status, OperationNotExecuted)
+      assertStatus(resp, OperationNotExecuted)
       assertTrue(Arrays.equals(v(m), resp.previous.get))
       resp  = client.replaceIfUnmodified(k(m), 0, 0, v(m, "v3-"), getResp.version, 1).asInstanceOf[TestResponseWithPrevious]
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertTrue(Arrays.equals(v(m), resp.previous.get))
    }
 
    def testRemoveBasic(m: Method) {
       client.assertPut(m)
-      val status = client.remove(k(m)).status
-      assertStatus(status, Success)
+      val resp = client.remove(k(m))
+      assertStatus(resp, Success)
       assertKeyDoesNotExist(client.assertGet(m))
    }
 
    def testRemoveDoesNotExist(m: Method) {
-      val status = client.remove(k(m)).status
-      assertStatus(status, KeyDoesNotExist)
+      assertStatus(client.remove(k(m)), KeyDoesNotExist)
    }
 
    def testRemoveWithPreviousValue(m: Method) {
       var resp = client.remove(k(m), 1).asInstanceOf[TestResponseWithPrevious]
-      assertStatus(resp.status, KeyDoesNotExist)
+      assertStatus(resp, KeyDoesNotExist)
       assertEquals(resp.previous, None)
       client.assertPut(m)
       resp = client.remove(k(m), 1).asInstanceOf[TestResponseWithPrevious]
@@ -270,17 +269,17 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
       val resp = client.getWithVersion(k(m), 0)
       assertSuccess(resp, v(m), 0)
       assertTrue(resp.version != 0)
-      val status = client.removeIfUnmodified(k(m), 0, 0, v(m, "v1-"), resp.version).status
-      assertStatus(status, Success)
+      val resp2 = client.removeIfUnmodified(k(m), 0, 0, v(m, "v1-"), resp.version)
+      assertStatus(resp2, Success)
       assertKeyDoesNotExist(client.assertGet(m))
    }
 
    def testRemoveIfUnmodifiedNotFound(m: Method) {
       client.assertPut(m)
-      var resp = client.getWithVersion(k(m), 0)
+      val resp = client.getWithVersion(k(m), 0)
       assertSuccess(resp, v(m), 0)
-      val status = client.removeIfUnmodified(k(m, "k1-"), 0, 0, v(m, "v1-"), resp.version).status
-      assertStatus(status, KeyDoesNotExist)
+      val resp2 = client.removeIfUnmodified(k(m, "k1-"), 0, 0, v(m, "v1-"), resp.version)
+      assertStatus(resp2, KeyDoesNotExist)
       assertSuccess(client.assertGet(m), v(m))
    }
 
@@ -288,54 +287,54 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
       client.assertPut(m)
       val resp = client.getWithVersion(k(m), 0)
       assertSuccess(resp, v(m), 0)
-      var status = client.replaceIfUnmodified(k(m), 0, 0, v(m, "v1-"), resp.version).status
-      assertStatus(status, Success)
-      val resp2 = client.getWithVersion(k(m), 0)
-      assertSuccess(resp2, v(m, "v1-"), 0)
-      assertTrue(resp.version != resp2.version)
-      status = client.removeIfUnmodified(k(m), 0, 0, v(m, "v2-"), resp.version).status
-      assertStatus(status, OperationNotExecuted)
-      status = client.removeIfUnmodified(k(m), 0, 0, v(m, "v2-"), resp2.version).status
-      assertStatus(status, Success)
+      var resp2 = client.replaceIfUnmodified(k(m), 0, 0, v(m, "v1-"), resp.version)
+      assertStatus(resp2, Success)
+      val resp3 = client.getWithVersion(k(m), 0)
+      assertSuccess(resp3, v(m, "v1-"), 0)
+      assertTrue(resp.version != resp3.version)
+      val resp4 = client.removeIfUnmodified(k(m), 0, 0, v(m, "v2-"), resp.version)
+      assertStatus(resp4, OperationNotExecuted)
+      val resp5 = client.removeIfUnmodified(k(m), 0, 0, v(m, "v2-"), resp3.version)
+      assertStatus(resp5, Success)
    }
 
    def testRemoveIfUmodifiedWithPreviousValue(m: Method) {
       var resp = client.removeIfUnmodified(k(m) , 0, 0, v(m), 999, 1).asInstanceOf[TestResponseWithPrevious]
-      assertStatus(resp.status, KeyDoesNotExist)
+      assertStatus(resp, KeyDoesNotExist)
       assertEquals(resp.previous, None)
       client.assertPut(m)
       val getResp = client.getWithVersion(k(m), 0)
       assertSuccess(getResp, v(m), 0)
       resp  = client.removeIfUnmodified(k(m), 0, 0, v(m, "v2-"), 888, 1).asInstanceOf[TestResponseWithPrevious]
-      assertStatus(resp.status, OperationNotExecuted)
+      assertStatus(resp, OperationNotExecuted)
       assertTrue(Arrays.equals(v(m), resp.previous.get))
       resp = client.removeIfUnmodified(k(m), 0, 0, v(m, "v3-"), getResp.version, 1).asInstanceOf[TestResponseWithPrevious]
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertTrue(Arrays.equals(v(m), resp.previous.get))
    }
 
    def testContainsKeyBasic(m: Method) {
       client.assertPut(m)
-      assertStatus(client.containsKey(k(m), 0).status, Success)
+      assertStatus(client.containsKey(k(m), 0), Success)
    }
 
    def testContainsKeyDoesNotExist(m: Method) {
-      assertStatus(client.containsKey(k(m), 0).status, KeyDoesNotExist)
+      assertStatus(client.containsKey(k(m), 0), KeyDoesNotExist)
    }
 
    def testClear(m: Method) {
       for (i <- 1 to 5) {
          val key = k(m, "k" + i + "-");
          val value = v(m, "v" + i + "-");
-         assertStatus(client.put(key, 0, 0, value).status, Success)
-         assertStatus(client.containsKey(key, 0).status, Success)
+         assertStatus(client.put(key, 0, 0, value), Success)
+         assertStatus(client.containsKey(key, 0), Success)
       }
 
-      assertStatus(client.clear.status, Success)
+      assertStatus(client.clear, Success)
 
       for (i <- 1 to 5) {
          val key = k(m, "k" + i + "-")
-         assertStatus(client.containsKey(key, 0).status, KeyDoesNotExist)
+         assertStatus(client.containsKey(key, 0), KeyDoesNotExist)
       }
    }
 
@@ -353,33 +352,32 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
    }
 
    def testPing(m: Method) {
-      val status = client.ping.status
-      assertStatus(status, Success)
+      assertStatus(client.ping, Success)
    }
 
    def testPingWithTopologyAwareClient(m: Method) {
       var resp = client.ping
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
       resp = client.ping(1, 0)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
       resp = client.ping(2, 0)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
       resp = client.ping(3, 0)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
    }
 
    def testBulkGet(m: Method) {
       var size = 100
       for (i <- 0 until size) {
-         val status = client.put(k(m, i + "k-") , 0, 0, v(m, i + "v-")).status
-         assertStatus(status, Success)
+         val resp = client.put(k(m, i + "k-") , 0, 0, v(m, i + "v-"))
+         assertStatus(resp, Success)
       }
       var resp = client.bulkGet
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       var bulkData = resp.bulkData
       assertEquals(size, bulkData.size)
       for (i <- 0 until size)
@@ -387,7 +385,7 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
 
       size = 50
       resp = client.bulkGet(size)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       bulkData = resp.bulkData
       assertEquals(size, bulkData.size)
       for (i <- 0 until size) {
@@ -400,14 +398,12 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
 
    def testPutBigSizeKey(m: Method) {
       val key = generateRandomString(1024 * 1024).getBytes
-      val status = client.put(key, 0, 0, v(m)).status
-      assertStatus(status, Success)
+      assertStatus(client.put(key, 0, 0, v(m)), Success)
    }
 
    def testPutBigSizeValue(m: Method) {
       val value = generateRandomString(1024 * 1024).getBytes
-      val status = client.put(k(m), 0, 0, value).status
-      assertStatus(status, Success)
+      assertStatus(client.put(k(m), 0, 0, value), Success)
    }
 
 }

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodProxyTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodProxyTest.scala
@@ -60,7 +60,7 @@ class HotRodProxyTest extends HotRodMultiNodeTest {
 
    def testTopologyWithProxiesReturned {
       val resp = clients.head.ping(2, 0)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       val topoResp = resp.topologyResponse.get
       assertEquals(topoResp.view.topologyId, 2)
       assertEquals(topoResp.view.members.size, 2)

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodReplicationTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodReplicationTest.scala
@@ -49,65 +49,65 @@ class HotRodReplicationTest extends HotRodMultiNodeTest {
    }
 
    def testReplicatedPut(m: Method) {
-      val putSt = clients.head.put(k(m) , 0, 0, v(m)).status
-      assertStatus(putSt, Success)
+      val resp = clients.head.put(k(m) , 0, 0, v(m))
+      assertStatus(resp, Success)
       assertSuccess(clients.tail.head.get(k(m), 0), v(m))
    }
 
    def testReplicatedPutIfAbsent(m: Method) {
       assertKeyDoesNotExist(clients.head.assertGet(m))
       assertKeyDoesNotExist(clients.tail.head.assertGet(m))
-      var putSt = clients.head.putIfAbsent(k(m) , 0, 0, v(m)).status
-      assertStatus(putSt, Success)
+      val resp = clients.head.putIfAbsent(k(m) , 0, 0, v(m))
+      assertStatus(resp, Success)
       assertSuccess(clients.tail.head.get(k(m), 0), v(m))
-      assertStatus(clients.tail.head.putIfAbsent(k(m) , 0, 0, v(m, "v2-")).status, OperationNotExecuted)
+      assertStatus(clients.tail.head.putIfAbsent(k(m) , 0, 0, v(m, "v2-")), OperationNotExecuted)
    }
 
    def testReplicatedReplace(m: Method) {
-      var status = clients.head.replace(k(m), 0, 0, v(m)).status
-      assertStatus(status, OperationNotExecuted)
-      status = clients.tail.head.replace(k(m), 0, 0, v(m)).status
-      assertStatus(status , OperationNotExecuted)
+      var resp = clients.head.replace(k(m), 0, 0, v(m))
+      assertStatus(resp, OperationNotExecuted)
+      resp = clients.tail.head.replace(k(m), 0, 0, v(m))
+      assertStatus(resp , OperationNotExecuted)
       clients.tail.head.assertPut(m)
-      status = clients.tail.head.replace(k(m), 0, 0, v(m, "v1-")).status
-      assertStatus(status, Success)
+      resp = clients.tail.head.replace(k(m), 0, 0, v(m, "v1-"))
+      assertStatus(resp, Success)
       assertSuccess(clients.head.assertGet(m), v(m, "v1-"))
-      status = clients.head.replace(k(m), 0, 0, v(m, "v2-")).status
-      assertStatus(status, Success)
+      resp = clients.head.replace(k(m), 0, 0, v(m, "v2-"))
+      assertStatus(resp, Success)
       assertSuccess(clients.tail.head.assertGet(m), v(m, "v2-"))
    }
 
    def testPingWithTopologyAwareClient {
       var resp = clients.head.ping
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
       resp = clients.tail.head.ping(1, 0)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
       resp = clients.head.ping(2, 0)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertTopologyReceived(resp.topologyResponse.get, servers)
       resp = clients.tail.head.ping(2, 1)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertTopologyReceived(resp.topologyResponse.get, servers)
       resp = clients.tail.head.ping(2, 2)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
    }
 
    def testReplicatedPutWithTopologyChanges(m: Method) {
       var resp = clients.head.put(k(m) , 0, 0, v(m), 1, 0)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
       assertSuccess(clients.tail.head.get(k(m), 0), v(m))
       resp = clients.head.put(k(m) , 0, 0, v(m, "v1-"), 2, 0)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertTopologyReceived(resp.topologyResponse.get, servers)
       resp = clients.tail.head.put(k(m) , 0, 0, v(m, "v2-"), 2, 1)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertTopologyReceived(resp.topologyResponse.get, servers)
       resp = clients.head.put(k(m) , 0, 0, v(m, "v3-"), 2, 2)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
       assertSuccess(clients.tail.head.get(k(m), 0), v(m, "v3-"))
 
@@ -117,7 +117,7 @@ class HotRodReplicationTest extends HotRodMultiNodeTest {
 
       try {
          val resp = clients.head.put(k(m) , 0, 0, v(m, "v4-"), 2, 2)
-         assertStatus(resp.status, Success)
+         assertStatus(resp, Success)
          assertEquals(resp.topologyResponse.get.view.topologyId, 3)
          assertEquals(resp.topologyResponse.get.view.members.size, 3)
          assertAddressEquals(resp.topologyResponse.get.view.members.head, servers.head.getAddress)
@@ -130,7 +130,7 @@ class HotRodReplicationTest extends HotRodMultiNodeTest {
       }
 
       resp = clients.head.put(k(m) , 0, 0, v(m, "v5-"), 2, 3)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.topologyResponse.get.view.topologyId, 4)
       assertEquals(resp.topologyResponse.get.view.members.size, 2)
       assertAddressEquals(resp.topologyResponse.get.view.members.head, servers.head.getAddress)
@@ -143,7 +143,7 @@ class HotRodReplicationTest extends HotRodMultiNodeTest {
 
       try {
          val resp = clients.head.put(k(m) , 0, 0, v(m, "v6-"), 2, 4)
-         assertStatus(resp.status, Success)
+         assertStatus(resp, Success)
          assertEquals(resp.topologyResponse.get.view.topologyId, 5)
          assertEquals(resp.topologyResponse.get.view.members.size, 3)
          assertAddressEquals(resp.topologyResponse.get.view.members.head, servers.head.getAddress)
@@ -158,7 +158,7 @@ class HotRodReplicationTest extends HotRodMultiNodeTest {
       TestingUtil.blockUntilViewsReceived(10000, true, manager(0), manager(1))
 
       resp = clients.head.put(k(m) , 0, 0, v(m, "v7-"), 2, 5)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       assertEquals(resp.topologyResponse.get.view.topologyId, 6)
       assertEquals(resp.topologyResponse.get.view.members.size, 2)
       assertAddressEquals(resp.topologyResponse.get.view.members.head, servers.head.getAddress)
@@ -166,7 +166,7 @@ class HotRodReplicationTest extends HotRodMultiNodeTest {
       assertSuccess(clients.tail.head.get(k(m), 0), v(m, "v7-"))
 
       resp = clients.head.put(k(m) , 0, 0, v(m, "v8-"), 3, 1)
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       val hashTopologyResp = resp.topologyResponse.get.asInstanceOf[HashDistAwareResponse]
       assertEquals(hashTopologyResp.view.topologyId, 6)
       assertEquals(hashTopologyResp.view.members.size, 2)

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodSingleClusteredTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodSingleClusteredTest.scala
@@ -52,8 +52,7 @@ class HotRodSingleClusteredTest extends MultipleCacheManagersTest {
    }
 
    def testPutGet(m: Method) {
-      val putSt = hotRodClient.put(k(m) , 0, 0, v(m)).status
-      assertStatus(putSt, Success)
+      assertStatus(hotRodClient.put(k(m) , 0, 0, v(m)), Success)
       assertSuccess(hotRodClient.get(k(m), 0), v(m))
    }
 

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodClient.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodClient.scala
@@ -82,8 +82,7 @@ class HotRodClient(host: String, port: Int, defaultCacheName: String, rspTimeout
       execute(0xA0, 0x01, defaultCacheName, k, lifespan, maxIdle, v, 0, clientIntelligence, topologyId)
 
    def assertPut(m: Method) {
-      val status = put(k(m) , 0, 0, v(m)).status
-      assertStatus(status, Success)
+      assertStatus(put(k(m) , 0, 0, v(m)), Success)
    }
 
    def assertPutFail(m: Method) {
@@ -95,13 +94,11 @@ class HotRodClient(host: String, port: Int, defaultCacheName: String, rspTimeout
    }
 
    def assertPut(m: Method, kPrefix: String, vPrefix: String) {
-      val status = put(k(m, kPrefix) , 0, 0, v(m, vPrefix)).status
-      assertStatus(status, Success)
+      assertStatus(put(k(m, kPrefix) , 0, 0, v(m, vPrefix)), Success)
    }
 
    def assertPut(m: Method, lifespan: Int, maxIdle: Int) {
-      val status = put(k(m) , lifespan, maxIdle, v(m)).status
-      assertStatus(status, Success)
+      assertStatus(put(k(m) , lifespan, maxIdle, v(m)), Success)
    }
 
    def put(k: Array[Byte], lifespan: Int, maxIdle: Int, v: Array[Byte], flags: Int): TestResponse =

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodTestingUtil.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodTestingUtil.scala
@@ -138,14 +138,23 @@ object HotRodTestingUtil extends Log {
 
    def v(m: Method): Array[Byte] = v(m, "v-")
 
-   def assertStatus(status: OperationStatus, expected: OperationStatus): Boolean = {
+   def assertStatus(resp: TestResponse, expected: OperationStatus): Boolean = {
+      val status = resp.status
       val isSuccess = status == expected
-      assertTrue(isSuccess, "Status should have been '" + expected + "' but instead was: " + status)
+      resp match {
+         case e: TestErrorResponse =>
+            assertTrue(isSuccess,
+               "Status should have been '%s' but instead was: '%s', and the error message was: %s"
+               .format(expected, status, e.msg))
+         case _ => assertTrue(isSuccess,
+               "Status should have been '%s' but instead was: '%s'"
+               .format(expected, status))
+      }
       isSuccess
    }
 
    def assertSuccess(resp: TestGetResponse, expected: Array[Byte]): Boolean = {
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       val isArrayEquals = Arrays.equals(expected, resp.data.get)
       assertTrue(isArrayEquals, "Retrieved data should have contained " + Util.printArray(expected, true)
             + " (" + new String(expected) + "), but instead we received " + Util.printArray(resp.data.get, true) + " (" +  new String(resp.data.get) +")")
@@ -158,7 +167,7 @@ object HotRodTestingUtil extends Log {
    }
 
    def assertSuccess(resp: TestResponseWithPrevious, expected: Array[Byte]): Boolean = {
-      assertStatus(resp.status, Success)
+      assertStatus(resp, Success)
       val isSuccess = Arrays.equals(expected, resp.previous.get)
       assertTrue(isSuccess)
       isSuccess


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1182
- Suspect and timeout exceptions are now handled when trying to update
  the topology view on startup so that it can be retried.
- The amount of time to wait for topology to be updated is now
  configurable.
- Removing self from topology on stoppage is done with 0 lock timeout
  and silent failure, to avoid blocking stop procedure. Crashed member
  detection listener can deal with nodes having issues at stop time.
- Tests have been enhanced so that if a failure is received, the error
  message is printed in the failure message, giving more clues about the
  error.
