### PR TITLE
ISPN-1217 HotRod server now maintains all virtual node hash ids

### DIFF
--- a/core/src/main/java/org/infinispan/config/FluentConfiguration.java
+++ b/core/src/main/java/org/infinispan/config/FluentConfiguration.java
@@ -673,6 +673,9 @@ public class FluentConfiguration extends AbstractFluentConfigurationBean {
        * Get's the current groupers in use
        */
       List<Grouper<?>> getGroupers();
+
+      @Override // Override definition so that Scala classes can see it.
+      Configuration build();
    }
 
    /**

--- a/core/src/main/java/org/infinispan/distribution/ch/ConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/ConsistentHash.java
@@ -86,13 +86,17 @@ public interface ConsistentHash {
    boolean isKeyLocalToAddress(Address a, Object key, int replCount);
 
    /**
-    * Returns the value between 0 and the hash space limit, or hash id, for a particular address. If there's no such
-    * value for an address, this method will return -1.
+    * Returns a list of values between 0 and the hash space limit, or hash id,
+    * for a particular address. If virtual nodes are disabled, the list will
+    * only contain a single element, whereas if virtual nodes are enabled, this
+    * list's size will be the number of virtual nodes configured. If there are
+    * no hash ids for that address, it returns an empty list.
     *
-    * @return An int between 0 and hash space if the address is present in the hash wheel, otherwise it returns -1.
-    * @throws IllegalStateException If virtual nodes are enabled.
+    * @return A list of N size where N is the configured number of virtual
+    *         nodes, or an empty list if there're no hash ids associated with
+    *         the address.
     */
-   int getHashId(Address a);
+   List<Integer> getHashIds(Address a);
 
    /**
     * Returns the hash space constant for this consistent hash algorithm class. This integer is often used as modulus

--- a/core/src/main/java/org/infinispan/distribution/ch/ExperimentalDefaultConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/ExperimentalDefaultConsistentHash.java
@@ -305,7 +305,7 @@ public class ExperimentalDefaultConsistentHash extends AbstractConsistentHash {
    }
 
    @Override
-   public int getHashId(Address a) {
+   public List<Integer> getHashIds(Address a) {
       throw new RuntimeException("Not yet implemented");
    }
 

--- a/core/src/main/java/org/infinispan/distribution/ch/UnionConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/UnionConsistentHash.java
@@ -74,7 +74,7 @@ public class UnionConsistentHash extends AbstractConsistentHash {
    }
 
    @Override
-   public int getHashId(Address a) {
+   public List<Integer> getHashIds(Address a) {
       throw new UnsupportedOperationException("Unsupported!");
    }
 

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/TopologyAddress.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/TopologyAddress.scala
@@ -26,33 +26,47 @@ import java.io.{ObjectInput, ObjectOutput}
 import org.infinispan.remoting.transport.Address
 import org.infinispan.marshall.AbstractExternalizer
 import scala.collection.JavaConversions._
+import collection.{immutable, mutable}
 
 /**
  * A Hot Rod topology address represents a Hot Rod endpoint that belongs to a Hot Rod cluster. It contains host/port
  * information where the Hot Rod endpoint is listening. To be able to detect crashed members in the cluster and update
  * the Hot Rod topology accordingly, it also contains the corresponding cluster address. Finally, since each cache
- * could potentially be configured with a different hash algorithm, a topology address also contains per cache hash id.
+ * could potentially be configured with a different hash algorithm, a topology address also contains a collection of
+ * per cache hash ids. If virtual nodes are disabled, this collection will have a single hash id element. If virtual
+ * nodes are disabled, the collection will have the number of configured virtual nodes as size.
  * 
  * @author Galder Zamarreño
  * @since 4.1
  */
