### PR TITLE
ISPN-1638 Return values should only be serialized if needed when using D...

### DIFF
--- a/core/src/main/java/org/infinispan/commands/write/AbstractDataWriteCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/AbstractDataWriteCommand.java
@@ -46,4 +46,9 @@ public abstract class AbstractDataWriteCommand extends AbstractDataCommand imple
    public Set<Object> getAffectedKeys() {
       return Collections.singleton(key);
    }
+
+   @Override
+   public boolean isReturnValueExpected() {
+      return flags == null || !flags.contains(Flag.SKIP_REMOTE_LOOKUP);
+   }
 }

--- a/core/src/main/java/org/infinispan/commands/write/ClearCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/ClearCommand.java
@@ -114,6 +114,11 @@ public class ClearCommand implements WriteCommand {
    }
 
    @Override
+   public boolean isReturnValueExpected() {
+      return false;
+   }
+
+   @Override
    public Set<Flag> getFlags() {
       return flags;
    }

--- a/core/src/main/java/org/infinispan/commands/write/PutMapCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/PutMapCommand.java
@@ -157,6 +157,11 @@ public class PutMapCommand implements WriteCommand {
       return map.keySet();
    }
 
+   @Override
+   public boolean isReturnValueExpected() {
+      return false;
+   }
+
    public long getLifespanMillis() {
       return lifespanMillis;
    }

--- a/core/src/main/java/org/infinispan/commands/write/WriteCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/WriteCommand.java
@@ -58,4 +58,11 @@ public interface WriteCommand extends VisitableCommand, FlagAffectedCommand {
     * an empty collection for this method.
     */
    Set<Object> getAffectedKeys();
+
+   /**
+    * If true, a return value will be provided when performed remotely.  Otherwise, a remote {@link org.infinispan.remoting.responses.ResponseGenerator}
+    * may choose to simply return null to save on marshalling costs.
+    * @return true or false
+    */
+   boolean isReturnValueExpected();
 }

--- a/core/src/main/java/org/infinispan/factories/ResponseGeneratorFactory.java
+++ b/core/src/main/java/org/infinispan/factories/ResponseGeneratorFactory.java
@@ -25,6 +25,7 @@ package org.infinispan.factories;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.remoting.responses.DefaultResponseGenerator;
 import org.infinispan.remoting.responses.DistributionResponseGenerator;
