### PR TITLE
ISPN-1367 Make class resolver configurable

### DIFF
--- a/core/src/main/java/org/infinispan/config/FluentGlobalConfiguration.java
+++ b/core/src/main/java/org/infinispan/config/FluentGlobalConfiguration.java
@@ -32,6 +32,7 @@ import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.marshall.AdvancedExternalizer;
 import org.infinispan.marshall.Marshaller;
 import org.infinispan.remoting.transport.Transport;
+import org.jboss.marshalling.ClassResolver;
 
 import java.util.Properties;
 
@@ -108,6 +109,13 @@ public class FluentGlobalConfiguration extends AbstractConfigurationBeanWithGCR 
        * @param advancedExternalizers
        */
       <T> SerializationConfig addAdvancedExternalizer(AdvancedExternalizer<T>... advancedExternalizers);
+
+      /**
+       * Class resolver to use when unmarshallig objects.
+       *
+       * @param classResolver
+       */
+      SerializationConfig classResolver(ClassResolver classResolver);
    }
 
    /**

--- a/core/src/main/java/org/infinispan/config/GlobalConfiguration.java
+++ b/core/src/main/java/org/infinispan/config/GlobalConfiguration.java
@@ -50,6 +50,7 @@ import org.infinispan.util.TypedProperties;
 import org.infinispan.util.Util;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.jboss.marshalling.ClassResolver;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -693,6 +694,10 @@ public class GlobalConfiguration extends AbstractConfigurationBean {
 
    public List<AdvancedExternalizerConfig> getExternalizers() {
       return serialization.externalizerTypes.advancedExternalizers;
+   }
+
+   public ClassResolver getClassResolver() {
+      return serialization.classResolver;
    }
 
    public long getDistributedSyncTimeout() {
@@ -1361,6 +1366,9 @@ public class GlobalConfiguration extends AbstractConfigurationBean {
       @XmlElement(name = "advancedExternalizers")
       protected AdvancedExternalizersType externalizerTypes = new AdvancedExternalizersType();
 
+      @XmlTransient
+      private ClassResolver classResolver;
+
       public SerializationType() {
          super();
       }
@@ -1451,6 +1459,12 @@ public class GlobalConfiguration extends AbstractConfigurationBean {
       public <T> SerializationConfig addAdvancedExternalizer(int id, AdvancedExternalizer<T> advancedExternalizer) {
          externalizerTypes.addExternalizer(
                new AdvancedExternalizerConfig().setId(id).setAdvancedExternalizer(advancedExternalizer));
+         return this;
+      }
+
+      @Override
+      public SerializationConfig classResolver(ClassResolver classResolver) {
+         this.classResolver = classResolver;
          return this;
       }
    }

--- a/core/src/main/java/org/infinispan/configuration/global/LegacyGlobalConfigurationAdaptor.java
+++ b/core/src/main/java/org/infinispan/configuration/global/LegacyGlobalConfigurationAdaptor.java
@@ -73,6 +73,8 @@ public class LegacyGlobalConfigurationAdaptor {
       for (Entry<Integer, AdvancedExternalizer<?>> entry : config.serialization().advancedExternalizers().entrySet()) {
          legacy.serialization().addAdvancedExternalizer(entry.getKey(), entry.getValue());
       }
+
+      legacy.serialization().classResolver(config.serialization().classResolver());
       
       legacy.asyncTransportExecutor()
          .factory(config.asyncTransportExecutor().factory().getClass())
@@ -134,6 +136,8 @@ public class LegacyGlobalConfigurationAdaptor {
       for (AdvancedExternalizerConfig externalizerConfig : legacy.getExternalizers()) {
          builder.serialization().addAdvancedExternalizer(externalizerConfig.getId(), externalizerConfig.getAdvancedExternalizer());
       }
+
+      builder.serialization().classResolver(legacy.getClassResolver());
       
       builder.asyncTransportExecutor()
          .factory(Util.<ExecutorFactory>getInstance(legacy.getAsyncTransportExecutorFactoryClass(), legacy.getClassLoader()))

--- a/core/src/main/java/org/infinispan/configuration/global/SerializationConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/SerializationConfiguration.java
@@ -24,18 +24,22 @@ import java.util.Map;
 
 import org.infinispan.marshall.AdvancedExternalizer;
 import org.infinispan.marshall.Marshaller;
+import org.jboss.marshalling.ClassResolver;
 
 public class SerializationConfiguration {
 
    private final Marshaller marshaller;
    private final short version;
    private final Map<Integer, AdvancedExternalizer<?>> advancedExternalizers;
+   private final ClassResolver classResolver;
    
    SerializationConfiguration(Marshaller marshaller, short version,
-         Map<Integer, AdvancedExternalizer<?>> advancedExternalizers) {
+         Map<Integer, AdvancedExternalizer<?>> advancedExternalizers,
+         ClassResolver classResolver) {
       this.marshaller = marshaller;
       this.version = version;
       this.advancedExternalizers = Collections.unmodifiableMap(new HashMap<Integer, AdvancedExternalizer<?>>(advancedExternalizers));
+      this.classResolver = classResolver;
    }
 
    public Marshaller marshaller() {
@@ -50,12 +54,17 @@ public class SerializationConfiguration {
       return advancedExternalizers;
    }
 
+   public ClassResolver classResolver() {
+      return classResolver;
+   }
+
    @Override
    public String toString() {
       return "SerializationConfiguration{" +
             "advancedExternalizers=" + advancedExternalizers +
             ", marshaller=" + marshaller +
             ", version=" + version +
+            ", classResolver=" + classResolver +
             '}';
    }
 

--- a/core/src/main/java/org/infinispan/configuration/global/SerializationConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/SerializationConfigurationBuilder.java
@@ -22,6 +22,8 @@ import org.infinispan.Version;
 import org.infinispan.marshall.AdvancedExternalizer;
 import org.infinispan.marshall.Marshaller;
 import org.infinispan.marshall.VersionAwareMarshaller;
+import org.jboss.marshalling.ClassResolver;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,6 +35,7 @@ public class SerializationConfigurationBuilder extends AbstractGlobalConfigurati
    private Marshaller marshaller = new VersionAwareMarshaller();
    private short marshallVersion = Short.valueOf(Version.MAJOR_MINOR.replace(".", ""));
    private Map<Integer, AdvancedExternalizer<?>> advancedExternalizers = new HashMap<Integer, AdvancedExternalizer<?>>();
+   private ClassResolver classResolver;
 
    SerializationConfigurationBuilder(GlobalConfigurationBuilder globalConfig) {
       super(globalConfig);
@@ -111,6 +114,16 @@ public class SerializationConfigurationBuilder extends AbstractGlobalConfigurati
       return this;
    }
 
+   /**
+    * Class resolver to use when unmarshallig objects.
+    *
+    * @param classResolver
+    */
+   public SerializationConfigurationBuilder classResolver(ClassResolver classResolver) {
+      this.classResolver = classResolver;
+      return this;
+   }
+
    @Override
    protected void validate() {
       // No-op, no validation required
@@ -118,7 +131,8 @@ public class SerializationConfigurationBuilder extends AbstractGlobalConfigurati
 
    @Override
    SerializationConfiguration create() {
-      return new SerializationConfiguration(marshaller, marshallVersion, advancedExternalizers);
+      return new SerializationConfiguration(
+            marshaller, marshallVersion, advancedExternalizers, classResolver);
    }
 
    @Override
@@ -136,6 +150,7 @@ public class SerializationConfigurationBuilder extends AbstractGlobalConfigurati
             "advancedExternalizers=" + advancedExternalizers +
             ", marshaller=" + marshaller +
             ", marshallVersion=" + marshallVersion +
+            ", classResolver=" + classResolver +
             '}';
    }
 
