### PR TITLE
Use File.separator in TestNameVerifier and SampleConfigFiles...

### DIFF
--- a/core/src/test/java/org/infinispan/config/SampleConfigFilesCorrectnessTest.java
+++ b/core/src/test/java/org/infinispan/config/SampleConfigFilesCorrectnessTest.java
@@ -47,7 +47,7 @@ import java.util.Arrays;
  */
 @Test(groups = "functional", testName = "config.SampleConfigFilesCorrectnessTest")
 public class SampleConfigFilesCorrectnessTest {
-   public static final String CONFIG_ROOT = "src/main/resources/config-samples";
+   public static final String CONFIG_ROOT = "src" + File.separator + "main" + File.separator + "resources" + File.separator + "config-samples";
    private static final Log log = LogFactory.getLog(SampleConfigFilesCorrectnessTest.class);
 
    private InMemoryAppender appender;
@@ -74,7 +74,7 @@ public class SampleConfigFilesCorrectnessTest {
    public void testConfigWarnings() throws Exception {
       for (String aConfFile : getConfigFileNames()) {
          log.tracef("Analysing %s", aConfFile);
-         EmbeddedCacheManager dcm = TestCacheManagerFactory.fromXml(getRootFolder() + "/" + aConfFile);
+         EmbeddedCacheManager dcm = TestCacheManagerFactory.fromXml(getRootFolder() + File.separator + aConfFile);
          try {
             dcm.getCache();
             assert !appender.isFoundUnknownWarning() : String.format(
@@ -115,12 +115,7 @@ public class SampleConfigFilesCorrectnessTest {
    }
 
    private File getRootFolder() {
-      File file = new File(CONFIG_ROOT);
-      //this is a hack. If the tests are run from core folder then following if should not be entered.
-      //otherwise assume we are runnin
-      if (!file.isDirectory()) {
-         file = new File("core/" + CONFIG_ROOT);
-      }
+      File file = new File(new File(CONFIG_ROOT).getAbsolutePath());
       return file;
    }
 

--- a/tools/src/test/java/org/infinispan/test/fwk/TestNameVerifier.java
+++ b/tools/src/test/java/org/infinispan/test/fwk/TestNameVerifier.java
@@ -37,13 +37,14 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Class that tests that test names are correclty set for each test.
+ * Class that tests that test names are correctly set for each test.
  *
  * @author Mircea.Markus@jboss.com
  */
 @Test(groups = "functional", testName = "test.fwk.TestNameVerifier")
 public class TestNameVerifier {
-   String dir = "src/test/java/org/infinispan";
+    
+   String dir = "src" + File.separator + "test" + File.separator + "java" + File.separator + "org" + File.separator + "infinispan";
    public List<String> modules = new ArrayList<String>();
 
 
@@ -222,25 +223,20 @@ public class TestNameVerifier {
    // method that populates the list of module names
    private void populateModuleList() {
       modules.add("core");
-      modules.add("cachestore/cloud");
-      modules.add("cachestore/bdbje");
-      modules.add("cachestore/jdbc");
-      modules.add("cachestore/jdbm");
+      modules.add("cachestore" + File.separator + "cloud");
+      modules.add("cachestore" + File.separator + "bdbje");
+      modules.add("cachestore" + File.separator + "jdbc");
+      modules.add("cachestore" + File.separator + "jdbm");
       modules.add("rhq-plugin");
       modules.add("tree");
    }
 
    // Old method that Mircea wrote that originally returned an array. Now returns a list and will be added to the list in getAllJavaFiles()
    private List<File> getFilesFromModule(String moduleName) {
-      File file = new File(dir);
-      if (!file.exists()) {
-         // try prepending dir with module name
-         file = new File(moduleName + File.separator + dir);
-      }
+      File file = new File(new File(dir).getAbsolutePath());
       assert file.isDirectory();
       ArrayList<File> result = new ArrayList<File>();
       addJavaFiles(file, result);
       return result;
-
    }
 }


### PR DESCRIPTION
...CorrectnessTest so that they work with Windows

I tested this on Linux Ubuntu (both from root folder and from core/ and tools/ subfolders), also tested with Windows 2008 x64. It works now! :)
