### PR TITLE
TestingUtil.waitForInitRehashToComplete() is not reliable when the cluster forms via a merge

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
@@ -159,6 +159,7 @@ public abstract class BaseDistFunctionalTest extends MultipleCacheManagersTest {
          }
       }
 
+      assert reordered.size() == INIT_CLUSTER_SIZE : "Reordering caches lost some caches: started with " + caches + ", ended with " + reordered;
       caches = reordered;
    }
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/OngoingTransactionsAndJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/OngoingTransactionsAndJoinTest.java
@@ -142,7 +142,7 @@ public class OngoingTransactionsAndJoinTest extends MultipleCacheManagersTest {
 
       for (Thread t : threads) t.join();
 
-      TestingUtil.waitForInitRehashToComplete(cache(1));
+      TestingUtil.waitForRehashToComplete(cache(0), cache(1));
 
       for (int i = 0; i < 10; i++) {
          Object key = "OLD" + i;

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -267,7 +267,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       Cache<Object, Object> cache = caches.get(0);
       TestingUtil.blockUntilViewsReceived(10000, caches);
       if (cache.getConfiguration().getCacheMode().isDistributed()) {
-         TestingUtil.waitForInitRehashToComplete(caches);
+         TestingUtil.waitForRehashToComplete(caches);
       }
    }
 

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -176,6 +176,9 @@ public class TestingUtil {
       waitForRehashToComplete(caches.toArray(new Cache[caches.size()]));
    }
 
+   /**
+    * @deprecated Should use {@link #waitForRehashToComplete(org.infinispan.Cache[])} instead, this is not reliable with merges
+    */
    public static void waitForInitRehashToComplete(Cache... caches) {
       int gracetime = 30000; // 30 seconds?
       long giveup = System.currentTimeMillis() + gracetime;
@@ -194,6 +197,9 @@ public class TestingUtil {
       }
    }
 
+   /**
+    * @deprecated Should use {@link #waitForRehashToComplete(org.infinispan.Cache[])} instead, this is not reliable with merges
+    */
    public static void waitForInitRehashToComplete(Collection<? extends Cache> caches) {
       Set<Cache> cachesSet = new HashSet<Cache>();
       cachesSet.addAll(caches);

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/SimpleCacheRecoveryAdminTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/SimpleCacheRecoveryAdminTest.java
@@ -82,7 +82,7 @@ public class SimpleCacheRecoveryAdminTest extends AbstractRecoveryTest {
       cache(1, "test");
       cache(2, "test");
 
-      TestingUtil.waitForInitRehashToComplete(caches("test"));
+      TestingUtil.waitForRehashToComplete(caches("test"));
 
       threadMBeanServer = PerThreadMBeanServerLookup.getThreadMBeanServer();
 


### PR DESCRIPTION
No JIRA for this one.

I deprecated it, and I changed the tests to use waitForRehashToComplete() instead.
