### PR TITLE
ISPN-1852 - If a global component fails to start during cache startup, f...

### DIFF
--- a/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
@@ -222,7 +222,14 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
       if (old == null) getLog().tracef("Registering component %s under name %s", c, name);
       if (state == ComponentStatus.RUNNING) {
          populateLifeCycleMethods(c);
-         invokeStartMethods(Arrays.asList(c.startMethods));
+         try {
+            invokeStartMethods(Arrays.asList(c.startMethods));
+         } catch (Throwable t) {
+            // the component hasn't started properly, remove its registration
+            componentLookup.remove(name);
+            // the caller will log the exception
+            handleLifecycleTransitionFailure(t);
+         }
       }
    }
 

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -649,6 +649,10 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
          if (existingCache != null)
             return null;
 
+         // start the global components here, while we have the global lock
+         // do it before we have created the CacheWrapper, so that we don't have to clean it up in case of a failure
+         globalComponentRegistry.start();
+
          Configuration c = getConfiguration(cacheName);
          setConfigurationName(cacheName, c);
 
@@ -661,9 +665,6 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
          if (existingCache != null) {
             throw new IllegalStateException("attempt to initialize the cache twice");
          }
-
-         // start the global components here, while we have the global lock
-         globalComponentRegistry.start();
 
          return cache;
       } catch (InterruptedException e) {

--- a/core/src/main/java/org/infinispan/util/ReflectionUtil.java
+++ b/core/src/main/java/org/infinispan/util/ReflectionUtil.java
@@ -28,6 +28,7 @@ import org.infinispan.util.logging.LogFactory;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -232,9 +233,12 @@ public class ReflectionUtil {
       try {
          method.setAccessible(true);
          return method.invoke(instance, parameters);
+      } catch (InvocationTargetException e) {
+         throw new CacheException("Unable to invoke method " + method + " on object " + //instance +
+                                        (parameters != null ? " with parameters " + Arrays.asList(parameters) : ""), e.getCause());
       } catch (Exception e) {
          throw new CacheException("Unable to invoke method " + method + " on object " + //instance +
-                                        (parameters != null ? " with parameters " + Arrays.asList(parameters) : ""), e);
+               (parameters != null ? " with parameters " + Arrays.asList(parameters) : ""), e);
       }
    }
 

--- a/core/src/test/java/org/infinispan/jmx/CacheMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheMBeanTest.java
@@ -116,7 +116,7 @@ public class CacheMBeanTest extends SingleCacheManagerTest {
          otherContainer.getCache();
          assert false : "Failure expected, " + JMX_DOMAIN + " is a duplicate!";
       } catch (CacheException e) {
-         assert e.getCause().getCause() instanceof JmxDomainConflictException;
+         assert e.getCause() instanceof JmxDomainConflictException;
       } finally {
          otherContainer.stop();
       }

--- a/core/src/test/java/org/infinispan/marshall/jboss/JBossMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/jboss/JBossMarshallerTest.java
@@ -171,15 +171,22 @@ public class JBossMarshallerTest extends AbstractInfinispanTest {
    }
 
    private void withExpectedFailure(GlobalConfiguration globalCfg, String message) {
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(globalCfg);
       try {
-         EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(globalCfg);
+         getCacheWithExpectedFailure(message, cm);
+         // another getCache call should fail with the same exception
+         getCacheWithExpectedFailure(message, cm);
+      } finally {
+         cm.stop();
+      }
+   }
+
+   private void getCacheWithExpectedFailure(String message, EmbeddedCacheManager cm) {
+      try {
          cm.getCache();
          fail(message);
-      } catch (EmbeddedCacheManagerStartupException e) {
-         if (e.getCause() instanceof ConfigurationException)
-            log.trace("Expected exception", e);
-         else
-            throw e;
+      } catch (ConfigurationException e) {
+         log.trace("Expected exception", e);
       }
    }
 


### PR DESCRIPTION
...uture getCache calls for that cache will never return
https://issues.jboss.org/browse/ISPN-1852

Also t_1852_51 for the 5.1.x branch.

Start the global components registry before wiring the cache.
If the cache needs extra global components, they will start when they are registered in the global registry.

If one of the startup methods fails, don't register the component (don't call the stop methods either).
