### PR TITLE
ISPN-1332 Make tree cache element holders Serializable

### DIFF
--- a/tree/pom.xml
+++ b/tree/pom.xml
@@ -55,6 +55,14 @@
          <type>test-jar</type>
          <scope>test</scope>
       </dependency>
+
+      <dependency>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>infinispan-cachestore-jdbm</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+
    </dependencies>
 
    <build>

--- a/tree/src/main/java/org/infinispan/tree/Fqn.java
+++ b/tree/src/main/java/org/infinispan/tree/Fqn.java
@@ -30,6 +30,7 @@ import org.infinispan.util.Util;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -80,7 +81,7 @@ import java.util.Set;
  * @since 4.0
  */
 @Immutable
-public class Fqn implements Comparable<Fqn> {
+public class Fqn implements Comparable<Fqn>, Serializable {
    /**
     * Separator between FQN elements.
     */

--- a/tree/src/main/java/org/infinispan/tree/NodeKey.java
+++ b/tree/src/main/java/org/infinispan/tree/NodeKey.java
@@ -29,6 +29,7 @@ import static org.infinispan.tree.NodeKey.Type.STRUCTURE;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.io.Serializable;
 import java.util.Set;
 
 import org.infinispan.marshall.AbstractExternalizer;
@@ -40,7 +41,7 @@ import org.infinispan.util.Util;
  * @author Manik Surtani
  * @since 4.0
  */
-public class NodeKey {
+public class NodeKey implements Serializable {
    final Fqn fqn;
    final Type contents;
 

--- a/tree/src/test/java/org/infinispan/loaders/TreeCacheWithJdbmLoaderTest.java
+++ b/tree/src/test/java/org/infinispan/loaders/TreeCacheWithJdbmLoaderTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.loaders;
+
+import org.infinispan.loaders.jdbm.JdbmCacheStoreConfig;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+/**
+ * Test tree cache storing data into a cache store that requires data to be
+ * serializable as per standard Java rules, such as a the JDBM cache store.
+ *
+ * @author Galder Zamarreño
+ * @since 5.1
+ */
+@Test(groups = "functional", testName = "loaders.TreeCacheWithJdbmLoaderTest")
+public class TreeCacheWithJdbmLoaderTest extends TreeCacheWithLoaderTest {
+
+   private String tmpDirectory;
+
+   @Override
+   protected CacheStoreConfig getCacheStoreCfg() {
+      JdbmCacheStoreConfig cfg = new JdbmCacheStoreConfig();
+      cfg.setLocation(tmpDirectory);
+      cfg.setPurgeSynchronously(true); // for more accurate unit testing
+      return cfg;
+   }
+
+   @BeforeClass
+   @Parameters({"basedir"})
+   protected void setUpTempDir(@Optional("/tmp") String basedir) {
+      tmpDirectory = TestingUtil.tmpDirectory(basedir, this);
+   }
+
+   @AfterClass
+   protected void clearTempDir() {
+      TestingUtil.recursiveFileRemove(tmpDirectory);
+      new File(tmpDirectory).mkdirs();
+   }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1332

This is done in order to support cache stores whose marshalling layer
cannot be swapped, and therefore it requires stored elements to be
Serializable as per standard Java rules.
