### PR TITLE
ISPN-1123 Fix HotRod server testsuite failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ target
 atlassian-ide-plugin.xml
 maven-ant-tasks.jar
 test-output
+classes
 # log files
 *.log
 # vim files

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodConfigurationTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodConfigurationTest.scala
@@ -63,8 +63,8 @@ class HotRodConfigurationTest {
       props.setProperty(PROP_KEY_TOPOLOGY_REPL_TIMEOUT, "43000")
       withClusteredServer(props) { cfg =>
          assertEquals(cfg.getSyncReplTimeout, 43000)
-         assertFalse(cfg.isStateTransferEnabled)
-         val clcfg = cfg.getCacheLoaderManagerConfig.getFirstCacheLoaderConfig
+         assertTrue(cfg.isStateTransferEnabled)
+         val clcfg = cfg.getCacheLoaders.get(0)
          assertNotNull(clcfg)
          assertEquals(clcfg.getCacheLoaderClassName, classOf[ClusterCacheLoader].getName)
          assertEquals(clcfg.asInstanceOf[ClusterCacheLoaderConfig].getRemoteCallTimeout, 43000)

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDistributionTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDistributionTest.scala
@@ -81,9 +81,7 @@ class HotRodDistributionTest extends HotRodMultiNodeTest {
       assertHashTopologyReceived(resp.topologyResponse.get, servers, expectedHashIds)
       assertSuccess(clients.tail.head.get(k(m), 0), v(m, "v5-"))
 
-      val cm = addClusterEnabledCacheManager()
-      cm.defineConfiguration(cacheName, createCacheConfig)
-      val newServer = startHotRodServer(cm, servers.tail.head.getPort + 25)
+      val newServer = startClusteredServer(servers.tail.head.getPort + 25)
       val newClient = new HotRodClient("127.0.0.1", newServer.getPort, cacheName, 60)
       try {
          log.trace("New client started, modify key to be v6-*")
@@ -107,8 +105,7 @@ class HotRodDistributionTest extends HotRodMultiNodeTest {
          assertSuccess(clients.tail.head.get(k(m), 0), v(m, "v6-"))
       } finally {
          newClient.stop
-         newServer.stop
-         cm.stop
+         stopClusteredServer(newServer)
       }
 
       resp = clients.tail.head.put(k(m) , 0, 0, v(m, "v7-"), 3, 3)

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodClient.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodClient.scala
@@ -160,7 +160,7 @@ class HotRodClient(host: String, port: Int, defaultCacheName: String, rspTimeout
 
    private def execute(op: Op, expectedResponseMessageId: Long): TestResponse = {
       writeOp(op)
-      var handler = ch.getPipeline.getLast.asInstanceOf[ClientHandler]
+      val handler = ch.getPipeline.getLast.asInstanceOf[ClientHandler]
       handler.getResponse(expectedResponseMessageId)
    }
 

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodTestingUtil.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodTestingUtil.scala
@@ -95,6 +95,9 @@ object HotRodTestingUtil extends Log {
       props.setProperty(PROP_KEY_HOST, host)
       props.setProperty(PROP_KEY_PORT, port.toString)
       server.start(props, manager)
+
+
+
       server
    }
 


### PR DESCRIPTION
- Make sure that both when servers are started and stopped, the tests
  wait for views to be received.
- State transfer is now enabled by default for replicated caches, so
  change the HotRod configuration test accordingly.

Master only.
