### PR TITLE
Fix https://issues.jboss.org/browse/ISPN-1463 by making sure that the tem

### DIFF
--- a/core/src/test/java/org/infinispan/loaders/file/FileCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/file/FileCacheStoreTest.java
@@ -110,7 +110,7 @@ public class FileCacheStoreTest extends BaseCacheStoreTest {
       File cacheStoreDirectory = new File(tmpDirectory);
       assert cacheStoreDirectory.exists();
       assert cacheStoreDirectory.canWrite();
-      String newfile = cacheStoreDirectory.getAbsolutePath() + File.separator + "mockCache-org.infinispan.loaders.file.FileCacheStoreTest" + File.separator + "externalExistingFile";
+      String newfile = cacheStoreDirectory.getAbsolutePath() + File.separator + "mockCache-" + this.getClass().getName() + File.separator + "externalExistingFile";
       File file = new File(newfile);
       boolean created = file.createNewFile();
       assert created;


### PR DESCRIPTION
Fix https://issues.jboss.org/browse/ISPN-1463 by making sure that the temporary file is
created in the appropriate directory for the test (the test is subclassed)
