### PR TITLE
ISPN-1225 Check length of VInt and VLong values

### DIFF
--- a/server/core/src/main/scala/org/infinispan/server/core/transport/VLong.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/transport/VLong.scala
@@ -44,14 +44,18 @@ object VLong {
 
    def read(in: ChannelBuffer): Long = {
       val b = in.readByte
-      read(in, b, 7, b & 0x7F)
+      read(in, b, 7, b & 0x7F, 1)
    }
 
-   private def read(in: ChannelBuffer, b: Byte, shift: Int, i: Long): Long = {
+   private def read(in: ChannelBuffer, b: Byte, shift: Int, i: Long, count: Int): Long = {
       if ((b & 0x80) == 0) i
       else {
+         if (count > 9)
+            throw new IllegalStateException(
+               "Stream corrupted.  A variable length long cannot be longer than 9 bytes.")
+
          val bb = in.readByte
-         read(in, bb, shift + 7, i | (bb & 0x7FL) << shift)
+         read(in, bb, shift + 7, i | (bb & 0x7FL) << shift, count + 1)
       }
    }
 }

--- a/server/core/src/test/scala/org/infinispan/server/core/VariableLengthTest.scala
+++ b/server/core/src/test/scala/org/infinispan/server/core/VariableLengthTest.scala
@@ -104,6 +104,14 @@ class VariableLengthTest {
       writeReadLong(9223372036854775807L, 9)
    }
 
+   @Test(expectedExceptions = Array(classOf[IllegalStateException]))
+   def testTooLongInt {
+      val buffer = ChannelBuffers.directBuffer(1024)
+      assert(buffer.writerIndex == 0)
+      writeUnsignedLong(9223372036854775807L, buffer)
+      readUnsignedInt(buffer)
+   }
+
 //   def test2pow63() {
 //      writeReadLong(9223372036854775808L, 10)
 //   }
@@ -124,14 +132,4 @@ class VariableLengthTest {
       assertEquals(readUnsignedLong(buffer), num)
    }
 
-//   def testEquals128Old() {
-//      val baos = new ByteArrayOutputStream(1024);
-//      val oos = new ObjectOutputStream(baos);
-//      UnsignedNumeric.writeUnsignedInt(oos, 128);
-//      oos.flush();
-//      assertEquals(baos.size() - 6, 2);
-//      val bais = new ByteArrayInputStream(baos.toByteArray());
-//      val ois = new ObjectInputStream(bais);
-//      assertEquals(UnsignedNumeric.readUnsignedInt(ois), 128);
-//   }
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
@@ -190,6 +190,11 @@ class HotRodDecoder(cacheManager: EmbeddedCacheManager, transport: NettyTranspor
                   "%s: %s".format(r.getMessage, r.getCause.toString)
             (new HotRodException(new ErrorResponse(r.messageId, "", 1, ParseError, 0, msg), e), true)
          }
+         case i: IllegalStateException => {
+            // Some internal server code could throw this, so make sure it's logged
+            logExceptionReported(i)
+            (new HotRodException(header.decoder.createErrorResponse(header, i), e), false)
+         }
          case t: Throwable => (new HotRodException(header.decoder.createErrorResponse(header, t), e), false)
       }
    }

--- a/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedDecoder.scala
+++ b/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedDecoder.scala
@@ -433,12 +433,13 @@ class MemcachedDecoder(memcachedCache: Cache[String, MemcachedValue], scheduler:
                   null // no-op, only log
                }
                case i: IOException => {
-                  logExceptionReported(i)
-                  sb.append(m.getMessage).append(CRLF)
+                  logAndCreateErrorMessage(sb, m)
                }
                case n: NumberFormatException => {
-                  logExceptionReported(n)
-                  sb.append(m.getMessage).append(CRLF)
+                  logAndCreateErrorMessage(sb, m)
+               }
+               case i: IllegalStateException => {
+                  logAndCreateErrorMessage(sb, m)
                }
                case _ => sb.append(m.getMessage).append(CRLF)
             }
@@ -449,6 +450,11 @@ class MemcachedDecoder(memcachedCache: Cache[String, MemcachedValue], scheduler:
          }
          case _ => sb.append(SERVER_ERROR).append(t.getMessage).append(CRLF)
       }
+   }
+
+   private def logAndCreateErrorMessage(sb: StringBuilder, m: MemcachedException): StringBuilder = {
+      logExceptionReported(m.getCause)
+      sb.append(m.getMessage).append(CRLF)
    }
 
    override protected def createServerException(e: Exception, b: ChannelBuffer): (MemcachedException, Boolean) = {


### PR DESCRIPTION
I've added explicit exception handling for IllegalStateException
instances to make sure these are logged. The code does this to
avoid indiscriminate logging of exceptions cominng from the
Infinispan core.

https://issues.jboss.org/browse/ISPN-1225
