### PR TITLE
ISPN-2075 WriteSkewCheck failures when an AtomicMap is removed in the sa...

### DIFF
--- a/core/src/main/java/org/infinispan/container/entries/DeltaAwareCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/DeltaAwareCacheEntry.java
@@ -43,7 +43,7 @@ import static org.infinispan.container.entries.DeltaAwareCacheEntry.Flags.*;
  * @author Manik Surtani (<a href="mailto:manik@jboss.org">manik@jboss.org</a>)
  * @since 5.1
  */
-public class DeltaAwareCacheEntry implements CacheEntry {
+public class DeltaAwareCacheEntry implements CacheEntry, StateChangingEntry {
    private static final Log log = LogFactory.getLog(DeltaAwareCacheEntry.class);
    private static final boolean trace = log.isTraceEnabled();
 
@@ -63,6 +63,16 @@ public class DeltaAwareCacheEntry implements CacheEntry {
       this.wrappedEntry = wrappedEntry;
       this.uncommittedChanges = new AtomicHashMap();
       this.deltas = new LinkedList<Delta>();
+   }
+
+   @Override
+   public byte getStateFlags() {
+      return flags;
+   }
+
+   @Override
+   public void copyStateFlagsFrom(StateChangingEntry other) {
+      this.flags = other.getStateFlags();
    }
 
    public void appendDelta(Delta d) {

--- a/core/src/main/java/org/infinispan/container/entries/MVCCEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/MVCCEntry.java
@@ -30,7 +30,7 @@ import org.infinispan.container.DataContainer;
  * @author Manik Surtani
  * @since 4.0
  */
-public interface MVCCEntry extends CacheEntry {
+public interface MVCCEntry extends CacheEntry, StateChangingEntry {
 
    /**
     * Makes internal copies of the entry for updates

--- a/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
@@ -58,6 +58,16 @@ public class ReadCommittedEntry implements MVCCEntry {
       this.lifespan = lifespan;
    }
 
+   @Override
+   public byte getStateFlags() {
+      return flags;
+   }
+
+   @Override
+   public void copyStateFlagsFrom(StateChangingEntry other) {
+      this.flags = other.getStateFlags();
+   }
+
    // if this or any MVCC entry implementation ever needs to store a boolean, always use a flag instead.  This is far
    // more space-efficient.  Note that this value will be stored in a byte, which means up to 8 flags can be stored in
    // a single byte.  Always start shifting with 0, the last shift cannot be greater than 7.

--- a/core/src/main/java/org/infinispan/container/entries/StateChangingEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/StateChangingEntry.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.entries;
+
+/**
+ * An entry that may have state, such as created, changed, valid, etc.
+ *
+ * @author Manik Surtani
+ * @since 5.1
+ */
+public interface StateChangingEntry {
+
+   byte getStateFlags();
+
+   void copyStateFlagsFrom(StateChangingEntry other);
+
+}


### PR DESCRIPTION
...me transaction in which it was created
- Add test based on Sanne's test
- Refactor WriteSkewTest to use the current configuration API
- Create a new StateChangingEntry interface to allow internal state of an entry to be copied so this information is not lost when wrapping a CacheEntry as a RepeatableReadEntry

Fixes https://issues.jboss.org/browse/ISPN-2075 - also merge `t_2075_5` for branch `5.1.x`
