### PR TITLE
ISPN-1531

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -24,7 +24,7 @@
 	</parent>
 
 	<artifactId>infinispan-api</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Infinispan API</name>
 	<description>Infinispan API</description>
 

--- a/cachestore/bdbje/pom.xml
+++ b/cachestore/bdbje/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-cachestore-bdbje</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan BDBJE CacheStore</name>
    <description>Infinispan BerkeleyDB JavaEdition CacheStore module</description>
    <dependencies>

--- a/cachestore/cassandra/pom.xml
+++ b/cachestore/cassandra/pom.xml
@@ -31,7 +31,7 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>infinispan-cachestore-cassandra</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
 	<name>Infinispan CassandraCacheStore</name>
 	<description>Infinispan CassandraCacheStore module</description>
 

--- a/cachestore/cloud/pom.xml
+++ b/cachestore/cloud/pom.xml
@@ -32,7 +32,7 @@
       <relativePath>../pom.xml</relativePath>
    </parent>
    <artifactId>infinispan-cachestore-cloud</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan CloudCacheStore</name>
    <description>Infinispan CloudCacheStore module</description>
 

--- a/cachestore/jdbc/pom.xml
+++ b/cachestore/jdbc/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-cachestore-jdbc</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan JDBC CacheStore</name>
    <description>Infinispan JDBC CacheStore module</description>
 

--- a/cachestore/jdbm/pom.xml
+++ b/cachestore/jdbm/pom.xml
@@ -32,7 +32,7 @@
       <relativePath>../pom.xml</relativePath>
    </parent>
    <artifactId>infinispan-cachestore-jdbm</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan JDBM CacheStore</name>
    <description>Infinispan JDBM CacheStore module</description>
    <properties>

--- a/cachestore/remote/pom.xml
+++ b/cachestore/remote/pom.xml
@@ -32,7 +32,7 @@
       <relativePath>../pom.xml</relativePath>
    </parent>
    <artifactId>infinispan-cachestore-remote</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan remote CacheStore</name>
    <description>Infinispan remote CacheStore based on Hotrod protocol</description>
    <properties>

--- a/cdi/extension/pom.xml
+++ b/cdi/extension/pom.xml
@@ -35,7 +35,7 @@
    </parent>
 
    <artifactId>infinispan-cdi</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan CDI support</name>
    <description>Infinispan CDI support module</description>
 

--- a/client/hotrod-client/pom.xml
+++ b/client/hotrod-client/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-client-hotrod</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan Hot Rod Client</name>
    <description>Infinispan Hot Rod Client</description>
    <properties>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -24,7 +24,7 @@
 	</parent>
 
 	<artifactId>infinispan-commons</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 	<name>Infinispan Commons</name>
 	<description>Infinispan Commons</description>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,7 +34,7 @@
    </parent>
 
    <artifactId>infinispan-core</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan Core</name>
    <description>Infinispan core module</description>
 

--- a/lucene-directory/pom.xml
+++ b/lucene-directory/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-lucene-directory</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan Lucene Directory Implementation</name>
    <description>A Lucene directory implementation based on Infinispan</description>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -567,7 +567,7 @@
                <instructions>
                   <Bundle-DocURL>http://www.infinispan.org/</Bundle-DocURL>
                   <Export-Package>
-                     ${project.groupId}.*;version=${project.version};-split-package:=merge-last
+                     ${project.groupId}.*;version=${project.version};-split-package:=error
                   </Export-Package>
                </instructions>
             </configuration>
@@ -750,7 +750,7 @@
          </activation>
          <properties>
             <!-- By default create OSGI bundles -->
-            <packaging>bundle</packaging>
+            <packaging>jar</packaging>
          </properties>
          <build>
             <plugins>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-query</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan Query API</name>
    <description>Infinispan Query API module</description>
    <dependencies>

--- a/server/core/pom.xml
+++ b/server/core/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-server-core</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan Server - Core Components</name>
    <description>Infinispan Server - Core Components</description>
 

--- a/server/hotrod/pom.xml
+++ b/server/hotrod/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-server-hotrod</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan Hot Rod Server</name>
    <description>Infinispan Hot Rod Server</description>
 

--- a/server/memcached/pom.xml
+++ b/server/memcached/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-server-memcached</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan Memcached Server</name>
    <description>Infinispan Memcached Server</description>
 

--- a/server/websocket/pom.xml
+++ b/server/websocket/pom.xml
@@ -32,7 +32,7 @@
    </parent>
 
    <artifactId>infinispan-server-websocket</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan WebSocket Server</name>
    <description>WebSocket interface for Infinispan</description>
 

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -9,7 +9,7 @@
    </parent>
 
    <artifactId>infinispan-spring</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
 
    <name>Infinispan Spring Integration</name>
    <description>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -34,7 +34,7 @@
    </parent>
 
    <artifactId>infinispan-tools</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan Tools</name>
    <description>Infinispan - Tools for project</description>
 

--- a/tree/pom.xml
+++ b/tree/pom.xml
@@ -33,7 +33,7 @@
    </parent>
 
    <artifactId>infinispan-tree</artifactId>
-   <packaging>bundle</packaging>
+   <packaging>jar</packaging>
    <name>Infinispan Tree API</name>
    <description>Infinispan tree API module</description>
    <dependencies>


### PR DESCRIPTION
Disable OSGi bundles for all artifacts because of a bug in the felix maven-bundle-plugin which incorporates classes in case of split packages. Sorry about this: when a proper fix can be delivered they will be re-enabled.
