### PR TITLE
ISPN-1357 Fix several RHQ monitoring issues

### DIFF
--- a/core/src/main/java/org/infinispan/util/Util.java
+++ b/core/src/main/java/org/infinispan/util/Util.java
@@ -576,4 +576,18 @@ public final class Util {
 
       return buf.toString();
    }
+
+   public static Double constructDouble(Class type, Object o) {
+      if (type.equals(Long.class) || type.equals(long.class))
+         return Double.valueOf((Long) o);
+      else if (type.equals(Double.class) || type.equals(double.class))
+         return (Double) o;
+      else if (type.equals(Integer.class) || type.equals(int.class))
+         return Double.valueOf((Integer) o);
+      else if (type.equals(String.class))
+         return Double.valueOf((String) o);
+
+      throw new IllegalStateException(String.format("Expected a value that can be converted into a double: type=%s, value=%s", type, o));
+   }
+
 }

--- a/demos/distexec/src/main/resources/runPiApproximationDemo.sh
+++ b/demos/distexec/src/main/resources/runPiApproximationDemo.sh
@@ -91,6 +91,11 @@ fi
 
 JVM_PARAMS="${JVM_PARAMS} -Djava.net.preferIPv4Stack=true -Dlog4j.configuration=file:${LOG4J_CONFIG}"
 
+# RHQ monitoring options
+#JVM_PARAMS="$JVM_PARAMS -Dcom.sun.management.jmxremote.ssl=false"
+#JVM_PARAMS="$JVM_PARAMS -Dcom.sun.management.jmxremote.authenticate=false"
+#JVM_PARAMS="$JVM_PARAMS -Dcom.sun.management.jmxremote.port=6996"
+
 # Sample JPDA settings for remote socket debuging
 #JVM_PARAMS="$JVM_PARAMS -Xrunjdwp:transport=dt_socket,address=8686,server=y,suspend=n"
 #echo Classpath is $CP

--- a/demos/distexec/src/main/resources/runWordCountDemo.sh
+++ b/demos/distexec/src/main/resources/runWordCountDemo.sh
@@ -91,6 +91,11 @@ fi
 
 JVM_PARAMS="${JVM_PARAMS} -Djava.net.preferIPv4Stack=true -Dlog4j.configuration=file:${LOG4J_CONFIG}"
 
+# RHQ monitoring options
+#JVM_PARAMS="$JVM_PARAMS -Dcom.sun.management.jmxremote.ssl=false"
+#JVM_PARAMS="$JVM_PARAMS -Dcom.sun.management.jmxremote.authenticate=false"
+#JVM_PARAMS="$JVM_PARAMS -Dcom.sun.management.jmxremote.port=6996"
+
 # Sample JPDA settings for remote socket debuging
 #JVM_PARAMS="$JVM_PARAMS -Xrunjdwp:transport=dt_socket,address=8686,server=y,suspend=n"
 #echo Classpath is $CP

--- a/demos/ec2/src/main/resources/runEC2Demo-all.sh
+++ b/demos/ec2/src/main/resources/runEC2Demo-all.sh
@@ -13,6 +13,11 @@ add_jvm_args $JVM_PARAMS
 add_jvm_args '-Djava.net.preferIPv4Stack=true'
 add_jvm_args "-DCFGPath=${ISPN_HOME}/etc/config-samples/ec2-demo/"
 
+# RHQ monitoring options
+#add_jvm_args '-Dcom.sun.management.jmxremote.ssl=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.authenticate=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.port=6996'
+
 # Sample JPDA settings for remote socket debugging
 #add_jvm_args "-Xrunjdwp:transport=dt_socket,address=8686,server=y,suspend=n"
 

--- a/demos/ec2/src/main/resources/runEC2Demo-influenza.sh
+++ b/demos/ec2/src/main/resources/runEC2Demo-influenza.sh
@@ -17,6 +17,11 @@ add_jvm_args $JVM_PARAMS
 add_jvm_args '-Djava.net.preferIPv4Stack=true'
 add_jvm_args "-DCFGPath=${ISPN_HOME}/etc/config-samples/ec2-demo/"
 
+# RHQ monitoring options
+#add_jvm_args '-Dcom.sun.management.jmxremote.ssl=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.authenticate=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.port=6996'
+
 # Sample JPDA settings for remote socket debugging
 #add_jvm_args "-Xrunjdwp:transport=dt_socket,address=8686,server=y,suspend=n"
 

--- a/demos/ec2/src/main/resources/runEC2Demo-nucleotide.sh
+++ b/demos/ec2/src/main/resources/runEC2Demo-nucleotide.sh
@@ -17,6 +17,11 @@ add_jvm_args $JVM_PARAMS
 add_jvm_args '-Djava.net.preferIPv4Stack=true'
 add_jvm_args "-DCFGPath=${ISPN_HOME}/etc/config-samples/ec2-demo/"
 
+# RHQ monitoring options
+#add_jvm_args '-Dcom.sun.management.jmxremote.ssl=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.authenticate=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.port=6996'
+
 # Sample JPDA settings for remote socket debugging
 #add_jvm_args "-Xrunjdwp:transport=dt_socket,address=8686,server=y,suspend=n"
 