+import org.infinispan.remoting.responses.NoReturnValuesDistributionResponseGenerator;
 import org.infinispan.remoting.responses.ResponseGenerator;
 
 /**
@@ -38,9 +39,12 @@ public class ResponseGeneratorFactory extends AbstractNamedCacheComponentFactory
 
    @SuppressWarnings("unchecked")
    public <T> T construct(Class<T> componentType) {
-      if (configuration.getCacheMode().isDistributed())
-         return (T) new DistributionResponseGenerator();
-      else
+      if (configuration.getCacheMode().isDistributed()) {
+         if (configuration.isUnsafeUnreliableReturnValues())
+            return (T) new NoReturnValuesDistributionResponseGenerator();
+         else
+            return (T) new DistributionResponseGenerator();
+      } else
          return (T) new DefaultResponseGenerator();
    }
 }

--- a/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
@@ -179,10 +179,7 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
       Response resp = handleInternal(cmd);
 
       // A null response is valid and OK ...
-      if (resp == null || resp.isValid()) {
-         //TODO Check if message replaying is still needed without FLUSH
-         //if (replayIgnored) resp = new ExtendedResponse(resp, true);
-      } else {
+      if (trace && resp != null && !resp.isValid()) {
          // invalid response
          log.tracef("Unable to execute command, got invalid response %s", resp);
       }
@@ -208,3 +205,4 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
       return handleWithWaitForBlocks(cmd);
    }
 }
+

--- a/core/src/main/java/org/infinispan/remoting/responses/AbstractResponseGenerator.java
+++ b/core/src/main/java/org/infinispan/remoting/responses/AbstractResponseGenerator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.remoting.responses;
+
+import org.infinispan.commands.read.MapReduceCommand;
+import org.infinispan.commands.remote.ClusteredGetCommand;
+import org.infinispan.commands.remote.recovery.CompleteTransactionCommand;
+import org.infinispan.commands.remote.recovery.GetInDoubtTransactionsCommand;
+import org.infinispan.commands.remote.recovery.GetInDoubtTxInfoCommand;
+import org.infinispan.commands.tx.CommitCommand;
+import org.infinispan.commands.tx.PrepareCommand;
+import org.infinispan.commands.tx.VersionedCommitCommand;
+import org.infinispan.commands.tx.VersionedPrepareCommand;
+
+public abstract class AbstractResponseGenerator implements ResponseGenerator {
+   protected boolean commandNeedsNonNullResponse(byte commandId) {
+      switch (commandId) {
+         case ClusteredGetCommand.COMMAND_ID:
+         case GetInDoubtTransactionsCommand.COMMAND_ID:
+         case GetInDoubtTxInfoCommand.COMMAND_ID:
+         case CompleteTransactionCommand.COMMAND_ID:
+         case CommitCommand.COMMAND_ID:
+         case VersionedCommitCommand.COMMAND_ID:
+         case PrepareCommand.COMMAND_ID:
+         case VersionedPrepareCommand.COMMAND_ID:
+         case MapReduceCommand.COMMAND_ID:
+            return true;
+         default:
+            return false;
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/remoting/responses/DefaultResponseGenerator.java
+++ b/core/src/main/java/org/infinispan/remoting/responses/DefaultResponseGenerator.java
@@ -23,12 +23,6 @@
 package org.infinispan.remoting.responses;
 
 import org.infinispan.commands.remote.CacheRpcCommand;
-import org.infinispan.commands.remote.ClusteredGetCommand;
-import org.infinispan.commands.remote.recovery.CompleteTransactionCommand;
-import org.infinispan.commands.remote.recovery.GetInDoubtTransactionsCommand;
-import org.infinispan.commands.remote.recovery.GetInDoubtTxInfoCommand;
-import org.infinispan.commands.tx.CommitCommand;
-import org.infinispan.commands.tx.VersionedCommitCommand;
 import org.infinispan.container.versioning.EntryVersionsMap;
 
 /**
@@ -37,7 +31,7 @@ import org.infinispan.container.versioning.EntryVersionsMap;
  * @author Manik Surtani
  * @since 4.0
  */
-public class DefaultResponseGenerator implements ResponseGenerator {
+public class DefaultResponseGenerator extends AbstractResponseGenerator {
    public Response getResponse(CacheRpcCommand command, Object returnValue) {
       if (returnValue == null) return null;
       if (requiresResponse(command.getCommandId(), returnValue)) {
@@ -48,10 +42,6 @@ public class DefaultResponseGenerator implements ResponseGenerator {
    }
 
    private boolean requiresResponse(byte commandId, Object rv) {
-      boolean commandRequiresResp = commandId == ClusteredGetCommand.COMMAND_ID || commandId == GetInDoubtTransactionsCommand.COMMAND_ID
-            || commandId == GetInDoubtTxInfoCommand.COMMAND_ID || commandId == CompleteTransactionCommand.COMMAND_ID
-            || commandId == CommitCommand.COMMAND_ID || commandId == VersionedCommitCommand.COMMAND_ID;
-
-      return commandRequiresResp || rv instanceof EntryVersionsMap;
+      return commandNeedsNonNullResponse(commandId) || rv instanceof EntryVersionsMap;
    }
 }

--- a/core/src/main/java/org/infinispan/remoting/responses/NoReturnValuesDistributionResponseGenerator.java
+++ b/core/src/main/java/org/infinispan/remoting/responses/NoReturnValuesDistributionResponseGenerator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.remoting.responses;
+
+import org.infinispan.commands.write.WriteCommand;
+
+public class NoReturnValuesDistributionResponseGenerator extends DistributionResponseGenerator {
+   @Override
+   protected Response handleWriteCommand(WriteCommand wc, Object returnValue) {
+      return wc.isSuccessful() ? null : UnsuccessfulResponse.INSTANCE;
+   }
+}


### PR DESCRIPTION
...istribution

https://issues.jboss.org/browse/ISPN-1638

This optimisation should significantly improve performance when using distribution, and not using transactions.  Or using SKIP_REMOTE_LOOKUPs.
