### PR TITLE
ISPN-2092 - Write skew check not detected in LOCAL mode when doing multi...

### DIFF
--- a/core/src/main/java/org/infinispan/container/entries/DeltaAwareCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/DeltaAwareCacheEntry.java
@@ -67,6 +67,10 @@ public class DeltaAwareCacheEntry implements CacheEntry, StateChangingEntry {
 
    @Override
    public byte getStateFlags() {
+      if (wrappedEntry instanceof StateChangingEntry) {
+         return ((StateChangingEntry)wrappedEntry).getStateFlags();
+      }
+
       return flags;
    }
 

--- a/core/src/main/java/org/infinispan/container/entries/RepeatableReadEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/RepeatableReadEntry.java
@@ -22,7 +22,6 @@
  */
 package org.infinispan.container.entries;
 
-import org.infinispan.CacheException;
 import org.infinispan.container.DataContainer;
 import org.infinispan.transaction.WriteSkewException;
 import org.infinispan.util.logging.Log;

--- a/core/src/main/java/org/infinispan/interceptors/locking/OptimisticLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/OptimisticLockingInterceptor.java
@@ -125,7 +125,6 @@ public class OptimisticLockingInterceptor extends AbstractTxLockingInterceptor {
          } else {
             log.tracef("Using lock reordering, order is: %s", orderedKeys);
             acquireAllLocks(ctx, orderedKeys);
-            ctx.addAllAffectedKeys(Arrays.asList(orderedKeys));
          }
       }
       return invokeNextAndCommitIf1Pc(ctx, command);
@@ -271,14 +270,17 @@ public class OptimisticLockingInterceptor extends AbstractTxLockingInterceptor {
    private class LocalWriteSkewCheckingLockAcquisitionVisitor extends LockAcquisitionVisitor {
       @Override
       protected void performWriteSkewCheck(TxInvocationContext ctx, Object key) {
-         CacheEntry ce = ctx.lookupEntry(key);
-         if (ce instanceof RepeatableReadEntry && ctx.getCacheTransaction().keyRead(key)) {
-               ((RepeatableReadEntry) ce).performLocalWriteSkewCheck(dataContainer, true);
-         }
+         performLocalWriteSkewCheck(ctx, key);
       }
    }
-   
-   
+
+   private void performLocalWriteSkewCheck(TxInvocationContext ctx, Object key) {
+      CacheEntry ce = ctx.lookupEntry(key);
+      if (ce instanceof RepeatableReadEntry && ctx.getCacheTransaction().keyRead(key)) {
+         ((RepeatableReadEntry) ce).performLocalWriteSkewCheck(dataContainer, true);
+      }
+   }
+
    private Object[] sort(WriteCommand[] writes) {
       Set<Object> set = new HashSet<Object>();
       for (WriteCommand wc: writes) {
@@ -309,7 +311,11 @@ public class OptimisticLockingInterceptor extends AbstractTxLockingInterceptor {
    }
 
    private void acquireAllLocks(TxInvocationContext ctx, Object[] orderedKeys) throws InterruptedException {
-      for (Object key: orderedKeys) lockAndRegisterBackupLock(ctx, key);
+      for (Object key: orderedKeys) {
+         lockAndRegisterBackupLock(ctx, key);
+         performLocalWriteSkewCheck(ctx, key);
+         ctx.addAffectedKey(key);
+      }
    }
 
    private void acquireLocksVisitingCommands(TxInvocationContext ctx, PrepareCommand command) throws Throwable {

--- a/core/src/main/java/org/infinispan/transaction/WriteSkewHelper.java
+++ b/core/src/main/java/org/infinispan/transaction/WriteSkewHelper.java
@@ -19,7 +19,6 @@
 
 package org.infinispan.transaction;
 
-import org.infinispan.CacheException;
 import org.infinispan.commands.tx.VersionedPrepareCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.container.DataContainer;


### PR DESCRIPTION
...ple modifications
- OptimisticLockingInterceptor does not handle PrepareCommands properly in LOCAL
  mode when there are multiple modifications. LocalWriteSkewCheckingLockAcquisitionVisitor
  is not invoked on this code path and no write skew check is done.
- DeltaAwareCacheEntry.getStateFlags() does not properly delegate to the wrapped
  entry and reports incorrect flags leading to false write skew check detection.
- Remove some unused imports from related classes
- Add WriteSkewTest.testCheckWriteSkewWithMultipleModifications() and fix some generics related warnings

Jira issue: https://issues.jboss.org/browse/ISPN-2092

Please also merge t_ISPN-2092_5 into 5.1.x.
