### PR TITLE
ISPN-1276 - warn when using indexing but query module isn't present on cl

### DIFF
--- a/core/src/main/java/org/infinispan/config/ConfigurationValidatingVisitor.java
+++ b/core/src/main/java/org/infinispan/config/ConfigurationValidatingVisitor.java
@@ -128,6 +128,9 @@ public class ConfigurationValidatingVisitor extends AbstractConfigurationBeanVis
 
    @Override
    public void visitQueryConfigurationBean(Configuration.QueryConfigurationBean qcb) {
+      if ( ! qcb.enabled ) {
+         return;
+      }
       // Check that the query module is on the classpath.
       try {
          String clazz = "org.infinispan.query.Search";

--- a/core/src/test/java/org/infinispan/config/SampleConfigFilesCorrectnessTest.java
+++ b/core/src/test/java/org/infinispan/config/SampleConfigFilesCorrectnessTest.java
@@ -26,6 +26,7 @@ import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
+import org.infinispan.config.Configuration.CacheMode;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -86,6 +87,17 @@ public class SampleConfigFilesCorrectnessTest {
          } finally {
             TestingUtil.killCacheManagers(dcm);
          }
+      }
+   }
+
+   public void testWarningForMissingQuery() {
+      EmbeddedCacheManager embeddedCacheManager = TestCacheManagerFactory.createCacheManager(CacheMode.LOCAL, true);
+      try {
+         embeddedCacheManager.getCache();
+         assert appender.isFoundUnknownWarning();
+         assert appender.unknownWarning().contains("infinispan-query.jar");
+      } finally {
+         TestingUtil.killCacheManagers(embeddedCacheManager);
       }
    }
 


### PR DESCRIPTION
ISPN-1276 - warn when using indexing but query module isn't present on classpath

(reopened the issue as it wasn't complete)

https://issues.jboss.org/browse/ISPN-1276

please apply on both branches!
