### PR TITLE
ISPN-1277 TreeCache with an index-enabled Cache should not be supported

### DIFF
--- a/tree/src/main/java/org/infinispan/tree/TreeCacheImpl.java
+++ b/tree/src/main/java/org/infinispan/tree/TreeCacheImpl.java
@@ -26,6 +26,7 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.CacheException;
 import org.infinispan.atomic.AtomicMap;
+import org.infinispan.config.ConfigurationException;
 import org.infinispan.context.Flag;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -44,6 +45,8 @@ public class TreeCacheImpl<K, V> extends TreeStructureSupport implements TreeCac
    public TreeCacheImpl(Cache<?, ?> cache) {
       super(cache, ((AdvancedCache) cache).getBatchContainer(),
             ((AdvancedCache) cache).getInvocationContextContainer());
+      if (cache.getConfiguration().isIndexingEnabled())
+         throw new ConfigurationException("TreeCache cannot be used with a Cache instance configured to use indexing!");
       assertBatchingSupported(cache.getConfiguration());
       createRoot();
    }


### PR DESCRIPTION
And t_1277_5 for 5.0.x

https://issues.jboss.org/browse/ISPN-1277
