### PR TITLE
ISPN-1233 Cluster ID generator now generates a version on creation

### DIFF
--- a/core/src/main/java/org/infinispan/transaction/xa/TransactionFactory.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/TransactionFactory.java
@@ -287,13 +287,7 @@ public class TransactionFactory {
       init(dldEnabled, recoveryEnabled, xa);
       isClustered = configuration.getCacheMode().isClustered();
       if (recoveryEnabled) {
-         clusterIdGenerator = new ClusterIdGenerator();
-         ClusterIdGenerator.RankCalculator rcl = clusterIdGenerator.getRankCalculatorListener();
-         cm.addListener(rcl);
-         if (rpcManager != null) {
-            Transport transport = rpcManager.getTransport();
-            rcl.calculateRank(rpcManager.getAddress(), transport.getMembers(), transport.getViewId());
-         }
+         clusterIdGenerator = new ClusterIdGenerator(cm, rpcManager);
       }
    }
 

--- a/core/src/test/java/org/infinispan/util/ClusterIdGeneratorTest.java
+++ b/core/src/test/java/org/infinispan/util/ClusterIdGeneratorTest.java
@@ -35,13 +35,13 @@ import static org.testng.AssertJUnit.assertEquals;
    public class ClusterIdGeneratorTest {
 
    public void testGenerateVersion() {
-      ClusterIdGenerator vg = new ClusterIdGenerator();
+      ClusterIdGenerator vg = new ClusterIdGenerator(null, null);
       vg.resetCounter();
       TestAddress addr1 = new TestAddress(1);
       TestAddress addr2 = new TestAddress(2);
       TestAddress addr3 = new TestAddress(1);
       List<Address> members = Arrays.asList((Address)addr1, addr2, addr3);
-      vg.getRankCalculatorListener().calculateRank(addr2, members, 1);
+      vg.calculateRank(addr2, members, 1);
 
 
       assertEquals(vg.newVersion(true), (Object)0x1000200000001L);

--- a/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolServer.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolServer.scala
@@ -25,13 +25,12 @@ package org.infinispan.server.core
 import java.net.InetSocketAddress
 import org.infinispan.manager.EmbeddedCacheManager
 import org.infinispan.server.core.Main._
-import java.util.Properties
 import transport.NettyTransport
-import org.infinispan.util.{ClusterIdGenerator, TypedProperties, Util, FileLookup}
+import org.infinispan.util.{ClusterIdGenerator, TypedProperties, FileLookup}
 import logging.Log
 import org.infinispan.jmx.{JmxUtil, ResourceDMBean}
-import org.infinispan.config.GlobalConfiguration
 import javax.management.{ObjectName, MBeanServer}
+import java.util.Properties
 
 /**
  * A common protocol server dealing with common property parameter validation and assignment and transport lifecycle.
@@ -90,12 +89,13 @@ abstract class AbstractProtocolServer(threadNamePrefix: String) extends Protocol
                   "idleTimeout=%d, tcpNoDelay=%b, sendBufSize=%d, recvBufSize=%d", host, port,
                   masterThreads, workerThreads, idleTimeout, tcpNoDelay, sendBufSize, recvBufSize)
          }
-         this.versionGenerator = new ClusterIdGenerator()
 
-         // Register rank calculator before starting any cache so that we can capture all view changes
-         cacheManager.addListener(this.versionGenerator.getRankCalculatorListener)
          // Start default cache
          startDefaultCache
+
+         this.versionGenerator = new ClusterIdGenerator(
+            cacheManager, cacheManager.getCache().getAdvancedCache.getRpcManager)
+
          startTransport(idleTimeout, tcpNoDelay, sendBufSize, recvBufSize, typedProps)
       }
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1233

This avoids issues of version not being set when the JGroups transport
is started before the view listener has been associated.
