### PR TITLE
Revert ISPN-1754 IllegalStateException during cluster shutdown (again)

### DIFF
--- a/core/src/main/java/org/infinispan/cacheviews/CacheViewsManagerImpl.java
+++ b/core/src/main/java/org/infinispan/cacheviews/CacheViewsManagerImpl.java
@@ -482,10 +482,10 @@ public class CacheViewsManagerImpl implements CacheViewsManager {
       cacheViewInfo.prepareView(pendingView);
       if (isLocal) {
          CacheViewListener cacheViewListener = cacheViewInfo.getListener();
-         if (cacheViewListener == null) {
-            log.debug(String.format("%s: Received cache view prepare request after the local node has already shut down", cacheName));
-         } else {
+         if (cacheViewListener != null) {
             cacheViewListener.prepareView(pendingView, lastCommittedView);
+         } else {
+            throw new IllegalStateException(String.format("%s: Received cache view prepare request after the local node has already shut down", cacheName));
          }
       }
       // any exception here will be propagated back to the coordinator, which will roll back the view installation

--- a/core/src/main/java/org/infinispan/statetransfer/BaseStateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/BaseStateTransferManagerImpl.java
@@ -87,7 +87,6 @@ public abstract class BaseStateTransferManagerImpl implements StateTransferManag
    private final ReclosableLatch stateTransferInProgressLatch = new ReclosableLatch(false);
    private volatile BaseStateTransferTask stateTransferTask;
    private CommandBuilder commandBuilder;
-   private volatile boolean shuttingDown = false;
 
    public BaseStateTransferManagerImpl() {
    }
@@ -107,16 +106,6 @@ public abstract class BaseStateTransferManagerImpl implements StateTransferManag
       this.icc = icc;
       this.cacheNotifier = cacheNotifier;
       this.cacheViewsManager = cacheViewsManager;
-   }
-
-   @Start(priority = 1)
-   private void setStartStatus() {
-      shuttingDown = false;
-   }
-
-   @Stop(priority = 1)
-   private void setStopStatus() {
-      shuttingDown = true;
    }
 
    // needs to be AFTER the DistributionManager and *after* the cache loader manager (if any) inits and preloads
@@ -361,10 +350,7 @@ public abstract class BaseStateTransferManagerImpl implements StateTransferManag
       try {
          stateTransferLock.unblockNewTransactions(viewId);
       } catch (Exception e) {
-         if (shuttingDown)
-            log.trace("Unable to release state transfer lock, possibly because we're shutting down.");
-         else
-            log.errorUnblockingTransactions(e);
+         log.errorUnblockingTransactions(e);
       }
 
       stateTransferInProgressLatch.open();

--- a/core/src/main/java/org/infinispan/transaction/TransactionCoordinator.java
+++ b/core/src/main/java/org/infinispan/transaction/TransactionCoordinator.java
@@ -32,6 +32,7 @@ import org.infinispan.context.InvocationContextContainer;
 import org.infinispan.context.impl.LocalTxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.Stop;
 import org.infinispan.interceptors.InterceptorChain;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.logging.Log;
@@ -39,7 +40,6 @@ import org.infinispan.util.logging.LogFactory;
 
 import javax.transaction.Transaction;
 import javax.transaction.xa.XAException;
-
 import java.util.List;
 
 import static javax.transaction.xa.XAResource.XA_OK;
@@ -62,6 +62,7 @@ public class TransactionCoordinator {
    private TransactionTable txTable;
    private Configuration configuration;
    private CommandCreator commandCreator;
+   private volatile boolean shuttingDown = false;
 
    boolean trace;
 
@@ -74,6 +75,16 @@ public class TransactionCoordinator {
       this.txTable = txTable;
       this.configuration = configuration;
       trace = log.isTraceEnabled();
+   }
+
+   @Start(priority = 1)
+   private void setStartStatus() {
+      shuttingDown = false;
+   }
+
+   @Stop(priority = 1)
+   private void setStopStatus() {
+      shuttingDown = true;
    }
 
    @Start
@@ -137,7 +148,11 @@ public class TransactionCoordinator {
             return XA_OK;
          }
       } catch (Throwable e) {
-         log.error("Error while processing PrepareCommand", e);
+         if (shuttingDown)
+            log.trace("Exception while preparing back, probably because we're shutting down.");
+         else
+            log.error("Error while processing prepare", e);
+
          //rollback transaction before throwing the exception as there's no guarantee the TM calls XAResource.rollback
          //after prepare failed.
          rollback(localTransaction);
@@ -175,7 +190,11 @@ public class TransactionCoordinator {
       try {
          rollbackInternal(localTransaction);
       } catch (Throwable e) {
-         log.errorRollingBack(e);
+         if (shuttingDown)
+            log.trace("Exception while rolling back, probably because we're shutting down.");
+         else
+            log.errorRollingBack(e);
+
          final Transaction transaction = localTransaction.getTransaction();
          //this might be possible if the cache has stopped and TM still holds a reference to the XAResource
          if (transaction != null) {


### PR DESCRIPTION
Properly revert the state transfer-related part of commit d38077c.
My previous revert left the state transfer part as it was
and reverted the TransactionCoordinator.
