### PR TITLE
ISPN-1826 Make sure address cache is updated before comparing view ids

### DIFF
--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/AbstractVersionedEncoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/AbstractVersionedEncoder.scala
@@ -23,7 +23,6 @@ import org.jboss.netty.buffer.ChannelBuffer
 import org.infinispan.Cache
 import org.infinispan.manager.EmbeddedCacheManager
 import org.infinispan.remoting.transport.Address
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * This class represents the work to be done by an encoder of a particular
@@ -38,7 +37,7 @@ abstract class AbstractVersionedEncoder {
     * Write the header to the given channel buffer
     */
    def writeHeader(r: Response, buf: ChannelBuffer,
-         addressCache: Cache[Address, ServerAddress], viewId: AtomicInteger)
+         addressCache: Cache[Address, ServerAddress], server: HotRodServer)
 
    /**
     * Write operation response using the given channel buffer

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Encoder10.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Encoder10.scala
@@ -41,8 +41,8 @@ import java.util.concurrent.atomic.AtomicInteger
 object Encoder10 extends AbstractVersionedEncoder with Constants with Log {
 
    override def writeHeader(r: Response, buf: ChannelBuffer,
-            addressCache: Cache[Address, ServerAddress], viewId: AtomicInteger) {
-      val topologyResp = getTopologyResponse(r, addressCache, viewId)
+            addressCache: Cache[Address, ServerAddress], server: HotRodServer) {
+      val topologyResp = getTopologyResponse(r, addressCache, server)
       buf.writeByte(MAGIC_RES.byteValue)
       writeUnsignedLong(r.messageId, buf)
       buf.writeByte(r.operation.id.byteValue)
@@ -113,12 +113,12 @@ object Encoder10 extends AbstractVersionedEncoder with Constants with Log {
    }
 
    def getTopologyResponse(r: Response, addressCache: Cache[Address, ServerAddress],
-            viewId: AtomicInteger): AbstractTopologyResponse = {
+            server: HotRodServer): AbstractTopologyResponse = {
       // If clustered, set up a cache for topology information
       if (addressCache != null) {
          r.clientIntel match {
             case 2 | 3 => {
-               val lastViewId = viewId.get()
+               val lastViewId = server.getViewId
                if (r.topologyId != lastViewId) {
                   val cache = getCacheInstance(r.cacheName, addressCache.getCacheManager)
                   val config = cache.getConfiguration

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Encoder11.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Encoder11.scala
@@ -40,8 +40,8 @@ object Encoder11 extends AbstractVersionedEncoder with Constants with Log {
    val encoder10 = Encoder10
 
    override def writeHeader(r: Response, buf: ChannelBuffer,
-            addressCache: Cache[Address, ServerAddress], viewId: AtomicInteger) {
-      val topologyResp = getTopologyResponse(r, addressCache, viewId)
+            addressCache: Cache[Address, ServerAddress], server: HotRodServer) {
+      val topologyResp = getTopologyResponse(r, addressCache, server)
       buf.writeByte(MAGIC_RES.byteValue)
       writeUnsignedLong(r.messageId, buf)
       buf.writeByte(r.operation.id.byteValue)
@@ -67,12 +67,12 @@ object Encoder11 extends AbstractVersionedEncoder with Constants with Log {
       encoder10.writeResponse(this, r, buf, cacheManager)
 
    def getTopologyResponse(r: Response, addressCache: Cache[Address, ServerAddress],
-            viewId: AtomicInteger): AbstractTopologyResponse = {
+            server: HotRodServer): AbstractTopologyResponse = {
       // If clustered, set up a cache for topology information
       if (addressCache != null) {
          r.clientIntel match {
             case 2 | 3 => {
-               val lastViewId = viewId.get()
+               val lastViewId = server.getViewId
                if (r.topologyId != lastViewId) {
                   val cache = getCacheInstance(r.cacheName, addressCache.getCacheManager)
                   val config = cache.getConfiguration

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
@@ -30,7 +30,6 @@ import org.jboss.netty.handler.codec.oneone.OneToOneEncoder
 import org.jboss.netty.channel.Channel
 import org.infinispan.server.core.transport.ExtendedChannelBuffer._
 import org.infinispan.remoting.transport.Address
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Hot Rod specific encoder.
@@ -38,7 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger
  * @author Galder Zamarreño
  * @since 4.1
  */
-class HotRodEncoder(cacheManager: EmbeddedCacheManager, viewId: AtomicInteger)
+class HotRodEncoder(cacheManager: EmbeddedCacheManager, server: HotRodServer)
         extends OneToOneEncoder with Constants with Log {
    import HotRodServer._
 
@@ -59,7 +58,7 @@ class HotRodEncoder(cacheManager: EmbeddedCacheManager, viewId: AtomicInteger)
       }
 
       r.version match {
-         case VERSION_10 | VERSION_11 => encoder.writeHeader(r, buf, addressCache, viewId)
+         case VERSION_10 | VERSION_11 => encoder.writeHeader(r, buf, addressCache, server)
          // if error before reading version, don't send any topology changes
          // cos the encoding might vary from one version to the other
          case 0 => encoder.writeHeader(r, buf, null, null)

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/CrashedMemberDetectorTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/CrashedMemberDetectorTest.scala
@@ -22,12 +22,12 @@ package org.infinispan.server.hotrod
 import org.testng.annotations.Test
 import org.infinispan.test.fwk.TestCacheManagerFactory
 import org.infinispan.remoting.transport.Address
-import org.infinispan.notifications.cachemanagerlistener.event.EventImpl
 import org.infinispan.notifications.cachemanagerlistener.event.Event.Type
 import org.infinispan.distribution.TestAddress
 import java.util.ArrayList
 import org.testng.AssertJUnit._
 import org.infinispan.test.SingleCacheManagerTest
+import org.infinispan.notifications.cachemanagerlistener.event.{ViewChangedEvent, EventImpl}
 
 /**
  * Tests crashed or stopped member logic.
@@ -47,7 +47,11 @@ class CrashedMemberDetectorTest extends SingleCacheManagerTest {
       cache.put(new TestAddress(2), new ServerAddress("b", 456))
       cache.put(new TestAddress(3), new ServerAddress("c", 789))
 
-      val detector = new CrashedMemberDetectorListener(cache)
+      val detector = new CrashedMemberDetectorListener(cache, null) {
+         override protected def updateViewdId(e: ViewChangedEvent) = {
+            // Do nothing...
+         }
+      }
 
       val oldMembers = new ArrayList[Address]()
       oldMembers.add(new TestAddress(1))


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1826

This avoids a race condition where a view id might be updated before the address cache, so clients could end up receiving views that do not contain the address updates.