--- a/demos/ec2/src/main/resources/runEC2Demo-protein.sh
+++ b/demos/ec2/src/main/resources/runEC2Demo-protein.sh
@@ -17,6 +17,11 @@ add_jvm_args $JVM_PARAMS
 add_jvm_args '-Djava.net.preferIPv4Stack=true'
 add_jvm_args "-DCFGPath=${ISPN_HOME}/etc/config-samples/ec2-demo/"
 
+# RHQ monitoring options
+#add_jvm_args '-Dcom.sun.management.jmxremote.ssl=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.authenticate=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.port=6996'
+
 # Sample JPDA settings for remote socket debugging
 #add_jvm_args "-Xrunjdwp:transport=dt_socket,address=8686,server=y,suspend=n"
 

--- a/demos/ec2/src/main/resources/runEC2Demo-query.sh
+++ b/demos/ec2/src/main/resources/runEC2Demo-query.sh
@@ -13,6 +13,11 @@ add_jvm_args $JVM_PARAMS
 add_jvm_args '-Djava.net.preferIPv4Stack=true'
 add_jvm_args "-DCFGPath=${ISPN_HOME}/etc/config-samples/ec2-demo/"
 
+# RHQ monitoring options
+#add_jvm_args '-Dcom.sun.management.jmxremote.ssl=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.authenticate=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.port=6996'
+
 # Sample JPDA settings for remote socket debugging
 #add_jvm_args "-Xrunjdwp:transport=dt_socket,address=8686,server=y,suspend=n"
 

--- a/demos/ec2/src/main/resources/runEC2Demo-reader.sh
+++ b/demos/ec2/src/main/resources/runEC2Demo-reader.sh
@@ -13,6 +13,11 @@ add_jvm_args $JVM_PARAMS
 add_jvm_args '-Djava.net.preferIPv4Stack=true'
 add_jvm_args "-DCFGPath=${ISPN_HOME}/etc/config-samples/ec2-demo/"
 
+# RHQ monitoring options
+#add_jvm_args '-Dcom.sun.management.jmxremote.ssl=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.authenticate=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.port=6996'
+
 # Sample JPDA settings for remote socket debugging
 #add_jvm_args "-Xrunjdwp:transport=dt_socket,address=8686,server=y,suspend=n"
 

--- a/demos/gui/src/main/resources/runGuiDemo.sh
+++ b/demos/gui/src/main/resources/runGuiDemo.sh
@@ -10,6 +10,11 @@ add_jvm_args $JVM_PARAMS
 add_jvm_args '-Dbind.address=127.0.0.1'
 add_jvm_args '-Djava.net.preferIPv4Stack=true'
 
+# RHQ monitoring options
+#add_jvm_args '-Dcom.sun.management.jmxremote.ssl=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.authenticate=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.port=6996'
+
 # Sample JPDA settings for remote socket debugging
 #add_jvm_args "-Xrunjdwp:transport=dt_socket,address=8686,server=y,suspend=n"
 

--- a/demos/lucene-directory-demo/src/main/resources/runLuceneDemo.sh
+++ b/demos/lucene-directory-demo/src/main/resources/runLuceneDemo.sh
@@ -10,6 +10,11 @@ add_jvm_args $JVM_PARAMS
 add_jvm_args '-Dbind.address=127.0.0.1'
 add_jvm_args '-Djava.net.preferIPv4Stack=true'
 
+# RHQ monitoring options
+#add_jvm_args '-Dcom.sun.management.jmxremote.ssl=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.authenticate=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.port=6996'
+
 # Sample JPDA settings for remote socket debugging
 #add_jvm_args "-Xrunjdwp:transport=dt_socket,address=8686,server=y,suspend=n"
 

--- a/rhq-plugin/pom.xml
+++ b/rhq-plugin/pom.xml
@@ -191,6 +191,11 @@
                                  <artifactId>infinispan-core</artifactId>
                                  <version>${project.version}</version>
                              </artifactItem>
+                             <artifactItem>
+                                <groupId>org.jboss.logging</groupId>
+                                <artifactId>jboss-logging</artifactId>
+                                <version>${version.jboss.logging}</version>
+                             </artifactItem>
                          </artifactItems>
                          <outputDirectory>${project.build.outputDirectory}/lib</outputDirectory>
                      </configuration>

--- a/rhq-plugin/src/main/java/org/infinispan/rhq/CacheDiscovery.java
+++ b/rhq-plugin/src/main/java/org/infinispan/rhq/CacheDiscovery.java
@@ -27,7 +27,6 @@ import org.infinispan.util.logging.LogFactory;
 import org.mc4j.ems.connection.EmsConnection;
 import org.mc4j.ems.connection.bean.EmsBean;
 import org.rhq.core.pluginapi.inventory.DiscoveredResourceDetails;
-import org.rhq.core.pluginapi.inventory.ResourceDiscoveryComponent;
 import org.rhq.core.pluginapi.inventory.ResourceDiscoveryContext;
 import org.rhq.plugins.jmx.MBeanResourceDiscoveryComponent;
 import org.rhq.plugins.jmx.ObjectNameQueryUtility;
