### PR TITLE
ISPN-2056 Wrap component stop calls in try/catch to avoid leaks

### DIFF
--- a/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
@@ -671,7 +671,11 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
       for (PrioritizedMethod em : stopMethods) {
          if (traceEnabled)
             getLog().tracef("Invoking stop method %s on component %s", em.metadata.getMethod(), em.component.getName());
-         em.invoke();
+         try {
+            em.invoke();
+         } catch (Throwable t) {
+            getLog().componentFailedToStop(t);
+         }
       }
 
       destroy();

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -857,4 +857,9 @@ public interface Log extends BasicLogger {
    @LogMessage(level = ERROR)
    @Message(value = "Error while processing a commit in a two-phase transaction", id = 188)
    void errorProcessing2pcCommitCommand(@Cause Throwable e);
+
+   @LogMessage(level = WARN)
+   @Message(value = "While stopping a cache or cache manager, one of its components failed to stop", id = 189)
+   void componentFailedToStop(@Cause Throwable e);
+
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2056

If a component fails to stop, it should log it, but the rest of components to be stopped should be allowed to do so.

5.1.x branch: `t_2056_5`
