### PR TITLE
ISPN-1273 Hot Rod client consumes topologies with virtual nodes

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -39,7 +39,7 @@ import org.infinispan.util.logging.LogFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
@@ -84,7 +84,7 @@ import static org.infinispan.util.Util.getInstance;
  * <li><tt>infinispan.client.hotrod.async_executor_factory</tt>, default = org.infinispan.client.hotrod.impl.async.DefaultAsyncExecutorFactory.  Allows you to specify a custom asynchroous executor for async calls.</li>
  * <li><tt>infinispan.client.hotrod.default_executor_factory.pool_size</tt>, default = 10.  If the default executor is used, this configures the number of threads to initialize the executor with.</li>
  * <li><tt>infinispan.client.hotrod.default_executor_factory.queue_size</tt>, default = 100000.  If the default executor is used, this configures the queue size to initialize the executor with.</li>
- * <li><tt>infinispan.client.hotrod.hash_function_impl.1</tt>, default = org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashV1.  This specifies the version of the hash function and consistent hash algorithm in use, and is closely tied with the HotRod server version used.</li>
+ * <li><tt>infinispan.client.hotrod.hash_function_impl.1</tt>, default = It uses the hash function specified by the server in the responses as indicated in {@link org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashFactory}.  This specifies the version of the hash function and consistent hash algorithm in use, and is closely tied with the HotRod server version used.</li>
  * <li><tt>infinispan.client.hotrod.key_size_estimate</tt>, default = 64.  This hint allows sizing of byte buffers when serializing and deserializing keys, to minimize array resizing.</li>
  * <li><tt>infinispan.client.hotrod.value_size_estimate</tt>, default = 512.  This hint allows sizing of byte buffers when serializing and deserializing values, to minimize array resizing.</li>
  * <li><tt>infinispan.client.hotrod.socket_timeout</tt>, default = 60000 (60 seconds).  This property defines the maximum socket read timeout before giving up waiting for bytes from the server.</li>
