### PR TITLE
ISPN-1953 - Ensure that test methods in different test classes use diffe...

### DIFF
--- a/bin/failedTestLogs.sh
+++ b/bin/failedTestLogs.sh
@@ -21,7 +21,8 @@ if [ -z $FAILED_TESTS ] ; then
 fi
 
 for TEST in $FAILED_TESTS ; do
-  SHORTNAME=`perl -e '$t = $ARGV[0]; chomp $t; $t =~ s/[a-z0-9]//g; print lc $t;' $TEST`
-  echo "$TEST > $SHORTNAME.log"
-  $CAT $FILE | $DIR/greplog.py $TEST > $SHORTNAME.log
+  SHORTNAME=`perl -e '$t = $ARGV[0]; chomp $t; $t =~ s/[a-z0-9]//g; print $t;' $TEST`
+  LOWSHORTNAME=`perl -e '$t = $ARGV[0]; chomp $t; $t =~ s/[a-z0-9]//g; print lc $t;' $TEST`
+  echo "$TEST > $LOWSHORTNAME.log"
+  $CAT $FILE | $DIR/greplog.py "\b$TEST\b" | sed "s/\b$TEST\b/$SHORTNAME/g" > $LOWSHORTNAME.log
 done

--- a/core/src/test/java/org/infinispan/distribution/ConcurrentStartWithReplTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ConcurrentStartWithReplTest.java
@@ -31,6 +31,7 @@ import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.UnitTestTestNGListener;
 import org.infinispan.util.concurrent.AbstractInProcessFuture;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -63,6 +64,7 @@ public class ConcurrentStartWithReplTest extends AbstractInfinispanTest {
 
    @Test(timeOut = 60000)
    public void testSequence1() throws ExecutionException, InterruptedException {
+      TestCacheManagerFactory.backgroundTestStarted(this);
       /*
 
       Sequence 1:
@@ -100,6 +102,7 @@ public class ConcurrentStartWithReplTest extends AbstractInfinispanTest {
 
    @Test(timeOut = 60000)
    public void testSequence3() throws ExecutionException, InterruptedException {
+      TestCacheManagerFactory.backgroundTestStarted(this);
       /*
 
       Sequence 3:
@@ -117,6 +120,7 @@ public class ConcurrentStartWithReplTest extends AbstractInfinispanTest {
 
    @Test(timeOut = 60000)
    public void testSequence4() throws ExecutionException, InterruptedException {
+      TestCacheManagerFactory.backgroundTestStarted(this);
       /*
 
       Sequence 4:

--- a/core/src/test/java/org/infinispan/distribution/UnknownCacheStartTest.java
+++ b/core/src/test/java/org/infinispan/distribution/UnknownCacheStartTest.java
@@ -28,6 +28,7 @@ import org.infinispan.config.Configuration;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.TestException;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -55,6 +56,7 @@ public class UnknownCacheStartTest extends AbstractInfinispanTest {
 
    @Test (expectedExceptions = {CacheException.class, TestException.class}, timeOut = 60000, enabled = false)
    public void testStartingUnknownCaches() throws Throwable {
+      TestCacheManagerFactory.backgroundTestStarted(this);
       try {
          cm1 = createCacheManager(configuration);
 

--- a/core/src/test/java/org/infinispan/loaders/ClusterCacheLoaderTest.java
+++ b/core/src/test/java/org/infinispan/loaders/ClusterCacheLoaderTest.java
@@ -62,9 +62,7 @@ public class ClusterCacheLoaderTest extends MultipleCacheManagersTest {
 
       cacheManager1.defineConfiguration("clusteredCl", config1);
       cacheManager2.defineConfiguration("clusteredCl", config2);
-      Cache cache1 = cache(0, "clusteredCl");
-      Cache cache2 = cache(1, "clusteredCl");
-      
+      waitForClusterToForm("clusteredCl");
    }
 
    public void testRemoteLoad() {

--- a/core/src/test/java/org/infinispan/loaders/FlushingAsyncStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/FlushingAsyncStoreTest.java
@@ -60,6 +60,7 @@ public class FlushingAsyncStoreTest extends SingleCacheManagerTest {
 
    @Test(timeOut = 10000)
    public void writeOnStorage() {
+      TestCacheManagerFactory.backgroundTestStarted(this);
       cache = cacheManager.getCache("AsyncStoreInMemory");
       cache.put("key1", "value");
       cache.stop();

--- a/core/src/test/java/org/infinispan/loaders/decorators/AsyncTest.java
+++ b/core/src/test/java/org/infinispan/loaders/decorators/AsyncTest.java
@@ -24,6 +24,7 @@ package org.infinispan.loaders.decorators;
 
 import org.infinispan.CacheException;
 import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.loaders.CacheStore;
@@ -85,6 +86,7 @@ public class AsyncTest extends AbstractInfinispanTest {
 
    @Test(timeOut=10000)
    public void testPutRemove() throws Exception {
+      TestCacheManagerFactory.backgroundTestStarted(this);
       final int number = 1000;
       String key = "testPutRemove-k-";
       String value = "testPutRemove-v-";
@@ -94,6 +96,7 @@ public class AsyncTest extends AbstractInfinispanTest {
 
    @Test(timeOut=10000)
    public void testPutClearPut() throws Exception {
+      TestCacheManagerFactory.backgroundTestStarted(this);
       final int number = 1000;
       String key = "testPutClearPut-k-";
       String value = "testPutClearPut-v-";
@@ -106,6 +109,7 @@ public class AsyncTest extends AbstractInfinispanTest {
 
    @Test(timeOut=10000)
    public void testMultiplePutsOnSameKey() throws Exception {
+      TestCacheManagerFactory.backgroundTestStarted(this);
       final int number = 1000;
       String key = "testMultiplePutsOnSameKey-k";
       String value = "testMultiplePutsOnSameKey-v-";
@@ -115,6 +119,7 @@ public class AsyncTest extends AbstractInfinispanTest {
 
    @Test(timeOut=10000)
    public void testRestrictionOnAddingToAsyncQueue() throws Exception {
+      TestCacheManagerFactory.backgroundTestStarted(this);
       store.remove("blah");
 
       final int number = 10;

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferFunctionalTest.java
@@ -33,6 +33,7 @@ import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.TransportFlags;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -261,6 +262,7 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
 
    @Test (timeOut = 120000)
    public void testSTWithWritingNonTxThread(Method m) throws Exception {
+      TestCacheManagerFactory.backgroundTestStarted(this);
       testCount++;
       logTestStart(m);
       writingThreadTest(false);
@@ -269,6 +271,7 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
 
    @Test (timeOut = 120000)
    public void testSTWithWritingTxThread(Method m) throws Exception {
+      TestCacheManagerFactory.backgroundTestStarted(this);
       testCount++;
       logTestStart(m);
       writingThreadTest(true);

--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -40,6 +40,7 @@ import org.infinispan.util.LegacyKeySupportSystemProperties;
 import org.infinispan.util.Util;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.testng.internal.annotations.TestAnnotation;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -377,22 +378,7 @@ public class TestCacheManagerFactory {
 
          String fullTestName = perThreadCacheManagers.get().fullTestName;
          String nextCacheName = perThreadCacheManagers.get().getNextCacheName();
-         if (fullTestName == null) {
-            // Either we're running from within the IDE or it's a
-            // @Test(timeOut=nnn) test. We rely here on some specific TestNG
-            // thread naming convention which can break, but TestNG offers no
-            // other alternative. It does not offer any callbacks within the
-            // thread that runs the test that can timeout.
-            String threadName = Thread.currentThread().getName();
-            String pattern = "TestNGInvoker-";
-            if (threadName.startsWith(pattern)) {
-               // This is a timeout test, so for the moment rely on the test
-               // method name that comes in the thread name.
-               fullTestName = threadName;
-               nextCacheName = threadName.substring(
-                     threadName.indexOf("-") + 1, threadName.indexOf('('));
-            } // else, test is being run from IDE
-         }
+         checkTestName(fullTestName);
 
          newTransportProps.put(JGroupsTransport.CONFIGURATION_STRING,
                getJGroupsConfig(fullTestName, flags));
@@ -407,27 +393,28 @@ public class TestCacheManagerFactory {
       if (gc.transport().transport() != null) { //this is local
          String fullTestName = perThreadCacheManagers.get().fullTestName;
          String nextCacheName = perThreadCacheManagers.get().getNextCacheName();
-         if (fullTestName == null) {
-            // Either we're running from within the IDE or it's a
-            // @Test(timeOut=nnn) test. We rely here on some specific TestNG
-            // thread naming convention which can break, but TestNG offers no
-            // other alternative. It does not offer any callbacks within the
-            // thread that runs the test that can timeout.
-            String threadName = Thread.currentThread().getName();
-            String pattern = "TestNGInvoker-";
-            if (threadName.startsWith(pattern)) {
-               // This is a timeout test, so for the moment rely on the test
-               // method name that comes in the thread name.
-               fullTestName = threadName;
-               nextCacheName = threadName.substring(
-                     threadName.indexOf("-") + 1, threadName.indexOf('('));
-            } // else, test is being run from IDE
-         }
+         checkTestName(fullTestName);
 
          builder
                .transport()
                .addProperty(JGroupsTransport.CONFIGURATION_STRING, getJGroupsConfig(fullTestName, flags))
                .nodeName(nextCacheName);
+      }
+   }
+
+   private static void checkTestName(String fullTestName) {
+      if (fullTestName == null) {
+         // Either we're running from within the IDE or it's a
+         // @Test(timeOut=nnn) test. We rely here on some specific TestNG
+         // thread naming convention which can break, but TestNG offers no
+         // other alternative. It does not offer any callbacks within the
+         // thread that runs the test that can timeout.
+         String threadName = Thread.currentThread().getName();
+         String pattern = "TestNGInvoker-";
+         if (threadName.startsWith(pattern)) {
+            // This is a timeout test, so force the user to call our marking method
+            throw new RuntimeException("Test name is not set! Please call TestCacheManagerFactory.backgroundTestStarted(this) in your test method!");
+         } // else, test is being run from IDE
       }
    }
 
@@ -502,6 +489,13 @@ public class TestCacheManagerFactory {
             return e.toString();
       }
       return null;
+   }
+
+   public static void backgroundTestStarted(Object testInstance) {
+      String fullName = testInstance.getClass().getName();
+      String testName = testInstance.getClass().getSimpleName();
+
+      TestCacheManagerFactory.testStarted(testName, fullName);
    }
 
    static void testStarted(String testName, String fullName) {

--- a/core/src/test/java/org/infinispan/test/fwk/UnitTestTestNGListener.java
+++ b/core/src/test/java/org/infinispan/test/fwk/UnitTestTestNGListener.java
@@ -30,6 +30,8 @@ import org.testng.IInvokedMethodListener;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
+import org.testng.annotations.Test;
+import org.testng.internal.annotations.TestAnnotation;
 
 import java.util.concurrent.atomic.AtomicInteger;
 


### PR DESCRIPTION
...rent cluster addresses
https://issues.jboss.org/browse/ISPN-1953

Also `t_1953_51` for the 5.1.x branch.

Will throw an IllegalStateException if messages with a @Test(timeout = x) annotation don't call TestCacheManagerFactory.backgroundTestStarted(this) at the beginning.
