### PR TITLE
ISPN-1300 Reduce number of locks and buckets generated by BucketBasedCach

### DIFF
--- a/core/src/main/java/org/infinispan/loaders/bucket/BucketBasedCacheStore.java
+++ b/core/src/main/java/org/infinispan/loaders/bucket/BucketBasedCacheStore.java
@@ -22,14 +22,14 @@
  */
 package org.infinispan.loaders.bucket;
 
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.loaders.CacheLoaderException;
+import org.infinispan.loaders.LockSupportCacheStore;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-
-import org.infinispan.container.entries.InternalCacheEntry;
-import org.infinispan.loaders.CacheLoaderException;
-import org.infinispan.loaders.LockSupportCacheStore;
 
 /**
  * Base class for CacheStore implementations that combine entries into buckets when storing data.
@@ -120,8 +120,8 @@ public abstract class BucketBasedCacheStore extends LockSupportCacheStore<Intege
     * hash code of the key, as all keys having same hash code will be mapped to same bucket.
     */
    @Override
-   protected Integer getLockFromKey(Object key) {
-      return Integer.valueOf(key.hashCode());
+   public Integer getLockFromKey(Object key) {
+      return key.hashCode() & 0xfffffc00; // To reduce the number of buckets/locks that may be created.  TODO: This should be configurable.
    }
 
    /**

--- a/core/src/main/java/org/infinispan/loaders/file/FileCacheStore.java
+++ b/core/src/main/java/org/infinispan/loaders/file/FileCacheStore.java
@@ -369,7 +369,7 @@ public class FileCacheStore extends BucketBasedCacheStore {
    }
 
    public Bucket loadBucketContainingKey(String key) throws CacheLoaderException {
-      return loadBucket(key.hashCode());
+      return loadBucket(getLockFromKey(key));
    }
 
    private boolean deleteFile(File f) {

--- a/core/src/test/java/org/infinispan/loaders/file/FileCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/file/FileCacheStoreTest.java
@@ -22,14 +22,6 @@
  */
 package org.infinispan.loaders.file;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.HashSet;
-import java.util.Set;
-
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.InternalEntryFactory;
 import org.infinispan.io.UnclosableObjectInputStream;
@@ -45,6 +37,14 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.HashSet;
+import java.util.Set;
 
 @Test(groups = "unit", testName = "loaders.file.FileCacheStoreTest")
 public class FileCacheStoreTest extends BaseCacheStoreTest {
@@ -161,7 +161,7 @@ public class FileCacheStoreTest extends BaseCacheStoreTest {
       ObjectInput oi = marshaller.startObjectInput(in, false);
       try {
          assert oi.readInt() == 1 : "we have 3 different buckets";
-         assert oi.readObject().equals("k1".hashCode() + "");
+         assert oi.readObject().equals(fcs.getLockFromKey("k1") + "");
          assert oi.readInt() > 0; //size on disk
       } finally {
          marshaller.finishObjectInput(oi);


### PR DESCRIPTION
ISPN-1300 Reduce number of locks and buckets generated by BucketBasedCacheStore

Also `t_1300_5` for `5.0.x`

See https://issues.jboss.org/browse/ISPN-1300
