### PR TITLE
ISPN-1801 - Virtual nodes should be enabled by default

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/HashConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/HashConfigurationBuilder.java
@@ -34,7 +34,8 @@ public class HashConfigurationBuilder extends AbstractClusteringConfigurationChi
    private ConsistentHash consistentHash;
    private Hash hash = new MurmurHash3();
    private int numOwners = 2;
-   private int numVirtualNodes = 1;
+   // See VNodesKeyDistributionTest for an explanation of how we came up with the number of nodes
+   private int numVirtualNodes = 48;
    private boolean activated = false;
 
    private final GroupsConfigurationBuilder groupsConfigurationBuilder;

--- a/core/src/main/java/org/infinispan/distribution/ch/AbstractWheelConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/AbstractWheelConsistentHash.java
@@ -22,17 +22,25 @@
  */
 package org.infinispan.distribution.ch;
 
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
 import org.infinispan.commons.hash.Hash;
 import org.infinispan.marshall.AbstractExternalizer;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.Util;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.*;
 
 import static java.lang.String.format;
 
@@ -60,7 +68,7 @@ import static java.lang.String.format;
  */
 public abstract class AbstractWheelConsistentHash extends AbstractConsistentHash {
 
-   protected final Log log;
+   private static final Log LOG = LogFactory.getLog(AbstractWheelConsistentHash.class);
    protected final boolean trace;
 
    protected Hash hashFunction;
@@ -74,8 +82,7 @@ public abstract class AbstractWheelConsistentHash extends AbstractConsistentHash
    protected Address[] positionValues;
 
    protected AbstractWheelConsistentHash() {
-      log = LogFactory.getLog(getClass());
-      trace = log.isTraceEnabled();
+      trace = getLog().isTraceEnabled();
    }
 
    public void setHashFunction(Hash h) {
@@ -122,8 +129,8 @@ public abstract class AbstractWheelConsistentHash extends AbstractConsistentHash
          }
       }
 
-      log.debugf("Using %d virtualNodes to initialize consistent hash wheel ", numVirtualNodes);
-      log.tracef("Positions are: %s", positions);
+      getLog().debugf("Using %d virtualNodes to initialize consistent hash wheel ", numVirtualNodes);
+      getLog().tracef("Positions are: %s", positions);
 
       // then populate caches, positionKeys and positionValues with the correct values (and in the correct order)
       caches = new LinkedHashSet<Address>(newCaches.size());
@@ -136,7 +143,7 @@ public abstract class AbstractWheelConsistentHash extends AbstractConsistentHash
          positionValues[i] = position.getValue();
          i++;
       }
-      log.tracef("Consistent hash initialized: %s", this);
+      getLog().tracef("Consistent hash initialized: %s", this);
    }
 
    private void addNode(TreeMap<Integer, Address> positions, Address a, int positionIndex) {
@@ -259,6 +266,9 @@ public abstract class AbstractWheelConsistentHash extends AbstractConsistentHash
       return positionValues[getPositionIndex(normalizedHash)];
    }
 
