### PR TITLE
ISPN-1887 Produce a better error msg when lock called on non-tx caches

### DIFF
--- a/core/src/main/java/org/infinispan/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/CacheImpl.java
@@ -473,6 +473,9 @@ public class CacheImpl<K, V> extends CacheSupport<K, V> implements AdvancedCache
    }
 
    boolean lock(Collection<? extends K> keys, EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
+      if (!config.isTransactionalCache())
+         throw new UnsupportedOperationException("Calling lock() on non-transactional caches is not allowed");
+
       if (keys == null || keys.isEmpty()) {
          throw new IllegalArgumentException("Cannot lock empty list of keys");
       }

--- a/core/src/test/java/org/infinispan/lock/APITest.java
+++ b/core/src/test/java/org/infinispan/lock/APITest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static org.infinispan.context.Flag.FAIL_SILENTLY;
+import static org.infinispan.test.TestingUtil.withCacheManager;
 
 
 @Test(testName = "lock.APITest", groups = "functional")
@@ -207,4 +208,17 @@ public class APITest extends MultipleCacheManagersTest {
       assert !cache1.getAdvancedCache().withFlags(FAIL_SILENTLY).lock(Arrays.asList("k1", "k2", "k3"));
       tm(0).rollback();
    }
+
+   @Test(expectedExceptions = UnsupportedOperationException.class)
+   public void testLockOnNonTransactionalCache() throws Exception {
+      withCacheManager(new Callable<EmbeddedCacheManager>() {
+         @Override
+         public EmbeddedCacheManager call() throws Exception {
+            EmbeddedCacheManager cm = TestCacheManagerFactory.createLocalCacheManager(false);
+            cm.getCache().getAdvancedCache().lock("k");
+            return cm;
+         }
+      });
+   }
+
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1887

`5.1.x` branch is: `t_1887_5`