-case class TopologyAddress(val host: String, val port: Int, val hashIds: Map[String, Int], val clusterAddress: Address)
+case class TopologyAddress(val host: String, val port: Int, val hashIds: Map[String, Seq[Int]], val clusterAddress: Address)
 
 object TopologyAddress {
    class Externalizer extends AbstractExternalizer[TopologyAddress] {
       override def writeObject(output: ObjectOutput, topologyAddress: TopologyAddress) {
          output.writeObject(topologyAddress.host)
          output.writeInt(topologyAddress.port)
-         output.writeObject(topologyAddress.hashIds)
+         output.writeInt(topologyAddress.hashIds.size)
+         topologyAddress.hashIds.foreach { case (cacheName, cacheHashIds) =>
+            output.writeObject(cacheName)
+            // Write arrays instead since writing Lists causes issues
+            output.writeObject(cacheHashIds.toArray)
+         }
          output.writeObject(topologyAddress.clusterAddress)
       }
 
       override def readObject(input: ObjectInput): TopologyAddress = {
          val host = input.readObject.asInstanceOf[String]
          val port = input.readInt
-         val hashIds = input.readObject.asInstanceOf[Map[String, Int]]
+         val size = input.readInt
+         val hashIds = mutable.Map.empty[String, Seq[Int]]
+         for (i <- 0 until size) {
+            val cacheName = input.readObject().asInstanceOf[String]
+            val cacheHashIds = input.readObject.asInstanceOf[Array[Int]]
+            hashIds += (cacheName -> cacheHashIds.toList)
+         }
          val clusterAddress = input.readObject.asInstanceOf[Address]
-         TopologyAddress(host, port, hashIds, clusterAddress)
+         TopologyAddress(host, port, immutable.Map[String, Seq[Int]]() ++ hashIds, clusterAddress)
       }
 
       override def getTypeClasses =

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/TopologyView.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/TopologyView.scala
@@ -43,7 +43,8 @@ object TopologyView {
    class Externalizer extends AbstractExternalizer[TopologyView] {
       override def writeObject(output: ObjectOutput, topologyView: TopologyView) {
          output.writeInt(topologyView.topologyId)
-         output.writeObject(topologyView.members.toArray) // Write arrays instead since writing Lists causes issues
+         // Write arrays instead since writing Lists causes issues
+         output.writeObject(topologyView.members.toArray)
       }
 
       override def readObject(input: ObjectInput): TopologyView = {

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodReplicationTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodReplicationTest.scala
@@ -159,8 +159,8 @@ class HotRodReplicationTest extends HotRodMultiNodeTest {
       val hashTopologyResp = resp.topologyResponse.get.asInstanceOf[HashDistAwareResponse]
       assertEquals(hashTopologyResp.view.topologyId, 6)
       assertEquals(hashTopologyResp.view.members.size, 2)
-      assertAddressEquals(hashTopologyResp.view.members.head, servers.head.getAddress, Map(cacheName -> 0))
-      assertAddressEquals(hashTopologyResp.view.members.tail.head, servers.tail.head.getAddress, Map(cacheName -> 0))
+      assertAddressEquals(hashTopologyResp.view.members.head, servers.head.getAddress, Map(cacheName -> List(0)))
+      assertAddressEquals(hashTopologyResp.view.members.tail.head, servers.tail.head.getAddress, Map(cacheName -> List(0)))
       assertEquals(hashTopologyResp.numOwners, 0)
       assertEquals(hashTopologyResp.hashFunction, 0)
       assertEquals(hashTopologyResp.hashSpace, 0)

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodVirtualNodesTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodVirtualNodesTest.scala
@@ -1,0 +1,18 @@
+package org.infinispan.server.hotrod
+
+import org.infinispan.config.Configuration
+import org.testng.annotations.Test
+
+/**
+ * Tests HotRod logic when underlying cache is configured with virtual nodes
+ *
+ * @author Galder Zamarreño
+ * @since 5.0
+ */
+@Test(groups = Array("functional"), testName = "server.hotrod.HotRodVirtualNodesTest")
+class HotRodVirtualNodesTest extends HotRodDistributionTest {
+
+   override protected def createCacheConfig: Configuration =
+      super.createCacheConfig.fluent.clustering.hash.numVirtualNodes(10).build
+
+}

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodTestingUtil.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodTestingUtil.scala
@@ -195,7 +195,7 @@ object HotRodTestingUtil extends Log {
       assertEquals(actual.port, expected.port)
    }
 
-   def assertHashTopologyReceived(topoResp: AbstractTopologyResponse, servers: List[HotRodServer], hashIds: List[Map[String, Int]]) {
+   def assertHashTopologyReceived(topoResp: AbstractTopologyResponse, servers: List[HotRodServer], hashIds: List[Map[String, Seq[Int]]]) {
       val hashTopologyResp = topoResp.asInstanceOf[HashDistAwareResponse]
       assertEquals(hashTopologyResp.view.topologyId, 2)
       assertEquals(hashTopologyResp.view.members.size, 2)
@@ -206,7 +206,7 @@ object HotRodTestingUtil extends Log {
       assertEquals(hashTopologyResp.hashSpace, 10240)
    }
 
-   def assertNoHashTopologyReceived(topoResp: AbstractTopologyResponse, servers: List[HotRodServer], hashIds: List[Map[String, Int]]) {
+   def assertNoHashTopologyReceived(topoResp: AbstractTopologyResponse, servers: List[HotRodServer], hashIds: List[Map[String, Seq[Int]]]) {
       val hashTopologyResp = topoResp.asInstanceOf[HashDistAwareResponse]
       assertEquals(hashTopologyResp.view.topologyId, 2)
       assertEquals(hashTopologyResp.view.members.size, 2)
@@ -217,7 +217,7 @@ object HotRodTestingUtil extends Log {
       assertEquals(hashTopologyResp.hashSpace, 0)
    }
 
-   def assertAddressEquals(actual: TopologyAddress, expected: TopologyAddress, expectedHashIds: Map[String, Int]) {
+   def assertAddressEquals(actual: TopologyAddress, expected: TopologyAddress, expectedHashIds: Map[String, Seq[Int]]) {
       assertEquals(actual.host, expected.host)
       assertEquals(actual.port, expected.port)
       assertEquals(actual.hashIds, expectedHashIds)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1217
- Topology change header now sends back as many host:port:hash entries
  as (virtual nodes) \* (num cluster nodes) are in the cluster, enabling
  clients to determine the right node to send requests to.
- ConsistentHash.getHashId() has been refactored into getHashIds and
  now returns a List<Integer> instead of just an int.
