### PR TITLE
ISPN-1573: DefaultTwoWayKey2StringMapper should support ByteArrayKeys

### DIFF
--- a/core/src/main/java/org/infinispan/loaders/keymappers/DefaultTwoWayKey2StringMapper.java
+++ b/core/src/main/java/org/infinispan/loaders/keymappers/DefaultTwoWayKey2StringMapper.java
@@ -22,6 +22,10 @@
  */
 package org.infinispan.loaders.keymappers;
 
+import java.nio.charset.Charset;
+
+import org.infinispan.util.Base64;
+import org.infinispan.util.ByteArrayKey;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -45,6 +49,7 @@ public class DefaultTwoWayKey2StringMapper implements TwoWayKey2StringMapper {
    private static final char DOUBLE_IDENTIFIER = '5';
    private static final char FLOAT_IDENTIFIER = '6';
    private static final char BOOLEAN_IDENTIFIER = '7';
+   private static final char BYTEARRAYKEY_IDENTIFIER = '8';
 
    @Override
    public String getStringMapping(Object key) {
@@ -65,6 +70,8 @@ public class DefaultTwoWayKey2StringMapper implements TwoWayKey2StringMapper {
          identifier = FLOAT_IDENTIFIER;
       } else if (key.getClass().equals(Boolean.class)) {
          identifier = BOOLEAN_IDENTIFIER;
+      } else if (key.getClass().equals(ByteArrayKey.class)) {
+         return generateString(BYTEARRAYKEY_IDENTIFIER, Base64.encodeBytes(((ByteArrayKey)key).getData()));
       } else {
          throw new IllegalArgumentException("Unsupported key type: " + key.getClass().getName());
       }
@@ -93,6 +100,8 @@ public class DefaultTwoWayKey2StringMapper implements TwoWayKey2StringMapper {
                return Float.parseFloat(value);
             case BOOLEAN_IDENTIFIER:
                return Boolean.parseBoolean(value);
+            case BYTEARRAYKEY_IDENTIFIER:
+               return new ByteArrayKey(Base64.decode(value));
             default:
                throw new IllegalArgumentException("Unsupported type code: " + type);
          }
@@ -111,6 +120,6 @@ public class DefaultTwoWayKey2StringMapper implements TwoWayKey2StringMapper {
    }
 
    static boolean isPrimitive(Class<?> key) {
-      return key == String.class || key == Short.class || key == Byte.class || key == Long.class || key == Integer.class || key == Double.class || key == Float.class || key == Boolean.class;
+      return key == String.class || key == Short.class || key == Byte.class || key == Long.class || key == Integer.class || key == Double.class || key == Float.class || key == Boolean.class || key == ByteArrayKey.class;
    }
 }

--- a/core/src/main/java/org/infinispan/util/ByteArrayKey.java
+++ b/core/src/main/java/org/infinispan/util/ByteArrayKey.java
@@ -46,6 +46,7 @@ import java.util.Set;
  */
 public class ByteArrayKey implements Serializable {
 
+   private static final long serialVersionUID = 7305972805432411725L;
    private final byte[] data;
 
    public ByteArrayKey(byte[] data) {

--- a/core/src/test/java/org/infinispan/loaders/keymappers/DefaultTwoWayKey2StringMapperTest.java
+++ b/core/src/test/java/org/infinispan/loaders/keymappers/DefaultTwoWayKey2StringMapperTest.java
@@ -22,6 +22,7 @@
  */
 package org.infinispan.loaders.keymappers;
 
+import org.infinispan.util.ByteArrayKey;
 import org.testng.annotations.Test;
 
 @Test(groups = "unit", testName = "loaders.keymappers.DefaultTwoWayKey2StringMapperTest")
@@ -55,6 +56,12 @@ public class DefaultTwoWayKey2StringMapperTest {
       Double d = (Double) mapper.getKeyMapping(skey);
 
       assert d == 3.141592d;
+
+      byte[] bytes = new byte[] { 0, 1, 2, 40, -128, -127, 127, 126, 0 };
+
+      skey = mapper.getStringMapping(new ByteArrayKey(bytes));
+
+      assert !skey.equals("\000\001\002\050\0377\0376\0177\0176\000");
    }
 
    public void testPrimitivesAreSupported() {
@@ -66,10 +73,11 @@ public class DefaultTwoWayKey2StringMapperTest {
       assert mapper.isSupportedType(Float.class);
       assert mapper.isSupportedType(Boolean.class);
       assert mapper.isSupportedType(String.class);
+      assert mapper.isSupportedType(ByteArrayKey.class);
    }
 
    public void testTwoWayContract() {
-      Object[] toTest = { 0, new Byte("1"), new Short("2"), (long) 3, new Double("3.4"), new Float("3.5"), Boolean.FALSE, "some string" };
+      Object[] toTest = { 0, new Byte("1"), new Short("2"), (long) 3, new Double("3.4"), new Float("3.5"), Boolean.FALSE, "some string", new ByteArrayKey("\000\001\002\050\0377\0376\0177\0176\000".getBytes()) };
       for (Object o : toTest) {
          Class<?> type = o.getClass();
          String rep = mapper.getStringMapping(o);
@@ -124,6 +132,11 @@ public class DefaultTwoWayKey2StringMapperTest {
       assert mapper.isSupportedType(Boolean.class);
       assert assertWorks(true);
       assert assertWorks(false);
+   }
+
+   public void testByteArrayKey() {
+      assert mapper.isSupportedType(ByteArrayKey.class);
+      assert assertWorks(new ByteArrayKey("\000\001\002\050\0377\0376\0177\0176\000".getBytes()));
    }
 
    private boolean assertWorks(Object key) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1573
DefaultTwoWayKey2StringMapper should support ByteArrayKeys

Use Base64 encoding/decoding
