### PR TITLE
Ispn 1997

### DIFF
--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/TableManipulationTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/TableManipulationTest.java
@@ -22,13 +22,8 @@
  */
 package org.infinispan.loaders.jdbc;
 
-import static org.mockito.Mockito.*;
-import org.infinispan.loaders.CacheLoaderException;
-import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactoryConfig;
-import org.infinispan.test.fwk.UnitTestDatabaseManager;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -36,6 +31,13 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+
+import org.infinispan.loaders.CacheLoaderException;
+import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactoryConfig;
+import org.infinispan.test.fwk.UnitTestDatabaseManager;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 /**
  * Tester class for {@link org.infinispan.loaders.jdbc.TableManipulation}.
@@ -52,7 +54,7 @@ public class TableManipulationTest {
    public void createConnection() throws Exception {
       cfg = UnitTestDatabaseManager.getUniqueConnectionFactoryConfig();
       connection = DriverManager.getConnection(cfg.getConnectionUrl(), cfg.getUserName(), cfg.getPassword());
-      tableManipulation = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      tableManipulation = UnitTestDatabaseManager.buildStringTableManipulation();
       tableManipulation.setCacheName("aName");
    }
 

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/binary/BinaryStoreWithManagedConnectionTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/binary/BinaryStoreWithManagedConnectionTest.java
@@ -42,11 +42,12 @@ import org.testng.annotations.Test;
  */
 @Test (groups = "functional", testName = "loaders.jdbc.binary.BinaryStoreWithManagedConnectionTest")
 public class BinaryStoreWithManagedConnectionTest extends ManagedConnectionFactoryTest {
+   @Override
    protected CacheStore createCacheStore() throws Exception {
       ConnectionFactoryConfig connectionFactoryConfig = new ConnectionFactoryConfig();
       connectionFactoryConfig.setConnectionFactoryClass(ManagedConnectionFactory.class.getName());
       connectionFactoryConfig.setDatasourceJndiLocation(getDatasourceLocation());
-      TableManipulation tm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      TableManipulation tm = UnitTestDatabaseManager.buildBinaryTableManipulation();
       JdbcBinaryCacheStoreConfig config = new JdbcBinaryCacheStoreConfig(connectionFactoryConfig, tm);
       JdbcBinaryCacheStore jdbcBinaryCacheStore = new JdbcBinaryCacheStore();
       jdbcBinaryCacheStore.init(config, new CacheImpl("aName"), getMarshaller());

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/binary/JdbcBinaryCacheStoreFunctionalTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/binary/JdbcBinaryCacheStoreFunctionalTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 
 /**
  * JdbcBinaryCacheStoreFunctionalTest.
- * 
+ *
  * @author Galder Zamarreño
  * @since 4.0
  */
@@ -41,7 +41,7 @@ public class JdbcBinaryCacheStoreFunctionalTest extends BaseCacheStoreFunctional
    @Override
    protected CacheStoreConfig createCacheStoreConfig() throws Exception {
       ConnectionFactoryConfig connectionFactoryConfig = UnitTestDatabaseManager.getUniqueConnectionFactoryConfig();
-      TableManipulation tm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      TableManipulation tm = UnitTestDatabaseManager.buildBinaryTableManipulation();
       JdbcBinaryCacheStoreConfig config = new JdbcBinaryCacheStoreConfig(connectionFactoryConfig, tm);
       return config;
 //      JdbcBinaryCacheStore jdbcBucketCacheStore = new JdbcBinaryCacheStore();

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/binary/JdbcBinaryCacheStoreTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/binary/JdbcBinaryCacheStoreTest.java
@@ -22,10 +22,11 @@
  */
 package org.infinispan.loaders.jdbc.binary;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+
+import java.io.Serializable;
 
 import org.infinispan.CacheImpl;
-import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.loaders.BaseCacheStoreTest;
 import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.loaders.CacheStore;
@@ -34,10 +35,9 @@ import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactory;
 import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactoryConfig;
 import org.infinispan.marshall.TestObjectStreamMarshaller;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.test.fwk.UnitTestDatabaseManager;
 import org.testng.annotations.Test;
-
-import java.io.Serializable;
 
 /**
  * Tester class for {@link JdbcBinaryCacheStore}
@@ -50,7 +50,7 @@ public class JdbcBinaryCacheStoreTest extends BaseCacheStoreTest {
    @Override
    protected CacheStore createCacheStore() throws Exception {
       ConnectionFactoryConfig connectionFactoryConfig = UnitTestDatabaseManager.getUniqueConnectionFactoryConfig();
-      TableManipulation tm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      TableManipulation tm = UnitTestDatabaseManager.buildBinaryTableManipulation();
       JdbcBinaryCacheStoreConfig config = new JdbcBinaryCacheStoreConfig(connectionFactoryConfig, tm);
       JdbcBinaryCacheStore jdbcBucketCacheStore = new JdbcBinaryCacheStore();
       jdbcBucketCacheStore.init(config, new CacheImpl("aName"), getMarshaller());

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreFunctionalTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreFunctionalTest.java
@@ -35,9 +35,9 @@ public class JdbcMixedCacheStoreFunctionalTest extends BaseCacheStoreFunctionalT
    @Override
    protected CacheStoreConfig createCacheStoreConfig() throws Exception {
       JdbcMixedCacheStoreConfig jdbcCacheStoreConfig = new JdbcMixedCacheStoreConfig();
-      TableManipulation stringsTm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      TableManipulation stringsTm = UnitTestDatabaseManager.buildStringTableManipulation();
       stringsTm.setTableNamePrefix("STRINGS_TABLE");
-      TableManipulation binaryTm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      TableManipulation binaryTm = UnitTestDatabaseManager.buildBinaryTableManipulation();
       binaryTm.setTableNamePrefix("BINARY_TABLE");
       ConnectionFactoryConfig cfc = UnitTestDatabaseManager.getUniqueConnectionFactoryConfig();
       jdbcCacheStoreConfig.setConnectionFactoryConfig(cfc);

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreTest.java
@@ -22,9 +22,14 @@
  */
 package org.infinispan.loaders.jdbc.mixed;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Set;
+
 import org.infinispan.CacheImpl;
 import org.infinispan.container.entries.InternalCacheEntry;
-import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.io.UnclosableObjectInputStream;
 import org.infinispan.io.UnclosableObjectOutputStream;
 import org.infinispan.loaders.CacheLoaderException;
@@ -36,16 +41,11 @@ import org.infinispan.loaders.jdbc.stringbased.Person;
 import org.infinispan.loaders.keymappers.DefaultTwoWayKey2StringMapper;
 import org.infinispan.marshall.StreamingMarshaller;
 import org.infinispan.marshall.TestObjectStreamMarshaller;
+import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.test.fwk.UnitTestDatabaseManager;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.Set;
 
 /**
  * Tester class for {@link JdbcMixedCacheStore}
@@ -65,9 +65,9 @@ public class JdbcMixedCacheStoreTest {
 
    @BeforeMethod
    public void createCacheStore() throws CacheLoaderException {
-      stringsTm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      stringsTm = UnitTestDatabaseManager.buildStringTableManipulation();
       stringsTm.setTableNamePrefix("STRINGS_TABLE");
-      binaryTm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      binaryTm = UnitTestDatabaseManager.buildBinaryTableManipulation();
       binaryTm.setTableNamePrefix("BINARY_TABLE");
       cfc = UnitTestDatabaseManager.getUniqueConnectionFactoryConfig();
       JdbcMixedCacheStoreConfig cacheStoreConfig = new JdbcMixedCacheStoreConfig(cfc, binaryTm, stringsTm);

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreTest2.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreTest2.java
@@ -22,7 +22,9 @@
  */
 package org.infinispan.loaders.jdbc.mixed;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.infinispan.Cache;
 import org.infinispan.loaders.BaseCacheStoreTest;
 import org.infinispan.loaders.CacheStore;
@@ -36,9 +38,9 @@ public class JdbcMixedCacheStoreTest2 extends BaseCacheStoreTest {
    @Override
    protected CacheStore createCacheStore() throws Exception {
       JdbcMixedCacheStoreConfig jdbcCacheStoreConfig = new JdbcMixedCacheStoreConfig();
-      TableManipulation stringsTm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      TableManipulation stringsTm = UnitTestDatabaseManager.buildStringTableManipulation();
       stringsTm.setTableNamePrefix("STRINGS_TABLE");
-      TableManipulation binaryTm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      TableManipulation binaryTm = UnitTestDatabaseManager.buildBinaryTableManipulation();
       binaryTm.setTableNamePrefix("BINARY_TABLE");
 
       ConnectionFactoryConfig cfc = UnitTestDatabaseManager.getUniqueConnectionFactoryConfig();

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/MixedStoreWithManagedConnectionTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/MixedStoreWithManagedConnectionTest.java
@@ -43,13 +43,14 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "loaders.jdbc.mixed.MixedStoreWithManagedConnectionTest")
 public class MixedStoreWithManagedConnectionTest extends ManagedConnectionFactoryTest {
 
+   @Override
    protected CacheStore createCacheStore() throws Exception {
       ConnectionFactoryConfig connectionFactoryConfig = new ConnectionFactoryConfig();
       connectionFactoryConfig.setConnectionFactoryClass(ManagedConnectionFactory.class.getName());
       connectionFactoryConfig.setDatasourceJndiLocation(getDatasourceLocation());
-      TableManipulation stringsTm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      TableManipulation stringsTm = UnitTestDatabaseManager.buildStringTableManipulation();
       stringsTm.setTableNamePrefix("STRINGS_TABLE");
-      TableManipulation binaryTm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      TableManipulation binaryTm = UnitTestDatabaseManager.buildBinaryTableManipulation();
       binaryTm.setTableNamePrefix("BINARY_TABLE");
       JdbcMixedCacheStoreConfig cacheStoreConfig = new JdbcMixedCacheStoreConfig(connectionFactoryConfig, binaryTm, stringsTm);
       JdbcMixedCacheStore store = new JdbcMixedCacheStore();

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreFunctionalTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreFunctionalTest.java
@@ -22,18 +22,14 @@
  */
 package org.infinispan.loaders.jdbc.stringbased;
 
-import org.infinispan.Cache;
+import java.lang.reflect.Method;
+
 import org.infinispan.loaders.BaseCacheStoreFunctionalTest;
 import org.infinispan.loaders.CacheStoreConfig;
 import org.infinispan.loaders.jdbc.TableManipulation;
 import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactoryConfig;
-import org.infinispan.manager.CacheContainer;
-import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.UnitTestDatabaseManager;
-import org.infinispan.util.ByteArrayKey;
 import org.testng.annotations.Test;
-
-import java.lang.reflect.Method;
 
 @Test(groups = "functional", testName = "loaders.jdbc.stringbased.JdbcStringBasedCacheStoreFunctionalTest")
 public class JdbcStringBasedCacheStoreFunctionalTest extends BaseCacheStoreFunctionalTest {
@@ -41,11 +37,12 @@ public class JdbcStringBasedCacheStoreFunctionalTest extends BaseCacheStoreFunct
    @Override
    protected CacheStoreConfig createCacheStoreConfig() throws Exception {
       ConnectionFactoryConfig connectionFactoryConfig = UnitTestDatabaseManager.getUniqueConnectionFactoryConfig();
-      TableManipulation tm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      TableManipulation tm = UnitTestDatabaseManager.buildStringTableManipulation();
       JdbcStringBasedCacheStoreConfig config = new JdbcStringBasedCacheStoreConfig(connectionFactoryConfig, tm);
       return config;
    }
 
+   @Override
    @Test(enabled = false, description = "JdbcStringBasedCacheStore does not support ByteArrayKey yet")
    public void testByteArrayKey(Method m) {
    }

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreTest.java
@@ -22,7 +22,10 @@
  */
 package org.infinispan.loaders.jdbc.stringbased;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+
+import org.infinispan.CacheImpl;
 import org.infinispan.loaders.BaseCacheStoreTest;
 import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.loaders.CacheStore;
@@ -31,7 +34,6 @@ import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactory;
 import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactoryConfig;
 import org.infinispan.loaders.keymappers.UnsupportedKeyTypeException;
 import org.infinispan.test.fwk.UnitTestDatabaseManager;
-import org.infinispan.CacheImpl;
 import org.testng.annotations.Test;
 
 /**
@@ -45,7 +47,7 @@ public class JdbcStringBasedCacheStoreTest extends BaseCacheStoreTest {
    @Override
    protected CacheStore createCacheStore() throws Exception {
       ConnectionFactoryConfig connectionFactoryConfig = UnitTestDatabaseManager.getUniqueConnectionFactoryConfig();
-      TableManipulation tm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      TableManipulation tm = UnitTestDatabaseManager.buildStringTableManipulation();
       JdbcStringBasedCacheStoreConfig config = new JdbcStringBasedCacheStoreConfig(connectionFactoryConfig, tm);
       JdbcStringBasedCacheStore stringBasedCacheStore = new JdbcStringBasedCacheStore();
       CacheImpl cache = new CacheImpl("aName");

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreTest2.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreTest2.java
@@ -22,10 +22,15 @@
  */
 package org.infinispan.loaders.jdbc.stringbased;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.infinispan.Cache;
 import org.infinispan.container.entries.InternalCacheEntry;
-import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.loaders.CacheStore;
 import org.infinispan.loaders.jdbc.TableManipulation;
@@ -35,15 +40,12 @@ import org.infinispan.loaders.keymappers.TwoWayKey2StringMapper;
 import org.infinispan.loaders.keymappers.UnsupportedKeyTypeException;
 import org.infinispan.marshall.StreamingMarshaller;
 import org.infinispan.marshall.TestObjectStreamMarshaller;
+import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.test.fwk.UnitTestDatabaseManager;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Tester for {@link JdbcStringBasedCacheStore} with an alternative {@link org.infinispan.loaders.keymappers.Key2StringMapper}.
@@ -61,7 +63,7 @@ public class JdbcStringBasedCacheStoreTest2 {
 
    @BeforeTest
    public void createCacheStore() throws CacheLoaderException {
-      tableManipulation = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      tableManipulation = UnitTestDatabaseManager.buildStringTableManipulation();
       cfc = UnitTestDatabaseManager.getUniqueConnectionFactoryConfig();
       JdbcStringBasedCacheStoreConfig config = new JdbcStringBasedCacheStoreConfig(cfc, tableManipulation);
       config.setKey2StringMapperClass(TwoWayKey2StringMapper.class.getName());

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/NonStringKeyPreloadTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/NonStringKeyPreloadTest.java
@@ -22,6 +22,10 @@
  */
 package org.infinispan.loaders.jdbc.stringbased;
 
+import static junit.framework.Assert.assertEquals;
+
+import java.sql.Connection;
+
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.CacheException;
@@ -39,10 +43,6 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.UnitTestDatabaseManager;
 import org.testng.annotations.Test;
-
-import java.sql.Connection;
-
-import static junit.framework.Assert.assertEquals;
 
 /**
  * Tester for https://jira.jboss.org/browse/ISPN-579.
@@ -128,7 +128,7 @@ public class NonStringKeyPreloadTest extends AbstractInfinispanTest {
       if (wrap) {
          connectionFactoryConfig.setConnectionFactoryClass(SharedConnectionFactory.class.getName());
       }
-      TableManipulation tm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      TableManipulation tm = UnitTestDatabaseManager.buildStringTableManipulation();
       JdbcStringBasedCacheStoreConfig csConfig = new JdbcStringBasedCacheStoreConfig(connectionFactoryConfig, tm);
       csConfig.setFetchPersistentState(true);
       csConfig.setKey2StringMapperClass(mapperName);

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/StringStoreWithManagedConnectionTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/StringStoreWithManagedConnectionTest.java
@@ -45,11 +45,12 @@ import org.testng.annotations.Test;
 @Test (groups = "functional", testName = "loaders.jdbc.stringbased.StringStoreWithManagedConnectionTest")
 public class StringStoreWithManagedConnectionTest extends ManagedConnectionFactoryTest {
 
+   @Override
    protected CacheStore createCacheStore() throws Exception {
       ConnectionFactoryConfig connectionFactoryConfig = new ConnectionFactoryConfig();
       connectionFactoryConfig.setConnectionFactoryClass(ManagedConnectionFactory.class.getName());
       connectionFactoryConfig.setDatasourceJndiLocation(getDatasourceLocation());
-      TableManipulation tm = UnitTestDatabaseManager.buildDefaultTableManipulation();
+      TableManipulation tm = UnitTestDatabaseManager.buildStringTableManipulation();
       JdbcStringBasedCacheStoreConfig config = new JdbcStringBasedCacheStoreConfig(connectionFactoryConfig, tm);
       JdbcStringBasedCacheStore stringBasedCacheStore = new JdbcStringBasedCacheStore();
       stringBasedCacheStore.init(config, new CacheImpl("aName"), getMarshaller());

--- a/cachestore/jdbc/src/test/java/org/infinispan/test/fwk/UnitTestDatabaseManager.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/test/fwk/UnitTestDatabaseManager.java
@@ -22,15 +22,6 @@
  */
 package org.infinispan.test.fwk;
 
-import com.mysql.jdbc.Driver;
-import org.infinispan.loaders.jdbc.DatabaseType;
-import org.infinispan.loaders.jdbc.JdbcUtil;
-import org.infinispan.loaders.jdbc.TableManipulation;
-import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactory;
-import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactoryConfig;
-import org.infinispan.loaders.jdbc.connectionfactory.PooledConnectionFactory;
-import org.infinispan.loaders.jdbc.connectionfactory.SimpleConnectionFactory;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -39,6 +30,16 @@ import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.infinispan.loaders.jdbc.DatabaseType;
+import org.infinispan.loaders.jdbc.JdbcUtil;
+import org.infinispan.loaders.jdbc.TableManipulation;
+import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactory;
+import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactoryConfig;
+import org.infinispan.loaders.jdbc.connectionfactory.PooledConnectionFactory;
+import org.infinispan.loaders.jdbc.connectionfactory.SimpleConnectionFactory;
+
+import com.mysql.jdbc.Driver;
 
 /**
  * Class that assures concurrent access to the in memory database.
@@ -151,13 +152,19 @@ public class UnitTestDatabaseManager {
    }
 
 
-   public static TableManipulation buildDefaultTableManipulation() {
+   public static TableManipulation buildStringTableManipulation() {
 
       return new TableManipulation("ID_COLUMN", "VARCHAR(255)", "ISPN_JDBC", "DATA_COLUMN",
               "BLOB", "TIMESTAMP_COLUMN", "BIGINT");
 
    }
 
+   public static TableManipulation buildBinaryTableManipulation() {
+
+      return new TableManipulation("ID_COLUMN", "INT", "ISPN_JDBC", "DATA_COLUMN",
+              "BLOB", "TIMESTAMP_COLUMN", "BIGINT");
+
+   }
 
    /**
     * Counts the number of rows in the given table.

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -126,7 +126,7 @@
       <version.easymockclassext>2.4</version.easymockclassext>
       <version.gnu.getopt>1.0.13</version.gnu.getopt>
       <version.guava>r03</version.guava>
-      <version.h2.driver>1.1.117</version.h2.driver>
+      <version.h2.driver>1.3.166</version.h2.driver>
       <version.hibernate.annotations>3.4.0.GA</version.hibernate.annotations>
       <version.hibernate.core>3.3.1.GA</version.hibernate.core>
       <version.hibernate.search>4.1.0.CR2</version.hibernate.search>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1997
use appropriate type for ID column in binary store tests
upgrade H2 to the latest release (1.3.166) to expose the issue
Applies to 5.1.x, cherry-picks cleanly to master
