### PR TITLE
ISPN-1116 Versioned Entries.

### DIFF
--- a/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
@@ -42,6 +42,8 @@ import org.infinispan.commands.remote.recovery.TxCompletionNotificationCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
+import org.infinispan.commands.tx.VersionedCommitCommand;
+import org.infinispan.commands.tx.VersionedPrepareCommand;
 import org.infinispan.commands.write.ApplyDeltaCommand;
 import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.commands.write.InvalidateCommand;
@@ -50,6 +52,7 @@ import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
+import org.infinispan.commands.write.VersionedPutKeyValueCommand;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.KnownComponentNames;
 import org.infinispan.factories.annotations.ComponentName;
@@ -109,6 +112,9 @@ public class RemoteCommandsFactory {
          switch (id) {
             case PutKeyValueCommand.COMMAND_ID:
                command = new PutKeyValueCommand();
+               break;
+            case VersionedPutKeyValueCommand.COMMAND_ID:
+               command = new VersionedPutKeyValueCommand();
                break;
             case PutMapCommand.COMMAND_ID:
                command = new PutMapCommand();
@@ -170,8 +176,14 @@ public class RemoteCommandsFactory {
             case PrepareCommand.COMMAND_ID:
                command = new PrepareCommand(cacheName);
                break;
+            case VersionedPrepareCommand.COMMAND_ID:
+               command = new VersionedPrepareCommand(cacheName);
+               break;
             case CommitCommand.COMMAND_ID:
                command = new CommitCommand(cacheName);
+               break;
+            case VersionedCommitCommand.COMMAND_ID:
+               command = new VersionedCommitCommand(cacheName);
                break;
             case RollbackCommand.COMMAND_ID:
                command = new RollbackCommand(cacheName);

--- a/core/src/main/java/org/infinispan/commands/read/EntrySetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/EntrySetCommand.java
@@ -22,13 +22,6 @@
  */
 package org.infinispan.commands.read;
 
-import java.util.AbstractSet;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
-
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.Visitor;
 import org.infinispan.container.DataContainer;
@@ -36,6 +29,13 @@ import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.InternalEntryFactory;
 import org.infinispan.context.InvocationContext;
+
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 import static org.infinispan.util.Immutables.immutableInternalCacheEntry;
 
@@ -176,7 +176,7 @@ public class EntrySetCommand extends AbstractLocalCommand implements VisitableCo
                   CacheEntry e = it1.next();
                   if (e.isCreated()) {
                      next = immutableInternalCacheEntry(
-                        InternalEntryFactory.create(e.getKey(), e.getValue()));
+                        InternalEntryFactory.create(e.getKey(), e.getValue(), e.getVersion()));
                      found = true;
                      break;
                   }
@@ -201,7 +201,7 @@ public class EntrySetCommand extends AbstractLocalCommand implements VisitableCo
                   }
                   if (e.isChanged()) {
                      next = immutableInternalCacheEntry(
-                           InternalEntryFactory.create(key, e.getValue()));
+                           InternalEntryFactory.create(key, e.getValue(), e.getVersion()));
                      found = true;
                      break;
                   }

--- a/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
@@ -131,7 +131,7 @@ public class ClusteredGetCommand extends BaseRpcCommand implements FlagAffectedC
       if (cacheEntry instanceof MVCCEntry) {
          if (trace) log.trace("Handling an internal cache entry...");
          MVCCEntry mvccEntry = (MVCCEntry) cacheEntry;
-         return InternalEntryFactory.createValue(mvccEntry.getValue(), -1, mvccEntry.getLifespan(), -1, mvccEntry.getMaxIdle());
+         return InternalEntryFactory.createValue(mvccEntry.getValue(), mvccEntry.getVersion(), -1, mvccEntry.getLifespan(), -1, mvccEntry.getMaxIdle());
       } else {
          InternalCacheEntry internalCacheEntry = (InternalCacheEntry) cacheEntry;
          return internalCacheEntry.toInternalCacheValue();

--- a/core/src/main/java/org/infinispan/commands/tx/VersionedCommitCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/VersionedCommitCommand.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.commands.tx;
+
+import org.infinispan.container.versioning.EntryVersionsMap;
+import org.infinispan.transaction.xa.GlobalTransaction;
+
+/**
+ * The same as a {@link CommitCommand} except that version information is also carried by this command, used by
+ * optimistically transactional caches making use of write skew checking when using {@link org.infinispan.util.concurrent.IsolationLevel#REPEATABLE_READ}.
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+public class VersionedCommitCommand extends CommitCommand {
+   public static final byte COMMAND_ID = 27;
+   private EntryVersionsMap updatedVersions;
+
+   public VersionedCommitCommand() {
+      super("");
+   }
+
+   public VersionedCommitCommand(String cacheName, GlobalTransaction gtx) {
+      super(cacheName, gtx);
+   }
+
+   public VersionedCommitCommand(String cacheName) {
+      super(cacheName);
+   }
+
+   public EntryVersionsMap getUpdatedVersions() {
+      return updatedVersions;
+   }
+
+   public void setUpdatedVersions(EntryVersionsMap updatedVersions) {
+      this.updatedVersions = updatedVersions;
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public Object[] getParameters() {
+      return new Object[]{globalTx, updatedVersions};
+   }
+
+   @Override
+   public void setParameters(int commandId, Object[] args) {
+      globalTx = (GlobalTransaction) args[0];
+      updatedVersions = (EntryVersionsMap) args[1];
+   }
+}

--- a/core/src/main/java/org/infinispan/commands/tx/VersionedPrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/VersionedPrepareCommand.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.commands.tx;
+
+import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.container.versioning.EntryVersionsMap;
+import org.infinispan.transaction.xa.GlobalTransaction;
+
+import java.util.List;
+
+/**
+ * Same as {@link PrepareCommand} except that the transaction originator makes evident the versions of entries touched
+ * and stored in a transaction context so that accurate write skew checks may be performed by the lock owner(s).
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+public class VersionedPrepareCommand extends PrepareCommand {
+   public static final byte COMMAND_ID = 26;
+   private EntryVersionsMap versionsSeen = null;
+
+   public VersionedPrepareCommand() {
+      super("");
+   }
+
+   public VersionedPrepareCommand(String cacheName, GlobalTransaction gtx, List<WriteCommand> modifications) {
+      // VersionedPrepareCommands are *always* 2-phase.
+      super(cacheName, gtx, modifications, false);
+   }
+
+   public VersionedPrepareCommand(String cacheName) {
+      super(cacheName);
+   }
+
+   public EntryVersionsMap getVersionsSeen() {
+      return versionsSeen;
+   }
+
+   public void setVersionsSeen(EntryVersionsMap versionsSeen) {
+      this.versionsSeen = versionsSeen;
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public Object[] getParameters() {
+      int numMods = modifications == null ? 0 : modifications.length;
+      int i = 0;
+      final int params = 3;
+      Object[] retval = new Object[numMods + params];
+      retval[i++] = globalTx;
+      retval[i++] = versionsSeen;
+      retval[i++] = numMods;
+      if (numMods > 0) System.arraycopy(modifications, 0, retval, params, numMods);
+      return retval;
+   }
+
+   @Override
+   @SuppressWarnings("unchecked")
+   public void setParameters(int commandId, Object[] args) {
+      int i = 0;
+      globalTx = (GlobalTransaction) args[i++];
+      onePhaseCommit = false;
+      versionsSeen = (EntryVersionsMap) args[i++];
+      int numMods = (Integer) args[i++];
+      if (numMods > 0) {
+         modifications = new WriteCommand[numMods];
+         System.arraycopy(args, i, modifications, 0, numMods);
+      }
+   }
+
+}

--- a/core/src/main/java/org/infinispan/commands/write/VersionedPutKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/VersionedPutKeyValueCommand.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.commands.write;
+
+import org.infinispan.atomic.Delta;
+import org.infinispan.container.entries.MVCCEntry;
+import org.infinispan.container.versioning.EntryVersion;
+import org.infinispan.context.Flag;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.notifications.cachelistener.CacheNotifier;
+
+import java.util.Set;
+
+/**
+ * A form of {@link PutKeyValueCommand} that also applies a version to the entry created.
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+public class VersionedPutKeyValueCommand extends PutKeyValueCommand {
+   public static final byte COMMAND_ID = 28;
+   private EntryVersion version;
+
+   public VersionedPutKeyValueCommand() {
+   }
+
+   public VersionedPutKeyValueCommand(Object key, Object value, boolean putIfAbsent, CacheNotifier notifier, long lifespanMillis, long maxIdleTimeMillis, Set<Flag> flags, EntryVersion version) {
+      super(key, value, putIfAbsent, notifier, lifespanMillis, maxIdleTimeMillis, flags);
+      this.version = version;
+   }
+
+   public EntryVersion getVersion() {
+      return version;
+   }
+
+   public void setVersion(EntryVersion version) {
+      this.version = version;
+   }
+
+   @Override
+   public Object perform(InvocationContext ctx) throws Throwable {
+      // Perform the regular put
+      Object r = super.perform(ctx);
+
+      // Apply the version to the entry
+      MVCCEntry e = (MVCCEntry) ctx.lookupEntry(key);
+      Object entryValue = e.getValue();
+      if ((entryValue == null || !putIfAbsent || e.isRemoved()) && !(value instanceof Delta)) {
+         e.setVersion(version);
+      }
+
+      return r;
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public Object[] getParameters() {
+      return new Object[]{key, value, lifespanMillis, maxIdleTimeMillis, version, flags};
+   }
+
+   @SuppressWarnings("unchecked")
+   @Override
+   public void setParameters(int commandId, Object[] parameters) {
+      if (commandId != COMMAND_ID) throw new IllegalStateException("Invalid method id");
+      key = parameters[0];
+      value = parameters[1];
+      lifespanMillis = (Long) parameters[2];
+      maxIdleTimeMillis = (Long) parameters[3];
+      version = (EntryVersion) parameters[4];
+      flags = (Set<Flag>) parameters[5];
+   }
+}

--- a/core/src/main/java/org/infinispan/config/AbstractConfigurationBeanVisitor.java
+++ b/core/src/main/java/org/infinispan/config/AbstractConfigurationBeanVisitor.java
@@ -243,6 +243,11 @@ public abstract class AbstractConfigurationBeanVisitor implements ConfigurationB
       defaultVisit(config);
    }
 
+   @Override
+   public void visitVersioningConfigurationBean(Configuration.VersioningConfigurationBean config) {
+      defaultVisit(config);
+   }
+
    public void defaultVisit(AbstractConfigurationBean c) {
    }
 }

--- a/core/src/main/java/org/infinispan/config/Configuration.java
+++ b/core/src/main/java/org/infinispan/config/Configuration.java
@@ -26,6 +26,7 @@ import org.infinispan.CacheException;
 import org.infinispan.commons.hash.Hash;
 import org.infinispan.commons.hash.MurmurHash3;
 import org.infinispan.config.FluentConfiguration.*;
+import org.infinispan.configuration.cache.VersioningScheme;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.DefaultDataContainer;
 import org.infinispan.distribution.ch.ConsistentHash;
@@ -157,6 +158,9 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
 
    @XmlElement
    QueryConfigurationBean indexing = new QueryConfigurationBean().setConfiguration(this);
+
+   @XmlElement
+   VersioningConfigurationBean versioning = new VersioningConfigurationBean().setConfiguration(this);
 
    @SuppressWarnings("unused")
    @Start(priority = 1)
@@ -649,12 +653,33 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
       this.eviction.setMaxEntries(evictionMaxEntries);
    }
 
+   @Deprecated
+   public void setVersioningScheme(VersioningScheme versioningScheme) {
+      this.versioning.setVersioningScheme(versioningScheme);
+   }
+
+   @Deprecated
+   public void setEnableVersioning(boolean enabled) {
+      this.versioning.setEnabled(enabled);
+   }
+
    /**
     * Expiration lifespan, in milliseconds
     */
    public long getExpirationLifespan() {
       return expiration.lifespan;
    }
+
+   @Deprecated
+   public VersioningScheme getVersioningScheme() {
+      return this.versioning.versioningScheme;
+   }
+
+   @Deprecated
+   public boolean isEnableVersioning() {
+      return this.versioning.enabled;
+   }
+
 
 
    /**
@@ -4051,6 +4076,95 @@ public class Configuration extends AbstractNamedCacheConfigurationBean {
 
       private void updateTransactionMode() {
          if (enabled && config != null) config.transaction.transactionMode(TransactionMode.TRANSACTIONAL);
+      }
+   }
+
+   @XmlAccessorType(XmlAccessType.PROPERTY)
+   @ConfigurationDoc(name = "versioning")
+   @Deprecated
+   public static class VersioningConfigurationBean extends AbstractFluentConfigurationBean implements VersioningConfig {
+      private static final long serialVersionUID = -123456789001234L;
+
+      @ConfigurationDocRef(bean = Configuration.class, targetElement = "setEnableVersioning")
+      protected Boolean enabled = false;
+
+      @ConfigurationDocRef(bean = Configuration.class, targetElement = "setVersioningScheme")
+      protected VersioningScheme versioningScheme = VersioningScheme.NONE;
+
+      public void accept(ConfigurationBeanVisitor v) {
+         v.visitVersioningConfigurationBean(this);
+      }
+
+      @XmlAttribute
+      public Boolean isEnabled() {
+         return enabled;
+      }
+
+      /**
+       * @deprecated The visibility of this will be reduced
+       */
+      @Deprecated
+      public void setEnabled(Boolean enabled) {
+         testImmutability("enabled");
+         this.enabled = enabled;
+      }
+
+      @XmlAttribute
+      public VersioningScheme getVersioningScheme() {
+         return versioningScheme;
+      }
+
+      /**
+       * @deprecated The visibility of this will be reduced, use {@link #versioningScheme(org.infinispan.configuration.cache.VersioningScheme)}
+       */
+      @Deprecated
+      public void setVersioningScheme(VersioningScheme versioningScheme) {
+         testImmutability("versioningScheme");
+         this.versioningScheme = versioningScheme;
+      }
+
+      @Override
+      public VersioningConfigurationBean versioningScheme(VersioningScheme versioningScheme) {
+         setVersioningScheme(versioningScheme);
+         return this;
+      }
+
+      @Override
+      protected VersioningConfigurationBean setConfiguration(Configuration config) {
+         super.setConfiguration(config);
+         return this;
+      }
+
+      @Override
+      public VersioningConfigurationBean disable() {
+         setEnabled(false);
+         return this;
+      }
+
+      @Override
+      public VersioningConfigurationBean enable() {
+         setEnabled(true);
+         return this;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) return true;
+         if (!(o instanceof VersioningConfigurationBean)) return false;
+
+         VersioningConfigurationBean that = (VersioningConfigurationBean) o;
+
+         if (!Util.safeEquals(enabled, that.enabled)) return false;
+         if (!Util.safeEquals(versioningScheme, that.versioningScheme)) return false;
+
+         return true;
+      }
+
+      @Override
+      public int hashCode() {
+         int result = enabled != null ? enabled.hashCode() : 0;
+         result = 31 * result + (versioningScheme != null ? versioningScheme.hashCode() : 0);
+         return result;
       }
    }
 

