### PR TITLE
ISPN-1231 Adjust HotRod topology cache state transfer timeout

### DIFF
--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
@@ -37,13 +37,13 @@ import org.infinispan.server.core.{CacheValue, AbstractProtocolServer}
 import org.infinispan.eviction.EvictionStrategy
 import org.infinispan.util.{TypedProperties, ByteArrayKey, Util};
 import org.infinispan.server.core.Main._
-import org.infinispan.config.{CacheLoaderManagerConfig, Configuration}
 import org.infinispan.loaders.cluster.ClusterCacheLoaderConfig
 import collection.mutable
 import collection.immutable
 import org.infinispan.util.concurrent.TimeoutException
 import org.infinispan.remoting.transport.jgroups.SuspectException
 import org.infinispan.context.Flag
+import org.infinispan.config.{GlobalConfiguration, CacheLoaderManagerConfig, Configuration}
 
 /**
  * Hot Rod server, in charge of defining its encoder/decoder and, if clustered, update the topology information
@@ -252,10 +252,12 @@ class HotRodServer extends AbstractProtocolServer("HotRod") with Log {
    }
 
    private def defineTopologyCacheConfig(cacheManager: EmbeddedCacheManager, typedProps: TypedProperties) {
-      cacheManager.defineConfiguration(TopologyCacheName, createTopologyCacheConfig(typedProps))
+      cacheManager.defineConfiguration(TopologyCacheName,
+         createTopologyCacheConfig(typedProps,
+            cacheManager.getGlobalConfiguration.getDistributedSyncTimeout))
    }
 
-   protected def createTopologyCacheConfig(typedProps: TypedProperties): Configuration = {
+   protected def createTopologyCacheConfig(typedProps: TypedProperties, distSyncTimeout: Long): Configuration = {
       val lockTimeout = typedProps.getLongProperty(PROP_KEY_TOPOLOGY_LOCK_TIMEOUT, TOPO_LOCK_TIMEOUT_DEFAULT, true)
       val replTimeout = typedProps.getLongProperty(PROP_KEY_TOPOLOGY_REPL_TIMEOUT, TOPO_REPL_TIMEOUT_DEFAULT, true)
       val doStateTransfer = typedProps.getBooleanProperty(PROP_KEY_TOPOLOGY_STATE_TRANSFER, TOPO_STATE_TRANSFER_DEFAULT, true)
@@ -271,7 +273,8 @@ class HotRodServer extends AbstractProtocolServer("HotRod") with Log {
       topologyCacheConfig.setExpirationMaxIdle(-1); // No maximum idle time
       if (doStateTransfer) {
          topologyCacheConfig.setFetchInMemoryState(true) // State transfer required
-         topologyCacheConfig.setStateRetrievalTimeout(replTimeout)
+         // State transfer timeout should be bigger than the distributed lock timeout
+         topologyCacheConfig.setStateRetrievalTimeout(distSyncTimeout + replTimeout)
       } else {
          // Otherwise configure a cluster cache loader
          val loaderConfigs = new CacheLoaderManagerConfig

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodTestingUtil.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodTestingUtil.scala
@@ -29,11 +29,11 @@ import org.testng.Assert._
 import org.infinispan.server.hotrod._
 import logging.Log
 import org.infinispan.config.Configuration.CacheMode
-import org.infinispan.config.Configuration
 import org.infinispan.manager.EmbeddedCacheManager
 import org.infinispan.server.core.Main._
 import java.util.{Properties, Arrays}
 import org.infinispan.util.{TypedProperties, Util}
+import org.infinispan.config.{GlobalConfiguration, Configuration}
 
 /**
  * Test utils for Hot Rod tests.
@@ -82,11 +82,11 @@ object HotRodTestingUtil extends Log {
 
    def startHotRodServer(manager: EmbeddedCacheManager, port: Int, delay: Long, props: Properties): HotRodServer = {
       val server = new HotRodServer {
-         override protected def createTopologyCacheConfig(typedProps: TypedProperties): Configuration = {
+         override protected def createTopologyCacheConfig(typedProps: TypedProperties, distSyncTimeout: Long): Configuration = {
             if (delay > 0)
                Thread.sleep(delay)
 
-            val cfg = super.createTopologyCacheConfig(typedProps)
+            val cfg = super.createTopologyCacheConfig(typedProps, distSyncTimeout)
             cfg.setSyncCommitPhase(true) // Only for testing, so that asserts work fine.
             cfg.setSyncRollbackPhase(true) // Only for testing, so that asserts work fine.
             cfg
@@ -113,8 +113,8 @@ object HotRodTestingUtil extends Log {
 
    def startCrashingHotRodServer(manager: EmbeddedCacheManager, port: Int): HotRodServer = {
       val server = new HotRodServer {
-         override protected def createTopologyCacheConfig(typedProps: TypedProperties): Configuration = {
-            val cfg = super.createTopologyCacheConfig(typedProps)
+         override protected def createTopologyCacheConfig(typedProps: TypedProperties, distSyncTimeout: Long): Configuration = {
+            val cfg = super.createTopologyCacheConfig(typedProps, distSyncTimeout)
             cfg.setSyncCommitPhase(true) // Only for testing, so that asserts work fine.
             cfg.setSyncRollbackPhase(true) // Only for testing, so that asserts work fine.
             cfg


### PR DESCRIPTION
The state transfer timeout should be bigger than the distributed sync
timeout, so make sure that's taken into account when defining it.
