### PR TITLE
ISPN-1885 RPCs can arrive before CommandAwareRpcDispatcher sets its request/response marshaller

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -292,6 +292,7 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
       MarshallerAdapter adapter = new MarshallerAdapter(marshaller);
       dispatcher.setRequestMarshaller(adapter);
       dispatcher.setResponseMarshaller(adapter);
+      dispatcher.start();
    }
 
    // This is per CM, so the CL in use should be the CM CL


### PR DESCRIPTION
.Refactor CommandAwareRpcDispatcher construction so that it does not implicitly start.
Start dispatcher only after request/response marshallers are set.
