### PR TITLE
ISPN-1798 Add test for forceReturnValues flag

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ForceReturnValuesTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ForceReturnValuesTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.client.hotrod;
+
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+import scala.remote;
+
+import java.util.Properties;
+
+@Test(testName = "client.hotrod.ForceReturnValuesTest", groups = "functional")
+@CleanupAfterMethod
+public class ForceReturnValuesTest extends SingleCacheManagerTest {
+   private HotRodServer hotRodServer;
+   private RemoteCacheManager remoteCacheManager;
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      cacheManager = TestCacheManagerFactory.createLocalCacheManager(false);
+      cache = cacheManager.getCache();
+
+      hotRodServer = TestHelper.startHotRodServer(cacheManager);
+
+      Properties hotrodClientConf = new Properties();
+      hotrodClientConf.put("infinispan.client.hotrod.server_list", "localhost:" + hotRodServer.getPort());
+      remoteCacheManager = new RemoteCacheManager(hotrodClientConf);
+      return cacheManager;
+   }
+
+   @AfterMethod
+   void shutdown() {
+      remoteCacheManager.stop();
+      remoteCacheManager = null;
+   }
+   
+   public void testDontForceReturnValues() {
+      RemoteCache<String, String> rc = remoteCacheManager.getCache();
+      String rv = rc.put("Key", "Value");
+      assert rv == null;
+      rv = rc.put("Key", "Value2");
+      assert rv == null;
+   }
+
+   public void testForceReturnValues() {
+      RemoteCache<String, String> rc = remoteCacheManager.getCache(true);
+      String rv = rc.put("Key", "Value");
+      assert rv == null;
+      rv = rc.put("Key", "Value2");
+      assert rv != null;
+      assert "Value".equals(rv);
+   }
+}


### PR DESCRIPTION
Adds a unit test for ISPN-1798 - https://issues.jboss.org/browse/ISPN-1798

ISPN-1798 can now be closed.

Note that there is a separate topic branch containing this fix for 5.1.x.  Please apply to both.  Look at t_1798_test_5.1.x