@@ -151,6 +166,8 @@ public class SerializationConfigurationBuilder extends AbstractGlobalConfigurati
          return false;
       if (marshaller != null ? !marshaller.equals(that.marshaller) : that.marshaller != null)
          return false;
+      if (classResolver != null ? !classResolver.equals(that.classResolver) : that.classResolver != null)
+         return false;
 
       return true;
    }
@@ -160,6 +177,7 @@ public class SerializationConfigurationBuilder extends AbstractGlobalConfigurati
       int result = marshaller != null ? marshaller.hashCode() : 0;
       result = 31 * result + (int) marshallVersion;
       result = 31 * result + (advancedExternalizers != null ? advancedExternalizers.hashCode() : 0);
+      result = 31 * result + (classResolver != null ? classResolver.hashCode() : 0);
       return result;
    }
 

--- a/core/src/main/java/org/infinispan/marshall/CacheMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/CacheMarshaller.java
@@ -1,6 +1,7 @@
 package org.infinispan.marshall;
 
 import org.infinispan.config.Configuration;
+import org.infinispan.config.GlobalConfiguration;
 import org.infinispan.context.InvocationContextContainer;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Stop;
@@ -22,8 +23,10 @@ public class CacheMarshaller extends AbstractDelegatingMarshaller {
    }
 
    @Inject
