### PR TITLE
add support for dumping all the threads in the system in the case of OOM

### DIFF
--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -46,6 +46,7 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.infinispan.test.fwk.JGroupsConfigBuilder.getJGroupsConfig;
@@ -64,6 +65,9 @@ public class TestCacheManagerFactory {
 
    public static final String MARSHALLER = LegacyKeySupportSystemProperties.getProperty("infinispan.test.marshaller.class", "infinispan.marshaller.class");
    private static final Log log = LogFactory.getLog(TestCacheManagerFactory.class);
+   
+   private static volatile boolean shuttingDown;
+   private static CountDownLatch shutDownLatch = new CountDownLatch(1);
 
    private static ThreadLocal<PerThreadCacheManagers> perThreadCacheManagers = new ThreadLocal<PerThreadCacheManagers>() {
       @Override
@@ -234,7 +238,7 @@ public class TestCacheManagerFactory {
 
    /**
     * Creates a cache manager that won't try to modify the configured jmx domain name: {@link
-    * org.infinispan.config.GlobalConfiguration#getJmxDomain()}}. This method must be used with care, and one should
+    * org.infinispan.config.GlobalConfiguration#getJmxDomain()}. This method must be used with care, and one should
     * make sure that no domain name collision happens when the parallel suite executes. An approach to ensure this, is
     * to set the domain name to the name of the test class that instantiates the CacheManager.
     */
@@ -485,6 +489,13 @@ public class TestCacheManagerFactory {
    }
 
    private static DefaultCacheManager addThreadCacheManager(DefaultCacheManager cm) {
+      if (shuttingDown) {
+         try {
+            shutDownLatch.await();
+         } catch (InterruptedException e) {
+            throw new IllegalStateException(e);
+         }
+      }
       PerThreadCacheManagers threadCacheManagers = perThreadCacheManagers.get();
       String methodName = extractMethodName();
       log.trace("Adding DCM (" + cm.getAddress() + ") for method: '" + methodName + "'");
@@ -529,6 +540,12 @@ public class TestCacheManagerFactory {
                      "!!!!!! (" + thName + ") The still-running cacheManager was created here: " + cmEntry.getValue() + " !!!!!!!\n" +
                      "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
                log.error(errorMessage);
+               shuttingDown = true;//just reduce noise..
+               try {
+                  Thread.sleep(60000); //wait for the thread dump to be logged in case of OOM
+               } catch (InterruptedException e) {
+                  e.printStackTrace();
+               }
                System.err.println(errorMessage);
                System.exit(9);
             }


### PR DESCRIPTION
this basically dumps all the threads in the system when an OOM takes place. Useful to investigate test suite's thread leak. 
