### PR TITLE
ISPN-1780 - MurmurHash3 performance optimizations

### DIFF
--- a/core/src/main/java/org/infinispan/commons/hash/MurmurHash3.java
+++ b/core/src/main/java/org/infinispan/commons/hash/MurmurHash3.java
@@ -23,25 +23,25 @@
 
 package org.infinispan.commons.hash;
 
+import java.io.ObjectInput;
+import java.nio.charset.Charset;
+import java.util.Set;
+
 import net.jcip.annotations.ThreadSafe;
 import org.infinispan.marshall.Ids;
 import org.infinispan.marshall.exts.NoStateExternalizer;
 import org.infinispan.util.ByteArrayKey;
 import org.infinispan.util.Util;
 
-import java.io.ObjectInput;
-import java.nio.charset.Charset;
-import java.util.Set;
-
 /**
  * MurmurHash3 implementation in Java, based on Austin Appleby's <a href=
  * "https://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp"
  * >original in C</a>
- * 
+ *
  * Only implementing x64 version, because this should always be faster on 64 bit
  * native processors, even 64 bit being ran with a 32 bit OS; this should also
  * be as fast or faster than the x86 version on some modern 32 bit processors.
- * 
+ *
  * @author Patrick McFarland
  * @see <a href="http://sites.google.com/site/murmurhash/">MurmurHash website</a>
  * @see <a href="http://en.wikipedia.org/wiki/MurmurHash">MurmurHash entry on Wikipedia</a>
@@ -108,7 +108,7 @@ public class MurmurHash3 implements Hash {
 
    /**
     * Hash a value using the x64 128 bit variant of MurmurHash3
-    * 
+    *
     * @param key value to hash
     * @param seed random value
     * @return 128 bit hashed key, in an array containing two longs
@@ -170,29 +170,81 @@ public class MurmurHash3 implements Hash {
 
    /**
     * Hash a value using the x64 64 bit variant of MurmurHash3
-    * 
+    *
     * @param key value to hash
     * @param seed random value
     * @return 64 bit hashed key
     */
    public static long MurmurHash3_x64_64(final byte[] key, final int seed) {
-      return MurmurHash3_x64_128(key, seed)[0];
+      // Exactly the same as MurmurHash3_x64_128, except it only returns state.h1
+      State state = new State();
+
+      state.h1 = 0x9368e53c2f6af274L ^ seed;
+      state.h2 = 0x586dcd208f7cd3fdL ^ seed;
+
+      state.c1 = 0x87c37b91114253d5L;
+      state.c2 = 0x4cf5ad432745937fL;
+
+      for (int i = 0; i < key.length / 16; i++) {
+         state.k1 = getblock(key, i * 2 * 8);
+         state.k2 = getblock(key, (i * 2 + 1) * 8);
+
+         bmix(state);
+      }
+
+      state.k1 = 0;
+      state.k2 = 0;
+
+      int tail = (key.length >>> 4) << 4;
+
+      switch (key.length & 15) {
+         case 15: state.k2 ^= (long) key[tail + 14] << 48;
+         case 14: state.k2 ^= (long) key[tail + 13] << 40;
+         case 13: state.k2 ^= (long) key[tail + 12] << 32;
+         case 12: state.k2 ^= (long) key[tail + 11] << 24;
+         case 11: state.k2 ^= (long) key[tail + 10] << 16;
+         case 10: state.k2 ^= (long) key[tail + 9] << 8;
+         case 9:  state.k2 ^= (long) key[tail + 8];
+
+         case 8:  state.k1 ^= (long) key[tail + 7] << 56;
+         case 7:  state.k1 ^= (long) key[tail + 6] << 48;
+         case 6:  state.k1 ^= (long) key[tail + 5] << 40;
+         case 5:  state.k1 ^= (long) key[tail + 4] << 32;
+         case 4:  state.k1 ^= (long) key[tail + 3] << 24;
+         case 3:  state.k1 ^= (long) key[tail + 2] << 16;
+         case 2:  state.k1 ^= (long) key[tail + 1] << 8;
+         case 1:  state.k1 ^= (long) key[tail + 0];
+            bmix(state);
+      }
+
+      state.h2 ^= key.length;
+
+      state.h1 += state.h2;
+      state.h2 += state.h1;
+
+      state.h1 = fmix(state.h1);
+      state.h2 = fmix(state.h2);
+
+      state.h1 += state.h2;
+      state.h2 += state.h1;
+
+      return state.h1;
    }
 
    /**
     * Hash a value using the x64 32 bit variant of MurmurHash3
-    * 
+    *
     * @param key value to hash
     * @param seed random value
     * @return 32 bit hashed key
     */
    public static int MurmurHash3_x64_32(final byte[] key, final int seed) {
-      return (int) (MurmurHash3_x64_128(key, seed)[0] >>> 32);
+      return (int) (MurmurHash3_x64_64(key, seed) >>> 32);
    }
 
    /**
     * Hash a value using the x64 128 bit variant of MurmurHash3
-    * 
+    *
     * @param key value to hash
     * @param seed random value
     * @return 128 bit hashed key, in an array containing two longs
@@ -236,24 +288,58 @@ public class MurmurHash3 implements Hash {
 
    /**
     * Hash a value using the x64 64 bit variant of MurmurHash3
-    * 
+    *
     * @param key value to hash
     * @param seed random value
     * @return 64 bit hashed key
     */
    public static long MurmurHash3_x64_64(final long[] key, final int seed) {
-      return MurmurHash3_x64_128(key, seed)[0];
+      // Exactly the same as MurmurHash3_x64_128, except it only returns state.h1
+      State state = new State();
+
+      state.h1 = 0x9368e53c2f6af274L ^ seed;
+      state.h2 = 0x586dcd208f7cd3fdL ^ seed;
+
+      state.c1 = 0x87c37b91114253d5L;
+      state.c2 = 0x4cf5ad432745937fL;
+
+      for (int i = 0; i < key.length / 2; i++) {
+         state.k1 = key[i * 2];
+         state.k2 = key[i * 2 + 1];
+
+         bmix(state);
+      }
+
+      long tail = key[key.length - 1];
+
+      if (key.length % 2 != 0) {
+         state.k1 ^= tail;
+         bmix(state);
+      }
+
+      state.h2 ^= key.length * 8;
+
+      state.h1 += state.h2;
+      state.h2 += state.h1;
+
+      state.h1 = fmix(state.h1);
+      state.h2 = fmix(state.h2);
+
+      state.h1 += state.h2;
+      state.h2 += state.h1;
+
+      return state.h1;
    }
 
    /**
     * Hash a value using the x64 32 bit variant of MurmurHash3
-    * 
+    *
     * @param key value to hash
     * @param seed random value
     * @return 32 bit hashed key
     */
    public static int MurmurHash3_x64_32(final long[] key, final int seed) {
-      return (int) (MurmurHash3_x64_128(key, seed)[0] >>> 32);
+      return (int) (MurmurHash3_x64_64(key, seed) >>> 32);
    }
 
    public int hash(byte[] payload) {
@@ -262,7 +348,7 @@ public class MurmurHash3 implements Hash {
 
    /**
     * Hashes a byte array efficiently.
-    * 
+    *
     * @param payload a byte array to hash
     * @return a hash code for the byte array
     */
@@ -271,12 +357,41 @@ public class MurmurHash3 implements Hash {
    }
 
    public int hash(int hashcode) {
-      byte[] b = new byte[4];
-      b[0] = (byte) hashcode;
-      b[1] = (byte) (hashcode >>> 8);
-      b[2] = (byte) (hashcode >>> 16);
-      b[3] = (byte) (hashcode >>> 24);
-      return hash(b);
+      // Obtained by inlining MurmurHash3_x64_32(byte[], 9001) and removing all the unused code
+      // (since we know the input is always 4 bytes and we only need 4 bytes of output)
+      byte b0 = (byte) hashcode;
+      byte b1 = (byte) (hashcode >>> 8);
+      byte b2 = (byte) (hashcode >>> 16);
+      byte b3 = (byte) (hashcode >>> 24);
+      State state = new State();
+
+      state.h1 = 0x9368e53c2f6af274L ^ 9001;
+      state.h2 = 0x586dcd208f7cd3fdL ^ 9001;
+
+      state.c1 = 0x87c37b91114253d5L;
+      state.c2 = 0x4cf5ad432745937fL;
+
+      state.k1 = 0;
+      state.k2 = 0;
+
+      state.k1 ^= (long) b3 << 24;
+      state.k1 ^= (long) b2 << 16;
+      state.k1 ^= (long) b1 << 8;
+      state.k1 ^= (long) b0;
+      bmix(state);
+
+      state.h2 ^= 4;
+
+      state.h1 += state.h2;
+      state.h2 += state.h1;
+
+      state.h1 = fmix(state.h1);
+      state.h2 = fmix(state.h2);
+
+      state.h1 += state.h2;
+      state.h2 += state.h1;
+
+      return (int) (state.h1 >>> 32);
    }
 
    public int hash(Object o) {


### PR DESCRIPTION
I inlined the MurmurHash3_x64_128 method into MurmurHash3_x64_64 and hash(hashCode),
then I removed the extra array allocations.

The resulting hash is still identical to the old methods.
