### PR TITLE
ISPN-1205 Per-cache marshallers to enable AdvancedCache.with() calls

### DIFF
--- a/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/BdbjeCacheStoreIntegrationVamTest.java
+++ b/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/BdbjeCacheStoreIntegrationVamTest.java
@@ -22,11 +22,14 @@
  */
 package org.infinispan.loaders.bdbje;
 
-import org.infinispan.commands.RemoteCommandsFactory;
-import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.loaders.CacheLoaderException;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
-import org.infinispan.marshall.VersionAwareMarshaller;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+
+import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
 
 /**
  * BdjeCacheStoreIntegrationTest using production level marshaller.
@@ -36,12 +39,21 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "unit", enabled = true, testName = "loaders.bdbje.BdbjeCacheStoreIntegrationVamTest")
 public class BdbjeCacheStoreIntegrationVamTest extends BdbjeCacheStoreIntegrationTest {
+   private EmbeddedCacheManager cm;
+
    @Override
    protected StreamingMarshaller getMarshaller() {
-      VersionAwareMarshaller marshaller = new VersionAwareMarshaller();
-      marshaller.inject(Thread.currentThread().getContextClassLoader(), new RemoteCommandsFactory(), new GlobalConfiguration());
-      marshaller.start();
-      return marshaller;
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      return extractCacheMarshaller(cm.getCache());
    }
 
+   @AfterMethod(alwaysRun = true)
+   @Override
+   public void tearDown() throws CacheLoaderException {
+      try {
+         super.tearDown();
+      } finally {
+         cm.stop();
+      }
+   }
 }

--- a/cachestore/cloud/src/integrationtest/java/org/infinispan/loaders/cloud/CloudCacheStoreIntegrationVamTest.java
+++ b/cachestore/cloud/src/integrationtest/java/org/infinispan/loaders/cloud/CloudCacheStoreIntegrationVamTest.java
@@ -22,11 +22,14 @@
  */
 package org.infinispan.loaders.cloud;
 
-import org.infinispan.commands.RemoteCommandsFactory;
-import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.loaders.CacheLoaderException;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
-import org.infinispan.marshall.VersionAwareMarshaller;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+
+import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
 
 /**
  * CloudCacheStoreIntegrationTest using production level marshaller.
@@ -36,11 +39,21 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "unit", sequential = true, testName = "loaders.cloud.CloudCacheStoreIntegrationVamTest")
 public class CloudCacheStoreIntegrationVamTest extends CloudCacheStoreIntegrationTest {
+   private EmbeddedCacheManager cm;
+
    @Override
    protected StreamingMarshaller getMarshaller() {
-      VersionAwareMarshaller marshaller = new VersionAwareMarshaller();
-      marshaller.inject(Thread.currentThread().getContextClassLoader(), new RemoteCommandsFactory(), new GlobalConfiguration());
-      marshaller.start();
-      return marshaller;
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      return extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterMethod(alwaysRun = true)
+   @Override
+   public void tearDown() throws CacheLoaderException {
+      try {
+         super.tearDown();
+      } finally {
+         cm.stop();
+      }
    }
 }

--- a/cachestore/cloud/src/test/java/org/infinispan/loaders/cloud/CloudCacheStoreVamTest.java
+++ b/cachestore/cloud/src/test/java/org/infinispan/loaders/cloud/CloudCacheStoreVamTest.java
@@ -22,11 +22,14 @@
  */
 package org.infinispan.loaders.cloud;
 
-import org.infinispan.commands.RemoteCommandsFactory;
-import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.loaders.CacheLoaderException;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
-import org.infinispan.marshall.VersionAwareMarshaller;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+
+import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
 
 /**
  * CloudCacheStoreVamTest using production level marshaller.
@@ -36,11 +39,19 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "unit", testName = "loaders.cloud.CloudCacheStoreVamTest")
 public class CloudCacheStoreVamTest extends CloudCacheStoreTest {
+   private EmbeddedCacheManager cm;
+
    @Override
    protected StreamingMarshaller getMarshaller() {
-      VersionAwareMarshaller marshaller = new VersionAwareMarshaller();
-      marshaller.inject(Thread.currentThread().getContextClassLoader(), new RemoteCommandsFactory(), new GlobalConfiguration());
-      marshaller.start();
-      return marshaller;
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      return extractCacheMarshaller(cm.getCache());
    }
+
+   @AfterMethod(alwaysRun = true)
+   @Override
+   public void tearDown() throws CacheLoaderException {
+      super.tearDown();
+      cm.stop();
+   }
+
 }

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/binary/JdbcBinaryCacheStoreVamTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/binary/JdbcBinaryCacheStoreVamTest.java
@@ -22,11 +22,14 @@
  */
 package org.infinispan.loaders.jdbc.binary;
 
-import org.infinispan.commands.RemoteCommandsFactory;
-import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.loaders.CacheLoaderException;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
-import org.infinispan.marshall.VersionAwareMarshaller;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+
+import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
 
 /**
  * JdbcBinaryCacheStoreTest using production level marshaller.
@@ -36,11 +39,21 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "loaders.jdbc.binary.JdbcBinaryCacheStoreVamTest")
 public class JdbcBinaryCacheStoreVamTest extends JdbcBinaryCacheStoreTest {   
+   private EmbeddedCacheManager cm;
+
    @Override
    protected StreamingMarshaller getMarshaller() {
-      VersionAwareMarshaller marshaller = new VersionAwareMarshaller();
-      marshaller.inject(Thread.currentThread().getContextClassLoader(), new RemoteCommandsFactory(), new GlobalConfiguration());
-      marshaller.start();
-      return marshaller;
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      return extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterMethod(alwaysRun = true)
+   @Override
+   public void tearDown() throws CacheLoaderException {
+      try {
+         super.tearDown();
+      } finally {
+         cm.stop();
+      }
    }
 }

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreVamTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreVamTest.java
@@ -22,11 +22,13 @@
  */
 package org.infinispan.loaders.jdbc.mixed;
 
-import org.infinispan.commands.RemoteCommandsFactory;
-import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
-import org.infinispan.marshall.VersionAwareMarshaller;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+
+import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
 
 /**
  * JdbcMixedCacheStoreTest using production level marshaller.
@@ -36,11 +38,21 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "loaders.jdbc.mixed.JdbcMixedCacheStoreVamTest")
 public class JdbcMixedCacheStoreVamTest extends JdbcMixedCacheStoreTest {
+   private EmbeddedCacheManager cm;
+
    @Override
    protected StreamingMarshaller getMarshaller() {
-      VersionAwareMarshaller marshaller = new VersionAwareMarshaller();
-      marshaller.inject(Thread.currentThread().getContextClassLoader(), new RemoteCommandsFactory(), new GlobalConfiguration());
-      marshaller.start();
-      return marshaller;
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      return extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterMethod(alwaysRun = true)
+   @Override
+   public void clearStore() throws Exception {
+      try {
+         super.clearStore();
+      } finally {
+         cm.stop();
+      }
    }
 }

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreVamTest2.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreVamTest2.java
@@ -22,11 +22,14 @@
  */
 package org.infinispan.loaders.jdbc.mixed;
 
-import org.infinispan.commands.RemoteCommandsFactory;
-import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.loaders.CacheLoaderException;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
-import org.infinispan.marshall.VersionAwareMarshaller;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+
+import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
 
 /**
  * JdbcMixedCacheStoreTest2 using production level marshaller.
@@ -36,11 +39,22 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "loaders.jdbc.mixed.JdbcMixedCacheStoreVamTest2")
 public class JdbcMixedCacheStoreVamTest2 extends JdbcMixedCacheStoreTest2 {
+   private EmbeddedCacheManager cm;
+
    @Override
    protected StreamingMarshaller getMarshaller() {
-      VersionAwareMarshaller marshaller = new VersionAwareMarshaller();
-      marshaller.inject(Thread.currentThread().getContextClassLoader(), new RemoteCommandsFactory(), new GlobalConfiguration());
-      marshaller.start();
-      return marshaller;
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      return extractCacheMarshaller(cm.getCache());
    }
+
+   @AfterMethod(alwaysRun = true)
+   @Override
+   public void tearDown() throws CacheLoaderException {
+      try {
+         super.tearDown();
+      } finally {
+         cm.stop();
+      }
+   }
+
 }

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreVamTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreVamTest.java
@@ -22,11 +22,14 @@
  */
 package org.infinispan.loaders.jdbc.stringbased;
 
-import org.infinispan.commands.RemoteCommandsFactory;
-import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.loaders.CacheLoaderException;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
-import org.infinispan.marshall.VersionAwareMarshaller;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+
+import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
 
 /**
  * JdbcStringBasedCacheStoreTest using production level marshaller.
@@ -36,11 +39,21 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "loaders.jdbc.stringbased.JdbcStringBasedCacheStoreVamTest")
 public class JdbcStringBasedCacheStoreVamTest extends JdbcStringBasedCacheStoreTest {
+   private EmbeddedCacheManager cm;
+
    @Override
    protected StreamingMarshaller getMarshaller() {
-      VersionAwareMarshaller marshaller = new VersionAwareMarshaller();
-      marshaller.inject(Thread.currentThread().getContextClassLoader(), new RemoteCommandsFactory(), new GlobalConfiguration());
-      marshaller.start();
-      return marshaller;
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      return extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterMethod(alwaysRun = true)
+   @Override
+   public void tearDown() throws CacheLoaderException {
+      try {
+         super.tearDown();
+      } finally {
+         cm.stop();
+      }
    }
 }

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreVamTest2.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreVamTest2.java
@@ -22,11 +22,13 @@
  */
 package org.infinispan.loaders.jdbc.stringbased;
 