--- a/core/src/main/java/org/infinispan/config/ConfigurationBeanVisitor.java
+++ b/core/src/main/java/org/infinispan/config/ConfigurationBeanVisitor.java
@@ -22,23 +22,7 @@
  */
 package org.infinispan.config;
 
-import org.infinispan.config.Configuration.AsyncType;
-import org.infinispan.config.Configuration.BooleanAttributeType;
-import org.infinispan.config.Configuration.ClusteringType;
-import org.infinispan.config.Configuration.CustomInterceptorsType;
-import org.infinispan.config.Configuration.DataContainerType;
-import org.infinispan.config.Configuration.DeadlockDetectionType;
-import org.infinispan.config.Configuration.EvictionType;
-import org.infinispan.config.Configuration.ExpirationType;
-import org.infinispan.config.Configuration.HashType;
-import org.infinispan.config.Configuration.L1Type;
-import org.infinispan.config.Configuration.LockingType;
-import org.infinispan.config.Configuration.QueryConfigurationBean;
-import org.infinispan.config.Configuration.StateRetrievalType;
-import org.infinispan.config.Configuration.SyncType;
-import org.infinispan.config.Configuration.TransactionType;
-import org.infinispan.config.Configuration.UnsafeType;
-import org.infinispan.config.FluentConfiguration.GroupsConfig;
+import org.infinispan.config.Configuration.*;
 import org.infinispan.config.GlobalConfiguration.AdvancedExternalizersType;
 import org.infinispan.config.GlobalConfiguration.FactoryClassWithPropertiesType;
 import org.infinispan.config.GlobalConfiguration.GlobalJmxStatisticsType;
@@ -133,4 +117,6 @@ public interface ConfigurationBeanVisitor {
    void visitRecoveryType(Configuration.RecoveryType config);
 
    void visitStoreAsBinaryType(Configuration.StoreAsBinary config);
+
+   void visitVersioningConfigurationBean(VersioningConfigurationBean config);
 }

--- a/core/src/main/java/org/infinispan/config/ConfigurationValidatingVisitor.java
+++ b/core/src/main/java/org/infinispan/config/ConfigurationValidatingVisitor.java
@@ -125,6 +125,10 @@ public class ConfigurationValidatingVisitor extends AbstractConfigurationBeanVis
    }
 
    @Override