@@ -439,7 +439,7 @@ public class RemoteCacheManager implements CacheContainer {
    public void start() {
       String factory = config.getTransportFactory();
       transportFactory = (TransportFactory) getInstance(factory, classLoader);
-      Collection<InetSocketAddress> servers = config.getServerList();
+      Collection<SocketAddress> servers = config.getServerList();
       transportFactory.start(config, servers, topologyId, classLoader);
       if (marshaller == null) {
          String marshallerName = config.getMarshaller();

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
@@ -29,6 +29,7 @@ import org.infinispan.marshall.jboss.GenericJBossMarshaller;
 import org.infinispan.util.TypedProperties;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Properties;
@@ -83,8 +84,8 @@ public class ConfigurationProperties {
       return props.getProperty(TRANSPORT_FACTORY, TcpTransportFactory.class.getName());
    }
 
-   public Collection<InetSocketAddress> getServerList() {
-      Set<InetSocketAddress> addresses = new HashSet<InetSocketAddress>();
+   public Collection<SocketAddress> getServerList() {
+      Set<SocketAddress> addresses = new HashSet<SocketAddress>();
       String servers = props.getProperty(SERVER_LIST, "127.0.0.1:" + DEFAULT_HOTROD_PORT);
       for (String server: servers.split(";")) {
          String[] components = server.trim().split(":");

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHash.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHash.java
@@ -22,8 +22,9 @@
  */
 package org.infinispan.client.hotrod.impl.consistenthash;
 
-import java.net.InetSocketAddress;
-import java.util.LinkedHashMap;
+import java.net.SocketAddress;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Abstraction for the used consistent hash.
@@ -33,7 +34,8 @@ import java.util.LinkedHashMap;
  */
 public interface ConsistentHash {
    
-   void init(LinkedHashMap<InetSocketAddress,Integer> servers2HashCode, int numKeyOwners, int hashSpace);
+   void init(Map<SocketAddress, Set<Integer>> servers2Hash, int numKeyOwners, int hashSpace);
 
-   InetSocketAddress getServer(byte[] key);
+   SocketAddress getServer(byte[] key);
+
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
@@ -24,9 +24,10 @@ package org.infinispan.client.hotrod.impl.transport;
 
 import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Collection;
-import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -41,13 +42,13 @@ public interface TransportFactory {
 
    public void releaseTransport(Transport transport);
 
-   void start(ConfigurationProperties props, Collection<InetSocketAddress> staticConfiguredServers, AtomicInteger topologyId, ClassLoader classLoader);
+   void start(ConfigurationProperties props, Collection<SocketAddress> staticConfiguredServers, AtomicInteger topologyId, ClassLoader classLoader);
 
-   void updateServers(Collection<InetSocketAddress> newServers);
+   void updateServers(Collection<SocketAddress> newServers);
 
    void destroy();
 
-   void updateHashFunction(LinkedHashMap<InetSocketAddress,Integer> servers2HashCode, int numKeyOwners, short hashFunctionVersion, int hashSpace);
+   void updateHashFunction(Map<SocketAddress, Set<Integer>> servers2Hash, int numKeyOwners, short hashFunctionVersion, int hashSpace);
 
    Transport getTransport(byte[] key);
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/RequestBalancingStrategy.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/RequestBalancingStrategy.java
@@ -24,7 +24,7 @@ package org.infinispan.client.hotrod.impl.transport.tcp;
 
 import net.jcip.annotations.ThreadSafe;
 
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Collection;
 
 /**
@@ -36,7 +36,8 @@ import java.util.Collection;
 @ThreadSafe
 public interface RequestBalancingStrategy {
 
-   void setServers(Collection<InetSocketAddress> servers);
+   void setServers(Collection<SocketAddress> servers);
 
-   InetSocketAddress nextServer();
+   SocketAddress nextServer();
+
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/RoundRobinBalancingStrategy.java
@@ -27,12 +27,9 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Round-robin implementation for {@link org.infinispan.client.hotrod.impl.transport.tcp.RequestBalancingStrategy}.
@@ -47,10 +44,10 @@ public class RoundRobinBalancingStrategy implements RequestBalancingStrategy {
 
    private int index = 0;
 
-   private InetSocketAddress[] servers;
+   private SocketAddress[] servers;
 
    @Override
-   public void setServers(Collection<InetSocketAddress> servers) {
+   public void setServers(Collection<SocketAddress> servers) {
       this.servers = servers.toArray(new InetSocketAddress[servers.size()]);
       // keep the old index if possible so that we don't produce more requests for the first server
       if (index >= this.servers.length) {
@@ -65,8 +62,8 @@ public class RoundRobinBalancingStrategy implements RequestBalancingStrategy {
     * Multiple threads might call this method at the same time.
     */
    @Override
-   public InetSocketAddress nextServer() {
-      InetSocketAddress server = getServerByIndex(index++);
+   public SocketAddress nextServer() {
+      SocketAddress server = getServerByIndex(index++);
       // don't allow index to overflow and have a negative value
       if (index >= servers.length)
          index = 0;
@@ -76,19 +73,19 @@ public class RoundRobinBalancingStrategy implements RequestBalancingStrategy {
    /**
     * Returns same value as {@link #nextServer()} without modifying indexes/state.
     */
-   public InetSocketAddress dryRunNextServer() {
+   public SocketAddress dryRunNextServer() {
       return getServerByIndex(index);
    }
 
-   private InetSocketAddress getServerByIndex(int pos) {
-      InetSocketAddress server = servers[pos];
+   private SocketAddress getServerByIndex(int pos) {
+      SocketAddress server = servers[pos];
       if (log.isTraceEnabled()) {
          log.tracef("Returning server: %s", server);
       }
       return server;
    }
 
-   public InetSocketAddress[] getServers() {
+   public SocketAddress[] getServers() {
       return servers;
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
@@ -23,7 +23,6 @@
 package org.infinispan.client.hotrod.logging;
 
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
-import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransport;
 import org.jboss.logging.Cause;
 import org.jboss.logging.LogMessage;
@@ -32,7 +31,8 @@ import org.jboss.logging.MessageLogger;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.LinkedHashMap;
+import java.net.SocketAddress;
+import java.util.Set;
 
 import static org.jboss.logging.Logger.Level.*;
 
@@ -68,7 +68,7 @@ public interface Log extends org.infinispan.util.logging.Log {
 
    @LogMessage(level = INFO)
    @Message(value = "New topology: %s", id = 4006)
-   void newTopology(LinkedHashMap<InetSocketAddress, Integer> servers2HashCode);
+   void newTopology(Set<SocketAddress> topology);
 
    @LogMessage(level = ERROR)
    @Message(value = "Exception encountered. Retry %d out of %d", id = 4007)
@@ -100,15 +100,15 @@ public interface Log extends org.infinispan.util.logging.Log {
 
    @LogMessage(level = INFO)
    @Message(value = "New server added(%s), adding to the pool.", id = 4014)
-   void newServerAdded(InetSocketAddress server);
+   void newServerAdded(SocketAddress server);
 
    @LogMessage(level = WARN)
    @Message(value = "Failed adding new server %s", id = 4015)
-   void failedAddingNewServer(InetSocketAddress server, @Cause Exception e);
+   void failedAddingNewServer(SocketAddress server, @Cause Exception e);
 
    @LogMessage(level = INFO)
    @Message(value = "Server not in cluster anymore(%s), removing from the pool.", id = 4016)
-   void removingServer(InetSocketAddress server);
+   void removingServer(SocketAddress server);
 
    @LogMessage(level = ERROR)
    @Message(value = "Could not fetch transport", id = 4017)

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV1IntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV1IntegrationTest.java
@@ -94,7 +94,7 @@ public class ConsistentHashV1IntegrationTest extends MultipleCacheManagersTest {
                                                             2, true);
 
       for (int i = 0; i < 4; i++) {
-         advancedCache(i).addInterceptor(new HitsAwareCacheManagersTest.HitCountInterceptor(null), 1);
+         advancedCache(i).addInterceptor(new HitsAwareCacheManagersTest.HitCountInterceptor(), 1);
       }
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV1Test.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV1Test.java
@@ -28,9 +28,12 @@ import org.infinispan.util.hash.Hash;
 import org.testng.annotations.Test;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
 
 import static org.testng.Assert.assertEquals;
 
@@ -54,11 +57,11 @@ public class ConsistentHashV1Test {
       a2 = new InetSocketAddress(2);
       a3 = new InetSocketAddress(3);
       a4 = new InetSocketAddress(4);
-      LinkedHashMap<InetSocketAddress, Integer> map = new LinkedHashMap<InetSocketAddress, Integer>();
-      map.put(a1, 0);
-      map.put(a2, 1000);
-      map.put(a3, 2000);
-      map.put(a4, 3000);
+      LinkedHashMap<SocketAddress, Set<Integer>> map = new LinkedHashMap<SocketAddress, Set<Integer>>();
+      map.put(a1, Collections.singleton(0));
+      map.put(a2, Collections.singleton(1000));
+      map.put(a3, Collections.singleton(2000));
+      map.put(a4, Collections.singleton(3000));
 
       this.v1 = new ConsistentHashV1();
       this.v1.init(map, numOwners, 10000);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
@@ -33,6 +33,7 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.testng.annotations.BeforeMethod;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,7 +71,7 @@ public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTe
       return hitCountInterceptor;
    }
 
-   protected void assertOnlyServerHit(InetSocketAddress serverAddress) {
+   protected void assertOnlyServerHit(SocketAddress serverAddress) {
       CacheContainer cacheContainer = hrServ2CacheManager.get(serverAddress);
       HitCountInterceptor interceptor = getHitCountInterceptor(cacheContainer.getCache());
       assert interceptor.getHits() == 1 : "Expected one hit but received " + interceptor.getHits();
@@ -109,9 +110,7 @@ public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTe
    }
 
    private void addHitCountInterceptor(Cache<Object, Object> cache) {
-      InetSocketAddress addr;
-      addr = getHotRodServerAddress(cache);
-      HitCountInterceptor interceptor = new HitCountInterceptor(addr);
+      HitCountInterceptor interceptor = new HitCountInterceptor();
       cache.getAdvancedCache().addInterceptor(interceptor, 1);
    }
 
@@ -132,11 +131,6 @@ public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTe
    public static class HitCountInterceptor extends CommandInterceptor{
 
       private volatile int invocationCount;
-      private volatile InetSocketAddress addr;
-
-      public HitCountInterceptor(InetSocketAddress addr) {
-         this.addr = addr;
-      }
 
       @Override
       protected Object handleDefault(InvocationContext ctx, VisitableCommand command) throws Throwable {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/PingOnStartupTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/PingOnStartupTest.java
@@ -23,12 +23,11 @@
 package org.infinispan.client.hotrod;
 
 import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory;
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
 import org.infinispan.config.Configuration;
-import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.config.Configuration.CacheMode;
 import org.infinispan.server.hotrod.HotRodServer;
-import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.util.Properties;
@@ -40,44 +39,17 @@ import static org.testng.AssertJUnit.assertEquals;
  * @since 4.1
  */
 @Test(groups = "functional", testName = "client.hotrod.PingOnStartupTest")
-public class PingOnStartupTest extends MultipleCacheManagersTest {
-   private HotRodServer hotRodServer1;
-   private HotRodServer hotRodServer2;
+public class PingOnStartupTest extends MultiHotRodServersTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      Configuration config = getDefaultClusteredConfig(Configuration.CacheMode.DIST_SYNC);
-      addClusterEnabledCacheManager(config);
-      addClusterEnabledCacheManager(config);
-
-      hotRodServer1 = TestHelper.startHotRodServer(manager(0));
-      hotRodServer2 = TestHelper.startHotRodServer(manager(1));
-
-      assert manager(0).getCache() != null;
-      assert manager(1).getCache() != null;
-
-      TestingUtil.blockUntilViewReceived(manager(0).getCache(), 2, 10000);
-      TestingUtil.blockUntilCacheStatusAchieved(manager(0).getCache(), ComponentStatus.RUNNING, 10000);
-      TestingUtil.blockUntilCacheStatusAchieved(manager(1).getCache(), ComponentStatus.RUNNING, 10000);
-
-      cache(0).put("k","v");
-      assertEquals("v", cache(1).get("k"));
-   }
-
-   @AfterClass
-   @Override
-   protected void destroy() {
-      super.destroy();
-      try {
-         hotRodServer1.stop();
-         hotRodServer2.stop();
-      } catch (Exception e) {
-         //ignore
-      }
+      Configuration config = getDefaultClusteredConfig(CacheMode.DIST_SYNC);
+      createHotRodServers(2, config);
    }
 
    public void testTopologyFetched() throws Exception {
       Properties props = new Properties();
+      HotRodServer hotRodServer2 = server(1);
       props.put("infinispan.client.hotrod.server_list", "localhost:" + hotRodServer2.getPort() + ";localhost:" + hotRodServer2.getPort());
       props.put("infinispan.client.hotrod.ping_on_startup", "true");
       props.put("timeBetweenEvictionRunsMillis", "500");
@@ -100,6 +72,7 @@ public class PingOnStartupTest extends MultipleCacheManagersTest {
 
    public void testTopologyNotFetched() {
       Properties props = new Properties();
+      HotRodServer hotRodServer2 = server(1);
       props.put("infinispan.client.hotrod.server_list", "localhost:" + hotRodServer2.getPort() + ";localhost:" + hotRodServer2.getPort());
       props.put("infinispan.client.hotrod.ping_on_startup", "false");
       RemoteCacheManager remoteCacheManager = new RemoteCacheManager(props);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplTopologyChangeTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplTopologyChangeTest.java
@@ -35,6 +35,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Collection;
 
 import static org.testng.AssertJUnit.assertEquals;
@@ -164,7 +165,7 @@ public class ReplTopologyChangeTest extends MultipleCacheManagersTest {
          remoteCache.put("k" + i, "v" + i);         
          if (added == tcpConnectionFactory.getServers().contains(server1Address)) break;
       }
-      Collection<InetSocketAddress> addresses = tcpConnectionFactory.getServers();
+      Collection<SocketAddress> addresses = tcpConnectionFactory.getServers();
       assertEquals(server1Address + " not found in " + addresses, added, addresses.contains(server1Address));
    }
    

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RoundRobinBalancingIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RoundRobinBalancingIntegrationTest.java
@@ -36,6 +36,7 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.Test;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -127,7 +128,7 @@ public class RoundRobinBalancingIntegrationTest extends MultipleCacheManagersTes
       hotRodServer4 = TestHelper.startHotRodServer((EmbeddedCacheManager) c4.getCacheManager());
       registerCacheManager(c4.getCacheManager());
 
-      List<InetSocketAddress> serverAddresses = new ArrayList<InetSocketAddress>();
+      List<SocketAddress> serverAddresses = new ArrayList<SocketAddress>();
       serverAddresses.add(new InetSocketAddress("localhost", hotRodServer1.getPort()));
       serverAddresses.add(new InetSocketAddress("localhost", hotRodServer2.getPort()));
       serverAddresses.add(new InetSocketAddress("localhost", hotRodServer3.getPort()));
@@ -197,7 +198,7 @@ public class RoundRobinBalancingIntegrationTest extends MultipleCacheManagersTes
 
    @Test(dependsOnMethods = "testStopServer")
    public void testRemoveServers() {
-      List<InetSocketAddress> serverAddresses = new ArrayList<InetSocketAddress>();
+      List<SocketAddress> serverAddresses = new ArrayList<SocketAddress>();
       serverAddresses.add(new InetSocketAddress("localhost", hotRodServer1.getPort()));
       serverAddresses.add(new InetSocketAddress("localhost", hotRodServer2.getPort()));
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RoundRobinBalancingStrategyTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RoundRobinBalancingStrategyTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,17 +41,17 @@ import static org.testng.AssertJUnit.assertEquals;
 public class RoundRobinBalancingStrategyTest {
 
 
-   InetSocketAddress addr1 = new InetSocketAddress("localhost",1111);
-   InetSocketAddress addr2 = new InetSocketAddress("localhost",2222);
-   InetSocketAddress addr3 = new InetSocketAddress("localhost",3333);
-   InetSocketAddress addr4 = new InetSocketAddress("localhost",4444);
-   private List<InetSocketAddress> defaultServers;
+   SocketAddress addr1 = new InetSocketAddress("localhost",1111);
+   SocketAddress addr2 = new InetSocketAddress("localhost",2222);
+   SocketAddress addr3 = new InetSocketAddress("localhost",3333);
+   SocketAddress addr4 = new InetSocketAddress("localhost",4444);
+   private List<SocketAddress> defaultServers;
    private RoundRobinBalancingStrategy strategy;
 
    @BeforeMethod
    public void setUp() {
       strategy = new RoundRobinBalancingStrategy();
-      defaultServers = new ArrayList<InetSocketAddress>();
+      defaultServers = new ArrayList<SocketAddress>();
       defaultServers.add(addr1);
       defaultServers.add(addr2);
       defaultServers.add(addr3);
@@ -70,7 +71,7 @@ public class RoundRobinBalancingStrategyTest {
    }
 
    public void testAddServer() {
-      List<InetSocketAddress> newServers = new ArrayList<InetSocketAddress>(defaultServers);
+      List<SocketAddress> newServers = new ArrayList<SocketAddress>(defaultServers);
       newServers.add(addr4);
       strategy.setServers(newServers);
       assertEquals(addr1, strategy.nextServer());
@@ -87,7 +88,7 @@ public class RoundRobinBalancingStrategyTest {
    }
 
    public void testRemoveServer() {
-      List<InetSocketAddress> newServers = new ArrayList<InetSocketAddress>(defaultServers);
+      List<SocketAddress> newServers = new ArrayList<SocketAddress>(defaultServers);
       newServers.remove(addr3);
       strategy.setServers(newServers);
       assertEquals(addr1, strategy.nextServer());
@@ -104,7 +105,7 @@ public class RoundRobinBalancingStrategyTest {
       assertEquals(addr3, strategy.nextServer());
       assertEquals(addr1, strategy.nextServer());
       assertEquals(addr2, strategy.nextServer());
-      List<InetSocketAddress> newServers = new ArrayList<InetSocketAddress>(defaultServers);
+      List<SocketAddress> newServers = new ArrayList<SocketAddress>(defaultServers);
       newServers.remove(addr3);
       strategy.setServers(newServers);
       // the next server index is reset to 0 because it would have been out of bounds
@@ -122,7 +123,7 @@ public class RoundRobinBalancingStrategyTest {
       assertEquals(addr3, strategy.nextServer());
       assertEquals(addr1, strategy.nextServer());
       assertEquals(addr2, strategy.nextServer());
-      List<InetSocketAddress> newServers = new ArrayList<InetSocketAddress>(defaultServers);
+      List<SocketAddress> newServers = new ArrayList<SocketAddress>(defaultServers);
       newServers.add(addr4);
       strategy.setServers(newServers);
       // the next server index is still valid, so it is not reset

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/VirtualNodesTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/VirtualNodesTest.java
@@ -1,0 +1,43 @@
+package org.infinispan.client.hotrod;
+
+import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory;
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.config.Configuration;
+import org.infinispan.config.Configuration.CacheMode;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.net.SocketAddress;
+import java.util.SortedMap;
+
+import static org.infinispan.test.TestingUtil.extractField;
+import static org.infinispan.test.TestingUtil.v;
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Tests that verify that Hot Rod clients work as expected when virtual nodes are enabled.
+ *
+ * @author Galder Zamarreño
+ * @since 5.0
+ */
+@Test(groups = "functional", testName = "client.hotrod.VirtualNodesTest")
+public class VirtualNodesTest extends MultiHotRodServersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      Configuration config = getDefaultClusteredConfig(CacheMode.DIST_SYNC).fluent()
+         .clustering().hash().numVirtualNodes(500).numOwners(1).build();
+      createHotRodServers(2, config);
+   }
+
+   public void testNumVirtualNodesInClient(Method m) {
+      RemoteCacheManager client = client(0);
+      client.getCache().put(1, v(m));
+      TcpTransportFactory tf = (TcpTransportFactory) extractField(
+            client, "transportFactory");
+      SortedMap<Integer, SocketAddress> positions = (SortedMap<Integer, SocketAddress>)
+            extractField(tf.getConsistentHash(), "positions");
+      assertEquals(1000, positions.size());
+   }
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ReplicationRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ReplicationRetryTest.java
@@ -24,7 +24,7 @@ package org.infinispan.client.hotrod.retry;
 
 import static org.testng.Assert.assertEquals;
 
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Map;
 
 import org.infinispan.client.hotrod.VersionedValue;
@@ -121,7 +121,7 @@ public class ReplicationRetryTest extends AbstractRetryTest {
    private void validateSequenceAndStopServer() {
       resetStats();
       assertNoHits();
-      InetSocketAddress expectedServer = strategy.getServers()[strategy.getNextPosition()];
+      SocketAddress expectedServer = strategy.getServers()[strategy.getNextPosition()];
       assertNoHits();
       remoteCache.put("k","v");
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
@@ -1,0 +1,91 @@
+package org.infinispan.client.hotrod.test;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.TestHelper;
+import org.infinispan.config.Configuration;
+import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.infinispan.test.TestingUtil.blockUntilCacheStatusAchieved;
+import static org.infinispan.test.TestingUtil.blockUntilViewReceived;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.infinispan.client.hotrod.impl.ConfigurationProperties.*;
+
+/**
+ * Base test class for Hot Rod tests.
+ *
+ * @author Galder Zamarreño
+ * @since 5.0
+ */
+public abstract class MultiHotRodServersTest extends MultipleCacheManagersTest {
+
+   protected List<HotRodServer> servers = new ArrayList<HotRodServer>();
+   protected List<RemoteCacheManager> clients = new ArrayList<RemoteCacheManager>();
+
+   protected void createHotRodServers(int num, Configuration defaultCfg) {
+      // Start Hot Rod servers
+      for (int i = 0; i < num; i++) addHotRodServer(defaultCfg);
+      // Verify that default caches should be started
+      for (int i = 0; i < num; i++) assert manager(i).getCache() != null;
+      // Block until views have been received
+      blockUntilViewReceived(manager(0).getCache(), num, 10000);
+      // Verify that caches running
+      for (int i = 0; i < num; i++) {
+         blockUntilCacheStatusAchieved(
+               manager(i).getCache(), ComponentStatus.RUNNING, 10000);
+      }
+      // Do a put and verify that is present in other nodes
+      cache(0).put("k","v");
+      for (int i = 0; i < num; i++) assertEquals("v", cache(i).get("k"));
+
+      for (int i = 0; i < num; i++) {
+         Properties props = new Properties();
+         props.put(SERVER_LIST, String.format("localhost:%d", server(i).getPort()));
+         props.put(PING_ON_STARTUP, "false");
+         clients.add(new RemoteCacheManager(props));
+      }
+   }
+
+   @AfterMethod(alwaysRun = true)
+   protected void clearContent() throws Throwable {
+      // Do not clear content to allow servers
+      // to stop gracefully and catch any issues there.
+   }
+
+   @AfterClass(alwaysRun = true)
+   @Override
+   protected void destroy() {
+      // Correct order is to stop servers first
+      try {
+         for (HotRodServer server : servers)
+            server.stop();
+      } finally {
+         // And then the caches and cache managers
+         super.destroy();
+      }
+   }
+
+   private HotRodServer addHotRodServer(Configuration cfg) {
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager(cfg);
+      HotRodServer server = TestHelper.startHotRodServer(cm);
+      servers.add(server);
+      return server;
+   }
+
+   protected HotRodServer server(int i) {
+      return servers.get(i);
+   }
+
+   protected RemoteCacheManager client(int i) {
+      return clients.get(i);
+   }
+
+}

--- a/core/src/main/java/org/infinispan/distribution/ch/AbstractWheelConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/AbstractWheelConsistentHash.java
@@ -119,6 +119,8 @@ public abstract class AbstractWheelConsistentHash extends AbstractConsistentHash
          }
       }
 
+      log.tracef("Positions are: %s", positions);
+
       // then populate caches, positionKeys and positionValues with the correct values (and in the correct order)
       caches = new LinkedHashSet<Address>(newCaches.size());
       positionKeys = new int[positions.size()];

--- a/server/core/src/main/scala/org/infinispan/server/core/transport/ExtendedChannelBuffer.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/transport/ExtendedChannelBuffer.scala
@@ -33,7 +33,7 @@ import org.jboss.netty.buffer.{ChannelBuffers, ChannelBuffer}
 object ExtendedChannelBuffer {
 
    def wrappedBuffer(array: Array[Byte]*) = ChannelBuffers.wrappedBuffer(array : _*)
-   def dynamicBuffer() = ChannelBuffers.dynamicBuffer()
+   def dynamicBuffer = ChannelBuffers.dynamicBuffer()
 
    def readUnsignedShort(bf: ChannelBuffer): Int = bf.readUnsignedShort
    def readUnsignedInt(bf: ChannelBuffer): Int = VInt.read(bf)

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
@@ -185,7 +185,8 @@ class HotRodEncoder(cacheManager: EmbeddedCacheManager) extends OneToOneEncoder 
       // If virtual nodes are enabled, we need to send as many hashes as
       // cluster members * num virtual nodes. Otherwise, rely on the default
       // when virtual nodes is disabled which is '1'.
-      writeUnsignedInt(h.view.members.size * numVNodes, buffer)
+      val totalNumServers = h.view.members.size * numVNodes
+      writeUnsignedInt(totalNumServers, buffer)
       h.view.members.foreach {address =>
          // Take hash ids associated with the cache
          val cacheHashIds = address.hashIds.get(r.cacheName).get

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
@@ -179,11 +179,16 @@ class HotRodServer extends AbstractProtocolServer("HotRod") with Log {
          val maxWaitTime = cache.getConfiguration.getRehashRpcTimeout() * 10 // after which we give up!
          val giveupTime = System.currentTimeMillis + maxWaitTime
          var hashIdRetrieved = false
+         val isTrace = isTraceEnabled
          do {
             try {
                val distHashIds = cacheDm.getConsistentHash.getHashIds(clusterAddress)
+               if (isTrace)
+                  trace("Cluster address (%s) has these hash ids associated: %s", clusterAddress, distHashIds)
                // Once hash ids retrieved, make them immutable and update the topology address
                hashIds += (hashIdKey -> asScalaBuffer(distHashIds.asInstanceOf[java.util.List[Int]]).toList)
+               if (isTrace)
+                  trace("After scala transformation, cluster address (%s) has these hash ids associated: %s", clusterAddress, hashIds)
                hashIdRetrieved = true
             } catch {
                case u: UnsupportedOperationException => {
@@ -191,7 +196,7 @@ class HotRodServer extends AbstractProtocolServer("HotRod") with Log {
                      debug("Unable to get all hash ids due to rehashing being in process.")
                   var time = rand.nextInt((maxSleepTime - minSleepTime) / 10)
                   time = (time * 10) + minSleepTime
-                  if (isTraceEnabled)
+                  if (isTrace)
                      trace("Sleeping for %s", Util.prettyPrintTime(time))
                   Thread.sleep(time) // sleep for a while and retry
                }

--- a/spring/src/test/java/org/infinispan/spring/mock/MockRequestBalancingStrategy.java
+++ b/spring/src/test/java/org/infinispan/spring/mock/MockRequestBalancingStrategy.java
@@ -23,7 +23,7 @@
 
 package org.infinispan.spring.mock;
 
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Collection;
 
 import org.infinispan.client.hotrod.impl.transport.tcp.RequestBalancingStrategy;
@@ -31,11 +31,11 @@ import org.infinispan.client.hotrod.impl.transport.tcp.RequestBalancingStrategy;
 public final class MockRequestBalancingStrategy implements RequestBalancingStrategy {
 
    @Override
-   public void setServers(final Collection<InetSocketAddress> servers) {
+   public void setServers(final Collection<SocketAddress> servers) {
    }
 
    @Override
-   public InetSocketAddress nextServer() {
+   public SocketAddress nextServer() {
       return null;
    }
 }

--- a/spring/src/test/java/org/infinispan/spring/mock/MockTransportFactory.java
+++ b/spring/src/test/java/org/infinispan/spring/mock/MockTransportFactory.java
@@ -23,9 +23,10 @@
 
 package org.infinispan.spring.mock;
 
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.Collection;
-import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.infinispan.client.hotrod.impl.ConfigurationProperties;
@@ -45,12 +46,12 @@ public final class MockTransportFactory implements TransportFactory {
 
    @Override
    public void start(final ConfigurationProperties props,
-            final Collection<InetSocketAddress> staticConfiguredServers,
+            final Collection<SocketAddress> staticConfiguredServers,
             final AtomicInteger topologyId, ClassLoader cl) {
    }
 
    @Override
-   public void updateServers(final Collection<InetSocketAddress> newServers) {
+   public void updateServers(final Collection<SocketAddress> newServers) {
    }
 
    @Override
@@ -58,7 +59,7 @@ public final class MockTransportFactory implements TransportFactory {
    }
 
    @Override
-   public void updateHashFunction(final LinkedHashMap<InetSocketAddress, Integer> servers2HashCode,
+   public void updateHashFunction(final Map<SocketAddress, Set<Integer>> servers2Hash,
             final int numKeyOwners, final short hashFunctionVersion, final int hashSpace) {
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1273
- Hot Rod client now correctly consumes virtual nodes enabled topologies.
- Changed references to implementation classes for interfaces or abstract classes.
- VirtualNodesTest might still fail randomly but that's being investigated in another JIRA (https://issues.jboss.org/browse/ISPN-1275).

Master and 5.0.x (branch = t_1273_5)
