### PR TITLE
L1OnRehashTest was waiting for the joiner to finish joining but not for ...

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/SingleOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/SingleOwnerTest.java
@@ -71,7 +71,7 @@ public class SingleOwnerTest extends BaseDistFunctionalTest {
          cacheAddresses.add(cacheManager.getAddress());
       }
 
-      waitForJoinTasksToComplete(60000, c1, c2);
+      waitForClusterToForm(cacheName);
    }
 
    public void testPutOnKeyOwner() {

--- a/core/src/test/java/org/infinispan/distribution/rehash/ConcurrentJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/ConcurrentJoinTest.java
@@ -34,8 +34,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 @Test(groups = "functional", testName = "distribution.rehash.ConcurrentJoinTest", description = "See ISPN-1123")
 public class ConcurrentJoinTest extends RehashTestBase {
 
@@ -84,7 +82,7 @@ public class ConcurrentJoinTest extends RehashTestBase {
       List<CacheContainer> allCacheManagers = new ArrayList<CacheContainer>(cacheManagers);
       // Collection already contains all cache managers, no need to add more
       TestingUtil.blockUntilViewsReceived(60000, false, allCacheManagers);
-      waitForJoinTasksToComplete(SECONDS.toMillis(480), joiners.toArray(new Cache[NUM_JOINERS]));
+      waitForClusterToForm(cacheName);
       int[] joinersPos = new int[NUM_JOINERS];
       for (int i = 0; i < NUM_JOINERS; i++) joinersPos[i] = locateJoiner(joinerManagers.get(i).getAddress());
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/L1OnRehashTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/L1OnRehashTest.java
@@ -64,7 +64,7 @@ public class L1OnRehashTest extends BaseDistFunctionalTest {
    int waitForJoinCompletion() {
       // need to block until this join has completed!
       TestingUtil.blockUntilViewsReceived(SECONDS.toMillis(10), c1, c2, joiner);
-      waitForJoinTasksToComplete(SECONDS.toMillis(480), joiner);
+      waitForClusterToForm(cacheName);
 
       // where does the joiner sit in relation to the other caches?
       int joinerPos = locateJoiner(joinerManager.getAddress());

--- a/core/src/test/java/org/infinispan/distribution/rehash/SingleJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/SingleJoinTest.java
@@ -31,8 +31,6 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 @Test(groups = "functional", testName = "distribution.rehash.SingleJoinTest")
 public class SingleJoinTest extends RehashTestBase {
    EmbeddedCacheManager joinerManager;
@@ -49,7 +47,7 @@ public class SingleJoinTest extends RehashTestBase {
       List<Cache> allCaches = new ArrayList(caches);
       allCaches.add(joiner);
       TestingUtil.blockUntilViewsReceived(60000, allCaches);
-      waitForJoinTasksToComplete(SECONDS.toMillis(480), joiner);
+      waitForClusterToForm(cacheName);
 
       // where does the joiner sit in relation to the other caches?
       int joinerPos = locateJoiner(joinerManager.getAddress());


### PR DESCRIPTION
...all the other caches to finish invalidating keys before checking the ownership.

Same thing with a few other tests: SingleJoinTest, ConcurrentJoinTest, SingleOwnerTest.
