### PR TITLE
ISPN 1377, ISPN-1420: Upgrade to Spring 3.1.0.M2 & fix ConfigurationOverride

### DIFF
--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -77,7 +77,7 @@
 		<!-- Dependency versions -->
 		<!-- ######################################################### -->
 		<!-- Spring -->
-      <version.spring>3.1.0.M1</version.spring>
+      <version.spring>3.1.0.M2</version.spring>
       <version.commons.dbcp>1.4</version.commons.dbcp>
    </properties>
 

--- a/spring/src/main/java/org/infinispan/spring/AbstractEmbeddedCacheManagerFactory.java
+++ b/spring/src/main/java/org/infinispan/spring/AbstractEmbeddedCacheManagerFactory.java
@@ -55,6 +55,7 @@ import org.springframework.core.io.Resource;
  * </p>
  * 
  * @author <a href="mailto:olaf DOT bergner AT gmx DOT de">Olaf Bergner</a>
+ * @author Marius Bogoevici
  * 
  */
 public class AbstractEmbeddedCacheManagerFactory {
@@ -522,11 +523,11 @@ public class AbstractEmbeddedCacheManagerFactory {
    }
 
    /**
-    * @param evictionWakeUpInterval
-    * @see org.infinispan.spring.ConfigurationOverrides#setEvictionWakeUpInterval(java.lang.Long)
+    * @param expirationWakeUpInterval
+    * @see org.infinispan.spring.ConfigurationOverrides#setExpirationWakeUpInterval(Long) (java.lang.Long)
     */
-   public void setEvictionWakeUpInterval(final Long evictionWakeUpInterval) {
-      this.configurationOverrides.setEvictionWakeUpInterval(evictionWakeUpInterval);
+   public void setExpirationWakeUpInterval(final Long expirationWakeUpInterval) {
+      this.configurationOverrides.setExpirationWakeUpInterval(expirationWakeUpInterval);
    }
 
    /**

--- a/spring/src/main/java/org/infinispan/spring/ConfigurationOverrides.java
+++ b/spring/src/main/java/org/infinispan/spring/ConfigurationOverrides.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.infinispan.config.CacheLoaderManagerConfig;
 import org.infinispan.config.Configuration;
 import org.infinispan.config.CustomInterceptorConfig;
+import org.infinispan.config.FluentConfiguration;
 import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.eviction.EvictionThreadPolicy;
 import org.infinispan.transaction.lookup.TransactionManagerLookup;
@@ -82,7 +83,7 @@ public final class ConfigurationOverrides {
 
    private String cacheModeString;
 
-   private Long evictionWakeUpInterval;
+   private Long expirationWakeUpInterval;
 
    private EvictionStrategy evictionStrategy;
 
@@ -291,11 +292,11 @@ public final class ConfigurationOverrides {
    }
 
    /**
-    * @param evictionWakeUpInterval
-    *           the evictionWakeUpInterval to set
+    * @param expirationWakeUpInterval
+    *           the expiration expirationWakeUpInterval to set
     */
-   public void setEvictionWakeUpInterval(final Long evictionWakeUpInterval) {
-      this.evictionWakeUpInterval = evictionWakeUpInterval;
+   public void setExpirationWakeUpInterval(final Long expirationWakeUpInterval) {
+      this.expirationWakeUpInterval = expirationWakeUpInterval;
    }
 
    /**
@@ -669,10 +670,11 @@ public final class ConfigurationOverrides {
                   + this.cacheModeString + "]");
          configurationToOverride.setCacheModeString(this.cacheModeString);
       }
-      if (this.evictionWakeUpInterval != null) {
-         this.logger.debug("Overriding property [evictionWakeUpInterval] with value ["
-                  + this.evictionWakeUpInterval + "]");
-         configurationToOverride.setEvictionWakeUpInterval(this.evictionWakeUpInterval);
+      if (this.expirationWakeUpInterval != null) {
+         this.logger.debug("Overriding property [expirationWakeUpInterval] with value ["
+                  + this.expirationWakeUpInterval + "]");
+         FluentConfiguration fluentConfiguration = new FluentConfiguration(configurationToOverride);
+         fluentConfiguration.expiration().wakeUpInterval(expirationWakeUpInterval);
       }
       if (this.evictionStrategy != null) {
          this.logger.debug("Overriding property [evictionStrategy] with value ["

--- a/spring/src/main/java/org/infinispan/spring/provider/SpringCache.java
+++ b/spring/src/main/java/org/infinispan/spring/provider/SpringCache.java
@@ -24,6 +24,7 @@
 package org.infinispan.spring.provider;
 
 import org.springframework.cache.Cache;
+import org.springframework.cache.interceptor.DefaultValueWrapper;
 import org.springframework.util.Assert;
 
 /**
@@ -34,16 +35,17 @@ import org.springframework.util.Assert;
  * </p>
  * 
  * @author <a href="mailto:olaf DOT bergner AT gmx DOT de">Olaf Bergner</a>
+ * @author <a href="mailto:marius.bogoevici@gmail.com">Marius Bogoevici</a>
  * 
  */
-public class SpringCache<K, V> implements Cache<K, V> {
+public class SpringCache implements Cache {
 
-   private final org.infinispan.Cache<K, V> nativeCache;
+   private final org.infinispan.Cache<Object, Object> nativeCache;
 
    /**
     * @param nativeCache
     */
-   public SpringCache(final org.infinispan.Cache<K, V> nativeCache) {
+   public SpringCache(final org.infinispan.Cache<Object, Object> nativeCache) {
       Assert.notNull(nativeCache, "A non-null Infinispan cache implementation is required");
       this.nativeCache = nativeCache;
    }
@@ -60,74 +62,35 @@ public class SpringCache<K, V> implements Cache<K, V> {
     * @see org.springframework.cache.Cache#getNativeCache()
     */
    @Override
-   public org.infinispan.Cache<K, V> getNativeCache() {
+   public org.infinispan.Cache<?, ?> getNativeCache() {
       return this.nativeCache;
-   }
-
-   /**
-    * @see org.springframework.cache.Cache#containsKey(java.lang.Object)
-    */
-   @Override
-   public boolean containsKey(final Object key) {
-      return this.nativeCache.containsKey(key);
    }
 
    /**
     * @see org.springframework.cache.Cache#get(java.lang.Object)
     */
    @Override
-   public V get(final Object key) {
-      return this.nativeCache.get(key);
+   public ValueWrapper get(final Object key) {
+      Object v = nativeCache.get(key);
+	  return (v != null ? new DefaultValueWrapper(v) : null);
    }
 
    /**
     * @see org.springframework.cache.Cache#put(java.lang.Object, java.lang.Object)
     */
    @Override
-   public V put(final K key, final V value) {
-      return this.nativeCache.put(key, value);
+   public void put(final Object key, final Object value) {
+      this.nativeCache.put(key, value);
    }
 
    /**
-    * @see org.springframework.cache.Cache#putIfAbsent(java.lang.Object, java.lang.Object)
+    * @see org.springframework.cache.Cache#evict(java.lang.Object)
     */
    @Override
-   public V putIfAbsent(final K key, final V value) {
-      return this.nativeCache.putIfAbsent(key, value);
+   public void evict(final Object key) {
+     this.nativeCache.remove(key);
    }
 
-   /**
-    * @see org.springframework.cache.Cache#remove(java.lang.Object)
-    */
-   @Override
-   public V remove(final Object key) {
-      return this.nativeCache.remove(key);
-   }
-
-   /**
-    * @see org.springframework.cache.Cache#remove(java.lang.Object, java.lang.Object)
-    */
-   @Override
-   public boolean remove(final Object key, final Object value) {
-      return this.nativeCache.remove(key, value);
-   }
-
-   /**
-    * @see org.springframework.cache.Cache#replace(java.lang.Object, java.lang.Object,
-    *      java.lang.Object)
-    */
-   @Override
-   public boolean replace(final K key, final V oldValue, final V newValue) {
-      return this.nativeCache.replace(key, oldValue, newValue);
-   }
-
-   /**
-    * @see org.springframework.cache.Cache#replace(java.lang.Object, java.lang.Object)
-    */
-   @Override
-   public V replace(final K key, final V value) {
-      return this.nativeCache.replace(key, value);
-   }
 
    /**
     * @see org.springframework.cache.Cache#clear()

--- a/spring/src/main/java/org/infinispan/spring/provider/SpringEmbeddedCacheManager.java
+++ b/spring/src/main/java/org/infinispan/spring/provider/SpringEmbeddedCacheManager.java
@@ -25,6 +25,7 @@ package org.infinispan.spring.provider;
 
 import java.util.Collection;
 
+import org.infinispan.Cache;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.springframework.cache.CacheManager;
 import org.springframework.util.Assert;
@@ -43,6 +44,7 @@ import org.springframework.util.Assert;
  * </p>
  * 
  * @author <a href="mailto:olaf DOT bergner AT gmx DOT de">Olaf Bergner</a>
+ * @author Marius Bogoevici
  * 
  */
 public class SpringEmbeddedCacheManager implements CacheManager {
@@ -59,8 +61,8 @@ public class SpringEmbeddedCacheManager implements CacheManager {
    }
 
    @Override
-   public <K, V> SpringCache<K, V> getCache(final String name) {
-      return new SpringCache<K, V>(this.nativeCacheManager.<K, V> getCache(name));
+   public SpringCache getCache(final String name) {
+      return new SpringCache(this.nativeCacheManager.getCache(name));
    }
 
    @Override

--- a/spring/src/main/java/org/infinispan/spring/provider/SpringRemoteCacheManager.java
+++ b/spring/src/main/java/org/infinispan/spring/provider/SpringRemoteCacheManager.java
@@ -37,6 +37,7 @@ import org.springframework.util.Assert;
  * </p>
  * 
  * @author <a href="mailto:olaf DOT bergner AT gmx DOT de">Olaf Bergner</a>
+ * @author Marius Bogoevici
  * 
  */
 public class SpringRemoteCacheManager implements org.springframework.cache.CacheManager {
@@ -56,8 +57,8 @@ public class SpringRemoteCacheManager implements org.springframework.cache.Cache
     * @see org.springframework.cache.CacheManager#getCache(java.lang.String)
     */
    @Override
-   public <K, V> Cache<K, V> getCache(final String name) {
-      return new SpringCache<K, V>(this.nativeCacheManager.<K, V> getCache(name));
+   public Cache getCache(final String name) {
+      return new SpringCache(this.nativeCacheManager.getCache(name));
    }
 
    /**

--- a/spring/src/main/java/org/infinispan/spring/support/embedded/InfinispanNamedEmbeddedCacheFactoryBean.java
+++ b/spring/src/main/java/org/infinispan/spring/support/embedded/InfinispanNamedEmbeddedCacheFactoryBean.java
@@ -102,6 +102,7 @@ import org.springframework.util.StringUtils;
  * </p>
  * 
  * @author <a href="mailto:olaf DOT bergner AT gmx DOT de">Olaf Bergner</a>
+ * @author Marius Bogoevici
  * 
  */
 public class InfinispanNamedEmbeddedCacheFactoryBean<K, V> implements FactoryBean<Cache<K, V>>,
@@ -496,11 +497,11 @@ public class InfinispanNamedEmbeddedCacheFactoryBean<K, V> implements FactoryBea
    }
 
    /**
-    * @param evictionWakeUpInterval
-    * @see org.infinispan.spring.ConfigurationOverrides#setEvictionWakeUpInterval(java.lang.Long)
+    * @param expirationWakeUpInterval
+    * @see org.infinispan.spring.ConfigurationOverrides#setExpirationWakeUpInterval(Long)
     */
-   public void setEvictionWakeUpInterval(final Long evictionWakeUpInterval) {
-      this.configurationOverrides.setEvictionWakeUpInterval(evictionWakeUpInterval);
+   public void setExpirationWakeUpInterval(final Long expirationWakeUpInterval) {
+      this.configurationOverrides.setExpirationWakeUpInterval(expirationWakeUpInterval);
    }
 
    /**

--- a/spring/src/test/java/org/infinispan/spring/ConfigurationOverridesTest.java
+++ b/spring/src/test/java/org/infinispan/spring/ConfigurationOverridesTest.java
@@ -422,18 +422,18 @@ public class ConfigurationOverridesTest {
    @Test
    public final void configurationOverridesShouldOverrideEvictionWakeUpIntervalPropIfExplicitlySet()
             throws Exception {
-      final long expectedEvictionWakeUpInterval = 100000L;
+      final long expectedExpirationWakeUpInterval = 100000L;
 
       final ConfigurationOverrides objectUnderTest = new ConfigurationOverrides();
-      objectUnderTest.setEvictionWakeUpInterval(expectedEvictionWakeUpInterval);
+      objectUnderTest.setExpirationWakeUpInterval(expectedExpirationWakeUpInterval);
       final Configuration defaultConfiguration = new Configuration();
       objectUnderTest.applyOverridesTo(defaultConfiguration);
 
       AssertJUnit
                .assertEquals(
                         "ConfigurationOverrides should have overridden default value with explicitly set EvictionWakeUpInterval property. However, it didn't.",
-                        expectedEvictionWakeUpInterval,
-                        defaultConfiguration.getEvictionWakeUpInterval());
+                        expectedExpirationWakeUpInterval,
+                        defaultConfiguration.getExpirationWakeUpInterval());
    }
 
    /**

--- a/spring/src/test/java/org/infinispan/spring/provider/SpringCacheCacheTest.java
+++ b/spring/src/test/java/org/infinispan/spring/provider/SpringCacheCacheTest.java
@@ -31,6 +31,7 @@ import static org.testng.AssertJUnit.assertTrue;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.spring.support.embedded.InfinispanNamedEmbeddedCacheFactoryBean;
 import org.springframework.cache.Cache;
+import org.springframework.cache.interceptor.DefaultValueWrapper;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -46,6 +47,7 @@ import org.testng.annotations.Test;
  * </p>
  * 
  * @author <a href="mailto:olaf DOT bergner AT gmx DOT de">Olaf Bergner</a>
+ * @author Marius Bogoevici
  * 
  */
 @Test(testName = "spring.provider.SpringCacheCacheTest", groups = "unit")
@@ -57,7 +59,7 @@ public class SpringCacheCacheTest {
 
    private org.infinispan.Cache<Object, Object> nativeCache;
 
-   private Cache<Object, Object> cache;
+   private Cache cache;
 
    @BeforeMethod
    public void setUp() throws Exception {
@@ -91,7 +93,7 @@ public class SpringCacheCacheTest {
 
       assertNull(this.cache.get(key));
       this.cache.put(key, value);
-      assertEquals(value, this.cache.get(key));
+      assertEquals(value, this.cache.get(key).get());
    }
 
    @Test
@@ -101,18 +103,7 @@ public class SpringCacheCacheTest {
 
       this.cache.put(key, value);
 
-      assertTrue(this.cache.containsKey(key));
-   }
-
-   @Test
-   public void testCacheRemove() throws Exception {
-      final Object key = "enescu";
-      final Object value = "george";
-
-      assertNull(this.cache.get(key));
-      this.cache.put(key, value);
-      assertEquals(value, this.cache.remove(key));
-      assertNull(this.cache.get(key));
+      assertTrue(this.cache.get(key) != null);
    }
 
    @Test
@@ -126,66 +117,7 @@ public class SpringCacheCacheTest {
       assertNull(this.cache.get("enescu"));
    }
 
-   @Test
-   public void testPutIfAbsent() throws Exception {
-      final Object key = "enescu";
-      final Object value1 = "george";
-      final Object value2 = "geo";
 
-      assertNull(this.cache.get(key));
-      this.cache.put(key, value1);
-      this.cache.putIfAbsent(key, value2);
-      assertEquals(value1, this.cache.get(key));
-   }
-
-   @Test
-   public void testConcurrentRemove() throws Exception {
-      final Object key = "enescu";
-      final Object value1 = "george";
-      final Object value2 = "geo";
-
-      assertNull(this.cache.get(key));
-      this.cache.put(key, value1);
-      // no remove
-      this.cache.remove(key, value2);
-      assertEquals(value1, this.cache.get(key));
-      // one remove
-      this.cache.remove(key, value1);
-      assertNull(this.cache.get(key));
-   }
-
-   @Test
-   public void testConcurrentReplace() throws Exception {
-      final Object key = "enescu";
-      final Object value1 = "george";
-      final Object value2 = "geo";
-
-      assertNull(this.cache.get(key));
-      this.cache.put(key, value1);
-      this.cache.replace(key, value2);
-      assertEquals(value2, this.cache.get(key));
-      this.cache.remove(key);
-      this.cache.replace(key, value1);
-      assertNull(this.cache.get(key));
-   }
-
-   @Test
-   public void testConcurrentReplaceIfEqual() throws Exception {
-      final Object key = "enescu";
-      final Object value1 = "george";
-      final Object value2 = "geo";
-
-      assertNull(this.cache.get(key));
-      this.cache.put(key, value1);
-      assertEquals(value1, this.cache.get(key));
-      // no replace
-      this.cache.replace(key, value2, value1);
-      assertEquals(value1, this.cache.get(key));
-      this.cache.replace(key, value1, value2);
-      assertEquals(value2, this.cache.get(key));
-      this.cache.replace(key, value2, value1);
-      assertEquals(value1, this.cache.get(key));
-   }
 
    private org.infinispan.Cache<Object, Object> createNativeCache() throws Exception {
       this.fb.setInfinispanEmbeddedCacheManager(new DefaultCacheManager());
@@ -195,8 +127,8 @@ public class SpringCacheCacheTest {
       return this.fb.getObject();
    }
 
-   private Cache<Object, Object> createCache(final org.infinispan.Cache<Object, Object> nativeCache) {
-      return new SpringCache<Object, Object>(nativeCache);
+   private Cache createCache(final org.infinispan.Cache<Object, Object> nativeCache) {
+      return new SpringCache(nativeCache);
    }
 
 }

--- a/spring/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBeanTest.java
+++ b/spring/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBeanTest.java
@@ -53,6 +53,7 @@ import org.testng.annotations.Test;
  * </p>
  * 
  * @author <a href="mailto:olaf DOT bergner AT gmx DOT de">Olaf Bergner</a>
+ * @author Marius Bogoevici
  * 
  */
 @Test(testName = "spring.provider.SpringEmbeddedCacheManagerFactoryBeanTest", groups = "unit")
@@ -106,7 +107,7 @@ public class SpringEmbeddedCacheManagerFactoryBeanTest {
                "getObject() should have returned a valid SpringEmbeddedCacheManager, configured using the configuration file "
                         + "set on SpringEmbeddedCacheManagerFactoryBean. However, it returned null.",
                springEmbeddedCacheManager);
-      final SpringCache<Object, Object> cacheDefinedInCustomConfiguration = springEmbeddedCacheManager
+      final SpringCache cacheDefinedInCustomConfiguration = springEmbeddedCacheManager
                .getCache(CACHE_NAME_FROM_CONFIGURATION_FILE);
       final Configuration configuration = cacheDefinedInCustomConfiguration.getNativeCache()
                .getConfiguration();

--- a/spring/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerTest.java
+++ b/spring/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerTest.java
@@ -42,6 +42,7 @@ import org.testng.annotations.Test;
  * </p>
  * 
  * @author <a href="mailto:olaf DOT bergner AT gmx DOT de">Olaf Bergner</a>
+ * @author Marius Bogoevici
  * 
  */
 @Test(testName = "spring.provider.SpringEmbeddedCacheManagerTest", groups = "unit")
@@ -75,7 +76,7 @@ public class SpringEmbeddedCacheManagerTest {
       final SpringEmbeddedCacheManager objectUnderTest = new SpringEmbeddedCacheManager(
                nativeCacheManager);
 
-      final Cache<Object, Object> cacheExpectedToHaveTheProvidedName = objectUnderTest
+      final Cache cacheExpectedToHaveTheProvidedName = objectUnderTest
                .getCache(CACHE_NAME_FROM_CONFIGURATION_FILE);
 
       assertEquals(
@@ -106,7 +107,7 @@ public class SpringEmbeddedCacheManagerTest {
       final org.infinispan.Cache<Object, Object> infinispanCacheAddedLater = nativeCacheManager
                .getCache(nameOfInfinispanCacheAddedLater);
 
-      final Cache<Object, Object> springCacheAddedLater = objectUnderTest
+      final Cache springCacheAddedLater = objectUnderTest
                .getCache(nameOfInfinispanCacheAddedLater);
 
       assertEquals(

--- a/spring/src/test/java/org/infinispan/spring/provider/SpringRemoteCacheManagerTest.java
+++ b/spring/src/test/java/org/infinispan/spring/provider/SpringRemoteCacheManagerTest.java
@@ -48,6 +48,7 @@ import org.testng.annotations.Test;
  * </p>
  * 
  * @author <a href="mailto:olaf DOT bergner AT gmx DOT de">Olaf Bergner</a>
+ * @author Marius Bogoevici
  * 
  */
 @Test(testName = "spring.provider.SpringRemoteCacheManagerTest", groups = "functional")
@@ -98,7 +99,7 @@ public class SpringRemoteCacheManagerTest extends SingleCacheManagerTest {
       final SpringRemoteCacheManager objectUnderTest = new SpringRemoteCacheManager(
                remoteCacheManager);
 
-      final Cache<Object, Object> defaultCache = objectUnderTest.getCache(TEST_CACHE_NAME);
+      final Cache defaultCache = objectUnderTest.getCache(TEST_CACHE_NAME);
 
       assertNotNull("getCache(" + TEST_CACHE_NAME
                + ") should have returned a default cache. However, it returned null.", defaultCache);

--- a/spring/src/test/java/org/infinispan/spring/provider/sample/CachingBookDaoContextTest.java
+++ b/spring/src/test/java/org/infinispan/spring/provider/sample/CachingBookDaoContextTest.java
@@ -8,6 +8,7 @@ import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
 import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
 import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
+import org.infinispan.spring.provider.SpringCache;
 import org.infinispan.spring.provider.SpringEmbeddedCacheManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -29,6 +30,7 @@ import org.testng.annotations.Test;
  * </p>
  * 
  * @author <a href="mailto:olaf DOT bergner AT gmx DOT de">Olaf Bergner</a>
+ * @author Marius Bogoevici
  * @since 5.1
  */
 @Test(testName = "spring.provider.CachingBookDaoContextTest", groups = "integration")
@@ -141,7 +143,7 @@ public class CachingBookDaoContextTest extends AbstractTestNGSpringContextTests 
                + ") should have removed updated book from cache";
    }
 
-   private Cache<Object, Object> booksCache() {
+   private Cache<?,?> booksCache() {
       return this.booksCacheManager.getCache("books").getNativeCache();
    }
 }


### PR DESCRIPTION
ISPN 1377, ISPN-1420: Upgrade to Spring 3.1.0.M2 & fix ConfigurationOverride to match Infinispan 5.1
- abide by Spring 3.1 M2 Cache/CacheManager interfaces
- replaced evictionWakeUpInterval with expirationWakeUpInterval (non-backwards compatible)

The two issues are part of the same commit because the tests are currently broken (so adding the fixes requires to fix the tests as well)
