### PR TITLE
ISPN-1931 - The command retry mechanism in StateTransferLockInterceptor ...

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/StateTransferLockInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/StateTransferLockInterceptor.java
@@ -18,6 +18,7 @@
  */
 package org.infinispan.interceptors;
 
+import org.infinispan.CacheException;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.control.LockControlCommand;
 import org.infinispan.commands.tx.CommitCommand;
@@ -207,9 +208,11 @@ public class StateTransferLockInterceptor extends CommandInterceptor {
             return invokeNextInterceptor(ctx, command);
          } catch (StateTransferInProgressException e) {
             newCacheViewId = e.getNewCacheViewId();
+            log.debugf("Caught StateTransferInProgressException, waiting for the state transfer %d to start", newCacheViewId);
          } catch (SuspectException e) {
             // a node has left, that means the coordinator will soon install a new cache view
             newCacheViewId = newCacheViewId + 1;
+            log.debugf("Caught SuspectException, waiting for the state transfer %d to start", newCacheViewId);
          }
          if (endNanos < System.nanoTime()) {
             throw new TimeoutException("Timed out waiting for the state transfer to end");

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
@@ -39,6 +39,7 @@ import org.infinispan.util.logging.LogFactory;
 import org.jgroups.Address;
 import org.jgroups.Channel;
 import org.jgroups.Message;
+import org.jgroups.SuspectedException;
 import org.jgroups.UpHandler;
 import org.jgroups.blocks.RequestOptions;
 import org.jgroups.blocks.ResponseMode;
@@ -133,6 +134,8 @@ public class CommandAwareRpcDispatcher extends RpcDispatcher {
                                     req_marshaller, this, oob, anycasting);
          } catch (InterruptedException e) {
             throw e;
+         } catch (SuspectedException e) {
+            throw new SuspectException("One of the nodes " + recipients + " was suspected", e);
          } catch (Exception e) {
             throw rewrapAsCacheException(e);
          }
@@ -164,6 +167,8 @@ public class CommandAwareRpcDispatcher extends RpcDispatcher {
                                          req_marshaller, this, oob, transport);
          } catch (InterruptedException e) {
             throw e;
+         } catch (SuspectedException e) {
+            throw new SuspectException("Node " + recipient + " was suspected", e);
          } catch (Exception e) {
             throw rewrapAsCacheException(e);
          }

--- a/core/src/test/java/org/infinispan/statetransfer/StaleLocksWithCommitDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StaleLocksWithCommitDuringStateTransferTest.java
@@ -23,8 +23,14 @@
 package org.infinispan.statetransfer;
 
 import org.infinispan.Cache;
+import org.infinispan.commands.VisitableCommand;
+import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.config.Configuration;
+import org.infinispan.context.InvocationContext;
 import org.infinispan.distribution.MagicKey;
+import org.infinispan.interceptors.InterceptorChain;
+import org.infinispan.interceptors.StateTransferLockInterceptor;
+import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
@@ -56,22 +62,25 @@ public class StaleLocksWithCommitDuringStateTransferTest extends MultipleCacheMa
    }
 
    public void testRollbackLocalFailure() throws Exception {
-      doTest(false, true);
+      doStateTransferInProgressTest(false, true);
    }
 
    public void testCommitLocalFailure() throws Exception {
-      doTest(true, true);
+      doStateTransferInProgressTest(true, true);
    }
 
    public void testRollbackRemoteFailure() throws Exception {
-      doTest(false, false);
+      doStateTransferInProgressTest(false, false);
    }
 
    public void testCommitRemoteFailure() throws Exception {
-      doTest(true, false);
+      doStateTransferInProgressTest(true, false);
    }
 
-   private void doTest(boolean commit, boolean failOnOriginator) throws Exception {
+   /**
+    * Check that the transaction commit/rollback recovers if we receive a StateTransferInProgressException from the remote node
+    */
+   private void doStateTransferInProgressTest(boolean commit, boolean failOnOriginator) throws Exception {
       MagicKey k1 = new MagicKey(c1, "k1");
       MagicKey k2 = new MagicKey(c2, "k2");
 
@@ -130,5 +139,78 @@ public class StaleLocksWithCommitDuringStateTransferTest extends MultipleCacheMa
       assertNotLocked(c1, k2);
       assertNotLocked(c2, k2);
    }
-}
 
+   public void testRollbackSuspectFailure() throws Exception {
+      doTestSuspect(false);
+   }
+
+   public void testCommitSuspectFailure() throws Exception {
+      doTestSuspect(true);
+   }
+
+   /**
+    * Check that the transaction commit/rollback recovers if the remote node dies during the RPC
+    */
+   private void doTestSuspect(boolean commit) throws Exception {
+      MagicKey k1 = new MagicKey(c1, "k1");
+      MagicKey k2 = new MagicKey(c2, "k2");
+
+      tm(c1).begin();
+      c1.put(k1, "v1");
+      c1.put(k2, "v2");
+
+      // We split the transaction commit in two phases by calling the TransactionCoordinator methods directly
+      TransactionTable txTable = TestingUtil.extractComponent(c1, TransactionTable.class);
+      TransactionCoordinator txCoordinator = TestingUtil.extractComponent(c1, TransactionCoordinator.class);
+
+      // Execute the prepare on both nodes
+      LocalTransaction localTx = txTable.getLocalTransaction(tm(c1).getTransaction());
+      txCoordinator.prepare(localTx);
+
+      // Delay the commit on the remote node. Can't used blockNewTransactions because we don't want a StateTransferInProgressException
+      InterceptorChain c2ic = TestingUtil.extractComponent(c2, InterceptorChain.class);
+      c2ic.addInterceptorBefore(new CommandInterceptor() {
+         protected Object handleDefault(InvocationContext ctx, VisitableCommand command) throws Throwable {
+            if (command instanceof CommitCommand) {
+               Thread.sleep(3000);
+            }
+            return super.handleDefault(ctx, command);
+         }
+      }, StateTransferLockInterceptor.class);
+
+      // Schedule the remote node to stop on another thread since the main thread will be busy with the commit call
+      Thread worker = new Thread("RehasherSim,StaleLocksWithCommitDuringStateTransferTest") {
+         @Override
+         public void run() {
+            try {
+               // should be much larger than the lock acquisition timeout
+               Thread.sleep(1000);
+               manager(c2).stop();
+               // stLock.unblockNewTransactions(1000);
+            } catch (InterruptedException e) {
+               log.errorf(e, "Error stopping cache");
+            }
+         }
+      };
+      worker.start();
+
+      try {
+         // finally commit or rollback the transaction
+         if (commit) {
+            txCoordinator.commit(localTx, false);
+         } else {
+            txCoordinator.rollback(localTx);
+         }
+
+         // make the transaction manager forget about our tx so that we don't get rollback exceptions in the log
+         tm(c1).suspend();
+      } finally {
+         // don't leak threads
+         worker.join();
+      }
+
+      // test that we don't leak locks
+      assertNotLocked(c1, k1);
+      assertNotLocked(c1, k2);
+   }
+}


### PR DESCRIPTION
...doesn't work properly if a target node died
https://issues.jboss.org/browse/ISPN-1931

Also `t_1931_51` for the 5.1.x branch.

The JGroups SuspectedException was treated like any other exception, and it wasn't mapped to the Infinispan SuspectException.
