### PR TITLE
ISPN-1285 Document limitation of default expiry lifespan/maxIdle values

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCache.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCache.java
@@ -72,6 +72,15 @@ import java.util.concurrent.TimeUnit;
  * the case of lifespan (naturally does NOT apply for max idle): If number of seconds is bigger than 30 days, this
  * number of seconds is treated as UNIX time and so, represents the number of seconds since 1/1/1970. <br/>
  *
+ * <b>Note on default expiration values:<b/> Due to limitations on the first
+ * version of the protocol, it's not possible for clients to rely on default
+ * lifespan and maxIdle values set on the server. This is because the protocol
+ * does not support a way to tell the server that no expiration lifespan and/or
+ * maxIdle were provided and that default values should be used. This will be
+ * resolved in a future revision of the protocol. In the mean time, the
+ * workaround is to explicitly provide the desired expiry lifespan/maxIdle
+ * values in each remote cache operation.
+ *
  * @author Mircea.Markus@jboss.com
  * @since 4.1
  */

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExpiryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExpiryTest.java
@@ -1,0 +1,42 @@
+package org.infinispan.client.hotrod;
+
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.config.Configuration;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+
+import static org.infinispan.test.TestingUtil.v;
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * This test verifies that an entry can be expired from the Hot Rod server
+ * using the default expiry lifespan or maxIdle. </p>
+ *
+ * This test is disabled because the limitations of the protocol do not allow
+ * for this to work as expected. This test will be enabled once v2 of the
+ * protocol has been implemented and the functionality is there to support it.
+ *
+ * @author Galder Zamarreño
+ * @since 5.0
+ */
+@Test(groups = "functional", testName = "client.hotrod.ExpiryTest", enabled = false)
+public class ExpiryTest extends MultiHotRodServersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      Configuration config = getDefaultClusteredConfig(Configuration.CacheMode.REPL_SYNC)
+            .fluent().expiration().lifespan(2000L).maxIdle(3000L).build();
+      createHotRodServers(1, config);
+   }
+
+   public void testGlobalExpiry(Method m) throws Exception {
+      RemoteCacheManager client0 = client(0);
+      RemoteCache<Object, Object> cache0 = client0.getCache();
+      String v1 = v(m);
+      cache0.put(1, v1);
+      Thread.sleep(2500);
+      assertEquals(null, cache0.get(1));
+   }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1285

Apart from documenting the limitation, created a test that replicates
the issue. This test has been disabled for the time being until the
protocol is improved to support the functionality.

5.0.x branch: t_1285_5

I'll be cross referencing the v2 protocol jira with this so that this is looked into and the javadoc+test can be fixed as per the new protocol capabilities.
