### PR TITLE
ISPN-2053

### DIFF
--- a/server/memcached/src/main/scala/org/infinispan/server/memcached/TextProtocolUtil.scala
+++ b/server/memcached/src/main/scala/org/infinispan/server/memcached/TextProtocolUtil.scala
@@ -98,7 +98,7 @@ object TextProtocolUtil {
 
    @tailrec
    private def readElement(buffer: ChannelBuffer, sb: StringBuilder): (String, Boolean) = {
-      var next = buffer.readByte 
+      var next = buffer.readByte
       if (next == SP) { // Space
          (sb.toString.trim, false)
       }
@@ -148,20 +148,18 @@ object TextProtocolUtil {
 
    @tailrec
    def skipLine(buffer: ChannelBuffer) {
-      if (readableBytes(buffer) > 0) {
-         var next = buffer.readByte
-         if (next == CR) { // CR
-            next = buffer.readByte
-            if (next == LF) { // LF
-               return
-            } else {
-               skipLine(buffer)
-            }
-         } else if (next == LF) { //LF
+      var next = buffer.readByte
+      if (next == CR) { // CR
+         next = buffer.readByte
+         if (next == LF) { // LF
             return
          } else {
             skipLine(buffer)
          }
+      } else if (next == LF) { //LF
+         return
+      } else {
+         skipLine(buffer)
       }
    }
 

--- a/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedFunctionalTest.scala
+++ b/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedFunctionalTest.scala
@@ -509,10 +509,10 @@ class MemcachedFunctionalTest extends MemcachedSingleNodeTest {
 
    def testFlagsIsUnsigned(m: Method) {
       val k = m.getName
-      assertClientError(send("set boo1 -1 0 0\r\n"))
-      assertStored(send("set " + k + " 4294967295 0 0\r\n"))
-      assertClientError(send("set boo2 4294967296 0 0\r\n"))
-      assertClientError(send("set boo2 18446744073709551615 0 0\r\n"))
+      assertClientError(send("set boo1 -1 0 0\r\n\r\n"))
+      assertStored(send("set " + k + " 4294967295 0 0\r\n\r\n"))
+      assertClientError(send("set boo2 4294967296 0 0\r\n\r\n"))
+      assertClientError(send("set boo2 18446744073709551615 0 0\r\n\r\n"))
    }
 
    def testIncrDecrIsUnsigned(m: Method) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2053

don't assume there isn't a CR/LF after a data block (even if empty) just because the current ChannelBuffer is empty.

For 5.1.x and master (cherry-picks cleanly on both)
