### PR TITLE
ISPN-1326 Added multiplexing of Cache oriented command marshalling

### DIFF
--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -208,21 +208,15 @@ public class CommandsFactoryImpl implements CommandsFactory {
    }
 
    public PrepareCommand buildPrepareCommand(GlobalTransaction gtx, List<WriteCommand> modifications, boolean onePhaseCommit) {
-      PrepareCommand command = new PrepareCommand(gtx, modifications, onePhaseCommit);
-      command.setCacheName(cacheName);
-      return command;
+      return new PrepareCommand(cacheName, gtx, modifications, onePhaseCommit);
    }
 
    public CommitCommand buildCommitCommand(GlobalTransaction gtx) {
-      CommitCommand commitCommand = new CommitCommand(gtx);
-      commitCommand.setCacheName(cacheName);
-      return commitCommand;
+      return new CommitCommand(cacheName, gtx);
    }
 
    public RollbackCommand buildRollbackCommand(GlobalTransaction gtx) {
-      RollbackCommand rollbackCommand = new RollbackCommand(gtx);
-      rollbackCommand.setCacheName(cacheName);
-      return rollbackCommand;
+      return new RollbackCommand(cacheName, gtx);
    }
 
    public MultipleRpcCommand buildReplicateCommand(List<ReplicableCommand> toReplicate) {

--- a/core/src/main/java/org/infinispan/commands/RemoveCacheCommand.java
+++ b/core/src/main/java/org/infinispan/commands/RemoveCacheCommand.java
@@ -44,17 +44,14 @@ public class RemoveCacheCommand extends BaseRpcCommand {
    private EmbeddedCacheManager cacheManager;
    private GlobalComponentRegistry registry;
 
-   RemoveCacheCommand() {
-      // For command id uniqueness test
+   private RemoveCacheCommand() {
+      super(null); // For command id uniqueness test
    }
 
-   public RemoveCacheCommand(EmbeddedCacheManager cacheManager, GlobalComponentRegistry registry) {
+   public RemoveCacheCommand(String cacheName, EmbeddedCacheManager cacheManager, GlobalComponentRegistry registry) {
+      super(cacheName);
       this.cacheManager = cacheManager;
       this.registry = registry;
-   }
-
-   public void setCacheName(String cacheName) {
-      this.cacheName = cacheName;
    }
 
    @Override
@@ -72,11 +69,11 @@ public class RemoveCacheCommand extends BaseRpcCommand {
 
    @Override
    public Object[] getParameters() {
-      return new Object[]{cacheName};
+      return new Object[0];
    }
 
    @Override
    public void setParameters(int commandId, Object[] parameters) {
-      cacheName = (String) parameters[0];
+      // No parameters
    }
 }

--- a/core/src/main/java/org/infinispan/commands/control/RehashControlCommand.java
+++ b/core/src/main/java/org/infinispan/commands/control/RehashControlCommand.java
@@ -80,11 +80,11 @@ public class RehashControlCommand extends BaseRpcCommand {
    CommandsFactory commandsFactory;
    private static final Log log = LogFactory.getLog(RehashControlCommand.class);
 
-   public RehashControlCommand() {
+   private RehashControlCommand() {
+      super(null); // For command id uniqueness test
    }
 
-
-   public RehashControlCommand(String cacheName, Type type, Address sender, int viewId, Map<Object, InternalCacheValue> state,ConsistentHash oldConsistentHash,
+   public RehashControlCommand(String cacheName, Type type, Address sender, int viewId, Map<Object, InternalCacheValue> state, ConsistentHash oldConsistentHash,
                                 ConsistentHash consistentHash) {
       super(cacheName);
       this.type = type;
@@ -102,7 +102,8 @@ public class RehashControlCommand extends BaseRpcCommand {
       this.viewId = viewId;
    }
 
-   public RehashControlCommand(Transport transport) {
+   public RehashControlCommand(String cacheName, Transport transport) {
+      super(cacheName);
       this.transport = transport;
    }
 
@@ -147,13 +148,12 @@ public class RehashControlCommand extends BaseRpcCommand {
    }
 
    public Object[] getParameters() {
-      return new Object[]{cacheName, (byte) type.ordinal(), sender, viewId, state, oldCH, newCH};
+      return new Object[]{(byte) type.ordinal(), sender, viewId, state, oldCH, newCH};
    }
 
    @SuppressWarnings("unchecked")
    public void setParameters(int commandId, Object[] parameters) {
       int i = 0;
-      cacheName = (String) parameters[i++];
       type = Type.values()[(Byte) parameters[i++]];
       sender = (Address) parameters[i++];
       viewId = (Integer) parameters[i++];

--- a/core/src/main/java/org/infinispan/commands/read/MapReduceCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/MapReduceCommand.java
@@ -67,10 +67,15 @@ public class MapReduceCommand extends BaseRpcCommand {
    protected DistributionManager dm;
    protected Address localAddress;
 
-   public MapReduceCommand() {
+   private MapReduceCommand() {
+      super(null); // For command id uniqueness test
    }
 
-   public MapReduceCommand( Mapper m, Reducer r, String cacheName, Object... inputKeys) {
+   public MapReduceCommand(String cacheName) {
+      super(cacheName);
+   }
+
+   public MapReduceCommand(Mapper m, Reducer r, String cacheName, Object... inputKeys) {
       super(cacheName);
       if (inputKeys == null || inputKeys.length == 0) {
          this.keys = new HashSet<Object>();
@@ -82,7 +87,7 @@ public class MapReduceCommand extends BaseRpcCommand {
       this.reducer = r;
    }
 
-   public MapReduceCommand( Mapper m, Reducer r, String cacheName, Collection<Object> inputKeys) {
+   public MapReduceCommand(Mapper m, Reducer r, String cacheName, Collection<Object> inputKeys) {
       super(cacheName);
       if (inputKeys == null || inputKeys.isEmpty())
          this.keys = new HashSet<Object>();
@@ -160,8 +165,7 @@ public class MapReduceCommand extends BaseRpcCommand {
 
    @Override
    public Object[] getParameters() {
-      
-      return new Object[] { cacheName, keys, mapper, reducer};
+      return new Object[] {keys, mapper, reducer};
    }
 
    @Override
@@ -169,7 +173,6 @@ public class MapReduceCommand extends BaseRpcCommand {
       if (commandId != COMMAND_ID)
          throw new IllegalStateException("Invalid method id");
       int i = 0;
-      cacheName = (String) args[i++];
       keys = (Set<Object>) args[i++];
       mapper = (Mapper)args[i++];
       reducer = (Reducer) args[i++];

--- a/core/src/main/java/org/infinispan/commands/remote/BaseRpcCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/BaseRpcCommand.java
@@ -27,11 +27,15 @@ import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.remoting.transport.Address;
 
 public abstract class BaseRpcCommand implements CacheRpcCommand {
-   protected String cacheName;
+   protected final String cacheName;
 
    protected Configuration configuration;
    protected ComponentRegistry componentRegistry;
    private Address origin;
+
+   protected BaseRpcCommand(String cacheName) {
+      this.cacheName = cacheName;
+   }
 
    public void injectComponents(Configuration configuration, ComponentRegistry componentRegistry) {
       this.configuration = configuration;
@@ -44,14 +48,6 @@ public abstract class BaseRpcCommand implements CacheRpcCommand {
 
    public ComponentRegistry getComponentRegistry() {
       return componentRegistry;
-   }
-
-
-   protected BaseRpcCommand(String cacheName) {
-      this.cacheName = cacheName;
-   }
-
-   protected BaseRpcCommand() {
    }
 
    public String getCacheName() {

--- a/core/src/main/java/org/infinispan/commands/remote/BaseRpcInvokingCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/BaseRpcInvokingCommand.java
@@ -48,9 +48,6 @@ public abstract class BaseRpcInvokingCommand extends BaseRpcCommand {
       super(cacheName);
    }
 
-   BaseRpcInvokingCommand() {
-   }
-
    public void init(InterceptorChain interceptorChain, InvocationContextContainer icc) {
       this.interceptorChain = interceptorChain;
       this.icc = icc;

--- a/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
@@ -66,12 +66,17 @@ public class ClusteredGetCommand extends BaseRpcCommand implements FlagAffectedC
 
    private DistributionManager distributionManager;
 
-   public ClusteredGetCommand() {
+   private ClusteredGetCommand() {
+      super(null); // For command id uniqueness test
+   }
+
+   public ClusteredGetCommand(String cacheName) {
+      super(cacheName);
    }
 
    public ClusteredGetCommand(Object key, String cacheName, Set<Flag> flags) {
+      super(cacheName);
       this.key = key;
-      this.cacheName = cacheName;
       this.flags = flags;
    }
 
@@ -123,15 +128,13 @@ public class ClusteredGetCommand extends BaseRpcCommand implements FlagAffectedC
    }
 
    public Object[] getParameters() {
-      return new Object[]{key, cacheName, flags};
+      return new Object[]{key, flags};
    }
 
    public void setParameters(int commandId, Object[] args) {
-      key = args[0];
-      cacheName = (String) args[1];
-      if (args.length>2) {
-         this.flags = (Set<Flag>) args[2];
-      }
+      int i = 0;
+      key = args[i++];
+      flags = (Set<Flag>) args[i++];
    }
 
    @Override
@@ -159,10 +162,6 @@ public class ClusteredGetCommand extends BaseRpcCommand implements FlagAffectedC
          .append(", flags=").append(flags)
          .append("}")
          .toString();
-   }
-
-   public String getCacheName() {
-      return cacheName;
    }
 
    public Object getKey() {

--- a/core/src/main/java/org/infinispan/commands/remote/MultipleRpcCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/MultipleRpcCommand.java
@@ -51,12 +51,17 @@ public class MultipleRpcCommand extends BaseRpcInvokingCommand {
 
    private ReplicableCommand[] commands;
 
+   private MultipleRpcCommand() {
+      super(null); // For command id uniqueness test
+   }
+
    public MultipleRpcCommand(List<ReplicableCommand> modifications, String cacheName) {
       super(cacheName);
       commands = modifications.toArray(new ReplicableCommand[modifications.size()]);
    }
 
-   public MultipleRpcCommand() {
+   public MultipleRpcCommand(String cacheName) {
+      super(cacheName);
    }
 
    /**
@@ -84,18 +89,16 @@ public class MultipleRpcCommand extends BaseRpcInvokingCommand {
 
    public Object[] getParameters() {
       int numCommands = commands.length;
-      Object[] retval = new Object[numCommands + 1];
-      retval[0] = cacheName;
-      System.arraycopy(commands, 0, retval, 1, numCommands);
+      Object[] retval = new Object[numCommands];
+      System.arraycopy(commands, 0, retval, 0, numCommands);
       return retval;
    }
 
    @SuppressWarnings("unchecked")
    public void setParameters(int commandId, Object[] args) {
-      cacheName = (String) args[0];
-      int numCommands = args.length - 1;
+      int numCommands = args.length;
       commands = new ReplicableCommand[numCommands];
-      System.arraycopy(args, 1, commands, 0, numCommands);
+      System.arraycopy(args, 0, commands, 0, numCommands);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/remote/SingleRpcCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/SingleRpcCommand.java
@@ -36,18 +36,22 @@ public class SingleRpcCommand extends BaseRpcInvokingCommand {
 
    private ReplicableCommand command;
 
+   private SingleRpcCommand() {
+      super(null); // For command id uniqueness test
+   }
+
    public SingleRpcCommand(String cacheName, ReplicableCommand command) {
       super(cacheName);
       this.command = command;
    }
 
-   public SingleRpcCommand() {
+   public SingleRpcCommand(String cacheName) {
+      super(cacheName);
    }
 
    public void setParameters(int commandId, Object[] parameters) {
       if (commandId != COMMAND_ID) throw new IllegalStateException("Unusupported command id:" + commandId);
-      cacheName = (String) parameters[0];
-      command = (ReplicableCommand) parameters[1];
+      command = (ReplicableCommand) parameters[0];
    }
 
    public byte getCommandId() {
@@ -55,7 +59,7 @@ public class SingleRpcCommand extends BaseRpcInvokingCommand {
    }
 
    public Object[] getParameters() {
-      return new Object[]{cacheName, command};
+      return new Object[]{command};
    }
 
    public Object perform(InvocationContext ctx) throws Throwable {

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/CompleteTransactionCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/CompleteTransactionCommand.java
@@ -46,7 +46,12 @@ public class CompleteTransactionCommand extends RecoveryCommand {
     */
    private boolean commit;
 
-   public CompleteTransactionCommand() {
+   private CompleteTransactionCommand() {
+      super(null); // For command id uniqueness test
+   }
+
+   public CompleteTransactionCommand(String cacheName) {
+      super(cacheName);
    }
 
    public CompleteTransactionCommand(String cacheName, Xid xid, boolean commit) {
@@ -67,7 +72,7 @@ public class CompleteTransactionCommand extends RecoveryCommand {
 
    @Override
    public Object[] getParameters() {
-      return new Object[]{xid, commit, cacheName};
+      return new Object[]{xid, commit};
    }
 
    @Override
@@ -75,9 +80,9 @@ public class CompleteTransactionCommand extends RecoveryCommand {
       if (commandId != COMMAND_ID) {
          throw new IllegalArgumentException("Unexpected command id: " + commandId + ". Expected " + COMMAND_ID);
       }
-      xid = (Xid) parameters[0];
-      commit = (Boolean) parameters[1];
-      cacheName = (String) parameters[2];
+      int i = 0;
+      xid = (Xid) parameters[i++];
+      commit = (Boolean) parameters[i++];
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/GetInDoubtTransactionsCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/GetInDoubtTransactionsCommand.java
@@ -42,11 +42,12 @@ public class GetInDoubtTransactionsCommand extends RecoveryCommand {
 
    public static final int COMMAND_ID = 21;
 
-   public GetInDoubtTransactionsCommand() {
+   private GetInDoubtTransactionsCommand() {
+      super(null); // For command id uniqueness test
    }
 
    public GetInDoubtTransactionsCommand(String cacheName) {
-      this.cacheName = cacheName;
+      super(cacheName);
    }
 
    @Override
@@ -63,14 +64,14 @@ public class GetInDoubtTransactionsCommand extends RecoveryCommand {
 
    @Override
    public Object[] getParameters() {
-      return new Object[] {cacheName};
+      return new Object[0];
    }
 
    @Override
    public void setParameters(int commandId, Object[] parameters) {
       if (commandId != COMMAND_ID)
          throw new IllegalStateException("Expected " + COMMAND_ID + "and received " + commandId);
-      cacheName = (String) parameters[0];
+      // No parameters
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/GetInDoubtTxInfoCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/GetInDoubtTxInfoCommand.java
@@ -35,12 +35,12 @@ public class GetInDoubtTxInfoCommand extends RecoveryCommand {
 
    public static final int COMMAND_ID = 23;
 
-   public GetInDoubtTxInfoCommand(String cacheName) {
-      super();
-      this.cacheName = cacheName;
+   private GetInDoubtTxInfoCommand() {
+      super(null); // For command id uniqueness test
    }
 
-   public GetInDoubtTxInfoCommand() {
+   public GetInDoubtTxInfoCommand(String cacheName) {
+      super(cacheName);
    }
 
    @Override
@@ -55,14 +55,14 @@ public class GetInDoubtTxInfoCommand extends RecoveryCommand {
 
    @Override
    public Object[] getParameters() {
-      return new Object[]{cacheName};
+      return new Object[0];
    }
 
    @Override
    public void setParameters(int commandId, Object[] parameters) {
       if (commandId != COMMAND_ID)
          throw new IllegalStateException("Expected " + COMMAND_ID + "and received " + commandId);
-      cacheName = (String) parameters[0];
+      // No parameters
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/RecoveryCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/RecoveryCommand.java
@@ -35,7 +35,8 @@ public abstract class RecoveryCommand extends BaseRpcCommand {
 
    protected RecoveryManager recoveryManager;
 
-   public RecoveryCommand() {
+   private RecoveryCommand() {
+      super(null); // For command id uniqueness test
    }
 
    protected RecoveryCommand(String cacheName) {

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/RemoveRecoveryInfoCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/RemoveRecoveryInfoCommand.java
@@ -38,17 +38,22 @@ public class RemoveRecoveryInfoCommand extends RecoveryCommand {
    private Xid xid;
    private long internalId;
 
-   public RemoveRecoveryInfoCommand(Xid xid, String cacheName) {
-      this.xid = xid;
-      this.cacheName = cacheName;
+   private RemoveRecoveryInfoCommand() {
+      super(null); // For command id uniqueness test
    }
 
-   public RemoveRecoveryInfoCommand() {
+   public RemoveRecoveryInfoCommand(Xid xid, String cacheName) {
+      super(cacheName);
+      this.xid = xid;
    }
 
    public RemoveRecoveryInfoCommand(long internalId, String cacheName) {
+      super(cacheName);
       this.internalId = internalId;
-      this.cacheName = cacheName;
+   }
+
+   public RemoveRecoveryInfoCommand(String cacheName) {
+      super(cacheName);
    }
 
    @Override
@@ -68,14 +73,7 @@ public class RemoveRecoveryInfoCommand extends RecoveryCommand {
 
    @Override
    public Object[] getParameters() {
-      Object[] result = new Object[2];
-      if (xid != null) {
-         result[0] = xid;
-      } else {
-         result[0] = internalId;
-      }
-      result[1] = cacheName;
-      return result;
+      return new Object[]{xid != null ? xid : internalId};
    }
 
    @Override
@@ -88,7 +86,6 @@ public class RemoveRecoveryInfoCommand extends RecoveryCommand {
       } else {
          internalId = (Long) parameters[0];
       }
-      cacheName = (String) parameters[1];
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/tx/AbstractTransactionBoundaryCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/AbstractTransactionBoundaryCommand.java
@@ -49,13 +49,17 @@ public abstract class AbstractTransactionBoundaryCommand implements TransactionB
    private static boolean trace = log.isTraceEnabled();
 
    protected GlobalTransaction globalTx;
-   protected String cacheName;
+   protected final String cacheName;
    protected InterceptorChain invoker;
    protected InvocationContextContainer icc;
    protected TransactionTable txTable;
    protected Configuration configuration;
    protected ComponentRegistry componentRegistry;
    private Address origin;
+
+   public AbstractTransactionBoundaryCommand(String cacheName) {
+      this.cacheName = cacheName;
+   }
 
    public void injectComponents(Configuration configuration, ComponentRegistry componentRegistry) {
       this.configuration = configuration;
@@ -78,10 +82,6 @@ public abstract class AbstractTransactionBoundaryCommand implements TransactionB
 
    public String getCacheName() {
       return cacheName;
-   }
-
-   public void setCacheName(String cacheName) {
-      this.cacheName = cacheName;
    }
 
    public GlobalTransaction getGlobalTransaction() {
@@ -125,12 +125,11 @@ public abstract class AbstractTransactionBoundaryCommand implements TransactionB
    }
 
    public Object[] getParameters() {
-      return new Object[]{globalTx, cacheName};
+      return new Object[]{globalTx};
    }
 
    public void setParameters(int commandId, Object[] args) {
       globalTx = (GlobalTransaction) args[0];
-      cacheName = (String) args[1];
    }
 
    public boolean shouldInvoke(InvocationContext ctx) {

--- a/core/src/main/java/org/infinispan/commands/tx/CommitCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/CommitCommand.java
@@ -44,11 +44,17 @@ public class CommitCommand extends AbstractTransactionBoundaryCommand {
     */
    public static final byte RESEND_PREPARE = 1;
 
-   public CommitCommand(GlobalTransaction gtx) {
+   private CommitCommand() {
+      super(null); // For command id uniqueness test
+   }
+
+   public CommitCommand(String cacheName, GlobalTransaction gtx) {
+      super(cacheName);
       this.globalTx = gtx;
    }
 
-   public CommitCommand() {
+   public CommitCommand(String cacheName) {
+      super(cacheName);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/tx/RollbackCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/RollbackCommand.java
@@ -37,11 +37,17 @@ import org.infinispan.transaction.RemoteTransaction;
 public class RollbackCommand extends AbstractTransactionBoundaryCommand {
    public static final byte COMMAND_ID = 13;
 
-   public RollbackCommand(GlobalTransaction globalTransaction) {
+   private RollbackCommand() {
+      super(null); // For command id uniqueness test
+   }
+
+   public RollbackCommand(String cacheName, GlobalTransaction globalTransaction) {
+      super(cacheName);
       this.globalTx = globalTransaction;
    }
 
-   public RollbackCommand() {
+   public RollbackCommand(String cacheName) {
+      super(cacheName);
    }
 
    public Object acceptVisitor(InvocationContext ctx, Visitor visitor) throws Throwable {

--- a/core/src/main/java/org/infinispan/factories/MarshallerFactory.java
+++ b/core/src/main/java/org/infinispan/factories/MarshallerFactory.java
@@ -23,11 +23,14 @@
 package org.infinispan.factories;
 
 import org.infinispan.CacheException;
+import org.infinispan.config.GlobalConfiguration;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.marshall.CacheMarshaller;
 import org.infinispan.marshall.GlobalMarshaller;
 import org.infinispan.marshall.Marshaller;
 import org.infinispan.marshall.StreamingMarshaller;
+import org.infinispan.marshall.VersionAwareMarshaller;
+import org.infinispan.util.Util;
 
 import static org.infinispan.factories.KnownComponentNames.*;
 
@@ -44,9 +47,9 @@ public class MarshallerFactory extends NamedComponentFactory implements AutoInst
    public <T> T construct(Class<T> componentType, String componentName) {
       Object comp;
       if (componentName.equals(GLOBAL_MARSHALLER))
-         comp = new GlobalMarshaller();
+         comp = new GlobalMarshaller(createMarshaller());
       else if (componentName.equals(CACHE_MARSHALLER))
-         comp = new CacheMarshaller();
+         comp = new CacheMarshaller(createMarshaller());
       else
          throw new CacheException("Don't know how to handle type " + componentType);
 
@@ -55,6 +58,11 @@ public class MarshallerFactory extends NamedComponentFactory implements AutoInst
       } catch (Exception e) {
          throw new CacheException("Problems casting bootstrap component " + comp.getClass() + " to type " + componentType, e);
       }
+   }
+
+   protected VersionAwareMarshaller createMarshaller() {
+      return (VersionAwareMarshaller) Util.getInstance(
+            globalConfiguration.getMarshallerClass(), globalConfiguration.getClassLoader());
    }
 
 }

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -506,9 +506,8 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
 
    @Override
    public void removeCache(String cacheName) {
-      RemoveCacheCommand cmd = new RemoveCacheCommand(this, globalComponentRegistry);
+      RemoveCacheCommand cmd = new RemoveCacheCommand(cacheName, this, globalComponentRegistry);
       cmd.injectComponents(null, globalComponentRegistry.getNamedComponentRegistry(cacheName));
-      cmd.setCacheName(cacheName);
       Transport transport = getTransport();
       try {
          if (transport != null) {

--- a/core/src/main/java/org/infinispan/marshall/AbstractDelegatingMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/AbstractDelegatingMarshaller.java
@@ -1,9 +1,6 @@
 package org.infinispan.marshall;
 
-import org.infinispan.config.GlobalConfiguration;
 import org.infinispan.io.ByteBuffer;
-import org.infinispan.marshall.jboss.ExternalizerTable;
-import org.infinispan.util.Util;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,22 +20,9 @@ public abstract class AbstractDelegatingMarshaller implements StreamingMarshalle
 
    // TODO: Should avoid hardcoding but it's really not likely to change
    protected VersionAwareMarshaller marshaller;
-   private ExternalizerTable extTable;
-
-   public void inject(ExternalizerTable extTable) {
-      this.extTable = extTable;
-   }
-
-   public void start() {
-      marshaller.start(extTable);
-   }
 
    public void stop() {
       marshaller.stop();
-   }
-
-   protected VersionAwareMarshaller createMarshaller(GlobalConfiguration globalCfg, ClassLoader loader) {
-      return (VersionAwareMarshaller) Util.getInstance(globalCfg.getMarshallerClass(), loader);
    }
 
    @Override
@@ -104,10 +88,6 @@ public abstract class AbstractDelegatingMarshaller implements StreamingMarshalle
    @Override
    public boolean isMarshallable(Object o) throws Exception {
       return marshaller.isMarshallable(o);
-   }
-
-   String getCacheName() {
-      return marshaller.getCacheName();
    }
 
 }

--- a/core/src/main/java/org/infinispan/marshall/AbstractMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/AbstractMarshaller.java
@@ -38,14 +38,6 @@ public abstract class AbstractMarshaller implements Marshaller {
 
    protected static final int DEFAULT_BUF_SIZE = 512;
 
-   private ThreadLocal<BufferSizePredictor> bufferSizePredictorTL =
-      new ThreadLocal<BufferSizePredictor>() {
-         @Override
-         protected BufferSizePredictor initialValue() {
-            return new AdaptiveBufferSizePredictor();
-         }
-      };
-
    /**
     * This is a convenience method for converting an object into a {@link org.infinispan.io.ByteBuffer} which takes
     * an estimated size as parameter. A {@link org.infinispan.io.ByteBuffer} allows direct access to the byte
@@ -60,7 +52,7 @@ public abstract class AbstractMarshaller implements Marshaller {
 
    @Override
    public ByteBuffer objectToBuffer(Object obj) throws IOException, InterruptedException {
-      BufferSizePredictor sizePredictor = bufferSizePredictorTL.get();
+      BufferSizePredictor sizePredictor = BufferSizePredictorFactory.getBufferSizePredictor();
       int estimatedSize = sizePredictor.nextSize(obj);
       ByteBuffer byteBuffer = objectToBuffer(obj, estimatedSize);
       int length = byteBuffer.getLength();
@@ -75,7 +67,7 @@ public abstract class AbstractMarshaller implements Marshaller {
 
    @Override
    public byte[] objectToByteBuffer(Object o) throws IOException, InterruptedException {
-      BufferSizePredictor sizePredictor = bufferSizePredictorTL.get();
+      BufferSizePredictor sizePredictor = BufferSizePredictorFactory.getBufferSizePredictor();
       byte[] bytes = objectToByteBuffer(o, sizePredictor.nextSize(o));
       sizePredictor.recordSize(bytes.length);
       return bytes;

--- a/core/src/main/java/org/infinispan/marshall/BufferSizePredictorFactory.java
+++ b/core/src/main/java/org/infinispan/marshall/BufferSizePredictorFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.marshall;
+
+/**
+ * Factory class for retrieving {@link BufferSizePredictor} instances.
+ *
+ * @author Galder Zamarreño
+ * @since 5.1
+ */
+public class BufferSizePredictorFactory {
+
+   private static final ThreadLocal<BufferSizePredictor> bufferSizePredictorTL =
+      new ThreadLocal<BufferSizePredictor>() {
+         @Override
+         protected BufferSizePredictor initialValue() {
+            return new AdaptiveBufferSizePredictor();
+         }
+      };
+
+   public static BufferSizePredictor getBufferSizePredictor() {
+      return bufferSizePredictorTL.get();
+   }
+
+}

--- a/core/src/main/java/org/infinispan/marshall/CacheMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/CacheMarshaller.java
@@ -1,16 +1,12 @@
 package org.infinispan.marshall;
 
 import org.infinispan.config.Configuration;
-import org.infinispan.config.GlobalConfiguration;
 import org.infinispan.context.InvocationContextContainer;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.marshall.jboss.ExternalizerTable;
-
-import static org.infinispan.factories.KnownComponentNames.GLOBAL_MARSHALLER;
 
 /**
  * A cache-scoped marshaller.
@@ -21,17 +17,13 @@ import static org.infinispan.factories.KnownComponentNames.GLOBAL_MARSHALLER;
 @Scope(Scopes.NAMED_CACHE)
 public class CacheMarshaller extends AbstractDelegatingMarshaller {
 
-   @Inject
-   public void inject(GlobalConfiguration globalCfg, Configuration cfg,
-                      InvocationContextContainer icc, ExternalizerTable extTable) {
-      super.inject(extTable);
-      this.marshaller = createMarshaller(globalCfg, cfg.getClassLoader());
-      this.marshaller.inject(cfg, null, icc);
+   public CacheMarshaller(VersionAwareMarshaller marshaller) {
+      this.marshaller = marshaller;
    }
 
-   @Start(priority = 7) // should start before RPCManager
-   public void start() {
-      super.start();
+   @Inject
+   public void inject(Configuration cfg, InvocationContextContainer icc, ExternalizerTable extTable) {
+      this.marshaller.inject(cfg, null, icc, extTable);
    }
 
    @Stop(priority = 11) // Stop after RPCManager to avoid send/receive and marshaller not being ready

--- a/core/src/main/java/org/infinispan/marshall/GlobalMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/GlobalMarshaller.java
@@ -1,8 +1,6 @@
 package org.infinispan.marshall;
 
-import org.infinispan.config.GlobalConfiguration;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
@@ -19,16 +17,13 @@ import org.infinispan.marshall.jboss.ExternalizerTable;
 @Scope(Scopes.GLOBAL)
 public class GlobalMarshaller extends AbstractDelegatingMarshaller {
 
-   @Inject
-   public void inject(ClassLoader loader, GlobalConfiguration globalCfg, ExternalizerTable extTable) {
-      super.inject(extTable);
-      this.marshaller = createMarshaller(globalCfg, loader);
-      this.marshaller.inject(null, loader, null);
+   public GlobalMarshaller(VersionAwareMarshaller marshaller) {
+      this.marshaller = marshaller;
    }
 
-   @Start(priority = 9) // Should start before Transport component
-   public void start() {
-      super.start();
+   @Inject
+   public void inject(ClassLoader loader, ExternalizerTable extTable) {
+      this.marshaller.inject(null, loader, null, extTable);
    }
 
    @Stop(priority = 11) // Stop after transport to avoid send/receive and marshaller not being ready

--- a/core/src/main/java/org/infinispan/marshall/Ids.java
+++ b/core/src/main/java/org/infinispan/marshall/Ids.java
@@ -93,4 +93,5 @@ public interface Ids {
    int MURMURHASH_2_COMPAT = 72;
    int MURMURHASH_3 = 73;
 
+   int CACHE_RPC_COMMAND = 74;
 }

--- a/core/src/main/java/org/infinispan/marshall/VersionAwareMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/VersionAwareMarshaller.java
@@ -22,14 +22,8 @@
  */
 package org.infinispan.marshall;
 
-import org.infinispan.commands.RemoteCommandsFactory;
 import org.infinispan.config.Configuration;
-import org.infinispan.config.GlobalConfiguration;
 import org.infinispan.context.InvocationContextContainer;
-import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.factories.annotations.Inject;
-import org.infinispan.factories.annotations.Start;
-import org.infinispan.factories.annotations.Stop;
 import org.infinispan.io.ByteBuffer;
 import org.infinispan.io.ExposedByteArrayOutputStream;
 import org.infinispan.marshall.jboss.ExternalizerTable;
@@ -72,7 +66,7 @@ public class VersionAwareMarshaller extends AbstractMarshaller implements Stream
       defaultMarshaller = new JBossMarshaller();
    }
 
-   public void inject(Configuration cfg, ClassLoader loader, InvocationContextContainer icc) {
+   public void inject(Configuration cfg, ClassLoader loader, InvocationContextContainer icc, ExternalizerTable extTable) {
       if (cfg == null) {
          this.loader = loader;
          this.cacheName = null;
@@ -82,10 +76,7 @@ public class VersionAwareMarshaller extends AbstractMarshaller implements Stream
       }
 
       this.icc = icc;
-   }
-
-   public void start(ExternalizerTable externalizerTable) {
-      defaultMarshaller.start(externalizerTable, loader, icc);
+      this.defaultMarshaller.inject(extTable, this.loader, this.icc);
    }
 
    public void stop() {

--- a/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.marshall.exts;
+
+import org.infinispan.commands.RemoteCommandsFactory;
+import org.infinispan.commands.RemoveCacheCommand;
+import org.infinispan.commands.control.LockControlCommand;
+import org.infinispan.commands.control.RehashControlCommand;
+import org.infinispan.commands.read.MapReduceCommand;
+import org.infinispan.commands.remote.CacheRpcCommand;
+import org.infinispan.commands.remote.ClusteredGetCommand;
+import org.infinispan.commands.remote.MultipleRpcCommand;
+import org.infinispan.commands.remote.SingleRpcCommand;
+import org.infinispan.commands.remote.recovery.CompleteTransactionCommand;
+import org.infinispan.commands.remote.recovery.GetInDoubtTransactionsCommand;
+import org.infinispan.commands.remote.recovery.GetInDoubtTxInfoCommand;
+import org.infinispan.commands.remote.recovery.RemoveRecoveryInfoCommand;
+import org.infinispan.commands.tx.CommitCommand;
+import org.infinispan.commands.tx.PrepareCommand;
+import org.infinispan.commands.tx.RollbackCommand;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.factories.KnownComponentNames;
+import org.infinispan.io.ExposedByteArrayOutputStream;
+import org.infinispan.io.UnsignedNumeric;
+import org.infinispan.marshall.AbstractExternalizer;
+import org.infinispan.marshall.BufferSizePredictor;
+import org.infinispan.marshall.BufferSizePredictorFactory;
+import org.infinispan.marshall.Ids;
+import org.infinispan.marshall.StreamingMarshaller;
+import org.infinispan.marshall.jboss.ExtendedRiverUnmarshaller;
+import org.infinispan.util.ModuleProperties;
+import org.infinispan.util.Util;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Set;
+
+/**
+ * Externalizer in charge of marshalling cache specific commands. At read time,
+ * this marshaller is able to locate the right cache marshaller and provide
+ * it any externalizers implementations that follow.
+ *
+ * @author Galder Zamarreño
+ * @since 5.1
+ */
+public class CacheRpcCommandExternalizer extends AbstractExternalizer<CacheRpcCommand> {
+   private GlobalComponentRegistry gcr;
+   private ReplicableCommandExternalizer commandExt = new ReplicableCommandExternalizer();
+
+   public void inject(RemoteCommandsFactory cmdFactory, GlobalComponentRegistry gcr) {
+      commandExt.inject(cmdFactory);
+      this.gcr = gcr;
+   }
+
+   @Override
+   public Set<Class<? extends CacheRpcCommand>> getTypeClasses() {
+      Set<Class<? extends CacheRpcCommand>> coreCommands = Util.asSet(
+            MapReduceCommand.class, LockControlCommand.class,
+            RehashControlCommand.class, ClusteredGetCommand.class,
+            MultipleRpcCommand.class, SingleRpcCommand.class, CommitCommand.class,
+            PrepareCommand.class, RollbackCommand.class, RemoveCacheCommand.class,
+            RemoveRecoveryInfoCommand.class, GetInDoubtTransactionsCommand.class,
+            GetInDoubtTxInfoCommand.class, CompleteTransactionCommand.class);
+
+      coreCommands.addAll(ModuleProperties.moduleCacheRpcCommands());
+      return coreCommands;
+   }
+
+   @Override
+   public void writeObject(ObjectOutput output, CacheRpcCommand command) throws IOException {
+      commandExt.writeCommandHeader(output, command);
+
+      String cacheName = command.getCacheName();
+      output.writeUTF(cacheName);
+      ComponentRegistry registry = gcr.getNamedComponentRegistry(cacheName);
+      StreamingMarshaller marshaller = registry.getComponent(
+            StreamingMarshaller.class, KnownComponentNames.CACHE_MARSHALLER);
+      // Take the cache marshaller and generate the payload for the rest of
+      // the command using that cache marshaller and the write the bytes in
+      // the original payload.
+      ExposedByteArrayOutputStream os = marshallParameters(command, marshaller);
+      UnsignedNumeric.writeUnsignedInt(output, os.size());
+      // Do not rely on the raw buffer's lenght which is likely to be much longer!
+      output.write(os.getRawBuffer(), 0, os.size());
+   }
+
+   private ExposedByteArrayOutputStream marshallParameters(
+         CacheRpcCommand cmd, StreamingMarshaller marshaller) throws IOException {
+      BufferSizePredictor sizePredictor = BufferSizePredictorFactory.getBufferSizePredictor();
+      int estimatedSize = sizePredictor.nextSize(cmd);
+      ExposedByteArrayOutputStream baos = new ExposedByteArrayOutputStream(estimatedSize);
+      ObjectOutput output = marshaller.startObjectOutput(baos, true);
+      try {
+         commandExt.writeCommandParameters(output, cmd);
+      } finally {
+         marshaller.finishObjectOutput(output);
+      }
+      return baos;
+   }
+
+   @Override
+   public CacheRpcCommand readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+      byte type = input.readByte();
+      byte methodId = (byte) input.readShort();
+
+      String cacheName = input.readUTF();
+      ComponentRegistry registry = gcr.getNamedComponentRegistry(cacheName);
+      StreamingMarshaller marshaller;
+      if (registry == null) {
+         // Even though the command is directed at a cache, it could happen
+         // that the cache is not yet started, so fallback on global marshaller.
+         marshaller = gcr.getComponent(
+               StreamingMarshaller.class, KnownComponentNames.GLOBAL_MARSHALLER);
+      } else {
+         marshaller = registry.getComponent(
+               StreamingMarshaller.class, KnownComponentNames.CACHE_MARSHALLER);
+      }
+
+      byte[] paramsRaw = new byte[UnsignedNumeric.readUnsignedInt(input)];
+      // This is not ideal cos it forces the code to read all parameters into
+      // memory and then splitting them, potentially leading to excessive
+      // buffering. An alternative solution is shown in SharedStreamMultiMarshallerTest
+      // but it requires some special treatment - iow, hacking :)
+      input.readFully(paramsRaw);
+      ByteArrayInputStream is = new ByteArrayInputStream(paramsRaw, 0, paramsRaw.length);
+      ObjectInput paramsInput = marshaller.startObjectInput(is, true);
+      // Not ideal, but the alternative (without changing API), would have been
+      // using thread locals which are expensive to retrieve.
+      // Remember that the aim with externalizers is for them to be stateless.
+      if (paramsInput instanceof ExtendedRiverUnmarshaller)
+         ((ExtendedRiverUnmarshaller) paramsInput).setInfinispanMarshaller(marshaller);
+
+      try {
+         Object[] args = commandExt.readParameters(paramsInput);
+         return commandExt.cmdFactory.fromStream(methodId, args, type, cacheName);
+      } catch (IOException e) {
+         throw e;
+      } finally {
+         marshaller.finishObjectInput(paramsInput);
+      }
+   }
+
+   @Override
+   public Integer getId() {
+      return Ids.CACHE_RPC_COMMAND;
+   }
+
+}

--- a/core/src/main/java/org/infinispan/marshall/jboss/AbstractJBossMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/jboss/AbstractJBossMarshaller.java
@@ -46,11 +46,7 @@ public abstract class AbstractJBossMarshaller extends AbstractMarshaller {
    private final ConcurrentMap<Class, Boolean> isMarshallableMap = new ConcurrentWeakKeyHashMap<Class, Boolean>();
 
    public AbstractJBossMarshaller() {
-      factory = Marshalling.getMarshallerFactory("river", Marshalling.class.getClassLoader());
-      if (factory == null)
-         throw new IllegalStateException(
-            "River marshaller factory not found.  Verify that the JBoss Marshalling River jar archive is in the classpath.");
-
+      factory = new JBossMarshallerFactory();
       // Class resolver now set when marshaller/unmarshaller will be created
       baseCfg = new MarshallingConfiguration();
       baseCfg.setCreator(new SunReflectiveCreator());

--- a/core/src/main/java/org/infinispan/marshall/jboss/ExtendedRiverMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/jboss/ExtendedRiverMarshaller.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.marshall.jboss;
+
+import org.jboss.marshalling.MarshallingConfiguration;
+import org.jboss.marshalling.reflect.SerializableClassRegistry;
+import org.jboss.marshalling.river.RiverMarshaller;
+import org.jboss.marshalling.river.RiverMarshallerFactory;
+
+import java.io.IOException;
+
+/**
+ * {@link RiverMarshaller} extension that allows Infinispan code to directly
+ * create instances of it.
+ *
+ * @author Galder Zamarreño
+ * @since 5.1
+ */
+public class ExtendedRiverMarshaller extends RiverMarshaller {
+
+   public ExtendedRiverMarshaller(RiverMarshallerFactory factory,
+         SerializableClassRegistry registry, MarshallingConfiguration cfg) throws IOException {
+      super(factory, registry, cfg);
+   }
+
+}

--- a/core/src/main/java/org/infinispan/marshall/jboss/ExtendedRiverUnmarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/jboss/ExtendedRiverUnmarshaller.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.marshall.jboss;
+
+import org.infinispan.marshall.StreamingMarshaller;
+import org.jboss.marshalling.MarshallingConfiguration;
+import org.jboss.marshalling.reflect.SerializableClassRegistry;
+import org.jboss.marshalling.river.RiverMarshallerFactory;
+import org.jboss.marshalling.river.RiverUnmarshaller;
+
+/**
+ * An extended {@link RiverUnmarshaller} that allows Infinispan {@link StreamingMarshaller}
+ * instances to travel down the stack to potential externalizer implementations
+ * that might need it, such as {@link org.infinispan.marshall.MarshalledValue.Externalizer}
+ *
+ * @author Galder Zamarreño
+ * @since 5.1
+ */
+public class ExtendedRiverUnmarshaller extends RiverUnmarshaller {
+
+   private StreamingMarshaller infinispanMarshaller;
+
+   protected ExtendedRiverUnmarshaller(RiverMarshallerFactory factory,
+         SerializableClassRegistry registry, MarshallingConfiguration cfg) {
+      super(factory, registry, cfg);
+   }
+
+   public StreamingMarshaller getInfinispanMarshaller() {
+      return infinispanMarshaller;
+   }
+
+   public void setInfinispanMarshaller(StreamingMarshaller infinispanMarshaller) {
+      this.infinispanMarshaller = infinispanMarshaller;
+   }
+
+}

--- a/core/src/main/java/org/infinispan/marshall/jboss/ExternalizerTable.java
+++ b/core/src/main/java/org/infinispan/marshall/jboss/ExternalizerTable.java
@@ -42,7 +42,6 @@ import org.infinispan.container.entries.TransientCacheValue;
 import org.infinispan.container.entries.TransientMortalCacheEntry;
 import org.infinispan.container.entries.TransientMortalCacheValue;
 import org.infinispan.distribution.RemoteTransactionLogDetails;
-import org.infinispan.distribution.ch.AbstractWheelConsistentHash;
 import org.infinispan.distribution.ch.DefaultConsistentHash;
 import org.infinispan.distribution.ch.TopologyAwareConsistentHash;
 import org.infinispan.distribution.ch.UnionConsistentHash;
@@ -57,8 +56,8 @@ import org.infinispan.loaders.bucket.Bucket;
 import org.infinispan.marshall.AdvancedExternalizer;
 import org.infinispan.marshall.Ids;
 import org.infinispan.marshall.MarshalledValue;
-import org.infinispan.marshall.StreamingMarshaller;
 import org.infinispan.marshall.exts.ArrayListExternalizer;
+import org.infinispan.marshall.exts.CacheRpcCommandExternalizer;
 import org.infinispan.marshall.exts.LinkedListExternalizer;
 import org.infinispan.marshall.exts.MapExternalizer;
 import org.infinispan.marshall.exts.ReplicableCommandExternalizer;
@@ -160,6 +159,7 @@ public class ExternalizerTable implements ObjectTable {
       internalExternalizers.add(new UnsureResponse.Externalizer());
 
       internalExternalizers.add(new ReplicableCommandExternalizer());
+      internalExternalizers.add(new CacheRpcCommandExternalizer());
 
       internalExternalizers.add(new ImmortalCacheEntry.Externalizer());
       internalExternalizers.add(new MortalCacheEntry.Externalizer());
@@ -281,6 +281,8 @@ public class ExternalizerTable implements ObjectTable {
       for (AdvancedExternalizer ext : internalExternalizers) {
          if (ext instanceof ReplicableCommandExternalizer)
             ((ReplicableCommandExternalizer) ext).inject(cmdFactory);
+         if (ext instanceof CacheRpcCommandExternalizer)
+            ((CacheRpcCommandExternalizer) ext).inject(cmdFactory, gcr);
          if (ext instanceof MarshalledValue.Externalizer)
             ((MarshalledValue.Externalizer) ext).inject(gcr);
 

--- a/core/src/main/java/org/infinispan/marshall/jboss/JBossMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/jboss/JBossMarshaller.java
@@ -50,7 +50,7 @@ public class JBossMarshaller extends AbstractJBossMarshaller implements Streamin
    private InvocationContextContainer icc;
    ExternalizerTable externalizerTable;
 
-   public void start(ExternalizerTable externalizerTable, ClassLoader cl, InvocationContextContainer icc) {
+   public void inject(ExternalizerTable externalizerTable, ClassLoader cl, InvocationContextContainer icc) {
       if (log.isDebugEnabled()) log.debug("Using JBoss Marshalling");
       this.icc = icc;
       this.externalizerTable = externalizerTable;

--- a/core/src/main/java/org/infinispan/marshall/jboss/JBossMarshallerFactory.java
+++ b/core/src/main/java/org/infinispan/marshall/jboss/JBossMarshallerFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.marshall.jboss;
+
+import org.jboss.marshalling.AbstractMarshallerFactory;
+import org.jboss.marshalling.Marshaller;
+import org.jboss.marshalling.Marshalling;
+import org.jboss.marshalling.MarshallingConfiguration;
+import org.jboss.marshalling.Unmarshaller;
+import org.jboss.marshalling.reflect.SerializableClassRegistry;
+import org.jboss.marshalling.river.RiverMarshallerFactory;
+
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * A JBoss Marshalling factory class for retrieving marshaller/unmarshaller
+ * instances. The aim of this factory is to allow Infinispan to provide its own
+ * JBoss Marshalling marshaller/unmarshaller extensions.
+ *
+ * @author Galder Zamarreño
+ * @since 5.1
+ */
+public class JBossMarshallerFactory extends AbstractMarshallerFactory {
+
+   private final SerializableClassRegistry registry;
+
+   private final RiverMarshallerFactory factory;
+
+   public JBossMarshallerFactory() {
+      factory = (RiverMarshallerFactory) Marshalling.getMarshallerFactory(
+            "river", Marshalling.class.getClassLoader());
+      if (factory == null)
+         throw new IllegalStateException(
+            "River marshaller factory not found.  Verify that the JBoss Marshalling River jar archive is in the classpath.");
+
+      registry = AccessController.doPrivileged(new PrivilegedAction<SerializableClassRegistry>() {
+          public SerializableClassRegistry run() {
+              return SerializableClassRegistry.getInstance();
+          }
+      });
+   }
+
+   @Override
+   public Unmarshaller createUnmarshaller(MarshallingConfiguration configuration) throws IOException {
+      return new ExtendedRiverUnmarshaller(factory, registry, configuration);
+   }
+
+   @Override
+   public Marshaller createMarshaller(MarshallingConfiguration configuration) throws IOException {
+      return new ExtendedRiverMarshaller(factory, registry, configuration);
+   }
+
+}

--- a/core/src/main/java/org/infinispan/transaction/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/TransactionTable.java
@@ -281,7 +281,8 @@ public class TransactionTable {
             if (keys.size() > 0) {
                if (trace) log.tracef("Unlocking keys %s for remote transaction %s as we are no longer an owner", keys, gtx);
                Set<Flag> flags = EnumSet.of(Flag.CACHE_MODE_LOCAL);
-               LockControlCommand unlockCmd = new LockControlCommand(keys, configuration.getName(), flags, false);
+               String cacheName = configuration.getName();
+               LockControlCommand unlockCmd = new LockControlCommand(keys, cacheName, flags, false);
                unlockCmd.init(invoker, icc, TransactionTable.this);
                unlockCmd.attachGlobalTransaction(gtx);
                unlockCmd.setUnlock(true);
@@ -295,7 +296,7 @@ public class TransactionTable {
                // if the transaction doesn't touch local keys any more, we can roll it back
                if (!txHasLocalKeys) {
                   if (trace) log.tracef("Killing remote transaction without any local keys %s", gtx);
-                  RollbackCommand rc = new RollbackCommand(gtx);
+                  RollbackCommand rc = new RollbackCommand(cacheName, gtx);
                   rc.init(invoker, icc, TransactionTable.this);
                   try {
                      rc.perform(null);
@@ -345,7 +346,7 @@ public class TransactionTable {
 
       for (GlobalTransaction gtx : toKill) {
          if (trace) log.tracef("Killing remote transaction originating on leaver %s", gtx);
-         RollbackCommand rc = new RollbackCommand(gtx);
+         RollbackCommand rc = new RollbackCommand(configuration.getName(), gtx);
          rc.init(invoker, icc, TransactionTable.this);
          try {
             rc.perform(null);

--- a/core/src/main/java/org/infinispan/util/ModuleProperties.java
+++ b/core/src/main/java/org/infinispan/util/ModuleProperties.java
@@ -28,6 +28,7 @@ import org.infinispan.CacheException;
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commands.module.ModuleCommandFactory;
 import org.infinispan.commands.module.ModuleCommandInitializer;
+import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.config.ConfigurationException;
 import org.infinispan.lifecycle.ModuleLifecycle;
 import org.infinispan.util.logging.Log;
@@ -279,4 +280,19 @@ public class ModuleProperties extends Properties {
          moduleCommandsGuard.unlock();
       }
    }
+
+   public static Collection<Class<? extends CacheRpcCommand>> moduleCacheRpcCommands() {
+      Collection<Class<? extends ReplicableCommand>> cmds = moduleCommands(null);
+      Collection<Class<? extends CacheRpcCommand>> cacheRpcCmds = new HashSet<Class<? extends CacheRpcCommand>>();
+      if (cmds == null || cmds.isEmpty())
+         return Collections.emptySet();
+
+      for (Class<? extends ReplicableCommand> moduleCmdClass : cmds) {
+         if (CacheRpcCommand.class.isAssignableFrom(moduleCmdClass))
+            cacheRpcCmds.add((Class<? extends CacheRpcCommand>) moduleCmdClass);
+      }
+
+      return cacheRpcCmds;
+   }
+
 }

--- a/core/src/test/java/org/infinispan/api/WithClassLoaderTest.java
+++ b/core/src/test/java/org/infinispan/api/WithClassLoaderTest.java
@@ -46,16 +46,16 @@ public class WithClassLoaderTest extends MultipleCacheManagersTest {
       cacheManagers.add(cm1);
    }
 
-   public void testReadingWithCorrectClassLoader() {
+   public void testReadingWithCorrectClassLoaderAfterReplication() {
       Cache<Integer, Car> cache0 = cache(0);
+      Cache<Integer, Car> cache1 = cache(1);
+
       Car value = new Car().plateNumber("1234");
       cache0.put(1, value);
 
-      Cache<Integer, Car> cache1 = cache(1);
-
       try {
          cache1.get(1);
-         fail("Expected a class ClassNotFoundException");
+         fail("Expected a ClassNotFoundException");
       } catch (CacheException e) {
          if (!(e.getCause() instanceof ClassNotFoundException))
             throw e;
@@ -63,6 +63,9 @@ public class WithClassLoaderTest extends MultipleCacheManagersTest {
 
       assertEquals(value, cache1.getAdvancedCache().with(systemCl).get(1));
    }
+
+   // TODO: Add test where contents come from state transfer rather than replication
+   // TODO: For that to work, memory state might need wrapping in a cache rpc command (i.e. state transfer command)
 
    public static class Car implements Serializable {
       String plateNumber;

--- a/core/src/test/java/org/infinispan/marshall/SharedStreamMultiMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/SharedStreamMultiMarshallerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.marshall;
+
+import org.infinispan.commands.write.PutKeyValueCommand;
+import org.infinispan.context.Flag;
+import org.infinispan.io.ExposedByteArrayOutputStream;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.jgroups.stack.IpAddress;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Collections;
+
+import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
+import static org.infinispan.test.TestingUtil.extractGlobalMarshaller;
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Test to verify whether the same stream can be used with different marshallers.
+ * The test does work but it requires some special treatment. This could be a
+ * more efficient way of dealing with global/cache marshaller transition.
+ *
+ * @author Galder Zamarreño
+ * @since 5.1
+ */
+@Test(groups = "functional", testName = "marshall.SharedStreamMultiMarshallerTest", enabled = true)
+public class SharedStreamMultiMarshallerTest {
+
+   public void testSharingStream() throws Exception {
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager();
+      cm.getCache(); // Start cache so that global marshaller is resolved
+      JGroupsAddress address = new JGroupsAddress(new IpAddress(12345));
+      PutKeyValueCommand cmd = new PutKeyValueCommand(
+            "k", "v", false, null, 0, 0, Collections.<Flag>emptySet());
+      try {
+         // Write
+         StreamingMarshaller globalMarshal = extractGlobalMarshaller(cm);
+         ExposedByteArrayOutputStream baos = new ExposedByteArrayOutputStream(1024);
+         ObjectOutput globalOO = globalMarshal.startObjectOutput(baos, false);
+         try {
+            globalOO.writeObject(address);
+            /** BEGIN: Special treatment **/
+            globalOO.flush(); // IMPORTANT: Flush needed to make sure the address gets written!!
+            globalOO.writeInt(baos.size()); // Note amount of bytes that have been read so far
+            globalOO.flush(); // IMPORTANT: Flush again!
+            /** END: Special treatment **/
+
+            // Now try cache marshaller to 'borrow' the output stream
+            StreamingMarshaller cacheMarshaller = extractCacheMarshaller(cm.getCache());
+            ObjectOutput cacheOO = cacheMarshaller.startObjectOutput(baos, true);
+            try {
+               cacheOO.writeObject(cmd);
+            } finally {
+               cacheMarshaller.finishObjectOutput(cacheOO);
+            }
+         } finally {
+            globalMarshal.finishObjectOutput(globalOO);
+         }
+
+         byte[] bytes = new byte[baos.size()];
+         System.arraycopy(baos.getRawBuffer(), 0, bytes, 0, bytes.length);
+
+         // Read
+         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+         ObjectInput globalOI = globalMarshal.startObjectInput(bais, false);
+         try {
+            assertEquals(address, globalOI.readObject());
+
+            /** BEGIN: Special treatment **/
+            int offset = globalOI.readInt();
+            // Now try the cache marshaller and borrow the input stream to read
+            StreamingMarshaller cacheMarshaller = extractCacheMarshaller(cm.getCache());
+            // Advance 4 bytes to go over the number of bytes written
+            bais = new ByteArrayInputStream(bytes, offset + 4, bytes.length);
+            ObjectInput cacheOI = cacheMarshaller.startObjectInput(bais, true);
+            /** END: Special treatment **/
+
+            try {
+               assertEquals(cmd, cacheOI.readObject());
+            } finally {
+               cacheMarshaller.finishObjectInput(cacheOI);
+            }
+         } finally {
+            globalMarshal.finishObjectInput(globalOI);
+         }
+      } finally {
+         cm.stop();
+      }
+   }
+
+   public void testIndividualStream() throws Exception {
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager();
+      cm.getCache(); // Start cache so that global marshaller is resolved
+      JGroupsAddress address = new JGroupsAddress(new IpAddress(12345));
+      PutKeyValueCommand cmd = new PutKeyValueCommand(
+            "k", "v", false, null, 0, 0, Collections.<Flag>emptySet());
+      try {
+         // Write
+         StreamingMarshaller globalMarshal = extractGlobalMarshaller(cm);
+         ExposedByteArrayOutputStream baos = new ExposedByteArrayOutputStream(1024);
+         ObjectOutput globalOO = globalMarshal.startObjectOutput(baos, false);
+         try {
+            globalOO.writeObject(address);
+         } finally {
+            globalMarshal.finishObjectOutput(globalOO);
+         }
+
+         byte[] bytes = new byte[baos.size()];
+         System.arraycopy(baos.getRawBuffer(), 0, bytes, 0, bytes.length);
+
+         // Read
+         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+         ObjectInput globalOI = globalMarshal.startObjectInput(bais, false);
+         try {
+            assertEquals(address, globalOI.readObject());
+         } finally {
+            globalMarshal.finishObjectInput(globalOI);
+         }
+      } finally {
+         cm.stop();
+      }
+   }
+
+}

--- a/core/src/test/java/org/infinispan/remoting/TransportSenderExceptionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/remoting/TransportSenderExceptionHandlingTest.java
@@ -67,8 +67,8 @@ public class TransportSenderExceptionHandlingTest extends MultipleCacheManagersT
          PutKeyValueCommand putCommand = new PutKeyValueCommand();
          putCommand.setKey(key);
          putCommand.setValue(value);
-         SingleRpcCommand rpcCommand = new SingleRpcCommand();
-         Object[] params = new Object[]{"replSync", putCommand};
+         SingleRpcCommand rpcCommand = new SingleRpcCommand("replSync");
+         Object[] params = new Object[]{putCommand};
          rpcCommand.setParameters(SingleRpcCommand.COMMAND_ID, params);
          expect(mockMarshaller1.objectToBuffer(anyObject())).andReturn(originalMarshaller1.objectToBuffer(rpcCommand));
          expect(mockMarshaller2.objectFromByteBuffer((byte[]) anyObject(), anyInt(), anyInt())).andThrow(new EOFException());

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -817,6 +817,12 @@ public class TestingUtil {
       return (AbstractDelegatingMarshaller) marshaller;
    }
 
+   public static AbstractDelegatingMarshaller extractGlobalMarshaller(EmbeddedCacheManager cm) {
+      GlobalComponentRegistry gcr = (GlobalComponentRegistry) extractField(cm, "globalComponentRegistry");
+      return (AbstractDelegatingMarshaller)
+            gcr.getComponent(StreamingMarshaller.class, KnownComponentNames.GLOBAL_MARSHALLER);
+   }
+
    public static ExternalizerTable extractExtTable(CacheContainer cacheContainer) {
       GlobalComponentRegistry gcr = (GlobalComponentRegistry) extractField(cacheContainer, "globalComponentRegistry");
       return gcr.getComponent(ExternalizerTable.class);

--- a/core/src/test/resources/byteman/JBossMarshallingDebug.btm
+++ b/core/src/test/resources/byteman/JBossMarshallingDebug.btm
@@ -1,0 +1,36 @@
+# ByteMan rules to debug JBoss Marshalling - This could be handy in the future
+
+RULE debug marshaller
+CLASS org.jboss.marshalling.AbstractObjectOutput
+METHOD writeObject(Object)
+AT ENTRY
+BIND nullobj : java.lang.Object = null
+IF TRUE
+DO   System.out.println("Write type=" + ($1 == nullobj ? "NULL" : $1.getClass().getName()))
+ENDRULE
+
+RULE debug unmarshaller
+CLASS org.jboss.marshalling.AbstractObjectInput
+METHOD readObject()
+AT EXIT
+BIND nullobj : java.lang.Object = null
+IF TRUE
+DO   System.out.println("Read type=" + ($! == nullobj ? "NULL" : $!.getClass().getName()))
+ENDRULE
+
+RULE debug unmarshaller lead byte
+CLASS org.jboss.marshalling.river.RiverUnmarshaller
+METHOD doReadObject(int, boolean)
+AT ENTRY
+IF TRUE
+DO   System.out.println("Lead byte=" + $1)
+ENDRULE
+
+RULE debug unmarshaller buffer position and lead byte
+CLASS org.jboss.marshalling.SimpleDataInput
+METHOD readUnsignedByteDirect()
+AT EXIT
+BIND input = $this
+IF TRUE
+DO   System.out.println("Unsigned byte=" + $! + ". Read buffer position=" + input.position)
+ENDRULE


### PR DESCRIPTION
- A brand new externalizer was created to deal with CacheRpcCommand instances, allowing lookup of per-cache marshallers.
- Extended RiverMarshaller and RiverUnmarshaller instances to allow cache marshaller to travel down the stack to externalizer impls.
