### PR TITLE
Upgrade to Cassandra 1.0.2 from 1.0.0rc2 

### DIFF
--- a/cachestore/cassandra/pom.xml
+++ b/cachestore/cassandra/pom.xml
@@ -45,6 +45,11 @@
 			<artifactId>cassandra-connection-pool</artifactId>
 			<version>${version.cassandra.pool}</version>
 		</dependency>
+        <dependency>
+            <groupId>org.apache.cassandra</groupId>
+            <artifactId>cassandra-thrift</artifactId>
+            <version>${version.cassandra}</version>
+        </dependency>
 		<dependency>
 			<groupId>org.apache.cassandra</groupId>
 			<artifactId>cassandra-all</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -105,7 +105,7 @@
       <version.arquillian.container.weld>1.0.0.CR2</version.arquillian.container.weld>
       <version.bdbje>4.0.92</version.bdbje>
       <version.c3p0>0.9.1.2</version.c3p0>
-      <version.cassandra>1.0.0-rc2</version.cassandra>
+      <version.cassandra>1.0.2</version.cassandra>
       <version.cassandra.pool>1.0.0.CR1</version.cassandra.pool>
       <version.cdi>1.0-SP4</version.cdi>
       <version.com.intellij.forms_rt>6.0.5</version.com.intellij.forms_rt>


### PR DESCRIPTION
Upgrade to Cassandra 1.0.2 from 1.0.0rc2  in a blind attempt to resolve intermittent failures of the testOnePhaseCommit unit test. Also force the cassandra-thrift dependency to be aligned to the
cassandra-all dependency (and not the one pulled in by the cassandra connection pool)
