### PR TITLE
Critical fix for ISPN-1686

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/LegacyConfigurationAdaptor.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LegacyConfigurationAdaptor.java
@@ -229,6 +229,7 @@ public class LegacyConfigurationAdaptor {
          .syncRollbackPhase(config.transaction().syncRollbackPhase())
          .transactionManagerLookup(config.transaction().transactionManagerLookup())
          .transactionMode(config.transaction().transactionMode())
+         .transactionSynchronizationRegistryLookup(config.transaction().transactionSynchronizationRegistryLookup())
          .useEagerLocking(config.transaction().useEagerLocking())
          .useSynchronization(config.transaction().useSynchronization());
       
@@ -425,6 +426,7 @@ public class LegacyConfigurationAdaptor {
          .syncRollbackPhase(legacy.isSyncRollbackPhase())
          .transactionManagerLookup(legacy.getTransactionManagerLookup())
          .transactionMode(legacy.getTransactionMode())
+         .transactionSynchronizationRegistryLookup(legacy.getTransactionSynchronizationRegistryLookup())
          .useEagerLocking(legacy.isUseEagerLocking())
          .useSynchronization(legacy.isUseSynchronizationForTransactions());
       


### PR DESCRIPTION
ISPN-1686 LegacyConfigurationAdaptor loses transactionSynchronizationRegistryLookup
