### PR TITLE
ISPN-1298 Added profile that generates TRACE logging for testsuite

### DIFF
--- a/core/src/test/resources/log4j-trace.xml
+++ b/core/src/test/resources/log4j-trace.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2009 Red Hat Inc. and/or its affiliates and other
+  ~ contributors as indicated by the @author tags. All rights reserved.
+  ~ See the copyright.txt in the distribution for a full listing of
+  ~ individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<!--
+   For more configuration infromation and examples see the Apache Log4j website: http://logging.apache.org/log4j/
+ -->
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+
+   <!-- A time/date based rolling appender -->
+   <appender name="FILE" class="org.infinispan.util.logging.log4j.CompressedFileAppender">
+      <param name="File" value="trace-infinispan.log.gz"/>
+      <param name="Append" value="false"/>
+
+      <param name="Threshold" value="TRACE"/>
+
+      <layout class="org.apache.log4j.PatternLayout">
+         <!-- The default pattern: Date Priority (Thread) [Category] Message\n -->
+         <param name="ConversionPattern" value="%d %-5p (%t) [%c] %m%n"/>
+
+         <!-- The full pattern: Date MS Priority [Category] (Thread:NDC) Message\n
+        <param name="ConversionPattern" value="%d %-5r %-5p [%c] (%t:%x) %m%n"/>
+         -->
+      </layout>
+   </appender>
+
+   <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+      <param name="Threshold" value="WARN"/>
+      <param name="Target" value="System.out"/>
+
+      <layout class="org.apache.log4j.PatternLayout">
+         <!-- The default pattern: Date Priority [Category] Message\n -->
+         <param name="ConversionPattern" value="%d %-5p [%c{1}] (%t) %m%n"/>
+      </layout>
+   </appender>
+
+
+   <!-- ================ -->
+   <!-- Limit categories -->
+   <!-- ================ -->
+
+   <category name="org.infinispan">
+      <priority value="TRACE"/>
+   </category>
+
+   <category name="com.mchange">
+      <priority value="WARN"/>
+   </category>
+
+   <category name="org.jgroups">
+      <priority value="INFO"/>
+   </category>
+
+   <!-- ======================= -->
+   <!-- Setup the Root category -->
+   <!-- ======================= -->
+
+   <root>
+      <priority value="INFO"/>
+      <appender-ref ref="CONSOLE"/>
+      <appender-ref ref="FILE"/>
+   </root>
+
+</log4j:configuration>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -98,6 +98,7 @@
       <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
       <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
       <packaging>jar</packaging>
+      <infinispan.log4j.configuration>log4j.xml</infinispan.log4j.configuration>
 
       <!-- Versions for dependencies -->
       <version.apacheds.jdbm>1.5.7</version.apacheds.jdbm>
@@ -464,12 +465,12 @@
                      <value>true</value>
                   </property>
                   <property>
-                     <name>infinispan.test.marshaller.class</name>
-                     <value>${infinispan.test.marshaller.class}</value>
-                  </property>
-                  <property>
                      <name>infinispan.suppress_cache_creation_warning</name>
                      <value>true</value>
+                  </property>
+                  <property>
+                     <name>log4j.configuration</name>
+                     <value>${infinispan.log4j.configuration}</value>
                   </property>
                </systemProperties>
                <trimStackTrace>false</trimStackTrace>
@@ -856,6 +857,16 @@
          </activation>
          <properties>
             <infinispan.test.parallel.threads>1</infinispan.test.parallel.threads>
+            <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
+         </properties>
+      </profile>
+      <profile>
+         <id>traceTests</id>
+         <activation>
+            <activeByDefault>false</activeByDefault>
+         </activation>
+         <properties>
+            <infinispan.log4j.configuration>log4j-trace.xml</infinispan.log4j.configuration>
             <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
          </properties>
       </profile>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1298

It generates a GZIP file that can be output via: 'gunzip -c trace-infinispan.log.gz > trace-infinsipan.log'

Apart from updating the documentation, a manual job will be added to CI in order to run with this profile 
(-PtraceTests) which should help diagnose random issues happening only in CI.
