### PR TITLE
ISPN-1380 Modules using custom commands should use a defined range for co

### DIFF
--- a/query/src/main/java/org/infinispan/query/ModuleCommandIds.java
+++ b/query/src/main/java/org/infinispan/query/ModuleCommandIds.java
@@ -1,0 +1,32 @@
+/* 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.query;
+
+/**
+ * The Query module is using custom RPC commands; to make sure the used command ids
+ * are unique all numbers are defined here, and should stay in the range 100-119
+ * which is the reserved range for this module.
+ *
+ * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
+ */
+public interface ModuleCommandIds {
+
+   public static final byte CLUSTERED_QUERY = 101;
+
+}

--- a/query/src/main/java/org/infinispan/query/clustered/ClusteredQueryCommand.java
+++ b/query/src/main/java/org/infinispan/query/clustered/ClusteredQueryCommand.java
@@ -28,6 +28,7 @@ import org.infinispan.Cache;
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.query.ModuleCommandIds;
 import org.infinispan.query.clustered.commandworkers.ClusteredQueryCommandWorker;
 
 /**
@@ -38,7 +39,7 @@ import org.infinispan.query.clustered.commandworkers.ClusteredQueryCommandWorker
  */
 public class ClusteredQueryCommand extends BaseRpcCommand implements ReplicableCommand {
 
-   public static final byte COMMAND_ID = 33;
+   public static final byte COMMAND_ID = ModuleCommandIds.CLUSTERED_QUERY;
 
    private ClusteredQueryCommandType commandType;
 


### PR DESCRIPTION
ISPN-1380 Modules using custom commands should use a defined range for commandIds

for master only, to be included for 5.0.0.Alpha1.
