### PR TITLE
ISPN-1567 Disable repl queue in topology cache explictly

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodAsyncReplicationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodAsyncReplicationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.client.hotrod;
+
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.commands.write.PutKeyValueCommand;
+import org.infinispan.config.Configuration;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+
+import static org.infinispan.test.TestingUtil.v;
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * // TODO: Document this
+ *
+ * @author Galder Zamarreño
+ * @since // TODO
+ */
+@Test(groups = "functional", testName = "client.hotrod.HotRodAsyncReplicationTest")
+public class HotRodAsyncReplicationTest extends MultiHotRodServersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      Configuration cfg = new Configuration().fluent()
+         .clustering()
+            .mode(Configuration.CacheMode.REPL_ASYNC)
+            .async()
+               .replQueueInterval(1000L)
+               .useReplQueue(true)
+         .eviction()
+            .maxEntries(3)
+         .build();
+
+      createHotRodServers(2, cfg);
+   }
+
+   public void testPutKeyValue(Method m) {
+      RemoteCache<Object, Object> remoteCache0 = client(0).getCache();
+      RemoteCache<Object, Object> remoteCache1 = client(1).getCache();
+
+      replListener(cache(1)).expect(PutKeyValueCommand.class);
+      String v1 = v(m);
+      remoteCache0.put(1, v1);
+      replListener(cache(1)).waitForRpc();
+      assertEquals(v1, remoteCache1.get(1));
+   }
+
+}

--- a/core/src/test/java/org/infinispan/config/ProgrammaticConfigurationTest.java
+++ b/core/src/test/java/org/infinispan/config/ProgrammaticConfigurationTest.java
@@ -193,7 +193,7 @@ public class ProgrammaticConfigurationTest extends AbstractInfinispanTest {
          .expiration()
             .maxIdle(8392L).lifespan(4372L).wakeUpInterval(7585L)
          .clustering()
-            .mode(Configuration.CacheMode.INVALIDATION_SYNC)
+            .mode(Configuration.CacheMode.INVALIDATION_ASYNC)
             .async()
                .replQueueClass(ReplicationQueueImpl.class)
                .asyncMarshalling(false)
@@ -257,7 +257,7 @@ public class ProgrammaticConfigurationTest extends AbstractInfinispanTest {
       assert c.isL1CacheEnabled();
       assert c.isL1OnRehash();
       assert 65738L == c.getL1Lifespan();
-      assert Configuration.CacheMode.INVALIDATION_SYNC == c.getCacheMode();
+      assert Configuration.CacheMode.INVALIDATION_ASYNC == c.getCacheMode();
       assert !c.isUseAsyncMarshalling();
       assertEquals(ReplicationQueueImpl.class.getName(), c.getReplQueueClass());
       assert 5738L == c.getReplQueueInterval();

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
@@ -136,6 +136,7 @@ class HotRodServer extends AbstractProtocolServer("HotRod") with Log {
 
       val topologyCacheConfig = new Configuration
       topologyCacheConfig.setCacheMode(CacheMode.REPL_SYNC)
+      topologyCacheConfig.setUseReplQueue(false) // Avoid getting mixed up with default config
       topologyCacheConfig.setSyncReplTimeout(replTimeout) // Milliseconds
       topologyCacheConfig.setLockAcquisitionTimeout(lockTimeout) // Milliseconds
       topologyCacheConfig.setEvictionStrategy(EvictionStrategy.NONE); // No eviction


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1567

This is to avoid default cache configuration settings being used here.
