### PR TITLE
ISPN-1661 Update of transient entries resulted in null value

### DIFF
--- a/core/src/main/java/org/infinispan/container/InternalEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/InternalEntryFactoryImpl.java
@@ -118,7 +118,7 @@ public class InternalEntryFactoryImpl implements InternalEntryFactory {
       } else if (ice instanceof TransientCacheEntry) {
          if (lifespan < 0) {
             if (maxIdle < 0) {
-               return new ImmortalCacheEntry(ice.getKey(), ice.getVersion());
+               return new ImmortalCacheEntry(ice.getKey(), ice.getValue());
             } else {
                ice.setMaxIdle(maxIdle);
                return ice;

--- a/core/src/test/java/org/infinispan/api/APINonTxTest.java
+++ b/core/src/test/java/org/infinispan/api/APINonTxTest.java
@@ -43,8 +43,8 @@ import java.util.Set;
  * @author Mircea Markus
  * @since 5.1
  */
-@Test (groups = "functional", testName = "api.TestAPINonTxTest")
-public class TestAPINonTxTest extends SingleCacheManagerTest {
+@Test (groups = "functional", testName = "api.APINonTxTest")
+public class APINonTxTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
@@ -336,4 +336,10 @@ public class TestAPINonTxTest extends SingleCacheManagerTest {
       assert cache.replace("X", "A") == null;
       assert !cache.containsKey("X");
    }
+
+   @Test(expectedExceptions = NullPointerException.class)
+   public void testNullKeyParameter() {
+      cache.put(null, null);
+   }
+
 }

--- a/core/src/test/java/org/infinispan/api/CacheAPITest.java
+++ b/core/src/test/java/org/infinispan/api/CacheAPITest.java
@@ -39,7 +39,6 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.annotations.Test;
 
-import static junit.framework.Assert.assertNull;
 import static org.infinispan.test.TestingUtil.v;
 import static org.testng.AssertJUnit.assertEquals;
 
@@ -49,7 +48,7 @@ import static org.testng.AssertJUnit.assertEquals;
  * @author <a href="mailto:manik@jboss.org">Manik Surtani</a>
  */
 @Test(groups = "functional")
-public abstract class CacheAPITest extends TestAPINonTxTest {
+public abstract class CacheAPITest extends APINonTxTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {

--- a/core/src/test/java/org/infinispan/expiry/ExpiryTest.java
+++ b/core/src/test/java/org/infinispan/expiry/ExpiryTest.java
@@ -451,6 +451,13 @@ public class ExpiryTest extends AbstractInfinispanTest {
       }
    }
 
+   public void testTransientEntrypUpdates() {
+      Cache<Integer, String> cache = cm.getCache();
+      cache.put(1, "boo", -1, TimeUnit.SECONDS, 10, TimeUnit.SECONDS);
+      cache.put(1, "boo2");
+      cache.put(1, "boo3");
+   }
+
    private void doValuesAfterExpiryInTransaction(Method m, CacheContainer cc) throws Exception {
       Cache<Integer, String> cache = cc.getCache();
       // Values come as a Collection, but comparison of HashMap#Values is done


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1661
- The NullPointerException was happening because version was being passed as value parameter.
- Added a test to ExpiryTest to replicate the scenario that resulted in the NPE.