-import org.infinispan.commands.RemoteCommandsFactory;
-import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
-import org.infinispan.marshall.VersionAwareMarshaller;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+
+import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
 
 /**
  * JdbcStringBasedCacheStoreTest2 using production level marshaller.
@@ -36,11 +38,21 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "loaders.jdbc.stringbased.JdbcStringBasedCacheStoreVamTest2")
 public class JdbcStringBasedCacheStoreVamTest2 extends JdbcStringBasedCacheStoreTest2 {
+   private EmbeddedCacheManager cm;
+
    @Override
    protected StreamingMarshaller getMarshaller() {
-      VersionAwareMarshaller marshaller = new VersionAwareMarshaller();
-      marshaller.inject(Thread.currentThread().getContextClassLoader(), new RemoteCommandsFactory(), new GlobalConfiguration());
-      marshaller.start();
-      return marshaller;
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      return extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterMethod(alwaysRun = true)
+   @Override
+   public void clearStore() throws Exception {
+      try {
+         super.clearStore();
+      } finally {
+         cm.stop();
+      }
    }
 }

--- a/cachestore/jdbm/src/test/java/org/infinispan/loaders/jdbm/JdbmCacheStoreVamTest.java
+++ b/cachestore/jdbm/src/test/java/org/infinispan/loaders/jdbm/JdbmCacheStoreVamTest.java
@@ -22,11 +22,14 @@
  */
 package org.infinispan.loaders.jdbm;
 
-import org.infinispan.commands.RemoteCommandsFactory;
-import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.loaders.CacheLoaderException;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
-import org.infinispan.marshall.VersionAwareMarshaller;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+
+import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
 
 /**
  * JdbmCacheStoreTest using production level marshaller.
@@ -36,11 +39,21 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "unit", testName = "loaders.jdbm.JdbmCacheStoreVamTest")
 public class JdbmCacheStoreVamTest extends JdbmCacheStoreTest {
+   private EmbeddedCacheManager cm;
+
    @Override
    protected StreamingMarshaller getMarshaller() {
-      VersionAwareMarshaller marshaller = new VersionAwareMarshaller();
-      marshaller.inject(Thread.currentThread().getContextClassLoader(), new RemoteCommandsFactory(), new GlobalConfiguration());
-      marshaller.start();
-      return marshaller;
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      return extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterMethod(alwaysRun = true)
+   @Override
+   public void tearDown() throws CacheLoaderException {
+      try {
+         super.tearDown();
+      } finally {
+         cm.stop();
+      }
    }
 }

--- a/core/src/main/java/org/infinispan/AdvancedCache.java
+++ b/core/src/main/java/org/infinispan/AdvancedCache.java
@@ -146,30 +146,96 @@ public interface AdvancedCache<K, V> extends Cache<K, V> {
     */
    boolean lock(Collection<? extends K> keys);
 
+   /**
+    * Returns the component in charge of communication with other caches in
+    * the cluster.  If the cache's {@link org.infinispan.config.Configuration.CacheMode}
+    * is {@link org.infinispan.config.Configuration.CacheMode#LOCAL}, this
+    * method will return null.
+    *
+    * @return the RPC manager component associated with this cache instance or null
+    */
    RpcManager getRpcManager();
 
+   /**
+    * Returns the component in charge of batching cache operations.
+    *
+    * @return the batching component associated with this cache instance
+    */
    BatchContainer getBatchContainer();
 
+   /**
+    * Returns the component in charge of managing the interactions between the
+    * cache operations and the context information associated with them.
+    *
+    * @return the invocation context container component
+    */
    InvocationContextContainer getInvocationContextContainer();
 
+   /**
+    * Returns the container where data is stored in the cache. Users should
+    * interact with this component with care because direct calls on it bypass
+    * the internal interceptors and other infrastructure in place to guarantee
+    * the consistency of data.
+    *
+    * @return the data container associated with this cache instance
+    */
    DataContainer getDataContainer();
 
+   /**
+    * Returns the transaction manager configured for this cache. If no
+    * transaction manager was configured, this method returns null.
+    *
+    * @return the transaction manager associated with this cache instance or null
+    */
    TransactionManager getTransactionManager();
 
    /**
-    * @return retrieves the lock manager associated with this cache instance.
+    * Returns the component that deals with all aspects of acquiring and
+    * releasing locks for cache entries.
+    *
+    * @return retrieves the lock manager associated with this cache instance
     */
    LockManager getLockManager();
 
+   /**
+    * Returns a {@link Stats} object that allows several statistics associated
+    * with this cache at runtime.
+    *
+    * @return this cache's {@link Stats} object
+    */
    Stats getStats();
 
    /**
-    * Returns an Infinispan XAResource implementation. Useful e.g. for recovery, when the recovery process needs a
-    * reference to Infinispan's XAResource implementation.
+    * Returns the {@link XAResource} associated with this cache which can be
+    * used to do transactional recovery.
+    *
+    * @return an instance of {@link XAResource}
     */
    XAResource getXAResource();
    
+   /**
+    * Returns the cache loader associated associated with this cache.
+    *
+    * @return this cache's cache loader
+    */
    ClassLoader getClassLoader();
    
+   /**
+    * Using this operation, users can call any {@link AdvancedCache} operation
+    * with a given class loader. This means that any class loading happening
+    * as a result of the cache operation will be done using the class loader
+    * given. For example: </p>
+    *
+    * When users store POJO instances in caches configured with {@link org.infinispan.config.Configuration#storeAsBinary},
+    * these instances are transformed into byte arrays. When these entries are
+    * read from the cache, a lazy unmarshalling process happens where these byte
+    * arrays are transformed back into POJO instances. Using {@link AdvancedCache#with(ClassLoader)}
+    * when reading that enables users to provide the class loader that should
+    * be used when trying to locate the classes that are constructed as a result
+    * of the unmarshalling process.
+    *
+    * @return an advanced cache instance upon which operations can be called
+    * with a particular cache loader.
+    */
    AdvancedCache<K, V> with(ClassLoader classLoader);
 }

--- a/core/src/main/java/org/infinispan/config/GlobalConfiguration.java
+++ b/core/src/main/java/org/infinispan/config/GlobalConfiguration.java
@@ -828,14 +828,25 @@ public class GlobalConfiguration extends AbstractConfigurationBean {
     *
     * @return a new global configuration
     */
-   public static GlobalConfiguration getClusteredDefault() {
-      GlobalConfiguration gc = new GlobalConfiguration();
+   public static GlobalConfiguration getClusteredDefault(ClassLoader cl) {
+      GlobalConfiguration gc =
+            cl == null ? new GlobalConfiguration() : new GlobalConfiguration(cl);
       gc.setTransportClass(JGroupsTransport.class.getName());
       gc.setTransportProperties((Properties) null);
       Properties p = new Properties();
       p.setProperty("threadNamePrefix", "asyncTransportThread");
       gc.setAsyncTransportExecutorProperties(p);
       return gc;
+   }
+
+   /**
+    * Helper method that gets you a default constructed GlobalConfiguration, preconfigured to use the default clustering
+    * stack.
+    *
+    * @return a new global configuration
+    */
+   public static GlobalConfiguration getClusteredDefault() {
+      return getClusteredDefault(null);
    }
 
    /**

--- a/core/src/main/java/org/infinispan/context/InvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/InvocationContext.java
@@ -57,15 +57,48 @@ public interface InvocationContext extends EntryLookup, FlagContainer, Cloneable
     */
    Object getLockOwner();
 
+   /**
+    * Indicates whether the call requires a {@link java.util.concurrent.Future}
+    * as return type.
+    *
+    * @return true if the call requires a {@link java.util.concurrent.Future}
+    *              as return type, false otherwise
+    */
    boolean isUseFutureReturnType();
 
+   /**
+    * Sets whether the call requires a {@link java.util.concurrent.Future}
+    * as return type.
+    *
+    * @param useFutureReturnType boolean indicating whether a {@link java.util.concurrent.Future}
+    *                            will be needed.
+    */
    void setUseFutureReturnType(boolean useFutureReturnType);
 
+   /**
+    * Clones the invocation context.
+    *
+    * @return A cloned instance of this invocation context instance
+    */
    InvocationContext clone();
 
    /**
     * Returns the set of keys that are locked for writing.
     */
-   public Set<Object> getLockedKeys();
+   Set<Object> getLockedKeys();
 
+   /**
+    * Returns the class loader associated with this invocation
+    *
+    * @return a class loader instance or null if no class loader was
+    *         specifically associated
+    */
+   ClassLoader getClassLoader();
+
+   /**
+    * Sets the class loader associated for this invocation
+    *
+    * @param classLoader
+    */
+   void setClassLoader(ClassLoader classLoader);
 }

--- a/core/src/main/java/org/infinispan/context/InvocationContextContainer.java
+++ b/core/src/main/java/org/infinispan/context/InvocationContextContainer.java
@@ -97,8 +97,8 @@ public interface InvocationContextContainer {
    InvocationContext createRemoteInvocationContext(Address origin);
 
    /**
-    * As {@link #createRemoteInvocationContext()}, but returning the flags to the context from
-    * the Command if any Flag was set.
+    * As {@link #createRemoteInvocationContext(org.infinispan.remoting.transport.Address)},
+    * but returning the flags to the context from the Command if any Flag was set.
     * 
     * @param cacheCommand
     * @param origin the origin of the command, or null if local
@@ -125,4 +125,14 @@ public interface InvocationContextContainer {
     */
    void resume(InvocationContext ic);
 
+   /**
+    * Returns the {@link InvocationContext} that is currently associated with
+    * the calling thread. <b>Important:<b/> implementations of this method is
+    * most likely expensive (ThreadLocal.get), it is recommended to cache the
+    * result of this method rather than repeating the call.
+    *
+    * @return the invocation context associated with the calling thread or
+    *         null if none has been associated yet
+    */
+   InvocationContext peekInvocationContext();
 }

--- a/core/src/main/java/org/infinispan/context/InvocationContextContainerImpl.java
+++ b/core/src/main/java/org/infinispan/context/InvocationContextContainerImpl.java
@@ -169,6 +169,11 @@ public class InvocationContextContainerImpl implements InvocationContextContaine
       if (ctxt != null) icTl.set(ctxt);
    }
 