@@ -67,10 +66,11 @@ public class CacheDiscovery extends MBeanResourceDiscoveryComponent<CacheManager
           * stay the same when the resource is discovered the next
           * time */
          String name = bean.getAttribute("CacheName").getValue().toString();
-         if (trace) log.tracef("Resource name is %s", name);
+         String mbeanCacheName = bean.getBeanName().getKeyProperty("name");
+         if (trace) log.tracef("Resource name is %s and resource key %s", name, mbeanCacheName);
          DiscoveredResourceDetails detail = new DiscoveredResourceDetails(
                ctx.getResourceType(), // Resource Type
-               name, // Resource Key
+               mbeanCacheName, // Resource Key
                name, // Resource name 
                null, // Version
                "One cache within Infinispan", // ResourceDescription

--- a/rhq-plugin/src/main/java/org/infinispan/rhq/CacheManagerComponent.java
+++ b/rhq-plugin/src/main/java/org/infinispan/rhq/CacheManagerComponent.java
@@ -26,6 +26,7 @@ import org.infinispan.rhq.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.mc4j.ems.connection.EmsConnection;
 import org.mc4j.ems.connection.bean.EmsBean;
+import org.mc4j.ems.connection.bean.attribute.EmsAttribute;
 import org.rhq.core.domain.measurement.AvailabilityType;
 import org.rhq.core.domain.measurement.DataType;
 import org.rhq.core.domain.measurement.MeasurementDataNumeric;
@@ -42,6 +43,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.infinispan.jmx.CacheManagerJmxRegistration.CACHE_MANAGER_JMX_GROUP;
+import static org.infinispan.rhq.RhqUtil.constructNumericMeasure;
 
 /**
  * The component class for the Infinispan manager
@@ -111,10 +113,8 @@ public class CacheManagerComponent extends MBeanResourceComponent<MBeanResourceC
       for (MeasurementScheduleRequest req : metrics) {
          DataType type = req.getDataType();
          if (type == DataType.MEASUREMENT) {
-            String tmp = (String) bean.getAttribute(req.getName()).getValue();
-            Double val = Double.valueOf(tmp);
-            if (trace) log.tracef("Metric (%s) is measurement with value %s", req.getName(), val);
-            MeasurementDataNumeric res = new MeasurementDataNumeric(req, val);
+            EmsAttribute att = bean.getAttribute(req.getName());
+            MeasurementDataNumeric res = constructNumericMeasure(att.getTypeClass(), att.getValue(), req);
             report.addData(res);
          } else if (type == DataType.TRAIT) {
             String value = (String) bean.getAttribute(req.getName()).getValue();

--- a/rhq-plugin/src/main/java/org/infinispan/rhq/RhqUtil.java
+++ b/rhq-plugin/src/main/java/org/infinispan/rhq/RhqUtil.java
@@ -1,0 +1,26 @@
+package org.infinispan.rhq;
+
+import org.infinispan.rhq.logging.Log;
+import org.infinispan.util.Util;
+import org.infinispan.util.logging.LogFactory;
+import org.rhq.core.domain.measurement.MeasurementDataNumeric;
+import org.rhq.core.domain.measurement.MeasurementScheduleRequest;
+
+/**
+ * RHQ utility methods
+ *
+ * @author Galder Zamarreño
+ * @since 5.1
+ */
+public class RhqUtil {
+
+   private static final Log log = LogFactory.getLog(RhqUtil.class, Log.class);
+
+   public static MeasurementDataNumeric constructNumericMeasure(
+         Class attrType, Object o, MeasurementScheduleRequest req) {
+      if (log.isTraceEnabled())
+         log.tracef("Metric (%s) is measurement with value %s", req.getName(), o);
+      return new MeasurementDataNumeric(req, Util.constructDouble(attrType, o));
+   }
+
+}

--- a/server/core/src/main/resources/startServer.sh
+++ b/server/core/src/main/resources/startServer.sh
@@ -11,6 +11,11 @@ add_classpath "${ISPN_HOME}/modules/websocket"
 add_jvm_args $JVM_PARAMS
 add_jvm_args '-Djava.net.preferIPv4Stack=true'
 
+# RHQ monitoring options
+#add_jvm_args '-Dcom.sun.management.jmxremote.ssl=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.authenticate=false'
+#add_jvm_args '-Dcom.sun.management.jmxremote.port=6996'
+
 # Sample JPDA settings for remote socket debugging
 #add_jvm_args "-Xrunjdwp:transport=dt_socket,address=8686,server=y,suspend=n"
 


### PR DESCRIPTION
Several fixes into one JIRA:
- Make sure JBoss Logging gets included within the RHQ plugin, otherwise ClassNotFoundException is thrown.
- CacheManager component should be able to cope with measurements that are ints, long...etc.
- Cache discovery was broken due for default cache due to different cache name representations. Make sure the internal name, which is the one used in the MBean is used to locate the default cache.
- Added commented lines to demo scripts to make it easier for users to enable RHQ monitoring system properties.
