### PR TITLE
ISPN-1526 - make DefaultCacheManager.getTransport() public

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientSocketReadTimeoutTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientSocketReadTimeoutTest.java
@@ -31,6 +31,7 @@ import org.infinispan.config.GlobalConfiguration;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.Transport;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -193,6 +194,11 @@ public class ClientSocketReadTimeoutTest extends SingleCacheManagerTest {
       @Override
       public void removeCache(String cacheName) {
          delegate.removeCache(cacheName);
+      }
+
+      @Override
+      public Transport getTransport() {
+         return delegate.getTransport();
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -832,7 +832,8 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
          throw new IllegalStateException("Cache container has been stopped and cannot be reused. Recreate the cache container.");
    }
 
-   private Transport getTransport() {
+   @Override
+   public Transport getTransport() {
       if (globalComponentRegistry == null) return null;
       return globalComponentRegistry.getComponent(Transport.class);
    }

--- a/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
@@ -31,6 +31,7 @@ import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.notifications.Listenable;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.Transport;
 
 import java.util.List;
 import java.util.Set;
@@ -233,4 +234,8 @@ public interface EmbeddedCacheManager extends CacheContainer, Listenable {
     */
    void removeCache(String cacheName);
 
+   /**
+    * @since 5.1
+    */
+   Transport getTransport();
 }

--- a/core/src/main/java/org/infinispan/transaction/xa/TransactionFactory.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/TransactionFactory.java
@@ -30,13 +30,14 @@ import org.infinispan.factories.annotations.Start;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.Transport;
 import org.infinispan.transaction.LocalTransaction;
 import org.infinispan.transaction.RemoteTransaction;
 import org.infinispan.transaction.synchronization.SyncLocalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryAwareDldGlobalTransaction;
-import org.infinispan.transaction.xa.recovery.RecoveryAwareRemoteTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryAwareGlobalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryAwareLocalTransaction;
+import org.infinispan.transaction.xa.recovery.RecoveryAwareRemoteTransaction;
 import org.infinispan.util.ClusterIdGenerator;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -286,7 +287,8 @@ public class TransactionFactory {
       init(dldEnabled, recoveryEnabled, xa);
       isClustered = configuration.getCacheMode().isClustered();
       if (recoveryEnabled) {
-         clusterIdGenerator = new ClusterIdGenerator(cm, rpcManager);
+         Transport transport = rpcManager != null ? rpcManager.getTransport() : null;
+         clusterIdGenerator = new ClusterIdGenerator(cm, transport);
       }
    }
 

--- a/core/src/main/java/org/infinispan/util/ClusterIdGenerator.java
+++ b/core/src/main/java/org/infinispan/util/ClusterIdGenerator.java
@@ -27,7 +27,6 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged;
 import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
-import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.Transport;
 import org.infinispan.util.logging.Log;
@@ -54,14 +53,12 @@ public class ClusterIdGenerator {
    private final AtomicLong versionPrefix = new AtomicLong();
    private RankCalculator rankCalculator = new RankCalculator();
 
-   public ClusterIdGenerator(EmbeddedCacheManager cm, RpcManager rpcManager) {
+   public ClusterIdGenerator(EmbeddedCacheManager cm, Transport transport) {
       if (cm != null)
          cm.addListener(rankCalculator);
 
-      if (rpcManager != null) {
-         Transport transport = rpcManager.getTransport();
-         calculateRank(rpcManager.getAddress(),
-                       transport.getMembers(), transport.getViewId());
+      if (transport != null) {
+         calculateRank(transport.getAddress(), transport.getMembers(), transport.getViewId());
       }
    }
 

--- a/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolServer.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolServer.scala
@@ -94,7 +94,7 @@ abstract class AbstractProtocolServer(threadNamePrefix: String) extends Protocol
          startDefaultCache
 
          this.versionGenerator = new ClusterIdGenerator(
-            cacheManager, cacheManager.getCache().getAdvancedCache.getRpcManager)
+            cacheManager, cacheManager.getTransport)
 
          startTransport(idleTimeout, tcpNoDelay, sendBufSize, recvBufSize, typedProps)
       }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1526

I also added the method to the EmbeddedCacheManager interface.

AbstractProtocolServer was relying on the default cache's RpcManager
to get the Transport, that stopped working after ISPN-1508 so I changed it
to use EmbeddedCacheManager.getTransport() instead.
