### PR TITLE
ISPN-1251

### DIFF
--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -119,6 +119,17 @@
                <parallel>none</parallel>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <configuration>
+               <instructions>
+                  <Export-Package>
+                     ${project.groupId}.cdi.*;version=${project.version};-split-package:=error
+                  </Export-Package>
+               </instructions>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
    <profiles>


### PR DESCRIPTION
While working on an Infinispan CDI sample application I've found a problem in the CDI integration module packaging (all Infinispan classes are packaged in the jar due to the maven-bundle-plugin configuration in the parent pom).
