### PR TITLE
ISPN-1238 - Root cause of exceptions thrown by custom JGroupsTransportLoo

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -275,9 +275,11 @@ public class JGroupsTransport extends AbstractTransport implements ExtendedMembe
                startChannel = lookup.shouldStartAndConnect();
                stopChannel = lookup.shouldStopAndDisconnect();
             } catch (ClassCastException e) {
-               log.wrongTypeForJGroupsChannelLookup(channelLookupClassName);
+               log.wrongTypeForJGroupsChannelLookup(channelLookupClassName, e);
+               throw new CacheException(e);
             } catch (Exception e) {
-               log.errorInstantiatingJGroupsChannelLookup(channelLookupClassName);
+               log.errorInstantiatingJGroupsChannelLookup(channelLookupClassName, e);
+               throw new CacheException(e);
             }
          }
 

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -438,11 +438,11 @@ public interface Log extends BasicLogger {
 
    @LogMessage(level = ERROR)
    @Message(value = "Class [%s] cannot be cast to JGroupsChannelLookup!  Not using a channel lookup.", id = 83)
-   void wrongTypeForJGroupsChannelLookup(String channelLookupClassName);
+   void wrongTypeForJGroupsChannelLookup(String channelLookupClassName, @Cause Exception e);
 
    @LogMessage(level = ERROR)
    @Message(value = "Errors instantiating [%s]!  Not using a channel lookup.", id = 84)
-   void errorInstantiatingJGroupsChannelLookup(String channelLookupClassName);
+   void errorInstantiatingJGroupsChannelLookup(String channelLookupClassName, @Cause Exception e);
 
    @LogMessage(level = ERROR)
    @Message(value = "Error while trying to create a channel using config files: %s", id = 85)


### PR DESCRIPTION
ISPN-1238 - Root cause of exceptions thrown by custom JGroupsTransportLookup getting swallowed

Throw exception when lookup fails, only try the other configuration methods if lookup wasn't configured at all.
