### PR TITLE
ISPN-1123 - Revert TCPPING port_range change

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/ConsistentHashPerfTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ConsistentHashPerfTest.java
@@ -26,13 +26,13 @@ import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
 import org.infinispan.test.AbstractInfinispanTest;
-import org.infinispan.test.TestingUtil;
 import org.infinispan.util.Util;
 import org.testng.annotations.Test;
 
 import java.util.*;
-import static java.lang.Math.*;
 import java.util.concurrent.TimeUnit;
+
+import static java.lang.Math.*;
 
 /**
  * Tests the uniformity of the distribution hash algo.
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  * @author Manik Surtani
  * @since 4.0
  */
-@Test(testName = "distribution.ConsistentHashPerfTest", groups = "manual")
+@Test(testName = "distribution.ConsistentHashPerfTest", groups = "manual", description = "Disabled until we can configure Surefire to skip manual tests")
 public class ConsistentHashPerfTest extends AbstractInfinispanTest {
 
    private Set<Address> createAddresses(int numNodes) {

--- a/core/src/test/java/org/infinispan/distribution/virtualnodes/VNodesCHPerfTest.java
+++ b/core/src/test/java/org/infinispan/distribution/virtualnodes/VNodesCHPerfTest.java
@@ -41,7 +41,7 @@ import static org.testng.Assert.*;
  * @author Dan Berindei <dberinde@redhat.com>
  * @since 5.0
  */
-@Test(testName = "distribution.VNodesCHPerfTest", groups = "manual")
+@Test(testName = "distribution.VNodesCHPerfTest", groups = "manual", enabled = false, description = "Disabled until we can configure Surefire to skip manual tests")
 public class VNodesCHPerfTest extends AbstractInfinispanTest {
 
    private Set<Address> createAddresses(int numNodes) {

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -55,7 +55,7 @@
    <!-- Ergonomics, new in JGroups 2.11, are disabled by default until JGRP-1253 is resolved -->
    <TCPPING timeout="3000"
             initial_hosts="localhost[7800]"
-            port_range="30"
+            port_range="3"
             ergonomics="false"
 	/>
 


### PR DESCRIPTION
A very large port_range value seems to lead to timeouts waiting for the cluster to form.
Seems to be especially bad with high CPU load, as I only got the timeouts on my machine when I has MapStressTest enabled.
So I changed the port_range back from 30 to 3 and I disabled the CH performance tests.
