### PR TITLE
ISPN-1198 entrySet,keySet and values now remove expired entries

### DIFF
--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
@@ -80,7 +80,7 @@ class HotRodEncoder(cacheManager: EmbeddedCacheManager) extends OneToOneEncoder 
             if (isTrace) trace("About to respond to bulk get request")
             if (g.status == Success) {
                val cache: Cache[ByteArrayKey, CacheValue] = getCacheInstance(g.cacheName, cacheManager)
-               var iterator = asIterator(cache.entrySet.iterator)
+               var iterator = asScalaIterator(cache.entrySet.iterator)
                if (g.count != 0) {
                   if (isTrace) trace("About to write (max) %d messages to the client", g.count)
                   iterator = iterator.take(g.count)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1198
- The commit also extends the test coverage in CacheAPITest in order to
  verify not only that the entry set has the correct length, but that it
  also has the expected contents.
- Also fixed an small issue in entrySet when transaction modifications
  are ongoing. It should send back immutable cache entries back to the
  user.

As usual now, master only.
