### PR TITLE
ISPN-1934 - Joiners fail to start if the coordinator leaves before responding to the join request

### DIFF
--- a/core/src/test/java/org/infinispan/test/fwk/UnitTestTestNGListener.java
+++ b/core/src/test/java/org/infinispan/test/fwk/UnitTestTestNGListener.java
@@ -120,8 +120,6 @@ public class UnitTestTestNGListener implements ITestListener, IInvokedMethodList
 
    @Override
    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
-      if (!method.isTestMethod())
-         return;
       if (testResult.getThrowable() != null)
          log.errorf(testResult.getThrowable(), "Method %s threw an exception", getTestDesc(testResult));
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1934

There's also `t_1934_51` for the 5.1.x branch.

This is caused by the way JGroups immediately throws SuspectExceptions for unicast requests like our join request.
We work around it by forcing commands through the anycast branch when the response mode is SYNCHRONOUS_IGNORE_LEAVERS.