+   @Override
+   public InvocationContext peekInvocationContext() {
+      return icTl.get();
+   }
+
    private Transaction getRunningTx() {
       try {
          return tm == null ? null : tm.getTransaction();

--- a/core/src/main/java/org/infinispan/context/InvocationContextFlagsOverride.java
+++ b/core/src/main/java/org/infinispan/context/InvocationContextFlagsOverride.java
@@ -169,4 +169,13 @@ public class InvocationContextFlagsOverride implements InvocationContext {
       return new InvocationContextFlagsOverride(delegate, flags);
    }
 
+   @Override
+   public ClassLoader getClassLoader() {
+      return delegate.getClassLoader();
+   }
+
+   @Override
+   public void setClassLoader(ClassLoader classLoader) {
+      delegate.setClassLoader(classLoader);
+   }
 }

--- a/core/src/main/java/org/infinispan/context/impl/AbstractInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/AbstractInvocationContext.java
@@ -48,6 +48,8 @@ public abstract class AbstractInvocationContext implements InvocationContext {
    // an EnumSet.
    protected byte contextFlags = 0;
    private Address origin;
+   // Class loader associated with this invocation which supports AdvancedCache.with() functionality
+   private ClassLoader classLoader;
 
    // if this or any context subclass ever needs to store a boolean, always use a context flag instead.  This is far
    // more space-efficient.  Note that this value will be stored in a byte, which means up to 8 flags can be stored in
@@ -182,6 +184,16 @@ public abstract class AbstractInvocationContext implements InvocationContext {
             result.add(key);
       }
       return result;
+   }
+
+   @Override
+   public ClassLoader getClassLoader() {
+      return classLoader;
+   }
+
+   @Override
+   public void setClassLoader(ClassLoader classLoader) {
+      this.classLoader = classLoader;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/context/impl/ImmutableContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/ImmutableContext.java
@@ -144,6 +144,16 @@ public final class ImmutableContext implements InvocationContext {
       return this;
    }
 
+   @Override
+   public ClassLoader getClassLoader() {
+      return null;
+   }
+
+   @Override
+   public void setClassLoader(ClassLoader classLoader) {
+      throw newUnsupportedMethod();
+   }
+
    /**
     * @return an exception to state this context is read only
     */

--- a/core/src/main/java/org/infinispan/distexec/DefaultExecutorService.java
+++ b/core/src/main/java/org/infinispan/distexec/DefaultExecutorService.java
@@ -59,7 +59,6 @@ import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.read.DistributedExecuteCommand;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
-import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.interceptors.InterceptorChain;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.marshall.Marshaller;
@@ -74,6 +73,8 @@ import org.infinispan.util.concurrent.NotifyingFuture;
 import org.infinispan.util.concurrent.NotifyingNotifiableFuture;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+
+import static org.infinispan.factories.KnownComponentNames.CACHE_MARSHALLER;
 
 /**
  * Infinispan's implementation of an {@link ExecutorService} and {@link DistributedExecutorService}.
@@ -119,12 +120,11 @@ public class DefaultExecutorService extends AbstractExecutorService implements D
 
       this.cache = masterCacheNode.getAdvancedCache();
       ComponentRegistry registry = cache.getComponentRegistry();
-      GlobalComponentRegistry globalRegistry = cache.getComponentRegistry().getGlobalComponentRegistry();
 
       this.rpc = cache.getRpcManager();
       this.invoker = registry.getComponent(InterceptorChain.class);
       this.factory = registry.getComponent(CommandsFactory.class);
-      this.marshaller = globalRegistry.getComponent(StreamingMarshaller.class);
+      this.marshaller = registry.getComponent(StreamingMarshaller.class, CACHE_MARSHALLER);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/distexec/mapreduce/MapReduceTask.java
+++ b/core/src/main/java/org/infinispan/distexec/mapreduce/MapReduceTask.java
@@ -44,7 +44,6 @@ import org.infinispan.commands.read.MapReduceCommand;
 import org.infinispan.context.InvocationContextContainer;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
-import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.interceptors.InterceptorChain;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.marshall.Marshaller;
@@ -61,6 +60,8 @@ import org.infinispan.util.concurrent.NotifyingFuture;
 import org.infinispan.util.concurrent.NotifyingNotifiableFuture;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+
+import static org.infinispan.factories.KnownComponentNames.*;
 
 /**
  * MapReduceTask is a distributed task allowing a large scale computation to be transparently
@@ -156,9 +157,7 @@ public class MapReduceTask<KIn, VIn, KOut, VOut> {
       ensureProperCacheState(masterCacheNode.getAdvancedCache());      
       this.cache = masterCacheNode.getAdvancedCache();
       this.keys = new LinkedList<KIn>();
-      
-      GlobalComponentRegistry globalRegistry = cache.getComponentRegistry().getGlobalComponentRegistry();
-      this.marshaller = globalRegistry.getComponent(StreamingMarshaller.class);      
+      this.marshaller = cache.getComponentRegistry().getComponent(StreamingMarshaller.class, CACHE_MARSHALLER);
    }
 
    /**

--- a/core/src/main/java/org/infinispan/factories/EmptyConstructorFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EmptyConstructorFactory.java
@@ -27,6 +27,7 @@ import org.infinispan.distribution.L1Manager;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.marshall.jboss.ExternalizerTable;
 import org.infinispan.remoting.InboundInvocationHandler;
 import org.infinispan.transaction.xa.TransactionFactory;
 import org.infinispan.util.Util;
@@ -38,8 +39,7 @@ import org.infinispan.util.Util;
  * @author <a href="mailto:galder.zamarreno@jboss.com">Galder Zamarreno</a>
  * @since 4.0
  */
-
-@DefaultFactoryFor(classes = {InboundInvocationHandler.class, RemoteCommandsFactory.class, TransactionFactory.class, L1Manager.class })
+@DefaultFactoryFor(classes = {InboundInvocationHandler.class, RemoteCommandsFactory.class, TransactionFactory.class, L1Manager.class, ExternalizerTable.class })
 @Scope(Scopes.GLOBAL)
 public class EmptyConstructorFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
    public <T> T construct(Class<T> componentType) {

--- a/core/src/main/java/org/infinispan/factories/KnownComponentNames.java
+++ b/core/src/main/java/org/infinispan/factories/KnownComponentNames.java
@@ -39,6 +39,8 @@ public class KnownComponentNames {
    public static final String ASYNC_REPLICATION_QUEUE_EXECUTOR = "org.infinispan.executors.replicationQueue";
    public static final String MODULE_COMMAND_INITIALIZERS ="org.infinispan.modules.command.initializers";
    public static final String MODULE_COMMAND_FACTORIES ="org.infinispan.modules.command.factories";
+   public static final String GLOBAL_MARSHALLER = "org.infinispan.marshaller.global";
+   public static final String CACHE_MARSHALLER = "org.infinispan.marshaller.cache";
 
    private static final Map<String, Integer> DEFAULT_THREADCOUNTS = new HashMap<String, Integer>(2);
    private static final Map<String, Integer> DEFAULT_THREADPRIO = new HashMap<String, Integer>(4);

--- a/core/src/main/java/org/infinispan/interceptors/IsMarshallableInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/IsMarshallableInterceptor.java
@@ -33,6 +33,7 @@ import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.distribution.DistributionManager;
+import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.interceptors.base.CommandInterceptor;
@@ -40,6 +41,8 @@ import org.infinispan.marshall.NotSerializableException;
 import org.infinispan.marshall.StreamingMarshaller;
 
 import java.util.Map;
+
+import static org.infinispan.factories.KnownComponentNames.CACHE_MARSHALLER;
 
 /**
  * Interceptor to verify whether parameters passed into cache are marshallables
@@ -62,7 +65,8 @@ public class IsMarshallableInterceptor extends CommandInterceptor {
    private boolean storeAsBinary;
 
    @Inject
-   protected void injectMarshaller(StreamingMarshaller marshaller, DistributionManager distManager) {
+   protected void injectMarshaller(@ComponentName(CACHE_MARSHALLER) StreamingMarshaller marshaller,
+                                   DistributionManager distManager) {
       this.marshaller = marshaller;
       this.distManager = distManager;
    }

--- a/core/src/main/java/org/infinispan/interceptors/MarshalledValueInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/MarshalledValueInterceptor.java
@@ -36,6 +36,7 @@ import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.InternalEntryFactory;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.interceptors.base.CommandInterceptor;
@@ -51,6 +52,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static org.infinispan.factories.KnownComponentNames.CACHE_MARSHALLER;
 import static org.infinispan.marshall.MarshalledValue.isTypeExcluded;
 
 /**
@@ -73,7 +75,7 @@ public class MarshalledValueInterceptor extends CommandInterceptor {
    private boolean wrapValues = true;
 
    @Inject
-   protected void injectMarshaller(StreamingMarshaller marshaller) {
+   protected void injectMarshaller(@ComponentName(CACHE_MARSHALLER) StreamingMarshaller marshaller) {
       this.marshaller = marshaller;
    }
 

--- a/core/src/main/java/org/infinispan/loaders/CacheLoaderManagerImpl.java
+++ b/core/src/main/java/org/infinispan/loaders/CacheLoaderManagerImpl.java
@@ -33,6 +33,7 @@ import static org.infinispan.context.Flag.*;
 
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.InvocationContextContainer;
+import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
@@ -51,6 +52,7 @@ import java.util.Collections;
 import java.util.Set;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.infinispan.context.Flag.SKIP_REMOTE_LOOKUP;
+import static org.infinispan.factories.KnownComponentNames.CACHE_MARSHALLER;
 
 public class CacheLoaderManagerImpl implements CacheLoaderManager {
 
@@ -63,7 +65,9 @@ public class CacheLoaderManagerImpl implements CacheLoaderManager {
    private static final Log log = LogFactory.getLog(CacheLoaderManagerImpl.class);
 
    @Inject
-   public void inject(AdvancedCache<Object, Object> cache, StreamingMarshaller marshaller, Configuration configuration, InvocationContextContainer icc) {
+   public void inject(AdvancedCache<Object, Object> cache,
+                      @ComponentName(CACHE_MARSHALLER) StreamingMarshaller marshaller,
+                      Configuration configuration, InvocationContextContainer icc) {
       this.cache = cache;
       this.m = marshaller;
       this.configuration = configuration;

--- a/core/src/main/java/org/infinispan/marshall/AbstractDelegatingMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/AbstractDelegatingMarshaller.java
@@ -1,0 +1,113 @@
+package org.infinispan.marshall;
+
+import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.io.ByteBuffer;
+import org.infinispan.marshall.jboss.ExternalizerTable;
+import org.infinispan.util.Util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.OutputStream;
+
+/**
+ * With the introduction of global and cache marshallers, there's a need to
+ * separate marshallers but still rely on the same marshalling backend as
+ * previously. So, this class acts as a delegator for the new marshallers.
+ *
+ * @author Galder Zamarreño
+ * @since 5.0
+ */
+public abstract class AbstractDelegatingMarshaller implements StreamingMarshaller {
+
+   // TODO: Should avoid hardcoding but it's really not likely to change
+   protected VersionAwareMarshaller marshaller;
+   private ExternalizerTable extTable;
+
+   public void inject(ExternalizerTable extTable) {
+      this.extTable = extTable;
+   }
+
+   public void start() {
+      marshaller.start(extTable);
+   }
+
+   public void stop() {
+      marshaller.stop();
+   }
+
+   protected VersionAwareMarshaller createMarshaller(GlobalConfiguration globalCfg, ClassLoader loader) {
+      return (VersionAwareMarshaller) Util.getInstance(globalCfg.getMarshallerClass(), loader);
+   }
+
+   @Override
+   public ObjectOutput startObjectOutput(OutputStream os, boolean isReentrant) throws IOException {
+      return marshaller.startObjectOutput(os, isReentrant);
+   }
+
+   @Override
+   public void finishObjectOutput(ObjectOutput oo) {
+      marshaller.finishObjectOutput(oo);
+   }
+
+   @Override
+   public void objectToObjectStream(Object obj, ObjectOutput out) throws IOException {
+      marshaller.objectToObjectStream(obj, out);
+   }
+
+   @Override
+   public ObjectInput startObjectInput(InputStream is, boolean isReentrant) throws IOException {
+      return marshaller.startObjectInput(is, isReentrant);
+   }
+
+   @Override
+   public void finishObjectInput(ObjectInput oi) {
+      marshaller.finishObjectInput(oi);
+   }
+
+   @Override
+   public Object objectFromObjectStream(ObjectInput in) throws IOException, ClassNotFoundException, InterruptedException {
+      return marshaller.objectFromObjectStream(in);
+   }
+
+   @Override
+   public Object objectFromInputStream(InputStream is) throws IOException, ClassNotFoundException {
+      return marshaller.objectFromInputStream(is);
+   }
+
+   @Override
+   public byte[] objectToByteBuffer(Object obj, int estimatedSize) throws IOException, InterruptedException {
+      return marshaller.objectToByteBuffer(obj, estimatedSize);
+   }
+
+   @Override
+   public byte[] objectToByteBuffer(Object obj) throws IOException, InterruptedException {
+      return marshaller.objectToByteBuffer(obj);
+   }
+
+   @Override
+   public Object objectFromByteBuffer(byte[] buf) throws IOException, ClassNotFoundException {
+      return marshaller.objectFromByteBuffer(buf);
+   }
+
+   @Override
+   public Object objectFromByteBuffer(byte[] buf, int offset, int length) throws IOException, ClassNotFoundException {
+      return marshaller.objectFromByteBuffer(buf, offset, length);
+   }
+
+   @Override
+   public ByteBuffer objectToBuffer(Object o) throws IOException, InterruptedException {
+      return marshaller.objectToBuffer(o);
+   }
+
+   @Override
+   public boolean isMarshallable(Object o) throws Exception {
+      return marshaller.isMarshallable(o);
+   }
+
+   String getCacheName() {
+      return marshaller.getCacheName();
+   }
+
+}

--- a/core/src/main/java/org/infinispan/marshall/CacheMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/CacheMarshaller.java
@@ -1,0 +1,42 @@
+package org.infinispan.marshall;
+
+import org.infinispan.config.Configuration;
+import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.context.InvocationContextContainer;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.Stop;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.marshall.jboss.ExternalizerTable;
+
+import static org.infinispan.factories.KnownComponentNames.GLOBAL_MARSHALLER;
+
+/**
+ * A cache-scoped marshaller.
+ *
+ * @author Galder Zamarreño
+ * @since 5.0
+ */
+@Scope(Scopes.NAMED_CACHE)
+public class CacheMarshaller extends AbstractDelegatingMarshaller {
+
+   @Inject
+   public void inject(GlobalConfiguration globalCfg, Configuration cfg,
+                      InvocationContextContainer icc, ExternalizerTable extTable) {
+      super.inject(extTable);
+      this.marshaller = createMarshaller(globalCfg, cfg.getClassLoader());
+      this.marshaller.inject(cfg, null, icc);
+   }
+
+   @Start(priority = 7) // should start before RPCManager
+   public void start() {
+      super.start();
+   }
+
+   @Stop(priority = 11) // Stop after RPCManager to avoid send/receive and marshaller not being ready
+   public void stop() {
+      super.stop();
+   }
+
+}

--- a/core/src/main/java/org/infinispan/marshall/GlobalMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/GlobalMarshaller.java
@@ -1,0 +1,39 @@
+package org.infinispan.marshall;
+
+import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.Stop;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.marshall.jboss.ExternalizerTable;
+
+/**
+ * A globally-scoped marshaller. This is needed so that the transport layer
+ * can unmarshall requests even before it's known which cache's marshaller can
+ * do the job.
+ *
+ * @author Galder Zamarreño
+ * @since 5.0
+ */
+@Scope(Scopes.GLOBAL)
+public class GlobalMarshaller extends AbstractDelegatingMarshaller {
+
+   @Inject
+   public void inject(ClassLoader loader, GlobalConfiguration globalCfg, ExternalizerTable extTable) {
+      super.inject(extTable);
+      this.marshaller = createMarshaller(globalCfg, loader);
+      this.marshaller.inject(null, loader, null);
+   }
+
+   @Start(priority = 9) // Should start before Transport component
+   public void start() {
+      super.start();
+   }
+
+   @Stop(priority = 11) // Stop after transport to avoid send/receive and marshaller not being ready
+   public void stop() {
+      super.stop();
+   }
+
+}

--- a/core/src/main/java/org/infinispan/marshall/Ids.java
+++ b/core/src/main/java/org/infinispan/marshall/Ids.java
@@ -88,4 +88,9 @@ public interface Ids {
    int XID_GLOBAL_TRANSACTION = 68;
 
    int IN_DOUBT_TX_INFO = 70;
+
+   int MURMURHASH_2 = 71;
+   int MURMURHASH_2_COMPAT = 72;
+   int MURMURHASH_3 = 73;
+
 }

--- a/core/src/main/java/org/infinispan/marshall/Marshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/Marshaller.java
@@ -23,8 +23,6 @@
 package org.infinispan.marshall;
 
 import net.jcip.annotations.ThreadSafe;
-import org.infinispan.factories.scopes.Scope;
-import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.io.ByteBuffer;
 
 import java.io.IOException;
@@ -46,7 +44,6 @@ import java.io.IOException;
  * @author Manik Surtani
  * @version 4.1
  */
-@Scope(Scopes.GLOBAL)
 @ThreadSafe
 public interface Marshaller {
 

--- a/core/src/main/java/org/infinispan/marshall/StreamingMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/StreamingMarshaller.java
@@ -23,8 +23,6 @@
 package org.infinispan.marshall;
 
 import net.jcip.annotations.ThreadSafe;
-import org.infinispan.factories.scopes.Scope;
-import org.infinispan.factories.scopes.Scopes;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,7 +43,6 @@ import java.io.OutputStream;
  * @see Marshaller
  */
 @ThreadSafe
-@Scope(Scopes.GLOBAL)
 public interface StreamingMarshaller extends Marshaller {
 
    /**

--- a/core/src/main/java/org/infinispan/marshall/VersionAwareMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/VersionAwareMarshaller.java
@@ -23,12 +23,16 @@
 package org.infinispan.marshall;
 
 import org.infinispan.commands.RemoteCommandsFactory;
+import org.infinispan.config.Configuration;
 import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.context.InvocationContextContainer;
+import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.io.ByteBuffer;
 import org.infinispan.io.ExposedByteArrayOutputStream;
+import org.infinispan.marshall.jboss.ExternalizerTable;
 import org.infinispan.marshall.jboss.JBossMarshaller;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -58,37 +62,34 @@ public class VersionAwareMarshaller extends AbstractMarshaller implements Stream
 //   private static final int VERSION_410 = 410;
 //   private static final int VERSION_500 = 500;
    private static final int VERSION_510 = 510;
-   private static final int CUSTOM_MARSHALLER = 999;
 
    private final JBossMarshaller defaultMarshaller;
    private ClassLoader loader;
-   private RemoteCommandsFactory remoteCommandsFactory;
-   private GlobalConfiguration globalCfg;
+   private InvocationContextContainer icc;
+   private String cacheName;
 
    public VersionAwareMarshaller() {
       defaultMarshaller = new JBossMarshaller();
    }
 
-   @Inject
-   public void inject(ClassLoader loader, RemoteCommandsFactory remoteCommandsFactory, GlobalConfiguration globalCfg) {
-      this.loader = loader;
-      this.remoteCommandsFactory = remoteCommandsFactory;
-      this.globalCfg = globalCfg;
+   public void inject(Configuration cfg, ClassLoader loader, InvocationContextContainer icc) {
+      if (cfg == null) {
+         this.loader = loader;
+         this.cacheName = null;
+      } else {
+         this.loader = cfg.getClassLoader();
+         this.cacheName = cfg.getName();
+      }
+
+      this.icc = icc;
    }
 
-   @Start(priority = 9)
-   // should start before Transport component
-   public void start() {
-      defaultMarshaller.start(loader, remoteCommandsFactory, this, globalCfg);
+   public void start(ExternalizerTable externalizerTable) {
+      defaultMarshaller.start(externalizerTable, loader, icc);
    }
 
-   @Stop(priority = 11) // Stop after transport to avoid send/receive and marshaller not being ready
    public void stop() {
       defaultMarshaller.stop();
-   }
-
-   protected int getCustomMarshallerVersionInt() {
-      return CUSTOM_MARSHALLER;
    }
 
    @Override
@@ -131,8 +132,9 @@ public class VersionAwareMarshaller extends AbstractMarshaller implements Stream
    public ObjectOutput startObjectOutput(OutputStream os, boolean isReentrant) throws IOException {
       ObjectOutput out = defaultMarshaller.startObjectOutput(os, isReentrant);
       try {
-         out.writeShort(VERSION_510);
-         if (trace) log.tracef("Wrote version %s", VERSION_510);
+         final int version = VERSION_510;
+         out.writeShort(version);
+         if (trace) log.tracef("Wrote version %s", version);
       } catch (Exception e) {
          finishObjectOutput(out);
          log.unableToReadVersionId();

--- a/core/src/main/java/org/infinispan/marshall/exts/NoStateExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/NoStateExternalizer.java
@@ -1,0 +1,21 @@
+package org.infinispan.marshall.exts;
+
+import org.infinispan.marshall.AbstractExternalizer;
+
+import java.io.IOException;
+import java.io.ObjectOutput;
+
+/**
+ * An externalizer that writes no state. It simply marshalls class information.
+ *
+ * @author Galder Zamarreño
+ * @since 5.0
+ */
+public abstract class NoStateExternalizer<T> extends AbstractExternalizer<T> {
+
+   @Override
+   public void writeObject(ObjectOutput output, T object) throws IOException {
+      // The instance has no state, so no-op.
+   }
+
+}

--- a/core/src/main/java/org/infinispan/marshall/jboss/AbstractJBossMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/jboss/AbstractJBossMarshaller.java
@@ -1,0 +1,228 @@
+package org.infinispan.marshall.jboss;
+
+import org.infinispan.io.ByteBuffer;
+import org.infinispan.io.ExposedByteArrayOutputStream;
+import org.infinispan.marshall.AbstractMarshaller;
+import org.infinispan.util.ConcurrentWeakKeyHashMap;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.jboss.marshalling.ExceptionListener;
+import org.jboss.marshalling.Marshaller;
+import org.jboss.marshalling.MarshallerFactory;
+import org.jboss.marshalling.Marshalling;
+import org.jboss.marshalling.MarshallingConfiguration;
+import org.jboss.marshalling.TraceInformation;
+import org.jboss.marshalling.Unmarshaller;
+import org.jboss.marshalling.reflect.SunReflectiveCreator;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Common parent for both embedded and standalone JBoss Marshalling-based marshallers.
+ *
+ * @author Galder Zamarreño
+ * @since 5.0
+ */
+public abstract class AbstractJBossMarshaller extends AbstractMarshaller {
+
+   protected static final Log log = LogFactory.getLog(JBossMarshaller.class);
+   protected final MarshallingConfiguration baseCfg;
+   protected final MarshallerFactory factory;
+   /**
+    * Cache of classes that are considered to be marshallable. Since checking
+    * whether a type is marshallable requires attempting to marshalling them,
+    * a cache for the types that are known to be marshallable or not is
+    * advantageous.
+    */
+   private final ConcurrentMap<Class, Boolean> isMarshallableMap = new ConcurrentWeakKeyHashMap<Class, Boolean>();
+
+   public AbstractJBossMarshaller() {
+      factory = Marshalling.getMarshallerFactory("river", Marshalling.class.getClassLoader());
+      if (factory == null)
+         throw new IllegalStateException(
+            "River marshaller factory not found.  Verify that the JBoss Marshalling River jar archive is in the classpath.");
+
+      // Class resolver now set when marshaller/unmarshaller will be created
+      baseCfg = new MarshallingConfiguration();
+      baseCfg.setCreator(new SunReflectiveCreator());
+      baseCfg.setExceptionListener(new DebuggingExceptionListener());
+      baseCfg.setClassExternalizerFactory(new SerializeWithExtFactory());
+      baseCfg.setVersion(3);
+   }
+
+   public void objectToObjectStream(Object obj, ObjectOutput out) throws IOException {
+      out.writeObject(obj);
+   }
+
+   @Override
+   protected ByteBuffer objectToBuffer(Object o, int estimatedSize) throws IOException {
+      ExposedByteArrayOutputStream baos = new ExposedByteArrayOutputStream(estimatedSize);
+      ObjectOutput marshaller = startObjectOutput(baos, false);
+      try {
+         objectToObjectStream(o, marshaller);
+      } finally {
+         finishObjectOutput(marshaller);
+      }
+      return new ByteBuffer(baos.getRawBuffer(), 0, baos.size());
+   }
+
+   public ObjectOutput startObjectOutput(OutputStream os, boolean isReentrant) throws IOException {
+      org.jboss.marshalling.Marshaller marshaller = getMarshaller(isReentrant);
+      marshaller.start(Marshalling.createByteOutput(os));
+      return marshaller;
+   }
+
+   protected abstract Marshaller getMarshaller(boolean isReentrant) throws IOException;
+
+   public void finishObjectOutput(ObjectOutput oo) {
+      try {
+         if (log.isTraceEnabled())
+            log.trace("Stop marshaller");
+
+         ((org.jboss.marshalling.Marshaller) oo).finish();
+      } catch (IOException ignored) {
+      }
+   }
+
+   @Override
+   public Object objectFromByteBuffer(byte[] buf, int offset, int length) throws IOException,
+           ClassNotFoundException {
+      ByteArrayInputStream is = new ByteArrayInputStream(buf, offset, length);
+      ObjectInput unmarshaller = startObjectInput(is, false);
+      Object o = null;
+      try {
+         o = objectFromObjectStream(unmarshaller);
+      } finally {
+         finishObjectInput(unmarshaller);
+      }
+      return o;
+   }
+
+   public ObjectInput startObjectInput(InputStream is, boolean isReentrant) throws IOException {
+      Unmarshaller unmarshaller = getUnmarshaller(isReentrant);
+
+      if (log.isTraceEnabled())
+         log.tracef("Start unmarshaller after retrieving marshaller from %s",
+                   isReentrant ? "factory" : "thread local");
+
+      unmarshaller.start(Marshalling.createByteInput(is));
+      return unmarshaller;
+   }
+
+   protected abstract Unmarshaller getUnmarshaller(boolean isReentrant) throws IOException;
+
+   public Object objectFromObjectStream(ObjectInput in) throws IOException, ClassNotFoundException {
+      return in.readObject();
+   }
+
+   public void finishObjectInput(ObjectInput oi) {
+      try {
+         if (log.isTraceEnabled())
+            log.trace("Stop unmarshaller");
+
+         if (oi != null) ((Unmarshaller) oi).finish();
+      } catch (IOException ignored) {
+      }
+   }
+
+   @Override
+   public boolean isMarshallable(Object o) throws Exception {
+      Class clazz = o.getClass();
+      Object isClassMarshallable = isMarshallableMap.get(clazz);
+      if (isClassMarshallable != null) {
+         return (Boolean) isClassMarshallable;
+      } else {
+         if (isMarshallableCandidate(o)) {
+            boolean isMarshallable = true;
+            try {
+               objectToBuffer(o);
+            } catch (Exception e) {
+               isMarshallable = false;
+               throw e;
+            } finally {
+               isMarshallableMap.putIfAbsent(clazz, isMarshallable);
+            }
+            return isMarshallable;
+         }
+         return false;
+      }
+   }
+
+   public void stop() {
+       // Clear class cache
+      isMarshallableMap.clear();
+   }
+
+   protected boolean isMarshallableCandidate(Object o) {
+      return o instanceof Serializable;
+   }
+
+   protected static class DebuggingExceptionListener implements ExceptionListener {
+      private static final URL[] EMPTY_URLS = {};
+      private static final Class[] EMPTY_CLASSES = {};
+      private static final Object[] EMPTY_OBJECTS = {};
+
+      @Override
+      public void handleMarshallingException(Throwable problem, Object subject) {
+         if (log.isDebugEnabled()) {
+            TraceInformation.addUserInformation(problem, "toString = " + subject.toString());
+         }
+      }
+
+      @Override
+      public void handleUnmarshallingException(Throwable problem, Class<?> subjectClass) {
+         if (log.isDebugEnabled()) {
+            StringBuilder builder = new StringBuilder();
+            ClassLoader cl = subjectClass.getClassLoader();
+            builder.append("classloader hierarchy:");
+            ClassLoader parent = cl;
+            while (parent != null) {
+               if (parent.equals(cl)) {
+                  builder.append("\n\t\t-> type classloader = ").append(parent);
+               } else {
+                  builder.append("\n\t\t-> parent classloader = ").append(parent);
+               }
+               URL[] urls = getClassLoaderURLs(parent);
+
+               if (urls != null) {
+                  for (URL u : urls) builder.append("\n\t\t->...").append(u);
+               }
+
+               parent = parent.getParent();
+            }
+            TraceInformation.addUserInformation(problem, builder.toString());
+         }
+      }
+
+      @Override
+      public void handleUnmarshallingException(Throwable problem) {
+         // no-op
+      }
+
+      private static URL[] getClassLoaderURLs(ClassLoader cl) {
+         URL[] urls = EMPTY_URLS;
+         try {
+            Class returnType = urls.getClass();
+            Class[] parameterTypes = EMPTY_CLASSES;
+            Method getURLs = cl.getClass().getMethod("getURLs", parameterTypes);
+            if (returnType.isAssignableFrom(getURLs.getReturnType())) {
+               Object[] args = EMPTY_OBJECTS;
+               urls = (URL[]) getURLs.invoke(cl, args);
+            }
+         } catch (Exception ignore) {
+         }
+         return urls;
+      }
+
+   }
+
+}

--- a/core/src/main/java/org/infinispan/marshall/jboss/GenericJBossMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/jboss/GenericJBossMarshaller.java
@@ -30,6 +30,7 @@ import org.infinispan.util.ConcurrentWeakKeyHashMap;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.jboss.marshalling.ExceptionListener;
+import org.jboss.marshalling.Marshaller;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;
@@ -49,53 +50,28 @@ import java.net.URL;
 import java.util.concurrent.ConcurrentMap;
 
 /**
- * A marshaller that makes use of <a href="http://www.jboss.org/jbossmarshalling">JBoss Marshalling</a> to serialize
- * and deserialize objects.
- * <p />
- * In addition to making use of JBoss Marshalling, this Marshaller 
+ * A marshaller that makes use of <a href="http://www.jboss.org/jbossmarshalling">JBoss Marshalling</a>
+ * to serialize and deserialize objects. This marshaller is oriented at external,
+ * non-core Infinispan use, such as the Java Hot Rod client.
+ *
  * @author Manik Surtani
  * @version 4.1
  * @see <a href="http://www.jboss.org/jbossmarshalling">JBoss Marshalling</a>
  */
-public class GenericJBossMarshaller extends AbstractMarshaller {
-
-   protected static final Log log = LogFactory.getLog(JBossMarshaller.class);
-   protected ClassLoader appClassLoader = this.getClass().getClassLoader();
-   protected MarshallingConfiguration configuration;
-   protected MarshallerFactory factory;
-   /**
-    * Cache of classes that are considered to be marshallable. Since checking
-    * whether a type is marshallable requires attempting to marshalling them,
-    * a cache for the types that are known to be marshallable or not is
-    * advantageous.
-    */
-   private final ConcurrentMap<Class, Boolean> isMarshallableMap = new ConcurrentWeakKeyHashMap<Class, Boolean>();
-
-   public GenericJBossMarshaller() {
-      factory = Marshalling.getMarshallerFactory("river", Marshalling.class.getClassLoader());
-      if (factory == null)
-         throw new IllegalStateException(
-            "River marshaller factory not found.  Verify that the JBoss Marshalling River jar archive is in the classpath.");
-
-      configuration = new MarshallingConfiguration();
-      configuration.setCreator(new SunReflectiveCreator());
-      configuration.setExceptionListener(new DebuggingExceptionListener());
-      // ContextClassResolver provides same functionality as MarshalledValueInputStream
-      configuration.setClassResolver(new DefaultContextClassResolver(appClassLoader));
-      configuration.setClassExternalizerFactory(new SerializeWithExtFactory());
-      configuration.setVersion(3);
-   }
+public class GenericJBossMarshaller extends AbstractJBossMarshaller {
 
    /**
-    * Marshaller thread local. JBossMarshaller is a singleton shared by all caches (global component), so no urgent need
-    * for static here. JBMAR clears pretty much any state during finish(), so no urgent need to clear the thread local
-    * since it shouldn't be leaking.
+    * Marshaller thread local. In non-internal marshaller usages, such as Java
+    * Hot Rod client, this is a singleton shared by all so no urgent need for
+    * static here. JBMAR clears pretty much any state during finish(), so no
+    * urgent need to clear the thread local since it shouldn't be leaking.
     */
-   private ThreadLocal<org.jboss.marshalling.Marshaller> marshallerTL = new ThreadLocal<org.jboss.marshalling.Marshaller>() {
+   private ThreadLocal<org.jboss.marshalling.Marshaller> marshallerTL =
+         new ThreadLocal<org.jboss.marshalling.Marshaller>() {
       @Override
       protected org.jboss.marshalling.Marshaller initialValue() {
          try {
-            return factory.createMarshaller(configuration);
+            return factory.createMarshaller(baseCfg);
          } catch (IOException e) {
             throw new CacheException(e);
          }
@@ -103,195 +79,49 @@ public class GenericJBossMarshaller extends AbstractMarshaller {
    };
 
    /**
-    * Unmarshaller thread local. JBossMarshaller is a singleton shared by all caches (global component), so no urgent
-    * need for static here. JBMAR clears pretty much any state during finish(), so no urgent need to clear the thread
-    * local since it shouldn't be leaking.
+    * Unmarshaller thread local. In non-internal marshaller usages, such as
+    * Java Hot Rod client, this is a singleton shared by all so no urgent need
+    * for static here. JBMAR clears pretty much any state during finish(), so
+    * no urgent need to clear the thread local since it shouldn't be leaking.
     */
-   private ThreadLocal<Unmarshaller> unmarshallerTL = new ThreadLocal<Unmarshaller>() {
+   private ThreadLocal<Unmarshaller> unmarshallerTL = new
+         ThreadLocal<Unmarshaller>() {
       @Override
       protected Unmarshaller initialValue() {
          try {
-            return factory.createUnmarshaller(configuration);
+            return factory.createUnmarshaller(baseCfg);
          } catch (IOException e) {
             throw new CacheException(e);
          }
       }
    };
 
-   public void objectToObjectStream(Object obj, ObjectOutput out) throws IOException {
-      out.writeObject(obj);
+   public GenericJBossMarshaller() {
+      super();
+      baseCfg.setClassResolver(
+            new DefaultContextClassResolver(this.getClass().getClassLoader()));
    }
 
-   @Override
-   protected ByteBuffer objectToBuffer(Object o, int estimatedSize) throws IOException {
-      ExposedByteArrayOutputStream baos = new ExposedByteArrayOutputStream(estimatedSize);
-      ObjectOutput marshaller = startObjectOutput(baos, false);
-      try {
-         objectToObjectStream(o, marshaller);
-      } finally {
-         finishObjectOutput(marshaller);
-      }
-      return new ByteBuffer(baos.getRawBuffer(), 0, baos.size());
-   }
-
-   public ObjectOutput startObjectOutput(OutputStream os, boolean isReentrant) throws IOException {
-      org.jboss.marshalling.Marshaller marshaller;
-      if (isReentrant) {
-         marshaller = factory.createMarshaller(configuration);
-      } else {
-         marshaller = marshallerTL.get();
-      }
+   protected Marshaller getMarshaller(boolean isReentrant) throws IOException {
+      Marshaller marshaller = isReentrant ?
+            factory.createMarshaller(baseCfg) : marshallerTL.get();
 
       if (log.isTraceEnabled())
          log.tracef("Start marshaller after retrieving marshaller from %s",
                    isReentrant ? "factory" : "thread local");
 
-      marshaller.start(Marshalling.createByteOutput(os));
       return marshaller;
    }
 
-   public void finishObjectOutput(ObjectOutput oo) {
-      try {
-         if (log.isTraceEnabled())
-            log.trace("Stop marshaller");
-
-         ((org.jboss.marshalling.Marshaller) oo).finish();
-      } catch (IOException ignored) {
-      }
-   }
-
-   @Override
-   public Object objectFromByteBuffer(byte[] buf, int offset, int length) throws IOException,
-           ClassNotFoundException {
-      ByteArrayInputStream is = new ByteArrayInputStream(buf, offset, length);
-      ObjectInput unmarshaller = startObjectInput(is, false);
-      Object o = null;
-      try {
-         o = objectFromObjectStream(unmarshaller);
-      } finally {
-         finishObjectInput(unmarshaller);
-      }
-      return o;
-   }
-
-   public ObjectInput startObjectInput(InputStream is, boolean isReentrant) throws IOException {
-      Unmarshaller unmarshaller;
-      if (isReentrant) {
-         unmarshaller = factory.createUnmarshaller(configuration);
-      } else {
-         unmarshaller = unmarshallerTL.get();
-      }
+   protected Unmarshaller getUnmarshaller(boolean isReentrant) throws IOException {
+      Unmarshaller unmarshaller = isReentrant ?
+            factory.createUnmarshaller(baseCfg) : unmarshallerTL.get();
 
       if (log.isTraceEnabled())
          log.tracef("Start unmarshaller after retrieving marshaller from %s",
                    isReentrant ? "factory" : "thread local");
 
-      unmarshaller.start(Marshalling.createByteInput(is));
       return unmarshaller;
    }
 
-   public Object objectFromObjectStream(ObjectInput in) throws IOException, ClassNotFoundException {
-      return in.readObject();
-   }   
-
-   public void finishObjectInput(ObjectInput oi) {
-      try {
-         if (log.isTraceEnabled())
-            log.trace("Stop unmarshaller");
-
-         if (oi != null) ((Unmarshaller) oi).finish();
-      } catch (IOException ignored) {
-      }
-   }
-
-   @Override
-   public boolean isMarshallable(Object o) throws Exception {
-      Class clazz = o.getClass();
-      Object isClassMarshallable = isMarshallableMap.get(clazz);
-      if (isClassMarshallable != null) {
-         return (Boolean) isClassMarshallable;
-      } else {
-         if (isMarshallableCandidate(o)) {
-            boolean isMarshallable = true;
-            try {
-               objectToBuffer(o);
-            } catch (Exception e) {
-               isMarshallable = false;
-               throw e;
-            } finally {
-               isMarshallableMap.putIfAbsent(clazz, isMarshallable);
-            }
-            return isMarshallable;
-         }
-         return false;
-      }
-   }
-
-   public void stop() {
-       // Clear class cache
-      isMarshallableMap.clear();
-   }
-
-   protected boolean isMarshallableCandidate(Object o) {
-      return o instanceof Serializable;
-   }
-
-   protected static class DebuggingExceptionListener implements ExceptionListener {
-      private static final URL[] EMPTY_URLS = {};
-      private static final Class[] EMPTY_CLASSES = {};
-      private static final Object[] EMPTY_OBJECTS = {};
-
-      @Override
-      public void handleMarshallingException(Throwable problem, Object subject) {
-         if (log.isDebugEnabled()) {
-            TraceInformation.addUserInformation(problem, "toString = " + subject.toString());
-         }
-      }
-
-      @Override
-      public void handleUnmarshallingException(Throwable problem, Class<?> subjectClass) {
-         if (log.isDebugEnabled()) {
-            StringBuilder builder = new StringBuilder();
-            ClassLoader cl = subjectClass.getClassLoader();
-            builder.append("classloader hierarchy:");
-            ClassLoader parent = cl;
-            while (parent != null) {
-               if (parent.equals(cl)) {
-                  builder.append("\n\t\t-> type classloader = ").append(parent);
-               } else {
-                  builder.append("\n\t\t-> parent classloader = ").append(parent);
-               }
-               URL[] urls = getClassLoaderURLs(parent);
-
-               if (urls != null) {
-                  for (URL u : urls) builder.append("\n\t\t->...").append(u);
-               }
-
-               parent = parent.getParent();
-            }
-            TraceInformation.addUserInformation(problem, builder.toString());
-         }
-      }
-
-      @Override
-      public void handleUnmarshallingException(Throwable problem) {
-         // no-op
-      }
-
-      private static URL[] getClassLoaderURLs(ClassLoader cl) {
-         URL[] urls = EMPTY_URLS;
-         try {
-            Class returnType = urls.getClass();
-            Class[] parameterTypes = EMPTY_CLASSES;
-            Method getURLs = cl.getClass().getMethod("getURLs", parameterTypes);
-            if (returnType.isAssignableFrom(getURLs.getReturnType())) {
-               Object[] args = EMPTY_OBJECTS;
-               urls = (URL[]) getURLs.invoke(cl, args);
-            }
-         } catch (Exception ignore) {
-         }
-         return urls;
-      }
-
-   }   
 }

--- a/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
@@ -33,6 +33,7 @@ import org.infinispan.config.GlobalConfiguration;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
@@ -70,6 +71,7 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.infinispan.factories.KnownComponentNames.*;
 
 /**
  * Sets the cache interceptor chain on an RPCCommand before calling it to perform
@@ -102,7 +104,10 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
    }
 
    @Inject
-   public void inject(GlobalComponentRegistry gcr, StreamingMarshaller marshaller, EmbeddedCacheManager embeddedCacheManager, Transport transport, GlobalConfiguration globalConfiguration) {
+   public void inject(GlobalComponentRegistry gcr,
+                      @ComponentName(GLOBAL_MARSHALLER) StreamingMarshaller marshaller,
+                      EmbeddedCacheManager embeddedCacheManager, Transport transport,
+                      GlobalConfiguration globalConfiguration) {
       this.gcr = gcr;
       this.marshaller = marshaller;
       this.embeddedCacheManager = embeddedCacheManager;

--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
@@ -28,7 +28,6 @@ import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commands.control.StateTransferControlCommand;
 import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.config.Configuration;
-import org.infinispan.factories.KnownComponentNames;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
@@ -36,6 +35,7 @@ import org.infinispan.factories.annotations.Stop;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.marshall.StreamingMarshaller;
 import org.infinispan.remoting.RpcException;
 import org.infinispan.remoting.ReplicationQueue;
 import org.infinispan.remoting.responses.Response;
@@ -62,6 +62,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static org.infinispan.factories.KnownComponentNames.*;
 
 /**
  * This component really is just a wrapper around a {@link org.infinispan.remoting.transport.Transport} implementation,
@@ -92,16 +94,19 @@ public class RpcManagerImpl implements RpcManager {
    private ReplicationQueue replicationQueue;
    private ExecutorService asyncExecutor;
    private CommandsFactory cf;
+   private StreamingMarshaller marshaller;
 
 
    @Inject
    public void injectDependencies(Transport t, Configuration configuration, ReplicationQueue replicationQueue, CommandsFactory cf,
-                                  @ComponentName(KnownComponentNames.ASYNC_TRANSPORT_EXECUTOR) ExecutorService e) {
+                                  @ComponentName(ASYNC_TRANSPORT_EXECUTOR) ExecutorService e,
+                                  @ComponentName(CACHE_MARSHALLER) StreamingMarshaller marshaller) {
       this.t = t;
       this.configuration = configuration;
       this.replicationQueue = replicationQueue;
       this.asyncExecutor = e;
       this.cf = cf;
+      this.marshaller = marshaller;
    }
 
    @Start(priority = 9)

--- a/core/src/main/java/org/infinispan/remoting/transport/Transport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/Transport.java
@@ -24,7 +24,6 @@ package org.infinispan.remoting.transport;
 
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.config.GlobalConfiguration;
-import org.infinispan.factories.KnownComponentNames;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
@@ -45,6 +44,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+
+import static org.infinispan.factories.KnownComponentNames.*;
 
 /**
  * An interface that provides a communication link with remote caches.  Also allows remote caches to invoke commands on
@@ -70,8 +71,8 @@ public interface Transport extends Lifecycle {
     * @param notifier      notifier to use
     */
    @Inject
-   void initialize(StreamingMarshaller marshaller,
-                   @ComponentName(KnownComponentNames.ASYNC_TRANSPORT_EXECUTOR) ExecutorService asyncExecutor,
+   void initialize(@ComponentName(GLOBAL_MARSHALLER) StreamingMarshaller marshaller,
+                   @ComponentName(ASYNC_TRANSPORT_EXECUTOR) ExecutorService asyncExecutor,
                    InboundInvocationHandler handler, CacheManagerNotifier notifier);
 
    /**
@@ -166,7 +167,18 @@ public interface Transport extends Lifecycle {
    @Stop
    void stop();
 
+   /**
+    * TODO: Document
+    *
+    * @return
+    */
    int getViewId();
 
+   /**
+    * TODO: Document
+    *
+    * @return
+    */
    Log getLog();
+
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -25,6 +25,7 @@ package org.infinispan.remoting.transport.jgroups;
 import org.infinispan.CacheException;
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.config.parsing.XmlConfigHelper;
+import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.jmx.JmxUtil;
 import org.infinispan.marshall.StreamingMarshaller;
 import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifier;
@@ -61,6 +62,7 @@ import java.util.*;
 import java.util.concurrent.*;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.infinispan.factories.KnownComponentNames.GLOBAL_MARSHALLER;
 
 /**
  * An encapsulation of a JGroups transport.  JGroups transports can be configured using a variety of methods, usually by
@@ -132,8 +134,9 @@ public class JGroupsTransport extends AbstractTransport implements ExtendedMembe
    // Lifecycle and setup stuff
    // ------------------------------------------------------------------------------------------------------------------
 
-   public void initialize(StreamingMarshaller marshaller, ExecutorService asyncExecutor,
-                          InboundInvocationHandler inboundInvocationHandler, CacheManagerNotifier notifier) {
+   public void initialize(@ComponentName(GLOBAL_MARSHALLER) StreamingMarshaller marshaller,
+                          ExecutorService asyncExecutor, InboundInvocationHandler inboundInvocationHandler,
+                          CacheManagerNotifier notifier) {
       this.marshaller = marshaller;
       this.asyncExecutor = asyncExecutor;
       this.inboundInvocationHandler = inboundInvocationHandler;

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -33,6 +33,7 @@ import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.InvocationContextContainer;
 import org.infinispan.context.impl.RemoteTxInvocationContext;
+import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.interceptors.InterceptorChain;
@@ -61,6 +62,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.infinispan.context.Flag.CACHE_MODE_LOCAL;
 import static org.infinispan.context.Flag.SKIP_CACHE_STORE;
 import static org.infinispan.context.Flag.SKIP_SHARED_CACHE_STORE;
+import static org.infinispan.factories.KnownComponentNames.CACHE_MARSHALLER;
 
 public class StateTransferManagerImpl implements StateTransferManager {
 
@@ -88,7 +90,7 @@ public class StateTransferManagerImpl implements StateTransferManager {
    @Inject
    @SuppressWarnings("unchecked")
    public void injectDependencies(RpcManager rpcManager, AdvancedCache cache, Configuration configuration,
-                                  DataContainer dataContainer, CacheLoaderManager clm, StreamingMarshaller marshaller,
+                                  DataContainer dataContainer, CacheLoaderManager clm, @ComponentName(CACHE_MARSHALLER) StreamingMarshaller marshaller,
                                   TransactionLog transactionLog, InterceptorChain interceptorChain, InvocationContextContainer invocationContextContainer,
                                   CommandsFactory commandsFactory, TransactionTable txTable) {
       this.rpcManager = rpcManager;

--- a/core/src/main/java/org/infinispan/util/hash/MurmurHash2.java
+++ b/core/src/main/java/org/infinispan/util/hash/MurmurHash2.java
@@ -22,9 +22,14 @@
  */
 package org.infinispan.util.hash;
 
+import org.infinispan.marshall.Ids;
+import org.infinispan.marshall.exts.NoStateExternalizer;
 import org.infinispan.util.ByteArrayKey;
+import org.infinispan.util.Util;
 
+import java.io.ObjectInput;
 import java.nio.charset.Charset;
+import java.util.Set;
 
 /**
  * An implementation of Austin Appleby's MurmurHash2.0 algorithm, as documented on <a href="http://sites.google.com/site/murmurhash/">his website</a>.
@@ -101,5 +106,22 @@ public class MurmurHash2 implements Hash {
          return hash(((ByteArrayKey) o).getData());
       else
          return hash(o.hashCode());
+   }
+
+   public static class Externalizer extends NoStateExternalizer<MurmurHash2> {
+      @Override
+      public Set<Class<? extends MurmurHash2>> getTypeClasses() {
+         return Util.<Class<? extends MurmurHash2>>asSet(MurmurHash2.class);
+      }
+
+      @Override
+      public MurmurHash2 readObject(ObjectInput input) {
+         return new MurmurHash2();
+      }
+
+      @Override
+      public Integer getId() {
+         return Ids.MURMURHASH_2;
+      }
    }
 }

--- a/core/src/main/java/org/infinispan/util/hash/MurmurHash2Compat.java
+++ b/core/src/main/java/org/infinispan/util/hash/MurmurHash2Compat.java
@@ -22,7 +22,13 @@
  */
 package org.infinispan.util.hash;
 
+import org.infinispan.marshall.Ids;
+import org.infinispan.marshall.exts.NoStateExternalizer;
 import org.infinispan.util.ByteArrayKey;
+import org.infinispan.util.Util;
+
+import java.io.ObjectInput;
+import java.util.Set;
 
 /**
  * An implementation of Austin Appleby's MurmurHash2.0 algorithm, as documented on <a href="http://sites.google.com/site/murmurhash/">his website</a>.
@@ -103,5 +109,22 @@ public class MurmurHash2Compat implements Hash {
          return hash(((ByteArrayKey) o).getData());
       else
          return hash(o.hashCode());
+   }
+
+   public static class Externalizer extends NoStateExternalizer<MurmurHash2Compat> {
+      @Override
+      public Set<Class<? extends MurmurHash2Compat>> getTypeClasses() {
+         return Util.<Class<? extends MurmurHash2Compat>>asSet(MurmurHash2Compat.class);
+      }
+
+      @Override
+      public MurmurHash2Compat readObject(ObjectInput input) {
+         return new MurmurHash2Compat();
+      }
+
+      @Override
+      public Integer getId() {
+         return Ids.MURMURHASH_2_COMPAT;
+      }
    }
 }

--- a/core/src/main/java/org/infinispan/util/hash/MurmurHash3.java
+++ b/core/src/main/java/org/infinispan/util/hash/MurmurHash3.java
@@ -23,9 +23,14 @@
 
 package org.infinispan.util.hash;
 
+import org.infinispan.marshall.Ids;
+import org.infinispan.marshall.exts.NoStateExternalizer;
 import org.infinispan.util.ByteArrayKey;
+import org.infinispan.util.Util;
 
+import java.io.ObjectInput;
 import java.nio.charset.Charset;
+import java.util.Set;
 
 /**
  * MurmurHash3 implementation in Java, based on Austin Appleby's <a href=
@@ -285,4 +290,23 @@ public class MurmurHash3 implements Hash {
       else
          return hash(o.hashCode());
    }
+
+   public static class Externalizer extends NoStateExternalizer<MurmurHash3> {
+      @Override
+      public Set<Class<? extends MurmurHash3>> getTypeClasses() {
+         return Util.<Class<? extends MurmurHash3>>asSet(MurmurHash3.class);
+      }
+
+      @Override
+      public MurmurHash3 readObject(ObjectInput input) {
+         return new MurmurHash3();
+      }
+
+      @Override
+      public Integer getId() {
+         return Ids.MURMURHASH_3;
+      }
+   }
+
+
 }

--- a/core/src/test/java/org/infinispan/api/WithClassLoaderTest.java
+++ b/core/src/test/java/org/infinispan/api/WithClassLoaderTest.java
@@ -1,0 +1,90 @@
+package org.infinispan.api;
+
+import org.infinispan.Cache;
+import org.infinispan.CacheException;
+import org.infinispan.config.Configuration.CacheMode;
+import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.CherryPickClassLoader;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.annotations.Test;
+
+import java.io.Serializable;
+
+import static org.infinispan.test.fwk.TestCacheManagerFactory.createCacheManager;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.fail;
+
+/**
+ * A test that verifies the correctness of {@link org.infinispan.AdvancedCache#with(ClassLoader)} API.
+ *
+ * @author Galder Zamarreño
+ * @since 5.0
+ */
+@Test(groups = "functional", testName = "api.WithClassLoaderTest")
+public class WithClassLoaderTest extends MultipleCacheManagersTest {
+
+   private static final String BASE = WithClassLoaderTest.class.getName() + "$";
+   private static final String CAR = BASE + "Car";
+   private ClassLoader systemCl;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      EmbeddedCacheManager cm0 = createCacheManager(GlobalConfiguration.getClusteredDefault());
+      cm0.getDefaultConfiguration().fluent()
+         .clustering().mode(CacheMode.REPL_SYNC)
+         .storeAsBinary().build();
+      cacheManagers.add(cm0);
+
+      String[] notFound = new String[]{CAR};
+      systemCl = Thread.currentThread().getContextClassLoader();
+      CherryPickClassLoader cl = new CherryPickClassLoader(null, null, notFound, systemCl);
+      EmbeddedCacheManager cm1 = createCacheManager(GlobalConfiguration.getClusteredDefault(cl));
+      cm1.getDefaultConfiguration().fluent()
+         .clustering().mode(CacheMode.REPL_SYNC)
+         .storeAsBinary().build();
+      cacheManagers.add(cm1);
+   }
+
+   public void testReadingWithCorrectClassLoader() {
+      Cache<Integer, Car> cache0 = cache(0);
+      Car value = new Car().plateNumber("1234");
+      cache0.put(1, value);
+
+      Cache<Integer, Car> cache1 = cache(1);
+
+      try {
+         cache1.get(1);
+         fail("Expected a class ClassNotFoundException");
+      } catch (CacheException e) {
+         if (!(e.getCause() instanceof ClassNotFoundException))
+            throw e;
+      }
+
+      assertEquals(value, cache1.getAdvancedCache().with(systemCl).get(1));
+   }
+
+   public static class Car implements Serializable {
+      String plateNumber;
+      Car plateNumber(String s) { plateNumber = s; return this; }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) return true;
+         if (o == null || getClass() != o.getClass()) return false;
+
+         Car car = (Car) o;
+
+         if (plateNumber != null ? !plateNumber.equals(car.plateNumber) : car.plateNumber != null)
+            return false;
+
+         return true;
+      }
+
+      @Override
+      public int hashCode() {
+         return plateNumber != null ? plateNumber.hashCode() : 0;
+      }
+   }
+
+}

--- a/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadTest.java
+++ b/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadTest.java
@@ -22,7 +22,6 @@
  */
 package org.infinispan.api.mvcc;
 
-import org.easymock.EasyMock;
 import static org.easymock.EasyMock.*;
 import org.infinispan.Cache;
 import static org.infinispan.context.Flag.CACHE_MODE_LOCAL;
@@ -40,12 +39,15 @@ import org.infinispan.test.ReplListener;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.transaction.TransactionTable;
 
+import static org.infinispan.test.TestingUtil.k;
+import static org.infinispan.test.TestingUtil.v;
 import static org.testng.AssertJUnit.*;
 import org.testng.annotations.Test;
 
 import javax.transaction.Status;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -231,7 +233,7 @@ public class PutForExternalReadTest extends MultipleCacheManagersTest {
    public void testBasicPropagation() throws Exception {
       Cache cache1 = cache(0, "replSync");
       Cache cache2 = cache(1, "replSync");
-      
+
       assert !cache1.containsKey(key);
       assert !cache2.containsKey(key);
       ReplListener replListener2 = replListener(cache2);
@@ -255,9 +257,8 @@ public class PutForExternalReadTest extends MultipleCacheManagersTest {
     *
     * @throws Exception
     */
-   public void
-   testSimpleCacheModeLocal() throws Exception {
-      cacheModeLocalTest(false);
+   public void testSimpleCacheModeLocal(Method m) throws Exception {
+      cacheModeLocalTest(false, m);
    }
 
    /**
@@ -266,8 +267,8 @@ public class PutForExternalReadTest extends MultipleCacheManagersTest {
     *
     * @throws Exception
     */
-   public void testCacheModeLocalInTx() throws Exception {
-      cacheModeLocalTest(true);
+   public void testCacheModeLocalInTx(Method m) throws Exception {
+      cacheModeLocalTest(true, m);
    }
 
    /**
@@ -347,35 +348,18 @@ public class PutForExternalReadTest extends MultipleCacheManagersTest {
     *
     * @throws Exception
     */
-   private void cacheModeLocalTest(boolean transactional) throws Exception {
+   private void cacheModeLocalTest(boolean transactional, Method m) throws Exception {
       Cache<Object, Object> cache1 = cache(0, "replSync");
       Cache<Object, Object> cache2 = cache(1, "replSync");
       TransactionManager tm1 = TestingUtil.getTransactionManager(cache1);
-      TransactionManager tm2 = TestingUtil.getTransactionManager(cache2);
-      RpcManager rpcManager = EasyMock.createMock(RpcManager.class);
-      RpcManager originalRpcManager = TestingUtil.replaceComponent(cache1.getCacheManager(), RpcManager.class, rpcManager, true);
-      try {
+      if (transactional)
+         tm1.begin();
 
-         // specify that we expectWithTx nothing will be called on the mock Rpc Manager.
-         replay(rpcManager);
+      String k = k(m);
+      cache1.getAdvancedCache().withFlags(CACHE_MODE_LOCAL).putForExternalRead(k, v(m));
+      assertFalse(cache2.containsKey(k));
 
-         // now try a simple replication.  Since the RpcManager is a mock object it will not actually replicate anything.
-         if (transactional)
-            tm1.begin();
-
-         cache1.getAdvancedCache().withFlags(CACHE_MODE_LOCAL).putForExternalRead(key, value);
-
-         if (transactional)
-            tm1.commit();
-
-         verify(rpcManager);
-      } finally {
-         if (originalRpcManager != null) {
-            // cleanup
-            TestingUtil.replaceComponent(cache1.getCacheManager(), RpcManager.class, originalRpcManager, true);
-            cache1.remove(key);
-            cache2.remove(key);
-         }
-      }
+      if (transactional)
+         tm1.commit();
    }
 }

--- a/core/src/test/java/org/infinispan/loaders/file/FileCacheStoreVamTest.java
+++ b/core/src/test/java/org/infinispan/loaders/file/FileCacheStoreVamTest.java
@@ -22,11 +22,13 @@
  */
 package org.infinispan.loaders.file;
 
-import org.infinispan.commands.RemoteCommandsFactory;
-import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
-import org.infinispan.marshall.VersionAwareMarshaller;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterTest;
 import org.testng.annotations.Test;
+
+import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
 
 /**
  * FileCacheStoreTest using production level marshaller.
@@ -36,11 +38,19 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "unit", testName = "loaders.file.FileCacheStoreVamTest")
 public class FileCacheStoreVamTest extends FileCacheStoreTest {
+   private EmbeddedCacheManager cm;
+
    @Override
    protected StreamingMarshaller getMarshaller() {
-      VersionAwareMarshaller marshaller = new VersionAwareMarshaller();
-      marshaller.inject(Thread.currentThread().getContextClassLoader(), new RemoteCommandsFactory(), new GlobalConfiguration());
-      marshaller.start();
-      return marshaller;
+      if (cm == null)
+         cm = TestCacheManagerFactory.createLocalCacheManager();
+
+      return extractCacheMarshaller(cm.getCache());
    }
+
+   @AfterTest(alwaysRun = true)
+   public void destroy() {
+      cm.stop();
+   }
+
 }

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -36,6 +36,7 @@ import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.DistributionManagerImpl;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.factories.KnownComponentNames;
 import org.infinispan.interceptors.InterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.lifecycle.ComponentStatus;
@@ -43,6 +44,9 @@ import org.infinispan.loaders.CacheLoader;
 import org.infinispan.loaders.CacheLoaderManager;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.marshall.AbstractDelegatingMarshaller;
+import org.infinispan.marshall.StreamingMarshaller;
+import org.infinispan.marshall.jboss.ExternalizerTable;
 import org.infinispan.remoting.ReplicationQueue;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.Transport;
@@ -807,6 +811,16 @@ public class TestingUtil {
       return (ComponentRegistry) extractField(ci, "componentRegistry");
    }
 
+   public static AbstractDelegatingMarshaller extractCacheMarshaller(Cache cache) {
+      ComponentRegistry cr = (ComponentRegistry) extractField(cache, "componentRegistry");
+      StreamingMarshaller marshaller = cr.getComponent(StreamingMarshaller.class, KnownComponentNames.CACHE_MARSHALLER);
+      return (AbstractDelegatingMarshaller) marshaller;
+   }
+
+   public static ExternalizerTable extractExtTable(CacheContainer cacheContainer) {
+      GlobalComponentRegistry gcr = (GlobalComponentRegistry) extractField(cacheContainer, "globalComponentRegistry");
+      return gcr.getComponent(ExternalizerTable.class);
+   }
 
    /**
     * Replaces the existing interceptor chain in the cache wih one represented by the interceptor passed in.  This


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1205
- The global marshaller has been split in two: a global marshaller and a cache marshaller.
- To keep memory consumption low, any cache-level variables in ExternalizerTable have been refactored to other class, hence making ExternalizerTable a global component now.
- For example, hash functions must now be marshallable somehow to avoid duplication class loading functionality present in JBoss Marshalling already.
- MarshalledValues need to ship the cache name where they're stored so that the correct marshaller can be resolved on the receiving end.
- A new JBoss Marshalling class resolver has been created that can peek the invocation-associated class loader.
- Simplified the way marshallers are created in marshalling related tests by simply retrieving the marshaller component from the cache. This should make changes in the internal marshalling structure less prone to break compilation of tests.
