### PR TITLE
ISPN-1536 Upgrade JBoss Logging dependencies to 3.1.0.CR1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -128,8 +128,8 @@
       <version.jbossjta>4.15.1.Final</version.jbossjta>
       <version.osgi>4.3.0</version.osgi>
       <version.jboss.jandex>1.0.3.Final</version.jboss.jandex>
-      <version.jboss.logging>3.1.0.Beta3</version.jboss.logging>
-      <version.jboss.logging.processor>1.0.0.CR3</version.jboss.logging.processor>
+      <version.jboss.logging>3.1.0.CR1</version.jboss.logging>
+      <version.jboss.logging.processor>1.0.0.CR5</version.jboss.logging.processor>
       <version.jboss.logmanager>1.2.0.GA</version.jboss.logmanager>
       <version.jboss.spec>1.0.0.Final</version.jboss.spec>
       <version.jcipannotations>1.0</version.jcipannotations>


### PR DESCRIPTION
This is very important, or we'll be incompatible with other frameworks (e.g. Hibernate & OGM)
