### PR TITLE
Fix usage of generics in API of org.infinispan.util.Immutables

### DIFF
--- a/core/src/main/java/org/infinispan/util/Immutables.java
+++ b/core/src/main/java/org/infinispan/util/Immutables.java
@@ -75,7 +75,7 @@ public class Immutables {
     * @param list the list to copy
     * @return the immutable copy
     */
-   public static <T> List<T> immutableListCopy(List<? extends T> list) {
+   public static <T> List<T> immutableListCopy(List<T> list) {
       if (list == null) return null;
       if (list.isEmpty()) return Collections.emptyList();
       if (list.size() == 1) return Collections.singletonList(list.get(0));
@@ -141,7 +141,7 @@ public class Immutables {
     * @param set the set to copy from
     * @return an immutable set copy
     */
-   public static <T> Set<T> immutableSetCopy(Set<? extends T> set) {
+   public static <T> Set<T> immutableSetCopy(Set<T> set) {
       if (set == null) return null;
       if (set.isEmpty()) return Collections.emptySet();
       if (set.size() == 1) return Collections.singleton(set.iterator().next());
@@ -172,11 +172,11 @@ public class Immutables {
     * @param map the map to copy from
     * @return an immutable map copy
     */
-   public static <K, V> Map<K, V> immutableMapCopy(Map<? extends K, ? extends V> map) {
+   public static <K, V> Map<K, V> immutableMapCopy(Map<K, V> map) {
       if (map == null) return null;
       if (map.isEmpty()) return Collections.emptyMap();
       if (map.size() == 1) {
-         Map.Entry<? extends K, ? extends V> me = map.entrySet().iterator().next();
+         Map.Entry<K, V> me = map.entrySet().iterator().next();
          return Collections.singletonMap(me.getKey(), me.getValue());
       }
 
@@ -196,7 +196,7 @@ public class Immutables {
     * @param collection the collection to copy
     * @return an immutable copy
     */
-   public static <T> Collection<T> immutableCollectionCopy(Collection<? extends T> collection) {
+   public static <T> Collection<T> immutableCollectionCopy(Collection<T> collection) {
       if (collection == null) return null;
       if (collection.isEmpty()) return Collections.emptySet();
       if (collection.size() == 1) return Collections.singleton(collection.iterator().next());


### PR DESCRIPTION
The current code is not compiling in Eclipse since the introduction of the java collections helpers cleanup - and I think it's right since generics are not compatible even on inheritance, and we're not guaranteeing to upper cast received collections.
