### PR TITLE
[DEFERRED] Allow SpringCache to be configured to use asynchronous operations

### DIFF
--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -197,6 +197,12 @@
          <scope>test</scope>
       </dependency>
       <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-all</artifactId>
+          <version>${version.mockito}</version>
+          <scope>test</scope>
+      </dependency>
+      <dependency>
          <groupId>commons-dbcp</groupId>
          <artifactId>commons-dbcp</artifactId>
          <scope>test</scope>

--- a/spring/src/main/java/org/infinispan/spring/provider/SpringAsynchronousCache.java
+++ b/spring/src/main/java/org/infinispan/spring/provider/SpringAsynchronousCache.java
@@ -1,0 +1,124 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *   ~
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.spring.provider;
+
+
+import org.infinispan.CacheException;
+import org.infinispan.api.BasicCache;
+import org.infinispan.util.concurrent.NotifyingFuture;
+import org.springframework.cache.support.SimpleValueWrapper;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * <p>
+ * A {@link org.springframework.cache.Cache <code>Cache</code>} implementation that delegates to a
+ * {@link org.infinispan.Cache <code>org.infinispan.Cache</code>} instance supplied at construction
+ * time.
+ * </p>
+ * <p>
+ * The primary difference between this class and {@link org.infinispan.spring.provider.SpringCache}
+ * is that the {@link #put(Object, Object)}, {@link #evict(Object)}, and {@link #clear()} are
+ * performed using the asynchronous operation of the {@link org.infinispan.Cache <code>org.infinispan.Cache</code>}
+ * </p>
+ *
+ * @author <a href="mailto:ryebrye AT gmail DOT com">Ryan Gardner</a>
+ *
+ */
+public class SpringAsynchronousCache extends SpringCache {
+
+    /**
+     * @param nativeCache
+     */
+    public SpringAsynchronousCache(final BasicCache<Object, Object> nativeCache) {
+        super(nativeCache);
+    }
+
+    @Override
+    public ValueWrapper get(final Object key) {
+      // It may be better to just do the get synchronously.
+      // (the contract of the spring cache requires you to return null if the key isn't in the cache, or a ValueWrapper if it is)
+      return (nativeCache.containsKey(key)) ? (new NotifyingFutureValueWrapper(nativeCache.getAsync(key))) : null;
+    }
+
+    /**
+     * Associate the specified value with the specified key in this cache.
+     * <p>If the cache previously contained a mapping for this key, the old
+     * value is replaced by the specified value.
+     *
+     * @param key   the key with which the specified value is to be associated
+     * @param value the value to be associated with the specified key
+     */
+    @Override
+    public void put(Object key, Object value) {
+        nativeCache.putAsync(key, value);
+    }
+
+    /**
+     * Evict the mapping for this key from this cache if it is present.
+     *
+     * @param key the key whose mapping is to be removed from the cache
+     */
+    @Override
+    public void evict(Object key) {
+        nativeCache.removeAsync(key);
+    }
+
+    /**
+     * Remove all mappings from the cache.
+     */
+    @Override
+    public void clear() {
+        nativeCache.clearAsync();
+    }
+
+    public static final class NotifyingFutureValueWrapper implements ValueWrapper {
+        private NotifyingFuture<Object> futureObject;
+
+        public NotifyingFutureValueWrapper(NotifyingFuture<Object> futureObject) {
+            this.futureObject = futureObject;
+        }
+
+        /**
+         * Return the actual value in the cache.
+         *
+         * If there is an exception when retrieving the value, a null value will be returned
+         * which Spring will take to indicate that there is no entry in the cache.
+         *
+         * (This prevents an exception from bubbling up to something in Spring that uses @Cacheable)
+         */
+        @Override
+        public Object get() {
+            try {
+                return futureObject.get();
+            } catch (CacheException e) {
+                return null;
+            } catch (InterruptedException e) {
+                return null;
+            } catch (ExecutionException e) {
+                return null;
+            }
+        }
+    }
+}

--- a/spring/src/main/java/org/infinispan/spring/provider/SpringCache.java
+++ b/spring/src/main/java/org/infinispan/spring/provider/SpringCache.java
@@ -44,7 +44,7 @@ import org.springframework.util.Assert;
 public class SpringCache implements Cache {
    protected final Log logger = LogFactory.getLog(getClass());
 
-   private final org.infinispan.api.BasicCache<Object, Object> nativeCache;
+   protected final org.infinispan.api.BasicCache<Object, Object> nativeCache;
 
    /**
     * @param nativeCache

--- a/spring/src/main/java/org/infinispan/spring/provider/SpringEmbeddedCacheManager.java
+++ b/spring/src/main/java/org/infinispan/spring/provider/SpringEmbeddedCacheManager.java
@@ -49,6 +49,7 @@ import org.springframework.util.Assert;
 public class SpringEmbeddedCacheManager implements CacheManager {
 
    private final EmbeddedCacheManager nativeCacheManager;
+   private boolean useAsynchronousCacheOperations = false;
 
    /**
     * @param nativeCacheManager
@@ -61,7 +62,11 @@ public class SpringEmbeddedCacheManager implements CacheManager {
 
    @Override
    public SpringCache getCache(final String name) {
-      return new SpringCache(this.nativeCacheManager.getCache(name));
+       if (this.useAsynchronousCacheOperations) {
+           return new SpringAsynchronousCache(this.nativeCacheManager.getCache(name));
+       } else {
+           return new SpringCache(this.nativeCacheManager.getCache(name));
+       }
    }
 
    @Override
@@ -88,5 +93,23 @@ public class SpringEmbeddedCacheManager implements CacheManager {
     */
    public void stop() {
       this.nativeCacheManager.stop();
+   }
+
+   public boolean isUseAsynchronousCacheOperations() {
+      return useAsynchronousCacheOperations;
+   }
+
+   /**
+    * Set a value indicating if the SpringCache's returned by this CacheManager should use
+    * using a {@link SpringAsynchronousCache} rather than a {@link SpringCache}
+    *
+    * Setting this value only affects any future calls to {@link #getCache(String)}.
+    *
+    * The default value is false.
+    *
+    * @param useAsynchronousCacheOperations
+    */
+   public void setUseAsynchronousCacheOperations(boolean useAsynchronousCacheOperations) {
+      this.useAsynchronousCacheOperations = useAsynchronousCacheOperations;
    }
 }

--- a/spring/src/main/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBean.java
+++ b/spring/src/main/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBean.java
@@ -73,6 +73,7 @@ public class SpringEmbeddedCacheManagerFactoryBean extends AbstractEmbeddedCache
          implements FactoryBean<SpringEmbeddedCacheManager>, InitializingBean, DisposableBean {
 
    private SpringEmbeddedCacheManager cacheManager;
+   private boolean useAsynchronousCacheOperations = false;
 
    // ------------------------------------------------------------------------
    // org.springframework.beans.factory.InitializingBean
@@ -87,7 +88,7 @@ public class SpringEmbeddedCacheManagerFactoryBean extends AbstractEmbeddedCache
 
       final EmbeddedCacheManager nativeEmbeddedCacheManager = createBackingEmbeddedCacheManager();
       this.cacheManager = new SpringEmbeddedCacheManager(nativeEmbeddedCacheManager);
-
+      this.cacheManager.setUseAsynchronousCacheOperations(useAsynchronousCacheOperations);
       this.logger.info("Successfully initialized SpringEmbeddedCacheManager instance ["
                + this.cacheManager + "]");
    }
@@ -143,4 +144,24 @@ public class SpringEmbeddedCacheManagerFactoryBean extends AbstractEmbeddedCache
          this.cacheManager.stop();
       }
    }
