### PR TITLE
ISPN-1268 Move wakeUpInterval to expiration XML element

### DIFF
--- a/cachestore/jdbc/src/test/resources/configs/jdbc-parsing-test.xml
+++ b/cachestore/jdbc/src/test/resources/configs/jdbc-parsing-test.xml
@@ -148,11 +148,14 @@
    <namedCache name="evictionCache">
 
       <!--
-         Eviction configuration.  WakeupInterval defines how often the eviction thread runs, in milliseconds.  0 means
-         the eviction thread will never run.  A separate executor is used for eviction in each cache.
+         Eviction configuration.
       -->
-      <eviction wakeUpInterval="500" maxEntries="5000" strategy="FIFO"/>
-      <expiration lifespan="60000" maxIdle="1000"/>
+      <eviction maxEntries="5000" strategy="FIFO"/>
+      <!--
+         Expiration wakeUpInterval defines the interval between successive runs
+         to purge expired entries from memory and any cache stores.
+      -->
+      <expiration wakeUpInterval="500" lifespan="60000" maxIdle="1000"/>
    </namedCache>
 
    <namedCache name="withouthJmxEnabled">

--- a/cachestore/remote/src/test/java/org/infinispan/loaders/remote/RemoteCacheStoreTest.java
+++ b/cachestore/remote/src/test/java/org/infinispan/loaders/remote/RemoteCacheStoreTest.java
@@ -56,13 +56,10 @@ public class RemoteCacheStoreTest extends BaseCacheStoreTest {
       assert remoteCacheStoreConfig.isUseDefaultRemoteCache();
 
       localCacheManager = TestCacheManagerFactory.createLocalCacheManager();
-      localCacheManager.getDefaultConfiguration()
-         .fluent()
-            .eviction()
-               .maxEntries(100)
-               .wakeUpInterval(10L)
-               .strategy(EvictionStrategy.UNORDERED)
-             .build();
+      localCacheManager.getDefaultConfiguration().fluent()
+         .eviction().maxEntries(100).strategy(EvictionStrategy.UNORDERED)
+         .expiration().wakeUpInterval(10L)
+         .build();
       hrServer = TestHelper.startHotRodServer(localCacheManager);
       Properties properties = new Properties();
       properties.put("infinispan.client.hotrod.server_list", "localhost:" + hrServer.getPort());

--- a/cdi/src/test/java/org/infinispan/cdi/test/cachemanager/external/Config.java
+++ b/cdi/src/test/java/org/infinispan/cdi/test/cachemanager/external/Config.java
@@ -64,18 +64,14 @@ public class Config {
       EmbeddedCacheManager externalCacheContainerManager = new DefaultCacheManager();
 
       // define large configuration
-      Configuration largeConfiguration = new Configuration();
-      largeConfiguration.fluent()
-            .eviction()
-            .maxEntries(100);
+      Configuration largeConfiguration = new Configuration().fluent()
+         .eviction().maxEntries(100).build();
 
       externalCacheContainerManager.defineConfiguration("large", largeConfiguration);
 
       // define quick configuration
-      Configuration quickConfiguration = new Configuration();
-      quickConfiguration.fluent()
-            .eviction()
-            .wakeUpInterval(1l);
+      Configuration quickConfiguration = new Configuration().fluent()
+         .expiration().wakeUpInterval(1l).build();
 
       externalCacheContainerManager.defineConfiguration("quick", quickConfiguration);
 

--- a/cdi/src/test/java/org/infinispan/cdi/test/cachemanager/external/ExternalCacheContainerTest.java
+++ b/cdi/src/test/java/org/infinispan/cdi/test/cachemanager/external/ExternalCacheContainerTest.java
@@ -62,6 +62,6 @@ public class ExternalCacheContainerTest extends Arquillian {
    }
 
    public void testQuickCache() {
-      assertEquals(quickCache.getConfiguration().getEvictionWakeUpInterval(), 1);
+      assertEquals(quickCache.getConfiguration().getExpirationWakeUpInterval(), 1);
    }
 }

--- a/cdi/src/test/java/org/infinispan/cdi/test/cachemanager/xml/Config.java
+++ b/cdi/src/test/java/org/infinispan/cdi/test/cachemanager/xml/Config.java
@@ -67,10 +67,8 @@ public class Config {
    public EmbeddedCacheManager getDefaultCacheManager(@Resource("infinispan.xml") InputStream xml) throws IOException {
       EmbeddedCacheManager externalCacheContainerManager = new DefaultCacheManager(xml);
 
-      Configuration quickVeryLargeConfiguration = externalCacheContainerManager.getDefaultConfiguration().clone();
-      quickVeryLargeConfiguration.fluent()
-            .eviction()
-            .wakeUpInterval(1l);
+      Configuration quickVeryLargeConfiguration = new Configuration().fluent()
+            .expiration().wakeUpInterval(1l).build();
 
       externalCacheContainerManager.defineConfiguration("quick-very-large", quickVeryLargeConfiguration);
 

--- a/cdi/src/test/java/org/infinispan/cdi/test/cachemanager/xml/XMLConfiguredCacheContainerTest.java
+++ b/cdi/src/test/java/org/infinispan/cdi/test/cachemanager/xml/XMLConfiguredCacheContainerTest.java
@@ -62,6 +62,6 @@ public class XMLConfiguredCacheContainerTest extends Arquillian {
 
    public void testQuickCache() {
       assertEquals(quickCache.getConfiguration().getEvictionMaxEntries(), 1000);
-      assertEquals(quickCache.getConfiguration().getEvictionWakeUpInterval(), 1);
+      assertEquals(quickCache.getConfiguration().getExpirationWakeUpInterval(), 1);
    }
 }

--- a/core/src/main/java/org/infinispan/config/Configuration.java
+++ b/core/src/main/java/org/infinispan/config/Configuration.java
@@ -543,18 +543,14 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
    }
 
    /**
-    * Eviction thread wake up interval, in milliseconds.
+    * @deprecated Use {@link #getExpirationWakeUpInterval()}
     */
    public long getEvictionWakeUpInterval() {
-      return eviction.wakeUpInterval;
+      return getExpirationWakeUpInterval();
    }
 
    /**
-    * Interval between subsequent eviction runs, in milliseconds. If you wish to disable the periodic eviction process
-    * altogether, set wakeupInterval to -1.
-    *
-    * @param evictionWakeUpInterval
-    * @deprecated Use {@link FluentConfiguration.EvictionConfig#wakeUpInterval(Long)} instead
+    * @deprecated Use {@link FluentConfiguration.ExpirationConfig#wakeUpInterval(Long)} instead
     */
    @Deprecated
    public void setEvictionWakeUpInterval(long evictionWakeUpInterval) {
@@ -676,6 +672,13 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
    @Deprecated
    public void setExpirationMaxIdle(long expirationMaxIdle) {
       this.expiration.setMaxIdle(expirationMaxIdle);
+   }
+
+   /**
+    * Eviction thread wake up interval, in milliseconds.
+    */
+   public long getExpirationWakeUpInterval() {
+      return expiration.wakeUpInterval;
    }
 
    /**
@@ -2493,6 +2496,10 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
       @ConfigurationDocRef(bean = Configuration.class, targetElement = "setExpirationMaxIdle")
       protected Long maxIdle = -1L;
 
+      @ConfigurationDocRef(bean = ExpirationConfig.class, targetElement = "wakeUpInterval")
+      @XmlAttribute
+      protected Long wakeUpInterval = 5000L;
+
       public void accept(ConfigurationBeanVisitor v) {
          v.visitExpirationType(this);
       }
@@ -2538,6 +2545,13 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
       }
 
       @Override
+      public ExpirationConfig wakeUpInterval(Long wakeUpInterval) {
+         testImmutability("wakeUpInterval");
+         this.wakeUpInterval = wakeUpInterval;
+         return this;
+      }
+
+      @Override
       protected ExpirationType setConfiguration(Configuration config) {
          super.setConfiguration(config);
          return this;
@@ -2552,6 +2566,8 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
 
          if (lifespan != null ? !lifespan.equals(that.lifespan) : that.lifespan != null) return false;
          if (maxIdle != null ? !maxIdle.equals(that.maxIdle) : that.maxIdle != null) return false;
+         if (wakeUpInterval != null ? !wakeUpInterval.equals(that.wakeUpInterval) : that.wakeUpInterval != null)
+            return false;
 
          return true;
       }
@@ -2560,6 +2576,7 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
       public int hashCode() {
          int result = lifespan != null ? lifespan.hashCode() : 0;
          result = 31 * result + (maxIdle != null ? maxIdle.hashCode() : 0);
+         result = 31 * result + (wakeUpInterval != null ? wakeUpInterval.hashCode() : 0);
          return result;
       }
    }
@@ -2578,8 +2595,8 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
        */
       private static final long serialVersionUID = -1248563712058858791L;
 
-      @ConfigurationDocRef(bean = Configuration.class, targetElement = "setEvictionWakeUpInterval")
-      protected Long wakeUpInterval = 5000L;
+      @Deprecated
+      protected Long wakeUpInterval = Long.MIN_VALUE;
 
       @ConfigurationDocRef(bean = Configuration.class, targetElement = "setEvictionStrategy")
       protected EvictionStrategy strategy = EvictionStrategy.NONE;
@@ -2594,24 +2611,24 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
          v.visitEvictionType(this);
       }
 
+      /**
+       * @deprecated Use {@link org.infinispan.config.Configuration#getExpirationWakeUpInterval()}
+       */
       @XmlAttribute
+      @Deprecated
       public Long getWakeUpInterval() {
+         log.evictionWakeUpIntervalDeprecated();
          return wakeUpInterval;
       }
 
       /**
-       * @deprecated The visibility of this will be reduced, use {@link #wakeUpInterval(Long)}
+       * @deprecated Use {@link ExpirationConfig#wakeUpInterval(Long)}
        */
       @Deprecated
       public void setWakeUpInterval(Long wakeUpInterval) {
+         log.evictionWakeUpIntervalDeprecated();
          testImmutability("wakeUpInterval");
          this.wakeUpInterval = wakeUpInterval;
-      }
-
-      @Override
-      public EvictionConfig wakeUpInterval(Long wakeUpInterval) {
-         setWakeUpInterval(wakeUpInterval);
-         return this;
       }
 
       @XmlAttribute
@@ -2690,16 +2707,13 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
          if (maxEntries != null ? !maxEntries.equals(that.maxEntries) : that.maxEntries != null) return false;
          if (strategy != that.strategy) return false;
          if (threadPolicy != that.threadPolicy) return false;
-         if (wakeUpInterval != null ? !wakeUpInterval.equals(that.wakeUpInterval) : that.wakeUpInterval != null)
-            return false;
 
          return true;
       }
 
       @Override
       public int hashCode() {
-         int result = wakeUpInterval != null ? wakeUpInterval.hashCode() : 0;
-         result = 31 * result + (strategy != null ? strategy.hashCode() : 0);
+         int result = strategy != null ? strategy.hashCode() : 0;
          result = 31 * result + (threadPolicy != null ? threadPolicy.hashCode() : 0);
          result = 31 * result + (maxEntries != null ? maxEntries.hashCode() : 0);
          return result;

--- a/core/src/main/java/org/infinispan/config/FluentConfiguration.java
+++ b/core/src/main/java/org/infinispan/config/FluentConfiguration.java
@@ -314,14 +314,6 @@ public class FluentConfiguration extends AbstractFluentConfigurationBean {
     */
    public interface EvictionConfig extends FluentTypes {
       /**
-       * Interval between subsequent eviction runs, in milliseconds. If you wish to disable the
-       * periodic eviction process altogether, set wakeupInterval to -1.
-       *
-       * @param wakeUpInterval
-       */
-      EvictionConfig wakeUpInterval(Long wakeUpInterval);
-
-      /**
        * Eviction strategy. Available options are 'UNORDERED', 'FIFO', 'LRU', 'LIRS' and 'NONE' (to disable
        * eviction).
        *
@@ -370,6 +362,15 @@ public class FluentConfiguration extends AbstractFluentConfigurationBean {
        * @param maxIdle
        */
       ExpirationConfig maxIdle(Long maxIdle);
+
+      /**
+       * Interval (in milliseconds) between subsequent runs to purge expired
+       * entries from memory and any cache stores. If you wish to disable the
+       * periodic eviction process altogether, set wakeupInterval to -1.
+       *
+       * @param wakeUpInterval
+       */
+      ExpirationConfig wakeUpInterval(Long wakeUpInterval);
    }
 
    /**

--- a/core/src/main/java/org/infinispan/eviction/EvictionManager.java
+++ b/core/src/main/java/org/infinispan/eviction/EvictionManager.java
@@ -34,9 +34,9 @@ import org.infinispan.factories.scopes.Scopes;
  * Central component that deals with eviction of cache entries.
  * <p />
  * Typically, {@link #processEviction()} is called periodically by the eviction thread (which can be configured using
- * {@link org.infinispan.config.Configuration#setEvictionWakeUpInterval(long)} and {@link org.infinispan.config.GlobalConfiguration#setEvictionScheduledExecutorFactoryClass(String)}).
+ * {@link org.infinispan.config.FluentConfiguration.ExpirationConfig#wakeUpInterval(Long)} and {@link org.infinispan.config.GlobalConfiguration#setEvictionScheduledExecutorFactoryClass(String)}).
  * <p />
- * If the eviction thread is disabled - by setting {@link org.infinispan.config.Configuration#setEvictionWakeUpInterval (long)} to <tt>0</tt> -
+ * If the eviction thread is disabled - by setting {@link org.infinispan.config.FluentConfiguration.ExpirationConfig#wakeUpInterval(Long)} to <tt>0</tt> -
  * then this method could be called directly, perhaps by any other maintenance thread that runs periodically in the application.
  * <p />
  * Note that this method is a no-op if the eviction strategy configured is {@link org.infinispan.eviction.EvictionStrategy#NONE}.

--- a/core/src/main/java/org/infinispan/eviction/EvictionManagerImpl.java
+++ b/core/src/main/java/org/infinispan/eviction/EvictionManagerImpl.java
@@ -81,11 +81,12 @@ public class EvictionManagerImpl implements EvictionManager {
             cacheStore = cacheLoaderManager.getCacheStore();
          }
          // Set up the eviction timer task
-         if (configuration.getEvictionWakeUpInterval() <= 0) {
+         long expWakeUpInt = configuration.getExpirationWakeUpInterval();
+         if (expWakeUpInt <= 0) {
             log.notStartingEvictionThread();
          } else {
-            evictionTask = executor.scheduleWithFixedDelay(new ScheduledTask(), configuration.getEvictionWakeUpInterval(),
-                                                           configuration.getEvictionWakeUpInterval(), TimeUnit.MILLISECONDS);
+            evictionTask = executor.scheduleWithFixedDelay(new ScheduledTask(),
+                  expWakeUpInt, expWakeUpInt, TimeUnit.MILLISECONDS);
          }
       }
    }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -200,7 +200,7 @@ public interface Log extends BasicLogger {
    void unableToStopTransactionLogging(@Cause IllegalMonitorStateException imse);
 
    @LogMessage(level = INFO)
-   @Message(value = "wakeUpInterval is <= 0, not starting eviction thread", id = 25)
+   @Message(value = "wakeUpInterval is <= 0, not starting expired purge thread", id = 25)
    void notStartingEvictionThread();
 
    @LogMessage(level = WARN)
@@ -731,5 +731,9 @@ public interface Log extends BasicLogger {
    @Message(value = "Passivation configured without a valid eviction policy.  " +
       "This could mean that the cache store will never get used unless code calls Cache.evict() manually.", id = 152)
    void passivationWithoutEviction();
+
+   @LogMessage(level = WARN)
+   @Message(value = "Ignoring eviction wakeUpInterval configuration since it is deprecated, please configure Expiration's wakeUpInterval instead", id = 153)
+   void evictionWakeUpIntervalDeprecated();
 
 }

--- a/core/src/main/resources/config-samples/sample.xml
+++ b/core/src/main/resources/config-samples/sample.xml
@@ -314,8 +314,10 @@
    -->
 
    <!--
-      A cache configured with eviction.  WakeupInterval defines how often the eviction thread runs, in milliseconds.
-      0 means the eviction thread will never run.  A separate executor is used for eviction in each cache.
+      A cache configured with eviction.
+
+      Expiration wakeUpInterval defines the interval between successive runs
+      to purge expired entries from memory and any cache stores.
 
       See:
 
@@ -325,11 +327,11 @@
    <!--
    <namedCache name="evictionCache">
       <eviction
-         wakeUpInterval="500"
          maxEntries="5000"
          strategy="FIFO"
       />
       <expiration
+         wakeUpInterval="500"
          lifespan="60000"
          maxIdle="1000"
       />
@@ -387,11 +389,11 @@
    <!--
    <namedCache name="evictionAndPassivationCache">
       <eviction 
-         wakeUpInterval="500"
          maxEntries="5000"
          strategy="LIRS"
       />
       <expiration
+         wakeUpInterval="500"
          lifespan="60000"
          maxIdle="1000"
       />

--- a/core/src/main/resources/xslt/ehcache1x2infinispan4x.xslt
+++ b/core/src/main/resources/xslt/ehcache1x2infinispan4x.xslt
@@ -95,18 +95,6 @@
                </xsl:if>
             </xsl:attribute>
 
-            <xsl:attribute name="wakeUpInterval">
-               <xsl:choose>
-                  <xsl:when test="@diskExpiryThreadIntervalSeconds">
-                     <xsl:value-of select="concat(@diskExpiryThreadIntervalSeconds,'000')"/>
-                  </xsl:when>
-                  <xsl:otherwise>
-                     <!-- by default the value is 120 seconds in EHCache-->
-                     <xsl:value-of select="120000"/>
-                  </xsl:otherwise>
-               </xsl:choose>
-            </xsl:attribute>
-
             <xsl:if test="@maxElementsInMemory">
                <xsl:attribute name="maxEntries">
                   <xsl:value-of select="@maxElementsInMemory"/>
@@ -128,6 +116,17 @@
                   <xsl:value-of select="@timeToLiveSeconds"/>
                </xsl:attribute>
             </xsl:if>
+            <xsl:attribute name="wakeUpInterval">
+               <xsl:choose>
+                  <xsl:when test="@diskExpiryThreadIntervalSeconds">
+                     <xsl:value-of select="concat(@diskExpiryThreadIntervalSeconds,'000')"/>
+                  </xsl:when>
+                  <xsl:otherwise>
+                     <!-- by default the value is 120 seconds in EHCache-->
+                     <xsl:value-of select="120000"/>
+                  </xsl:otherwise>
+               </xsl:choose>
+            </xsl:attribute>
          </xsl:element>
       </xsl:if>
 

--- a/core/src/main/resources/xslt/jbc3x2infinispan4x.xslt
+++ b/core/src/main/resources/xslt/jbc3x2infinispan4x.xslt
@@ -398,11 +398,6 @@
          </xsl:attribute>
       </xsl:if>
       <xsl:element name="eviction">
-         <xsl:if test="/jbosscache/eviction[@wakeUpInterval]">
-            <xsl:attribute name="wakeUpInterval">
-               <xsl:value-of select="/jbosscache/eviction/@wakeUpInterval"/>
-            </xsl:attribute>
-         </xsl:if>
          <xsl:if test="property[@name='maxNodes']">
             <xsl:attribute name="maxEntries">
                <xsl:value-of select="normalize-space(property[@name='maxNodes']/@value)"/>
@@ -437,6 +432,11 @@
             <xsl:if test="property[@name='maxAge']">
                <xsl:attribute name="lifespan">
                   <xsl:value-of select="property[@name='maxAge']/@value"/>
+               </xsl:attribute>
+            </xsl:if>
+            <xsl:if test="/jbosscache/eviction[@wakeUpInterval]">
+               <xsl:attribute name="wakeUpInterval">
+                  <xsl:value-of select="/jbosscache/eviction/@wakeUpInterval"/>
                </xsl:attribute>
             </xsl:if>
          </xsl:element>

--- a/core/src/test/java/org/infinispan/config/ProgrammaticConfigurationTest.java
+++ b/core/src/test/java/org/infinispan/config/ProgrammaticConfigurationTest.java
@@ -188,9 +188,9 @@ public class ProgrammaticConfigurationTest extends AbstractInfinispanTest {
             .add(new CacheLoaderInterceptor()).before(CallInterceptor.class)
          .eviction()
             .maxEntries(7676).strategy(EvictionStrategy.FIFO)
-            .threadPolicy(EvictionThreadPolicy.PIGGYBACK).wakeUpInterval(7585L)
+            .threadPolicy(EvictionThreadPolicy.PIGGYBACK)
          .expiration()
-            .maxIdle(8392L).lifespan(4372L)
+            .maxIdle(8392L).lifespan(4372L).wakeUpInterval(7585L)
          .clustering()
             .mode(Configuration.CacheMode.INVALIDATION_SYNC)
             .async()
@@ -269,7 +269,7 @@ public class ProgrammaticConfigurationTest extends AbstractInfinispanTest {
       assert 7676 == c.getEvictionMaxEntries();
       assert EvictionStrategy.FIFO == c.getEvictionStrategy();
       assert EvictionThreadPolicy.PIGGYBACK == c.getEvictionThreadPolicy();
-      assert 7585L == c.getEvictionWakeUpInterval();
+      assert 7585L == c.getExpirationWakeUpInterval();
 
       List<CustomInterceptorConfig> customInterceptors = c.getCustomInterceptors();
       assert customInterceptors.get(0).getInterceptor() instanceof LockingInterceptor;

--- a/core/src/test/java/org/infinispan/config/parsing/EHCache2InfinispanTransformerTest.java
+++ b/core/src/test/java/org/infinispan/config/parsing/EHCache2InfinispanTransformerTest.java
@@ -82,7 +82,7 @@ public class EHCache2InfinispanTransformerTest extends AbstractInfinispanTest {
          assert clmConfig != null;
          CacheLoaderConfig loaderConfig = clmConfig.getCacheLoaderConfigs().get(0);
          assert loaderConfig.getCacheLoaderClassName().equals("org.infinispan.loaders.file.FileCacheStore");
-         assertEquals(configuration.getEvictionWakeUpInterval(), 119000);
+         assertEquals(configuration.getExpirationWakeUpInterval(), 119000);
          assertEquals(configuration.getEvictionStrategy(), EvictionStrategy.LRU);
 
          assert dcm.getDefinedCacheNames().contains("sampleCache1");

--- a/core/src/test/java/org/infinispan/config/parsing/Jbc2InfinispanTransformerTest.java
+++ b/core/src/test/java/org/infinispan/config/parsing/Jbc2InfinispanTransformerTest.java
@@ -89,7 +89,7 @@ public class Jbc2InfinispanTransformerTest extends AbstractInfinispanTest {
          assert defaultConfig.getEvictionStrategy().equals(EvictionStrategy.LRU);
          assert defaultConfig.getEvictionMaxEntries() == 5001;
          assert defaultConfig.getExpirationMaxIdle() == 1001 : "Received " + defaultConfig.getExpirationLifespan();
-         assert defaultConfig.getEvictionWakeUpInterval() == 50015;
+         assert defaultConfig.getExpirationWakeUpInterval() == 50015;
 
          ConcurrentMap<String, Configuration> configurationOverrides = (ConcurrentMap<String, Configuration>) TestingUtil.extractField(ecm, "configurationOverrides");
 
@@ -97,13 +97,13 @@ public class Jbc2InfinispanTransformerTest extends AbstractInfinispanTest {
          assert regionOne != null;
          assert regionOne.getEvictionStrategy().equals(EvictionStrategy.LRU);
          assert regionOne.getExpirationMaxIdle() == 2002;
-         assert regionOne.getEvictionWakeUpInterval() == 50015;
+         assert regionOne.getExpirationWakeUpInterval() == 50015;
 
          Configuration regionTwo = configurationOverrides.get("/org/jboss/data2");
          assert regionTwo != null;
          assert regionTwo.getEvictionStrategy().equals(EvictionStrategy.FIFO);
          assert regionTwo.getEvictionMaxEntries() == 3003;
-         assert regionTwo.getEvictionWakeUpInterval() == 50015;
+         assert regionTwo.getExpirationWakeUpInterval() == 50015;
 
 
          CacheLoaderManagerConfig loaderManagerConfig = defaultConfig.getCacheLoaderManagerConfig();

--- a/core/src/test/java/org/infinispan/distribution/rehash/DataLossOnJoinOneOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/DataLossOnJoinOneOwnerTest.java
@@ -25,6 +25,7 @@ import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
 /**
@@ -86,7 +87,7 @@ public class DataLossOnJoinOneOwnerTest extends AbstractInfinispanTest {
                .hash().numOwners(1)
             .clustering().l1().disable()
             .build();
-      return new DefaultCacheManager(gc, c);
+      return TestCacheManagerFactory.createCacheManager(gc, c);
    }
 
 }

--- a/core/src/test/java/org/infinispan/eviction/BaseEvictionFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/eviction/BaseEvictionFunctionalTest.java
@@ -49,12 +49,12 @@ public abstract class BaseEvictionFunctionalTest extends SingleCacheManagerTest 
    protected abstract EvictionStrategy getEvictionStrategy();
 
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      Configuration cfg = new Configuration();
-      cfg.setEvictionStrategy(getEvictionStrategy());
-      cfg.setEvictionWakeUpInterval(100);
-      cfg.setEvictionMaxEntries(128); // 128 max entries
-      cfg.setUseLockStriping(false); // to minimize chances of deadlock in the unit test
-      cfg.setInvocationBatchingEnabled(true);
+      Configuration cfg = new Configuration().fluent()
+         .eviction().strategy(getEvictionStrategy()).maxEntries(128) // 128 max entries
+         .expiration().wakeUpInterval(100L)
+         .locking().useLockStriping(false) // to minimize chances of deadlock in the unit test
+         .invocationBatching()
+         .build();
       EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(cfg);
       cache = cm.getCache();
       cache.addListener(new EvictionListener());

--- a/core/src/test/java/org/infinispan/eviction/EvictionManagerTest.java
+++ b/core/src/test/java/org/infinispan/eviction/EvictionManagerTest.java
@@ -36,15 +36,13 @@ import static org.easymock.EasyMock.*;
 public class EvictionManagerTest extends AbstractInfinispanTest {
 
    private Configuration getCfg() {
-      Configuration cfg = new Configuration();
-      cfg.setEvictionStrategy(EvictionStrategy.FIFO);
-      return cfg;
+      return new Configuration().fluent()
+            .eviction().strategy(EvictionStrategy.FIFO).build();
    }
 
    public void testNoEvictionThread() {
       EvictionManagerImpl em = new EvictionManagerImpl();
-      Configuration cfg = getCfg();
-      cfg.setEvictionWakeUpInterval(0);
+      Configuration cfg = getCfg().fluent().expiration().wakeUpInterval(0L).build();
 
       ScheduledExecutorService mockService = createMock(ScheduledExecutorService.class);
       em.initialize(mockService, cfg, null, null, null);
@@ -57,8 +55,7 @@ public class EvictionManagerTest extends AbstractInfinispanTest {
 
    public void testWakeupInterval() {
       EvictionManagerImpl em = new EvictionManagerImpl();
-      Configuration cfg = getCfg();
-      cfg.setEvictionWakeUpInterval(789);
+      Configuration cfg = getCfg().fluent().expiration().wakeUpInterval(789L).build();
 
       ScheduledExecutorService mockService = createMock(ScheduledExecutorService.class);
       em.initialize(mockService, cfg, null, null, null);

--- a/core/src/test/java/org/infinispan/eviction/EvictionThreadCountTest.java
+++ b/core/src/test/java/org/infinispan/eviction/EvictionThreadCountTest.java
@@ -32,7 +32,6 @@ import org.testng.annotations.Test;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.util.Properties;
 
 /**
  * Tests eviction thread counts under several distinct circumstances.
@@ -47,20 +46,20 @@ public class EvictionThreadCountTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      GlobalConfiguration globalCfg = new GlobalConfiguration();
-      Properties props = new Properties();
-      props.setProperty("threadNamePrefix", EVICT_THREAD_NAME_PREFIX);
-      globalCfg.setEvictionScheduledExecutorProperties(props);
+      GlobalConfiguration globalCfg = new GlobalConfiguration().fluent()
+         .evictionScheduledExecutor()
+            .addProperty("threadNamePrefix", EVICT_THREAD_NAME_PREFIX)
+         .build();
       return TestCacheManagerFactory.createCacheManager(globalCfg);
    }
 
    public void testDefineMultipleCachesWithEviction() {
       for (int i = 0; i < 50; i++) {
-         Configuration cfg = new Configuration();
-         cfg.setEvictionStrategy(EvictionStrategy.LIRS);
-         cfg.setEvictionWakeUpInterval(100);
-         cfg.setEvictionMaxEntries(128); // 128 max entries
-         cfg.setUseLockStriping(false); // to minimize chances of deadlock in the unit test
+         Configuration cfg = new Configuration().fluent()
+            .eviction().strategy(EvictionStrategy.LIRS).maxEntries(128) // 128 max entries
+            .expiration().wakeUpInterval(100L)
+            .locking().useLockStriping(false) // to minimize chances of deadlock in the unit test
+            .build();
          String cacheName = Integer.toString(i);
          cacheManager.defineConfiguration(cacheName, cfg);
          cacheManager.getCache(cacheName);

--- a/core/src/test/java/org/infinispan/eviction/MarshalledValuesEvictionTest.java
+++ b/core/src/test/java/org/infinispan/eviction/MarshalledValuesEvictionTest.java
@@ -48,12 +48,12 @@ public class MarshalledValuesEvictionTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      Configuration cfg = new Configuration();
-      cfg.setEvictionStrategy(EvictionStrategy.FIFO);
-      cfg.setEvictionWakeUpInterval(100);
-      cfg.setEvictionMaxEntries(CACHE_SIZE); // CACHE_SIZE max entries
-      cfg.setUseLockStriping(false); // to minimise chances of deadlock in the unit test
-      cfg.setUseLazyDeserialization(true);
+      Configuration cfg = new Configuration().fluent()
+         .eviction().strategy(EvictionStrategy.FIFO).maxEntries(CACHE_SIZE) // CACHE_SIZE max entries
+         .expiration().wakeUpInterval(100L)
+         .locking().useLockStriping(false) // to minimise chances of deadlock in the unit test
+         .storeAsBinary()
+         .build();
       EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(cfg);
       cache = cm.getCache();
       StreamingMarshaller marshaller = TestingUtil.extractComponent(cache, StreamingMarshaller.class);
@@ -135,8 +135,7 @@ public class MarshalledValuesEvictionTest extends SingleCacheManagerTest {
          if (this == o) return true;
          if (o == null || getClass() != o.getClass()) return false;
          EvictionPojo pojo = (EvictionPojo) o;
-         if (i != pojo.i) return false;
-         return true;
+         return i == pojo.i;
       }
 
       public int hashCode() {

--- a/core/src/test/java/org/infinispan/loaders/ConcurrentLoadAndEvictTxTest.java
+++ b/core/src/test/java/org/infinispan/loaders/ConcurrentLoadAndEvictTxTest.java
@@ -46,13 +46,11 @@ public class ConcurrentLoadAndEvictTxTest extends SingleCacheManagerTest {
    TransactionManager tm;
 
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      Configuration config = new Configuration();
-      config.setEvictionStrategy(EvictionStrategy.FIFO);
-      config.setEvictionWakeUpInterval(10);
-      config.setEvictionMaxEntries(1);
-      CacheLoaderManagerConfig clmc = new CacheLoaderManagerConfig();
-      config.setCacheLoaderManagerConfig(clmc);
-      clmc.addCacheLoaderConfig(new DummyInMemoryCacheStore.Cfg());
+      Configuration config = new Configuration().fluent()
+         .eviction().strategy(EvictionStrategy.FIFO).maxEntries(10)
+         .expiration().wakeUpInterval(10L)
+         .loaders().addCacheLoader(new DummyInMemoryCacheStore.Cfg())
+         .build();
       EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(config, true);
       cache = cm.getCache();
       tm = getTransactionManager(cache);

--- a/core/src/test/java/org/infinispan/stress/MapStressTest.java
+++ b/core/src/test/java/org/infinispan/stress/MapStressTest.java
@@ -89,11 +89,10 @@ public class MapStressTest {
    }
 
    private Cache<String, Integer> configureAndBuildCache(int capacity) {
-      Configuration config = new Configuration().fluent().eviction().maxEntries(capacity).strategy(EvictionStrategy.LRU)
-            .wakeUpInterval(5000L)
-            .expiration()
-            .maxIdle(120000L)
-            .build();
+      Configuration config = new Configuration().fluent()
+         .eviction().maxEntries(capacity).strategy(EvictionStrategy.LRU)
+         .expiration().wakeUpInterval(5000L).maxIdle(120000L)
+         .build();
 
       DefaultCacheManager cm = new DefaultCacheManager(GlobalConfiguration.getNonClusteredDefault(), config);
       cm.start();

--- a/core/src/test/resources/configs/named-cache-test.xml
+++ b/core/src/test/resources/configs/named-cache-test.xml
@@ -183,11 +183,14 @@
    <namedCache name="evictionCache">
 
       <!--
-         Eviction configuration.  WakeupInterval defines how often the eviction thread runs, in milliseconds.  0 means
-         the eviction thread will never run.  A separate executor is used for eviction in each cache.
+         Eviction configuration.
       -->
-      <eviction wakeUpInterval="500" maxEntries="5000"  threadPolicy="PIGGYBACK" strategy="FIFO"/>
-      <expiration lifespan="60000" maxIdle="1000"/>
+      <eviction maxEntries="5000"  threadPolicy="PIGGYBACK" strategy="FIFO"/>
+      <!--
+         Expiration wakeUpInterval defines the interval between successive runs
+         to purge expired entries from memory and any cache stores.
+      -->
+      <expiration wakeUpInterval="500" lifespan="60000" maxIdle="1000"/>
    </namedCache>
 
    <namedCache name="withouthJmxEnabled">

--- a/spring/src/main/java/org/infinispan/spring/AbstractEmbeddedCacheManagerFactory.java
+++ b/spring/src/main/java/org/infinispan/spring/AbstractEmbeddedCacheManagerFactory.java
@@ -134,7 +134,7 @@ public class AbstractEmbeddedCacheManagerFactory {
     * Sets the {@link org.springframework.core.io.Resource <code>location</code>} of the
     * configuration file which will be used to configure the
     * {@link org.infinispan.manager.EmbeddedCacheManager <code>EmbeddedCacheManager</code>} the
-    * {@link org.infinispan.spring.spi.SpringEmbeddedCacheManager
+    * {@link org.infinispan.spring.provider.SpringEmbeddedCacheManager
     * <code>SpringEmbeddedCacheManager</code>} created by this <code>FactoryBean</code> delegates
     * to. If no location is supplied, <tt>Infinispan</tt>'s default configuration will be used.
     * </p>
@@ -149,7 +149,7 @@ public class AbstractEmbeddedCacheManagerFactory {
     *           configuration file which will be used to configure the
     *           {@link org.infinispan.manager.EmbeddedCacheManager
     *           <code>EmbeddedCacheManager</code>} the
-    *           {@link org.infinispan.spring.spi.SpringEmbeddedCacheManager
+    *           {@link org.infinispan.spring.provider.SpringEmbeddedCacheManager
     *           <code>SpringEmbeddedCacheManager</code>} created by this <code>FactoryBean</code>
     *           delegates to
     */

--- a/spring/src/test/resources/org/infinispan/spring/provider/named-async-cache.xml
+++ b/spring/src/test/resources/org/infinispan/spring/provider/named-async-cache.xml
@@ -24,8 +24,10 @@
 
 -->
 
-<infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:infinispan:config:4.2 http://www.infinispan.org/schemas/infinispan-config-4.2.xsd"
-    xmlns="urn:infinispan:config:4.2">
+<infinispan
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:infinispan:config:5.0 http://www.infinispan.org/schemas/infinispan-config-5.0.xsd"
+      xmlns="urn:infinispan:config:5.0">
 
    <!--
       ******************************************************************************************************************
@@ -288,8 +290,7 @@
    -->
 
    <!--
-      A cache configured with eviction.  WakeupInterval defines how often the eviction thread runs, in milliseconds.
-      0 means the eviction thread will never run.  A separate executor is used for eviction in each cache.
+      A cache configured with eviction.
 
       See:
 
@@ -299,11 +300,11 @@
    <!--
    <namedCache name="evictionCache">
       <eviction
-         wakeUpInterval="500"
          maxEntries="5000"
          strategy="FIFO"
       />
       <expiration
+         wakeUpInterval="500"
          lifespan="60000"
          maxIdle="1000"
       />
@@ -361,11 +362,11 @@
    <!--
    <namedCache name="evictionAndPassivationCache">
       <eviction 
-         wakeUpInterval="500"
          maxEntries="5000"
          strategy="LIRS"
       />
       <expiration
+         wakeUpInterval="500"
          lifespan="60000"
          maxIdle="1000"
       />

--- a/spring/src/test/resources/org/infinispan/spring/support/embedded/named-async-cache.xml
+++ b/spring/src/test/resources/org/infinispan/spring/support/embedded/named-async-cache.xml
@@ -24,8 +24,10 @@
 
 -->
 
-<infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:infinispan:config:4.2 http://www.infinispan.org/schemas/infinispan-config-4.2.xsd"
-    xmlns="urn:infinispan:config:4.2">
+<infinispan
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:infinispan:config:5.0 http://www.infinispan.org/schemas/infinispan-config-5.0.xsd"
+      xmlns="urn:infinispan:config:5.0">
 
    <!--
       ******************************************************************************************************************
@@ -288,8 +290,7 @@
    -->
 
    <!--
-      A cache configured with eviction.  WakeupInterval defines how often the eviction thread runs, in milliseconds.
-      0 means the eviction thread will never run.  A separate executor is used for eviction in each cache.
+      A cache configured with eviction.
 
       See:
 
@@ -299,11 +300,11 @@
    <!--
    <namedCache name="evictionCache">
       <eviction
-         wakeUpInterval="500"
          maxEntries="5000"
          strategy="FIFO"
       />
       <expiration
+         wakeUpInterval="500"
          lifespan="60000"
          maxIdle="1000"
       />
@@ -361,11 +362,11 @@
    <!--
    <namedCache name="evictionAndPassivationCache">
       <eviction 
-         wakeUpInterval="500"
          maxEntries="5000"
          strategy="LIRS"
       />
       <expiration
+         wakeUpInterval="500"
          lifespan="60000"
          maxIdle="1000"
       />


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1268

Ive just realised that DataLossOnJoinOneOwnerTest was creating cache managers directly, not via the TestCacheManagerFactory which might explain the view issues/failures seen in this test. I've fixed that now too.
