### PR TITLE
ISPN-1116 fix the mess of previous commit

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
@@ -30,6 +30,7 @@ import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.ImmortalCacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.MortalCacheEntry;
+import org.infinispan.container.entries.TransientMortalCacheEntry;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.distribution.ch.ConsistentHashHelper;
 import org.infinispan.distribution.ch.DefaultConsistentHash;
@@ -237,7 +238,7 @@ public abstract class BaseDistFunctionalTest extends MultipleCacheManagersTest {
             assert ice instanceof ImmortalCacheEntry : "Fail on owner cache " + addressOf(c) + ": dc.get(" + key + ") returned " + safeType(ice);
          } else {
             if (allowL1) {
-               assert ice == null || ice instanceof MortalCacheEntry : "Fail on non-owner cache " + addressOf(c) + ": dc.get(" + key + ") returned " + safeType(ice);
+               assert ice == null || ice instanceof MortalCacheEntry || ice instanceof TransientMortalCacheEntry : "Fail on non-owner cache " + addressOf(c) + ": dc.get(" + key + ") returned " + safeType(ice);
             } else {
                assert ice == null : "Fail on non-owner cache " + addressOf(c) + ": dc.get(" + key + ") returned " + ice + "!";
             }


### PR DESCRIPTION
This fixes the most common cause of tests failures introduced by ISPN-1116, but there are still some more especially in org.infinispan.container.SimpleDataContainerTest (opening issue for @maniksurtani )
