### PR TITLE
ISPN-1619: RemoteCacheStore should create a RemoteCacheManager with an appropriate ClassLoader

### DIFF
--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/RemoteCacheStore.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/RemoteCacheStore.java
@@ -157,7 +157,7 @@ public class RemoteCacheStore extends AbstractCacheStore {
       StreamingMarshaller marshaller = getMarshaller();
 
       if (marshaller == null) {throw new IllegalStateException("Null marshaller not allowed!");}
-      remoteCacheManager = new RemoteCacheManager(marshaller, config.getHotRodClientProperties(), config.getAsyncExecutorFactory());
+      remoteCacheManager = new RemoteCacheManager(marshaller, config.getHotRodClientProperties(), true, config.getClassLoader(), config.getAsyncExecutorFactory());
       if (config.getRemoteCacheName().equals(BasicCacheContainer.DEFAULT_CACHE_NAME))
          remoteCache = remoteCacheManager.getCache();
       else


### PR DESCRIPTION
Within AS7/EAP, we should use an appropriate ClassLoader and not the TCCL
