### PR TITLE
ISPN-1123 Remove duplicate old code on removing self from topology

### DIFF
--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
@@ -241,13 +241,8 @@ class HotRodServer extends AbstractProtocolServer("HotRod") with Log {
             Flag.FAIL_SILENTLY, Flag.ZERO_LOCK_ACQUISITION_TIMEOUT)
                  .replace("view", currentView, newView)
 
-         val replaced = topologyCache.replace("view", currentView, newView)
-         if (isDebug && !replaced) {
-            debug("Attempt to update topology view failed due to a concurrent modification. " +
-                  "Ignoring since logic to deal with crashed members will deal with it.")
-         } else if (isDebug) {
-            debug("Removed %s from topology view, new view is %s", address, newView)
-         }
+         if (isDebug)
+            debug("Attempted to update topology view (%s) on best-effort", newView)
       }
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1123

This should HotRod server stop procedures faster and should remove suspect exceptions from HotRod server testsuite.
