### PR TITLE
ISPN-1694 Upgrade to Hibernate Search 4.1.0.Alpha1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -120,7 +120,7 @@
       <version.gnu.getopt>1.0.13</version.gnu.getopt>
       <version.guava>r03</version.guava>
       <version.h2.driver>1.1.117</version.h2.driver>
-      <version.hibernate.search>4.0.0.Final</version.hibernate.search>
+      <version.hibernate.search>4.1.0.Alpha1</version.hibernate.search>
       <version.jackson>1.6.1</version.jackson>
       <version.javax.cache>0.4</version.javax.cache>
       <version.javax.persistence>1.0</version.javax.persistence>


### PR DESCRIPTION
Just upgrading version in the pom, but highly needed as it aligns with Search's dependency on compatible Infinispan, JGroups and Lucene versions.
