### PR TITLE
Properly parameterize KeyAffinityService and corresponding tests

### DIFF
--- a/core/src/main/java/org/infinispan/affinity/KeyAffinityServiceFactory.java
+++ b/core/src/main/java/org/infinispan/affinity/KeyAffinityServiceFactory.java
@@ -59,15 +59,15 @@ public class KeyAffinityServiceFactory {
     * @return an {@link org.infinispan.affinity.KeyAffinityService} implementation.
     * @throws IllegalStateException if the supplied cache is not DIST.
     */
-   public static <K, V> KeyAffinityService<K> newKeyAffinityService(Cache<K, V> cache, Executor ex, KeyGenerator keyGenerator, int keyBufferSize, boolean start) {
-      return new KeyAffinityServiceImpl(ex, cache, keyGenerator, keyBufferSize, null, start);
+   public static <K, V> KeyAffinityService<K> newKeyAffinityService(Cache<K, V> cache, Executor ex, KeyGenerator<K> keyGenerator, int keyBufferSize, boolean start) {
+      return new KeyAffinityServiceImpl<K>(ex, cache, keyGenerator, keyBufferSize, null, start);
    }
 
    /**
     * Same as {@link #newKeyAffinityService(org.infinispan.Cache, java.util.concurrent.Executor, KeyGenerator, int,
     * boolean)} with start == true;
     */
-   public static <K, V> KeyAffinityService<K> newKeyAffinityService(Cache<K, V> cache, Executor ex, KeyGenerator keyGenerator, int keyBufferSize) {
+   public static <K, V> KeyAffinityService<K> newKeyAffinityService(Cache<K, V> cache, Executor ex, KeyGenerator<K> keyGenerator, int keyBufferSize) {
       return newKeyAffinityService(cache, ex, keyGenerator, keyBufferSize, true);
    }
 
@@ -76,22 +76,22 @@ public class KeyAffinityServiceFactory {
     *
     * @param filter the set of addresses for which to generate keys
     */
-   public static <K, V> KeyAffinityService newKeyAffinityService(Cache<K, V> cache, Collection<Address> filter, KeyGenerator keyGenerator, Executor ex, int keyBufferSize, boolean start) {
-      return new KeyAffinityServiceImpl(ex, cache, keyGenerator, keyBufferSize, filter, start);
+   public static <K, V> KeyAffinityService<K> newKeyAffinityService(Cache<K, V> cache, Collection<Address> filter, KeyGenerator<K> keyGenerator, Executor ex, int keyBufferSize, boolean start) {
+      return new KeyAffinityServiceImpl<K>(ex, cache, keyGenerator, keyBufferSize, filter, start);
    }
 
    /**
     * Same as {@link #newKeyAffinityService(org.infinispan.Cache, java.util.Collection, KeyGenerator,
     * java.util.concurrent.Executor, int, boolean)} with start == true.
     */
-   public static <K, V> KeyAffinityService newKeyAffinityService(Cache<K, V> cache, Collection<Address> filter, KeyGenerator keyGenerator, Executor ex, int keyBufferSize) {
+   public static <K, V> KeyAffinityService<K> newKeyAffinityService(Cache<K, V> cache, Collection<Address> filter, KeyGenerator<K> keyGenerator, Executor ex, int keyBufferSize) {
       return newKeyAffinityService(cache, filter, keyGenerator, ex, keyBufferSize, true);
    }
 
    /**
     * Created an service that only generates keys for the local address.
     */
-   public static <K, V> KeyAffinityService newLocalKeyAffinityService(Cache<K, V> cache, KeyGenerator keyGenerator, Executor ex, int keyBufferSize, boolean start) {
+   public static <K, V> KeyAffinityService<K> newLocalKeyAffinityService(Cache<K, V> cache, KeyGenerator<K> keyGenerator, Executor ex, int keyBufferSize, boolean start) {
       Address localAddress = cache.getAdvancedCache().getRpcManager().getTransport().getAddress();
       Collection<Address> forAddresses = Collections.singletonList(localAddress);
       return newKeyAffinityService(cache, forAddresses, keyGenerator, ex, keyBufferSize, start);
@@ -100,7 +100,7 @@ public class KeyAffinityServiceFactory {
    /**
     * Same as {@link #newLocalKeyAffinityService(org.infinispan.Cache, KeyGenerator, java.util.concurrent.Executor, int, boolean)} with start == true.
     */
-   public static <K, V> KeyAffinityService newLocalKeyAffinityService(Cache<K, V> cache, KeyGenerator keyGenerator, Executor ex, int keyBufferSize) {
+   public static <K, V> KeyAffinityService<K> newLocalKeyAffinityService(Cache<K, V> cache, KeyGenerator<K> keyGenerator, Executor ex, int keyBufferSize) {
       return newLocalKeyAffinityService(cache, keyGenerator, ex, keyBufferSize, true);
    }
 }

--- a/core/src/main/java/org/infinispan/affinity/KeyAffinityServiceImpl.java
+++ b/core/src/main/java/org/infinispan/affinity/KeyAffinityServiceImpl.java
@@ -56,7 +56,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * @since 4.1
  */
 @ThreadSafe
-public class KeyAffinityServiceImpl implements KeyAffinityService {
+public class KeyAffinityServiceImpl<K> implements KeyAffinityService<K> {
 
    public final static float THRESHOLD = 0.5f;
    
@@ -65,13 +65,13 @@ public class KeyAffinityServiceImpl implements KeyAffinityService {
    private final Set<Address> filter;
 
    @GuardedBy("maxNumberInvariant")
-   private final Map<Address, BlockingQueue> address2key = ConcurrentMapFactory.makeConcurrentMap();
+   private final Map<Address, BlockingQueue<K>> address2key = ConcurrentMapFactory.makeConcurrentMap();
    private final Executor executor;
-   private final Cache cache;
-   private final KeyGenerator keyGenerator;
+   private final Cache<? extends K, ?> cache;
+   private final KeyGenerator<? extends K> keyGenerator;
    private final int bufferSize;
    private final AtomicInteger maxNumberOfKeys = new AtomicInteger(); //(nr. of addresses) * bufferSize;
-   private final AtomicInteger exitingNumberOfKeys = new AtomicInteger();
+   final AtomicInteger existingKeyCount = new AtomicInteger();
 
    private volatile boolean started;
 
@@ -88,7 +88,8 @@ public class KeyAffinityServiceImpl implements KeyAffinityService {
    private volatile ListenerRegistration listenerRegistration;
 
 
-   public KeyAffinityServiceImpl(Executor executor, Cache cache, KeyGenerator keyGenerator, int bufferSize, Collection<Address> filter, boolean start) {
+   public KeyAffinityServiceImpl(Executor executor, Cache<? extends K, ?> cache, KeyGenerator<? extends K> keyGenerator,
+                                 int bufferSize, Collection<Address> filter, boolean start) {
       this.executor = executor;
       this.cache = cache;
       this.keyGenerator = keyGenerator;
@@ -106,24 +107,24 @@ public class KeyAffinityServiceImpl implements KeyAffinityService {
    }
 
    @Override
-   public Object getCollocatedKey(Object otherKey) {
+   public K getCollocatedKey(K otherKey) {
       Address address = getAddressForKey(otherKey);
       return getKeyForAddress(address);
    }
 
    @Override
-   public Object getKeyForAddress(Address address) {
+   public K getKeyForAddress(Address address) {
       if (!started) {
          throw new IllegalStateException("You have to start the service first!");
       }
       if (address == null)
          throw new NullPointerException("Null address not supported!");
-      BlockingQueue queue = address2key.get(address);
+      BlockingQueue<K> queue = address2key.get(address);
       if (queue == null)
          throw new IllegalStateException("Address " + address + " is no longer in the cluster");
 
       try {
-         Object result = null;
+         K result = null;
          while (result == null && !keyGenWorker.isStopped()) {
             // obtain the read lock inside the loop, otherwise a topology change will never be able
             // to obtain the write lock
@@ -142,7 +143,7 @@ public class KeyAffinityServiceImpl implements KeyAffinityService {
                maxNumberInvariant.readLock().unlock();
             }
          }
-         exitingNumberOfKeys.decrementAndGet();
+         existingKeyCount.decrementAndGet();
          return result;
       } finally {
          if (queue.size() < bufferSize * THRESHOLD + 1) {
@@ -264,9 +265,9 @@ public class KeyAffinityServiceImpl implements KeyAffinityService {
             // in order to fill all the queues
             int maxMisses = maxNumberOfKeys.get();
             int missCount = 0;
-            while (!Thread.currentThread().isInterrupted() && exitingNumberOfKeys.get() < maxNumberOfKeys.get()
+            while (!Thread.currentThread().isInterrupted() && existingKeyCount.get() < maxNumberOfKeys.get()
                   && missCount < maxMisses) {
-               Object key = keyGenerator.getKey();
+               K key = keyGenerator.getKey();
                Address addressForKey = getAddressForKey(key);
                if (interestedInAddress(addressForKey)) {
                   boolean added = tryAddKey(addressForKey, key);
@@ -295,23 +296,14 @@ public class KeyAffinityServiceImpl implements KeyAffinityService {
          return false;
       }
 
-      private boolean tryAddKey(Address address, Object key) {
-         BlockingQueue queue = address2key.get(address);
+      private boolean tryAddKey(Address address, K key) {
+         BlockingQueue<K> queue = address2key.get(address);
          // on node stop the distribution manager might still return the dead server for a while after we have already removed its queue
          if (queue == null)
             return false;
 
          boolean added = queue.offer(key);
-         if (added) {
-            exitingNumberOfKeys.incrementAndGet();
-         }
-         if (log.isTraceEnabled()) {
-            if (added)
-               log.tracef("Successfully added key(%s) to the address(%s), maxNumberOfKeys=%d, exitingNumberOfKeys=%d",
-                          key, address, maxNumberOfKeys.get(), exitingNumberOfKeys.get());
-            else
-               log.tracef("Not added key(%s) to the address(%s)", key, address);
-         }
+         if (added) existingKeyCount.incrementAndGet();
          return added;
       }
 
@@ -329,10 +321,10 @@ public class KeyAffinityServiceImpl implements KeyAffinityService {
     */
    private void resetNumberOfKeys() {
       maxNumberOfKeys.set(address2key.keySet().size() * bufferSize);
-      exitingNumberOfKeys.set(0);
+      existingKeyCount.set(0);
       if (log.isTraceEnabled()) {
-         log.tracef("resetNumberOfKeys ends with: maxNumberOfKeys=%s, exitingNumberOfKeys=%s",
-                    maxNumberOfKeys.get(), exitingNumberOfKeys.get());
+         log.tracef("resetNumberOfKeys ends with: maxNumberOfKeys=%s, existingKeyCount=%s",
+                    maxNumberOfKeys.get(), existingKeyCount.get());
       }
    }
 
@@ -342,7 +334,7 @@ public class KeyAffinityServiceImpl implements KeyAffinityService {
    private void addQueuesForAddresses(Collection<Address> addresses) {
       for (Address address : addresses) {
          if (interestedInAddress(address)) {
-            address2key.put(address, new ArrayBlockingQueue(bufferSize));
+            address2key.put(address, new ArrayBlockingQueue<K>(bufferSize));
          } else {
             if (log.isTraceEnabled())
                log.tracef("Skipping address: %s", address);
@@ -377,16 +369,12 @@ public class KeyAffinityServiceImpl implements KeyAffinityService {
       return distributionManager;
    }
 
-   public Map<Address, BlockingQueue> getAddress2KeysMapping() {
+   public Map<Address, BlockingQueue<K>> getAddress2KeysMapping() {
       return Collections.unmodifiableMap(address2key);
    }
 
    public int getMaxNumberOfKeys() {
       return maxNumberOfKeys.intValue();
-   }
-
-   public int getExitingNumberOfKeys() {
-      return exitingNumberOfKeys.intValue();
    }
 
    public boolean isKeyGeneratorThreadActive() {

--- a/core/src/main/java/org/infinispan/affinity/ListenerRegistration.java
+++ b/core/src/main/java/org/infinispan/affinity/ListenerRegistration.java
@@ -36,9 +36,9 @@ import org.infinispan.notifications.cachemanagerlistener.event.CacheStoppedEvent
 */
 @Listener(sync = false)
 public class ListenerRegistration {
-   private final KeyAffinityServiceImpl keyAffinityService;
+   private final KeyAffinityServiceImpl<?> keyAffinityService;
 
-   public ListenerRegistration(KeyAffinityServiceImpl keyAffinityService) {
+   public ListenerRegistration(KeyAffinityServiceImpl<?> keyAffinityService) {
       this.keyAffinityService = keyAffinityService;
    }
 

--- a/core/src/main/java/org/infinispan/affinity/RndKeyGenerator.java
+++ b/core/src/main/java/org/infinispan/affinity/RndKeyGenerator.java
@@ -31,7 +31,7 @@ import java.util.Random;
  * @author Mircea.Markus@jboss.com
  * @since 4.1
  */
-public class RndKeyGenerator implements KeyGenerator {
+public class RndKeyGenerator implements KeyGenerator<Object> {
 
    public static final Random rnd = new Random();
 

--- a/core/src/test/java/org/infinispan/affinity/BaseFilterKeyAffinityServiceTest.java
+++ b/core/src/test/java/org/infinispan/affinity/BaseFilterKeyAffinityServiceTest.java
@@ -59,7 +59,7 @@ public abstract class BaseFilterKeyAffinityServiceTest extends BaseKeyAffinitySe
 
 
    protected void testSingleKey() throws InterruptedException {
-      Map<Address, BlockingQueue> blockingQueueMap = keyAffinityService.getAddress2KeysMapping();
+      Map<Address, BlockingQueue<Object>> blockingQueueMap = keyAffinityService.getAddress2KeysMapping();
       assertEquals(getAddresses().size(), blockingQueueMap.keySet().size());
       assertEventualFullCapacity(getAddresses());
    }

--- a/core/src/test/java/org/infinispan/affinity/ConcurrentStartupTest.java
+++ b/core/src/test/java/org/infinispan/affinity/ConcurrentStartupTest.java
@@ -47,8 +47,8 @@ public class ConcurrentStartupTest extends AbstractCacheTest {
 
    public static final int KEY_QUEUE_SIZE = 100;
    EmbeddedCacheManager manager1 = null, manager2 = null;
-   AdvancedCache cache1 = null, cache2 = null;
-   KeyAffinityService keyAffinityService1 = null, keyAffinityService2 = null;
+   AdvancedCache<Object, Object> cache1 = null, cache2 = null;
+   KeyAffinityService<Object> keyAffinityService1 = null, keyAffinityService2 = null;
 
    @BeforeMethod
    protected void setUp() throws Exception {

--- a/core/src/test/java/org/infinispan/affinity/FilteredKeyAffinityServiceTest.java
+++ b/core/src/test/java/org/infinispan/affinity/FilteredKeyAffinityServiceTest.java
@@ -37,8 +37,8 @@ import java.util.concurrent.ThreadFactory;
  * @author Mircea.Markus@jboss.com
  * @since 4.1
  */
-@Test (groups = "functional", testName = "affinity.FilteredKeyAffinityService")
-public class FilteredKeyAffinityService extends BaseFilterKeyAffinityServiceTest {
+@Test (groups = "functional", testName = "affinity.FilteredKeyAffinityServiceTest")
+public class FilteredKeyAffinityServiceTest extends BaseFilterKeyAffinityServiceTest {
    private List<Address> filter;
 
    @Override
@@ -53,7 +53,7 @@ public class FilteredKeyAffinityService extends BaseFilterKeyAffinityServiceTest
       filter.add(caches.get(0).getAdvancedCache().getRpcManager().getTransport().getAddress());
       filter.add(caches.get(1).getAdvancedCache().getRpcManager().getTransport().getAddress());
       cacheManager = caches.get(0).getCacheManager();
-      keyAffinityService = (KeyAffinityServiceImpl) KeyAffinityServiceFactory.
+      keyAffinityService = (KeyAffinityServiceImpl<Object>) KeyAffinityServiceFactory.
             newKeyAffinityService(cacheManager.getCache(cacheName), filter, new RndKeyGenerator(),
                                        Executors.newSingleThreadExecutor(tf), 100);
    }

--- a/core/src/test/java/org/infinispan/affinity/KeyAffinityServiceShutdownTest.java
+++ b/core/src/test/java/org/infinispan/affinity/KeyAffinityServiceShutdownTest.java
@@ -52,7 +52,7 @@ public class KeyAffinityServiceShutdownTest extends BaseKeyAffinityServiceTest {
       };
       executor = Executors.newSingleThreadExecutor(tf);
       cacheManager = manager(0);
-      keyAffinityService = (KeyAffinityServiceImpl) KeyAffinityServiceFactory.newKeyAffinityService(cacheManager.getCache(cacheName),
+      keyAffinityService = (KeyAffinityServiceImpl<Object>) KeyAffinityServiceFactory.newKeyAffinityService(cacheManager.getCache(cacheName),
                                                                                                     executor,
                                                                                                     new RndKeyGenerator(), 100);
    }

--- a/core/src/test/java/org/infinispan/affinity/KeyAffinityServiceTest.java
+++ b/core/src/test/java/org/infinispan/affinity/KeyAffinityServiceTest.java
@@ -58,11 +58,11 @@ public class KeyAffinityServiceTest extends BaseKeyAffinityServiceTest {
 
       ThreadFactory tf = new ThreadFactory() {
          @Override
-         public Thread newThread(Runnable r) {
+         public Thread newThread(Runnable r) {       
             return new Thread(r, "KeyGeneratorThread");
          }
       };
-      keyAffinityService = (KeyAffinityServiceImpl) KeyAffinityServiceFactory.newKeyAffinityService(manager(0).getCache(cacheName),
+      keyAffinityService = (KeyAffinityServiceImpl<Object>) KeyAffinityServiceFactory.newKeyAffinityService(manager(0).getCache(cacheName),
                                                                                                     Executors.newSingleThreadExecutor(tf),
                                                                                                     new RndKeyGenerator(), 100);
    }
@@ -97,7 +97,7 @@ public class KeyAffinityServiceTest extends BaseKeyAffinityServiceTest {
    public void testServerAdded() throws InterruptedException {
       EmbeddedCacheManager cm = addClusterEnabledCacheManager();
       cm.defineConfiguration(cacheName, configuration);
-      Cache cache = cm.getCache(cacheName);
+      Cache<Object, String> cache = cm.getCache(cacheName);
       caches.add(cache);
       waitForClusterToResize();
       eventually(new Condition() {

--- a/core/src/test/java/org/infinispan/affinity/LocalKeyAffinityServiceTest.java
+++ b/core/src/test/java/org/infinispan/affinity/LocalKeyAffinityServiceTest.java
@@ -49,7 +49,7 @@ public class LocalKeyAffinityServiceTest extends BaseFilterKeyAffinityServiceTes
             }
          };
          cacheManager = caches.get(0).getCacheManager();
-         keyAffinityService = (KeyAffinityServiceImpl) KeyAffinityServiceFactory.
+         keyAffinityService = (KeyAffinityServiceImpl<Object>) KeyAffinityServiceFactory.
                newLocalKeyAffinityService(cacheManager.getCache(cacheName), new RndKeyGenerator(),
                                           Executors.newSingleThreadExecutor(tf), 100);
       }


### PR DESCRIPTION
No JIRA for this, this patch just involves parameterisation for internal impl classes + factories, tests, etc., to reduce IDE warnings.

Also merge `t_key_affinity_parameterization_5` for branch `5.1.x`
