### PR TITLE
Re-add SerializationConfigurationBuilder.marshallerClass() but mark it a...

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/global/SerializationConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/SerializationConfigurationBuilder.java
@@ -1,26 +1,33 @@
 package org.infinispan.configuration.global;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.infinispan.Version;
 import org.infinispan.marshall.AdvancedExternalizer;
 import org.infinispan.marshall.Marshaller;
 import org.infinispan.marshall.VersionAwareMarshaller;
+import org.infinispan.util.Util;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Configures serialization and marshalling settings.
  */
 public class SerializationConfigurationBuilder extends AbstractGlobalConfigurationBuilder<SerializationConfiguration> {
+
+   private static final Log log = LogFactory.getLog(SerializationConfigurationBuilder.class);
    
    private Marshaller marshaller = new VersionAwareMarshaller();
+   @Deprecated
+   private Class<? extends Marshaller> marshallerClass;
    private short marshallVersion = Short.valueOf(Version.MAJOR_MINOR.replace(".", ""));
    private Map<Integer, AdvancedExternalizer<?>> advancedExternalizers = new HashMap<Integer, AdvancedExternalizer<?>>();
-   
+
    SerializationConfigurationBuilder(GlobalConfigurationBuilder globalConfig) {
       super(globalConfig);
    }
-   
+
    /**
     * Set the marshaller instance that will marshall and unmarshall cache entries.
     *
@@ -31,11 +38,24 @@ public class SerializationConfigurationBuilder extends AbstractGlobalConfigurati
       return this;
    }
 
+
    /**
-    * Largest allowable version to use when marshalling internal state. Set this to the lowest
-    * version cache instance in your cluster to ensure compatibility of communications. However,
-    * setting this too low will mean you lose out on the benefit of improvements in newer
-    * versions of the marshaller.
+    * Fully qualified name of the marshaller to use. It must implement org.infinispan.marshall.StreamingMarshaller Set the
+    * marshaller instance that will marshall and unmarshall cache entries.
+    *
+    * @param marshallerClass
+    * @deprecated Use {@link #marshaller(org.infinispan.marshall.Marshaller)} instead.
+    */
+   @Deprecated
+   public SerializationConfigurationBuilder marshallerClass(Class<? extends Marshaller> marshallerClass) {
+      this.marshallerClass = marshallerClass;
+      return this;
+   }
+
+   /**
+    * Largest allowable version to use when marshalling internal state. Set this to the lowest version cache instance in
+    * your cluster to ensure compatibility of communications. However, setting this too low will mean you lose out on
+    * the benefit of improvements in newer versions of the marshaller.
     *
     * @param marshallVersion
     */
@@ -43,12 +63,11 @@ public class SerializationConfigurationBuilder extends AbstractGlobalConfigurati
       this.marshallVersion = marshallVersion;
       return this;
    }
-   
+
    /**
-    * Largest allowable version to use when marshalling internal state. Set this to the lowest
-    * version cache instance in your cluster to ensure compatibility of communications. However,
-    * setting this too low will mean you lose out on the benefit of improvements in newer
-    * versions of the marshaller.
+    * Largest allowable version to use when marshalling internal state. Set this to the lowest version cache instance in
+    * your cluster to ensure compatibility of communications. However, setting this too low will mean you lose out on
+    * the benefit of improvements in newer versions of the marshaller.
     *
     * @param marshallVersion
     */
@@ -58,9 +77,9 @@ public class SerializationConfigurationBuilder extends AbstractGlobalConfigurati
    }
 
    /**
-    * Helper method that allows for quick registration of an {@link org.infinispan.marshall.AdvancedExternalizer} implementation
-    * alongside its corresponding identifier. Remember that the identifier needs to a be positive
-    * number, including 0, and cannot clash with other identifiers in the system.
+    * Helper method that allows for quick registration of an {@link org.infinispan.marshall.AdvancedExternalizer}
+    * implementation alongside its corresponding identifier. Remember that the identifier needs to a be positive number,
+    * including 0, and cannot clash with other identifiers in the system.
     *
     * @param id
     * @param advancedExternalizer
@@ -69,11 +88,11 @@ public class SerializationConfigurationBuilder extends AbstractGlobalConfigurati
       advancedExternalizers.put(id, advancedExternalizer);
       return this;
    }
-   
+
    /**
-    * Helper method that allows for quick registration of an {@link org.infinispan.marshall.AdvancedExternalizer} implementation
-    * alongside its corresponding identifier. Remember that the identifier needs to a be positive
-    * number, including 0, and cannot clash with other identifiers in the system.
+    * Helper method that allows for quick registration of an {@link org.infinispan.marshall.AdvancedExternalizer}
+    * implementation alongside its corresponding identifier. Remember that the identifier needs to a be positive number,
+    * including 0, and cannot clash with other identifiers in the system.
     *
     * @param advancedExternalizer
     */
@@ -83,33 +102,38 @@ public class SerializationConfigurationBuilder extends AbstractGlobalConfigurati
    }
 
    /**
-    * Helper method that allows for quick registration of {@link org.infinispan.marshall.AdvancedExternalizer} implementations.
+    * Helper method that allows for quick registration of {@link org.infinispan.marshall.AdvancedExternalizer}
+    * implementations.
     *
     * @param advancedExternalizers
     */
    public <T> SerializationConfigurationBuilder addAdvancedExternalizer(AdvancedExternalizer<T>... advancedExternalizers) {
-      for (AdvancedExternalizer<T> advancedExternalizer : advancedExternalizers)  {
+      for (AdvancedExternalizer<T> advancedExternalizer : advancedExternalizers) {
          this.addAdvancedExternalizer(advancedExternalizer);
       }
       return this;
    }
-   
+
    @Override
    protected void validate() {
       // No-op, no validation required
    }
-   
+
    @Override
    SerializationConfiguration create() {
+      if (marshallerClass != null && marshaller instanceof VersionAwareMarshaller) {
+         log.info("Creating marshaller from specified marshallerClass instead of the default. Please note that setting a marshaller using marshallerClass() is deprecated. Use marshaller() instead.");
+         marshaller = Util.getInstance(marshallerClass);
+      }
       return new SerializationConfiguration(marshaller, marshallVersion, advancedExternalizers);
    }
-   
+
    @Override
    SerializationConfigurationBuilder read(SerializationConfiguration template) {
       this.advancedExternalizers = template.advancedExternalizers();
       this.marshaller = template.marshaller();
       this.marshallVersion = template.version();
-      
+
       return this;
    }
 }


### PR DESCRIPTION
...s deprecated for backward compatibility.

No JIRA for this, since it is effectively to correct a patch ( https://github.com/infinispan/infinispan/commit/0cd2a2b5b110fcf8bd4aaaa23cf7075fb185e6c7#diff-4 ) that (a) didn't have a JIRA and (b) wasn't in any tagged release.