+   public void visitVersioningConfigurationBean(Configuration.VersioningConfigurationBean config) {
+   }
+
+   @Override
    public void visitEvictionType(EvictionType et) {
       evictionEnabled = et.strategy.isEnabled();
       if (et.strategy.isEnabled() && et.maxEntries <= 0)

--- a/core/src/main/java/org/infinispan/config/DelegatingConfigurationVisitor.java
+++ b/core/src/main/java/org/infinispan/config/DelegatingConfigurationVisitor.java
@@ -18,27 +18,7 @@
  */
 package org.infinispan.config;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.infinispan.config.Configuration.AsyncType;
-import org.infinispan.config.Configuration.BooleanAttributeType;
-import org.infinispan.config.Configuration.ClusteringType;
-import org.infinispan.config.Configuration.CustomInterceptorsType;
-import org.infinispan.config.Configuration.DataContainerType;
-import org.infinispan.config.Configuration.DeadlockDetectionType;
-import org.infinispan.config.Configuration.EvictionType;
-import org.infinispan.config.Configuration.ExpirationType;
-import org.infinispan.config.Configuration.HashType;
-import org.infinispan.config.Configuration.L1Type;
-import org.infinispan.config.Configuration.LockingType;
-import org.infinispan.config.Configuration.QueryConfigurationBean;
-import org.infinispan.config.Configuration.RecoveryType;
-import org.infinispan.config.Configuration.StateRetrievalType;
-import org.infinispan.config.Configuration.StoreAsBinary;
-import org.infinispan.config.Configuration.SyncType;
-import org.infinispan.config.Configuration.TransactionType;
-import org.infinispan.config.Configuration.UnsafeType;
+import org.infinispan.config.Configuration.*;
 import org.infinispan.config.GlobalConfiguration.AdvancedExternalizersType;
 import org.infinispan.config.GlobalConfiguration.FactoryClassWithPropertiesType;
 import org.infinispan.config.GlobalConfiguration.GlobalJmxStatisticsType;
@@ -49,22 +29,25 @@ import org.infinispan.loaders.CacheLoaderConfig;
 import org.infinispan.loaders.decorators.AsyncStoreConfig;
 import org.infinispan.loaders.decorators.SingletonStoreConfig;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
- * DelegatingConfigurationVisitor wraps a list of ConfigurationBeanVisitor visitors and delegates
- * visitor callbacks to all delegates in the list.
- * 
+ * DelegatingConfigurationVisitor wraps a list of ConfigurationBeanVisitor visitors and delegates visitor callbacks to
+ * all delegates in the list.
+ *
  * @author Vladimir Blagojevic
  * @since 5.0
  */
 public class DelegatingConfigurationVisitor implements ConfigurationBeanVisitor {
-   
+
    private List<ConfigurationBeanVisitor> delegates;
-   
-   public DelegatingConfigurationVisitor(ConfigurationBeanVisitor [] visitors){
+
+   public DelegatingConfigurationVisitor(ConfigurationBeanVisitor[] visitors) {
       delegates = Arrays.asList(visitors);
    }
-   
-   public DelegatingConfigurationVisitor(List<ConfigurationBeanVisitor> visitors){
+
+   public DelegatingConfigurationVisitor(List<ConfigurationBeanVisitor> visitors) {
       delegates = visitors;
    }
 
@@ -179,7 +162,7 @@ public class DelegatingConfigurationVisitor implements ConfigurationBeanVisitor 
          delegate.visitExpirationType(bean);
       }
    }
-   
+
    @Override
    public void visitGroupConfig(GroupsConfiguration bean) {
       for (ConfigurationBeanVisitor delegate : delegates) {
@@ -303,6 +286,13 @@ public class DelegatingConfigurationVisitor implements ConfigurationBeanVisitor 
    public void visitStoreAsBinaryType(StoreAsBinary bean) {
       for (ConfigurationBeanVisitor delegate : delegates) {
          delegate.visitStoreAsBinaryType(bean);
+      }
+   }
+
+   @Override
+   public void visitVersioningConfigurationBean(Configuration.VersioningConfigurationBean config) {
+      for (ConfigurationBeanVisitor delegate : delegates) {
+         delegate.visitVersioningConfigurationBean(config);
       }
    }
 }

--- a/core/src/main/java/org/infinispan/config/FluentConfiguration.java
+++ b/core/src/main/java/org/infinispan/config/FluentConfiguration.java
@@ -24,6 +24,7 @@
 package org.infinispan.config;
 
 import org.infinispan.commons.hash.Hash;
+import org.infinispan.configuration.cache.VersioningScheme;
 import org.infinispan.container.DataContainer;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.distribution.group.Group;
@@ -777,6 +778,13 @@ public class FluentConfiguration extends AbstractFluentConfigurationBean {
       IndexingConfig addProperty(String key, String value);
    }
 
+   @Deprecated
+   public static interface VersioningConfig extends FluentTypes {
+      VersioningConfig enable();
+      VersioningConfig disable();
+      VersioningConfig versioningScheme(VersioningScheme scheme);
+   }
+
    @Deprecated public static interface DataContainerConfig extends FluentTypes {
 
       DataContainerConfig dataContainerClass(Class<? extends DataContainer> dataContainerClass);
@@ -867,6 +875,8 @@ interface FluentTypes {
     */
    FluentConfiguration.InvocationBatchingConfig invocationBatching();
 
+   FluentConfiguration.VersioningConfig versioning();
+
    Configuration build();
 }
 
@@ -940,6 +950,11 @@ abstract class AbstractFluentConfigurationBean extends AbstractNamedCacheConfigu
    @Override
    public FluentConfiguration.StoreAsBinaryConfig storeAsBinary() {
       return config.storeAsBinary.enabled(true);
+   }
+
+   @Override
+   public FluentConfiguration.VersioningConfig versioning() {
+      return config.versioning.enable();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractConfigurationChildBuilder.java
@@ -72,6 +72,11 @@ abstract class AbstractConfigurationChildBuilder<T> implements ConfigurationChil
    public TransactionConfigurationBuilder transaction() {
       return builder.transaction();
    }
+
+   @Override
+   public VersioningConfigurationBuilder versioning() {
+     return builder.versioning();
+   }
    
    @Override
    public UnsafeConfigurationBuilder unsafe() {
@@ -85,7 +90,7 @@ abstract class AbstractConfigurationChildBuilder<T> implements ConfigurationChil
    public Configuration build() {
       return builder.build();
    }
-   
+
    abstract void validate();
    
    abstract T create();

--- a/core/src/main/java/org/infinispan/configuration/cache/Configuration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/Configuration.java
@@ -17,6 +17,7 @@ public class Configuration {
    private final LockingConfiguration lockingConfiguration;
    private final StoreAsBinaryConfiguration storeAsBinaryConfiguration;
    private final TransactionConfiguration transactionConfiguration;
+   private final VersioningConfiguration versioningConfiguration;
    private final UnsafeConfiguration unsafeConfiguration;
 
    Configuration(String name, ClusteringConfiguration clusteringConfiguration,
@@ -27,7 +28,8 @@ public class Configuration {
          JMXStatisticsConfiguration jmxStatisticsConfiguration,
          LoadersConfiguration loadersConfiguration,
          LockingConfiguration lockingConfiguration, StoreAsBinaryConfiguration storeAsBinaryConfiguration,
-         TransactionConfiguration transactionConfiguration, UnsafeConfiguration unsafeConfiguration, ClassLoader cl) {
+         TransactionConfiguration transactionConfiguration, UnsafeConfiguration unsafeConfiguration,
+         VersioningConfiguration versioningConfiguration, ClassLoader cl) {
       this.name = name;
       this.clusteringConfiguration = clusteringConfiguration;
       this.customInterceptorsConfiguration = customInterceptorsConfiguration;
@@ -43,6 +45,7 @@ public class Configuration {
       this.storeAsBinaryConfiguration = storeAsBinaryConfiguration;
       this.transactionConfiguration = transactionConfiguration;
       this.unsafeConfiguration = unsafeConfiguration;
+      this.versioningConfiguration = versioningConfiguration;
       this.classLoader = cl;
    }
 
@@ -114,15 +117,17 @@ public class Configuration {
    public UnsafeConfiguration unsafe() {
       return unsafeConfiguration;
    }
-   
+
+   public VersioningConfiguration versioningConfiguration() {
+      return versioningConfiguration;
+   }
+
    public boolean stateTransferEnabled() {
       return clustering().stateRetrieval().fetchInMemoryState() || loaders().fetchPersistentState();
    }
-   
+
    @Deprecated
    public boolean onePhaseCommit() {
       return clusteringConfiguration.cacheMode().isSynchronous();
    }
-
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/ConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ConfigurationBuilder.java
@@ -1,5 +1,7 @@
 package org.infinispan.configuration.cache;
 
+import static java.util.Arrays.asList;
+
 public class ConfigurationBuilder implements ConfigurationChildBuilder {
 
    private String name;
@@ -17,6 +19,7 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder {
    private final LockingConfigurationBuilder locking;
    private final StoreAsBinaryConfigurationBuilder storeAsBinary;
    private final TransactionConfigurationBuilder transaction;
+   private final VersioningConfigurationBuilder versioning;
    private final UnsafeConfigurationBuilder unsafe;
    
    public ConfigurationBuilder() {
@@ -33,6 +36,7 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder {
       this.locking = new LockingConfigurationBuilder(this);
       this.storeAsBinary = new StoreAsBinaryConfigurationBuilder(this);
       this.transaction = new TransactionConfigurationBuilder(this);
+      this.versioning = new VersioningConfigurationBuilder(this);
       this.unsafe = new UnsafeConfigurationBuilder(this);
    }
    
@@ -114,27 +118,26 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder {
    public TransactionConfigurationBuilder transaction() {
       return transaction;
    }
+
+   @Override
+   public VersioningConfigurationBuilder versioning() {
+      return versioning;
+   }
    
    @Override
    public UnsafeConfigurationBuilder unsafe() {
       return unsafe;
    }
-   
+
+   @SuppressWarnings("unchecked")
    public void validate() {
-      clustering.validate();
-      dataContainer.validate();
-      deadlockDetection.validate();
-      eviction.validate();
-      expiration.validate();
-      indexing.validate();
-      invocationBatching.validate();
-      jmxStatistics.validate();
-      loaders.validate();
-      locking.validate();
-      storeAsBinary.validate();
-      transaction.validate();
-      unsafe.validate();
-      
+      for (AbstractConfigurationChildBuilder<?> validatable:
+            asList(clustering, dataContainer, deadlockDetection, eviction, expiration, indexing,
+                   invocationBatching, jmxStatistics, loaders, locking, storeAsBinary, transaction,
+                   versioning, unsafe)) {
+         validatable.validate();
+      }
+
       // TODO validate that a transport is set if a singleton store is set
    }
 
@@ -155,7 +158,9 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder {
             locking.create(),
             storeAsBinary.create(),
             transaction.create(),
-            unsafe.create(), classLoader );// TODO
+            unsafe.create(),
+            versioning.create(),
+            classLoader );// TODO
    }
 
    

--- a/core/src/main/java/org/infinispan/configuration/cache/ConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ConfigurationChildBuilder.java
@@ -2,34 +2,35 @@ package org.infinispan.configuration.cache;
 
 public interface ConfigurationChildBuilder {
 
-   public ClusteringConfigurationBuilder clustering();
+   ClusteringConfigurationBuilder clustering();
    
-   public CustomInterceptorsConfigurationBuilder customInterceptors();
+   CustomInterceptorsConfigurationBuilder customInterceptors();
    
-   public DataContainerConfigurationBuilder dataContainer();
+   DataContainerConfigurationBuilder dataContainer();
    
-   public DeadlockDetectionConfigurationBuilder deadlockDetection();
+   DeadlockDetectionConfigurationBuilder deadlockDetection();
    
-   public EvictionConfigurationBuilder eviction();
+   EvictionConfigurationBuilder eviction();
    
-   public ExpirationConfigurationBuilder expiration();
+   ExpirationConfigurationBuilder expiration();
    
-   public IndexingConfigurationBuilder indexing();
+   IndexingConfigurationBuilder indexing();
    
-   public InvocationBatchingConfigurationBuilder invocationBatching();
+   InvocationBatchingConfigurationBuilder invocationBatching();
    
-   public JMXStatisticsConfigurationBuilder jmxStatistics();
+   JMXStatisticsConfigurationBuilder jmxStatistics();
    
-   public LoadersConfigurationBuilder loaders();
+   LoadersConfigurationBuilder loaders();
    
-   public LockingConfigurationBuilder locking();
+   LockingConfigurationBuilder locking();
    
-   public StoreAsBinaryConfigurationBuilder storeAsBinary();
+   StoreAsBinaryConfigurationBuilder storeAsBinary();
    
-   public TransactionConfigurationBuilder transaction();
+   TransactionConfigurationBuilder transaction();
+   
+   VersioningConfigurationBuilder versioning();
   
-   public UnsafeConfigurationBuilder unsafe();
+   UnsafeConfigurationBuilder unsafe();
    
-   public Configuration build();
-   
+   Configuration build();
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/L1ConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/L1ConfigurationBuilder.java
@@ -88,7 +88,7 @@ public class L1ConfigurationBuilder extends AbstractClusteringConfigurationChild
    @Override
    void validate() {
       // If L1 is disabled, L1ForRehash should also be disabled
-      if (!enabled && onRehash)
+      if (!enabled && onRehash != null && onRehash)
          throw new ConfigurationException("Can only move entries to L1 on rehash when L1 is enabled");
    }
 

--- a/core/src/main/java/org/infinispan/configuration/cache/LegacyConfigurationAdaptor.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LegacyConfigurationAdaptor.java
@@ -180,7 +180,12 @@ public class LegacyConfigurationAdaptor {
       }
         
       legacy.unsafe().unreliableReturnValues(config.unsafe().unreliableReturnValues());
-      
+
+      if (config.versioningConfiguration().enabled()) {
+         legacy.versioning()
+               .enable()
+               .versioningScheme(config.versioningConfiguration().scheme());
+      }
       
       return legacy.build();
    }

--- a/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
@@ -1,23 +1,23 @@
 package org.infinispan.configuration.cache;
 
-import java.util.concurrent.TimeUnit;
-
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
 import org.infinispan.transaction.lookup.TransactionManagerLookup;
 import org.infinispan.transaction.lookup.TransactionSynchronizationRegistryLookup;
+
+import java.util.concurrent.TimeUnit;
 
 public class TransactionConfigurationBuilder extends AbstractConfigurationChildBuilder<TransactionConfiguration> {
 
    private boolean autoCommit = true;
    private long cacheStopTimeout = TimeUnit.SECONDS.toMillis(30);
    private boolean eagerLockingSingleNode = false;
-   private LockingMode lockingMode = LockingMode.OPTIMISTIC;
+   LockingMode lockingMode = LockingMode.OPTIMISTIC;
    private boolean syncCommitPhase = true;
    private boolean syncRollbackPhase = false;
    private TransactionManagerLookup transactionManagerLookup ;
    private TransactionSynchronizationRegistryLookup transactionSynchronizationRegistryLookup;
-   private TransactionMode transactionMode = TransactionMode.NON_TRANSACTIONAL;
+   TransactionMode transactionMode = TransactionMode.NON_TRANSACTIONAL;
    private boolean useEagerLocking = false;
    private boolean useSynchronization = false;
    private final RecoveryConfigurationBuilder recovery;

--- a/core/src/main/java/org/infinispan/configuration/cache/VersioningConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/VersioningConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.configuration.cache;
+
+/**
+ * This configuration element controls whether entries are versioned.  Versioning is necessary, for example, when
+ * using optimistic transactions in a clustered environment, to be able to perform write-skew checks.
+ */
+public class VersioningConfiguration {
+   private final boolean enabled;
+   private final VersioningScheme scheme;
+
+   VersioningConfiguration(boolean enabled, VersioningScheme scheme) {
+      this.enabled = enabled;
+      this.scheme = scheme;
+   }
+
+   public boolean enabled() {
+      return enabled;
+   }
+
+   public VersioningScheme scheme() {
+      return scheme;
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/cache/VersioningConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/VersioningConfigurationBuilder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.configuration.cache;
+
+public class VersioningConfigurationBuilder extends AbstractConfigurationChildBuilder<VersioningConfiguration> {
+
+   boolean enabled = false;
+   VersioningScheme scheme = VersioningScheme.NONE;
+
+   protected VersioningConfigurationBuilder(ConfigurationBuilder builder) {
+      super(builder);
+   }
+
+   public VersioningConfigurationBuilder enable() {
+      this.enabled = true;
+      return this;
+   }
+
+   public VersioningConfigurationBuilder disable() {
+      this.enabled = false;
+      return this;
+   }
+
+   public VersioningConfigurationBuilder enabled(boolean enabled) {
+      this.enabled = enabled;
+      return this;
+   }
+
+   public VersioningConfigurationBuilder scheme(VersioningScheme scheme) {
+      this.scheme = scheme;
+      return this;
+   }
+
+   @Override
+   void validate() {
+   }
+
+   @Override
+   VersioningConfiguration create() {
+      return new VersioningConfiguration(enabled, scheme);
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/cache/VersioningScheme.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/VersioningScheme.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.configuration.cache;
+
+/**
+ * The various versioning schemes supported
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+public enum VersioningScheme {
+   SIMPLE, NONE
+}

--- a/core/src/main/java/org/infinispan/configuration/cache/package-info.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/package-info.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * Classes related to eviction.
+ * Need @XmlSchema annotation for EvictionStrategy.java
+ */
+@XmlSchema(namespace = ISPN_NS, elementFormDefault = XmlNsForm.QUALIFIED, attributeFormDefault = XmlNsForm.UNQUALIFIED,
+         xmlns = {
+         @javax.xml.bind.annotation.XmlNs(prefix = "tns", namespaceURI =ISPN_NS),
+         @javax.xml.bind.annotation.XmlNs(prefix = "xs", namespaceURI = "http://www.w3.org/2001/XMLSchema") })
+package org.infinispan.configuration.cache;
+
+
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;
+
+import static org.infinispan.config.parsing.NamespaceFilter.ISPN_NS;

--- a/core/src/main/java/org/infinispan/configuration/global/SerializationConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/SerializationConfigurationBuilder.java
@@ -14,7 +14,7 @@ import org.infinispan.marshall.VersionAwareMarshaller;
 public class SerializationConfigurationBuilder extends AbstractGlobalConfigurationBuilder<SerializationConfiguration> {
    
    private Class<? extends Marshaller> marshallerClass = VersionAwareMarshaller.class;
-   private short marshallVersion = Short.valueOf(Version.MAJOR_MINOR);
+   private short marshallVersion = Short.valueOf(Version.MAJOR_MINOR.replace(".", ""));
    private Map<Integer, AdvancedExternalizer<?>> advancedExternalizers = new HashMap<Integer, AdvancedExternalizer<?>>();
    
    SerializationConfigurationBuilder(GlobalConfigurationBuilder globalConfig) {

--- a/core/src/main/java/org/infinispan/container/DataContainer.java
+++ b/core/src/main/java/org/infinispan/container/DataContainer.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Set;
 
 import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.versioning.EntryVersion;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
@@ -70,7 +71,7 @@ public interface DataContainer extends Iterable<InternalCacheEntry> {
     * @param lifespan lifespan in milliseconds.  -1 means immortal.
     * @param maxIdle max idle time for which to store entry.  -1 means forever.
     */
-   void put(Object k, Object v, long lifespan, long maxIdle);
+   void put(Object k, Object v, EntryVersion version, long lifespan, long maxIdle);
 
    /**
     * Tests whether an entry exists in the container

--- a/core/src/main/java/org/infinispan/container/IncrementalVersionableEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/IncrementalVersionableEntryFactoryImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container;
+
+import org.infinispan.container.entries.ClusteredRepeatableReadEntry;
+import org.infinispan.container.entries.MVCCEntry;
+import org.infinispan.container.entries.NullMarkerEntry;
+import org.infinispan.container.entries.NullMarkerEntryForRemoval;
+import org.infinispan.container.versioning.EntryVersion;
+import org.infinispan.container.versioning.VersionGenerator;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+
+/**
+ * An entry factory that is capable of dealing with SimpleClusteredVersions.  This should <i>only</i> be used with
+ * optimistically transactional, repeatable read, write skew check enabled caches in replicated or distributed mode.
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+public class IncrementalVersionableEntryFactoryImpl extends EntryFactoryImpl {
+   private VersionGenerator versionGenerator;
+
+   @Inject
+   public void injectVersionGenerator(VersionGenerator versionGenerator) {
+      this.versionGenerator = versionGenerator;
+   }
+
+   @Start (priority = 9)
+   public void setWriteSkewCheckFlag() {
+      localModeWriteSkewCheck = false;
+      useRepeatableRead = true;
+   }
+
+   @Override
+   protected MVCCEntry createWrappedEntry(Object key, Object value, EntryVersion version, boolean isForInsert, boolean forRemoval, long lifespan) {
+      if (value == null && !isForInsert) return forRemoval ? new NullMarkerEntryForRemoval(key, version) : NullMarkerEntry.getInstance();
+
+      return new ClusteredRepeatableReadEntry(key, value, version, lifespan);
+   }
+}

--- a/core/src/main/java/org/infinispan/container/entries/AbstractInternalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/AbstractInternalCacheEntry.java
@@ -23,6 +23,7 @@
 package org.infinispan.container.entries;
 
 import org.infinispan.container.DataContainer;
+import org.infinispan.container.versioning.EntryVersion;
 
 /**
  * An abstract internal cache entry that is typically stored in the data container
@@ -41,7 +42,7 @@ public abstract class AbstractInternalCacheEntry implements InternalCacheEntry {
       this.key = key;
    }
 
-   public final void commit(DataContainer container) {
+   public final void commit(DataContainer container, EntryVersion newVersion) {
       // no-op
    }
 
@@ -103,7 +104,6 @@ public abstract class AbstractInternalCacheEntry implements InternalCacheEntry {
 
    public void setLifespan(long lifespan) {
    }
-
 
    public final Object getKey() {
       return key;

--- a/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
@@ -23,6 +23,7 @@
 package org.infinispan.container.entries;
 
 import org.infinispan.container.DataContainer;
+import org.infinispan.container.versioning.EntryVersion;
 
 import java.util.Map;
 
@@ -119,7 +120,7 @@ public interface CacheEntry extends Map.Entry<Object, Object> {
     *
     * @param container data container to commit to
     */
-   void commit(DataContainer container);
+   void commit(DataContainer container, EntryVersion newVersion);
 
    /**
     * Rolls back changes
@@ -144,4 +145,16 @@ public interface CacheEntry extends Map.Entry<Object, Object> {
     * flag is set to false.
     */
    boolean undelete(boolean doUndelete);
+   // TODO- do we need an un-versioned CacheEntry as well?
+    /**
+    * @return the version of the entry.  May be null if versioning is not supported, and must never be null if versioning
+    * is supported.
+    */
+   EntryVersion getVersion();
+
+   /**
+    * Sets the version on this entry.
+    * @param version version to set
+    */
+   void setVersion(EntryVersion version);
 }

--- a/core/src/main/java/org/infinispan/container/entries/ClusteredRepeatableReadEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ClusteredRepeatableReadEntry.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.entries;
+
+import org.infinispan.container.DataContainer;
+import org.infinispan.container.versioning.EntryVersion;
+import org.infinispan.container.versioning.InequalVersionComparisonResult;
+
+/**
+ * A version of RepeatableReadEntry that can perform write-skew checks during prepare.
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+public class ClusteredRepeatableReadEntry extends RepeatableReadEntry {
+   private EntryVersion version;
+
+   public ClusteredRepeatableReadEntry(Object key, Object value, EntryVersion version, long lifespan) {
+      super(key, value, version, lifespan);
+      this.version = version;
+   }
+
+   public boolean performWriteSkewCheck(DataContainer container) {
+      InternalCacheEntry ice = container.get(key);
+      if (ice == null) return version == null;
+      if (ice.getVersion() == null)
+         throw new IllegalStateException("Entries cannot have null versions!");
+      // Could be that we didn't do a remote get first ... so we haven't effectively read this entry yet.
+      if (version == null) return true;
+      return InequalVersionComparisonResult.AFTER != ice.getVersion().compareTo(version);
+   }
+
+   @Override
+   public EntryVersion getVersion() {
+      return version;
+   }
+
+   @Override
+   public void setVersion(EntryVersion version) {
+      this.version = version;
+   }
+}

--- a/core/src/main/java/org/infinispan/container/entries/DeltaAwareCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/DeltaAwareCacheEntry.java
@@ -22,16 +22,17 @@
  */
 package org.infinispan.container.entries;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.infinispan.atomic.AtomicHashMap;
 import org.infinispan.atomic.Delta;
 import org.infinispan.atomic.DeltaAware;
 import org.infinispan.container.DataContainer;
+import org.infinispan.container.versioning.EntryVersion;
 import org.infinispan.util.Util;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.infinispan.container.entries.DeltaAwareCacheEntry.Flags.*;
 
@@ -161,10 +162,10 @@ public class DeltaAwareCacheEntry implements CacheEntry {
          oldValue = value;
    }
 
-   public final void commit(DataContainer container) {
+   public final void commit(DataContainer container, EntryVersion version) {
       // only do stuff if there are changes.
       if (wrappedEntry != null) {
-         wrappedEntry.commit(container);
+         wrappedEntry.commit(container, version);
       }
       if (value != null && !deltas.isEmpty()) {
          for (Delta delta : deltas) {
@@ -285,5 +286,15 @@ public class DeltaAwareCacheEntry implements CacheEntry {
          return true;
       }
       return false;
+   }
+
+   @Override
+   public EntryVersion getVersion() {
+      return null;  // DeltaAware are always unversioned!  Since concurrent version updates are possible with the FineGrainedAtomicMap
+   }
+
+   @Override
+   public void setVersion(EntryVersion version) {
+      // TODO: DeltaAware are always unversioned!  Since concurrent version updates are possible with the FineGrainedAtomicMap
    }
 }

--- a/core/src/main/java/org/infinispan/container/entries/InternalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/InternalCacheEntry.java
@@ -22,6 +22,8 @@
  */
 package org.infinispan.container.entries;
 
+import org.infinispan.container.versioning.EntryVersion;
+
 /**
  * Interface for internal cache entries that expose whether an entry has expired.
  *

--- a/core/src/main/java/org/infinispan/container/entries/NullMarkerEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/NullMarkerEntry.java
@@ -36,7 +36,7 @@ public class NullMarkerEntry extends NullMarkerEntryForRemoval {
    private static final NullMarkerEntry INSTANCE = new NullMarkerEntry();
 
    private NullMarkerEntry() {
-      super(null);
+      super(null, null);
    }
 
    public static NullMarkerEntry getInstance() {
@@ -47,7 +47,7 @@ public class NullMarkerEntry extends NullMarkerEntryForRemoval {
     * A no-op.
     */
    @Override
-   public final void copyForUpdate(DataContainer d, boolean b) {
+   public final void copyForUpdate(DataContainer d, boolean localModeWriteSkewCheck) {
       // no op
    }
 }

--- a/core/src/main/java/org/infinispan/container/entries/NullMarkerEntryForRemoval.java
+++ b/core/src/main/java/org/infinispan/container/entries/NullMarkerEntryForRemoval.java
@@ -23,6 +23,8 @@
 package org.infinispan.container.entries;
 
 
+import org.infinispan.container.versioning.EntryVersion;
+
 /**
  * A null entry that is read in for removal
  *
@@ -31,8 +33,8 @@ package org.infinispan.container.entries;
  */
 public class NullMarkerEntryForRemoval extends RepeatableReadEntry {
 
-   public NullMarkerEntryForRemoval(Object key) {
-      super(key, null, -1);
+   public NullMarkerEntryForRemoval(Object key, EntryVersion version) {
+      super(key, null, version, -1);
    }
 
    /**

--- a/core/src/main/java/org/infinispan/container/versioning/EntryVersion.java
+++ b/core/src/main/java/org/infinispan/container/versioning/EntryVersion.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.versioning;
+
+/**
+ * A version is used to compare entries against one another.  Versions do not guarantee contiguity, but do guarantee
+ * to be comparable.  However this comparability is not the same as the JDK's {@link Comparable} interface.  It is
+ * richer in that {@link Comparable} doesn't differentiate between instances that are the same versus instances that
+ * are equal-but-different.
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+public interface EntryVersion {
+
+   /**
+    * Compares the given version against the current instance.
+    * @param other the other version to compare against
+    * @return a InequalVersionComparisonResult instance
+    */
+   InequalVersionComparisonResult compareTo(EntryVersion other);
+
+}

--- a/core/src/main/java/org/infinispan/container/versioning/EntryVersionsMap.java
+++ b/core/src/main/java/org/infinispan/container/versioning/EntryVersionsMap.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.versioning;
+
+import java.util.HashMap;
+
+public class EntryVersionsMap extends HashMap<Object, IncrementableEntryVersion> {
+   public EntryVersionsMap merge(EntryVersionsMap updatedVersions) {
+      if (updatedVersions != null && !updatedVersions.isEmpty()) {
+         updatedVersions.putAll(this);
+         return updatedVersions;
+      } else {
+         return this;
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/container/versioning/IncrementableEntryVersion.java
+++ b/core/src/main/java/org/infinispan/container/versioning/IncrementableEntryVersion.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.versioning;
+
+/**
+ * An interface indicating that a version of this type can be incremented.
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+public interface IncrementableEntryVersion extends EntryVersion {
+}

--- a/core/src/main/java/org/infinispan/container/versioning/InequalVersionComparisonResult.java
+++ b/core/src/main/java/org/infinispan/container/versioning/InequalVersionComparisonResult.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.versioning;
+
+/**
+ * Versions can be compared to each other to result in one version being before, after or at the same time as another
+ * version.  This is different from the JDK's {@link Comparable} interface, which is much more simplistic in that it
+ * doesn't differentiate between something that is the same versus equal-but-different.
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+public enum InequalVersionComparisonResult {
+   /**
+    * Denotes a version that was created temporally <i>before</i> another version.
+    */
+   BEFORE,
+   /**
+    * Denotes a version that was created temporally <i>after</i> another version.
+    */
+   AFTER,
+   /**
+    * Denotes that the two versions being comapred are equal.
+    */
+   EQUAL,
+   /**
+    * Denotes a version that was created at the same time as another version, but is not equal.  This is only really
+    * useful when using a partition-aware versioning scheme, such as vector or Lamport clocks.
+    */
+   CONFLICTING
+}

--- a/core/src/main/java/org/infinispan/container/versioning/SimpleClusteredVersion.java
+++ b/core/src/main/java/org/infinispan/container/versioning/SimpleClusteredVersion.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.versioning;
+
+import net.jcip.annotations.Immutable;
+
+import java.io.Serializable;
+
+/**
+ * A simple versioning scheme that is cluster-aware
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+@Immutable
+public class SimpleClusteredVersion implements IncrementableEntryVersion, Serializable {
+   private final int viewId;
+   final long version;
+
+   public SimpleClusteredVersion(int viewId, long version) {
+      this.version = version;
+      this.viewId = viewId;
+   }
+
+   @Override
+   public InequalVersionComparisonResult compareTo(EntryVersion other) {
+      if (other instanceof SimpleClusteredVersion) {
+         SimpleClusteredVersion otherVersion = (SimpleClusteredVersion) other;
+
+         if (viewId > otherVersion.viewId)
+            return InequalVersionComparisonResult.AFTER;
+         if (viewId < otherVersion.viewId)
+            return InequalVersionComparisonResult.BEFORE;
+
+         if (version > otherVersion.version)
+            return InequalVersionComparisonResult.AFTER;
+         if (version < otherVersion.version)
+            return InequalVersionComparisonResult.BEFORE;
+
+         return InequalVersionComparisonResult.EQUAL;
+      } else {
+         throw new IllegalArgumentException("I only know how to deal with SimpleClusteredVersions, not " + other.getClass().getName());
+      }
+   }
+
+   @Override
+   public String toString() {
+      return "SimpleClusteredVersion{" +
+            "viewId=" + viewId +
+            ", version=" + version +
+            '}';
+   }
+}

--- a/core/src/main/java/org/infinispan/container/versioning/SimpleClusteredVersionGenerator.java
+++ b/core/src/main/java/org/infinispan/container/versioning/SimpleClusteredVersionGenerator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.versioning;
+
+import org.infinispan.Cache;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged;
+import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
+import org.infinispan.remoting.transport.Transport;
+
+/**
+ * A version generator implementation for SimpleClusteredVersions
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+public class SimpleClusteredVersionGenerator implements VersionGenerator {
+   // The current cluster view ID is recorded and used as a part of the version generated, and as such used as the
+   // most significant part of a version comparison.  If a version is generated based on an old view and another is
+   // generated based on a newer view, the one based on the newer view wins regardless of the version's counter.
+   // See SimpleClusteredVersion for more details.
+   private volatile int viewId;
+   private Cache cache;
+   private Transport transport;
+
+   @Inject
+   public void init(Cache cache, Transport transport) {
+      this.cache = cache;
+      this.transport = transport;
+   }
+
+   @Start(priority = 11) // needs to happen *after* the transport starts.
+   public void start() {
+      if (transport != null) {
+         viewId = transport.getViewId();
+         cache.getCacheManager().addListener(new ViewIdUpdater());
+      }
+   }
+
+   @Override
+   public IncrementableEntryVersion generateNew() {
+      return new SimpleClusteredVersion(viewId, 1);
+   }
+
+   @Override
+   public IncrementableEntryVersion increment(IncrementableEntryVersion initialVersion) {
+      if (initialVersion instanceof SimpleClusteredVersion) {
+         SimpleClusteredVersion old = (SimpleClusteredVersion) initialVersion;
+         return new SimpleClusteredVersion(viewId, old.version + 1);
+      } else {
+         throw new IllegalArgumentException("I only know how to deal with SimpleClusteredVersions, not " + initialVersion.getClass().getName());
+      }
+   }
+
+   @Listener
+   public class ViewIdUpdater {
+      @ViewChanged
+      public void handleViewChange(ViewChangedEvent e) {
+         viewId = e.getViewId();
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/container/versioning/VersionGenerator.java
+++ b/core/src/main/java/org/infinispan/container/versioning/VersionGenerator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.versioning;
+
+/**
+ * Generates versions
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+public interface VersionGenerator {
+   /**
+    * Generates a new entry version
+    * @return a new entry version
+    */
+   IncrementableEntryVersion generateNew();
+
+   IncrementableEntryVersion increment(IncrementableEntryVersion initialVersion);
+}

--- a/core/src/main/java/org/infinispan/factories/EmptyConstructorNamedCacheFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EmptyConstructorNamedCacheFactory.java
@@ -52,7 +52,7 @@ import static org.infinispan.util.Util.loadClass;
  * @author Manik Surtani (<a href="mailto:manik@jboss.org">manik@jboss.org</a>)
  * @since 4.0
  */
-@DefaultFactoryFor(classes = {CacheNotifier.class, EntryFactory.class, CommandsFactory.class,
+@DefaultFactoryFor(classes = {CacheNotifier.class, CommandsFactory.class,
         CacheLoaderManager.class, InvocationContextContainer.class, PassivationManager.class,
         BatchContainer.class, TransactionLog.class, EvictionManager.class, InvocationContextContainer.class,
         TransactionCoordinator.class, RecoveryAdminOperations.class, StateTransferLock.class, ClusteringDependentLogic.class})

--- a/core/src/main/java/org/infinispan/factories/EntryMetaFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EntryMetaFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.factories;
+
+import org.infinispan.container.EntryFactory;
+import org.infinispan.container.EntryFactoryImpl;
+import org.infinispan.container.IncrementalVersionableEntryFactoryImpl;
+import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.util.concurrent.IsolationLevel;
+
+@DefaultFactoryFor(classes = EntryFactory.class)
+public class EntryMetaFactory extends AbstractNamedCacheComponentFactory implements AutoInstantiableFactory {
+
+   @Override
+   @SuppressWarnings("unchecked")
+   public <T> T construct(Class<T> componentType) {
+      // If we are repeatable-read and have write skew checking enabled and are clustered, lets create an appropriate EntryFactory.
+      if (configuration.getCacheMode().isClustered() &&
+            configuration.isTransactionalCache() &&
+            configuration.getIsolationLevel() == IsolationLevel.REPEATABLE_READ &&
+            configuration.isWriteSkewCheck() &&
+            configuration.getTransactionLockingMode() == LockingMode.OPTIMISTIC) {
+         return (T) new IncrementalVersionableEntryFactoryImpl();
+      }
+      // a "regular" entry factory
+      return (T) new EntryFactoryImpl();
+   }
+}

--- a/core/src/main/java/org/infinispan/factories/VersioningMetaFactory.java
+++ b/core/src/main/java/org/infinispan/factories/VersioningMetaFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.factories;
+
+import org.infinispan.container.versioning.SimpleClusteredVersionGenerator;
+import org.infinispan.container.versioning.VersionGenerator;
+import org.infinispan.factories.annotations.DefaultFactoryFor;
+
+@DefaultFactoryFor(classes = VersionGenerator.class)
+public class VersioningMetaFactory extends AbstractNamedCacheComponentFactory implements AutoInstantiableFactory {
+   @SuppressWarnings("unchecked")
+   @Override
+   public <T> T construct(Class<T> componentType) {
+      if (!configuration.isEnableVersioning())
+         return null;
+
+      switch (configuration.getVersioningScheme()) {
+         case SIMPLE: {
+            if (configuration.getCacheMode().isClustered())
+               return (T) new SimpleClusteredVersionGenerator();
+            else
+               return null;
+         }
+         default:
+            return null;
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/interceptors/CacheStoreInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheStoreInterceptor.java
@@ -354,7 +354,7 @@ public class CacheStoreInterceptor extends JmxStatsCommandInterceptor {
       if (entry instanceof InternalCacheEntry) {
          return (InternalCacheEntry) entry;
       } else {
-         return InternalEntryFactory.create(entry.getKey(), entry.getValue(), entry.getLifespan(), entry.getMaxIdle());
+         return InternalEntryFactory.create(entry.getKey(), entry.getValue(), entry.getVersion(), entry.getLifespan(), entry.getMaxIdle());
       }
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/MarshalledValueInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/MarshalledValueInterceptor.java
@@ -243,7 +243,7 @@ public class MarshalledValueInterceptor extends CommandInterceptor {
          if (value instanceof MarshalledValue) {
             value = ((MarshalledValue) value).get();
          }
-         InternalCacheEntry newEntry = Immutables.immutableInternalCacheEntry(InternalEntryFactory.create(key, value,
+         InternalCacheEntry newEntry = Immutables.immutableInternalCacheEntry(InternalEntryFactory.create(key, value, entry.getVersion(),
                                                                                                           entry.getCreated(), entry.getLifespan(), entry.getLastUsed(), entry.getMaxIdle()));
          copy.add(newEntry);
       }

--- a/core/src/main/java/org/infinispan/interceptors/ReplicationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/ReplicationInterceptor.java
@@ -50,8 +50,7 @@ import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Takes care of replicating modifications to other caches in a cluster. Also listens for prepare(), commit() and
- * rollback() messages which are received 'side-ways' (see docs/design/Refactoring.txt).
+ * Takes care of replicating modifications to other caches in a cluster.
  *
  * @author Bela Ban
  * @since 4.0
@@ -112,10 +111,14 @@ public class ReplicationInterceptor extends BaseRpcInterceptor {
       if (shouldInvokeRemoteTxCommand(ctx)) {
          stateTransferLock.waitForStateTransferToEnd(ctx, command, -1);
 
-         boolean async = configuration.getCacheMode() == Configuration.CacheMode.REPL_ASYNC;
-         rpcManager.broadcastRpcCommand(command, !async, false);
+         broadcastPrepare(ctx, command);
       }
       return retVal;
+   }
+
+   protected void broadcastPrepare(TxInvocationContext context, PrepareCommand command) {
+      boolean async = configuration.getCacheMode() == Configuration.CacheMode.REPL_ASYNC;
+      rpcManager.broadcastRpcCommand(command, !async, false);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/VersionedDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/VersionedDistributionInterceptor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.interceptors;
+
+import org.infinispan.commands.tx.PrepareCommand;
+import org.infinispan.commands.tx.VersionedPrepareCommand;
+import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.container.versioning.EntryVersionsMap;
+import org.infinispan.container.versioning.IncrementableEntryVersion;
+import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.responses.SuccessfulResponse;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.transaction.xa.CacheTransaction;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * A version of the {@link DistributionInterceptor} that adds logic to handling prepares when entries are versioned.
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+public class VersionedDistributionInterceptor extends DistributionInterceptor {
+   @Override
+   protected void prepareOnAffectedNodes(TxInvocationContext ctx, PrepareCommand command, Collection<Address> recipients, boolean ignored) {
+
+      // Build a map of keys to versions as they were seen by the transaction originator's transaction context
+      EntryVersionsMap vs = new EntryVersionsMap();
+      for (WriteCommand wc : command.getModifications()) {
+         for (Object k : wc.getAffectedKeys()) {
+            vs.put(k, (IncrementableEntryVersion) ctx.lookupEntry(k).getVersion());
+         }
+      }
+
+      // Make sure this version map is attached to the prepare command so that lock owners can perform write skew checks
+      ((VersionedPrepareCommand) command).setVersionsSeen(vs);
+
+      // Perform the RPC
+      Map<Address, Response> resps = rpcManager.invokeRemotely(recipients, command, true, true);
+
+      // Now store newly generated versions from lock owners for use during the commit phase.
+      CacheTransaction ct = ctx.getCacheTransaction();
+      for (Response r : resps.values()) {
+         if (r != null && r.isSuccessful()) {
+            SuccessfulResponse sr = (SuccessfulResponse) r;
+            EntryVersionsMap uv = (EntryVersionsMap) sr.getResponseValue();
+            if (uv != null) ct.setUpdatedEntryVersions(uv.merge(ct.getUpdatedEntryVersions()));
+         }
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/interceptors/VersionedEntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/VersionedEntryWrappingInterceptor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.interceptors;
+
+import org.infinispan.commands.tx.CommitCommand;
+import org.infinispan.commands.tx.PrepareCommand;
+import org.infinispan.commands.tx.VersionedCommitCommand;
+import org.infinispan.commands.tx.VersionedPrepareCommand;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.container.versioning.EntryVersion;
+import org.infinispan.container.versioning.EntryVersionsMap;
+import org.infinispan.container.versioning.VersionGenerator;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.factories.annotations.Inject;
+
+/**
+ * Interceptor in charge with wrapping entries and add them in caller's context.
+ *
+ * @author Mircea Markus
+ * @since 5.1
+ */
+public class VersionedEntryWrappingInterceptor extends EntryWrappingInterceptor {
+
+   private VersionGenerator versionGenerator;
+
+   @Inject
+   public void initialize(VersionGenerator versionGenerator) {
+      this.versionGenerator = versionGenerator;
+   }
+
+   @Override
+   public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
+      Object retval = super.visitPrepareCommand(ctx, command);
+      EntryVersionsMap newVersionData = cll.createNewVersionsAndCheckForWriteSkews(versionGenerator, ctx, (VersionedPrepareCommand) command);
+
+      return newVersionData == null ? retval : newVersionData;
+   }
+
+
+   @Override
+   public Object visitCommitCommand(TxInvocationContext ctx, CommitCommand command) throws Throwable {
+      try {
+         if (ctx.isOriginLocal())
+            ((VersionedCommitCommand) command).setUpdatedVersions(ctx.getCacheTransaction().getUpdatedEntryVersions());
+
+         return invokeNextInterceptor(ctx, command);
+      } finally {
+         log.fatal("Commit command is " + command);
+         if (!ctx.isOriginLocal())
+            ctx.getCacheTransaction().setUpdatedEntryVersions(((VersionedCommitCommand) command).getUpdatedVersions());
+         commitContextEntries(ctx);
+      }
+   }
+
+   @Override
+   protected void commitContextEntry(CacheEntry entry, InvocationContext ctx, boolean skipOwnershipCheck) {
+      if (ctx.isInTxScope()) {
+         EntryVersion version = ((TxInvocationContext) ctx).getCacheTransaction().getUpdatedEntryVersions().get(entry.getKey());
+         cll.commitEntry(entry, version, skipOwnershipCheck);
+      } else {
+         // This could be a state transfer call!
+         cll.commitEntry(entry, entry.getVersion(), skipOwnershipCheck);
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/interceptors/VersionedReplicationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/VersionedReplicationInterceptor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.interceptors;
+
+import org.infinispan.commands.tx.PrepareCommand;
+import org.infinispan.container.versioning.EntryVersionsMap;
+import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.responses.SuccessfulResponse;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.transaction.xa.CacheTransaction;
+
+import java.util.Map;
+
+/**
+ * A form of the {@link ReplicationInterceptor} that adds additional logic to how prepares are handled.
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+public class VersionedReplicationInterceptor extends ReplicationInterceptor {
+
+   @Override
+   protected void broadcastPrepare(TxInvocationContext context, PrepareCommand command) {
+      // The additional logic here is that we need to wait for a prepare command to complete on the coordinator
+      // since the coordinator provides updated version information in its response.  This updated version information
+      // is then stored in the transactional context to be used during the commit phase.
+      // However if the current node is already the coordinator, then we fall back to "normal" ReplicationInterceptor
+      // logic for this step.
+      if (!rpcManager.getTransport().isCoordinator()) {
+         Map<Address, Response> resps = rpcManager.invokeRemotely(null, command, true, true);
+         Response r = resps.get(rpcManager.getTransport().getCoordinator());  // We only really care about the coordinator's response.
+         CacheTransaction ct = context.getCacheTransaction();
+         if (r.isSuccessful()) {
+            SuccessfulResponse sr = (SuccessfulResponse) r;
+            EntryVersionsMap uv = (EntryVersionsMap) sr.getResponseValue();
+            ct.setUpdatedEntryVersions(uv);
+         }
+      } else {
+         super.broadcastPrepare(context, command);
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
@@ -36,6 +36,8 @@ import org.infinispan.commands.remote.recovery.TxCompletionNotificationCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
+import org.infinispan.commands.tx.VersionedCommitCommand;
+import org.infinispan.commands.tx.VersionedPrepareCommand;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.KnownComponentNames;
@@ -81,7 +83,7 @@ public class CacheRpcCommandExternalizer extends AbstractExternalizer<CacheRpcCo
             PrepareCommand.class, RollbackCommand.class, RemoveCacheCommand.class,
             TxCompletionNotificationCommand.class, GetInDoubtTransactionsCommand.class,
             GetInDoubtTxInfoCommand.class, CompleteTransactionCommand.class,
-            CacheViewControlCommand.class);
+            CacheViewControlCommand.class, VersionedPrepareCommand.class, VersionedCommitCommand.class);
       // Only interested in cache specific replicable commands
       coreCommands.addAll(gcr.getModuleProperties().moduleCacheRpcCommands());
       return coreCommands;

--- a/core/src/main/java/org/infinispan/remoting/responses/DefaultResponseGenerator.java
+++ b/core/src/main/java/org/infinispan/remoting/responses/DefaultResponseGenerator.java
@@ -28,6 +28,7 @@ import org.infinispan.commands.remote.recovery.CompleteTransactionCommand;
 import org.infinispan.commands.remote.recovery.GetInDoubtTransactionsCommand;
 import org.infinispan.commands.remote.recovery.GetInDoubtTxInfoCommand;
 import org.infinispan.commands.tx.CommitCommand;
+import org.infinispan.container.versioning.EntryVersionsMap;
 
 /**
  * The default response generator for most cache modes
@@ -38,16 +39,18 @@ import org.infinispan.commands.tx.CommitCommand;
 public class DefaultResponseGenerator implements ResponseGenerator {
    public Response getResponse(CacheRpcCommand command, Object returnValue) {
       if (returnValue == null) return null;
-      if (requiresResponse(command.getCommandId())) {
+      if (requiresResponse(command.getCommandId(), returnValue)) {
          return new SuccessfulResponse(returnValue);
       } else {
          return null; // saves on serializing a response!
       }
    }
 
-   private boolean requiresResponse(byte commandId) {
-      return commandId == ClusteredGetCommand.COMMAND_ID || commandId == GetInDoubtTransactionsCommand.COMMAND_ID
+   private boolean requiresResponse(byte commandId, Object rv) {
+      boolean commandRequiresResp = commandId == ClusteredGetCommand.COMMAND_ID || commandId == GetInDoubtTransactionsCommand.COMMAND_ID
             || commandId == GetInDoubtTxInfoCommand.COMMAND_ID || commandId == CompleteTransactionCommand.COMMAND_ID
             || commandId == CommitCommand.COMMAND_ID;
+
+      return commandRequiresResp || rv instanceof EntryVersionsMap;
    }
 }

--- a/core/src/main/java/org/infinispan/transaction/AbstractCacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/AbstractCacheTransaction.java
@@ -25,6 +25,7 @@ package org.infinispan.transaction;
 
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.container.versioning.EntryVersionsMap;
 import org.infinispan.transaction.xa.CacheTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.logging.Log;
@@ -69,6 +70,8 @@ public abstract class AbstractCacheTransaction implements CacheTransaction {
 
    protected volatile boolean prepared;
    protected Integer viewId;
+
+   private EntryVersionsMap updatedEntryVersions;
 
    public AbstractCacheTransaction(GlobalTransaction tx) {
       this.tx = tx;
@@ -183,5 +186,15 @@ public abstract class AbstractCacheTransaction implements CacheTransaction {
 
    private void initAffectedKeys() {
       if (affectedKeys == null) affectedKeys = new HashSet<Object>(INITIAL_LOCK_CAPACITY);
+   }
+
+   @Override
+   public EntryVersionsMap getUpdatedEntryVersions() {
+      return updatedEntryVersions;
+   }
+
+   @Override
+   public void setUpdatedEntryVersions(EntryVersionsMap updatedEntryVersions) {
+      this.updatedEntryVersions = updatedEntryVersions;
    }
 }

--- a/core/src/main/java/org/infinispan/transaction/xa/CacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/CacheTransaction.java
@@ -24,6 +24,7 @@ package org.infinispan.transaction.xa;
 
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.container.versioning.EntryVersionsMap;
 
 import java.util.List;
 import java.util.Map;
@@ -76,4 +77,8 @@ public interface CacheTransaction {
     * @see org.infinispan.interceptors.locking.AbstractTxLockingInterceptor#lockKeyAndCheckOwnership(org.infinispan.context.InvocationContext, Object)
     */
    boolean waitForLockRelease(Object key, long lockAcquisitionTimeout) throws InterruptedException;
+
+   EntryVersionsMap getUpdatedEntryVersions();
+
+   void setUpdatedEntryVersions(EntryVersionsMap updatedEntryVersions);
 }

--- a/core/src/main/java/org/infinispan/util/Immutables.java
+++ b/core/src/main/java/org/infinispan/util/Immutables.java
@@ -25,6 +25,7 @@ package org.infinispan.util;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.InternalCacheValue;
+import org.infinispan.container.versioning.EntryVersion;
 import org.infinispan.marshall.AbstractExternalizer;
 import org.infinispan.marshall.Ids;
 import org.infinispan.marshall.MarshallUtil;
@@ -36,19 +37,8 @@ import java.io.ObjectOutput;
 import java.io.Reader;
 import java.io.Serializable;
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.InvalidPropertiesFormatException;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
 
 /**
  * Factory for generating immutable type wrappers.
@@ -458,6 +448,10 @@ public class Immutables {
          throw new UnsupportedOperationException();
       }
 
+      public void commit(DataContainer container, EntryVersion newVersion) {
+         throw new UnsupportedOperationException();
+      }
+
       @SuppressWarnings("unchecked")
       public boolean equals(Object o) {
          if (!(o instanceof InternalCacheEntry))
@@ -515,7 +509,6 @@ public class Immutables {
          throw new UnsupportedOperationException();
       }
 
-      @Override
       public boolean undelete(boolean doUndelete) {
          throw new UnsupportedOperationException();
       }
@@ -524,7 +517,7 @@ public class Immutables {
          throw new UnsupportedOperationException();
       }
 
-      public void commit(DataContainer container) {
+      public void setVersion(EntryVersion version) {
          throw new UnsupportedOperationException();
       }
 
@@ -580,9 +573,12 @@ public class Immutables {
          throw new UnsupportedOperationException();
       }
 
-      @Override
       public boolean isLockPlaceholder() {
          return entry.isLockPlaceholder();
+      }
+
+      public EntryVersion getVersion() {
+         return entry.getVersion();
       }
 
       public InternalCacheEntry clone() {
@@ -771,7 +767,10 @@ public class Immutables {
    private static class ImmutableTypedProperties extends TypedProperties {
       
       ImmutableTypedProperties(TypedProperties properties) {
-         super(properties);
+         super();
+         if (properties != null && !properties.isEmpty()) {
+            for (Map.Entry<Object, Object> e: properties.entrySet()) super.put(e.getKey(), e.getValue());
+         }
       }
 
       @Override

--- a/core/src/test/java/org/infinispan/config/QueryableDataContainer.java
+++ b/core/src/test/java/org/infinispan/config/QueryableDataContainer.java
@@ -22,15 +22,16 @@
  */
 package org.infinispan.config;
 
-import static java.util.Collections.synchronizedCollection;
+import org.infinispan.container.DataContainer;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.versioning.EntryVersion;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
 
-import org.infinispan.container.DataContainer;
-import org.infinispan.container.entries.InternalCacheEntry;
+import static java.util.Collections.synchronizedCollection;
 
 public class QueryableDataContainer implements DataContainer {
 	
@@ -69,9 +70,9 @@ public class QueryableDataContainer implements DataContainer {
 	}
 
 	@Override
-	public void put(Object k, Object v, long lifespan, long maxIdle) {
+	public void put(Object k, Object v, EntryVersion ev, long lifespan, long maxIdle) {
 		loggedOperations.add("put(" + k + ", " + v + ", " + lifespan + ", " + maxIdle + ")");
-		delegate.put(k, v, lifespan, maxIdle);
+		delegate.put(k, v, ev, lifespan, maxIdle);
 	}
 
 	@Override

--- a/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
+++ b/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
@@ -58,7 +58,7 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
    }
 
    public void testExpiredData() throws InterruptedException {
-      dc.put("k", "v", -1, 6000000);
+      dc.put("k", "v", null, -1, 6000000);
       Thread.sleep(100);
 
       InternalCacheEntry entry = dc.get("k");
@@ -68,10 +68,10 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
       Thread.sleep(100);
       entry = dc.get("k");
       assert entry.getLastUsed() > entryLastUsed;
-      dc.put("k", "v", -1, 0);
+      dc.put("k", "v", null, -1, 0);
       dc.purgeExpired();
 
-      dc.put("k", "v", 6000000, -1);
+      dc.put("k", "v", null, 6000000, -1);
       Thread.sleep(100);
       assert dc.size() == 1;
 
@@ -80,12 +80,12 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
       assert entry.getClass().equals(mortaltype()) : "Expected "+mortaltype()+", was " + entry.getClass().getSimpleName();
       assert entry.getCreated() <= System.currentTimeMillis();
 
-      dc.put("k", "v", 0, -1);
+      dc.put("k", "v", null, 0, -1);
       Thread.sleep(10);
       assert dc.get("k") == null;
       assert dc.size() == 0;
 
-      dc.put("k", "v", 0, -1);
+      dc.put("k", "v", null, 0, -1);
       Thread.sleep(100);
       assert dc.size() == 1;
       dc.purgeExpired();
@@ -94,13 +94,13 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
 
    public void testUpdatingLastUsed() throws Exception {
       long idle = 600000;
-      dc.put("k", "v", -1, -1);
+      dc.put("k", "v", null, -1, -1);
       InternalCacheEntry ice = dc.get("k");
       assert ice.getClass().equals(immortaltype());
       assert ice.getExpiryTime() == -1;
       assert ice.getMaxIdle() == -1;
       assert ice.getLifespan() == -1;
-      dc.put("k", "v", -1, idle);
+      dc.put("k", "v", null, -1, idle);
       long oldTime = System.currentTimeMillis();
       Thread.sleep(100); // for time calc granularity
       ice = dc.get("k");
@@ -141,27 +141,27 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
 
    public void testExpirableToImmortalAndBack() {
       String value = "v";
-      dc.put("k", value, 6000000, -1);
+      dc.put("k", value, null, 6000000, -1);
       assertContainerEntry(mortaltype(), value);
 
       value = "v2";
-      dc.put("k", value, -1, -1);
+      dc.put("k", value, null, -1, -1);
       assertContainerEntry(immortaltype(), value);
 
       value = "v3";
-      dc.put("k", value, -1, 6000000);
+      dc.put("k", value, null, -1, 6000000);
       assertContainerEntry(transienttype(), value);
 
       value = "v4";
-      dc.put("k", value, 6000000, 6000000);
+      dc.put("k", value, null, 6000000, 6000000);
       assertContainerEntry(transientmortaltype(), value);
 
       value = "v41";
-      dc.put("k", value, 6000000, 6000000);
+      dc.put("k", value, null, 6000000, 6000000);
       assertContainerEntry(transientmortaltype(), value);
 
       value = "v5";
-      dc.put("k", value, 6000000, -1);
+      dc.put("k", value, null, 6000000, -1);
       assertContainerEntry(mortaltype(), value);
    }
 
@@ -174,10 +174,10 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
    }
 
    public void testKeySet() {
-      dc.put("k1", "v", 6000000, -1);
-      dc.put("k2", "v", -1, -1);
-      dc.put("k3", "v", -1, 6000000);
-      dc.put("k4", "v", 6000000, 6000000);
+      dc.put("k1", "v", null, 6000000, -1);
+      dc.put("k2", "v", null, -1, -1);
+      dc.put("k3", "v", null, -1, 6000000);
+      dc.put("k4", "v", null, 6000000, 6000000);
 
       Set expected = new HashSet();
       expected.add("k1");
@@ -191,10 +191,10 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
    }
 
    public void testContainerIteration() {
-      dc.put("k1", "v", 6000000, -1);
-      dc.put("k2", "v", -1, -1);
-      dc.put("k3", "v", -1, 6000000);
-      dc.put("k4", "v", 6000000, 6000000);
+      dc.put("k1", "v", null, 6000000, -1);
+      dc.put("k2", "v", null, -1, -1);
+      dc.put("k3", "v", null, -1, 6000000);
+      dc.put("k4", "v", null, 6000000, 6000000);
 
       Set expected = new HashSet();
       expected.add("k1");
@@ -210,10 +210,10 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
    }
    
    public void testKeys() {
-      dc.put("k1", "v1", 6000000, -1);
-      dc.put("k2", "v2", -1, -1);
-      dc.put("k3", "v3", -1, 6000000);
-      dc.put("k4", "v4", 6000000, 6000000);
+      dc.put("k1", "v1", null, 6000000, -1);
+      dc.put("k2", "v2", null, -1, -1);
+      dc.put("k3", "v3", null, -1, 6000000);
+      dc.put("k4", "v4", null, 6000000, 6000000);
 
       Set expected = new HashSet();
       expected.add("k1");
@@ -227,10 +227,10 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
    }
 
    public void testValues() {
-      dc.put("k1", "v1", 6000000, -1);
-      dc.put("k2", "v2", -1, -1);
-      dc.put("k3", "v3", -1, 6000000);
-      dc.put("k4", "v4", 6000000, 6000000);
+      dc.put("k1", "v1", null, 6000000, -1);
+      dc.put("k2", "v2", null, -1, -1);
+      dc.put("k3", "v3", null, -1, 6000000);
+      dc.put("k4", "v4", null, 6000000, 6000000);
 
       Set expected = new HashSet();
       expected.add("v1");
@@ -244,10 +244,10 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
    }
 
    public void testEntrySet() {
-      dc.put("k1", "v1", 6000000, -1);
-      dc.put("k2", "v2", -1, -1);
-      dc.put("k3", "v3", -1, 6000000);
-      dc.put("k4", "v4", 6000000, 6000000);
+      dc.put("k1", "v1", null, 6000000, -1);
+      dc.put("k2", "v2", null, -1, -1);
+      dc.put("k3", "v3", null, -1, 6000000);
+      dc.put("k4", "v4", null, 6000000, 6000000);
 
       Set expected = new HashSet();
       expected.add(Immutables.immutableInternalCacheEntry(dc.get("k1")));
@@ -262,7 +262,7 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
    }
 
    public void testGetDuringKeySetLoop() {
-      for (int i = 0; i < 10; i++) dc.put(i, "value", -1, -1);
+      for (int i = 0; i < 10; i++) dc.put(i, "value", null, -1, -1);
 
       int i = 0;
       for (Object key : dc.keySet()) {

--- a/core/src/test/java/org/infinispan/container/versioning/DistL1WriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/DistL1WriteSkewTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.versioning;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.testng.annotations.Test;
+
+@Test(testName = "container.versioning.DistL1WriteSkewTest", groups = "functional")
+@CleanupAfterMethod
+public class DistL1WriteSkewTest extends DistWriteSkewTest {
+   @Override
+   protected void decorate(ConfigurationBuilder builder) {
+      // Enable L1
+      builder.clustering().l1().enable();
+   }
+}

--- a/core/src/test/java/org/infinispan/container/versioning/DistWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/DistWriteSkewTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.versioning;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.VersioningScheme;
+import org.infinispan.distribution.DistributionTestHelper;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+import javax.transaction.RollbackException;
+import javax.transaction.Transaction;
+
+@Test(testName = "container.versioning.DistWriteSkewTest", groups = "functional")
+@CleanupAfterMethod
+public class DistWriteSkewTest extends MultipleCacheManagersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+
+      builder
+            .clustering()
+               .cacheMode(CacheMode.DIST_SYNC)
+               .l1()
+                  .disable()
+            .versioning()
+               .enable()
+               .scheme(VersioningScheme.SIMPLE)
+            .locking()
+               .isolationLevel(IsolationLevel.REPEATABLE_READ)
+               .writeSkewCheck(true)
+            .transaction()
+               .lockingMode(LockingMode.OPTIMISTIC)
+               .syncCommitPhase(true);
+
+      decorate(builder);
+
+      createCluster(builder, 4);
+   }
+
+   protected void decorate(ConfigurationBuilder builder) {
+      // No-op
+   }
+
+   public void testWriteSkew() throws Exception {
+      Cache<Object, Object> cache0 = cache(0);
+      Cache<Object, Object> cache1 = cache(1);
+      Cache<Object, Object> cache2 = cache(2);
+      Cache<Object, Object> cache3 = cache(3);
+
+      MagicKey hello = new MagicKey(cache(2), "hello");
+
+      // Auto-commit is true
+      cache1.put(hello, "world 1");
+
+      tm(1).begin();
+      assert "world 1".equals(cache1.get(hello));
+      Transaction t = tm(1).suspend();
+
+      // Induce a write skew
+      cache3.put(hello, "world 3");
+
+      assert cache0.get(hello).equals("world 3");
+      assert cache1.get(hello).equals("world 3");
+      assert cache2.get(hello).equals("world 3");
+      assert cache3.get(hello).equals("world 3");
+
+      tm(1).resume(t);
+      cache1.put(hello, "world 2");
+
+      try {
+         tm(1).commit();
+         assert false : "Transaction should roll back";
+      } catch (RollbackException re) {
+         // expected
+      }
+
+      assert "world 3".equals(cache0.get(hello));
+      assert "world 3".equals(cache1.get(hello));
+      assert "world 3".equals(cache2.get(hello));
+      assert "world 3".equals(cache3.get(hello));
+   }
+
+   public void testWriteSkewOnNonOwner() throws Exception {
+      Cache<Object, Object> cache0 = cache(0);
+      Cache<Object, Object> cache1 = cache(1);
+      Cache<Object, Object> cache2 = cache(2);
+      Cache<Object, Object> cache3 = cache(3);
+
+      MagicKey hello = new MagicKey(cache(0), "hello"); // Owned by cache0 and cache1
+
+      int owners[] = {0, 0};
+      int nonOwners[] = {0, 0};
+      int j=0, k = 0;
+      for (int i=0; i<4; i++) {
+         if (DistributionTestHelper.isOwner(cache(i), hello))
+            owners[j++] = i;
+         else
+            nonOwners[k++] = i;
+      }
+
+      // Auto-commit is true
+      cache(owners[1]).put(hello, "world 1");
+
+      tm(nonOwners[0]).begin();
+      assert "world 1".equals(cache(nonOwners[0]).get(hello));
+      Transaction t = tm(nonOwners[0]).suspend();
+
+      // Induce a write skew
+      cache(nonOwners[1]).put(hello, "world 3");
+
+      assert cache0.get(hello).equals("world 3");
+      assert cache1.get(hello).equals("world 3");
+      assert cache2.get(hello).equals("world 3");
+      assert cache3.get(hello).equals("world 3");
+
+      tm(nonOwners[0]).resume(t);
+      cache(nonOwners[0]).put(hello, "world 2");
+
+      try {
+         tm(nonOwners[0]).commit();
+         assert false : "Transaction should roll back";
+      } catch (RollbackException re) {
+         // expected
+      }
+
+      assert "world 3".equals(cache0.get(hello));
+      assert "world 3".equals(cache1.get(hello));
+      assert "world 3".equals(cache2.get(hello));
+      assert "world 3".equals(cache3.get(hello));
+   }
+
+   public void testWriteSkewMultiEntries() throws Exception {
+      Cache<Object, Object> cache0 = cache(0);
+      Cache<Object, Object> cache1 = cache(1);
+      Cache<Object, Object> cache2 = cache(2);
+      Cache<Object, Object> cache3 = cache(3);
+
+      MagicKey hello = new MagicKey(cache(2), "hello");
+      MagicKey hello2 = new MagicKey(cache(3), "hello2");
+      MagicKey hello3 = new MagicKey(cache(0), "hello3");
+
+      tm(1).begin();
+      cache1.put(hello, "world 1");
+      cache1.put(hello2, "world 1");
+      cache1.put(hello3, "world 1");
+      tm(1).commit();
+
+      tm(1).begin();
+      cache1.put(hello2, "world 2");
+      cache1.put(hello3, "world 2");
+      assert "world 1".equals(cache1.get(hello));
+      assert "world 2".equals(cache1.get(hello2));
+      assert "world 2".equals(cache1.get(hello3));
+      Transaction t = tm(1).suspend();
+
+      // Induce a write skew
+      // Auto-commit is true
+      cache3.put(hello, "world 3");
+
+      for (Cache<Object, Object> c : caches()) {
+         assert "world 3".equals(c.get(hello));
+         assert "world 1".equals(c.get(hello2));
+         assert "world 1".equals(c.get(hello3));
+      }
+
+      tm(1).resume(t);
+      cache1.put(hello, "world 2");
+
+      try {
+         tm(1).commit();
+         assert false : "Transaction should roll back";
+      } catch (RollbackException re) {
+         // expected
+      }
+
+      for (Cache<Object, Object> c : caches()) {
+         assert "world 3".equals(c.get(hello));
+         assert "world 1".equals(c.get(hello2));
+         assert "world 1".equals(c.get(hello3));
+      }
+   }
+
+   public void testNullEntries() throws Exception {
+      Cache<Object, Object> cache0 = cache(0);
+      Cache<Object, Object> cache1 = cache(1);
+      Cache<Object, Object> cache2 = cache(2);
+      Cache<Object, Object> cache3 = cache(3);
+
+      MagicKey hello = new MagicKey(cache(2), "hello");
+
+      // Auto-commit is true
+      cache0.put(hello, "world");
+
+      tm(0).begin();
+      assert "world".equals(cache0.get(hello));
+      Transaction t = tm(0).suspend();
+
+      cache1.remove(hello);
+
+      assert null == cache0.get(hello);
+      assert null == cache1.get(hello);
+      assert null == cache2.get(hello);
+      assert null == cache3.get(hello);
+
+      tm(0).resume(t);
+      cache0.put(hello, "world2");
+
+      try {
+         tm(0).commit();
+         assert false : "This transaction should roll back";
+      } catch (RollbackException expected) {
+         // expected
+      }
+
+      assert null == cache0.get(hello);
+      assert null == cache1.get(hello);
+      assert null == cache2.get(hello);
+      assert null == cache3.get(hello);
+   }
+}

--- a/core/src/test/java/org/infinispan/container/versioning/LocalWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/LocalWriteSkewTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.versioning;
+
+import org.infinispan.CacheException;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.VersioningScheme;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+import javax.transaction.RollbackException;
+import javax.transaction.Transaction;
+
+/**
+ * Tests local-mode versioning
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+@Test(testName = "container.versioning.LocalWriteSkewTest", groups = "functional")
+@CleanupAfterMethod
+public class LocalWriteSkewTest extends SingleCacheManagerTest {
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      ConfigurationBuilder builder = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+      builder
+            .versioning()
+               .enable()
+               .scheme(VersioningScheme.SIMPLE)
+            .locking()
+               .isolationLevel(IsolationLevel.REPEATABLE_READ)
+               .writeSkewCheck(true)
+            .transaction()
+               .lockingMode(LockingMode.OPTIMISTIC);
+
+      EmbeddedCacheManager cm = new DefaultCacheManager(builder.build());
+      builder.locking().writeSkewCheck(false).versioning().disable();
+      cm.defineConfiguration("no-ws-chk", builder.build());
+      return cm;
+   }
+
+   public void testWriteSkewEnabled() throws Exception {
+      // Auto-commit is true
+
+      cache.put("hello", "world 1");
+
+      tm().begin();
+      Object v = cache.get("hello");
+      assert "world 1".equals(v);
+      Transaction t = tm().suspend();
+
+      // Create a write skew
+      cache.put("hello", "world 3");
+
+      tm().resume(t);
+      try {
+         cache.put("hello", "world 2");
+         assert false: "Should have detected write skew";
+      } catch (CacheException e) {
+         // expected
+      }
+
+      try {
+         tm().commit();
+         assert false: "Transaction should roll back";
+      } catch (RollbackException re) {
+         // expected
+      }
+
+      assert "world 3".equals(cache.get("hello"));
+   }
+
+   public void testWriteSkewMultiEntries() throws Exception {
+      tm().begin();
+      cache.put("k1", "v1");
+      cache.put("k2", "v2");
+      tm().commit();
+
+      tm().begin();
+      cache.put("k2", "v2000");
+      Object v = cache.get("k1");
+      assert "v1".equals(v);
+      assert "v2000".equals(cache.get("k2"));
+      Transaction t = tm().suspend();
+
+      // Create a write skew
+      // Auto-commit is true
+      cache.put("k1", "v3");
+
+      tm().resume(t);
+      try {
+         cache.put("k1", "v5000");
+         assert false: "Should have detected write skew";
+      } catch (CacheException e) {
+         // expected
+      }
+
+      try {
+         tm().commit();
+         assert false: "Transaction should roll back";
+      } catch (RollbackException re) {
+         // expected
+      }
+
+      assert "v3".equals(cache.get("k1"));
+      assert "v2".equals(cache.get("k2"));
+   }
+
+   public void testWriteSkewDisabled() throws Exception {
+      cache = cacheManager.getCache("no-ws-chk");
+
+      // Auto-commit is true
+
+      cache.put("hello", "world 1");
+
+      tm().begin();
+      Object v = cache.get("hello");
+      assert "world 1".equals(v);
+      Transaction t = tm().suspend();
+
+      // Create a write skew
+      cache.put("hello", "world 3");
+
+      tm().resume(t);
+      cache.put("hello", "world 2");
+      tm().commit();
+
+      assert "world 2".equals(cache.get("hello"));
+   }
+
+   public void testNullEntries() throws Exception {
+      // Auto-commit is true
+      cache.put("hello", "world");
+
+      tm().begin();
+      assert "world".equals(cache.get("hello"));
+      Transaction t = tm().suspend();
+
+      cache.remove("hello");
+
+      assert null == cache.get("hello");
+
+      tm().resume(t);
+      try {
+         cache.put("hello", "world2");
+         assert false: "Write skew should have been detected";
+      } catch (CacheException expected) {
+         // expected
+      }
+
+      try {
+         tm().commit();
+         assert false: "This transaction should roll back";
+      } catch (RollbackException expected) {
+         // expected
+      }
+      assert null == cache.get("hello");
+   }
+}

--- a/core/src/test/java/org/infinispan/container/versioning/ReplWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/ReplWriteSkewTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.versioning;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.VersioningScheme;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+import javax.transaction.RollbackException;
+import javax.transaction.Transaction;
+
+@Test(testName = "container.versioning.ReplWriteSkewTest", groups = "functional")
+@CleanupAfterMethod
+public class ReplWriteSkewTest extends MultipleCacheManagersTest {
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+
+      builder
+            .clustering()
+               .cacheMode(CacheMode.REPL_SYNC)
+            .versioning()
+               .enable()
+               .scheme(VersioningScheme.SIMPLE)
+            .locking()
+               .isolationLevel(IsolationLevel.REPEATABLE_READ)
+               .writeSkewCheck(true)
+            .transaction()
+               .lockingMode(LockingMode.OPTIMISTIC)
+               .syncCommitPhase(true);
+
+      createCluster(builder, 2);
+   }
+
+   public void testWriteSkew() throws Exception {
+      Cache<Object, Object> cache0 = cache(0);
+      Cache<Object, Object> cache1 = cache(1);
+
+      // Auto-commit is true
+      cache0.put("hello", "world 1");
+
+      tm(0).begin();
+      assert "world 1".equals(cache0.get("hello"));
+      Transaction t = tm(0).suspend();
+
+      // Induce a write skew
+      cache1.put("hello", "world 3");
+
+      assert cache0.get("hello").equals("world 3");
+      assert cache1.get("hello").equals("world 3");
+
+      tm(0).resume(t);
+      cache0.put("hello", "world 2");
+
+      try {
+         tm(0).commit();
+         assert false : "Transaction should roll back";
+      } catch (RollbackException re) {
+         // expected
+      }
+
+      assert "world 3".equals(cache0.get("hello"));
+      assert "world 3".equals(cache1.get("hello"));
+   }
+
+   public void testWriteSkewMultiEntries() throws Exception {
+      Cache<Object, Object> cache0 = cache(0);
+      Cache<Object, Object> cache1 = cache(1);
+
+      tm(0).begin();
+      cache0.put("hello", "world 1");
+      cache0.put("hello2", "world 1");
+      tm(0).commit();
+
+      tm(0).begin();
+      cache0.put("hello2", "world 2");
+      assert "world 2".equals(cache0.get("hello2"));
+      assert "world 1".equals(cache0.get("hello"));
+      Transaction t = tm(0).suspend();
+
+      // Induce a write skew
+      // Auto-commit is true
+      cache1.put("hello", "world 3");
+
+      assert cache0.get("hello").equals("world 3");
+      assert cache0.get("hello2").equals("world 1");
+      assert cache1.get("hello").equals("world 3");
+      assert cache1.get("hello2").equals("world 1");
+
+      tm(0).resume(t);
+      cache0.put("hello", "world 2");
+
+      try {
+         tm(0).commit();
+         assert false : "Transaction should roll back";
+      } catch (RollbackException re) {
+         // expected
+      }
+
+      assert cache0.get("hello").equals("world 3");
+      assert cache0.get("hello2").equals("world 1");
+      assert cache1.get("hello").equals("world 3");
+      assert cache1.get("hello2").equals("world 1");
+   }
+
+   public void testNullEntries() throws Exception {
+      Cache<Object, Object> cache0 = cache(0);
+      Cache<Object, Object> cache1 = cache(1);
+
+      // Auto-commit is true
+      cache0.put("hello", "world");
+
+      tm(0).begin();
+      assert "world".equals(cache0.get("hello"));
+      Transaction t = tm(0).suspend();
+
+      cache1.remove("hello");
+
+      assert null == cache0.get("hello");
+      assert null == cache1.get("hello");
+
+      tm(0).resume(t);
+      cache0.put("hello", "world2");
+
+      try {
+         tm(0).commit();
+         assert false : "This transaction should roll back";
+      } catch (RollbackException expected) {
+         // expected
+      }
+
+      assert null == cache0.get("hello");
+      assert null == cache1.get("hello");
+   }
+}

--- a/core/src/test/java/org/infinispan/container/versioning/VersionedDistStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/VersionedDistStateTransferTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.versioning;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.VersioningScheme;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+import javax.transaction.RollbackException;
+import javax.transaction.Transaction;
+
+@Test(testName = "container.versioning.VersionedDistStateTransferTest", groups = "functional")
+@CleanupAfterMethod
+public class VersionedDistStateTransferTest extends MultipleCacheManagersTest {
+   ConfigurationBuilder builder;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      builder = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+
+      builder
+            .clustering()
+               .cacheMode(CacheMode.DIST_SYNC)
+               .l1()
+                  .disable()
+            .versioning()
+               .enable()
+               .scheme(VersioningScheme.SIMPLE)
+            .locking()
+               .isolationLevel(IsolationLevel.REPEATABLE_READ)
+               .writeSkewCheck(true)
+            .transaction()
+               .lockingMode(LockingMode.OPTIMISTIC)
+               .syncCommitPhase(true);
+
+      createCluster(builder, 4);
+   }
+
+   public void testStateTransfer() throws Exception {
+      Cache<Object, Object> cache0 = cache(0);
+      Cache<Object, Object> cache1 = cache(1);
+      Cache<Object, Object> cache2 = cache(2);
+      Cache<Object, Object> cache3 = cache(3);
+
+      MagicKey hello = new MagicKey(cache2, "hello");
+      cache0.put(hello, "world");
+
+      for (Cache<Object, Object> c: caches()) assert "world".equals(c.get(hello));
+
+      tm(1).begin();
+      assert "world".equals(cache1.get(hello));
+      Transaction t = tm(1).suspend();
+
+      addClusterEnabledCacheManager(builder);
+      Cache<Object, Object> cache4 = cache(4);
+
+      assert "world".equals(cache2.get(hello));
+      cacheManagers.get(2).stop();
+
+      // Cause a write skew
+      cache4.put(hello, "new world");
+
+      tm(1).resume(t);
+      cache1.put(hello, "world2");
+
+      try {
+         tm(1).commit();
+         assert false: "Should fail";
+      } catch (RollbackException expected) {
+         // Expected
+      }
+
+      assert "new world".equals(cache0.get(hello));
+      assert "new world".equals(cache1.get(hello));
+      // skip cache2, it has been killed.
+      assert "new world".equals(cache3.get(hello));
+      assert "new world".equals(cache3.get(hello));
+   }
+}

--- a/core/src/test/java/org/infinispan/container/versioning/VersionedReplStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/VersionedReplStateTransferTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.versioning;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.VersioningScheme;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+import javax.transaction.RollbackException;
+import javax.transaction.Transaction;
+
+@Test(testName = "container.versioning.VersionedReplStateTransferTest", groups = "functional")
+@CleanupAfterMethod
+public class VersionedReplStateTransferTest extends MultipleCacheManagersTest {
+
+   ConfigurationBuilder builder;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      builder = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+
+      builder
+            .clustering()
+               .cacheMode(CacheMode.REPL_SYNC)
+            .versioning()
+               .enable()
+               .scheme(VersioningScheme.SIMPLE)
+            .locking()
+               .isolationLevel(IsolationLevel.REPEATABLE_READ)
+               .writeSkewCheck(true)
+            .transaction()
+               .lockingMode(LockingMode.OPTIMISTIC)
+               .syncCommitPhase(true);
+
+      createCluster(builder, 2);
+   }
+
+   public void testStateTransfer() throws Exception {
+      Cache<Object, Object> cache0 = cache(0);
+      Cache<Object, Object> cache1 = cache(1);
+
+      cache0.put("hello", "world");
+
+      assert "world".equals(cache0.get("hello"));
+      assert "world".equals(cache1.get("hello"));
+
+      tm(1).begin();
+      assert "world".equals(cache1.get("hello"));
+      Transaction t = tm(1).suspend();
+
+      // create a cache2
+      addClusterEnabledCacheManager(builder);
+      Cache<Object, Object> cache2 = cache(2);
+
+      assert "world".equals(cache2.get("hello"));
+
+      cacheManagers.get(0).stop();
+
+      // Cause a write skew
+      cache2.put("hello", "new world");
+
+      tm(1).resume(t);
+      cache1.put("hello", "world2");
+
+      try {
+         tm(1).commit();
+         assert false : "Should fail";
+      } catch (RollbackException expected) {
+         // Expected
+      }
+
+      assert "new world".equals(cache(1).get("hello"));
+      assert "new world".equals(cache(2).get("hello"));
+   }
+}

--- a/core/src/test/java/org/infinispan/stress/DataContainerStressTest.java
+++ b/core/src/test/java/org/infinispan/stress/DataContainerStressTest.java
@@ -93,7 +93,7 @@ public class DataContainerStressTest {
             while (use_time && run.get() || runs < actual_num_loops) {
                if (runs % 100000 == 0) log.info("PUT run # " + runs);
 //               TestingUtil.sleepThread(10);
-               dc.put(key + R.nextInt(NUM_KEYS), "value", -1, -1);
+               dc.put(key + R.nextInt(NUM_KEYS), "value", null, -1, -1);
                runs++;
             }
             perf.put("PUT", opsPerMS(System.nanoTime() - start, runs));

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -246,6 +246,12 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       }
    }
 
+   protected void defineConfigurationOnAllManagers(String cacheName, ConfigurationBuilder b) {
+      for (EmbeddedCacheManager cm : cacheManagers) {
+         cm.defineConfiguration(cacheName, b.build());
+      }
+   }
+
    private List<Cache> getCaches(String cacheName) {
       List<Cache> caches;
       caches = new ArrayList<Cache>();
@@ -519,8 +525,8 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       return name == null ? cache(index) : cache(index, name);
    }
 
-   protected void forceTwoPhase(int cacheIndex, String cacheName) throws SystemException, RollbackException {
-      TransactionManager tm = tm(cacheIndex, cacheName);
+   protected void forceTwoPhase(int cacheIndex) throws SystemException, RollbackException {
+      TransactionManager tm = tm(cacheIndex);
       Transaction tx = tm.getTransaction();
       tx.enlistResource(new XAResourceAdapter());
    }


### PR DESCRIPTION
- This isn't a complete and general purpose versioned entries impl - it is specific to support clustered write skew checks in optimistically locked transactional caches only.
- Configuration is provided as a form of future-proofing - at the moment there is only one versioning scheme which is only and always used with clustered write skew checking.

http://issues.jboss.org/browse/ISPN-1116

I realise the InternalCacheEntry hierarchy is sub-optimal, and that an EntryVersion reference is created (although set to null) even if versioning is not used.  An extra 2 bytes per entry wasted. I intend to refactor this post-CR1.
