### PR TITLE
ISPN-1467: package the REST server classes in a separate artifact

### DIFF
--- a/server/rest/pom.xml
+++ b/server/rest/pom.xml
@@ -77,6 +77,13 @@
             <artifactId>jetty-maven-plugin</artifactId>
             <version>8.0.0.M3</version>
          </plugin>
+         <plugin>
+            <artifactId>maven-war-plugin</artifactId>
+            <version>2.1.1</version>
+            <configuration>
+            	<attachClasses>true</attachClasses>
+            </configuration>
+         </plugin>
       </plugins>
 
    </build>


### PR DESCRIPTION
so they can be used from other projects
The attachSources configuration option of the maven-war-plugin creates
an additional ${artifactId}-classes.jar artifact (it does not change the
packaging of the war file).
