### PR TITLE
ISPN-2097 - Tear down methods should run even if the test method failed

### DIFF
--- a/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/BdbjeCacheStoreConfigTest.java
+++ b/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/BdbjeCacheStoreConfigTest.java
@@ -43,7 +43,7 @@ public class BdbjeCacheStoreConfigTest {
         config = new BdbjeCacheStoreConfig();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void tearDown() throws CacheLoaderException {
         config = null;
     }

--- a/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/BdbjeCacheStoreFunctionalIntegrationTest.java
+++ b/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/BdbjeCacheStoreFunctionalIntegrationTest.java
@@ -43,7 +43,7 @@ public class BdbjeCacheStoreFunctionalIntegrationTest extends BaseCacheStoreFunc
       tmpDirectory = TestingUtil.tmpDirectory(this);
    }
    
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
       TestingUtil.recursiveFileRemove(tmpDirectory);
       new File(tmpDirectory).mkdirs();

--- a/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/BdbjeCacheStoreIntegrationTest.java
+++ b/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/BdbjeCacheStoreIntegrationTest.java
@@ -62,7 +62,7 @@ public class BdbjeCacheStoreIntegrationTest extends BaseCacheStoreTest {
       tmpDirectory = TestingUtil.tmpDirectory(this);
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
       TestingUtil.recursiveFileRemove(tmpDirectory);
       new File(tmpDirectory).mkdirs();

--- a/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/BdbjeCacheStoreTest.java
+++ b/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/BdbjeCacheStoreTest.java
@@ -149,7 +149,7 @@ public class BdbjeCacheStoreTest {
       runner = mock(PreparableTransactionRunner.class);
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() throws CacheLoaderException {
       runner = null;
       currentTransaction = null;

--- a/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/BdbjeLearningTest.java
+++ b/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/BdbjeLearningTest.java
@@ -103,7 +103,7 @@ public class BdbjeLearningTest extends AbstractInfinispanTest {
       tmpDirectory = TestingUtil.tmpDirectory(this);
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    protected void clearTempDir() {
       TestingUtil.recursiveFileRemove(tmpDirectory);
       new File(tmpDirectory).mkdirs();
@@ -161,7 +161,7 @@ public class BdbjeLearningTest extends AbstractInfinispanTest {
    }
 
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() throws Exception {
       storedEntriesDb.close();
       javaCatalog.close();

--- a/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/PreparableTransactionRunnerTest.java
+++ b/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/PreparableTransactionRunnerTest.java
@@ -64,7 +64,7 @@ public class PreparableTransactionRunnerTest {
       worker = mock(TransactionWorker.class);
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() throws CacheLoaderException {
       runner = null;
       env = null;

--- a/cachestore/cassandra/src/test/java/org/infinispan/loaders/cassandra/CassandraCacheStoreTest.java
+++ b/cachestore/cassandra/src/test/java/org/infinispan/loaders/cassandra/CassandraCacheStoreTest.java
@@ -53,7 +53,7 @@ public class CassandraCacheStoreTest extends BaseCacheStoreTest {
       embedded.setup();
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public static void cleanup() throws IOException {
       EmbeddedServerHelper.teardown();
       embedded = null;

--- a/cachestore/cloud/src/integrationtest/java/org/infinispan/loaders/cloud/CloudCacheStoreFunctionalIntegrationTest.java
+++ b/cachestore/cloud/src/integrationtest/java/org/infinispan/loaders/cloud/CloudCacheStoreFunctionalIntegrationTest.java
@@ -68,7 +68,7 @@ public class CloudCacheStoreFunctionalIntegrationTest extends BaseCacheStoreFunc
       System.out.printf("accessKey: %1$s, bucket: %2$s%n", accessKey, csBucket);
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    private void nukeBuckets() throws Exception {
       for (String name: cacheNames) {
          // use JClouds to nuke the buckets

--- a/cachestore/cloud/src/integrationtest/java/org/infinispan/loaders/cloud/CloudCacheStoreIntegrationTest.java
+++ b/cachestore/cloud/src/integrationtest/java/org/infinispan/loaders/cloud/CloudCacheStoreIntegrationTest.java
@@ -139,7 +139,7 @@ public class CloudCacheStoreIntegrationTest extends BaseCacheStoreTest {
    }
 
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    @Override
    public void tearDown() throws CacheLoaderException {
       if (cs != null) {

--- a/cachestore/cloud/src/test/java/org/infinispan/loaders/cloud/CloudCacheStoreTest.java
+++ b/cachestore/cloud/src/test/java/org/infinispan/loaders/cloud/CloudCacheStoreTest.java
@@ -97,7 +97,7 @@ public class CloudCacheStoreTest extends BaseCacheStoreTest {
    }
 
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    @Override
    public void tearDown() throws CacheLoaderException {
       for (CacheStore cacheStore : Arrays.asList(cs, cs2)) {

--- a/cachestore/hbase/src/test/java/org/infinispan/loaders/hbase/HBaseCacheStoreTest.java
+++ b/cachestore/hbase/src/test/java/org/infinispan/loaders/hbase/HBaseCacheStoreTest.java
@@ -46,7 +46,7 @@ public class HBaseCacheStoreTest extends BaseCacheStoreTest {
       }
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public static void cleanup() throws IOException {
       if (USE_EMBEDDED) {
          EmbeddedServerHelper.teardown();

--- a/cachestore/hbase/src/test/java/org/infinispan/loaders/hbase/HBaseCacheStoreTestStandalone.java
+++ b/cachestore/hbase/src/test/java/org/infinispan/loaders/hbase/HBaseCacheStoreTestStandalone.java
@@ -77,7 +77,7 @@ public class HBaseCacheStoreTestStandalone {
       }
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void tearDown() throws Exception {
       CACHE.clear();
       CACHE.stop();

--- a/cachestore/hbase/src/test/java/org/infinispan/loaders/hbase/HBaseFacadeTest.java
+++ b/cachestore/hbase/src/test/java/org/infinispan/loaders/hbase/HBaseFacadeTest.java
@@ -151,7 +151,7 @@ public class HBaseFacadeTest {
 
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void tearDown() throws Exception {
       HBF.deleteTable(TABLE_MESSAGE);
    }

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/PooledConnectionFactoryTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/PooledConnectionFactoryTest.java
@@ -44,7 +44,7 @@ public class PooledConnectionFactoryTest {
 
    private PooledConnectionFactory factory;
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void destroyFacotry() {
       factory.stop();
    }

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/TableManipulationTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/TableManipulationTest.java
@@ -58,7 +58,7 @@ public class TableManipulationTest {
       tableManipulation.setCacheName("aName");
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void closeConnection() throws SQLException {
       connection.close();
    }

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreTest.java
@@ -79,7 +79,7 @@ public class JdbcMixedCacheStoreTest {
       cacheStore.start();
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void destroyStore() throws Exception {
       cacheStore.clear();
       assertBinaryRowCount(0);

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreTest2.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStoreTest2.java
@@ -75,13 +75,13 @@ public class JdbcStringBasedCacheStoreTest2 {
       cacheStore.start();
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void clearStore() throws Exception {
       cacheStore.clear();
       assert rowCount() == 0;
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void destroyStore() throws CacheLoaderException {
       cacheStore.stop();
    }

--- a/cachestore/jdbm/src/test/java/org/infinispan/loaders/jdbm/JdbmCacheStoreFunctionalTest.java
+++ b/cachestore/jdbm/src/test/java/org/infinispan/loaders/jdbm/JdbmCacheStoreFunctionalTest.java
@@ -43,7 +43,7 @@ public class JdbmCacheStoreFunctionalTest extends BaseCacheStoreFunctionalTest {
       tmpDirectory = TestingUtil.tmpDirectory(this);
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
       TestingUtil.recursiveFileRemove(tmpDirectory);
       new File(tmpDirectory).mkdirs();

--- a/cachestore/jdbm/src/test/java/org/infinispan/loaders/jdbm/JdbmCacheStoreTest.java
+++ b/cachestore/jdbm/src/test/java/org/infinispan/loaders/jdbm/JdbmCacheStoreTest.java
@@ -50,7 +50,7 @@ public class JdbmCacheStoreTest extends BaseCacheStoreTest {
       tmpDirectory = TestingUtil.tmpDirectory(this);
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
       TestingUtil.recursiveFileRemove(tmpDirectory);
       new File(tmpDirectory).mkdirs();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
@@ -77,12 +77,12 @@ public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
       m = new GenericJBossMarshaller();
    }
 
-   @AfterTest   
+   @AfterTest(alwaysRun = true)
    public void destroyMarshaller() {
       m = null;
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    @Override
    protected void clearContent() throws Throwable {
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheManagerNotStartedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheManagerNotStartedTest.java
@@ -65,7 +65,7 @@ public class CacheManagerNotStartedTest extends SingleCacheManagerTest {
       killServers(hotrodServer);
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    @Override
    protected void destroyAfterClass() {
       super.destroyAfterClass();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientSocketReadTimeoutTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientSocketReadTimeoutTest.java
@@ -83,7 +83,7 @@ public class ClientSocketReadTimeoutTest extends SingleCacheManagerTest {
       return new RemoteCacheManager(config);
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void destroyRemoteCacheFactory() {
       killRemoteCacheManager(remoteCacheManager);
       killServers(hotrodServer);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV1IntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV1IntegrationTest.java
@@ -102,12 +102,12 @@ public class ConsistentHashV1IntegrationTest extends MultipleCacheManagersTest {
       }
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    @Override
    protected void clearContent() throws Throwable {
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void cleanUp() {
       ex.shutdownNow();
       kas.stop();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ForceReturnValuesTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ForceReturnValuesTest.java
@@ -49,7 +49,7 @@ public class ForceReturnValuesTest extends SingleCacheManagerTest {
       return cacheManager;
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    void shutdown() {
       remoteCacheManager.stop();
       remoteCacheManager = null;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodIntegrationTest.java
@@ -95,7 +95,7 @@ public class HotRodIntegrationTest extends SingleCacheManagerTest {
    }
 
 
-   @AfterClass 
+   @AfterClass(alwaysRun = true)
    public void testDestroyRemoteCacheFactory() {
       remoteCacheManager.stop();
       hotrodServer.stop();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodServerStartStopTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodServerStartStopTest.java
@@ -39,7 +39,7 @@ public class HotRodServerStartStopTest extends MultipleCacheManagersTest {
    private HotRodServer hotRodServer1;
    private HotRodServer hotRodServer2;
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    @Override
    protected void clearContent() throws Throwable {
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodStatisticsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodStatisticsTest.java
@@ -59,7 +59,7 @@ public class HotRodStatisticsTest {
       remoteCache = rcm.getCache();
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    void tearDown() {
       TestingUtil.killCacheManagers(cacheContainer);
       rcm.stop();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteAsyncAPITest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteAsyncAPITest.java
@@ -60,7 +60,7 @@ public class RemoteAsyncAPITest extends SingleCacheManagerTest {
       return cm;
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    @Override
    protected void destroyAfterClass() {
       super.destroyAfterClass();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplTopologyChangeTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplTopologyChangeTest.java
@@ -60,7 +60,7 @@ public class ReplTopologyChangeTest extends MultipleCacheManagersTest {
    protected void assertSupportedConfig() {
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    @Override
    protected void clearContent() throws Throwable {
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerErrorTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerErrorTest.java
@@ -74,7 +74,7 @@ public class ServerErrorTest extends SingleCacheManagerTest {
       return new RemoteCacheManager(config);
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void shutDownHotrod() {
       remoteCacheManager.stop();
       hotrodServer.stop();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerRestartTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerRestartTest.java
@@ -66,7 +66,7 @@ public class ServerRestartTest extends SingleCacheManagerTest {
    }
 
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void testDestroyRemoteCacheFactory() {
       remoteCacheManager.stop();
       hotrodServer.stop();

--- a/core/src/test/java/org/infinispan/affinity/BaseKeyAffinityServiceTest.java
+++ b/core/src/test/java/org/infinispan/affinity/BaseKeyAffinityServiceTest.java
@@ -57,7 +57,7 @@ public class BaseKeyAffinityServiceTest extends BaseDistFunctionalTest {
    protected ExecutorService executor  = Executors.newSingleThreadExecutor(threadFactory);
    protected KeyAffinityServiceImpl<Object> keyAffinityService;
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void stopExecutorService() throws InterruptedException {
       keyAffinityService.stop();
       executor.shutdown();

--- a/core/src/test/java/org/infinispan/affinity/ConcurrentStartupTest.java
+++ b/core/src/test/java/org/infinispan/affinity/ConcurrentStartupTest.java
@@ -79,7 +79,7 @@ public class ConcurrentStartupTest extends AbstractCacheTest {
       Thread.sleep(5000);
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    protected void tearDown() throws Exception {
       ex1.shutdownNow();
       ex2.shutdownNow();

--- a/core/src/test/java/org/infinispan/api/batch/BatchWithTMTest.java
+++ b/core/src/test/java/org/infinispan/api/batch/BatchWithTMTest.java
@@ -48,7 +48,7 @@ public class BatchWithTMTest extends AbstractBatchTest {
       cm = TestCacheManagerFactory.createLocalCacheManager(false);
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void destroyCacheManager() {
       TestingUtil.killCacheManagers(cm);
       cm = null;

--- a/core/src/test/java/org/infinispan/api/batch/BatchWithoutTMTest.java
+++ b/core/src/test/java/org/infinispan/api/batch/BatchWithoutTMTest.java
@@ -49,7 +49,7 @@ public class BatchWithoutTMTest extends AbstractBatchTest {
       cm = TestCacheManagerFactory.createCacheManager(defaultConfiguration);
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void destroyCacheManager() {
       TestingUtil.killCacheManagers(cm);
       cm = null;

--- a/core/src/test/java/org/infinispan/api/mvcc/repeatable_read/WriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/api/mvcc/repeatable_read/WriteSkewTest.java
@@ -86,7 +86,7 @@ public class WriteSkewTest extends AbstractInfinispanTest {
       cacheManager.defineConfiguration("writeSkew", configurationBuilder.build());
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void tearDown() {
       TestingUtil.killCacheManagers(cacheManager);
       cacheManager = null;

--- a/core/src/test/java/org/infinispan/atomic/APITest.java
+++ b/core/src/test/java/org/infinispan/atomic/APITest.java
@@ -55,14 +55,14 @@ public class APITest extends AbstractInfinispanTest {
       tm = TestingUtil.getTransactionManager(cache);
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void tearDown() {
       TestingUtil.killCacheManagers(cacheContainer);
       cache =null;
       tm = null;
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void clearUp() throws SystemException {
       if (tm.getTransaction() != null) {
          try {

--- a/core/src/test/java/org/infinispan/atomic/AtomicHashMapConcurrencyTest.java
+++ b/core/src/test/java/org/infinispan/atomic/AtomicHashMapConcurrencyTest.java
@@ -76,7 +76,7 @@ public class AtomicHashMapConcurrencyTest extends AbstractInfinispanTest {
       tm = TestingUtil.getTransactionManager(cache);
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    protected void tearDown() {
       try {
          tm.rollback();

--- a/core/src/test/java/org/infinispan/atomic/AtomicMapFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/atomic/AtomicMapFunctionalTest.java
@@ -64,7 +64,7 @@ public class AtomicMapFunctionalTest extends AbstractInfinispanTest {
       tm = TestingUtil.getTransactionManager(cache);
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() {
       TestingUtil.killCacheManagers(cm);
       cache = null;

--- a/core/src/test/java/org/infinispan/config/SampleConfigFilesCorrectnessTest.java
+++ b/core/src/test/java/org/infinispan/config/SampleConfigFilesCorrectnessTest.java
@@ -62,7 +62,7 @@ public class SampleConfigFilesCorrectnessTest {
       log4jLogger.addAppender(appender);
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDownTest() {
       Logger log4jLogger = Logger.getRootLogger();
       log4jLogger.setLevel(oldLevel);

--- a/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
+++ b/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
@@ -48,7 +48,7 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
       dc = createContainer();
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() {
       dc = null;
    }

--- a/core/src/test/java/org/infinispan/distribution/DistCacheStorePreloadTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistCacheStorePreloadTest.java
@@ -52,7 +52,7 @@ public class DistCacheStorePreloadTest extends BaseDistCacheStoreTest {
       preload = true;
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void clearStats() {
       for (Cache<?, ?> c: caches) {
          System.out.println("Clearing stats for cache store on cache "+ c);

--- a/core/src/test/java/org/infinispan/distribution/DistSyncCacheStoreSharedTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncCacheStoreSharedTest.java
@@ -53,7 +53,7 @@ public class DistSyncCacheStoreSharedTest extends BaseDistCacheStoreTest {
       shared = true;
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void clearStats() {
       for (Cache<?, ?> c: caches) {
          System.out.println("Clearing stats for cache store on cache "+ c);

--- a/core/src/test/java/org/infinispan/distribution/UnknownCacheStartTest.java
+++ b/core/src/test/java/org/infinispan/distribution/UnknownCacheStartTest.java
@@ -49,7 +49,7 @@ public class UnknownCacheStartTest extends AbstractInfinispanTest {
       configuration = getDefaultClusteredConfig(Configuration.CacheMode.DIST_SYNC);
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void tearDown() {
       killCacheManagers(cm1, cm2);
    }

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashStressTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashStressTest.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 @Test(testName = "org.infinispan.RehashStressTest", enabled = false)
 public class RehashStressTest extends AbstractInfinispanTest {
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public void stopAllCacheManageres() {
         while (!cacheManagers.isEmpty()) {
             cacheManagers.poll().stop();

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareStateTransferTest.java
@@ -62,7 +62,7 @@ public class TopologyAwareStateTransferTest extends MultipleCacheManagersTest {
       addresses = addressSet.toArray(new Address[addressSet.size()]);
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    @Override
    protected void clearContent() throws Throwable {
    }

--- a/core/src/test/java/org/infinispan/expiry/ExpiryTest.java
+++ b/core/src/test/java/org/infinispan/expiry/ExpiryTest.java
@@ -58,7 +58,7 @@ public class ExpiryTest extends AbstractInfinispanTest {
       cm = TestCacheManagerFactory.createLocalCacheManager(false);
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() {
       TestingUtil.killCacheManagers(cm);
       cm = null;

--- a/core/src/test/java/org/infinispan/interceptors/MarshalledValueInterceptorTest.java
+++ b/core/src/test/java/org/infinispan/interceptors/MarshalledValueInterceptorTest.java
@@ -52,7 +52,7 @@ public class MarshalledValueInterceptorTest extends AbstractInfinispanTest {
       cm = TestCacheManagerFactory.createLocalCacheManager(false);
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void tearDown() {
       TestingUtil.killCacheManagers(cm);
       cm = null;

--- a/core/src/test/java/org/infinispan/jmx/ActivationAndPassivationInterceptorMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/ActivationAndPassivationInterceptorMBeanTest.java
@@ -87,7 +87,7 @@ public class ActivationAndPassivationInterceptorMBeanTest extends SingleCacheMan
       return cacheManager;
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void resetStats() throws Exception {
       threadMBeanServer.invoke(activationInterceptorObjName, "resetStatistics", new Object[0], new String[0]);
    }

--- a/core/src/test/java/org/infinispan/jmx/CacheLoaderAndCacheStoreInterceptorMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheLoaderAndCacheStoreInterceptorMBeanTest.java
@@ -81,7 +81,7 @@ public class CacheLoaderAndCacheStoreInterceptorMBeanTest extends SingleCacheMan
       return cacheManager;
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void resetStats() throws Exception {
       threadMBeanServer.invoke(loaderInterceptorObjName, "resetStatistics", new Object[0], new String[0]);
       threadMBeanServer.invoke(storeInterceptorObjName, "resetStatistics", new Object[0], new String[0]);

--- a/core/src/test/java/org/infinispan/jmx/CacheMgmtInterceptorMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheMgmtInterceptorMBeanTest.java
@@ -68,7 +68,7 @@ public class CacheMgmtInterceptorMBeanTest extends SingleCacheManagerTest {
       return cacheManager;
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void resetStats() throws Exception {
       threadMBeanServer.invoke(mgmtInterceptor, "resetStatistics", new Object[0], new String[0]);
    }

--- a/core/src/test/java/org/infinispan/jmx/ComponentsJmxRegistrationTest.java
+++ b/core/src/test/java/org/infinispan/jmx/ComponentsJmxRegistrationTest.java
@@ -61,7 +61,7 @@ public class ComponentsJmxRegistrationTest extends AbstractInfinispanTest {
       cacheContainers.clear();
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() {
       MBeanServerFactory.releaseMBeanServer(mBeanServer);
       TestingUtil.killCacheManagers(cacheContainers);

--- a/core/src/test/java/org/infinispan/jmx/TxInterceptorMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/TxInterceptorMBeanTest.java
@@ -76,7 +76,7 @@ public class TxInterceptorMBeanTest extends MultipleCacheManagersTest {
       tm = TestingUtil.getTransactionManager(cache1);
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void resetStats() throws Exception {
       threadMBeanServer.invoke(txInterceptor, "resetStatistics", new Object[0], new String[0]);
       threadMBeanServer.invoke(txInterceptor2, "resetStatistics", new Object[0], new String[0]);

--- a/core/src/test/java/org/infinispan/jndi/BindingTest.java
+++ b/core/src/test/java/org/infinispan/jndi/BindingTest.java
@@ -66,7 +66,7 @@ public class BindingTest extends SingleCacheManagerTest {
       props.put("java.naming.factory.url.pkgs", "org.jboss.naming:org.jnp.interfaces");
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void stopJndiServer() throws Exception {
       namingServer.destroy();
       namingMain.stop();

--- a/core/src/test/java/org/infinispan/loaders/AbstractCacheStoreConfigTest.java
+++ b/core/src/test/java/org/infinispan/loaders/AbstractCacheStoreConfigTest.java
@@ -42,7 +42,7 @@ public class AbstractCacheStoreConfigTest extends AbstractInfinispanTest {
       config = new AbstractCacheStoreConfig();
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() throws CacheLoaderException {
       config = null;
    }

--- a/core/src/test/java/org/infinispan/loaders/CacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/loaders/CacheLoaderFunctionalTest.java
@@ -84,7 +84,7 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
       tm = TestingUtil.getTransactionManager(cache);
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void tearDown() {
       TestingUtil.killCacheManagers(cm);
       cache = null;
@@ -94,7 +94,7 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
       store = null;
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void afterMethod() throws CacheLoaderException {
       if (cache != null) cache.clear();
       if (store != null) store.clear();

--- a/core/src/test/java/org/infinispan/loaders/PassivatePersistentTest.java
+++ b/core/src/test/java/org/infinispan/loaders/PassivatePersistentTest.java
@@ -60,12 +60,12 @@ public class PassivatePersistentTest extends AbstractInfinispanTest {
       tm = TestingUtil.getTransactionManager(cache);
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void tearDown() {
       TestingUtil.killCacheManagers(cm);
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void afterMethod() throws CacheLoaderException {
       if (cache != null) cache.clear();
       if (store != null) store.clear();

--- a/core/src/test/java/org/infinispan/loaders/PassivationFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/loaders/PassivationFunctionalTest.java
@@ -69,12 +69,12 @@ public class PassivationFunctionalTest extends AbstractInfinispanTest {
       tm = TestingUtil.getTransactionManager(cache);
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void tearDown() {
       TestingUtil.killCacheManagers(cm);
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void afterMethod() throws CacheLoaderException {
       if (cache != null) cache.clear();
       if (store != null) store.clear();

--- a/core/src/test/java/org/infinispan/loaders/decorators/AsyncTest.java
+++ b/core/src/test/java/org/infinispan/loaders/decorators/AsyncTest.java
@@ -79,7 +79,7 @@ public class AsyncTest extends AbstractInfinispanTest {
       asyncExecutor = (ExecutorService) TestingUtil.extractField(store, "executor");
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() throws CacheLoaderException {
       if (store != null) store.stop();
    }

--- a/core/src/test/java/org/infinispan/loaders/decorators/BatchAsyncCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/decorators/BatchAsyncCacheStoreTest.java
@@ -126,7 +126,7 @@ public class BatchAsyncCacheStoreTest extends SingleCacheManagerTest {
       new File(tmpDirectory).mkdirs();
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
       TestingUtil.recursiveFileRemove(tmpDirectory);
    }

--- a/core/src/test/java/org/infinispan/loaders/decorators/ChainingCacheLoaderTest.java
+++ b/core/src/test/java/org/infinispan/loaders/decorators/ChainingCacheLoaderTest.java
@@ -89,7 +89,7 @@ public class ChainingCacheLoaderTest extends BaseCacheStoreTest {
       return store;
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void afterMethod() {
       if (store1 != null)
          store1.clear();

--- a/core/src/test/java/org/infinispan/loaders/dummy/DummyInMemoryCacheStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/loaders/dummy/DummyInMemoryCacheStoreFunctionalTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 @Test(groups = "unit", testName = "loaders.dummy.DummyInMemoryCacheStoreFunctionalTest")
 public class DummyInMemoryCacheStoreFunctionalTest extends BaseCacheStoreFunctionalTest {
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
       DummyInMemoryCacheStore.stores.remove(getClass().getName());
    }

--- a/core/src/test/java/org/infinispan/loaders/file/FileCacheStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/loaders/file/FileCacheStoreFunctionalTest.java
@@ -43,7 +43,7 @@ public class FileCacheStoreFunctionalTest extends BaseCacheStoreFunctionalTest {
       tmpDirectory = TestingUtil.tmpDirectory(this);
    }
    
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
       TestingUtil.recursiveFileRemove(tmpDirectory);
       new File(tmpDirectory).mkdirs();

--- a/core/src/test/java/org/infinispan/loaders/file/FileCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/file/FileCacheStoreTest.java
@@ -58,7 +58,7 @@ public class FileCacheStoreTest extends BaseCacheStoreTest {
       tmpDirectory = TestingUtil.tmpDirectory(this);
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
       TestingUtil.recursiveFileRemove(tmpDirectory);
       new File(tmpDirectory).mkdirs();

--- a/core/src/test/java/org/infinispan/manager/CacheManagerXmlConfigurationTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerXmlConfigurationTest.java
@@ -48,7 +48,7 @@ import static org.testng.Assert.assertEquals;
 public class CacheManagerXmlConfigurationTest extends AbstractInfinispanTest {
    EmbeddedCacheManager cm;
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() {
       if (cm != null) cm.stop();
       cm =null;

--- a/core/src/test/java/org/infinispan/marshall/MarshalledValueTest.java
+++ b/core/src/test/java/org/infinispan/marshall/MarshalledValueTest.java
@@ -111,7 +111,7 @@ public class MarshalledValueTest extends MultipleCacheManagersTest {
       super.destroy();
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() {
       Pojo.serializationCount = 0;
       Pojo.deserializationCount = 0;

--- a/core/src/test/java/org/infinispan/marshall/MarshalledValuesFineGrainedTest.java
+++ b/core/src/test/java/org/infinispan/marshall/MarshalledValuesFineGrainedTest.java
@@ -42,7 +42,7 @@ public class MarshalledValuesFineGrainedTest extends AbstractInfinispanTest {
    final CustomClass key = new CustomClass("key");
    final CustomClass value = new CustomClass("value");
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void cleanup() {
       TestingUtil.killCacheManagers(ecm);
       ecm = null;

--- a/core/src/test/java/org/infinispan/marshall/StoreAsBinaryConfigTest.java
+++ b/core/src/test/java/org/infinispan/marshall/StoreAsBinaryConfigTest.java
@@ -32,7 +32,7 @@ public class StoreAsBinaryConfigTest extends AbstractInfinispanTest {
 
    EmbeddedCacheManager ecm;
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void cleanup() {
       TestingUtil.killCacheManagers(ecm);
       ecm = null;

--- a/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
@@ -128,7 +128,7 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
       marshaller = extractCacheMarshaller(cm.getCache());
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void tearDown() {
       cm.stop();
    }

--- a/core/src/test/java/org/infinispan/marshall/jboss/JBossMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/jboss/JBossMarshallerTest.java
@@ -65,7 +65,7 @@ public class JBossMarshallerTest extends AbstractInfinispanTest {
       cm = TestCacheManagerFactory.createLocalCacheManager(false);
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void tearDown() {
       cm.stop();
    }

--- a/core/src/test/java/org/infinispan/marshall/jboss/JBossMarshallingTest.java
+++ b/core/src/test/java/org/infinispan/marshall/jboss/JBossMarshallingTest.java
@@ -64,7 +64,7 @@ public class JBossMarshallingTest extends AbstractInfinispanTest {
       unmarshaller = factory.createUnmarshaller(configuration);
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void tearDown() {
    }
    

--- a/core/src/test/java/org/infinispan/notifications/AsyncNotificationTest.java
+++ b/core/src/test/java/org/infinispan/notifications/AsyncNotificationTest.java
@@ -46,7 +46,7 @@ public class AsyncNotificationTest extends AbstractInfinispanTest {
       c = cm.getCache();
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() {
       TestingUtil.killCacheManagers(cm);
       cm = null;

--- a/core/src/test/java/org/infinispan/notifications/CacheListenerCacheLoaderTest.java
+++ b/core/src/test/java/org/infinispan/notifications/CacheListenerCacheLoaderTest.java
@@ -64,7 +64,7 @@ public class CacheListenerCacheLoaderTest extends AbstractInfinispanTest {
       cm.defineConfiguration("passivation", c);
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() {
       TestingUtil.killCacheManagers(cm);
       cm = null;

--- a/core/src/test/java/org/infinispan/notifications/CacheListenerRemovalTest.java
+++ b/core/src/test/java/org/infinispan/notifications/CacheListenerRemovalTest.java
@@ -49,7 +49,7 @@ public class CacheListenerRemovalTest extends AbstractInfinispanTest {
       cache = cm.getCache();
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() {
       TestingUtil.killCacheManagers(cm);
       cm = null;

--- a/core/src/test/java/org/infinispan/notifications/ConcurrentNotificationTest.java
+++ b/core/src/test/java/org/infinispan/notifications/ConcurrentNotificationTest.java
@@ -58,7 +58,7 @@ public class ConcurrentNotificationTest extends AbstractInfinispanTest {
       cache.addListener(listener);
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() {
       TestingUtil.killCacheManagers(cm);
       cm = null;

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierTest.java
@@ -84,7 +84,7 @@ public class CacheNotifierTest extends AbstractInfinispanTest {
       cm.stop();
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void destroyManager() {
       TestingUtil.killCacheManagers(cache.getCacheManager());
    }

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierTxTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierTxTest.java
@@ -81,7 +81,7 @@ public class CacheNotifierTxTest extends AbstractInfinispanTest {
       cm.stop();
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void destroyManager() {
       TestingUtil.killCacheManagers(cache.getCacheManager());
    }

--- a/core/src/test/java/org/infinispan/notifications/cachemanagerlistener/CacheManagerNotifierTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachemanagerlistener/CacheManagerNotifierTest.java
@@ -47,7 +47,7 @@ public class CacheManagerNotifierTest extends AbstractInfinispanTest {
    EmbeddedCacheManager cm1;
    EmbeddedCacheManager cm2;
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() {
       TestingUtil.killCacheManagers(cm1, cm2);
    }

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferLargeObjectTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferLargeObjectTest.java
@@ -173,7 +173,7 @@ public class StateTransferLargeObjectTest extends MultipleCacheManagersTest {
    }
 
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    @Override
    protected void clearContent() throws Throwable {
    }

--- a/core/src/test/java/org/infinispan/test/fwk/TcpMPingEnvironmentTest.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TcpMPingEnvironmentTest.java
@@ -60,7 +60,7 @@ public class TcpMPingEnvironmentTest {
    private boolean success = false;
    private static final String IP_ADDRESS = "228.10.10.5";
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void destroyCaches() {
       for (JChannel ch : openedChannles) {
          ch.disconnect();

--- a/core/src/test/java/org/infinispan/tx/OnePhaseXATest.java
+++ b/core/src/test/java/org/infinispan/tx/OnePhaseXATest.java
@@ -71,7 +71,7 @@ public class OnePhaseXATest extends AbstractInfinispanTest {
       for (int i = 0; i < CACHES_NUM; i++) caches.add(getCache());
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void tearDown() {
       if (caches != null) TestingUtil.killCacheManagers(cacheContainers);
    }

--- a/core/src/test/java/org/infinispan/tx/dld/LocalDeadlockDetectionTest.java
+++ b/core/src/test/java/org/infinispan/tx/dld/LocalDeadlockDetectionTest.java
@@ -79,7 +79,7 @@ public class LocalDeadlockDetectionTest extends SingleCacheManagerTest {
    }
 
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void stopExecutors() {
       t1.stopThread();
       t2.stopThread();

--- a/lucene-directory/src/test/java/org/infinispan/lucene/profiling/IndexReadingStressTest.java
+++ b/lucene-directory/src/test/java/org/infinispan/lucene/profiling/IndexReadingStressTest.java
@@ -163,7 +163,7 @@ public class IndexReadingStressTest {
       cacheFactory.start();
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public static void afterTest() {
       cacheFactory.stop();
       TestingUtil.recursiveFileRemove(indexName);

--- a/lucene-directory/src/test/java/org/infinispan/lucene/profiling/PerformanceCompareStressTest.java
+++ b/lucene-directory/src/test/java/org/infinispan/lucene/profiling/PerformanceCompareStressTest.java
@@ -166,7 +166,7 @@ public class PerformanceCompareStressTest {
       cache.clear();
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void afterTest() {
       TestingUtil.killCaches(cache);
       TestingUtil.killCacheManagers(cacheFactory);

--- a/query/src/test/java/org/infinispan/query/cacheloaders/EntryActivatingTest.java
+++ b/query/src/test/java/org/infinispan/query/cacheloaders/EntryActivatingTest.java
@@ -65,7 +65,7 @@ public class EntryActivatingTest extends AbstractInfinispanTest {
       recreateCacheManager();
    }
 
-   @AfterTest
+   @AfterTest(alwaysRun = true)
    public void tearDown() {
       TestingUtil.killCacheManagers(cm);
    }

--- a/query/src/test/java/org/infinispan/query/cacheloaders/InconsistentIndexesAfterRestartTest.java
+++ b/query/src/test/java/org/infinispan/query/cacheloaders/InconsistentIndexesAfterRestartTest.java
@@ -188,7 +188,7 @@ public class InconsistentIndexesAfterRestartTest extends AbstractInfinispanTest 
        new File(TMP_DIR).mkdirs();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     protected void clearTempDir() {
        TestingUtil.recursiveFileRemove(TMP_DIR);
     }

--- a/query/src/test/java/org/infinispan/query/config/IndexingConfigurationIgnored.java
+++ b/query/src/test/java/org/infinispan/query/config/IndexingConfigurationIgnored.java
@@ -45,7 +45,7 @@ public class IndexingConfigurationIgnored {
       manager = TestCacheManagerFactory.fromXml("configuration-parsing-test.xml");
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void destroy() throws Exception {
       TestingUtil.killCacheManagers(manager);
    }

--- a/query/src/test/java/org/infinispan/query/indexedembedded/CollectionsIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/indexedembedded/CollectionsIndexingTest.java
@@ -65,7 +65,7 @@ public class CollectionsIndexingTest extends SingleCacheManagerTest {
       qf = Search.getSearchManager(cache);
    }
    
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void cleanupData() {
       cache.clear();
    }

--- a/query/src/test/java/org/infinispan/query/queries/faceting/SimpleFacetingTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/faceting/SimpleFacetingTest.java
@@ -71,7 +71,7 @@ public class SimpleFacetingTest extends SingleCacheManagerTest {
       cache.put( "500_Superfast", new Car( "Ferrari 500_Superfast", "Rosso corsa", 4000 ) );
    }
    
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void cleanupData() {
       cache.clear();
    }

--- a/server/rest/src/test/scala/org/infinispan/rest/IntegrationTest.scala
+++ b/server/rest/src/test/scala/org/infinispan/rest/IntegrationTest.scala
@@ -63,7 +63,7 @@ class IntegrationTest {
       ServerInstance.start()
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    def tearDown() = {
       ServerInstance.stop()
    }

--- a/spring/src/test/java/org/infinispan/spring/provider/SpringRemoteCacheManagerTest.java
+++ b/spring/src/test/java/org/infinispan/spring/provider/SpringRemoteCacheManagerTest.java
@@ -75,7 +75,7 @@ public class SpringRemoteCacheManagerTest extends SingleCacheManagerTest {
       remoteCacheManager = new RemoteCacheManager("localhost", hotrodServer.getPort());
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void destroyRemoteCacheFactory() {
       remoteCacheManager.stop();
       hotrodServer.stop();

--- a/spring/src/test/java/org/infinispan/spring/provider/sample/CachingBookDaoContextTest.java
+++ b/spring/src/test/java/org/infinispan/spring/provider/sample/CachingBookDaoContextTest.java
@@ -50,7 +50,7 @@ public class CachingBookDaoContextTest extends AbstractTestNGSpringContextTests 
       booksCache().addListener(this.new LoggingListener());
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void clearBookCache() {
       booksCache().clear();
    }

--- a/spring/src/test/java/org/infinispan/spring/support/remote/InfinispanNamedRemoteCacheFactoryBeanTest.java
+++ b/spring/src/test/java/org/infinispan/spring/support/remote/InfinispanNamedRemoteCacheFactoryBeanTest.java
@@ -73,7 +73,7 @@ public class InfinispanNamedRemoteCacheFactoryBeanTest extends SingleCacheManage
       remoteCacheManager = new RemoteCacheManager("localhost", hotrodServer.getPort());
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void destroyRemoteCacheFactory() {
       remoteCacheManager.stop();
       hotrodServer.stop();

--- a/tree/src/test/java/org/infinispan/loaders/TreeCacheWithJdbmLoaderTest.java
+++ b/tree/src/test/java/org/infinispan/loaders/TreeCacheWithJdbmLoaderTest.java
@@ -54,7 +54,7 @@ public class TreeCacheWithJdbmLoaderTest extends TreeCacheWithLoaderTest {
       tmpDirectory = TestingUtil.tmpDirectory(this);
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
       TestingUtil.recursiveFileRemove(tmpDirectory);
       new File(tmpDirectory).mkdirs();

--- a/tree/src/test/java/org/infinispan/profiling/TreeProfileTest.java
+++ b/tree/src/test/java/org/infinispan/profiling/TreeProfileTest.java
@@ -93,7 +93,7 @@ public class TreeProfileTest {
       cache = new TreeCacheImpl(c);
    }
 
-   @AfterMethod
+   @AfterMethod(alwaysRun = true)
    public void tearDown() {
       TreeTestingUtil.killTreeCaches(cache);
       TestingUtil.killCacheManagers(cacheContainer);


### PR DESCRIPTION
By default TestNG doesn't run methods annotated with `@AfterMethod`/`@AfterTest`/`@AfterClass` if the test method failed.
This means we have to write `alwaysRun=true` explicitly, or the method won't run after a failure and it may leave cache managers lying around.