+   protected Log getLog() {
+      return LOG;
+   }
 
    public static abstract class Externalizer<T extends AbstractWheelConsistentHash> extends AbstractExternalizer<T> {
 

--- a/core/src/main/java/org/infinispan/distribution/ch/DefaultConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/DefaultConsistentHash.java
@@ -22,17 +22,21 @@
  */
 package org.infinispan.distribution.ch;
 
-import org.infinispan.commons.hash.Hash;
-import org.infinispan.marshall.Ids;
-import org.infinispan.remoting.transport.Address;
-import org.infinispan.util.Util;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.infinispan.commons.hash.Hash;
+import org.infinispan.marshall.Ids;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.Util;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
 public class DefaultConsistentHash extends AbstractWheelConsistentHash {
+
+   private static final Log LOG = LogFactory.getLog(DefaultConsistentHash.class);
 
    public DefaultConsistentHash() {
    }
@@ -43,8 +47,8 @@ public class DefaultConsistentHash extends AbstractWheelConsistentHash {
 
    @Override
    public List<Address> locate(final Object key, final int replCount) {
-      final int actualReplCount = Math.min(replCount, caches.size());
       final int normalizedHash = getNormalizedHash(getGrouping(key));
+      final int actualReplCount = Math.min(replCount, caches.size());
       final List<Address> owners = new ArrayList<Address>(actualReplCount);
       final boolean virtualNodesEnabled = isVirtualNodesEnabled();
 
@@ -85,6 +89,11 @@ public class DefaultConsistentHash extends AbstractWheelConsistentHash {
       }
 
       return false;
+   }
+
+   @Override
+   protected Log getLog() {
+      return LOG;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/distribution/ch/TopologyAwareConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/TopologyAwareConsistentHash.java
@@ -22,18 +22,20 @@
  */
 package org.infinispan.distribution.ch;
 
-import org.infinispan.commons.hash.Hash;
-import org.infinispan.marshall.Ids;
-import org.infinispan.remoting.transport.Address;
-import org.infinispan.remoting.transport.TopologyAwareAddress;
-import org.infinispan.util.Util;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
+import org.infinispan.commons.hash.Hash;
+import org.infinispan.marshall.Ids;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.TopologyAwareAddress;
+import org.infinispan.util.Util;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * Consistent hash that is aware of cluster topology. Design described here: http://community.jboss.org/wiki/DesigningServerHinting.
@@ -55,6 +57,8 @@ import java.util.TreeSet;
  * @since 4.2
  */
 public class TopologyAwareConsistentHash extends AbstractWheelConsistentHash {
+   private static final Log LOG = LogFactory.getLog(DefaultConsistentHash.class);
+
    private enum Level { SITE, RACK, MACHINE, NONE }
 
    private SortedSet<Integer> siteIdChangeIndexes = new TreeSet<Integer>();
@@ -188,6 +192,11 @@ public class TopologyAwareConsistentHash extends AbstractWheelConsistentHash {
             return true;
       }
       return false;
+   }
+
+   @Override
+   protected Log getLog() {
+      return LOG;
    }
 
    public static class Externalizer extends AbstractWheelConsistentHash.Externalizer<TopologyAwareConsistentHash> {

--- a/core/src/main/java/org/infinispan/distribution/ch/VirtualAddress.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/VirtualAddress.java
@@ -22,9 +22,9 @@
  */
 package org.infinispan.distribution.ch;
 
-import static org.infinispan.util.Util.formatString;
-
 import org.infinispan.remoting.transport.Address;
+
+import static org.infinispan.util.Util.formatString;
 
 /**
  * Virtual addresses are used internally by the consistent hashes in order to provide virtual nodes.
@@ -35,7 +35,7 @@ import org.infinispan.remoting.transport.Address;
  * @author Pete Muir
  *
  */
-class VirtualAddress implements Address {
+public class VirtualAddress implements Address {
    
    private final Address realAddress;
    private final int id;

--- a/core/src/test/java/org/infinispan/distribution/virtualnodes/VNodesKeyDistributionTest.java
+++ b/core/src/test/java/org/infinispan/distribution/virtualnodes/VNodesKeyDistributionTest.java
@@ -1,0 +1,273 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.infinispan.distribution.virtualnodes;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.infinispan.commons.hash.MurmurHash3;
+import org.infinispan.distribution.ch.DefaultConsistentHash;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.testng.annotations.Test;
+
+import static java.lang.Math.sqrt;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests the uniformity of the consistent hash algorithm with virtual nodes.
+ *
+ * <p>This test assumes that key hashes are random and follow a uniform distribution - so a key has the same chance
+ * to land on each one of the 2^31 positions on the hash wheel.
+ *
+ * <p>The output should stay pretty much the same between runs, so I added and example output here: vnodes_key_dist.txt.
+ *
+ * <p>Notes about the test output:
+ * <ul>
+ * <li>{@code P(p)} is the probability of proposition {@code p} being true
+ * <li>In the "Primary" rows {@code mean == total_keys / num_nodes} (each key has only one primary owner),
+ * but in the "Any owner" rows {@code mean == total_keys / num_nodes * num_owners} (each key is stored on
+ * {@code num_owner} nodes).
+ * </ul>
+ * @author Dan Berindei
+ * @since 5.1.1
+ */
+@Test(testName = "distribution.VNodesKeyDistributionTest", groups = "manual", enabled = false, description = "See the results in vnodes_key_dist.txt")
+public class VNodesKeyDistributionTest extends AbstractInfinispanTest {
+
+   // numbers of nodes to test
+   public static final int[] NUM_NODES = {2, 4, 8, 16, 32, 48, 64, 128, 256};
+   // numbers of virtual nodes to test
+   public static final int[] NUM_VIRTUAL_NODES = {1, 4, 16, 32, 48, 64, 96, 128};
+   // number of key owners
+   public static final int NUM_OWNERS = 2;
+
+   // controls precision + duration of test
+   public static final int LOOPS = 10000;
+   // confidence intervals to print for any owner
+   public static final double[] INTERVALS = { 1.25 };
+   // confidence intervals to print for primary owner
+   public static final double[] INTERVALS_PRIMARY = { 1.5 };
+   // percentiles to print
+   public static final double[] PERCENTILES = { .999 };
+
+   private TransparentDefaultConsistentHash createConsistentHash(int numNodes, int numVirtualNodes) {
+      MurmurHash3 hash = new MurmurHash3();
+      TransparentDefaultConsistentHash ch = new TransparentDefaultConsistentHash();
+      ch.setHashFunction(hash);
+      ch.setNumVirtualNodes(numVirtualNodes);
+      ch.setCaches(createAddresses(numNodes));
+      return ch;
+   }
+
+   private Set<Address> createAddresses(int numNodes) {
+      Set<Address> addresses = new HashSet<Address>(numNodes);
+      for (int i = 0; i < numNodes; i++) {
+         addresses.add(new IndexedJGroupsAddress(org.jgroups.util.UUID.randomUUID(), i));
+      }
+      return addresses;
+   }
+
+   public void testDistribution() {
+      for (int nn : NUM_NODES) {
+         Map<String, Map<Integer, String>> metrics = new TreeMap<String, Map<Integer, String>>();
+         for (int vn : NUM_VIRTUAL_NODES) {
+            for (Map.Entry<String, String> entry : computeMetrics(nn, vn, NUM_OWNERS).entrySet()) {
+               String metricName = entry.getKey();
+               String metricValue = entry.getValue();
+               Map<Integer, String> metric = metrics.get(metricName);
+               if (metric == null) {
+                  metric = new HashMap<Integer, String>();
+                  metrics.put(metricName, metric);
+               }
+               metric.put(vn, metricValue);
+            };
+         }
+
+         printMetrics(nn, metrics);
+      }
+   }
+
+   private void printMetrics(int nn, Map<String, Map<Integer, String>> metrics) {
+      // print the header
+      System.out.printf("Distribution for %3d nodes\n===\n", nn);
+      System.out.printf("%-54s = ", "Virtual nodes");
+      for (int i = 0; i < NUM_VIRTUAL_NODES.length; i++) {
+         System.out.printf("%7d", NUM_VIRTUAL_NODES[i]);
+      }
+      System.out.println();
+
+      // print each metric for each vnodes setting
+      for (Map.Entry<String, Map<Integer, String>> entry : metrics.entrySet()) {
+         String metricName = entry.getKey();
+         Map<Integer, String> metricValues = entry.getValue();
+
+         System.out.printf("%-54s = ", metricName);
+         for (int i = 0; i < NUM_VIRTUAL_NODES.length; i++) {
+            System.out.print(metricValues.get(NUM_VIRTUAL_NODES[i]));
+         }
+         System.out.println();
+      }
+      System.out.println();
+   }
+
+   private Map<String, String> computeMetrics(int numNodes, int numVirtualNodes, int numOwners) {
+      Map<String, String> metrics = new HashMap<String, String>();
+      long[] distribution = new long[LOOPS * numNodes];
+      long[] distributionPrimary = new long[LOOPS * numNodes];
+      for (int i = 0; i < LOOPS; i++) {
+         TransparentDefaultConsistentHash ch = createConsistentHash(numNodes, numVirtualNodes);
+         long[] dist = computeDistribution(numNodes, numOwners, ch);
+         System.arraycopy(dist, 0, distribution, i * numNodes, numNodes);
+         long[] distPrimary = computeDistribution(numNodes, 1, ch);
+         System.arraycopy(distPrimary, 0, distributionPrimary, i * numNodes, numNodes);
+      }
+      Arrays.sort(distribution);
+      Arrays.sort(distributionPrimary);
+
+      addMetrics(metrics, "Any owner:", numNodes, numOwners, distribution, INTERVALS);
+      addMetrics(metrics, "Primary:", numNodes, 1, distributionPrimary, INTERVALS_PRIMARY);
+      return metrics;
+   }
+
+   private void addMetrics(Map<String, String> metrics, String prefix, int numNodes, int numOwners, long[] distribution, double[] intervals) {
+      double mean = 0;
+      long sum = 0;
+      for (long x : distribution) sum += x;
+      assertEquals(sum, LOOPS * numOwners * (long)Integer.MAX_VALUE);
+      mean = sum / numNodes / LOOPS;
+
+      double variance = 0;
+      for (long x : distribution) variance += (x - mean) * (x - mean);
+
+      double stdDev = sqrt(variance);
+      // metrics.put(prefix + " relative standard deviation", stdDev / mean);
+
+      long max = distribution[distribution.length - 1];
+      // metrics.put(prefix + " min", (double) min / mean);
+      addDoubleMetric(metrics, prefix + " max(num_keys(node)/mean)", (double) max / mean);
+
+      double[] intervalConfidence = new double[intervals.length];
+      int intervalIndex = 0;
+      for (int i = 0; i < distribution.length; i++) {
+         long x = distribution[i];
+         if (x > intervals[intervalIndex] * mean) {
+            intervalConfidence[intervalIndex] = (double) i / distribution.length;
+            intervalIndex++;
+            if (intervalIndex >= intervals.length)
+               break;
+         }
+      }
+      for (int i = intervalIndex; i < intervals.length; i++) {
+         intervalConfidence[i] = 1.;
+      }
+
+      for (int i = 0; i < intervals.length; i++) {
+         if (intervals[i] < 1) {
+            addPercentageMetric(metrics, String.format("%s P(num_keys(node) < %3.2f * mean)", prefix, intervals[i]), intervalConfidence[i]);
+         } else {
+            addPercentageMetric(metrics, String.format("%s P(num_keys(node) > %3.2f * mean)", prefix, intervals[i]), 1 - intervalConfidence[i]);
+         }
+      }
+
+      double[] percentiles = new double[PERCENTILES.length];
+      for (int i = 0; i < PERCENTILES.length; i++) {
+         percentiles[i] = (double)distribution[(int) Math.ceil(PERCENTILES[i] * (LOOPS * numNodes + 1))] / mean;
+      }
+      for (int i = 0; i < PERCENTILES.length; i++) {
+         addDoubleMetric(metrics, String.format("%s P(num_keys(node) <= x * mean) = %5.2f%% => x", prefix, PERCENTILES[i] * 100), percentiles[i]);
+      }
+   }
+
+   private void addDoubleMetric(Map<String, String> metrics, String name, double value) {
+      metrics.put(name, String.format("%7.3f", value));
+   }
+
+   private void addPercentageMetric(Map<String, String> metrics, String name, double value) {
+      metrics.put(name, String.format("%6.2f%%", value * 100));
+   }
+
+   private long[] computeDistribution(int numNodes, int numOwners, TransparentDefaultConsistentHash ch) {
+      long[] distribution = new long[numNodes];
+
+      int[] hashPositions = ch.getHashPositions();
+      for (int i = 0; i < hashPositions.length; i++) {
+         int hashPosition = hashPositions[i];
+         int previousHashPosition = i > 0 ? hashPositions[i - 1] : hashPositions[hashPositions.length - 1];
+         List<Address> owners = ch.locateHash(hashPosition, numOwners);
+
+         for (Address a : owners) {
+            IndexedJGroupsAddress ma = (IndexedJGroupsAddress) a;
+            distribution[ma.nodeIndex] += hashPosition > previousHashPosition
+                  ? hashPosition - previousHashPosition
+                  : Integer.MAX_VALUE + hashPosition - previousHashPosition;
+         }
+      }
+      return distribution;
+   }
+}
+
+/**
+ * We extend DefaultConsistentHash because we need access to its {@code protected} internals
+ */
+class TransparentDefaultConsistentHash extends DefaultConsistentHash {
+   public int[] getHashPositions() { return positionKeys; }
+
+   // This method mirrors DefaultConsistentHash.locate(), but it takes an already-normalized hash as input
+   public List<Address> locateHash(int normalizedHash, int replCount) {
+      final int actualReplCount = Math.min(replCount, caches.size());
+      final List<Address> owners = new ArrayList<Address>(actualReplCount);
+      final boolean virtualNodesEnabled = isVirtualNodesEnabled();
+
+      for (Iterator<Address> it = getPositionsIterator(normalizedHash); it.hasNext();) {
+         Address a = it.next();
+         // if virtual nodes are enabled we have to avoid duplicate addresses
+         boolean isDuplicate = virtualNodesEnabled && owners.contains(a);
+         if (!isDuplicate) {
+            owners.add(a);
+            if (owners.size() >= actualReplCount)
+               return owners;
+         }
+      }
+
+      // might return < replCount owners if there aren't enough nodes in the list
+      return owners;
+   }
+}
+
+/**
+ * We extend JGroupsAddress to make mapping an address to a node easier.
+ */
+class IndexedJGroupsAddress extends JGroupsAddress {
+   final int nodeIndex;
+
+   IndexedJGroupsAddress(org.jgroups.Address address, int nodeIndex) {
+      super(address);
+      this.nodeIndex = nodeIndex;
+   }
+}

--- a/core/src/test/java/org/infinispan/distribution/virtualnodes/vnodes_key_dist.txt
+++ b/core/src/test/java/org/infinispan/distribution/virtualnodes/vnodes_key_dist.txt
@@ -1,0 +1,92 @@
+Generated with VNodesKeyDistributionTest
+===
+
+Distribution for   2 nodes
+===
+Virtual nodes                                          =       1      4     16     32     48     64     96    128
+Any owner: P(num_keys(node) <= x * mean) = 99.90% => x =   1.000  1.000  1.000  1.000  1.000  1.000  1.000  1.000
+Any owner: P(num_keys(node) > 1.25 * mean)             =   0.00%  0.00%  0.00%  0.00%  0.00%  0.00%  0.00%  0.00%
+Any owner: max(num_keys(node)/mean)                    =   1.000  1.000  1.000  1.000  1.000  1.000  1.000  1.000
+Primary: P(num_keys(node) <= x * mean) = 99.90% => x   =   1.998  1.865  1.513  1.368  1.313  1.278  1.220  1.190
+Primary: P(num_keys(node) > 1.50 * mean)               =  24.86%  7.04%  0.14%  0.00%  0.00%  0.00%  0.00%  0.00%
+Primary: max(num_keys(node)/mean)                      =   2.000  1.936  1.645  1.502  1.391  1.340  1.259  1.246
+
+Distribution for   4 nodes
+===
+Virtual nodes                                          =       1      4     16     32     48     64     96    128
+Any owner: P(num_keys(node) <= x * mean) = 99.90% => x =   1.965  1.809  1.466  1.332  1.282  1.240  1.203  1.170
+Any owner: P(num_keys(node) > 1.25 * mean)             =  31.56% 19.77%  5.12%  1.08%  0.31%  0.06%  0.00%  0.00%
+Any owner: max(num_keys(node)/mean)                    =   1.995  1.968  1.646  1.453  1.406  1.319  1.249  1.207
+Primary: P(num_keys(node) <= x * mean) = 99.90% => x   =   3.618  2.528  1.727  1.514  1.416  1.347  1.291  1.254
+Primary: P(num_keys(node) > 1.50 * mean)               =  24.56% 12.72%  1.54%  0.12%  0.01%  0.00%  0.00%  0.00%
+Primary: max(num_keys(node)/mean)                      =   3.848  2.924  2.009  1.731  1.561  1.446  1.387  1.322
+
+Distribution for   8 nodes
+===
+Virtual nodes                                          =       1      4     16     32     48     64     96    128
+Any owner: P(num_keys(node) <= x * mean) = 99.90% => x =   3.082  2.145  1.562  1.387  1.315  1.269  1.218  1.187
+Any owner: P(num_keys(node) > 1.25 * mean)             =  30.48% 21.27%  7.03%  2.06%  0.63%  0.21%  0.03%  0.00%
+Any owner: max(num_keys(node)/mean)                    =   3.511  2.593  1.875  1.622  1.437  1.363  1.333  1.252
+Primary: P(num_keys(node) <= x * mean) = 99.90% => x   =   5.048  2.867  1.845  1.578  1.470  1.402  1.319  1.275
+Primary: P(num_keys(node) > 1.50 * mean)               =  23.37% 14.21%  2.51%  0.31%  0.05%  0.00%  0.00%  0.00%
+Primary: max(num_keys(node)/mean)                      =   6.676  3.538  2.234  1.770  1.728  1.600  1.498  1.363
+
+Distribution for  16 nodes
+===
+Virtual nodes                                          =       1      4     16     32     48     64     96    128
+Any owner: P(num_keys(node) <= x * mean) = 99.90% => x =   3.737  2.305  1.594  1.412  1.325  1.283  1.229  1.195
+Any owner: P(num_keys(node) > 1.25 * mean)             =  29.69% 21.72%  7.80%  2.49%  0.83%  0.28%  0.04%  0.00%
+Any owner: max(num_keys(node)/mean)                    =   4.993  2.799  1.979  1.644  1.519  1.402  1.390  1.283
+Primary: P(num_keys(node) <= x * mean) = 99.90% => x   =   5.915  3.048  1.904  1.612  1.479  1.409  1.332  1.285
+Primary: P(num_keys(node) > 1.50 * mean)               =  22.92% 14.68%  3.05%  0.46%  0.07%  0.01%  0.00%  0.00%
+Primary: max(num_keys(node)/mean)                      =   8.714  4.067  2.426  1.918  1.754  1.574  1.496  1.437
+
+Distribution for  32 nodes
+===
+Virtual nodes                                          =       1      4     16     32     48     64     96    128
+Any owner: P(num_keys(node) <= x * mean) = 99.90% => x =   4.227  2.375  1.612  1.415  1.337  1.288  1.232  1.198
+Any owner: P(num_keys(node) > 1.25 * mean)             =  29.10% 21.82%  8.14%  2.69%  0.94%  0.33%  0.05%  0.01%
+Any owner: max(num_keys(node)/mean)                    =   6.280  3.479  1.975  1.621  1.549  1.451  1.337  1.315
+Primary: P(num_keys(node) <= x * mean) = 99.90% => x   =   6.407  3.163  1.929  1.616  1.496  1.425  1.340  1.289
+Primary: P(num_keys(node) > 1.50 * mean)               =  22.61% 14.91%  3.14%  0.49%  0.09%  0.02%  0.00%  0.00%
+Primary: max(num_keys(node)/mean)                      =  11.862  4.624  2.685  2.005  1.772  1.675  1.503  1.450
+
+Distribution for  48 nodes
+===
+Virtual nodes                                          =       1      4     16     32     48     64     96    128
+Any owner: P(num_keys(node) <= x * mean) = 99.90% => x =   4.264  2.413  1.619  1.422  1.341  1.291  1.234  1.202
+Any owner: P(num_keys(node) > 1.25 * mean)             =  28.96% 21.96%  8.32%  2.76%  0.98%  0.36%  0.05%  0.01%
+Any owner: max(num_keys(node)/mean)                    =   6.673  3.279  1.980  1.733  1.525  1.528  1.388  1.337
+Primary: P(num_keys(node) <= x * mean) = 99.90% => x   =   6.483  3.207  1.934  1.623  1.500  1.422  1.340  1.292
+Primary: P(num_keys(node) > 1.50 * mean)               =  22.49% 14.98%  3.28%  0.55%  0.10%  0.01%  0.00%  0.00%
+Primary: max(num_keys(node)/mean)                      =  11.508  5.108  2.541  2.173  1.799  1.675  1.548  1.435
+
+Distribution for  64 nodes
+===
+Virtual nodes                                          =       1      4     16     32     48     64     96    128
+Any owner: P(num_keys(node) <= x * mean) = 99.90% => x =   4.408  2.411  1.625  1.427  1.341  1.291  1.235  1.203
+Any owner: P(num_keys(node) > 1.25 * mean)             =  28.92% 21.98%  8.32%  2.79%  1.01%  0.36%  0.05%  0.01%
+Any owner: max(num_keys(node)/mean)                    =   6.962  3.474  1.951  1.634  1.539  1.514  1.358  1.299
+Primary: P(num_keys(node) <= x * mean) = 99.90% => x   =   6.642  3.228  1.934  1.629  1.505  1.424  1.342  1.294
+Primary: P(num_keys(node) > 1.50 * mean)               =  22.45% 15.02%  3.28%  0.56%  0.11%  0.02%  0.00%  0.00%
+Primary: max(num_keys(node)/mean)                      =  12.296  5.152  2.490  1.963  1.892  1.653  1.563  1.499
+
+Distribution for 128 nodes
+===
+Virtual nodes                                          =       1      4     16     32     48     64     96    128
+Any owner: P(num_keys(node) <= x * mean) = 99.90% => x =   4.512  2.436  1.630  1.425  1.343  1.295  1.238  1.204
+Any owner: P(num_keys(node) > 1.25 * mean)             =  28.88% 22.01%  8.44%  2.85%  1.03%  0.39%  0.06%  0.01%
+Any owner: max(num_keys(node)/mean)                    =   8.331  3.736  2.103  1.687  1.546  1.474  1.439  1.334
+Primary: P(num_keys(node) <= x * mean) = 99.90% => x   =   6.769  3.236  1.944  1.632  1.502  1.429  1.344  1.294
+Primary: P(num_keys(node) > 1.50 * mean)               =  22.40% 15.10%  3.37%  0.57%  0.10%  0.02%  0.00%  0.00%
+Primary: max(num_keys(node)/mean)                      =  13.966  5.472  2.700  2.116  1.842  1.771  1.657  1.457
+
+Distribution for 256 nodes
+===
+Virtual nodes                                          =       1      4     16     32     48     64     96    128
+Any owner: P(num_keys(node) <= x * mean) = 99.90% => x =   4.572  2.447  1.634  1.429  1.345  1.295  1.237  1.204
+Any owner: P(num_keys(node) > 1.25 * mean)             =  28.79% 22.02%  8.49%  2.86%  1.05%  0.39%  0.06%  0.01%
+Any owner: max(num_keys(node)/mean)                    =   8.807  3.636  2.083  1.740  1.617  1.513  1.379  1.331
+Primary: P(num_keys(node) <= x * mean) = 99.90% => x   =   6.836  3.251  1.948  1.631  1.504  1.431  1.344  1.295
+Primary: P(num_keys(node) > 1.50 * mean)               =  22.31% 15.11%  3.41%  0.58%  0.11%  0.02%  0.00%  0.00%
+Primary: max(num_keys(node)/mean)                      =  14.463  5.727  2.682  2.050  1.834  1.762  1.586  1.486


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1801
Also t_1801_51 for the 5.1.x branch.

I set the default number of virtual nodes to 48.

I added a test for key distribution with various numbers of virtual nodes,
48 seems to be a reasonable default.
