### PR TITLE
ISPN-1321 Creation and wiring of caches uses inefficient annotation scann

### DIFF
--- a/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
@@ -39,7 +39,6 @@ import org.infinispan.util.ReflectionUtil;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.reflect.AnnotatedMethodCache;
 import org.infinispan.util.reflect.CachedMethod;
-import org.jboss.jandex.AnnotationValue;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
@@ -473,7 +472,7 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
             PrioritizedMethod em = new PrioritizedMethod();
             em.component = c;
             em.method = m;
-            em.priority = getAnnotationValue(m.getMethodAnnotation().value("priority"));
+            em.priority = m.getAnnotationValueAsInt("priority");
             c.startMethods.add(em);
          }
 
@@ -481,17 +480,10 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
             PrioritizedMethod em = new PrioritizedMethod();
             em.component = c;
             em.method = m;
-            em.priority = getAnnotationValue(m.getMethodAnnotation().value("priority"));
+            em.priority = m.getAnnotationValueAsInt("priority");
             c.stopMethods.add(em);
          }
       }
-   }
-
-   private int getAnnotationValue(AnnotationValue value) {
-      if (value == null)
-         return 10;
-      else
-         return value.asInt();
    }
 
    /**

--- a/core/src/main/java/org/infinispan/util/ReflectionUtil.java
+++ b/core/src/main/java/org/infinispan/util/ReflectionUtil.java
@@ -57,7 +57,25 @@ public class ReflectionUtil {
       inspectRecursively(c, annotated, annotationType);
       return annotated;
    }
-   
+
+   /**
+    * Returns a set of Methods that contain the given method annotation.  This includes all public, protected, package
+    * and private methods, but not those of superclasses and interfaces.
+    *
+    * @param c              class to inspect
+    * @param annotationType the type of annotation to look for
+    * @return List of Method objects that require injection.
+    */
+   public static List<Method> getAllMethodsShallow(Class c, Class<? extends Annotation> annotationType) {
+      List<Method> annotated = new LinkedList<Method>();
+      for (Method m : c.getDeclaredMethods()) {
+         if (m.isAnnotationPresent(annotationType))
+            annotated.add(m);
+      }
+
+      return annotated;
+   }
+
    private static void getAnnotatedFieldHelper(List<Field> list, Class<?> c, Class<? extends Annotation> annotationType) {
       Field[] declaredFields = c.getDeclaredFields();
       for (Field field : declaredFields) {
@@ -66,15 +84,15 @@ public class ReflectionUtil {
          }
       }
    }