+
+
+   public boolean isUseAsynchronousCacheOperations() {
+      return useAsynchronousCacheOperations;
+   }
+
+   /**
+    *
+    * Set a value indicating if the SpringCache's returned by this CacheManager should use
+    * using a {@link SpringAsynchronousCache} rather than a {@link SpringCache}
+    *
+    * Setting this value only affects any future calls to {@link SpringEmbeddedCacheManager#getCache(String)}.
+    *
+    * The default value is false.
+    *
+    * @param useAsynchronousCacheOperations
+    */
+    public void setUseAsynchronousCacheOperations(boolean useAsynchronousCacheOperations) {
+       this.useAsynchronousCacheOperations = useAsynchronousCacheOperations;
+    }
 }

--- a/spring/src/main/java/org/infinispan/spring/provider/SpringRemoteCacheManager.java
+++ b/spring/src/main/java/org/infinispan/spring/provider/SpringRemoteCacheManager.java
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
 public class SpringRemoteCacheManager implements org.springframework.cache.CacheManager {
 
    private final RemoteCacheManager nativeCacheManager;
+   private boolean useAsynchronousCacheOperations = false;
 
    /**
     * @param nativeCacheManager
@@ -58,7 +59,11 @@ public class SpringRemoteCacheManager implements org.springframework.cache.Cache
     */
    @Override
    public Cache getCache(final String name) {
-      return new SpringCache(this.nativeCacheManager.getCache(name));
+       if (this.useAsynchronousCacheOperations) {
+           return new SpringAsynchronousCache(this.nativeCacheManager.getCache(name));
+       } else {
+           return new SpringCache(this.nativeCacheManager.getCache(name));
+       }
    }
 
    /**
@@ -107,4 +112,21 @@ public class SpringRemoteCacheManager implements org.springframework.cache.Cache
    public void stop() {
       this.nativeCacheManager.stop();
    }
+    public boolean isUseAsynchronousCacheOperations() {
+       return useAsynchronousCacheOperations;
+    }
+
+    /**
+     * Set a value indicating if the SpringCache's returned by this CacheManager should use
+     * using a {@link SpringAsynchronousCache} rather than a {@link SpringCache}
+     *
+     * Setting this value only affects any future calls to {@link #getCache(String)}.
+     *
+     * The default value is false.
+     *
+     * @param useAsynchronousCacheOperations
+     */
+    public void setUseAsynchronousCacheOperations(boolean useAsynchronousCacheOperations) {
+       this.useAsynchronousCacheOperations = useAsynchronousCacheOperations;
+    }
 }

