### PR TITLE
ISPN-284 - Chunked rehashing and state transfer && ISPN-1475 - Clean up state transfer and rehashing configuration options

### DIFF
--- a/core/src/main/java/org/infinispan/util/ByRef.java
+++ b/core/src/main/java/org/infinispan/util/ByRef.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.infinispan.util;
+
+/**
+ * This class can be used to pass an argument by reference.
+ * @param <T> The wrapped type.
+ *
+ * @author Dan Berindei
+ * @since 5.1
+ */
+public class ByRef<T> {
+   private T ref;
+
+   public ByRef(T t) {
+      ref = t;
+   }
+
+   public static <T> ByRef<T> create(T t) {
+      return new ByRef<T>(t);
+   }
+
+   public T get() {
+      return ref;
+   }
+
+   public void set(T t) {
+      ref = t;
+   }
+}

--- a/core/src/main/java/org/infinispan/util/concurrent/AggregatingNotifyingFutureBuilder.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/AggregatingNotifyingFutureBuilder.java
@@ -1,0 +1,101 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.infinispan.util.concurrent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An aggregating {@link NotifyingNotifiableFuture} implementation that allows a dynamic number of futures to be attached.
+ * <br/>
+ * Since we don't know when the user is done adding futures, this implementation doesn't notify its {@link FutureListener}s
+ * when it's done. Instead the user can use the {@link #build()} method to create another future that will call its listeners.
+ * <br/>
+ * If you don't need the notifying feature you can skip calling {@link #build()} and use only this future.
+ *
+ * @author Dan Berindei &lt;dan@infinispan.org&gt;
+ * @since 5.1
+ */
+public class AggregatingNotifyingFutureBuilder extends NotifyingFutureImpl {
+   final List<Future<Object>> futures;
+
+   public AggregatingNotifyingFutureBuilder(Object actualReturnValue, int capacity) {
+      super(actualReturnValue);
+      futures = new ArrayList<Future<Object>>(capacity);
+   }
+
+   public NotifyingNotifiableFuture build() {
+      AggregatingNotifyingFutureImpl notifyingAggregateFuture = new AggregatingNotifyingFutureImpl(actualReturnValue, futures.size());
+      for (FutureListener<Object> listener : listeners) {
+         notifyingAggregateFuture.attachListener(listener);
+      }
+      for (Future<Object> future : futures) {
+         notifyingAggregateFuture.setNetworkFuture(future);
+      }
+      return notifyingAggregateFuture;
+   }
+
+   @Override
+   public void setNetworkFuture(Future<Object> future) {
+      futures.add(future);
+   }
+
+   @Override
+   public boolean cancel(boolean mayInterruptIfRunning) {
+      boolean aggregateValue = false;
+      for (Future<Object> f : futures) aggregateValue = f.cancel(mayInterruptIfRunning) && aggregateValue;
+      return aggregateValue;
+   }
+
+   @Override
+   public boolean isCancelled() {
+      for (Future<Object> f : futures) if (f.isCancelled()) return true;
+      return false;
+   }
+
+   @Override
+   public boolean isDone() {
+      for (Future<Object> f : futures) if (!f.isDone()) return false;
+      return true;
+   }
+
+   @Override
+   public Object get() throws InterruptedException, ExecutionException {
+      for (Future<Object> f : futures) f.get();
+      return actualReturnValue;
+   }
+
+   @Override
+   public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {
+      for (Future<Object> f : futures) f.get(timeout, unit);
+      return actualReturnValue;
+   }
+
+   @Override
+   public void notifyDone() {
+      // do nothing, listeners will only be called by the AggregatingNotifyingFutureImpl created by build()
+   }
+}


### PR DESCRIPTION
Update: Don't integrate yet, I need to modify the pull req to support the old rehash/stateRetrieval config element as well as the new stateTransfer element.
Update 2: I removed the ISPN-1475 commit from this pull request so that we can get it into CR1.

https://issues.jboss.org/browse/ISPN-284
https://issues.jboss.org/browse/ISPN-1475

Please have a look at the new state transfer configuration, I'm not sure if it's the "right" way to do it. (Maybe we can find better names for fetchInMemoryState/fetchPersistentState.)

I implemented state splitting, each transferred state chunk will have a fixed number of cache entries. I considered serializing the state explicitly so I could configure the chunk size in bytes but I ultimately rejected it because sending partial entries in a state transfer command would be too complicated.

I consolidated state transfer options to a stateTransfer configuration element (out of hash and stateRetrieval).
I added a new chunkSize setting for chunked state transfer (ISPN-284).
