### PR TITLE
ISPN-1422 Upgrade to JGroups 3.0.0.CR4

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsAddress.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsAddress.java
@@ -27,7 +27,6 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
 
-import org.infinispan.CacheException;
 import org.infinispan.marshall.AbstractExternalizer;
 import org.infinispan.marshall.Ids;
 import org.infinispan.remoting.transport.Address;
@@ -82,7 +81,11 @@ public class JGroupsAddress implements Address {
    public static class Externalizer extends AbstractExternalizer<JGroupsAddress> {
       @Override
       public void writeObject(ObjectOutput output, JGroupsAddress address) throws IOException {
-         org.jgroups.util.Util.writeAddress(address.address, output);
+         try {
+            org.jgroups.util.Util.writeAddress(address.address, output);
+         } catch (Exception e) {
+            throw new IOException(e);
+         }
       }
 
       @Override
@@ -90,13 +93,10 @@ public class JGroupsAddress implements Address {
          JGroupsAddress address = new JGroupsAddress();
          try {
             address.address = org.jgroups.util.Util.readAddress(unmarshaller);
-         // TODO: Remove catches once JGroups removes them
-         } catch (IllegalAccessException e) {
-            throw new CacheException(e);
-         } catch (InstantiationException e) {
-            throw new CacheException(e);
+            return address;
+         } catch (Exception e) {
+            throw new IOException(e);
          }
-         return address;
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTopologyAwareAddress.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTopologyAwareAddress.java
@@ -19,7 +19,6 @@
 
 package org.infinispan.remoting.transport.jgroups;
 
-import org.infinispan.CacheException;
 import org.infinispan.marshall.Ids;
 import org.infinispan.remoting.transport.TopologyAwareAddress;
 import org.jgroups.Address;
@@ -82,7 +81,11 @@ public class JGroupsTopologyAwareAddress extends JGroupsAddress implements Topol
    public static class Externalizer implements org.infinispan.marshall.AdvancedExternalizer<JGroupsTopologyAwareAddress> {
       @Override
       public void writeObject(ObjectOutput output, JGroupsTopologyAwareAddress address) throws IOException {
-         org.jgroups.util.Util.writeAddress(address.address, output);
+         try {
+            org.jgroups.util.Util.writeAddress(address.address, output);
+         } catch (Exception e) {
+            throw new IOException(e);
+         }
       }
 
       public JGroupsTopologyAwareAddress readObject(ObjectInput unmarshaller) throws IOException, ClassNotFoundException {
@@ -90,11 +93,8 @@ public class JGroupsTopologyAwareAddress extends JGroupsAddress implements Topol
             Address jgroupsAddress = org.jgroups.util.Util.readAddress(unmarshaller);
             JGroupsTopologyAwareAddress address = new JGroupsTopologyAwareAddress(jgroupsAddress);
             return address;
-         // TODO: Remove catches once JGroups removes them
-         } catch (IllegalAccessException e) {
-            throw new CacheException(e);
-         } catch (InstantiationException e) {
-            throw new CacheException(e);
+         } catch (Exception e) {
+            throw new IOException(e);
          }
       }
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/ConcurrentJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/ConcurrentJoinTest.java
@@ -82,7 +82,7 @@ public class ConcurrentJoinTest extends RehashTestBase {
    @SuppressWarnings("unchecked")
    void waitForRehashCompletion() {
       List<CacheContainer> allCacheManagers = new ArrayList<CacheContainer>(cacheManagers);
-      allCacheManagers.addAll(joinerManagers);
+      // Collection already contains all cache managers, no need to add more
       TestingUtil.blockUntilViewsReceived(60000, false, allCacheManagers);
       waitForJoinTasksToComplete(SECONDS.toMillis(480), joiners.toArray(new Cache[NUM_JOINERS]));
       int[] joinersPos = new int[NUM_JOINERS];

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -136,7 +136,7 @@
       <version.jclouds>1.1.0</version.jclouds>
       <version.jetty>6.1.25</version.jetty>
       <version.jgoodies.forms>1.0.5</version.jgoodies.forms>
-      <version.jgroups>3.0.0.CR3</version.jgroups>
+      <version.jgroups>3.0.0.CR4</version.jgroups>
       <version.json>20090211</version.json>
       <version.jstl>1.2</version.jstl>
       <version.jta>1.0.1.GA</version.jta>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1422
- Fixed ConcurrentJoinTest which was waiting for a view of 12 nodes instead of 8 nodes (side effect of ISPN-1194).
