### PR TITLE
ISPN-1391 Use UNICAST2 instead of UNICAST

### DIFF
--- a/core/src/main/resources/jgroups-ec2.xml
+++ b/core/src/main/resources/jgroups-ec2.xml
@@ -66,7 +66,7 @@
          use_mcast_xmit="false"
          retransmit_timeout="300,600,1200,2400,4800"
          discard_delivered_msgs="false"/>
-   <UNICAST timeout="300,600,1200"/>
+   <UNICAST2 timeout="300,600,1200"/>
    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                   max_bytes="400000"/>
    <pbcast.GMS print_local_addr="false" join_timeout="7000" view_bundling="true"/>

--- a/core/src/main/resources/jgroups-tcp.xml
+++ b/core/src/main/resources/jgroups-tcp.xml
@@ -78,7 +78,7 @@
          use_mcast_xmit="false"
          retransmit_timeout="300,600,1200,2400,4800"
          discard_delivered_msgs="false"/>
-   <UNICAST timeout="300,600,1200"/>
+   <UNICAST2 timeout="300,600,1200"/>
    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                   max_bytes="400000"/>
    <pbcast.GMS print_local_addr="false" join_timeout="7000" view_bundling="true"/>

--- a/core/src/main/resources/jgroups-udp.xml
+++ b/core/src/main/resources/jgroups-udp.xml
@@ -67,7 +67,7 @@
                    use_mcast_xmit="true"
                    retransmit_timeout="300,600,1200"
                    discard_delivered_msgs="true"/>
-   <UNICAST timeout="300,600,1200"/>
+   <UNICAST2 timeout="300,600,1200"/>
    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000" max_bytes="1000000"/>
    <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
    <UFC max_credits="500000" min_threshold="0.20"/>

--- a/demos/distexec/src/main/resources/config-samples/distexec-demo/jgroups-s3_ping-aws.xml
+++ b/demos/distexec/src/main/resources/config-samples/distexec-demo/jgroups-s3_ping-aws.xml
@@ -9,7 +9,7 @@
    <VERIFY_SUSPECT timeout="1500"/>
    <pbcast.NAKACK use_mcast_xmit="false" gc_lag="0" retransmit_timeout="300,600,1200,2400,4800"
                   discard_delivered_msgs="true"/>
-   <UNICAST timeout="300,600,1200,2400,3600"/>
+   <UNICAST2 timeout="300,600,1200,2400,3600"/>
    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000" max_bytes="400000"/>
    <pbcast.GMS print_local_addr="true" join_timeout="60000" view_bundling="true"/>
    <FC max_credits="20000000" min_threshold="0.10"/>

--- a/demos/ec2/src/main/resources/config-samples/ec2-demo/jgroups-gossiprouter-aws.xml
+++ b/demos/ec2/src/main/resources/config-samples/ec2-demo/jgroups-gossiprouter-aws.xml
@@ -30,7 +30,7 @@
    <VERIFY_SUSPECT timeout="1500"/>
    <pbcast.NAKACK use_mcast_xmit="false" gc_lag="0" retransmit_timeout="300,600,1200,2400,4800"
                   discard_delivered_msgs="true"/>
-   <UNICAST timeout="300,600,1200,2400,3600"/>
+   <UNICAST2 timeout="300,600,1200,2400,3600"/>
    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000" max_bytes="400000"/>
    <pbcast.GMS print_local_addr="true" join_timeout="3000" shun="false" view_bundling="true"/>
    <FC max_credits="20000000" min_threshold="0.10"/>

--- a/demos/ec2/src/main/resources/config-samples/ec2-demo/jgroups-s3_ping-aws.xml
+++ b/demos/ec2/src/main/resources/config-samples/ec2-demo/jgroups-s3_ping-aws.xml
@@ -31,7 +31,7 @@
    <VERIFY_SUSPECT timeout="1500"/>
    <pbcast.NAKACK use_mcast_xmit="false" gc_lag="0" retransmit_timeout="300,600,1200,2400,4800"
                   discard_delivered_msgs="true"/>
-   <UNICAST timeout="300,600,1200,2400,3600"/>
+   <UNICAST2 timeout="300,600,1200,2400,3600"/>
    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000" max_bytes="400000"/>
    <VIEW_SYNC avg_send_interval="60000"/>
    <pbcast.GMS print_local_addr="true" join_timeout="60000" view_bundling="true"/>

--- a/demos/gui/src/main/resources/config-samples/jgroups-relay1.xml
+++ b/demos/gui/src/main/resources/config-samples/jgroups-relay1.xml
@@ -63,7 +63,7 @@
     <pbcast.NAKACK use_mcast_xmit="true" gc_lag="0"
                    retransmit_timeout="100,300,600,1200"
                    discard_delivered_msgs="true"/>
-    <UNICAST timeout="300,600,1200"/>
+    <UNICAST2 timeout="300,600,1200"/>
     <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                    max_bytes="1000000"/>
     <pbcast.GMS print_local_addr="true" join_timeout="5000"

--- a/demos/gui/src/main/resources/config-samples/jgroups-relay2.xml
+++ b/demos/gui/src/main/resources/config-samples/jgroups-relay2.xml
@@ -64,7 +64,7 @@
     <pbcast.NAKACK use_mcast_xmit="true" gc_lag="0"
                    retransmit_timeout="100,300,600,1200"
                    discard_delivered_msgs="true"/>
-    <UNICAST timeout="300,600,1200"/>
+    <UNICAST2 timeout="300,600,1200"/>
     <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                    max_bytes="1000000"/>
     <pbcast.GMS print_local_addr="true" join_timeout="5000"


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1391

Seems to be a clean drop-in replacement.  I haven't seen anything go bad with it so far.  :)
