### PR TITLE
ISPN-1267 Force disabling storeAsBinary via lifecycle callback

### DIFF
--- a/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolServer.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolServer.scala
@@ -26,7 +26,7 @@ import java.net.InetSocketAddress
 import org.infinispan.manager.EmbeddedCacheManager
 import org.infinispan.server.core.Main._
 import transport.NettyTransport
-import org.infinispan.util.{ClusterIdGenerator, TypedProperties, FileLookup, FileLookupFactory}
+import org.infinispan.util.{ClusterIdGenerator, TypedProperties, FileLookupFactory}
 import logging.Log
 import org.infinispan.jmx.{JmxUtil, ResourceDMBean}
 import javax.management.{ObjectName, MBeanServer}
@@ -88,11 +88,8 @@ abstract class AbstractProtocolServer(threadNamePrefix: String) extends Protocol
             debugf("Starting server with basic settings: host=%s, port=%d, masterThreads=%s, workerThreads=%d, " +
                   "idleTimeout=%d, tcpNoDelay=%b, sendBufSize=%d, recvBufSize=%d", host, port,
                   masterThreads, workerThreads, idleTimeout, tcpNoDelay, sendBufSize, recvBufSize)
-            debug("Avoid binary storage duplication and start default cache")
          }
 
-         // Disable store as binary for default cache
-         cacheManager.getDefaultConfiguration.fluent.storeAsBinary.disable
          // Start default cache
          startDefaultCache
 

--- a/server/core/src/main/scala/org/infinispan/server/core/LifecycleCallbacks.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/LifecycleCallbacks.scala
@@ -24,9 +24,9 @@
 package org.infinispan.server.core
 
 import org.infinispan.lifecycle.AbstractModuleLifecycle
-import org.infinispan.factories.GlobalComponentRegistry
-import org.infinispan.config.GlobalConfiguration
 import org.infinispan.server.core.ExternalizerIds._
+import org.infinispan.factories.{ComponentRegistry, GlobalComponentRegistry}
+import org.infinispan.config.{Configuration, GlobalConfiguration}
 
 /**
  * Module lifecycle callbacks implementation that enables module specific
@@ -37,8 +37,11 @@ import org.infinispan.server.core.ExternalizerIds._
  */
 class LifecycleCallbacks extends AbstractModuleLifecycle {
 
-   override def cacheManagerStarting(gcr: GlobalComponentRegistry, globalCfg: GlobalConfiguration)
-      = addExternalizer(globalCfg)
+   override def cacheManagerStarting(gcr: GlobalComponentRegistry, globalCfg: GlobalConfiguration) =
+      addExternalizer(globalCfg)
+
+   override def cacheStarting(cr: ComponentRegistry, cfg: Configuration, cacheName: String) =
+      cfg.fluent.storeAsBinary.disable
 
    private[core] def addExternalizer(globalCfg : GlobalConfiguration) =
       globalCfg.fluent.serialization

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
@@ -84,16 +84,9 @@ class HotRodServer extends AbstractProtocolServer("HotRod") with Log {
       // Start rest of the caches and self to view once we know for sure that we need to start
       // and we know that the rank calculator listener is registered
 
-      if (isDebugEnabled)
-         debug("Avoid binary storage duplication and start named caches")
-
       // Start defined caches to avoid issues with lazily started caches
-      for (cacheName <- asScalaIterator(cacheManager.getCacheNames.iterator)) {
-         val cfg = new Configuration().fluent.storeAsBinary.disable.build
-         // Force disabling binary storage cos the server already does that
-         cacheManager.defineConfiguration(cacheName, cfg)
+      for (cacheName <- asScalaIterator(cacheManager.getCacheNames.iterator))
          cacheManager.getCache(cacheName)
-      }
 
       // If clustered, set up a cache for topology information
       if (isClustered) {

--- a/server/rest/src/main/scala/org/infinispan/rest/StartupListener.scala
+++ b/server/rest/src/main/scala/org/infinispan/rest/StartupListener.scala
@@ -27,7 +27,6 @@ import scala.collection.JavaConversions._
 import javax.servlet.http.HttpServlet
 import org.infinispan.manager.{EmbeddedCacheManager, DefaultCacheManager}
 import javax.servlet.ServletConfig
-import org.infinispan.config.Configuration
 
 /**
  * To init the cache manager. Nice to do this on startup as any config problems will be picked up before any
@@ -62,18 +61,10 @@ class StartupListener extends HttpServlet with Log {
 
       val cm = ManagerInstance.instance
 
-      if (isDebugEnabled)
-         debug("Avoid binary storage duplication and start named and default caches")
-
       // Start defined caches to avoid issues with lazily started caches
-      for (cacheName <- asScalaIterator(cm.getCacheNames.iterator)) {
-         val cfg = new Configuration().fluent.storeAsBinary.disable.build
-         // Force disabling binary storage cos the server already does that
-         cm.defineConfiguration(cacheName, cfg)
+      for (cacheName <- asScalaIterator(cm.getCacheNames.iterator))
          cm.getCache(cacheName)
-      }
 
-      cm.getDefaultConfiguration.fluent.storeAsBinary.disable
       // Finally, start default cache as well
       cm.getCache[String, Any]()
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1267

Gets around situations where caches are started before the actual
servers have had the time to change the configuration (JBPAPP-6918)

_Master and 5.0.x!_ - 5.0.x branch: t_1267_5
