### PR TITLE
ISPN-1520 Use reflection to access package protected Netty classes

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
@@ -91,7 +91,9 @@ public class Codec10 implements Codec {
          throw new InvalidResponseException(String.format(message, HotRodConstants.RESPONSE_MAGIC, magic));
       }
       long receivedMessageId = transport.readVLong();
-      if (receivedMessageId != params.messageId) {
+      // If received id is 0, it could be that a failure was noted before the
+      // message id was detected, so don't consider it to a message id error
+      if (receivedMessageId != params.messageId && receivedMessageId != 0) {
          String message = "Invalid message id. Expected %d and received %d";
          log.invalidMessageId(params.messageId, receivedMessageId);
          if (isTrace)

--- a/server/core/src/main/scala/org/infinispan/server/core/logging/JavaLog.java
+++ b/server/core/src/main/scala/org/infinispan/server/core/logging/JavaLog.java
@@ -74,4 +74,8 @@ public interface JavaLog extends org.infinispan.util.logging.Log {
    @Message(value = "Setting the number of master threads is no longer supported", id = 5008)
    void settingMasterThreadsNotSupported();
 
+   @LogMessage(level = ERROR)
+   @Message(value = "Unexpected error before any request parameters read", id = 5009)
+   void errorBeforeReadingRequest(@Cause Throwable t);
+
 }

--- a/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
@@ -80,4 +80,7 @@ trait Log {
       log.channelStillConnected(ch, address)
 
    def logSettingMasterThreadsNotSupported = log.settingMasterThreadsNotSupported
+
+   def logErrorBeforeReadingRequest(t: Throwable) =
+      log.errorBeforeReadingRequest(t)
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
@@ -160,7 +160,10 @@ class HotRodDecoder(cacheManager: EmbeddedCacheManager, transport: NettyTranspor
       t match {
          case h: HotRodException => h.response
          case c: ClosedChannelException => null
-         case t: Throwable => new ErrorResponse(0, 0, "", 1, ServerError, 0, t.toString)
+         case t: Throwable => {
+            logErrorBeforeReadingRequest(t)
+            new ErrorResponse(0, 0, "", 1, ServerError, 0, t.toString)
+         }
       }
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1520
- This gets around the limitation of default package access not working between classloaders.
- Also fixed the Hot Rod client to propagate errors before message id has been read in a correct manner.
- Finally, added some logging to the Hot Rod encoder when the error happens before the request's message id has been read.