--- a/spring/src/main/java/org/infinispan/spring/provider/SpringRemoteCacheManagerFactoryBean.java
+++ b/spring/src/main/java/org/infinispan/spring/provider/SpringRemoteCacheManagerFactoryBean.java
@@ -77,6 +77,7 @@ public class SpringRemoteCacheManagerFactoryBean extends AbstractRemoteCacheMana
          implements FactoryBean<SpringRemoteCacheManager>, InitializingBean, DisposableBean {
 
    private SpringRemoteCacheManager springRemoteCacheManager;
+   private boolean useAsynchronousCacheOperations = false;
 
    // ------------------------------------------------------------------------
    // org.springframework.beans.factory.InitializingBean
@@ -144,4 +145,20 @@ public class SpringRemoteCacheManagerFactoryBean extends AbstractRemoteCacheMana
          this.springRemoteCacheManager.stop();
       }
    }
+
+    /**
+     *
+     * Set a value indicating if the SpringCache's returned by this CacheManager should use
+     * using a {@link SpringAsynchronousCache} rather than a {@link SpringCache}
+     *
+     * Setting this value only affects any future calls to {@link SpringEmbeddedCacheManager#getCache(String)}.
+     *
+     * The default value is false.
+     *
+     * @param useAsynchronousCacheOperations
+     */
+     public void setUseAsynchronousCacheOperations(boolean useAsynchronousCacheOperations) {
+        this.useAsynchronousCacheOperations = useAsynchronousCacheOperations;
+     }
+
 }

