### PR TITLE
ISPN-1814 - CacheViewsManagerImpl enters an infinite loop if a joining n...

### DIFF
--- a/core/src/main/java/org/infinispan/cacheviews/CacheViewsManagerImpl.java
+++ b/core/src/main/java/org/infinispan/cacheviews/CacheViewsManagerImpl.java
@@ -828,8 +828,7 @@ public class CacheViewsManagerImpl implements CacheViewsManager {
                // add leave requests for all the leavers x all the caches
                for (CacheViewInfo cacheViewInfo : viewsInfo.values()) {
                   // need to let the listener know about leavers first
-                  List<Address> leavers = MembershipArithmetic.getMembersLeft(cacheViewInfo.getCommittedView().getMembers(),
-                        members);
+                  List<Address> leavers = cacheViewInfo.computeLeavers(members);
                   if (!leavers.isEmpty()) {
                      handleLeavers(leavers, cacheViewInfo.getCacheName());
                   }

--- a/core/src/main/java/org/infinispan/cacheviews/PendingCacheViewChanges.java
+++ b/core/src/main/java/org/infinispan/cacheviews/PendingCacheViewChanges.java
@@ -204,6 +204,17 @@ public class PendingCacheViewChanges {
    }
 
    /**
+    * @return The nodes that are in the {@code joiners} collection but not in the {@code newMembers} collection.
+    */
+   public Set<Address> computeMissingJoiners(Collection<Address> newMembers) {
+      synchronized (lock) {
+         Set<Address> missingJoiners = new HashSet<Address>(joiners);
+         missingJoiners.removeAll(newMembers);
+         return missingJoiners;
+      }
+   }
+
+   /**
     * @return true if {@code createPendingView} has been called without a pair {@code resetChanges}
     */
    public boolean isViewInstallationInProgress() {


### PR DESCRIPTION
...ode is killed before installing the initial view
https://issues.jboss.org/browse/ISPN-1814

And t_1814_51 for the 5.1.x branch.

Fixed by removing the joiners that are no longer members of the cluster from the pending changes.
