### PR TITLE
ISPN-1839 - L1 invalidation fails when some of the requestors have left ...

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManager.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManager.java
@@ -183,6 +183,22 @@ public interface RpcManager {
    void invokeRemotelyInFuture(final Collection<Address> recipients, final ReplicableCommand rpc, final boolean usePriorityQueue, final NotifyingNotifiableFuture<Object> future, final long timeout);
 
    /**
+    * The same as {@link #invokeRemotelyInFuture(java.util.Collection, org.infinispan.commands.ReplicableCommand,
+    * boolean, org.infinispan.util.concurrent.NotifyingNotifiableFuture, long)} except that you can specify a response mode.
+    *
+    * @param recipients       recipients to invoke remote call on
+    * @param rpc              command to execute remotely
+    * @param usePriorityQueue if true, a priority queue is used
+    * @param future           the future which will be passed back to the user
+    * @param timeout          after which to give up (in millis)
+    * @param ignoreLeavers    if {@code true}, recipients that leave or have already left the cluster are ignored
+    *                         if {@code false}, a {@code SuspectException} is thrown when a leave is detected
+    */
+   void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpc,
+                               boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future,
+                               long timeout, boolean ignoreLeavers);
+
+   /**
     * @return a reference to the underlying transport.
     */
    Transport getTransport();

--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
@@ -202,6 +202,11 @@ public class RpcManagerImpl implements RpcManager {
    }
 
    public final Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpc, boolean sync, boolean usePriorityQueue, long timeout) throws RpcException {
+      ResponseMode responseMode = getResponseMode(sync);
+      return invokeRemotely(recipients, rpc, sync, usePriorityQueue, timeout, responseMode);
+   }
+
+   private Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpc, boolean sync, boolean usePriorityQueue, long timeout, ResponseMode responseMode) {
       if (trace) log.tracef("%s broadcasting call %s to recipient list %s", t.getAddress(), rpc, recipients);
 
       if (useReplicationQueue(sync)) {
@@ -211,7 +216,7 @@ public class RpcManagerImpl implements RpcManager {
          if (!(rpc instanceof CacheRpcCommand)) {
             rpc = cf.buildSingleRpcCommand(rpc);
          }
-         Map<Address, Response> rsps = invokeRemotely(recipients, rpc, getResponseMode(sync), timeout, usePriorityQueue);
+         Map<Address, Response> rsps = invokeRemotely(recipients, rpc, responseMode, timeout, usePriorityQueue);
          if (trace) log.tracef("Response(s) to %s is %s", rpc, rsps);
          if (sync) checkResponses(rsps);
          return rsps;
@@ -227,13 +232,21 @@ public class RpcManagerImpl implements RpcManager {
    }
 
    public final void invokeRemotelyInFuture(final Collection<Address> recipients, final ReplicableCommand rpc, final boolean usePriorityQueue, final NotifyingNotifiableFuture<Object> l, final long timeout) {
+      invokeRemotelyInFuture(recipients, rpc, usePriorityQueue, l, timeout, false);
+   }
+
+   @Override
+   public void invokeRemotelyInFuture(final Collection<Address> recipients, final ReplicableCommand rpc,
+                                      final boolean usePriorityQueue, final NotifyingNotifiableFuture<Object> l,
+                                      final long timeout, final boolean ignoreLeavers) {
       if (trace) log.tracef("%s invoking in future call %s to recipient list %s", t.getAddress(), rpc, recipients);
+      final ResponseMode responseMode = ignoreLeavers ? ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS : ResponseMode.SYNCHRONOUS;
       final CountDownLatch futureSet = new CountDownLatch(1);
       Callable<Object> c = new Callable<Object>() {
          public Object call() throws Exception {
             Object result = null;
             try {
-               result = invokeRemotely(recipients, rpc, true, usePriorityQueue, timeout);
+               result = invokeRemotely(recipients, rpc, true, usePriorityQueue, timeout, responseMode);
             } finally {
                try {
                   futureSet.await();
@@ -247,7 +260,7 @@ public class RpcManagerImpl implements RpcManager {
          }
       };
       l.setNetworkFuture(asyncExecutor.submit(c));
-      futureSet.countDown();      
+      futureSet.countDown();
    }
 
    public Transport getTransport() {

--- a/core/src/test/java/org/infinispan/lock/singlelock/SingleRpcOnPessimisticLockingTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/SingleRpcOnPessimisticLockingTest.java
@@ -235,6 +235,13 @@ public class SingleRpcOnPessimisticLockingTest extends MultipleCacheManagersTest
          realOne.invokeRemotelyInFuture(recipients, rpc, usePriorityQueue, future, timeout);
       }
 
+      @Override
+      public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpc, boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future, long timeout, boolean ignoreLeavers) {
+         log.trace("ControlledRpcManager.invokeRemotelyInFuture4");
+         aboutToInvokeRpc(rpc);
+         realOne.invokeRemotelyInFuture(recipients, rpc, usePriorityQueue, future, timeout, ignoreLeavers);
+      }
+
       public Transport getTransport() {
          return realOne.getTransport();
       }

--- a/core/src/test/java/org/infinispan/tx/dld/ControlledRpcManager.java
+++ b/core/src/test/java/org/infinispan/tx/dld/ControlledRpcManager.java
@@ -173,6 +173,13 @@ public class ControlledRpcManager implements RpcManager {
       realOne.invokeRemotelyInFuture(recipients, rpc, usePriorityQueue, future, timeout);
    }
 
+   @Override
+   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpc, boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future, long timeout, boolean ignoreLeavers) {
+      log.trace("ControlledRpcManager.invokeRemotelyInFuture4");
+      waitFirst(rpc);
+      realOne.invokeRemotelyInFuture(recipients, rpc, usePriorityQueue, future, timeout, ignoreLeavers);
+   }
+
    public Transport getTransport() {
       return realOne.getTransport();
    }

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodMultiNodeTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodMultiNodeTest.scala
@@ -85,7 +85,7 @@ abstract class HotRodMultiNodeTest extends MultipleCacheManagersTest {
       server.stop
       server.getCacheManager.stop
       TestingUtil.blockUntilViewsReceived(
-         50000, true, manager(0), manager(1))
+         50000, false, manager(0), manager(1))
    }
 
    @AfterClass(alwaysRun = true)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1839
Also t_1839_51 for the 5.1.x branch.

I've added an overload for RpcManager.invokeRemotelyInFuture that ignores
leavers and I've changed L1ManagerImpl to use it when invalidating.
