### PR TITLE
ISPN-1909: Don't treat non-numerical file names as potential buckets

### DIFF
--- a/cachestore/jdbm/src/test/java/org/infinispan/loaders/jdbm/JdbmCacheStoreTest.java
+++ b/cachestore/jdbm/src/test/java/org/infinispan/loaders/jdbm/JdbmCacheStoreTest.java
@@ -70,7 +70,7 @@ public class JdbmCacheStoreTest extends BaseCacheStoreTest {
    }
 
    @Override
-   public void testPreload() throws CacheLoaderException {
+   public void testPreload() throws Exception {
       super.testPreload();
    }
 
@@ -93,7 +93,7 @@ public class JdbmCacheStoreTest extends BaseCacheStoreTest {
       assert fcs.load("k2") == null;
       assert fcs.load("k3") == null;
    }
-   
+
    public void testStopStartDoesntNukeValues() throws InterruptedException, CacheLoaderException {
       assert !cs.containsKey("k1");
       assert !cs.containsKey("k2");
@@ -133,7 +133,7 @@ public class JdbmCacheStoreTest extends BaseCacheStoreTest {
       InternalCacheEntry k2 = TestInternalCacheEntryFactory.create("k2", "v2");
       cs.store(k1);
       cs.store(k2);
-      
+
       Set<InternalCacheEntry> set = cs.loadAll();
       Iterator<InternalCacheEntry> i = set.iterator();
       assert i.hasNext() == true;

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -764,7 +764,7 @@ public interface Log extends BasicLogger {
 
    @LogMessage(level = WARN)
    @Message(value = "FileCacheStore ignored an unexpected file %2$s in path %1$s. The store path should be dedicated!", id = 163)
-   void chacheLoaderIgnoringUnexpectedFile(String parentPath, String name);
+   void cacheLoaderIgnoringUnexpectedFile(Object parentPath, String name);
 
    @LogMessage(level = ERROR)
    @Message(value = "Rolling back to cache view %d, but last committed view is %d", id = 164)
@@ -805,11 +805,11 @@ public interface Log extends BasicLogger {
    @LogMessage(level = ERROR)
    @Message(value = "Custom interceptor %s has used @Inject, @Start or @Stop. These methods will not be processed.  Please extend org.infinispan.interceptors.base.BaseCustomInterceptor instead, and your custom interceptor will have access to a cache and cacheManager.  Override stop() and start() for lifecycle methods.", id = 173)
    void customInterceptorExpectsInjection(String customInterceptorFQCN);
-   
+
    @LogMessage(level = WARN)
    @Message(value = "Unexpected error reading configuration", id = 174)
    void errorReadingConfiguration(@Cause Exception e);
-   
+
    @LogMessage(level = WARN)
    @Message(value = "Unexpected error closing resource", id = 175)
    void failedToCloseResource(@Cause Throwable e);
@@ -817,7 +817,7 @@ public interface Log extends BasicLogger {
    @LogMessage(level = WARN)
    @Message(value = "The 'wakeUpInterval' attribute of the 'eviction' configuration XML element is deprecated. Setting the 'wakeUpInterval' attribute of the 'expiration' configuration XML element to %d instead", id = 176)
    void evictionWakeUpIntervalDeprecated(Long wakeUpInterval);
-   
+
    @LogMessage(level = WARN)
    @Message(value = "%s has been deprecated as a synonym for %s. Use one of %s instead", id = 177)
    void randomCacheModeSynonymsDeprecated(String candidate, String mode, List<String> synonyms);

--- a/core/src/test/java/org/infinispan/loaders/BaseCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/BaseCacheStoreTest.java
@@ -382,6 +382,7 @@ public abstract class BaseCacheStoreTest extends AbstractInfinispanTest {
       cs.prepare(mods, tx, false);
 
       Thread t = new Thread(new Runnable() {
+         @Override
          public void run() {
             cs.rollback(tx);
          }
@@ -403,6 +404,7 @@ public abstract class BaseCacheStoreTest extends AbstractInfinispanTest {
       cs.prepare(mods, tx, false);
 
       Thread t2 = new Thread(new Runnable() {
+         @Override
          public void run() {
             cs.rollback(tx);
          }
@@ -426,7 +428,7 @@ public abstract class BaseCacheStoreTest extends AbstractInfinispanTest {
       assert cs.containsKey("old");
    }
 
-   public void testPreload() throws CacheLoaderException {
+   public void testPreload() throws Exception {
       cs.store(TestInternalCacheEntryFactory.create("k1", "v1"));
       cs.store(TestInternalCacheEntryFactory.create("k2", "v2"));
       cs.store(TestInternalCacheEntryFactory.create("k3", "v3"));
@@ -635,6 +637,7 @@ public abstract class BaseCacheStoreTest extends AbstractInfinispanTest {
       final List<Exception> exceptions = new LinkedList<Exception>();
 
       final Runnable store = new Runnable() {
+         @Override
          public void run() {
             try {
                int randomInt = r.nextInt(10);
@@ -646,6 +649,7 @@ public abstract class BaseCacheStoreTest extends AbstractInfinispanTest {
       };
 
       final Runnable remove = new Runnable() {
+         @Override
          public void run() {
             try {
                cs.remove(keys[r.nextInt(10)]);
@@ -656,6 +660,7 @@ public abstract class BaseCacheStoreTest extends AbstractInfinispanTest {
       };
 
       final Runnable get = new Runnable() {
+         @Override
          public void run() {
             try {
                int randomInt = r.nextInt(10);
@@ -672,6 +677,7 @@ public abstract class BaseCacheStoreTest extends AbstractInfinispanTest {
 
       for (int i = 0; i < numThreads; i++) {
          threads[i] = new Thread(getClass().getSimpleName() + "-" + i) {
+            @Override
             public void run() {
                for (int i = 0; i < loops; i++) {
                   store.run();

--- a/core/src/test/java/org/infinispan/loaders/file/FileCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/file/FileCacheStoreTest.java
@@ -84,7 +84,8 @@ public class FileCacheStoreTest extends BaseCacheStoreTest {
    }
 
    @Override
-   public void testPreload() throws CacheLoaderException {
+   public void testPreload() throws Exception {
+      createUnrelatedFile();
       super.testPreload();
    }
 
@@ -215,5 +216,13 @@ public class FileCacheStoreTest extends BaseCacheStoreTest {
          assert expected.remove(se.getKey());
       }
       assert expected.isEmpty();
+   }
+
+   public void testNumericNamedFilesFilter() {
+      File dir = new File(".");
+      assert FileCacheStore.NUMERIC_NAMED_FILES_FILTER.accept(dir, "-123456789");
+      assert FileCacheStore.NUMERIC_NAMED_FILES_FILTER.accept(dir, "987654321");
+      assert !FileCacheStore.NUMERIC_NAMED_FILES_FILTER.accept(dir, ".nfs1234");
+      assert !FileCacheStore.NUMERIC_NAMED_FILES_FILTER.accept(dir, "12345678901");
    }
 }


### PR DESCRIPTION
I also have ISPN-1909-5.1.x for the stable branch
