### PR TITLE
ISPN-1381 Cache store tests now close the marshaller's cache manager

### DIFF
--- a/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/BdbjeCacheStoreIntegrationVamTest.java
+++ b/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/BdbjeCacheStoreIntegrationVamTest.java
@@ -26,7 +26,9 @@ import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
@@ -39,21 +41,24 @@ import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
  */
 @Test(groups = "unit", enabled = true, testName = "loaders.bdbje.BdbjeCacheStoreIntegrationVamTest")
 public class BdbjeCacheStoreIntegrationVamTest extends BdbjeCacheStoreIntegrationTest {
-   private EmbeddedCacheManager cm;
+
+   EmbeddedCacheManager cm;
+   StreamingMarshaller marshaller;
+
+   @BeforeClass(alwaysRun = true)
+   public void setUpClass() {
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      marshaller = extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterClass(alwaysRun = true)
+   public void tearDownClass() throws CacheLoaderException {
+      cm.stop();
+   }
 
    @Override
    protected StreamingMarshaller getMarshaller() {
-      cm = TestCacheManagerFactory.createLocalCacheManager();
-      return extractCacheMarshaller(cm.getCache());
+      return marshaller;
    }
 
-   @AfterMethod(alwaysRun = true)
-   @Override
-   public void tearDown() throws CacheLoaderException {
-      try {
-         super.tearDown();
-      } finally {
-         cm.stop();
-      }
-   }
 }

--- a/cachestore/cloud/src/integrationtest/java/org/infinispan/loaders/cloud/CloudCacheStoreIntegrationVamTest.java
+++ b/cachestore/cloud/src/integrationtest/java/org/infinispan/loaders/cloud/CloudCacheStoreIntegrationVamTest.java
@@ -39,21 +39,24 @@ import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
  */
 @Test(groups = "unit", sequential = true, testName = "loaders.cloud.CloudCacheStoreIntegrationVamTest")
 public class CloudCacheStoreIntegrationVamTest extends CloudCacheStoreIntegrationTest {
-   private EmbeddedCacheManager cm;
+
+   EmbeddedCacheManager cm;
+   StreamingMarshaller marshaller;
+
+   @BeforeClass(alwaysRun = true)
+   public void setUpClass() {
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      marshaller = extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterClass(alwaysRun = true)
+   public void tearDownClass() throws CacheLoaderException {
+      cm.stop();
+   }
 
    @Override
    protected StreamingMarshaller getMarshaller() {
-      cm = TestCacheManagerFactory.createLocalCacheManager();
-      return extractCacheMarshaller(cm.getCache());
+      return marshaller;
    }
 
-   @AfterMethod(alwaysRun = true)
-   @Override
-   public void tearDown() throws CacheLoaderException {
-      try {
-         super.tearDown();
-      } finally {
-         cm.stop();
-      }
-   }
 }

--- a/cachestore/cloud/src/test/java/org/infinispan/loaders/cloud/CloudCacheStoreVamTest.java
+++ b/cachestore/cloud/src/test/java/org/infinispan/loaders/cloud/CloudCacheStoreVamTest.java
@@ -26,7 +26,9 @@ import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
@@ -39,19 +41,24 @@ import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
  */
 @Test(groups = "unit", testName = "loaders.cloud.CloudCacheStoreVamTest")
 public class CloudCacheStoreVamTest extends CloudCacheStoreTest {
-   private EmbeddedCacheManager cm;
+
+   EmbeddedCacheManager cm;
+   StreamingMarshaller marshaller;
+
+   @BeforeClass(alwaysRun = true)
+   public void setUpClass() {
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      marshaller = extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterClass(alwaysRun = true)
+   public void tearDownClass() throws CacheLoaderException {
+      cm.stop();
+   }
 
    @Override
    protected StreamingMarshaller getMarshaller() {
-      cm = TestCacheManagerFactory.createLocalCacheManager();
-      return extractCacheMarshaller(cm.getCache());
-   }
-
-   @AfterMethod(alwaysRun = true)
-   @Override
-   public void tearDown() throws CacheLoaderException {
-      super.tearDown();
-      cm.stop();
+      return marshaller;
    }
 
 }

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/DataManipulationHelper.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/DataManipulationHelper.java
@@ -246,7 +246,7 @@ public abstract class DataManipulationHelper {
          rs.setFetchSize(tableManipulation.getFetchSize());
          Set<InternalCacheEntry> result = new HashSet<InternalCacheEntry>(maxEntries);
          while (rs.next()) {
-            loadAllProcess(rs, result);
+            loadAllProcess(rs, result, maxEntries);
          }
          return result;
       } catch (SQLException e) {
@@ -266,6 +266,8 @@ public abstract class DataManipulationHelper {
    protected abstract String getLoadAllKeysSql();
 
    protected abstract void loadAllProcess(ResultSet rs, Set<InternalCacheEntry> result) throws SQLException, CacheLoaderException;
+
+   protected abstract void loadAllProcess(ResultSet rs, Set<InternalCacheEntry> result, int maxEntries) throws SQLException, CacheLoaderException;
 
    protected abstract void loadAllKeysProcess(ResultSet rs, Set<Object> keys, Set<Object> keysToExclude) throws SQLException, CacheLoaderException;
 

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/binary/JdbcBinaryCacheStore.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/binary/JdbcBinaryCacheStore.java
@@ -119,6 +119,19 @@ public class JdbcBinaryCacheStore extends BucketBasedCacheStore {
          }
 
          @Override
+         public void loadAllProcess(ResultSet rs, Set<InternalCacheEntry> result, int maxEntries) throws SQLException, CacheLoaderException {
+            InputStream binaryStream = rs.getBinaryStream(1);
+            Bucket bucket = (Bucket) JdbcUtil.unmarshall(getMarshaller(), binaryStream);
+            for (InternalCacheEntry ice: bucket.getStoredEntries()) {
+               if (!ice.isExpired())
+                  result.add(ice);
+
+               if (result.size() == maxEntries)
+                  break;
+            }
+         }
+
+         @Override
          public void loadAllKeysProcess(ResultSet rs, Set<Object> keys, Set<Object> keysToExclude) throws SQLException, CacheLoaderException {
             InputStream binaryStream = rs.getBinaryStream(1);
             Bucket bucket = (Bucket) JdbcUtil.unmarshall(getMarshaller(), binaryStream);

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStore.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStore.java
@@ -147,6 +147,11 @@ public class JdbcStringBasedCacheStore extends LockSupportCacheStore<String> {
          }
 
          @Override
+         public void loadAllProcess(ResultSet rs, Set<InternalCacheEntry> result, int maxEntries) throws SQLException, CacheLoaderException {
+            loadAllProcess(rs, result);
+         }
+
+         @Override
          public void loadAllKeysProcess(ResultSet rs, Set<Object> keys, Set<Object> keysToExclude) throws SQLException, CacheLoaderException {
             String keyStr = rs.getString(1);
             Object key = ((TwoWayKey2StringMapper) key2StringMapper).getKeyMapping(keyStr);

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/binary/JdbcBinaryCacheStoreVamTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/binary/JdbcBinaryCacheStoreVamTest.java
@@ -26,7 +26,9 @@ import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
@@ -39,21 +41,24 @@ import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
  */
 @Test(groups = "functional", testName = "loaders.jdbc.binary.JdbcBinaryCacheStoreVamTest")
 public class JdbcBinaryCacheStoreVamTest extends JdbcBinaryCacheStoreTest {   
-   private EmbeddedCacheManager cm;
+
+   EmbeddedCacheManager cm;
+   StreamingMarshaller marshaller;
+
+   @BeforeClass(alwaysRun = true)
+   public void setUpClass() {
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      marshaller = extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterClass(alwaysRun = true)
+   public void tearDownClass() throws CacheLoaderException {
+      cm.stop();
+   }
 
    @Override
    protected StreamingMarshaller getMarshaller() {
-      cm = TestCacheManagerFactory.createLocalCacheManager();
-      return extractCacheMarshaller(cm.getCache());
+      return marshaller;
    }
 
-   @AfterMethod(alwaysRun = true)
-   @Override
-   public void tearDown() throws CacheLoaderException {
-      try {
-         super.tearDown();
-      } finally {
-         cm.stop();
-      }
-   }
 }

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreTest.java
@@ -39,6 +39,7 @@ import org.infinispan.marshall.TestObjectStreamMarshaller;
 import org.infinispan.test.fwk.UnitTestDatabaseManager;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -64,7 +65,7 @@ public class JdbcMixedCacheStoreTest {
    private static final Person MIRCEA = new Person("Mircea", "Markus", 28);
    private static final Person MANIK = new Person("Manik", "Surtani", 18);
 
-   @BeforeTest
+   @BeforeMethod
    public void createCacheStore() throws CacheLoaderException {
       stringsTm = UnitTestDatabaseManager.buildDefaultTableManipulation();
       stringsTm.setTableNamePrefix("STRINGS_TABLE");

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreVamTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreVamTest.java
@@ -22,10 +22,13 @@
  */
 package org.infinispan.loaders.jdbc.mixed;
 
+import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
@@ -38,21 +41,24 @@ import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
  */
 @Test(groups = "functional", testName = "loaders.jdbc.mixed.JdbcMixedCacheStoreVamTest")
 public class JdbcMixedCacheStoreVamTest extends JdbcMixedCacheStoreTest {
-   private EmbeddedCacheManager cm;
+
+   EmbeddedCacheManager cm;
+   StreamingMarshaller marshaller;
+
+   @BeforeClass(alwaysRun = true)
+   public void setUpClass() {
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      marshaller = extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterClass(alwaysRun = true)
+   public void tearDownClass() throws CacheLoaderException {
+      cm.stop();
+   }
 
    @Override
    protected StreamingMarshaller getMarshaller() {
-      cm = TestCacheManagerFactory.createLocalCacheManager();
-      return extractCacheMarshaller(cm.getCache());
+      return marshaller;
    }
 
-   @AfterMethod(alwaysRun = true)
-   @Override
-   public void clearStore() throws Exception {
-      try {
-         super.clearStore();
-      } finally {
-         cm.stop();
-      }
-   }
 }

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreVamTest2.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreVamTest2.java
@@ -26,7 +26,9 @@ import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
@@ -39,22 +41,24 @@ import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
  */
 @Test(groups = "functional", testName = "loaders.jdbc.mixed.JdbcMixedCacheStoreVamTest2")
 public class JdbcMixedCacheStoreVamTest2 extends JdbcMixedCacheStoreTest2 {
-   private EmbeddedCacheManager cm;
+
+   EmbeddedCacheManager cm;
+   StreamingMarshaller marshaller;
+
+   @BeforeClass(alwaysRun = true)
+   public void setUpClass() {
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      marshaller = extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterClass(alwaysRun = true)
+   public void tearDownClass() throws CacheLoaderException {
+      cm.stop();
+   }
 
    @Override
    protected StreamingMarshaller getMarshaller() {
-      cm = TestCacheManagerFactory.createLocalCacheManager();
-      return extractCacheMarshaller(cm.getCache());
-   }
-
-   @AfterMethod(alwaysRun = true)
-   @Override
-   public void tearDown() throws CacheLoaderException {
-      try {
-         super.tearDown();
-      } finally {
-         cm.stop();
-      }
+      return marshaller;
    }
 
 }

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreVamTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreVamTest.java
@@ -26,7 +26,8 @@ import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
@@ -39,21 +40,24 @@ import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
  */
 @Test(groups = "functional", testName = "loaders.jdbc.stringbased.JdbcStringBasedCacheStoreVamTest")
 public class JdbcStringBasedCacheStoreVamTest extends JdbcStringBasedCacheStoreTest {
-   private EmbeddedCacheManager cm;
+
+   EmbeddedCacheManager cm;
+   StreamingMarshaller marshaller;
+
+   @BeforeClass(alwaysRun = true)
+   public void setUpClass() {
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      marshaller = extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterClass(alwaysRun = true)
+   public void tearDownClass() throws CacheLoaderException {
+      cm.stop();
+   }
 
    @Override
    protected StreamingMarshaller getMarshaller() {
-      cm = TestCacheManagerFactory.createLocalCacheManager();
-      return extractCacheMarshaller(cm.getCache());
+      return marshaller;
    }
 
-   @AfterMethod(alwaysRun = true)
-   @Override
-   public void tearDown() throws CacheLoaderException {
-      try {
-         super.tearDown();
-      } finally {
-         cm.stop();
-      }
-   }
 }

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreVamTest2.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreVamTest2.java
@@ -22,10 +22,13 @@
  */
 package org.infinispan.loaders.jdbc.stringbased;
 
+import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
@@ -38,21 +41,24 @@ import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
  */
 @Test(groups = "functional", testName = "loaders.jdbc.stringbased.JdbcStringBasedCacheStoreVamTest2")
 public class JdbcStringBasedCacheStoreVamTest2 extends JdbcStringBasedCacheStoreTest2 {
-   private EmbeddedCacheManager cm;
+
+   EmbeddedCacheManager cm;
+   StreamingMarshaller marshaller;
+
+   @BeforeClass(alwaysRun = true)
+   public void setUpClass() {
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      marshaller = extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterClass(alwaysRun = true)
+   public void tearDownClass() throws CacheLoaderException {
+      cm.stop();
+   }
 
    @Override
    protected StreamingMarshaller getMarshaller() {
-      cm = TestCacheManagerFactory.createLocalCacheManager();
-      return extractCacheMarshaller(cm.getCache());
+      return marshaller;
    }
 
-   @AfterMethod(alwaysRun = true)
-   @Override
-   public void clearStore() throws Exception {
-      try {
-         super.clearStore();
-      } finally {
-         cm.stop();
-      }
-   }
 }

--- a/cachestore/jdbm/src/test/java/org/infinispan/loaders/jdbm/JdbmCacheStoreVamTest.java
+++ b/cachestore/jdbm/src/test/java/org/infinispan/loaders/jdbm/JdbmCacheStoreVamTest.java
@@ -26,7 +26,9 @@ import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
@@ -39,21 +41,24 @@ import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
  */
 @Test(groups = "unit", testName = "loaders.jdbm.JdbmCacheStoreVamTest")
 public class JdbmCacheStoreVamTest extends JdbmCacheStoreTest {
-   private EmbeddedCacheManager cm;
+
+   EmbeddedCacheManager cm;
+   StreamingMarshaller marshaller;
+
+   @BeforeClass(alwaysRun = true)
+   public void setUpClass() {
+      cm = TestCacheManagerFactory.createLocalCacheManager();
+      marshaller = extractCacheMarshaller(cm.getCache());
+   }
+
+   @AfterClass(alwaysRun = true)
+   public void tearDownClass() throws CacheLoaderException {
+      cm.stop();
+   }
 
    @Override
    protected StreamingMarshaller getMarshaller() {
-      cm = TestCacheManagerFactory.createLocalCacheManager();
-      return extractCacheMarshaller(cm.getCache());
+      return marshaller;
    }
 
-   @AfterMethod(alwaysRun = true)
-   @Override
-   public void tearDown() throws CacheLoaderException {
-      try {
-         super.tearDown();
-      } finally {
-         cm.stop();
-      }
-   }
 }

--- a/core/src/test/java/org/infinispan/loaders/BaseCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/BaseCacheStoreTest.java
@@ -46,6 +46,7 @@ import java.io.*;
 import java.util.*;
 
 import static java.util.Collections.emptySet;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * This is a base class containing various unit tests for each and every different CacheStore implementations. If you
@@ -443,7 +444,7 @@ public abstract class BaseCacheStoreTest extends AbstractInfinispanTest {
 
       Set<InternalCacheEntry> set = cs.load(2);
 
-      assert set.size() == 2;
+      assertEquals(2, set.size());
       Set expected = new HashSet();
       expected.add("k1");
       expected.add("k2");


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1381
- Fixed as well code issue that would lead to JDBC cache store preloading more data than it should.
