### PR TITLE
ISPN-1936 - FileCacheStore does not seem to close open files on Windows

### DIFF
--- a/core/src/main/java/org/infinispan/loaders/LockSupportCacheStore.java
+++ b/core/src/main/java/org/infinispan/loaders/LockSupportCacheStore.java
@@ -100,6 +100,20 @@ public abstract class LockSupportCacheStore<L> extends AbstractCacheStore {
    }
 
    /**
+    * Upgrades a read lock to a write lock.
+    */
+   protected final void upgradeLock(L key) {
+      locks.upgradeLock(key);
+   }
+
+   /**
+    * Downgrade a write lock to a read lock
+    */
+   protected final void downgradeLock(L key) {
+      locks.downgradeLock(key);
+   }
+
+   /**
     * Same as {@link #lockForWriting(Object)}, but with 0 timeout.
     */
    protected final boolean immediateLockForWriting(L key) {

--- a/core/src/main/java/org/infinispan/loaders/bucket/BucketBasedCacheStore.java
+++ b/core/src/main/java/org/infinispan/loaders/bucket/BucketBasedCacheStore.java
@@ -156,7 +156,12 @@ public abstract class BucketBasedCacheStore extends LockSupportCacheStore<Intege
       public boolean handle(Bucket bucket) throws CacheLoaderException {
          if (bucket != null) {
             if (bucket.removeExpiredEntries()) {
-               updateBucket(bucket);
+               upgradeLock(bucket.getBucketId());
+               try {
+                  updateBucket(bucket);
+               } finally {
+                  downgradeLock(bucket.getBucketId());
+               }
             }
             boolean enoughLooping = consider(bucket.getStoredEntries());
             if (enoughLooping) {

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/StripedLock.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/StripedLock.java
@@ -50,6 +50,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public class StripedLock {
 
    private static final Log log = LogFactory.getLog(StripedLock.class);
+   private static final boolean trace = log.isTraceEnabled();
 
    private static final int DEFAULT_CONCURRENCY = 20;
    private final int lockSegmentMask;
@@ -95,14 +96,10 @@ public class StripedLock {
       ReentrantReadWriteLock lock = getLock(key);
       if (exclusive) {
          lock.writeLock().lock();
-         if (log.isTraceEnabled()) {
-            log.tracef("WL acquired for '%s'", key);
-        }
+         if (trace) log.tracef("WL acquired for '%s'", key);
       } else {
          lock.readLock().lock();
-         if (log.isTraceEnabled()) {
-            log.tracef("RL acquired for '%s'", key);
-        }
+         if (trace) log.tracef("RL acquired for '%s'", key);
       }
    }
 
@@ -110,9 +107,13 @@ public class StripedLock {
       ReentrantReadWriteLock lock = getLock(key);
       try {
          if (exclusive) {
-            return lock.writeLock().tryLock(millis, TimeUnit.MILLISECONDS);
+            boolean success = lock.writeLock().tryLock(millis, TimeUnit.MILLISECONDS);
+            if (success && trace) log.tracef("WL acquired for '%s'", key);
+            return success;
          } else {
-            return lock.readLock().tryLock(millis, TimeUnit.MILLISECONDS);
+            boolean success = lock.readLock().tryLock(millis, TimeUnit.MILLISECONDS);
+            if (success && trace) log.tracef("RL acquired for '%s'", key);
+            return success;
          }
       } catch (InterruptedException e) {
          log.interruptedAcquiringLock(millis, e);
@@ -127,11 +128,26 @@ public class StripedLock {
       ReentrantReadWriteLock lock = getLock(key);
       if (lock.isWriteLockedByCurrentThread()) {
          lock.writeLock().unlock();
-         log.tracef("WL released for '%s'", key);
+         if (trace) log.tracef("WL released for '%s'", key);
       } else {
          lock.readLock().unlock();
-         log.tracef("RL released for '%s'", key);
+         if (trace) log.tracef("WL released for '%s'", key);
       }
+   }
+
+   public void upgradeLock(Object key) {
+      ReentrantReadWriteLock lock = getLock(key);
+      lock.readLock().unlock();
+      // another thread could come here and take the RL or WL, forcing us to wait
+      lock.writeLock().lock();
+      if (trace) log.tracef("RL upgraded to WL for '%s'", key);
+   }
+
+   public void downgradeLock(Object key) {
+      ReentrantReadWriteLock lock = getLock(key);
+      lock.readLock().lock();
+      lock.writeLock().unlock();
+      if (trace) log.tracef("WL downgraded to RL for '%s'", key);
    }
 
    final ReentrantReadWriteLock getLock(Object o) {
@@ -201,15 +217,11 @@ public class StripedLock {
          try {
             success = toAcquire.tryLock(timeout, TimeUnit.MILLISECONDS);
             if (!success) {
-               if (log.isTraceEnabled()) {
-                log.tracef("Could not aquire lock on %s. Exclusive? %b", toAcquire, exclusive);
-            }
+               if (trace) log.tracef("Could not aquire lock on %s. Exclusive? %b", toAcquire, exclusive);
                break;
             }
          } catch (InterruptedException e) {
-            if (log.isTraceEnabled()) {
-                log.trace("Cought InterruptedException while trying to aquire global lock", e);
-            }
+            if (trace) log.trace("Cought InterruptedException while trying to aquire global lock", e);
             success = false;
             Thread.currentThread().interrupt(); // Restore interrupted status
          } finally {


### PR DESCRIPTION
Writing an empty bucket deleted the file but it didn't close the channel first.
https://issues.jboss.org/browse/ISPN-1936

There's also `t_1936_51` for the 5.1.x branch.

The EOFExceptions were caused by the purge operations removing expired entries
and updating the bucket on disk, while holding the bucket lock only in shared mode.
