### PR TITLE
Cleanup RemoteCacheManager and RemoteCacheImpl

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -111,9 +111,9 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    public NotifyingFuture<Boolean> removeWithVersionAsync(final K key, final long version) {
       assertRemoteCacheManagerIsStarted();
       final NotifyingFutureImpl<Boolean> result = new NotifyingFutureImpl<Boolean>();
-      Future future = executorService.submit(new Callable() {
+      Future<Boolean> future = executorService.submit(new Callable<Boolean>() {
          @Override
-         public Object call() throws Exception {
+         public Boolean call() throws Exception {
             boolean removed = removeWithVersion(key, version);
             result.notifyFutureCompletion();
             return removed;
@@ -135,9 +135,9 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    public NotifyingFuture<Boolean> replaceWithVersionAsync(final K key, final V newValue, final long version, final int lifespanSeconds, final int maxIdleSeconds) {
       assertRemoteCacheManagerIsStarted();
       final NotifyingFutureImpl<Boolean> result = new NotifyingFutureImpl<Boolean>();
-      Future future = executorService.submit(new Callable() {
+      Future<Boolean> future = executorService.submit(new Callable<Boolean>() {
          @Override
-         public Object call() throws Exception {
+         public Boolean call() throws Exception {
             boolean removed = replaceWithVersion(key, newValue, version, lifespanSeconds, maxIdleSeconds);
             result.notifyFutureCompletion();
             return removed;
@@ -167,9 +167,9 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    public NotifyingFuture<Void> putAllAsync(final Map<? extends K, ? extends V> data, final long lifespan, final TimeUnit lifespanUnit, final long maxIdle, final TimeUnit maxIdleUnit) {
       assertRemoteCacheManagerIsStarted();
       final NotifyingFutureImpl<Void> result = new NotifyingFutureImpl<Void>();
-      Future future = executorService.submit(new Callable() {
+      Future<Void> future = executorService.submit(new Callable<Void>() {
          @Override
-         public Object call() throws Exception {
+         public Void call() throws Exception {
             putAll(data, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
             result.notifyFutureCompletion();
             return null;
@@ -181,6 +181,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    }
 
    @Override
+   @SuppressWarnings("unchecked")
    public int size() {
       assertRemoteCacheManagerIsStarted();
       StatsOperation op = operationsFactory.newStatsOperation();
@@ -193,6 +194,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    }
 
    @Override
+   @SuppressWarnings("unchecked")
    public ServerStatistics stats() {
       assertRemoteCacheManagerIsStarted();
       StatsOperation op = operationsFactory.newStatsOperation();
@@ -205,6 +207,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    }
 
    @Override
+   @SuppressWarnings("unchecked")
    public V put(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
       assertRemoteCacheManagerIsStarted();
       int lifespanSecs = toSeconds(lifespan, lifespanUnit);
@@ -219,6 +222,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
 
 
    @Override
+   @SuppressWarnings("unchecked")
    public V putIfAbsent(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
       assertRemoteCacheManagerIsStarted();
       int lifespanSecs = toSeconds(lifespan, lifespanUnit);
@@ -229,6 +233,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    }
 
    @Override
+   @SuppressWarnings("unchecked")
    public V replace(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
       assertRemoteCacheManagerIsStarted();
       int lifespanSecs = toSeconds(lifespan, lifespanUnit);
@@ -242,9 +247,9 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    public NotifyingFuture<V> putAsync(final K key, final V value, final long lifespan, final TimeUnit lifespanUnit, final long maxIdle, final TimeUnit maxIdleUnit) {
       assertRemoteCacheManagerIsStarted();
       final NotifyingFutureImpl<V> result = new NotifyingFutureImpl<V>();
-      Future future = executorService.submit(new Callable() {
+      Future<V> future = executorService.submit(new Callable<V>() {
          @Override
-         public Object call() throws Exception {
+         public V call() throws Exception {
             V prevValue = put(key, value, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
             result.notifyFutureCompletion();
             return prevValue;
@@ -258,9 +263,9 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    public NotifyingFuture<Void> clearAsync() {
       assertRemoteCacheManagerIsStarted();
       final NotifyingFutureImpl<Void> result = new NotifyingFutureImpl<Void>();
-      Future future = executorService.submit(new Callable() {
+      Future<Void> future = executorService.submit(new Callable<Void>() {
          @Override
-         public Object call() throws Exception {
+         public Void call() throws Exception {
             clear();
             result.notifyFutureCompletion();
             return null;
@@ -274,9 +279,9 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    public NotifyingFuture<V> putIfAbsentAsync(final K key,final V value,final long lifespan,final TimeUnit lifespanUnit,final long maxIdle,final TimeUnit maxIdleUnit) {
       assertRemoteCacheManagerIsStarted();
       final NotifyingFutureImpl<V> result = new NotifyingFutureImpl<V>();
-      Future future = executorService.submit(new Callable() {
+      Future<V> future = executorService.submit(new Callable<V>() {
          @Override
-         public Object call() throws Exception {
+         public V call() throws Exception {
             V prevValue = putIfAbsent(key, value, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
             result.notifyFutureCompletion();
             return prevValue;
@@ -290,9 +295,9 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    public NotifyingFuture<V> removeAsync(final Object key) {
       assertRemoteCacheManagerIsStarted();
       final NotifyingFutureImpl<V> result = new NotifyingFutureImpl<V>();
-      Future future = executorService.submit(new Callable() {
+      Future<V> future = executorService.submit(new Callable<V>() {
          @Override
-         public Object call() throws Exception {
+         public V call() throws Exception {
             V toReturn = remove(key);
             result.notifyFutureCompletion();
             return toReturn;
@@ -306,9 +311,9 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    public NotifyingFuture<V> replaceAsync(final K key,final V value,final long lifespan,final TimeUnit lifespanUnit,final long maxIdle,final TimeUnit maxIdleUnit) {
       assertRemoteCacheManagerIsStarted();
       final NotifyingFutureImpl<V> result = new NotifyingFutureImpl<V>();
-      Future future = executorService.submit(new Callable() {
+      Future<V> future = executorService.submit(new Callable<V>() {
          @Override
-         public Object call() throws Exception {
+         public V call() throws Exception {
             V v = replace(key, value, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
             result.notifyFutureCompletion();
             return v;
@@ -326,6 +331,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    }
 
    @Override
+   @SuppressWarnings("unchecked")
    public V get(Object key) {
       assertRemoteCacheManagerIsStarted();
       byte[] keyBytes = obj2bytes(key, true);
@@ -344,10 +350,11 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    }
 
    @Override
+   @SuppressWarnings("unchecked")
    public Map<K, V> getBulk(int size) {
       assertRemoteCacheManagerIsStarted();
       BulkGetOperation op = operationsFactory.newBulkGetOperation(size);
-      Map<byte[], byte[]> result = (Map) op.execute();
+      Map<byte[], byte[]> result = op.execute();
       Map<K,V> toReturn = new HashMap<K,V>();
       for (Map.Entry<byte[], byte[]> entry : result.entrySet()) {
          V value = (V) bytes2obj(entry.getValue());
@@ -358,6 +365,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    }
 
    @Override
+   @SuppressWarnings("unchecked")
    public V remove(Object key) {
       assertRemoteCacheManagerIsStarted();
       RemoveOperation removeOperation = operationsFactory.newRemoveOperation(obj2bytes(key, true));
@@ -406,9 +414,9 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    public NotifyingFuture<V> getAsync(final K key) {
       assertRemoteCacheManagerIsStarted();
       final NotifyingFutureImpl<V> result = new NotifyingFutureImpl<V>();
-      Future future = executorService.submit(new Callable() {
+      Future<V> future = executorService.submit(new Callable<V>() {
          @Override
-         public Object call() throws Exception {
+         public V call() throws Exception {
             V toReturn = get(key);
             result.notifyFutureCompletion();
             return toReturn;
@@ -442,6 +450,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
       }
    }
 
+   @SuppressWarnings("unchecked")
    private VersionedValue<V> binary2VersionedValue(BinaryVersionedValue value) {
       if (value == null)
          return null;
@@ -470,5 +479,4 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
       // Warning: never invoke put(K,V) in this scope or we'll get a stackoverflow.
       put(key, value, defaultLifespan, MILLISECONDS, defaultMaxIdleTime, MILLISECONDS);
    }
-
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AbstractKeyOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AbstractKeyOperation.java
@@ -43,7 +43,7 @@ import org.jboss.logging.BasicLogger;
  * @since 4.1
  */
 @Immutable
-public abstract class AbstractKeyOperation extends RetryOnFailureOperation {
+public abstract class AbstractKeyOperation<T> extends RetryOnFailureOperation<T> {
 
    private static final BasicLogger log = BasicLogFactory.getLog(AbstractKeyOperation.class);
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AbstractKeyValueOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AbstractKeyValueOperation.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @since 4.1
  */
 @Immutable
-public abstract class AbstractKeyValueOperation extends AbstractKeyOperation {
+public abstract class AbstractKeyValueOperation<T> extends AbstractKeyOperation<T> {
 
    protected final byte[] value;
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/BulkGetOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/BulkGetOperation.java
@@ -29,6 +29,7 @@ import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -37,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author Mircea.Markus@jboss.com
  * @since 4.1
  */
-public class BulkGetOperation extends RetryOnFailureOperation {
+public class BulkGetOperation extends RetryOnFailureOperation<Map<byte[], byte[]>> {
 
    private final int entryCount;
 
@@ -52,12 +53,12 @@ public class BulkGetOperation extends RetryOnFailureOperation {
    }
 
    @Override
-   protected Object executeOperation(Transport transport) {
+   protected Map<byte[], byte[]> executeOperation(Transport transport) {
       HeaderParams params = writeHeader(transport, BULK_GET_REQUEST);
       transport.writeVInt(entryCount);
       transport.flush();
       readHeaderAndValidate(transport, params);
-      HashMap result = new HashMap();
+      Map<byte[], byte[]> result = new HashMap<byte[], byte[]>();
       while ( transport.readByte() == 1) { //there's more!
          result.put(transport.readArray(), transport.readArray());
       }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ClearOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ClearOperation.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @since 4.1
  */
 @Immutable
-public class ClearOperation extends RetryOnFailureOperation {
+public class ClearOperation extends RetryOnFailureOperation<Void> {
 
    public ClearOperation(Codec codec, TransportFactory transportFactory,
             byte[] cacheName, AtomicInteger topologyId, Flag[] flags) {
@@ -51,7 +51,7 @@ public class ClearOperation extends RetryOnFailureOperation {
    }
 
    @Override
-   protected Object executeOperation(Transport transport) {
+   protected Void executeOperation(Transport transport) {
       HeaderParams params = writeHeader(transport, CLEAR_REQUEST);
       transport.flush();
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ContainsKeyOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ContainsKeyOperation.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @since 4.1
  */
 @Immutable
-public class ContainsKeyOperation extends AbstractKeyOperation {
+public class ContainsKeyOperation extends AbstractKeyOperation<Boolean> {
 
    public ContainsKeyOperation(Codec codec, TransportFactory transportFactory,
          byte[] key, byte[] cacheName, AtomicInteger topologyId, Flag[] flags) {
@@ -45,7 +45,7 @@ public class ContainsKeyOperation extends AbstractKeyOperation {
    }
 
    @Override
-   protected Object executeOperation(Transport transport) {
+   protected Boolean executeOperation(Transport transport) {
       boolean containsKey = false;
       short status = sendKeyOperation(key, transport, CONTAINS_KEY_REQUEST, CONTAINS_KEY_RESPONSE);
       if (status == KEY_DOES_NOT_EXIST_STATUS) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetOperation.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @since 4.1
  */
 @Immutable
-public class GetOperation extends AbstractKeyOperation {
+public class GetOperation extends AbstractKeyOperation<byte[]> {
 
    public GetOperation(Codec codec, TransportFactory transportFactory,
          byte[] key, byte[] cacheName, AtomicInteger topologyId, Flag[] flags) {
@@ -45,7 +45,7 @@ public class GetOperation extends AbstractKeyOperation {
    }
 
    @Override
-   public Object executeOperation(Transport transport) {
+   public byte[] executeOperation(Transport transport) {
       byte[] result = null;
       short status = sendKeyOperation(key, transport, GET_REQUEST, GET_RESPONSE);
       if (status == KEY_DOES_NOT_EXIST_STATUS) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetWithVersionOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetWithVersionOperation.java
@@ -42,7 +42,7 @@ import org.infinispan.client.hotrod.logging.LogFactory;
  * @since 4.1
  */
 @Immutable
-public class GetWithVersionOperation extends AbstractKeyOperation {
+public class GetWithVersionOperation extends AbstractKeyOperation<BinaryVersionedValue> {
 
    private static final Log log = LogFactory.getLog(GetWithVersionOperation.class);
 
@@ -52,9 +52,9 @@ public class GetWithVersionOperation extends AbstractKeyOperation {
    }
 
    @Override
-   protected Object executeOperation(Transport transport) {
+   protected BinaryVersionedValue executeOperation(Transport transport) {
       short status = sendKeyOperation(key, transport, GET_WITH_VERSION, GET_WITH_VERSION_RESPONSE);
-      Object result = null;
+      BinaryVersionedValue result = null;
       if (status == KEY_DOES_NOT_EXIST_STATUS) {
          result = null;
       } else if (status == NO_ERROR_STATUS) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutIfAbsentOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutIfAbsentOperation.java
@@ -42,7 +42,7 @@ import org.jboss.logging.BasicLogger;
  * @since 4.1
  */
 @Immutable
-public class PutIfAbsentOperation extends AbstractKeyValueOperation {
+public class PutIfAbsentOperation extends AbstractKeyValueOperation<byte[]> {
 
    private static final BasicLogger log = BasicLogFactory.getLog(PutIfAbsentOperation.class);
 
@@ -53,7 +53,7 @@ public class PutIfAbsentOperation extends AbstractKeyValueOperation {
    }
 
    @Override
-   protected Object executeOperation(Transport transport) {
+   protected byte[] executeOperation(Transport transport) {
       short status = sendPutOperation(transport, PUT_IF_ABSENT_REQUEST, PUT_IF_ABSENT_RESPONSE);
       byte[] previousValue = null;
       if (status == NO_ERROR_STATUS || status == NOT_PUT_REMOVED_REPLACED_STATUS) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutOperation.java
@@ -39,7 +39,7 @@ import org.infinispan.client.hotrod.impl.transport.TransportFactory;
  * @since 4.1
  */
 @Immutable
-public class PutOperation extends AbstractKeyValueOperation {
+public class PutOperation extends AbstractKeyValueOperation<byte[]> {
 
    public PutOperation(Codec codec, TransportFactory transportFactory,
                        byte[] key, byte[] cacheName, AtomicInteger topologyId,
@@ -48,7 +48,7 @@ public class PutOperation extends AbstractKeyValueOperation {
    }
 
    @Override
-   protected Object executeOperation(Transport transport) {
+   protected byte[] executeOperation(Transport transport) {
       short status = sendPutOperation(transport, PUT_REQUEST, PUT_RESPONSE);
       if (status != NO_ERROR_STATUS) {
          throw new InvalidResponseException("Unexpected response status: " + Integer.toHexString(status));

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveIfUnmodifiedOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveIfUnmodifiedOperation.java
@@ -24,6 +24,7 @@ package org.infinispan.client.hotrod.impl.operations;
 
 import net.jcip.annotations.Immutable;
 import org.infinispan.client.hotrod.Flag;
+import org.infinispan.client.hotrod.impl.VersionedOperationResponse;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.impl.protocol.HeaderParams;
 import org.infinispan.client.hotrod.impl.transport.Transport;
@@ -39,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @since 4.1
  */
 @Immutable
-public class RemoveIfUnmodifiedOperation extends AbstractKeyOperation {
+public class RemoveIfUnmodifiedOperation extends AbstractKeyOperation<VersionedOperationResponse> {
 
    private final long version;
 
@@ -50,7 +51,7 @@ public class RemoveIfUnmodifiedOperation extends AbstractKeyOperation {
    }
 
    @Override
-   protected Object executeOperation(Transport transport) {
+   protected VersionedOperationResponse executeOperation(Transport transport) {
       // 1) write header
       HeaderParams params = writeHeader(transport, REMOVE_IF_UNMODIFIED_REQUEST);
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveOperation.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @since 4.1
  */
 @Immutable
-public class RemoveOperation extends AbstractKeyOperation {
+public class RemoveOperation extends AbstractKeyOperation<byte[]> {
 
    public RemoveOperation(Codec codec, TransportFactory transportFactory,
             byte[] key, byte[] cacheName, AtomicInteger topologyId, Flag[] flags) {
@@ -46,7 +46,7 @@ public class RemoveOperation extends AbstractKeyOperation {
    }
 
    @Override
-   public Object executeOperation(Transport transport) {
+   public byte[] executeOperation(Transport transport) {
       byte[] result = null;
       short status = sendKeyOperation(key, transport, REMOVE_REQUEST, REMOVE_RESPONSE);
       if (status == KEY_DOES_NOT_EXIST_STATUS) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceIfUnmodifiedOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceIfUnmodifiedOperation.java
@@ -23,6 +23,7 @@
 package org.infinispan.client.hotrod.impl.operations;
 
 import org.infinispan.client.hotrod.Flag;
+import org.infinispan.client.hotrod.impl.VersionedOperationResponse;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.impl.protocol.HeaderParams;
 import org.infinispan.client.hotrod.impl.transport.Transport;
@@ -37,8 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author Mircea.Markus@jboss.com
  * @since 4.1
  */
-public class ReplaceIfUnmodifiedOperation extends AbstractKeyValueOperation {
-
+public class ReplaceIfUnmodifiedOperation extends AbstractKeyValueOperation<VersionedOperationResponse> {
    private final long version;
 
    public ReplaceIfUnmodifiedOperation(Codec codec, TransportFactory transportFactory, byte[] key, byte[] cacheName,
@@ -49,7 +49,7 @@ public class ReplaceIfUnmodifiedOperation extends AbstractKeyValueOperation {
    }
 
    @Override
-   protected Object executeOperation(Transport transport) {
+   protected VersionedOperationResponse executeOperation(Transport transport) {
       // 1) write header
       HeaderParams params = writeHeader(transport, REPLACE_IF_UNMODIFIED_REQUEST);
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceOperation.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @since 4.1
  */
 @Immutable
-public class ReplaceOperation extends AbstractKeyValueOperation {
+public class ReplaceOperation extends AbstractKeyValueOperation<byte[]> {
 
    public ReplaceOperation(Codec codec, TransportFactory transportFactory,
             byte[] key, byte[] cacheName, AtomicInteger topologyId,
@@ -47,7 +47,7 @@ public class ReplaceOperation extends AbstractKeyValueOperation {
    }
 
    @Override
-   protected Object executeOperation(Transport transport) {
+   protected byte[] executeOperation(Transport transport) {
       byte[] result = null;
       short status = sendPutOperation(transport, REPLACE_REQUEST, REPLACE_RESPONSE);
       if (status == NO_ERROR_STATUS || status == NOT_PUT_REMOVED_REPLACED_STATUS) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
@@ -42,9 +42,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @author Mircea.Markus@jboss.com
  * @since 4.1
+ * @param T the return type of this operation
  */
 @Immutable
-public abstract class RetryOnFailureOperation extends HotRodOperation {
+public abstract class RetryOnFailureOperation<T> extends HotRodOperation {
 
    private static final Log log = LogFactory.getLog(RetryOnFailureOperation.class, Log.class);
 
@@ -57,7 +58,7 @@ public abstract class RetryOnFailureOperation extends HotRodOperation {
    }
 
    @Override
-   public Object execute() {
+   public T execute() {
       int retryCount = 0;
       while (shouldRetry(retryCount)) {
          Transport transport = null;
@@ -99,5 +100,5 @@ public abstract class RetryOnFailureOperation extends HotRodOperation {
 
    protected abstract Transport getTransport(int retryCount);
 
-   protected abstract Object executeOperation(Transport transport);
+   protected abstract T executeOperation(Transport transport);
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/StatsOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/StatsOperation.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @since 4.1
  */
 @Immutable
-public class StatsOperation extends RetryOnFailureOperation {
+public class StatsOperation extends RetryOnFailureOperation<Map<String, String>> {
 
    public StatsOperation(Codec codec, TransportFactory transportFactory,
             byte[] cacheName, AtomicInteger topologyId, Flag[] flags) {
@@ -53,7 +53,7 @@ public class StatsOperation extends RetryOnFailureOperation {
    }
 
    @Override
-   protected Object executeOperation(Transport transport) {
+   protected Map<String, String> executeOperation(Transport transport) {
       Map<String, String> result;
       // 1) write header
       HeaderParams params = writeHeader(transport, STATS_REQUEST);


### PR DESCRIPTION
Some simple code cleanup (suppress warnings, un-Genericized Futures, etc) as well as the fact that the forceReturnValues parameter was being ignored!

https://issues.jboss.org/browse/ISPN-1798
