### PR TITLE
fix for regressions 

### DIFF
--- a/core/src/main/java/org/infinispan/context/TransactionalInvocationContextFlagsOverride.java
+++ b/core/src/main/java/org/infinispan/context/TransactionalInvocationContextFlagsOverride.java
@@ -72,8 +72,8 @@ public class TransactionalInvocationContextFlagsOverride extends InvocationConte
    }
 
    @Override
-   public void addAffectedKeys(Collection<Object> keys) {
-      delegate.addAffectedKeys(keys);
+   public void addAllAffectedKeys(Collection<Object> keys) {
+      delegate.addAllAffectedKeys(keys);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/context/impl/AbstractTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/AbstractTxInvocationContext.java
@@ -27,7 +27,6 @@ import javax.transaction.Transaction;
 import org.infinispan.transaction.AbstractCacheTransaction;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -51,9 +50,9 @@ public abstract class AbstractTxInvocationContext extends AbstractInvocationCont
       return getCacheTransaction().getAffectedKeys();
    }
 
-   public void addAffectedKeys(Collection<Object> keys) {
+   public void addAllAffectedKeys(Collection<Object> keys) {
       if (keys != null && !keys.isEmpty()) {
-         getCacheTransaction().addAffectedKeys(keys);
+         getCacheTransaction().addAllAffectedKeys(keys);
       }
    }
 

--- a/core/src/main/java/org/infinispan/context/impl/TxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/TxInvocationContext.java
@@ -73,7 +73,7 @@ public interface TxInvocationContext extends InvocationContext {
    /**
     * Registers a new participant with the transaction.
     */
-   void addAffectedKeys(Collection<Object> keys);
+   void addAllAffectedKeys(Collection<Object> keys);
 
    void addAffectedKey(Object key);
 

--- a/core/src/main/java/org/infinispan/interceptors/locking/OptimisticLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/OptimisticLockingInterceptor.java
@@ -88,6 +88,7 @@ public class OptimisticLockingInterceptor extends AbstractTxLockingInterceptor {
             if (!lre.hasClear) {
                log.tracef("Using lock reordering, order is: %s", lre.orderedKeys);
                acquireAllLocks(ctx, lre.orderedKeys.iterator());
+               ctx.addAllAffectedKeys(lre.orderedKeys);
             } else {
                log.trace("Not using lock reordering as the prepare contains a clear command.");
                acquireLocksVisitingCommands(ctx, command);

--- a/core/src/main/java/org/infinispan/interceptors/locking/PessimisticLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/PessimisticLockingInterceptor.java
@@ -210,7 +210,7 @@ public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor 
             LocalTransaction localTx = (LocalTransaction) ctx.getCacheTransaction();
             if (!localTx.getAffectedKeys().containsAll(command.getKeys())) {
                invokeNextInterceptor(ctx, command);
-               ctx.addAffectedKeys(command.getKeys());
+               ctx.addAllAffectedKeys(command.getKeys());
             } else {
                log.tracef("Already own locks on keys: %s, skipping remote call", command.getKeys());
             }
@@ -248,7 +248,7 @@ public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor 
             invokeNextInterceptor(ctx, lcc);
          }
       }
-      ((TxInvocationContext) ctx).addAffectedKeys(keys);
+      ((TxInvocationContext) ctx).addAllAffectedKeys(keys);
    }
 
    private void acquireRemoteIfNeeded(InvocationContext ctx, Object key, boolean localNodeIsLockOwner) throws Throwable {

--- a/core/src/main/java/org/infinispan/transaction/AbstractCacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/AbstractCacheTransaction.java
@@ -176,7 +176,7 @@ public abstract class AbstractCacheTransaction implements CacheTransaction {
       affectedKeys.add(key);
    }
 
-   public void addAffectedKeys(Collection<Object> keys) {
+   public void addAllAffectedKeys(Collection<Object> keys) {
       initAffectedKeys();
       affectedKeys.addAll(keys);
    }

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryManagerImpl.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryManagerImpl.java
@@ -310,7 +310,7 @@ public class RecoveryManagerImpl implements RecoveryManager {
             RecoveryAwareLocalTransaction localTx = (RecoveryAwareLocalTransaction) txFactory.newLocalTransaction(null, globalTransaction);
             localTx.setModifications(tx.getModifications());
             localTx.setXid(xid);
-            localTx.addAffectedKeys(((RecoveryAwareRemoteTransaction) tx).getAffectedKeys());
+            localTx.addAllAffectedKeys(((RecoveryAwareRemoteTransaction) tx).getAffectedKeys());
             for (Object lk : ((RecoveryAwareRemoteTransaction) tx).getLockedKeys()) localTx.registerLockedKey(lk);
             return completeTransaction(localTx, commit, xid);
          }


### PR DESCRIPTION
Affected keys were not correctly registered in the case of lock-reordered optimistic transactions
