### PR TITLE
ISPN-1427 Make sure Hot Rod servers are stopped in client retry tests

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV1IntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV1IntegrationTest.java
@@ -33,6 +33,7 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.util.Util;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.Test;
 
@@ -96,6 +97,11 @@ public class ConsistentHashV1IntegrationTest extends MultipleCacheManagersTest {
       for (int i = 0; i < 4; i++) {
          advancedCache(i).addInterceptor(new HitsAwareCacheManagersTest.HitCountInterceptor(), 1);
       }
+   }
+
+   @AfterMethod
+   @Override
+   protected void clearContent() throws Throwable {
    }
 
    @AfterTest

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/DistributionRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/DistributionRetryTest.java
@@ -47,7 +47,7 @@ import static org.testng.Assert.assertEquals;
  * @author Mircea.Markus@jboss.com
  * @since 4.1
  */
-@Test(testName = "hotrod.retry.DistributionRetryTest", groups = "functional", enabled = false, description = "Re-enabled after ISPN-1427")
+@Test(testName = "hotrod.retry.DistributionRetryTest", groups = "functional")
 public class DistributionRetryTest extends AbstractRetryTest {
 
    @Override

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ReplicationRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ReplicationRetryTest.java
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
  * @author Mircea.Markus@jboss.com
  * @since 4.1
  */
-@Test (testName = "client.hotrod.ReplicationRetryTest", groups = "functional", enabled = false, description = "Re-enabled after ISPN-1427")
+@Test (testName = "client.hotrod.ReplicationRetryTest", groups = "functional")
 public class ReplicationRetryTest extends AbstractRetryTest {
 
    public void testGet() {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ServerFailureRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ServerFailureRetryTest.java
@@ -42,7 +42,7 @@ import static org.infinispan.test.TestingUtil.v;
  * @author Galder Zamarreño
  * @since 4.2
  */
-@Test(groups = "functional", testName = "client.hotrod.retry.ServerFailureRetryTest", enabled = false, description = "Re-enabled after ISPN-1427")
+@Test(groups = "functional", testName = "client.hotrod.retry.ServerFailureRetryTest")
 public class ServerFailureRetryTest extends AbstractRetryTest {
 
    @Override

--- a/core/src/main/java/org/infinispan/distribution/ch/DefaultConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/DefaultConsistentHash.java
@@ -58,7 +58,12 @@ public class DefaultConsistentHash extends AbstractWheelConsistentHash {
     */
    private List<Address> locateInternal(Object key, int replCount, Address target) {
       int actualReplCount = Math.min(replCount, caches.size());
-      int normalizedHash = getNormalizedHash(getGrouping(key));
+      int normalizedHash;
+      if (key instanceof Address)
+         normalizedHash = getNormalizedHash(hashSeed.getHashSeed((Address) key));
+      else
+         normalizedHash = getNormalizedHash(getGrouping(key));
+
       List<Address> owners = new ArrayList<Address>(replCount);
 
       for (Iterator<Map.Entry<Integer, Address>> it = getPositionsIterator(normalizedHash); it.hasNext();) {

--- a/core/src/main/java/org/infinispan/distribution/group/GroupManagerImpl.java
+++ b/core/src/main/java/org/infinispan/distribution/group/GroupManagerImpl.java
@@ -111,7 +111,7 @@ public class GroupManagerImpl implements GroupManager {
             return groupMetadataCache.get(keyClass).get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new IllegalStateException("Error extracting @Group from class hierarchy", e);
+            return null;
         } catch (ExecutionException e) {
             throw new IllegalStateException("Error extracting @Group from class hierarchy", e);
         }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ch/ServerHashSeed.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ch/ServerHashSeed.scala
@@ -32,6 +32,13 @@ import org.infinispan.server.hotrod.ServerAddress
  */
 class ServerHashSeed(addressCache: Cache[Address, ServerAddress]) extends HashSeed {
 
-   def getHashSeed(clusterMember: Address) = addressCache.get(clusterMember)
+   def getHashSeed(clusterMember: Address) = {
+      val serverAddress = addressCache.get(clusterMember)
+      if (serverAddress == null)
+         throw new IllegalStateException(
+            "Server address for %s not present".format(clusterMember))
+
+      serverAddress
+   }
 
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1427

As part of this, also fixed the address locate consistent hash lookup code that was ignoring the hash seed. This fixes ConsistentHashV1IntegrationTest.
