### PR TITLE
ISPN-1999 Improve stability of Hot Rod testsuite

### DIFF
--- a/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolServer.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolServer.scala
@@ -129,8 +129,10 @@ abstract class AbstractProtocolServer(threadNamePrefix: String) extends Protocol
 
    def start(propertiesFileName: String, cacheManager: EmbeddedCacheManager) {
       val propsObject = new TypedProperties()
-      val stream = FileLookupFactory.newInstance().lookupFile(propertiesFileName, Thread.currentThread().getContextClassLoader())
-      propsObject.load(stream)
+      if (propertiesFileName != null) {
+         val stream = FileLookupFactory.newInstance().lookupFile(propertiesFileName, Thread.currentThread().getContextClassLoader())
+         propsObject.load(stream)
+      }
       start(propsObject, cacheManager)
    }
 

--- a/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
@@ -35,6 +35,12 @@ import org.infinispan.util.logging.LogFactory
 trait Log {
    private lazy val log: JavaLog = LogFactory.getLog(getClass, classOf[JavaLog])
 
+   def info(msg: => String) = log.info(msg)
+
+   def info(msg: => String, param1: Any) = log.infof(msg, param1)
+
+   def error(msg: => String, t: Throwable) = log.errorf(t, msg)
+
    def debug(msg: => String) = log.debug(msg)
 
    def debug(msg: => String, param1: Any) = log.debugf(msg, param1)

--- a/server/core/src/test/scala/org/infinispan/server/core/AbstractProtocolServerTest.scala
+++ b/server/core/src/test/scala/org/infinispan/server/core/AbstractProtocolServerTest.scala
@@ -29,6 +29,7 @@ import org.infinispan.manager.{DefaultCacheManager, EmbeddedCacheManager}
 import org.testng.Assert._
 import java.lang.reflect.Method
 import org.infinispan.util.TypedProperties
+import test.Stoppable
 
 /**
  * Abstract protocol server test.
@@ -174,7 +175,8 @@ class AbstractProtocolServerTest {
       Stoppable.useServer(createServer) { server =>
          Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
             server.start(p, cm)
-            assertEquals(server.tcpNoDelay, tcpNoDelay.toBoolean)
+            assertEquals(server.asInstanceOf[MockProtocolServer]
+                    .tcpNoDelay, tcpNoDelay.toBoolean)
          }
 
          tcpNoDelay = "${" + m.getName + "-mytcpnodelay:false}"
@@ -182,7 +184,7 @@ class AbstractProtocolServerTest {
          p.setProperty(PROP_KEY_TCP_NO_DELAY, tcpNoDelay);
          Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
             server.start(p, cm)
-            assertEquals(server.tcpNoDelay, false)
+            assertEquals(server.asInstanceOf[MockProtocolServer].tcpNoDelay, false)
          }
 
          tcpNoDelay = "${" + m.getName + "-mytcpnodelay:true}"
@@ -191,7 +193,7 @@ class AbstractProtocolServerTest {
          p.setProperty(PROP_KEY_TCP_NO_DELAY, tcpNoDelay);
          Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
             server.start(p, cm)
-            assertEquals(server.tcpNoDelay, false)
+            assertEquals(server.asInstanceOf[MockProtocolServer].tcpNoDelay, false)
          }
 
          tcpNoDelay = "${" + m.getName + "-othertcpnodelay}"
@@ -200,7 +202,7 @@ class AbstractProtocolServerTest {
          Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
             server.start(p, cm)
             // Boolean.parseBoolean() returning false to anything other than true, no exception thrown
-            assertEquals(server.tcpNoDelay, false)
+            assertEquals(server.asInstanceOf[MockProtocolServer].tcpNoDelay, false)
          }
 
          tcpNoDelay = "${" + m.getName + "-othertcpnodelay}"
@@ -209,7 +211,7 @@ class AbstractProtocolServerTest {
          p.setProperty(PROP_KEY_PORT, tcpNoDelay);
          Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
             server.start(p, cm)
-            assertEquals(server.tcpNoDelay, true)
+            assertEquals(server.asInstanceOf[MockProtocolServer].tcpNoDelay, true)
          }
       }
    }

--- a/server/core/src/test/scala/org/infinispan/server/core/test/ServerTestingUtil.scala
+++ b/server/core/src/test/scala/org/infinispan/server/core/test/ServerTestingUtil.scala
@@ -1,3 +1,5 @@
+package org.infinispan.server.core.test
+
 /*
  * Copyright 2012 Red Hat, Inc. and/or its affiliates.
  *
@@ -17,35 +19,22 @@
  * 02110-1301 USA
  */
 
-package org.infinispan.server.core
-
-import org.infinispan.manager.EmbeddedCacheManager
+import org.infinispan.server.core.logging.Log
+import org.infinispan.server.core.AbstractProtocolServer
 
 /**
- * // TODO: Document this
+ * Infinispan servers testing util
+ *
  * @author Galder Zamarreño
  * @since // TODO
  */
-class Stoppable {
-   // Empty - do not delete!
-}
+object ServerTestingUtil extends Log {
 
-object Stoppable {
-
-   def useCacheManager[T <: EmbeddedCacheManager](stoppable: EmbeddedCacheManager)
-           (block: EmbeddedCacheManager => Unit) {
+   def killServer(server: AbstractProtocolServer) {
       try {
-         block(stoppable)
-      } finally {
-         stoppable.stop()
-      }
-   }
-
-   def useServer[T <: {def stop : Unit}](stoppable: T)(block: T => Unit) {
-      try {
-         block(stoppable)
-      } finally {
-         stoppable.stop
+         if (server != null) server.stop
+      } catch {
+         case t: Throwable => error("Error stopping server", t)
       }
    }
 

--- a/server/core/src/test/scala/org/infinispan/server/core/test/Stoppable.scala
+++ b/server/core/src/test/scala/org/infinispan/server/core/test/Stoppable.scala
@@ -1,0 +1,55 @@
+package org.infinispan.server.core.test
+
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+import org.infinispan.manager.EmbeddedCacheManager
+import org.infinispan.test.TestingUtil
+import org.infinispan.server.core.AbstractProtocolServer
+
+/**
+ * // TODO: Document this
+ * @author Galder Zamarreño
+ * @since // TODO
+ */
+class Stoppable {
+   // Empty - do not delete!
+}
+
+object Stoppable {
+
+   def useCacheManager[T <: EmbeddedCacheManager](stoppable: EmbeddedCacheManager)
+           (block: EmbeddedCacheManager => Unit) {
+      try {
+         block(stoppable)
+      } finally {
+         TestingUtil.killCacheManagers(stoppable)
+      }
+   }
+
+   def useServer[T <: AbstractProtocolServer](stoppable: AbstractProtocolServer)
+           (block: AbstractProtocolServer => Unit) {
+      try {
+         block(stoppable)
+      } finally {
+         ServerTestingUtil.killServer(stoppable)
+      }
+   }
+
+}

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/CrashedMemberDetectorListener.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/CrashedMemberDetectorListener.scala
@@ -58,7 +58,8 @@ class CrashedMemberDetectorListener(cache: Cache[Address, ServerAddress], server
          val goneMembers = oldMembers.filterNot(newMembers contains _)
          if (!goneMembers.isEmpty) {
             // Consider doing removeAsync and then waiting for all removals...
-            goneMembers.foreach(addressCache.remove(_))
+            if (!addressCache.getStatus.isTerminated)
+               goneMembers.foreach(addressCache.remove(_))
             // Only update view id once we've removed all addresses to
             // guarantee that the cache will be up to date
             updateViewdId(e)

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRod11DistributionTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRod11DistributionTest.scala
@@ -40,7 +40,11 @@ class HotRod11DistributionTest extends HotRodMultiNodeTest {
 
    override protected def cacheName = "distributedVersion11"
 
-   override protected def createCacheConfig: Configuration = getDefaultClusteredConfig(CacheMode.DIST_SYNC)
+   override protected def createCacheConfig: Configuration = {
+      val cfg = getDefaultClusteredConfig(CacheMode.DIST_SYNC)
+      cfg.fluent().l1().disable() // Disable L1 explicitly
+      cfg
+   }
 
    override protected def protocolVersion = 11
 

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodConcurrentStartTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodConcurrentStartTest.scala
@@ -30,6 +30,7 @@ import org.infinispan.test.AbstractCacheTest._
 import test.{UniquePortThreadLocal, HotRodClient}
 import scala.concurrent.ops._
 import test.HotRodTestingUtil._
+import org.infinispan.server.core.test.ServerTestingUtil._
 
 /**
  * Tests concurrent Hot Rod server startups
@@ -56,8 +57,8 @@ class HotRodConcurrentStartTest extends MultipleCacheManagersTest {
    override def destroy {
       try {
          log.debug("Test finished, close Hot Rod server")
-         hotRodClients.foreach(_.stop)
-         hotRodServers.foreach(_.stop)
+         hotRodClients.foreach(killClient(_))
+         hotRodServers.foreach(killServer(_))
       } finally {
          super.destroy // Stop the caches last so that at stoppage time topology cache can be updated properly
       }

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDistributionTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDistributionTest.scala
@@ -50,7 +50,11 @@ class HotRodDistributionTest extends HotRodMultiNodeTest {
 
    override protected def cacheName: String = "hotRodDistSync"
 
-   override protected def createCacheConfig: Configuration = getDefaultClusteredConfig(CacheMode.DIST_SYNC)
+   override protected def createCacheConfig: Configuration = {
+      val cfg = getDefaultClusteredConfig(CacheMode.DIST_SYNC)
+      cfg.fluent().l1().disable() // Disable L1 explicitly
+      cfg
+   }
 
    override protected def protocolVersion = 10
 
@@ -107,7 +111,7 @@ class HotRodDistributionTest extends HotRodMultiNodeTest {
          log.trace("Get key and verify that's v6-*")
          assertSuccess(clients.tail.head.get(k(m), 0), v(m, "v6-"))
       } finally {
-         newClient.stop
+         killClient(newClient)
          stopClusteredServer(newServer)
          waitAddressCacheRemoval(addressRemovalLatches)
       }

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodServerTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodServerTest.scala
@@ -25,7 +25,7 @@ package org.infinispan.server.hotrod
 import org.testng.annotations.Test
 import org.infinispan.manager.DefaultCacheManager
 import org.testng.Assert._
-import org.infinispan.server.core.Stoppable
+import org.infinispan.server.core.test.Stoppable
 
 /**
  * Hot Rod server unit test.
@@ -37,8 +37,8 @@ import org.infinispan.server.core.Stoppable
 class HotRodServerTest {
 
    def testValidateProtocolServerNullProperties {
-      Stoppable.useServer(new HotRodServer) { server =>
-         Stoppable.useCacheManager(new DefaultCacheManager) { cm =>
+      Stoppable.useCacheManager(new DefaultCacheManager) { cm =>
+         Stoppable.useServer(new HotRodServer) { server =>
             server.start(null, cm)
             assertEquals(server.getHost, "127.0.0.1")
             assertEquals(server.getPort, 11222)

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodSingleClusteredTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodSingleClusteredTest.scala
@@ -22,7 +22,6 @@
  */
 package org.infinispan.server.hotrod
 
-import org.testng.annotations.Test
 import org.infinispan.config.Configuration
 import test.HotRodClient
 import java.lang.reflect.Method
@@ -30,6 +29,7 @@ import org.infinispan.server.hotrod.OperationStatus._
 import org.infinispan.test.MultipleCacheManagersTest
 import test.HotRodTestingUtil._
 import org.infinispan.test.AbstractCacheTest._
+import org.testng.annotations.{BeforeClass, Test}
 
 @Test(groups = Array("functional"), testName = "server.hotrod.HotRodSingleClusteredTest")
 class HotRodSingleClusteredTest extends MultipleCacheManagersTest {
@@ -42,7 +42,13 @@ class HotRodSingleClusteredTest extends MultipleCacheManagersTest {
    override def createCacheManagers {
       val cm = addClusterEnabledCacheManager()
       cm.defineConfiguration(cacheName, getDefaultClusteredConfig(Configuration.CacheMode.REPL_SYNC))
-      hotRodServer = startHotRodServer(cm)
+   }
+
+   @BeforeClass(alwaysRun = true)
+   @Test(enabled=false) // Disable explicitly to avoid TestNG thinking this is a test!!
+   override def createBeforeClass() {
+      super.createBeforeClass()
+      hotRodServer = startHotRodServer(cacheManagers.get(0))
       hotRodClient = new HotRodClient("127.0.0.1", hotRodServer.getPort, cacheName, 60, 10)
    }
 

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodSingleNodeTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodSingleNodeTest.scala
@@ -32,6 +32,7 @@ import org.jboss.netty.channel.ChannelFuture
 import org.infinispan.test.fwk.TestCacheManagerFactory
 import org.infinispan.manager.EmbeddedCacheManager
 import org.infinispan.util.ByteArrayKey
+import org.infinispan.server.core.test.ServerTestingUtil._
 
 /**
  * Base test class for single node Hot Rod tests.
@@ -50,9 +51,13 @@ abstract class HotRodSingleNodeTest extends SingleCacheManagerTest {
       val cacheManager = createTestCacheManager
       cacheManager.defineConfiguration(cacheName, cacheManager.getDefaultConfiguration)
       advancedCache = cacheManager.getCache[ByteArrayKey, CacheValue](cacheName).getAdvancedCache
+      cacheManager
+   }
+
+   protected override def setup() {
+      super.setup()
       hotRodServer = createStartHotRodServer(cacheManager)
       hotRodClient = connectClient
-      cacheManager
    }
 
    protected def createTestCacheManager: EmbeddedCacheManager = TestCacheManagerFactory.createLocalCacheManager(true)
@@ -64,7 +69,7 @@ abstract class HotRodSingleNodeTest extends SingleCacheManagerTest {
       log.debug("Test finished, close cache, client and Hot Rod server")
       super.destroyAfterClass
       shutdownClient
-      hotRodServer.stop
+      killServer(hotRodServer)
    }
 
    protected def server = hotRodServer
@@ -73,7 +78,7 @@ abstract class HotRodSingleNodeTest extends SingleCacheManagerTest {
 
    protected def jmxDomain = hotRodJmxDomain
 
-   protected def shutdownClient: ChannelFuture = hotRodClient.stop
+   protected def shutdownClient: ChannelFuture = killClient(hotRodClient)
 
    protected def connectClient: HotRodClient = new HotRodClient("127.0.0.1", hotRodServer.getPort, cacheName, 60, 10)
 }

--- a/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedServerTest.scala
+++ b/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedServerTest.scala
@@ -25,7 +25,7 @@ package org.infinispan.server.memcached
 import org.testng.annotations.Test
 import org.infinispan.manager.DefaultCacheManager
 import org.testng.Assert._
-import org.infinispan.server.core.Stoppable
+import org.infinispan.server.core.test.Stoppable
 
 /**
  * Memcached server unit test.
@@ -37,8 +37,8 @@ import org.infinispan.server.core.Stoppable
 class MemcachedServerTest {
 
    def testValidateProtocolServerNullProperties {
-      Stoppable.useServer(new MemcachedServer) { server =>
-         Stoppable.useCacheManager(new DefaultCacheManager) { cm =>
+      Stoppable.useCacheManager(new DefaultCacheManager) { cm =>
+         Stoppable.useServer(new MemcachedServer) { server =>
             server.start(null, cm)
             assertEquals(server.getHost, "127.0.0.1")
             assertEquals(server.getPort, 11211)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1999
- Make sure Hot Rod servers are started outside the cache manager creation method, in order to avoid leaks.
- Switch off L1 since it's not relevant for the tests.
- Add more logging around the weird case of different threads using the same server port. I cannot replicate this locally but I saw it in logs provided by Martin.
- Fix issue when property file name is null.

Do not close JIRA once this has been integrated, since I wanna the effect this has on the testsuite, and I might add more improvements.

`5.1.x` branch: `t_suite_5`
