### PR TITLE
ISPN-1799 - We should avoid using exceptions for flow control when acquiring state transfer lock

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/InvocationContextInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/InvocationContextInterceptor.java
@@ -37,6 +37,7 @@ import org.infinispan.factories.annotations.Stop;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.CacheContainer;
+import org.infinispan.statetransfer.StateTransferInProgressException;
 import org.infinispan.transaction.TransactionTable;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -138,7 +139,14 @@ public class InvocationContextInterceptor extends CommandInterceptor {
                      log.trace("Exception while executing code, failing silently...", th);
                   return null;
                } else {
-                  log.executionError(th);
+                  // HACK: There are way too many StateTransferInProgressExceptions on remote nodes during state transfer
+                  // and they not really exceptional (the originator will retry the command)
+                  boolean logAsError = !(th instanceof StateTransferInProgressException && !ctx.isOriginLocal());
+                  if (logAsError) {
+                     log.executionError(th);
+                  } else {
+                     log.trace("Exception while executing code", th);
+                  }
                   if (ctx.isInTxScope() && ctx.isOriginLocal()) {
                      if (trace) log.trace("Transaction marked for rollback as exception was received.");
                      markTxForRollbackAndRethrow(ctx, th);

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -32,9 +32,7 @@ import org.infinispan.loaders.bucket.Bucket;
 import org.infinispan.loaders.decorators.SingletonStore;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.transport.Address;
-import org.infinispan.statetransfer.StateTransferException;
 import org.infinispan.transaction.LocalTransaction;
-import org.infinispan.transaction.RemoteTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryAwareRemoteTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryAwareTransaction;
@@ -51,7 +49,6 @@ import javax.management.MBeanRegistrationException;
 import javax.management.ObjectName;
 import javax.naming.NamingException;
 import javax.transaction.Synchronization;
-import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAException;
 import java.io.File;
@@ -62,7 +59,6 @@ import java.nio.channels.FileChannel;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 
 import static org.jboss.logging.Logger.Level.*;
@@ -484,10 +480,6 @@ public interface Log extends BasicLogger {
    @LogMessage(level = INFO)
    @Message(value = "Received new cluster view: %s", id = 94)
    void receivedClusterView(View newView);
-
-   @LogMessage(level = ERROR)
-   @Message(value = "Caught while responding to state transfer request", id = 95)
-   void errorGeneratingState(@Cause StateTransferException e);
 
    @LogMessage(level = ERROR)
    @Message(value = "Caught while requesting or applying state", id = 96)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1799

Also `t_1799_51` for the 5.1.x branch.

I've implemented a workaround for now, we're still throwing StateTransferInProgressException
on the remote node but we're no longer logging it as an error.