-   
-   public static List<Field> getAnnotatedFields(Class<?> c, Class<? extends Annotation> annotationType){
+
+   public static List<Field> getAnnotatedFields(Class<?> c, Class<? extends Annotation> annotationType) {
       List<Field> fields = new ArrayList<Field>();
-      for(;!c.equals(Object.class);c=c.getSuperclass()){
+      for (; !c.equals(Object.class); c = c.getSuperclass()) {
          getAnnotatedFieldHelper(fields, c, annotationType);
       }
       return fields;
    }
-   
+
    private static void getFieldsHelper(List<Field> list, Class<?> c, Class<?> type) {
       Field[] declaredFields = c.getDeclaredFields();
       for (Field field : declaredFields) {
@@ -83,10 +101,10 @@ public class ReflectionUtil {
          }
       }
    }
-   
-   public static List<Field> getFields(Class<?> c, Class<?> type){
+
+   public static List<Field> getFields(Class<?> c, Class<?> type) {
       List<Field> fields = new ArrayList<Field>();
-      for(;!c.equals(Object.class);c=c.getSuperclass()){
+      for (; !c.equals(Object.class); c = c.getSuperclass()) {
          getFieldsHelper(fields, c, type);
       }
       return fields;
@@ -118,20 +136,20 @@ public class ReflectionUtil {
     * @param annotationType
     */
    private static void inspectRecursively(Class c, List<Method> s, Class<? extends Annotation> annotationType) {
-      
+
       for (Method m : c.getDeclaredMethods()) {
          // don't bother if this method has already been overridden by a subclass
          if (notFound(m, s) && m.isAnnotationPresent(annotationType)) {
             s.add(m);
          }
-      }       
-      
+      }
+
       if (!c.equals(Object.class)) {
          if (!c.isInterface()) {
             inspectRecursively(c.getSuperclass(), s, annotationType);
             for (Class ifc : c.getInterfaces()) inspectRecursively(ifc, s, annotationType);
          }
-      }      
+      }
    }
 
    /**
@@ -157,8 +175,7 @@ public class ReflectionUtil {
             throw new NoSuchMethodException("Cannot find field " + fieldName + " on " + instance.getClass() + " or superclasses");
          f.setAccessible(true);
          f.set(instance, value);
-      }
-      catch (Exception e) {
+      } catch (Exception e) {
          log.unableToSetValue(e);
       }
    }
@@ -167,8 +184,7 @@ public class ReflectionUtil {
       Field f = null;
       try {
          f = c.getDeclaredField(fieldName);
-      }
-      catch (NoSuchFieldException e) {
+      } catch (NoSuchFieldException e) {
          if (!c.equals(Object.class)) f = findFieldRecursively(c.getSuperclass(), fieldName);
       }
       return f;
@@ -185,24 +201,23 @@ public class ReflectionUtil {
       try {
          method.setAccessible(true);
          return method.invoke(instance, parameters);
-      }
-      catch (Exception e) {
+      } catch (Exception e) {
          throw new CacheException("Unable to invoke method " + method + " on object " + //instance +
-               (parameters != null ? " with parameters " + Arrays.asList(parameters) : ""), e);
+                                        (parameters != null ? " with parameters " + Arrays.asList(parameters) : ""), e);
       }
    }
-   
-   public static Method findGetterForField(Class<?> c, String fieldName) throws NoSuchMethodException{      
-      for(Method m:c.getDeclaredMethods()){
+
+   public static Method findGetterForField(Class<?> c, String fieldName) throws NoSuchMethodException {
+      for (Method m : c.getDeclaredMethods()) {
          String name = m.getName();
          String s = null;
-         if(name.startsWith("get")){
-            s = name.substring(3);            
-         } else if (name.startsWith("is")){
-            s = name.substring(2);            
+         if (name.startsWith("get")) {
+            s = name.substring(3);
+         } else if (name.startsWith("is")) {
+            s = name.substring(2);
          }
-         
-         if (s!= null && s.equalsIgnoreCase(fieldName)){
+
+         if (s != null && s.equalsIgnoreCase(fieldName)) {
             return m;
          }
       }
@@ -222,8 +237,7 @@ public class ReflectionUtil {
       try {
          f.setAccessible(true);
          return f.get(instance);
-      }
-      catch (IllegalAccessException iae) {
+      } catch (IllegalAccessException iae) {
          throw new CacheException("Cannot access field " + f, iae);
       }
    }

--- a/core/src/main/java/org/infinispan/util/reflect/AnnotatedMethodCache.java
+++ b/core/src/main/java/org/infinispan/util/reflect/AnnotatedMethodCache.java
@@ -23,6 +23,7 @@ import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
+import org.infinispan.util.ReflectionUtil;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.jboss.jandex.AnnotationInstance;
@@ -34,6 +35,8 @@ import org.jboss.jandex.MethodInfo;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -127,27 +130,27 @@ public class AnnotatedMethodCache {
    }
 
    public static List<CachedMethod> getInjectMethods(Class<?> clazz, ClassLoader classLoader) {
-      return getCachedMethods(clazz, classLoader, INJECT_METHODS, INJECT_METHODS_INC_SUB);
+      return getCachedMethods(clazz, classLoader, INJECT_METHODS, INJECT_METHODS_INC_SUB, Inject.class);
    }
 
    public static List<CachedMethod> getStartMethods(Class<?> clazz, ClassLoader classLoader) {
-      return getCachedMethods(clazz, classLoader, START_METHODS, START_METHODS_INC_SUB);
+      return getCachedMethods(clazz, classLoader, START_METHODS, START_METHODS_INC_SUB, Start.class);
    }
 
    public static List<CachedMethod> getStopMethods(Class<?> clazz, ClassLoader classLoader) {
-      return getCachedMethods(clazz, classLoader, STOP_METHODS, STOP_METHODS_INC_SUB);
+      return getCachedMethods(clazz, classLoader, STOP_METHODS, STOP_METHODS_INC_SUB, Stop.class);
    }
 
    private static List<CachedMethod> getCachedMethods(Class<?> clazz, ClassLoader classLoader,
                                                       Map<String, List<CachedMethod>> basicMethodCache,
-                                                      Map<String, List<CachedMethod>> richMethodCache) {
+                                                      Map<String, List<CachedMethod>> richMethodCache,
+                                                      Class<? extends Annotation> annotation) {
       String className = clazz.getName();
       List<CachedMethod> l = richMethodCache.get(className);
       if (l == null) {
          synchronized (AnnotatedMethodCache.class) {
             l = richMethodCache.get(className);
             if (l == null) {
-
                l = basicMethodCache.get(className);
                if (l != null) {
                   // check superclasses/interfaces
@@ -155,9 +158,18 @@ public class AnnotatedMethodCache {
                      if (match(clazz, e.getKey(), classLoader)) l.addAll(e.getValue());
                   }
                } else {
+                  // check using vanilla JDK reflection.
                   l = new LinkedList<CachedMethod>();
+
                   for (Map.Entry<String, List<CachedMethod>> e : basicMethodCache.entrySet()) {
                      if (match(clazz, e.getKey(), classLoader)) l.addAll(e.getValue());
+                  }
+
+                  // Now see if the class itself has anything on it, using reflection.  This is to deal with
+                  // annotated components declared in modules other than core, that aren't indexed using Jandex.
+                  for (Method m: ReflectionUtil.getAllMethodsShallow(clazz, annotation)) {
+                     CachedMethod cm = new CachedMethod(m);
+                     if (!l.contains(cm)) l.add(cm);
                   }
                }
                richMethodCache.put(className, l);

--- a/core/src/main/java/org/infinispan/util/reflect/CachedMethod.java
+++ b/core/src/main/java/org/infinispan/util/reflect/CachedMethod.java
@@ -21,6 +21,7 @@ package org.infinispan.util.reflect;
 
 import org.infinispan.util.ReflectionUtil;
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
@@ -39,12 +40,22 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class CachedMethod {
    private final AnnotationInstance annotationInstance;
-   private Method method;
+   private final boolean indexed;
+   private final Method method;
    private final Class[] params;
    private final Annotation[][] paramAnnotations;
    private final static Map<ClassInfo, Class<?>> CLASS_CACHE = new ConcurrentHashMap<ClassInfo, Class<?>>();
 
+   CachedMethod(Method reflectMethod) {
+      method = reflectMethod;
+      params = reflectMethod.getParameterTypes();
+      paramAnnotations = reflectMethod.getParameterAnnotations();
+      annotationInstance = null;
+      indexed = false;
+   }
+
    CachedMethod(AnnotationInstance annotationInstance, ClassLoader classLoader, MethodInfo methodInfo) throws ClassNotFoundException {
+      indexed = true;
       this.annotationInstance = annotationInstance;
       ClassInfo classInfo = methodInfo.declaringClass();
       Class<?> c;
@@ -72,11 +83,36 @@ public class CachedMethod {
       return params;
    }
 
-   public AnnotationInstance getMethodAnnotation() {
-      return annotationInstance;
-   }
-
    public final Annotation[][] getParamAnnotations() {
       return paramAnnotations;
+   }
+
+   public int getAnnotationValueAsInt(String property) {
+      if (indexed) {
+         AnnotationValue value = annotationInstance == null ? null : annotationInstance.value(property);
+         if (value == null)
+            return 10;
+         else
+            return value.asInt();
+      } else {
+         throw new UnsupportedOperationException("Operation not supported for non-core component " + method);
+      }
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      CachedMethod that = (CachedMethod) o;
+
+      if (method != null ? !method.equals(that.method) : that.method != null) return false;
+
+      return true;
+   }
+
+   @Override
+   public int hashCode() {
+      return method != null ? method.hashCode() : 0;
    }
 }


### PR DESCRIPTION
ISPN-1321 Creation and wiring of caches uses inefficient annotation scanning and reflection calls
- Allow fallback to JDK reflection if annotated method not found on a given component.