--- a/spring/src/test/java/org/infinispan/spring/provider/SpringAsynchronousCacheTest.java
+++ b/spring/src/test/java/org/infinispan/spring/provider/SpringAsynchronousCacheTest.java
@@ -1,0 +1,122 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *   ~
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.spring.provider;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertSame;
+import static org.testng.AssertJUnit.assertTrue;
+
+import org.infinispan.CacheImpl;
+import org.infinispan.client.hotrod.impl.async.NotifyingFutureImpl;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.spring.support.embedded.InfinispanNamedEmbeddedCacheFactoryBean;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.util.concurrent.NoOpFuture;
+import org.mockito.Mockito;
+import org.springframework.cache.Cache;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+/**
+ * <p>
+ * An integration test for {@link SpringAsynchronousCache}.
+ * </p>
+ * <p>
+ * In addition to the tests performed by {@link SpringCacheCacheTest} this test
+ * verifies that the proper asynchronous methods are called on the underlying cache
+ * </p>
+ * 
+ * @author <a href="mailto:olaf DOT bergner AT gmx DOT de">Olaf Bergner</a>
+ * @author Marius Bogoevici
+ * @author Ryan Gardner
+ * 
+ */
+@Test(testName = "spring.provider.SpringAsynchronousCacheCacheTest", groups = "unit")
+public class SpringAsynchronousCacheTest extends SpringCacheCacheTest {
+
+   @Test
+   public void testCachePutUsesAsyncMethod() throws Exception {
+      final Object key = "enescu";
+      final Object value = "value";
+      this.cache.put(key, value);
+      Mockito.verify(nativeCache).putAsync(key, value);
+      Mockito.verifyNoMoreInteractions(nativeCache);
+   }
+
+    @Test
+    public void testGetsUseASyncMethod() throws Exception {
+        final Object key1 = "key1";
+        final Object value = "value";
+        this.cache.put(key1, value);
+        Mockito.when(nativeCache.getAsync(key1)).thenReturn(new NoOpFuture<Object>(value));
+        Cache.ValueWrapper wrapper = this.cache.get(key1);
+
+        Mockito.verify(nativeCache, Mockito.atLeastOnce()).containsKey(key1);
+        Mockito.verify(nativeCache, Mockito.atLeastOnce()).getAsync(key1);
+        assertEquals(value,wrapper.get());
+    }
+
+    @Test
+    public void testGetsUseASyncMethodReturnsNullWrapperForObjectNotInCache() throws Exception {
+        final Object key2 = "key2";
+
+        Cache.ValueWrapper wrapper = this.cache.get(key2);
+        assertNull(wrapper);
+        Mockito.verify(nativeCache, Mockito.atLeastOnce()).containsKey(key2);
+        Mockito.verify(nativeCache, Mockito.never()).getAsync(key2);
+    }
+
+   @Test
+   public void testCacheClearUsesAsyncMethod() throws Exception {
+      this.cache.clear();
+      Mockito.verify(nativeCache).clearAsync();
+      Mockito.verifyNoMoreInteractions(nativeCache);
+   }
+
+   @Test
+   public void testEvictUsesAsyncMethod() throws Exception {
+      String somekey = "somekey";
+      this.cache.evict(somekey);
+      Mockito.verify(nativeCache).removeAsync(somekey);
+      Mockito.verifyNoMoreInteractions(nativeCache);
+   }
+
+   @Override
+   @SuppressWarnings("unchecked")
+   protected org.infinispan.Cache<Object, Object> createNativeCache() throws Exception {
+      return (org.infinispan.Cache<Object, Object>) Mockito.spy(super.createNativeCache());
+   }
+
+   @Override
+   protected Cache createCache(final org.infinispan.Cache<Object, Object> nativeCache) {
+      return new SpringAsynchronousCache(nativeCache);
+   }
+
+}

