### PR TITLE
ISPN-1206 Changed default cache used by Memcached server

### DIFF
--- a/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolDecoder.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolDecoder.scala
@@ -51,7 +51,6 @@ abstract class AbstractProtocolDecoder[K, V <: CacheValue](transport: NettyTrans
 
    var versionGenerator: ClusterIdGenerator = _
 
-   private val versionCounter = new AtomicInteger
    private val isTrace = isTraceEnabled
 
    protected var header: SuitableHeader = null.asInstanceOf[SuitableHeader]

--- a/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedFunctionalTest.scala
+++ b/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedFunctionalTest.scala
@@ -32,8 +32,9 @@ import org.infinispan.notifications.Listener
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved
 import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent
 import java.util.concurrent.{CountDownLatch, TimeUnit}
-import org.infinispan.Version
 import org.infinispan.test.fwk.TestCacheManagerFactory
+import org.infinispan.config.Configuration
+import org.infinispan.Version
 
 /**
  * Tests Memcached protocol functionality against Infinispan Memcached server.
@@ -547,11 +548,13 @@ class MemcachedFunctionalTest extends MemcachedSingleNodeTest {
 
    def testStoreAsBinaryOverride {
       val cm = TestCacheManagerFactory.createLocalCacheManager
-      val defaultCfg = cm.getDefaultConfiguration.fluent.storeAsBinary.build
-      assertTrue(defaultCfg.isStoreAsBinary)
+      val cfg = new Configuration().fluent.storeAsBinary.build
+      cm.defineConfiguration(MemcachedServer.cacheName, cfg)
+      assertTrue(cfg.isStoreAsBinary)
       val testServer = startMemcachedTextServer(cm, server.getPort + 33)
       try {
-         assertFalse(cm.getCache().getConfiguration.isStoreAsBinary)
+         val memcachedCache = cm.getCache(MemcachedServer.cacheName)
+         assertFalse(memcachedCache.getConfiguration.isStoreAsBinary)
       } finally {
          cm.stop
          testServer.stop

--- a/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedReplicationTest.scala
+++ b/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedReplicationTest.scala
@@ -47,7 +47,7 @@ class MemcachedReplicationTest extends MultipleCacheManagersTest with MemcachedT
 
    @Test(enabled = false) // Disable explicitly to avoid TestNG thinking this is a test!!
    override def createCacheManagers {
-      var config = getDefaultClusteredConfig(Configuration.CacheMode.REPL_SYNC)
+      val config = getDefaultClusteredConfig(Configuration.CacheMode.REPL_SYNC)
       config.setFetchInMemoryState(true)
       for (i <- 0 until 2) {
          val cm = addClusterEnabledCacheManager()

--- a/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedSingleNodeTest.scala
+++ b/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedSingleNodeTest.scala
@@ -48,6 +48,7 @@ abstract class MemcachedSingleNodeTest extends SingleCacheManagerTest with Memca
       cacheManager = createTestCacheManager
       memcachedServer = startMemcachedTextServer(cacheManager)
       memcachedClient = createMemcachedClient(60000, server.getPort)
+      cache = cacheManager.getCache(MemcachedServer.cacheName)
       return cacheManager
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1206

The reason for doing this is to avoid REST server requests finding
data that has been entered via Memcached and viceversa.

5.0.x branch: t_1206_5