-   public void inject(Configuration cfg, InvocationContextContainer icc, ExternalizerTable extTable) {
-      ((VersionAwareMarshaller) this.marshaller).inject(cfg, null, icc, extTable);
+   public void inject(Configuration cfg, InvocationContextContainer icc,
+            ExternalizerTable extTable, GlobalConfiguration globalCfg) {
+      ((VersionAwareMarshaller) this.marshaller).inject(
+            cfg, null, icc, extTable, globalCfg);
    }
 
    @Stop(priority = 11) // Stop after RPCManager to avoid send/receive and marshaller not being ready

--- a/core/src/main/java/org/infinispan/marshall/GlobalMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/GlobalMarshaller.java
@@ -1,5 +1,6 @@
 package org.infinispan.marshall;
 
+import org.infinispan.config.GlobalConfiguration;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.scopes.Scope;
@@ -22,8 +23,10 @@ public class GlobalMarshaller extends AbstractDelegatingMarshaller {
    }
 
    @Inject
-   public void inject(ClassLoader loader, ExternalizerTable extTable) {
-      ((VersionAwareMarshaller) this.marshaller).inject(null, loader, null, extTable);
+   public void inject(ClassLoader loader, ExternalizerTable extTable,
+            GlobalConfiguration globalCfg) {
+      ((VersionAwareMarshaller) this.marshaller).inject(
+            null, loader, null, extTable, globalCfg);
    }
 
    @Stop(priority = 11) // Stop after transport to avoid send/receive and marshaller not being ready

--- a/core/src/main/java/org/infinispan/marshall/VersionAwareMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/VersionAwareMarshaller.java
@@ -23,6 +23,7 @@
 package org.infinispan.marshall;
 
 import org.infinispan.config.Configuration;
+import org.infinispan.config.GlobalConfiguration;
 import org.infinispan.context.InvocationContextContainer;
 import org.infinispan.io.ByteBuffer;
 import org.infinispan.io.ExposedByteArrayOutputStream;
@@ -61,7 +62,9 @@ public class VersionAwareMarshaller extends AbstractMarshaller implements Stream
       defaultMarshaller = new JBossMarshaller();
    }
 
-   public void inject(Configuration cfg, ClassLoader loader, InvocationContextContainer icc, ExternalizerTable extTable) {
+   public void inject(Configuration cfg, ClassLoader loader,
+         InvocationContextContainer icc, ExternalizerTable extTable,
+         GlobalConfiguration globalCfg) {
       ClassLoader myClassLoader;
       if (cfg == null) {
          myClassLoader = loader;
@@ -71,7 +74,7 @@ public class VersionAwareMarshaller extends AbstractMarshaller implements Stream
          this.cacheName = cfg.getName();
       }
 
-      this.defaultMarshaller.inject(extTable, myClassLoader, icc);
+      this.defaultMarshaller.inject(extTable, myClassLoader, icc, globalCfg);
    }
 
    public void stop() {

--- a/core/src/main/java/org/infinispan/marshall/jboss/JBossMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/jboss/JBossMarshaller.java
@@ -22,14 +22,11 @@
  */
 package org.infinispan.marshall.jboss;
 
+import org.infinispan.config.GlobalConfiguration;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.InvocationContextContainer;
 import org.infinispan.marshall.StreamingMarshaller;
-import org.jboss.marshalling.Marshaller;
-import org.jboss.marshalling.MarshallingConfiguration;
-import org.jboss.marshalling.Unmarshaller;
-
-import java.io.IOException;
+import org.jboss.marshalling.ClassResolver;
 
 /**
  * A JBoss Marshalling based marshaller that is oriented at internal, embedded,
@@ -52,13 +49,20 @@ public final class JBossMarshaller extends AbstractJBossMarshaller implements St
 
    ExternalizerTable externalizerTable;
 
-   public void inject(ExternalizerTable externalizerTable, ClassLoader cl, InvocationContextContainer icc) {
+   public void inject(ExternalizerTable externalizerTable, ClassLoader cl,
+         InvocationContextContainer icc, GlobalConfiguration globalCfg) {
       log.debug("Using JBoss Marshalling");
       this.externalizerTable = externalizerTable;
       baseCfg.setObjectTable(externalizerTable);
-      // Override the class resolver with one that can detect injected
-      // classloaders via AdvancedCache.with(ClassLoader) calls.
-      baseCfg.setClassResolver(new EmbeddedContextClassResolver(cl, icc));
+
+      ClassResolver classResolver = globalCfg.getClassResolver();
+      if (classResolver == null) {
+         // Override the class resolver with one that can detect injected
+         // classloaders via AdvancedCache.with(ClassLoader) calls.
+         classResolver = new EmbeddedContextClassResolver(cl, icc);
+      }
+
+      baseCfg.setClassResolver(classResolver);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/configuration/ClassResolverConfigTest.java
+++ b/core/src/test/java/org/infinispan/configuration/ClassResolverConfigTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.configuration;
+
+import org.infinispan.api.WithClassLoaderTest;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.marshall.jboss.DefaultContextClassResolver;
+import org.testng.annotations.Test;
+
+/**
+ * A test that verifies that a class resolver can be configured successfully.
+ *
+ * @author Galder Zamarreño
+ * @since 5.1
+ */
+@Test(groups = "functional", testName = "configuration.ClassResolverConfigTest")
+public class ClassResolverConfigTest extends WithClassLoaderTest {
+
+   @Override
+   protected GlobalConfigurationBuilder createSecondGlobalCfgBuilder(ClassLoader cl) {
+      GlobalConfigurationBuilder gcBuilder = super.createSecondGlobalCfgBuilder(cl);
+      gcBuilder.serialization().classResolver(new DefaultContextClassResolver(cl));
+      return gcBuilder;
+   }
+
+   @Override
+   @Test(expectedExceptions = AssertionError.class,
+         expectedExceptionsMessageRegExp = "Expected a ClassNotFoundException")
+   public void testReadingWithCorrectClassLoaderAfterReplication() {
+      // With the default context class resolver, if configured correctly,
+      // the classloader that we set with the invocation context (i.e.
+      // coming from global configuration) is ignored (the super class test
+      // has one specific classloader that forces not finding a class), and
+      // so the class is found.
+      super.testReadingWithCorrectClassLoaderAfterReplication();
+   }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1367

To avoid needing to switch internals to new configuration, old configuration has been enhanced to allow class resolver to be configured. Obviously, new configuration has also been enhanced.

`5.1.x` branch: `t_1367_2_5`
