### PR TITLE
ISPN-1618 - Inverted condition to install address generator on channel

### DIFF
--- a/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
@@ -689,7 +689,11 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
 
       List<PrioritizedMethod> stopMethods = new ArrayList<PrioritizedMethod>(componentLookup.size());
       for (Component c : componentLookup.values()) {
-         Collections.addAll(stopMethods, c.stopMethods);
+         // if one of the components threw an exception during startup
+         // the stop methods list may not have been initialized
+         if (c.stopMethods != null) {
+            Collections.addAll(stopMethods, c.stopMethods);
+         }
       }
 
       Collections.sort(stopMethods);

--- a/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
@@ -225,11 +225,7 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
          }
       }
 
-      // Grab the executor factory
-      NamedExecutorsFactory execFactory = getComponent(NamedExecutorsFactory.class);
       super.stop();
-      // Now that all components are stopped, shutdown their executors
-      execFactory.stop();
 
       if (state == ComponentStatus.TERMINATED && needToNotify) {
          for (ModuleLifecycle l : moduleLifecycles) {

--- a/core/src/main/java/org/infinispan/factories/NamedExecutorsFactory.java
+++ b/core/src/main/java/org/infinispan/factories/NamedExecutorsFactory.java
@@ -26,6 +26,7 @@ import org.infinispan.config.ConfigurationException;
 import org.infinispan.executors.ExecutorFactory;
 import org.infinispan.executors.ScheduledExecutorFactory;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.factories.annotations.Stop;
 import org.infinispan.util.Util;
 
 import java.util.Properties;
@@ -100,6 +101,7 @@ public class NamedExecutorsFactory extends NamedComponentFactory implements Auto
       }
    }
 
+   @Stop(priority = 999)
    public void stop() {
       if (notificationExecutor != null) notificationExecutor.shutdownNow();
       if (asyncTransportExecutor != null) asyncTransportExecutor.shutdownNow();

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -265,7 +265,7 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
       // JGroups
       if (configuration.hasTopologyInfo()) {
          // We can do this only if the channel hasn't been started already
-         if (!startChannel) {
+         if (startChannel) {
             ((JChannel) channel).setAddressGenerator(new AddressGenerator() {
 
                @Override


### PR DESCRIPTION
There was a typo in Tristan's commit for ISPN-1618 (https://github.com/infinispan/infinispan/pull/725), it was _not_ attaching the address generator to the JGroups channel if we were the ones starting it.

I made some other changes to the shutdown to avoid stop exceptions after a start exception.
