### PR TITLE
ISPN-1158 Eviction without passivation is now a warning

### DIFF
--- a/core/src/main/java/org/infinispan/config/ConfigurationValidatingVisitor.java
+++ b/core/src/main/java/org/infinispan/config/ConfigurationValidatingVisitor.java
@@ -100,7 +100,7 @@ public class ConfigurationValidatingVisitor extends AbstractConfigurationBeanVis
    @Override
    public void visitCacheLoaderManagerConfig(CacheLoaderManagerConfig cacheLoaderManagerConfig) {
       if (!evictionEnabled && cacheLoaderManagerConfig.isPassivation())
-         throw new ConfigurationException("Passivation configured without a valid eviction policy.  This would mean that the cache store will never get used.");
+         log.passivationWithoutEviction();
 
       boolean shared = cacheLoaderManagerConfig.isShared();
       if (!shared) {

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -54,6 +54,7 @@ import org.jgroups.util.RspList;
 import org.jgroups.util.TopologyUUID;
 
 import javax.management.MBeanServer;
+import javax.management.ObjectName;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.*;
@@ -162,7 +163,7 @@ public class JGroupsTransport extends AbstractTransport implements ExtendedMembe
             // when first cache starts, so it's safer to do it here.
             globalStatsEnabled = configuration.isExposeGlobalJmxStatistics();
             if (globalStatsEnabled) {
-               String groupName = String.format("type=channel,cluster=%s", clusterName);
+               String groupName = String.format("type=channel,cluster=%s", ObjectName.quote(clusterName));
                mbeanServer = JmxUtil.lookupMBeanServer(configuration);
                domain = JmxUtil.buildJmxDomain(configuration, mbeanServer, groupName);
                JmxConfigurator.registerChannel((JChannel) channel, mbeanServer, domain, clusterName, true);

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -727,4 +727,9 @@ public interface Log extends BasicLogger {
    @Message(value = "Error flushing to file: %s", id = 151)
    void errorFlushingToFileChannel(FileChannel f, @Cause Exception e);
 
+   @LogMessage(level = WARN)
+   @Message(value = "Passivation configured without a valid eviction policy.  " +
+      "This could mean that the cache store will never get used unless code calls Cache.evict() manually.", id = 152)
+   void passivationWithoutEviction();
+
 }

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -1006,7 +1006,7 @@ public class TestingUtil {
    }
 
    public static ObjectName getJGroupsChannelObjectName(String jmxDomain, String clusterName) throws Exception {
-      return new ObjectName(String.format("%s:type=channel,cluster=%s", jmxDomain, clusterName));
+      return new ObjectName(String.format("%s:type=channel,cluster=%s", jmxDomain, ObjectName.quote(clusterName)));
    }
 
    public static String generateRandomString(int numberOfChars) {


### PR DESCRIPTION
Also fixed a regression as a result of the JGroups upgrade related
to the way JGroups forms the MBean names. It now quotes the cluster
names which is probably the result of AS7 work.
