### PR TITLE
ISPN-1882 - IllegalStateException in state transfer when starting a single clustered node

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/DummyInvalidationStateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/DummyInvalidationStateTransferManagerImpl.java
@@ -47,11 +47,15 @@ public class DummyInvalidationStateTransferManagerImpl extends BaseStateTransfer
    }
 
    @Override
-   protected BaseStateTransferTask createStateTransferTask(int viewId, List<Address> members, boolean initialView) {
+   protected BaseStateTransferTask createStateTransferTask(final int viewId, final List<Address> members,
+                                                           final boolean initialView) {
       return new BaseStateTransferTask(this, rpcManager, stateTransferLock, cacheNotifier, configuration, dataContainer,
             members, viewId, null, null, initialView) {
          public void doPerformStateTransfer() throws Exception {
-            // do nothing
+            // The state transfer lock is not really used in invalidation mode
+            // but it's easier to block write commands here than override the base methods
+            // to remove all the blocking and unblocking
+            stateTransferLock.blockNewTransactions(viewId);
          }
 
          @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1882

Also t_1882_51 for the 5.1.x branch.

In invalidation mode the state transfer lock interceptor is not loaded,
so we don't care about blocking write command. However, we have some
common code that blocks/unblocks write commands, so we must ensure that
the blocking/unblocking is symmetrical in invalidation mode as well.
