### PR TITLE
ISPN-1470 - Using cache loader preload with DIST triggers NPE

### DIFF
--- a/core/src/main/java/org/infinispan/distribution/DistributionManagerImpl.java
+++ b/core/src/main/java/org/infinispan/distribution/DistributionManagerImpl.java
@@ -30,6 +30,7 @@ import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.InternalCacheValue;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.distribution.ch.ConsistentHashHelper;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.jmx.annotations.MBean;
@@ -100,7 +101,8 @@ public class DistributionManagerImpl implements DistributionManager {
    // The DMI is cache-scoped, so it will always start after the RMI, which is global-scoped
    @Start(priority = 20)
    private void start() throws Exception {
-      if (trace) log.trace("starting distribution manager on " + getAddress());
+      log.tracef("starting distribution manager on %s", getAddress());
+      consistentHash = ConsistentHashHelper.createConsistentHash(configuration, Collections.singleton(rpcManager.getAddress()));
    }
 
    private int getReplCount() {

--- a/core/src/main/java/org/infinispan/interceptors/CacheStoreInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheStoreInterceptor.java
@@ -109,13 +109,12 @@ public class CacheStoreInterceptor extends JmxStatsCommandInterceptor {
    public final boolean skip(InvocationContext ctx, VisitableCommand command) {
       if (store == null) return true;  // could be because the cache loader does not implement cache store
       if ((!ctx.isOriginLocal() && loaderConfig.isShared()) || ctx.hasFlag(SKIP_CACHE_STORE)) {
-         if (trace)
-            log.trace("Passing up method call and bypassing this interceptor since the cache loader is shared and this call originated remotely.");
+         log.trace("Skipping cache store since the cache loader is shared and we are not the originator.");
          return true;
       }
 
       if (loaderConfig.isShared() && ctx.hasFlag(SKIP_SHARED_CACHE_STORE)) {
-         if (trace) log.trace("Explicitly requested to skip storage if cache store is shared - and it is.");
+         log.trace("Explicitly requested to skip storage if cache store is shared - and it is.");
          return true;
       }
 

--- a/core/src/main/java/org/infinispan/loaders/CacheLoaderManagerImpl.java
+++ b/core/src/main/java/org/infinispan/loaders/CacheLoaderManagerImpl.java
@@ -160,11 +160,11 @@ public class CacheLoaderManagerImpl implements CacheLoaderManager {
             for (InternalCacheEntry e : state) {
                if (clmConfig.isShared() || !(loader instanceof ChainingCacheStore)) {
                   cache.getAdvancedCache()
-                       .withFlags(SKIP_CACHE_STATUS_CHECK, CACHE_MODE_LOCAL, SKIP_CACHE_STORE, SKIP_REMOTE_LOOKUP, SKIP_INDEXING)
+                       .withFlags(SKIP_CACHE_STATUS_CHECK, CACHE_MODE_LOCAL, SKIP_OWNERSHIP_CHECK, SKIP_CACHE_STORE, SKIP_REMOTE_LOOKUP, SKIP_INDEXING)
                        .put(e.getKey(), e.getValue(), e.getLifespan(), MILLISECONDS, e.getMaxIdle(), MILLISECONDS);
                } else {
                   cache.getAdvancedCache()
-                       .withFlags(SKIP_CACHE_STATUS_CHECK, CACHE_MODE_LOCAL, SKIP_REMOTE_LOOKUP, SKIP_INDEXING)
+                       .withFlags(SKIP_CACHE_STATUS_CHECK, CACHE_MODE_LOCAL, SKIP_OWNERSHIP_CHECK, SKIP_REMOTE_LOOKUP, SKIP_INDEXING)
                        .put(e.getKey(), e.getValue(), e.getLifespan(), MILLISECONDS, e.getMaxIdle(), MILLISECONDS);
                }
             }

--- a/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
@@ -195,7 +195,7 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
          if (!hasJoinStarted(cmd.getComponentRegistry())) {
             log.cacheCanNotHandleInvocations(cmd.getCacheName());
             return new ExceptionResponse(new NamedCacheNotFoundException(cmd.getCacheName(),
-                  "Cache has not been started joined the cluster on node " + transport.getAddress()));
+                  "Cache has not been started on node " + transport.getAddress()));
          }
          // if we did start joining, the StateTransferLockInterceptor will make it wait until the state transfer is complete
          // TODO There is a small window between starting the join and blocking the transactions, we need to eliminate it

--- a/core/src/test/java/org/infinispan/distribution/BaseDistCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistCacheStoreTest.java
@@ -25,9 +25,6 @@ package org.infinispan.distribution;
 import org.infinispan.config.CacheLoaderManagerConfig;
 import org.infinispan.config.Configuration;
 import org.infinispan.loaders.dummy.DummyInMemoryCacheStore;
-import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.test.fwk.TransportFlags;
 
 /**
  * DistSyncCacheStoreTest.
@@ -37,18 +34,20 @@ import org.infinispan.test.fwk.TransportFlags;
  */
 public abstract class BaseDistCacheStoreTest extends BaseDistFunctionalTest {
    protected boolean shared;
-   static int id;
+   protected boolean preload;
 
    @Override
-   protected EmbeddedCacheManager addClusterEnabledCacheManager(TransportFlags flags) {
-      Configuration cfg = new Configuration();
+   protected Configuration buildConfiguration() {
+      Configuration cfg = super.buildConfiguration();
       CacheLoaderManagerConfig clmc = new CacheLoaderManagerConfig();
       clmc.setShared(shared);
-      int idToUse = shared ? 999 : id++;
-      clmc.addCacheLoaderConfig(new DummyInMemoryCacheStore.Cfg(getClass().getSimpleName() + "_" + idToUse));
+      if (shared) {
+         clmc.addCacheLoaderConfig(new DummyInMemoryCacheStore.Cfg(getClass().getSimpleName()));
+      } else {
+         clmc.addCacheLoaderConfig(new DummyInMemoryCacheStore.Cfg());
+      }
+      clmc.setPreload(preload);
       cfg.setCacheLoaderManagerConfig(clmc);
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(cfg, flags);
-      cacheManagers.add(cm);
-      return cm;
+      return cfg;
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1470

Don't use the consistent hash for preloading, the initial state transfer will invalidate the extra entries.
Clarified some log messages and changed BaseDistCacheStoreTest to use the dist cache, same as BaseDistFunctionalTest.
