### PR TITLE
Fixed issue where SerializationType was not passing visitor down to AdvancedExternalizersType.

### DIFF
--- a/core/src/main/java/org/infinispan/config/GlobalConfiguration.java
+++ b/core/src/main/java/org/infinispan/config/GlobalConfiguration.java
@@ -1343,6 +1343,7 @@ public class GlobalConfiguration extends AbstractConfigurationBean {
       }
 
       public void accept(ConfigurationBeanVisitor v) {
+         externalizerTypes.accept(v);
          v.visitSerializationType(this);
       }
 


### PR DESCRIPTION
This is a simple 1 line change.

I tried to look if you had any existing tests that were in use for the visitor code, but couldn't find any in the infinispan/core/src/test/java/org/infinispan/config so I left it out.  I didn't want to write a test that violated your guys standard of tests and have someone copy it or something.
