### PR TITLE
ISPN-1445

### DIFF
--- a/core/src/main/java/org/infinispan/loaders/file/FileCacheStore.java
+++ b/core/src/main/java/org/infinispan/loaders/file/FileCacheStore.java
@@ -201,7 +201,7 @@ public class FileCacheStore extends BucketBasedCacheStore {
       if (trace) log.trace("purgeInternal()");
 
       try {
-         File[] files = root.listFiles();
+         File[] files = root.listFiles(new NumericNamedFilesFilter());
          if (files == null)
             throw new CacheLoaderException("Root not directory or IO error occurred");
 
@@ -223,9 +223,7 @@ public class FileCacheStore extends BucketBasedCacheStore {
                            updateBucket(bucket);
                         }
                      } catch (InterruptedException ie) {
-                        if (log.isDebugEnabled()) {
-                           log.debug("Interrupted, so finish work.");
-                        }
+                        log.debug("Interrupted, so finish work.");
                      } catch (CacheLoaderException e) {
                         log.problemsPurgingFile(bucketFile, e);
                      } finally {
@@ -255,9 +253,7 @@ public class FileCacheStore extends BucketBasedCacheStore {
             }
          }
       } catch (InterruptedException ie) {
-         if (log.isDebugEnabled()) {
-            log.debug("Interrupted, so stop loading and finish with purging.");
-         }
+         log.debug("Interrupted, so stop loading and finish with purging.");
          Thread.currentThread().interrupt();
       }
    }
@@ -625,6 +621,25 @@ public class FileCacheStore extends BucketBasedCacheStore {
       public void stop() {
          // No-op
       }
+   }
+
+   /**
+    * Makes sure that files opened are actually named as numbers (ignore all other files)
+    */
+   private static class NumericNamedFilesFilter implements FilenameFilter {
+
+      @Override
+      public boolean accept(File dir, String name) {
+         try {
+            Integer.parseInt(name);
+            return true;
+         }
+         catch (NumberFormatException nfe) {
+            log.chacheLoaderIgnoringUnexpectedFile(dir.getAbsolutePath(), name);
+            return false;
+         }
+      }
+
    }
 
 

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -772,4 +772,9 @@ public interface Log extends BasicLogger {
    @LogMessage(level = INFO)
    @Message(value = "Could not instantiate transaction manager", id = 162)
    void couldNotInstantiateTransactionManager(@Cause Exception e);
+
+   @LogMessage(level = WARN)
+   @Message(value = "FileCacheStore ignored an unexpected file %2$s in path %1$s. The store path should be dedicated!", id = 163)
+   void chacheLoaderIgnoringUnexpectedFile(String parentPath, String name);
+
 }

--- a/core/src/test/java/org/infinispan/loaders/file/FileCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/file/FileCacheStoreTest.java
@@ -41,6 +41,7 @@ import org.testng.annotations.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.HashSet;
@@ -96,12 +97,23 @@ public class FileCacheStoreTest extends BaseCacheStoreTest {
       assert cs.containsKey("k1");
       assert cs.containsKey("k2");
       assert cs.containsKey("k3");
+      createUnrelatedFile();
       Thread.sleep(lifespan + 100);
       cs.purgeExpired();
       FileCacheStore fcs = (FileCacheStore) cs;
       assert fcs.load("k1") == null;
       assert fcs.load("k2") == null;
       assert fcs.load("k3") == null;
+   }
+
+   private void createUnrelatedFile() throws IOException {
+      File cacheStoreDirectory = new File(tmpDirectory);
+      assert cacheStoreDirectory.exists();
+      assert cacheStoreDirectory.canWrite();
+      String newfile = cacheStoreDirectory.getAbsolutePath() + File.separator + "mockCache-org.infinispan.loaders.file.FileCacheStoreTest" + File.separator + "externalExistingFile";
+      File file = new File(newfile);
+      boolean created = file.createNewFile();
+      assert created;
    }
 
    public void testBucketRemoval() throws Exception {


### PR DESCRIPTION
ISPN-1445 NumberFormatException thrown by FileCacheStore when unexpected files are stored in the same directory

https://issues.jboss.org/browse/ISPN-1445
