### PR TITLE
Clean up codebase

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodAsyncReplicationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodAsyncReplicationTest.java
@@ -30,12 +30,6 @@ import java.lang.reflect.Method;
 import static org.infinispan.test.TestingUtil.v;
 import static org.testng.AssertJUnit.assertEquals;
 
-/**
- * // TODO: Document this
- *
- * @author Galder Zamarreño
- * @since // TODO
- */
 @Test(groups = "functional", testName = "client.hotrod.HotRodAsyncReplicationTest")
 public class HotRodAsyncReplicationTest extends MultiHotRodServersTest {
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ApacheAvroMarshallerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ApacheAvroMarshallerTest.java
@@ -33,12 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * // TODO: Document this
- *
- * @author Galder Zamarreño
- * @since 5.0
- */
 @Test(groups = "functional", testName = "client.hotrod.ApacheAvroMarshallerTest")
 public class ApacheAvroMarshallerTest {
 

--- a/core/src/main/java/org/infinispan/config/FluentConfiguration.java
+++ b/core/src/main/java/org/infinispan/config/FluentConfiguration.java
@@ -151,12 +151,6 @@ public class FluentConfiguration extends AbstractFluentConfigurationBean {
        */
       LoadersConfig shared(Boolean shared);
 
-      /**
-       * TODO
-       *
-       * @param configs
-       * @return
-       */
       LoadersConfig addCacheLoader(CacheLoaderConfig... configs);
    }
 

--- a/core/src/main/java/org/infinispan/config/FluentGlobalConfiguration.java
+++ b/core/src/main/java/org/infinispan/config/FluentGlobalConfiguration.java
@@ -71,12 +71,6 @@ public class FluentGlobalConfiguration extends AbstractConfigurationBeanWithGCR 
        */
       SerializationConfig version(String marshallVersion);
 
-      /**
-       * TODO
-       *
-       * @param marshallVersion
-       * @return
-       */
       SerializationConfig version(short marshallVersion);
 
       /**
@@ -145,12 +139,6 @@ public class FluentGlobalConfiguration extends AbstractConfigurationBeanWithGCR 
        */
       TransportConfig siteId(String siteId);
 
-      /**
-       * TODO
-       *
-       * @param distributedSyncTimeout
-       * @return
-       */
       TransportConfig distributedSyncTimeout(Long distributedSyncTimeout);
 
       /**
@@ -188,13 +176,6 @@ public class FluentGlobalConfiguration extends AbstractConfigurationBeanWithGCR 
        */
       TransportConfig strictPeerToPeer(Boolean strictPeerToPeer);
 
-      /**
-       * TODO
-       *
-       * @param key
-       * @param value
-       * @return
-       */
       TransportConfig addProperty(String key, String value);
    }
 

--- a/core/src/main/java/org/infinispan/configuration/cache/AsyncLoaderConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AsyncLoaderConfigurationBuilder.java
@@ -97,8 +97,6 @@ public class AsyncLoaderConfigurationBuilder extends AbstractLoaderConfiguration
 
    @Override
    void validate() {
-      // TODO Auto-generated method stub
-
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/DataContainerConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/DataContainerConfigurationBuilder.java
@@ -31,7 +31,7 @@ import org.infinispan.util.TypedProperties;
  */
 public class DataContainerConfigurationBuilder extends AbstractConfigurationChildBuilder<DataContainerConfiguration> {
 
-   // TODO provide a deafult here
+   // TODO provide a default here
    private DataContainer dataContainer;
    private Properties properties = new Properties();
    
@@ -74,8 +74,6 @@ public class DataContainerConfigurationBuilder extends AbstractConfigurationChil
 
    @Override
    void validate() {
-      // TODO Auto-generated method stub
-      
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/DeadlockDetectionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/DeadlockDetectionConfigurationBuilder.java
@@ -67,8 +67,6 @@ public class DeadlockDetectionConfigurationBuilder extends AbstractConfiguration
 
    @Override
    void validate() {
-      // TODO Auto-generated method stub
-      
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/ExpirationConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ExpirationConfigurationBuilder.java
@@ -98,8 +98,6 @@ public class ExpirationConfigurationBuilder extends AbstractConfigurationChildBu
 
    @Override
    void validate() {
-      // TODO Auto-generated method stub
-      
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/FileCacheStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/FileCacheStoreConfigurationBuilder.java
@@ -72,7 +72,6 @@ public class FileCacheStoreConfigurationBuilder extends AbstractLoaderConfigurat
 
    @Override
    void validate() {
-      // TODO: Customise this generated block
    }
 
    // Shared with others cache stores...

--- a/core/src/main/java/org/infinispan/configuration/cache/GroupsConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/GroupsConfigurationBuilder.java
@@ -92,8 +92,6 @@ public class GroupsConfigurationBuilder extends AbstractClusteringConfigurationC
 
    @Override
    void validate() {
-      // TODO Auto-generated method stub
-
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/JMXStatisticsConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/JMXStatisticsConfigurationBuilder.java
@@ -58,8 +58,6 @@ public class JMXStatisticsConfigurationBuilder extends AbstractConfigurationChil
 
    @Override
    void validate() {
-      // TODO Auto-generated method stub
-
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/LockingConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LockingConfigurationBuilder.java
@@ -40,7 +40,6 @@ public class LockingConfigurationBuilder extends AbstractConfigurationChildBuild
 
    protected LockingConfigurationBuilder(ConfigurationBuilder builder) {
       super(builder);
-      // TODO Auto-generated constructor stub
    }
 
    /**

--- a/core/src/main/java/org/infinispan/configuration/cache/RecoveryConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/RecoveryConfigurationBuilder.java
@@ -68,8 +68,6 @@ public class RecoveryConfigurationBuilder extends AbstractTransportConfiguration
 
    @Override
    void validate() {
-      // TODO Auto-generated method stub
-
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/SingletonStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/SingletonStoreConfigurationBuilder.java
@@ -84,8 +84,6 @@ public class SingletonStoreConfigurationBuilder extends AbstractLoaderConfigurat
 
    @Override
    void validate() {
-      // TODO Auto-generated method stub
-      
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/global/TransportConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/TransportConfigurationBuilder.java
@@ -88,7 +88,7 @@ public class TransportConfigurationBuilder extends AbstractGlobalConfigurationBu
    }
 
    /**
-    * TODO
+    * Timeout for coordinating cluster formation when nodes join or leave the cluster.
     *
     * @param distributedSyncTimeout
     * @return

--- a/core/src/main/java/org/infinispan/marshall/jboss/JBossExternalizerAdapter.java
+++ b/core/src/main/java/org/infinispan/marshall/jboss/JBossExternalizerAdapter.java
@@ -30,12 +30,6 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
-/**
- * // TODO: Document this
- *
- * @author Galder Zamarreño
- * @since // TODO
- */
 public class JBossExternalizerAdapter implements org.jboss.marshalling.Externalizer {
 
    final Externalizer externalizer;

--- a/core/src/main/java/org/infinispan/remoting/transport/Transport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/Transport.java
@@ -144,11 +144,5 @@ public interface Transport extends Lifecycle {
     */
    int getViewId();
 
-   /**
-    * TODO: Document
-    *
-    * @return
-    */
    Log getLog();
-
 }

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashCompletedOnJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashCompletedOnJoinTest.java
@@ -33,12 +33,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-/**
- * // TODO: Document this
- *
- * @author Galder Zamarreño
- * @since 4.1
- */
 @Test(groups = "functional", testName = "distribution.rehash.RehashCompletedOnJoinTest")
 public class RehashCompletedOnJoinTest extends BaseDistFunctionalTest {
 

--- a/core/src/test/java/org/infinispan/lock/CheckRemoteLockAcquiredOnlyOnceTest.java
+++ b/core/src/test/java/org/infinispan/lock/CheckRemoteLockAcquiredOnlyOnceTest.java
@@ -132,7 +132,7 @@ public class CheckRemoteLockAcquiredOnlyOnceTest extends MultipleCacheManagersTe
       });
    }
 
-   public void testPutAllTheLock() throws Exception {
+   public void testPutAllThenLock() throws Exception {
       testOperationThenLock(new CacheOperation() {
          @Override
          public void execute() {

--- a/core/src/test/java/org/infinispan/lock/SimpleLockContainerTest.java
+++ b/core/src/test/java/org/infinispan/lock/SimpleLockContainerTest.java
@@ -33,12 +33,6 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
 
-/**
- * // TODO: Document this
- *
- * @author Mircea Markus
- * @since 5.1
- */
 @Test (groups = "functional")
 public class SimpleLockContainerTest extends AbstractInfinispanTest {
 
@@ -64,7 +58,7 @@ public class SimpleLockContainerTest extends AbstractInfinispanTest {
                   System.out.println("ownableReentrantLock = " + ownableReentrantLock);
                   if (ownableReentrantLock != null) return;
                } catch (InterruptedException e) {
-                  e.printStackTrace();  // TODO: Customise this generated block
+                  e.printStackTrace();
                }
             }
          }

--- a/core/src/test/java/org/infinispan/marshall/MarshallExternalPojosTest.java
+++ b/core/src/test/java/org/infinispan/marshall/MarshallExternalPojosTest.java
@@ -37,12 +37,6 @@ import java.lang.reflect.Method;
 import static org.infinispan.test.TestingUtil.k;
 import static org.testng.AssertJUnit.assertEquals;
 
-/**
- * // TODO: Document this
- *
- * @author Galder Zamarreño
- * @since // TODO
- */
 @Test(groups = "functional", testName = "marshall.jboss.MarshallExternalPojosTest")
 public class MarshallExternalPojosTest extends MultipleCacheManagersTest {
 

--- a/core/src/test/java/org/infinispan/marshall/MarshalledValueSingleNodeTest.java
+++ b/core/src/test/java/org/infinispan/marshall/MarshalledValueSingleNodeTest.java
@@ -29,12 +29,6 @@ import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
-/**
- * // TODO: Document this
- *
- * @author Galder Zamarreño
- * @since // TODO
- */
 @Test(groups = "functional", testName = "marshall.MarshalledValueSingleNodeTest")
 public class MarshalledValueSingleNodeTest extends SingleCacheManagerTest {
 

--- a/core/src/test/java/org/infinispan/statetransfer/BigObject.java
+++ b/core/src/test/java/org/infinispan/statetransfer/BigObject.java
@@ -24,12 +24,6 @@ package org.infinispan.statetransfer;
 
 import java.io.Serializable;
 
-/**
- * // TODO: Document this
- *
- * @author Mircea.Markus@jboss.com
- * @since 4.2
- */
 public class BigObject implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/core/src/test/java/org/infinispan/test/PerCacheExecutorThread.java
+++ b/core/src/test/java/org/infinispan/test/PerCacheExecutorThread.java
@@ -96,12 +96,12 @@ public final class PerCacheExecutorThread extends Thread {
          }
          log.tracef("about to process operation %s", operation);
          switch (operation) {
-            case BEGGIN_TX: {
+            case BEGIN_TX: {
                TransactionManager txManager = TestingUtil.getTransactionManager(cache);
                try {
                   txManager.begin();
                   ongoingTransaction = txManager.getTransaction();
-                  setResponse(OperationsResult.BEGGIN_TX_OK);
+                  setResponse(OperationsResult.BEGIN_TX_OK);
                } catch (Exception e) {
                   log.trace("Failure on beginning tx", e);
                   setResponse(e);
@@ -219,11 +219,11 @@ public final class PerCacheExecutorThread extends Thread {
     * @author Mircea.Markus@jboss.com
     */
    public static enum Operations {
-      BEGGIN_TX, COMMIT_TX, PUT_KEY_VALUE, REMOVE_KEY, REPLACE_KEY_VALUE, STOP_THREAD, FORCE2PC;
+      BEGIN_TX, COMMIT_TX, PUT_KEY_VALUE, REMOVE_KEY, REPLACE_KEY_VALUE, STOP_THREAD, FORCE2PC;
       public OperationsResult getCorrespondingOkResult() {
          switch (this) {
-            case BEGGIN_TX:
-               return OperationsResult.BEGGIN_TX_OK;
+            case BEGIN_TX:
+               return OperationsResult.BEGIN_TX_OK;
             case COMMIT_TX:
                return OperationsResult.COMMIT_TX_OK;
             case PUT_KEY_VALUE:
@@ -249,7 +249,7 @@ public final class PerCacheExecutorThread extends Thread {
     * @author Mircea.Markus@jboss.com
     */
    public static enum OperationsResult {
-      BEGGIN_TX_OK, COMMIT_TX_OK, PUT_KEY_VALUE_OK, REMOVE_KEY_OK, REPLACE_KEY_VALUE_OK, STOP_THREAD_OK , FORCE2PC_OK
+      BEGIN_TX_OK, COMMIT_TX_OK, PUT_KEY_VALUE_OK, REMOVE_KEY_OK, REPLACE_KEY_VALUE_OK, STOP_THREAD_OK , FORCE2PC_OK
    }
 
    public Transaction getOngoingTransaction() {

--- a/core/src/test/java/org/infinispan/tx/NoAutoCommitAndPferTest.java
+++ b/core/src/test/java/org/infinispan/tx/NoAutoCommitAndPferTest.java
@@ -25,12 +25,6 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.testng.annotations.Test;
 
-/**
- * // TODO: Document this
- *
- * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.
- * @since // TODO
- */
 @Test(groups = "functional", testName = "tx.NoAutoCommitAndPferTest")
 public class NoAutoCommitAndPferTest extends SingleCacheManagerTest {
 

--- a/core/src/test/java/org/infinispan/tx/SimpleLockTest.java
+++ b/core/src/test/java/org/infinispan/tx/SimpleLockTest.java
@@ -5,13 +5,7 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.transaction.LockingMode;
 import org.testng.annotations.Test;
 
-/**
- * // TODO: Document this
- *
- * @author Mircea Markus
- * @since 5.1
- */
-@Test
+@Test (testName = "tx.SimpleLockTest", groups = "functional")
 public class SimpleLockTest extends MultipleCacheManagersTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/tx/dld/BaseDldPessimisticLockingTest.java
+++ b/core/src/test/java/org/infinispan/tx/dld/BaseDldPessimisticLockingTest.java
@@ -22,10 +22,8 @@
  */
 package org.infinispan.tx.dld;
 
-import org.infinispan.config.Configuration;
 import org.infinispan.test.PerCacheExecutorThread;
 import org.infinispan.test.TestingUtil;
-import org.infinispan.transaction.LockingMode;
 import org.infinispan.util.concurrent.locks.DeadlockDetectingLockManager;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -65,8 +63,8 @@ public abstract class BaseDldPessimisticLockingTest extends BaseDldTest {
 
       log.trace("Here is where the test starts");
 
-      ex0.execute(PerCacheExecutorThread.Operations.BEGGIN_TX);
-      ex1.execute(PerCacheExecutorThread.Operations.BEGGIN_TX);
+      ex0.execute(PerCacheExecutorThread.Operations.BEGIN_TX);
+      ex1.execute(PerCacheExecutorThread.Operations.BEGIN_TX);
 
 
       ex0.setKeyValue(k0, "v0_0");

--- a/core/src/test/java/org/infinispan/tx/dld/DldPessimisticLockingReplicationTest.java
+++ b/core/src/test/java/org/infinispan/tx/dld/DldPessimisticLockingReplicationTest.java
@@ -29,8 +29,6 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.testng.annotations.Test;
 
-import javax.transaction.TransactionManager;
-
 /**
  * @author Mircea.Markus@jboss.com
  * @since 4.1
@@ -68,7 +66,7 @@ public class DldPessimisticLockingReplicationTest extends BaseDldPessimisticLock
       assert lm0.isLocked("k1");
       assert !lm1.isLocked("k1");
       try {
-         ex0.execute(PerCacheExecutorThread.Operations.BEGGIN_TX);
+         ex0.execute(PerCacheExecutorThread.Operations.BEGIN_TX);
          ex0.setKeyValue("k1", "v1_1");
          ex0.execute(PerCacheExecutorThread.Operations.PUT_KEY_VALUE);
          assert ex0.lastResponse() instanceof TimeoutException : "received " + ex0.lastResponse();

--- a/core/src/test/java/org/infinispan/tx/dld/LocalDeadlockDetectionTest.java
+++ b/core/src/test/java/org/infinispan/tx/dld/LocalDeadlockDetectionTest.java
@@ -176,8 +176,8 @@ public class LocalDeadlockDetectionTest extends SingleCacheManagerTest {
 
    private void testLocalVsLocalTxDeadlock(PerCacheExecutorThread.Operations firstOperation, PerCacheExecutorThread.Operations secondOperation) {
 
-      assert PerCacheExecutorThread.OperationsResult.BEGGIN_TX_OK == t1.execute(PerCacheExecutorThread.Operations.BEGGIN_TX);
-      assert PerCacheExecutorThread.OperationsResult.BEGGIN_TX_OK == t2.execute(PerCacheExecutorThread.Operations.BEGGIN_TX);
+      assert PerCacheExecutorThread.OperationsResult.BEGIN_TX_OK == t1.execute(PerCacheExecutorThread.Operations.BEGIN_TX);
+      assert PerCacheExecutorThread.OperationsResult.BEGIN_TX_OK == t2.execute(PerCacheExecutorThread.Operations.BEGIN_TX);
 
       t1.setKeyValue("k1", "value_1_t1");
       t2.setKeyValue("k2", "value_2_t2");

--- a/query/src/main/java/org/infinispan/query/QueryMetadataFileFinder.java
+++ b/query/src/main/java/org/infinispan/query/QueryMetadataFileFinder.java
@@ -21,12 +21,6 @@ package org.infinispan.query;
 
 import org.infinispan.factories.components.ModuleMetadataFileFinder;
 
-/**
- * // TODO: Document this
- *
- * @author Manik Surtani
- * @since 5.1
- */
 public class QueryMetadataFileFinder implements ModuleMetadataFileFinder {
    @Override
    public String getMetadataFilename() {

--- a/query/src/main/java/org/infinispan/query/QueryModuleCommandExtensions.java
+++ b/query/src/main/java/org/infinispan/query/QueryModuleCommandExtensions.java
@@ -23,12 +23,6 @@ import org.infinispan.commands.module.ExtendedModuleCommandFactory;
 import org.infinispan.commands.module.ModuleCommandInitializer;
 import org.infinispan.commands.module.ModuleCommandExtensions;
 
-/**
- * // TODO: Document this
- *
- * @author Galder Zamarreño
- * @since // TODO
- */
 public class QueryModuleCommandExtensions implements ModuleCommandExtensions {
 
    @Override

--- a/server/core/src/main/scala/org/infinispan/server/core/transport/ExtendedChannelBuffer.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/transport/ExtendedChannelBuffer.scala
@@ -25,11 +25,6 @@ package org.infinispan.server.core.transport
 
 import org.jboss.netty.buffer.{ChannelBuffers, ChannelBuffer}
 
-/**
- * // TODO: Document this
- * @author Galder Zamarreño
- * @since // TODO
- */
 object ExtendedChannelBuffer {
 
    def wrappedBuffer(array: Array[Byte]*) = ChannelBuffers.wrappedBuffer(array : _*)

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodSingleClusteredTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodSingleClusteredTest.scala
@@ -31,11 +31,6 @@ import org.infinispan.test.MultipleCacheManagersTest
 import test.HotRodTestingUtil._
 import org.infinispan.test.AbstractCacheTest._
 
-/**
- * // TODO: Document this
- * @author Galder Zamarreño
- * @since // TODO
- */
 @Test(groups = Array("functional"), testName = "server.hotrod.HotRodSingleClusteredTest")
 class HotRodSingleClusteredTest extends MultipleCacheManagersTest {
 

--- a/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedMainTest.scala
+++ b/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedMainTest.scala
@@ -27,11 +27,6 @@ import org.infinispan.server.core.Main
 import test.MemcachedTestingUtil
 import org.testng.Assert._
 
-/**
- * // TODO: Document this
- * @author Galder Zamarreño
- * @since // TODO
- */
 @Test(groups = Array("functional"), testName = "server.memcached.MemcachedMainTest")
 class MemcachedMainTest extends MemcachedTestingUtil {
 

--- a/server/websocket/src/main/java/org/infinispan/server/websocket/CacheListener.java
+++ b/server/websocket/src/main/java/org/infinispan/server/websocket/CacheListener.java
@@ -101,8 +101,6 @@ public class CacheListener {
 			
 			jsonObject.put("eventType", eventType.toString());
 		} catch (JSONException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
 			return;
 		}
 

--- a/server/websocket/src/main/java/org/infinispan/server/websocket/WebSocketServerHandler.java
+++ b/server/websocket/src/main/java/org/infinispan/server/websocket/WebSocketServerHandler.java
@@ -168,8 +168,6 @@ public class WebSocketServerHandler extends SimpleChannelUpstreamHandler {
             handler.handleOp(payload, cache, ctx);
          }
       } catch (JSONException e) {
-         // TODO Auto-generated catch block
-         e.printStackTrace();
       }
    }
 

--- a/server/websocket/src/test/java/org/infinispan/websocket/MockChannel.java
+++ b/server/websocket/src/test/java/org/infinispan/websocket/MockChannel.java
@@ -132,7 +132,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public ChannelFuture bind(SocketAddress arg0) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
@@ -141,7 +140,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public ChannelFuture close() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
@@ -150,7 +148,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public ChannelFuture connect(SocketAddress arg0) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
@@ -159,7 +156,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public ChannelFuture disconnect() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
@@ -182,7 +178,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public ChannelFactory getFactory() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
@@ -191,7 +186,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public Integer getId() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
@@ -200,7 +194,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public int getInterestOps() {
-		// TODO Auto-generated method stub
 		return 0;
 	}
 
@@ -209,7 +202,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public Channel getParent() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
@@ -218,7 +210,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public ChannelPipeline getPipeline() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
@@ -235,7 +226,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public boolean isReadable() {
-		// TODO Auto-generated method stub
 		return false;
 	}
 
@@ -244,7 +234,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public boolean isWritable() {
-		// TODO Auto-generated method stub
 		return false;
 	}
 
@@ -253,7 +242,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public ChannelFuture setInterestOps(int arg0) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
@@ -262,7 +250,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public ChannelFuture setReadable(boolean arg0) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
@@ -271,7 +258,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public ChannelFuture unbind() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
@@ -280,7 +266,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public ChannelFuture write(Object arg0, SocketAddress arg1) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
@@ -289,7 +274,6 @@ public class MockChannel implements Channel {
 	 */
 	@Override
 	public int compareTo(Channel o) {
-		// TODO Auto-generated method stub
 		return 0;
 	}
 }

--- a/tree/src/test/java/org/infinispan/api/tree/LazyDeserializationTreeCacheTest.java
+++ b/tree/src/test/java/org/infinispan/api/tree/LazyDeserializationTreeCacheTest.java
@@ -30,12 +30,6 @@ import org.infinispan.tree.TreeCache;
 import org.infinispan.tree.TreeCacheImpl;
 import org.testng.annotations.Test;
 
-/**
- * // TODO: Document this
- *
- * @author Galder Zamarreño
- * @since // TODO
- */
 @Test(groups = "functional", testName = "api.tree.LazyDeserializationTreeCacheTest")
 public class LazyDeserializationTreeCacheTest extends SingleCacheManagerTest {
 


### PR DESCRIPTION
- Add missing testName attribute to @Test annotations
- Spelling errors
- Remove generated TODOs for javadocs on inconsequential code (tests, etc)
- Add actual Javadocs where needed/useful

Also merge `t_cleanup_more_tests_5` for branch `5.1.x`
