### PR TITLE
perf optimisation: skip tx.notifyOnTransactionFinished call in some situations.

### DIFF
--- a/core/src/main/java/org/infinispan/transaction/AbstractCacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/AbstractCacheTransaction.java
@@ -107,13 +107,15 @@ public abstract class AbstractCacheTransaction implements CacheTransaction {
    }
 
    @Override
-   public void notifyOnTransactionFinished() {
-      log.tracef("Transaction %s has completed, notifying listening threads.", tx);
-      txComplete = true; //this one is cheap but does not guarantee visibility
-      if (needToNotifyWaiters) {
-         synchronized (this) {
-            txComplete = true; //in this case we want to guarantee visibility to other threads
-            this.notifyAll();
+   public void notifyOnTransactionFinished(int currentViewId) {
+      if (getViewId() != currentViewId) {
+         log.tracef("Transaction %s has completed, notifying listening threads.", tx);
+         txComplete = true; //this one is cheap but does not guarantee visibility
+         if (needToNotifyWaiters) {
+            synchronized (this) {
+               txComplete = true; //in this case we want to guarantee visibility to other threads
+               this.notifyAll();
+            }
          }
       }
    }

--- a/core/src/main/java/org/infinispan/transaction/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/TransactionTable.java
@@ -48,7 +48,6 @@ import org.infinispan.transaction.synchronization.SynchronizationAdapter;
 import org.infinispan.transaction.xa.CacheTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.TransactionFactory;
-import org.infinispan.util.Util;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -321,7 +320,7 @@ public class TransactionTable {
             recalculateMinViewIdIfNeeded(cacheTransaction);
          }
          log.tracef("Removed %s from transaction table.", cacheTransaction);
-         cacheTransaction.notifyOnTransactionFinished();
+         cacheTransaction.notifyOnTransactionFinished(currentViewId);
       }
    }
 
@@ -465,5 +464,9 @@ public class TransactionTable {
       } else {
          log.trace("All transactions terminated");
       }
+   }
+
+   public final int getCurrentViewId() {
+      return currentViewId;
    }
 }

--- a/core/src/main/java/org/infinispan/transaction/xa/CacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/CacheTransaction.java
@@ -69,7 +69,7 @@ public interface CacheTransaction {
    /**
     * @see org.infinispan.interceptors.locking.AbstractTxLockingInterceptor#lockKeyAndCheckOwnership(org.infinispan.context.InvocationContext, Object)
     */
-   void notifyOnTransactionFinished();
+   void notifyOnTransactionFinished(int currentViewId);
 
    /**
     * @see org.infinispan.interceptors.locking.AbstractTxLockingInterceptor#lockKeyAndCheckOwnership(org.infinispan.context.InvocationContext, Object)

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareTransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareTransactionTable.java
@@ -181,7 +181,7 @@ public class RecoveryAwareTransactionTable extends XaTransactionTable {
             if (xid.equals(gtx.getXid())) {
                it.remove();
                recalculateMinViewIdIfNeeded(next);
-               next.notifyOnTransactionFinished();
+               next.notifyOnTransactionFinished(getCurrentViewId());
                return next;
             }
          }


### PR DESCRIPTION
don't invoke the tx.notifyOnTransactionFinished in the case the current transaction was created in the current view.
