### PR TITLE
ISPN-1162 Index external and internal cmds differently in the stream

### DIFF
--- a/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
@@ -94,92 +94,98 @@ public class RemoteCommandsFactory {
     * You would typically set these parameters using {@link CommandsFactory#initializeReplicableCommand(ReplicableCommand,boolean)}
     * <p/>
     *
+    *
     * @param id         id of the command
     * @param parameters parameters to set
+    * @param type
     * @return a replicable command
     */
-   public ReplicableCommand fromStream(byte id, Object[] parameters) {
+   public ReplicableCommand fromStream(byte id, Object[] parameters, byte type) {
       ReplicableCommand command;
-      switch (id) {
-         case PutKeyValueCommand.COMMAND_ID:
-            command = new PutKeyValueCommand();
-            break;
-         case LockControlCommand.COMMAND_ID:
-            command = new LockControlCommand();
-            break;
-         case PutMapCommand.COMMAND_ID:
-            command = new PutMapCommand();
-            break;
-         case RemoveCommand.COMMAND_ID:
-            command = new RemoveCommand();
-            break;
-         case ReplaceCommand.COMMAND_ID:
-            command = new ReplaceCommand();
-            break;
-         case GetKeyValueCommand.COMMAND_ID:
-            command = new GetKeyValueCommand();
-            break;
-         case ClearCommand.COMMAND_ID:
-            command = new ClearCommand();
-            break;
-         case PrepareCommand.COMMAND_ID:
-            command = new PrepareCommand();
-            break;
-         case CommitCommand.COMMAND_ID:
-            command = new CommitCommand();
-            break;
-         case RollbackCommand.COMMAND_ID:
-            command = new RollbackCommand();
-            break;
-         case MultipleRpcCommand.COMMAND_ID:
-            command = new MultipleRpcCommand();
-            break;
-         case SingleRpcCommand.COMMAND_ID:
-            command = new SingleRpcCommand();
-            break;
-         case InvalidateCommand.COMMAND_ID:
-            command = new InvalidateCommand();
-            break;
-         case InvalidateL1Command.COMMAND_ID:
-            command = new InvalidateL1Command();
-            break;
-         case StateTransferControlCommand.COMMAND_ID:
-            command = new StateTransferControlCommand();
-            ((StateTransferControlCommand) command).init(transport);
-            break;
-         case ClusteredGetCommand.COMMAND_ID:
-            command = new ClusteredGetCommand();
-            break;
-         case RehashControlCommand.COMMAND_ID:
-            command = new RehashControlCommand(transport);
-            break;
-         case RemoveCacheCommand.COMMAND_ID:
-            command = new RemoveCacheCommand(cacheManager, registry);
-            break;
-         case RemoveRecoveryInfoCommand.COMMAND_ID:
-            command = new RemoveRecoveryInfoCommand();
-            break;
-         case GetInDoubtTransactionsCommand.COMMAND_ID:
-            command = new GetInDoubtTransactionsCommand();
-            break;
-         case MapReduceCommand.COMMAND_ID:
-            command = new MapReduceCommand();    
-            break;
-         case DistributedExecuteCommand.COMMAND_ID:
-            command = new DistributedExecuteCommand<Object>();
-            break;   
-         case GetInDoubtTxInfoCommand.COMMAND_ID:
-            command = new GetInDoubtTxInfoCommand();
-            break;
-         case CompleteTransactionCommand.COMMAND_ID:
-            command = new CompleteTransactionCommand();
-            break;
-         default:
-            ModuleCommandFactory mcf = commandFactories.get(id);
-            if (mcf != null)
-               return mcf.fromStream(id, parameters);
-            else
+      if (type == 0) {
+         switch (id) {
+            case PutKeyValueCommand.COMMAND_ID:
+               command = new PutKeyValueCommand();
+               break;
+            case LockControlCommand.COMMAND_ID:
+               command = new LockControlCommand();
+               break;
+            case PutMapCommand.COMMAND_ID:
+               command = new PutMapCommand();
+               break;
+            case RemoveCommand.COMMAND_ID:
+               command = new RemoveCommand();
+               break;
+            case ReplaceCommand.COMMAND_ID:
+               command = new ReplaceCommand();
+               break;
+            case GetKeyValueCommand.COMMAND_ID:
+               command = new GetKeyValueCommand();
+               break;
+            case ClearCommand.COMMAND_ID:
+               command = new ClearCommand();
+               break;
+            case PrepareCommand.COMMAND_ID:
+               command = new PrepareCommand();
+               break;
+            case CommitCommand.COMMAND_ID:
+               command = new CommitCommand();
+               break;
+            case RollbackCommand.COMMAND_ID:
+               command = new RollbackCommand();
+               break;
+            case MultipleRpcCommand.COMMAND_ID:
+               command = new MultipleRpcCommand();
+               break;
+            case SingleRpcCommand.COMMAND_ID:
+               command = new SingleRpcCommand();
+               break;
+            case InvalidateCommand.COMMAND_ID:
+               command = new InvalidateCommand();
+               break;
+            case InvalidateL1Command.COMMAND_ID:
+               command = new InvalidateL1Command();
+               break;
+            case StateTransferControlCommand.COMMAND_ID:
+               command = new StateTransferControlCommand();
+               ((StateTransferControlCommand) command).init(transport);
+               break;
+            case ClusteredGetCommand.COMMAND_ID:
+               command = new ClusteredGetCommand();
+               break;
+            case RehashControlCommand.COMMAND_ID:
+               command = new RehashControlCommand(transport);
+               break;
+            case RemoveCacheCommand.COMMAND_ID:
+               command = new RemoveCacheCommand(cacheManager, registry);
+               break;
+            case RemoveRecoveryInfoCommand.COMMAND_ID:
+               command = new RemoveRecoveryInfoCommand();
+               break;
+            case GetInDoubtTransactionsCommand.COMMAND_ID:
+               command = new GetInDoubtTransactionsCommand();
+               break;
+            case MapReduceCommand.COMMAND_ID:
+               command = new MapReduceCommand();
+               break;
+            case DistributedExecuteCommand.COMMAND_ID:
+               command = new DistributedExecuteCommand<Object>();
+               break;
+            case GetInDoubtTxInfoCommand.COMMAND_ID:
+               command = new GetInDoubtTxInfoCommand();
+               break;
+            case CompleteTransactionCommand.COMMAND_ID:
+               command = new CompleteTransactionCommand();
+               break;
+            default:
                throw new CacheException("Unknown command id " + id + "!");
+         }
+      } else {
+         ModuleCommandFactory mcf = commandFactories.get(id);
+         if (mcf != null)
+            return mcf.fromStream(id, parameters);
+         else
+            throw new CacheException("Unknown command id " + id + "!");
       }
       command.setParameters(id, parameters);
       return command;


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1162

Here's a summary of what I've done but a longer explanation can be found in jira. Please note that this deviates from what was suggested in the dev forum post:

"By doing this, duplicates can be checked at each scope independently. So, duplicates for internal commands are checked via the unit test and for external commands, via the ModuleProperties class.|"
