### PR TITLE
ISPN-1462 - JGroupsTransport doesn't initialize properly when it receives

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -183,10 +183,11 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
             throw new CacheException("Channel connected, but unable to register MBeans", e);
          }
       }
-      else {
-         channelConnectedLatch.countDown();
-      }
       address = fromJGroupsAddress(channel.getAddress());
+      if (!startChannel) {
+         // the channel was already started externally, we need to initialize our member list
+         viewAccepted(channel.getView());
+      }
       if (log.isInfoEnabled())
          log.localAndPhysicalAddress(getAddress(), getPhysicalAddresses());
    }


### PR DESCRIPTION
ISPN-1462 - JGroupsTransport doesn't initialize properly when it receives an already-connected JGroups channel

https://issues.jboss.org/browse/ISPN-1462

When the channel was connected before handing it to JGroupsTransport viewAccepted() was not called and the members list was not initialized.