--- a/spring/src/test/java/org/infinispan/spring/provider/SpringCacheCacheTest.java
+++ b/spring/src/test/java/org/infinispan/spring/provider/SpringCacheCacheTest.java
@@ -59,11 +59,11 @@ public class SpringCacheCacheTest extends SingleCacheManagerTest {
 
    protected final static String CACHE_NAME = "testCache";
 
-   private final InfinispanNamedEmbeddedCacheFactoryBean<Object, Object> fb = new InfinispanNamedEmbeddedCacheFactoryBean<Object, Object>();
+   protected final InfinispanNamedEmbeddedCacheFactoryBean<Object, Object> fb = new InfinispanNamedEmbeddedCacheFactoryBean<Object, Object>();
 
-   private org.infinispan.Cache<Object, Object> nativeCache;
+   protected org.infinispan.Cache<Object, Object> nativeCache;
 
-   private Cache cache;
+   protected Cache cache;
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
@@ -123,7 +123,7 @@ public class SpringCacheCacheTest extends SingleCacheManagerTest {
       assertNull(this.cache.get("enescu"));
    }
 
-   private org.infinispan.Cache<Object, Object> createNativeCache() throws Exception {
+   protected org.infinispan.Cache<Object, Object> createNativeCache() throws Exception {
       this.fb.setInfinispanEmbeddedCacheManager(cacheManager);
       this.fb.setBeanName(CACHE_NAME);
       this.fb.setCacheName(CACHE_NAME);
@@ -131,7 +131,7 @@ public class SpringCacheCacheTest extends SingleCacheManagerTest {
       return this.fb.getObject();
    }
 
-   private Cache createCache(final org.infinispan.Cache<Object, Object> nativeCache) {
+   protected Cache createCache(final org.infinispan.Cache<Object, Object> nativeCache) {
       return new SpringCache(nativeCache);
    }
 

--- a/spring/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBeanContextTest.java
+++ b/spring/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBeanContextTest.java
@@ -50,6 +50,9 @@ public class SpringEmbeddedCacheManagerFactoryBeanContextTest extends
 
    private static final String SPRING_EMBEDDED_CACHE_MANAGER_CONFIGURED_USING_SETTERS_BEAN_NAME = "springEmbeddedCacheManagerConfiguredUsingSetters";
 
+
+   private static final String SPRING_EMBEDDED_CACHE_MANAGER_CONFIGURED_WITH_ASYNC_OPS = "springEmbeddedCacheManagerFactoryBeanUsingAsynchronousOperations";
+
    @Test
    public final void shouldCreateAnEmbeddedCacheManagerWithDefaultSettingsIfNoFurtherConfigurationGiven() {
       final SpringEmbeddedCacheManager springEmbeddedCacheManagerWithDefaultConfiguration = this.applicationContext
@@ -93,5 +96,25 @@ public class SpringEmbeddedCacheManagerFactoryBeanContextTest extends
                                  + "\". However, it doesn't.",
                         springEmbeddedCacheManagerConfiguredUsingProperties);
       springEmbeddedCacheManagerConfiguredUsingProperties.stop();
+   }
+
+   @Test
+   public final void shouldCreateEmbeddedCacheManagerWithUseAsynchronousOperationsIfPropertyIsSet() {
+       final SpringEmbeddedCacheManager springEmbeddedCacheManagerConfiguredUsingProperties = this.applicationContext
+                .getBean(SPRING_EMBEDDED_CACHE_MANAGER_CONFIGURED_WITH_ASYNC_OPS,
+                         SpringEmbeddedCacheManager.class);
+
+       AssertJUnit
+                .assertNotNull(
+                         "Spring application context should contain a SpringEmbeddedCacheManager configured using properties having bean name = \""
+                                  + SPRING_EMBEDDED_CACHE_MANAGER_CONFIGURED_WITH_ASYNC_OPS
+                                  + "\". However, it doesn't.",
+                         springEmbeddedCacheManagerConfiguredUsingProperties);
+       AssertJUnit
+               .assertEquals("Configured factory bean should have the useAsynchronousOperations property set to true when provided in config, however, it doesn't",
+                             true, springEmbeddedCacheManagerConfiguredUsingProperties.isUseAsynchronousCacheOperations());
+
+       springEmbeddedCacheManagerConfiguredUsingProperties.stop();
+
    }
 }

--- a/spring/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBeanTest.java
+++ b/spring/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBeanTest.java
@@ -221,6 +221,34 @@ public class SpringEmbeddedCacheManagerFactoryBeanTest {
       springEmbeddedCacheManager.stop();
    }
 
+    /**
+     * Test method for
+     * {@link org.infinispan.spring.provider.SpringEmbeddedCacheManagerFactoryBean#setUseAsynchronousCacheOperations(boolean)}
+     * .
+     */
+    @Test
+    public final void springEmbeddedCacheManagerFactoryBeanShouldReturnAsynchronousCachesIfConfiguredToDoSo()
+             throws Exception {
+       final boolean useAsynchronousOperations = true;
+
+       final SpringEmbeddedCacheManagerFactoryBean objectUnderTest = new SpringEmbeddedCacheManagerFactoryBean() {
+          @Override
+          protected EmbeddedCacheManager createCacheManager(ConfigurationContainer template) {
+             return TestCacheManagerFactory.createCacheManager(
+                   template.globalConfiguration, template.defaultConfiguration);
+          }
+       };
+       objectUnderTest.setUseAsynchronousCacheOperations(useAsynchronousOperations);
+       objectUnderTest.afterPropertiesSet();
+       final SpringEmbeddedCacheManager springEmbeddedCacheManager = objectUnderTest.getObject();
+
+       assertEquals(
+                "SpringEmbeddedCacheManagerFactoryBean should have set the UseAsynchronousCacheOperations on created SpringEmbeddedCacheManger. However, it didn't.",
+                useAsynchronousOperations, springEmbeddedCacheManager.isUseAsynchronousCacheOperations());
+
+       springEmbeddedCacheManager.stop();
+    }
+
    /**
     * Test method for
     * {@link org.infinispan.spring.provider.SpringEmbeddedCacheManagerFactoryBean#setJmxDomain(java.lang.String)}

--- a/spring/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerTest.java
+++ b/spring/src/test/java/org/infinispan/spring/provider/SpringEmbeddedCacheManagerTest.java
@@ -25,6 +25,7 @@ package org.infinispan.spring.provider;
 
 import static org.infinispan.test.TestingUtil.withCacheManager;
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertSame;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -87,8 +88,82 @@ public class SpringEmbeddedCacheManagerTest {
                         + CACHE_NAME_FROM_CONFIGURATION_FILE
                         + ") should have returned the cache having the provided name. However, the cache returned has a different name.",
                CACHE_NAME_FROM_CONFIGURATION_FILE, cacheExpectedToHaveTheProvidedName.getName());
+
+      assertTrue(
+              "getCache("
+                      + CACHE_NAME_FROM_CONFIGURATION_FILE
+                      + ") should return an instance of SpringCache. However it didn't.",
+              cacheExpectedToHaveTheProvidedName instanceof org.springframework.cache.Cache);
+
       nativeCacheManager.stop();
    }
+
+    /**
+     * Test method for default returned cache type of SpringEmbeddedCache being the normal SpringCache
+     *
+     * {@link org.infinispan.spring.provider.SpringEmbeddedCacheManager#getCache(String)}.
+     *
+     * @throws IOException
+     */
+    @Test
+    public final void getCacheShouldNotReturnASpringAsynchronousCacheForDefaultCase() throws IOException {
+       final EmbeddedCacheManager nativeCacheManager = TestCacheManagerFactory.fromStream(
+                SpringEmbeddedCacheManagerTest.class
+                         .getResourceAsStream(NAMED_ASYNC_CACHE_CONFIG_LOCATION));
+       final SpringEmbeddedCacheManager objectUnderTest = new SpringEmbeddedCacheManager(
+                nativeCacheManager);
+
+       final Cache cacheExpectedToHaveTheProvidedName = objectUnderTest
+                .getCache(CACHE_NAME_FROM_CONFIGURATION_FILE);
+
+       assertFalse(
+               "getCache("
+                       + CACHE_NAME_FROM_CONFIGURATION_FILE
+                       + ") should not return an instance of SpringAsynchronousCache when useAsynchronousOperations is not set. However, it did.",
+               cacheExpectedToHaveTheProvidedName instanceof SpringAsynchronousCache);
+
+       assertTrue(
+                "getCache("
+                        + CACHE_NAME_FROM_CONFIGURATION_FILE
+                        + ") should not return an instance of SpringCache when useAsynchronousOperations is not set. However, it did not.",
+                cacheExpectedToHaveTheProvidedName instanceof SpringCache);
+
+       nativeCacheManager.stop();
+    }
+
+
+    /**
+     * Test method for default returned cache type of SpringEmbeddedCache
+     *
+     * {@link org.infinispan.spring.provider.SpringEmbeddedCacheManager#getCache(String)}.
+     *
+     * @throws IOException
+     */
+    @Test
+    public final void getCacheShouldReturnASpringAsynchronousCacheWhenUseAsynchronousOperationsIsSet() throws IOException {
+       final EmbeddedCacheManager nativeCacheManager = TestCacheManagerFactory.fromStream(
+                SpringEmbeddedCacheManagerTest.class
+                         .getResourceAsStream(NAMED_ASYNC_CACHE_CONFIG_LOCATION));
+       final SpringEmbeddedCacheManager objectUnderTest = new SpringEmbeddedCacheManager(
+                nativeCacheManager);
+       objectUnderTest.setUseAsynchronousCacheOperations(true);
+
+       final Cache cacheExpectedToHaveTheProvidedName = objectUnderTest
+                .getCache(CACHE_NAME_FROM_CONFIGURATION_FILE);
+
+       assertTrue(
+               "getCache("
+                       + CACHE_NAME_FROM_CONFIGURATION_FILE
+                       + ") should return an instance of SpringAsynchronousCache when useAsynchronousOperations is set. However, it did.",
+               cacheExpectedToHaveTheProvidedName instanceof SpringAsynchronousCache);
+
+       nativeCacheManager.stop();
+    }
+
+
+
+
+
 
    /**
     * Test method for

--- a/spring/src/test/resources/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBeanContextTest.xml
+++ b/spring/src/test/resources/org/infinispan/spring/provider/SpringEmbeddedCacheManagerFactoryBeanContextTest.xml
@@ -45,4 +45,11 @@
       p:jmxDomain="test:jmx.Domain"
       p:cacheManagerName="test.cacheManager" />
 
+    <bean
+       id="springEmbeddedCacheManagerFactoryBeanUsingAsynchronousOperations"
+       class="org.infinispan.spring.provider.SpringEmbeddedCacheManagerFactoryBean"
+       p:useAsynchronousCacheOperations="true"
+       />
+
+
 </beans>


### PR DESCRIPTION
In testing with a cache that was configured to use asynchronous replication, I was seeing some exceptions in my logs about timeout waiting for a lock on a key when doing a put. (It was not frequent - under heavy load testing it was only on a very small percentage of calls to my service)

Since I was using the @Cacheable annotation to do the caching around those method calls - there was no way for me to catch the CacheExceptions that were thrown. This means that these exceptions were resulting in my services returning 500 errors to the client.

Poking around, it seems that using the putAsync method would make the put methods return immediately and any exception would not be in the same thread so it wouldn't matter.

For my use, a put that fails is fine - spring will just put it in the next time if there is no value in the cache.

This pull request creates a configuration parameter on the EmbeddedCacheManagerFactory and EmbeddedRemoteCacheManagerFactory for "useAsynchronousCacheOperations" which, when set to true, will use a SpringAsynchrnousCache to wrap the native cache instead of the default SpringCache.

I added unit tests around this and updated other tests.

In my own load testing environment, I'm no longer seeing the errors related to cache put key lock timeouts and the execution time for my methods has improved in cases when it would have otherwise been blocking waiting for a put.

(this is a new pull request against the 5.1.x branch - although the changes also apply cleanly to the 5.2 branch as that's where I first created them)
