### PR TITLE
ISPN-1813 - Javadoc wrong on ClusteringConfigurationBuilder.stateTransfer()

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/ClusteringConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ClusteringConfigurationBuilder.java
@@ -86,8 +86,8 @@ public class ClusteringConfigurationBuilder extends AbstractConfigurationChildBu
    }
 
    /**
-    * Configure sync sub element. Once this method is invoked users cannot subsequently invoke
-    * <code>configureAsync()</code> as two are mutually exclusive
+    * Configure the {@code stateTransfer} sub element for distributed and replicated caches.
+    * It doesn't have any effect on LOCAL or INVALIDATION-mode caches.
     */
    @Override
    public StateTransferConfigurationBuilder stateTransfer() {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1813

Also t_1813_51 for the 5.1.x branch.
