### PR TITLE
ISPN-1630 - KeyAffinityService's topology change listener can hang state transfer/cache view installation

### DIFF
--- a/core/src/main/java/org/infinispan/affinity/ListenerRegistration.java
+++ b/core/src/main/java/org/infinispan/affinity/ListenerRegistration.java
@@ -34,7 +34,7 @@ import org.infinispan.notifications.cachemanagerlistener.event.CacheStoppedEvent
 * @author Mircea.Markus@jboss.com
 * @since 4.1
 */
-@Listener
+@Listener(sync = false)
 public class ListenerRegistration {
    private final KeyAffinityServiceImpl keyAffinityService;
 

--- a/core/src/main/java/org/infinispan/statetransfer/BaseStateTransferTask.java
+++ b/core/src/main/java/org/infinispan/statetransfer/BaseStateTransferTask.java
@@ -23,7 +23,6 @@ import org.infinispan.config.Configuration;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.distribution.ch.ConsistentHash;
-import org.infinispan.factories.annotations.Stop;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
@@ -109,7 +108,6 @@ public abstract class BaseStateTransferTask {
       } catch (Exception e) {
          log.errorUnblockingTransactions(e);
       }
-      stateTransferManager.endStateTransfer();
       log.debugf("Node %s completed state transfer for view %d in %s!", self, newViewId,
             Util.prettyPrintTime(System.currentTimeMillis() - stateTransferStartMillis));
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1630

Set an upper bound on the number of keys generated by KeyGeneratorWorker before releasing the maxNumberInvariant read lock.
When polling for a key, acquire the maxNumberInvariant read lock inside the loop.
