### PR TITLE
ISPN-2095 Use flag to identify atomic map operations

### DIFF
--- a/core/src/main/java/org/infinispan/context/Flag.java
+++ b/core/src/main/java/org/infinispan/context/Flag.java
@@ -179,7 +179,14 @@ public enum Flag {
     * Used by the DistLockingInterceptor to commit the change no matter what (if the flag is set). This is used when
     * a node A pushes state to another node B and A doesn't want B to check if the state really belongs to it
     */
-   SKIP_OWNERSHIP_CHECK;
+   SKIP_OWNERSHIP_CHECK,
+   /**
+    * Signals when a particular cache write operation is writing a delta of
+    * the object, rather than the full object. This can be useful in order to
+    * make decisions such as whether the cache store needs checking to see if
+    * the previous value needs to be loaded and merged.
+    */
+   DELTA_WRITE;
 
    /**
     * Creates a copy of a Flag Set removing instances of FAIL_SILENTLY.

--- a/core/src/main/java/org/infinispan/interceptors/CacheLoaderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheLoaderInterceptor.java
@@ -49,6 +49,7 @@ import org.rhq.helpers.pluginAnnotations.agent.MeasurementType;
 import org.rhq.helpers.pluginAnnotations.agent.Metric;
 import org.rhq.helpers.pluginAnnotations.agent.Operation;
 
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 @MBean(objectName = "CacheLoader", description = "Component that handles loading entries from a CacheStore into memory.")
@@ -128,7 +129,7 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
       return invokeNextInterceptor(ctx, command);
    }
 
-   protected boolean isPrimaryOwner(Object key) {
+   protected boolean forceLoad(Object key, Set<Flag> flags) {
       return false;
    }
 
@@ -139,7 +140,7 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
 
       // If this is a remote call, skip loading UNLESS we are the coordinator/primary data owner of this key, and
       // are using eviction or write skew checking.
-      if (!isRetrieval && !ctx.isOriginLocal() && !isPrimaryOwner(key)) return false;
+      if (!isRetrieval && !ctx.isOriginLocal() && !forceLoad(key, cmd.getFlags())) return false;
 
       // first check if the container contains the key we need.  Try and load this into the context.
       CacheEntry e = ctx.lookupEntry(key);

--- a/core/src/main/java/org/infinispan/interceptors/ClusteredActivationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/ClusteredActivationInterceptor.java
@@ -20,10 +20,13 @@
 package org.infinispan.interceptors;
 
 import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.context.Flag;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.remoting.transport.Transport;
+
+import java.util.Set;
 
 /**
  * The same as a regular cache loader interceptor, except that it contains additional logic to force loading from the
@@ -34,7 +37,7 @@ import org.infinispan.remoting.transport.Transport;
  */
 public class ClusteredActivationInterceptor extends ActivationInterceptor {
    private CacheMode cacheMode;
-   private boolean remoteNodeMayNeedToLoad;
+   private boolean isWriteSkewConfigured;
    private Transport transport;
    private DistributionManager distributionManager;
 
@@ -51,12 +54,32 @@ public class ClusteredActivationInterceptor extends ActivationInterceptor {
       // For now the coordinator/primary data owner may need to load from the cache store, even if
       // this is a remote call, if write skew checking is enabled.  Once ISPN-317 is in, this may also need to
       // happen if running in distributed mode and eviction is enabled.
-      remoteNodeMayNeedToLoad = cacheConfiguration.locking().writeSkewCheck() && cacheMode.isClustered();
+      isWriteSkewConfigured = cacheConfiguration.locking().writeSkewCheck() && cacheMode.isClustered();
    }
 
    @Override
-   protected boolean isPrimaryOwner(Object key) {
-      return remoteNodeMayNeedToLoad && ((cacheMode.isReplicated() && transport.isCoordinator()) ||
-                                               (cacheMode.isDistributed() && distributionManager.getPrimaryLocation(key).equals(transport.getAddress())));
+   protected boolean forceLoad(Object key, Set<Flag> flags) {
+      return isDeltaWrite(flags) || (isWriteSkewConfigured && isPrimaryOwner(key));
    }
+
+   /**
+    * Finding out whether a node is primary owner of a particular key is
+    * relevant when trying to do write checks in a clustered environment
+    * where passivation is enabled. This is important in order to compare
+    * previous values.
+    */
+   private boolean isPrimaryOwner(Object key) {
+      return ((cacheMode.isReplicated() && transport.isCoordinator()) ||
+                 (cacheMode.isDistributed() && distributionManager.getPrimaryLocation(key).equals(transport.getAddress())));
+   }
+
+   /**
+    * Indicates whether the operation is a delta write. If it is, the
+    * previous value needs to be loaded from the cache store so that
+    * it can be merged.
+    */
+   private boolean isDeltaWrite(Set<Flag> flags) {
+      return (flags != null && flags.contains(Flag.DELTA_WRITE));
+   }
+
 }

--- a/core/src/main/java/org/infinispan/interceptors/ClusteredCacheLoaderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/ClusteredCacheLoaderInterceptor.java
@@ -20,10 +20,13 @@
 package org.infinispan.interceptors;
 
 import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.context.Flag;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.remoting.transport.Transport;
+
+import java.util.Set;
 
 /**
  * The same as a regular cache loader interceptor, except that it contains additional logic to force loading from the
@@ -35,7 +38,7 @@ import org.infinispan.remoting.transport.Transport;
 public class ClusteredCacheLoaderInterceptor extends CacheLoaderInterceptor {
 
    private CacheMode cacheMode;
-   private boolean remoteNodeMayNeedToLoad;
+   private boolean isWriteSkewConfigured;
    private Transport transport;
    private DistributionManager distributionManager;
 
@@ -51,12 +54,12 @@ public class ClusteredCacheLoaderInterceptor extends CacheLoaderInterceptor {
       // For now the coordinator/primary data owner may need to load from the cache store, even if
       // this is a remote call, if write skew checking is enabled.  Once ISPN-317 is in, this may also need to
       // happen if running in distributed mode and eviction is enabled.
-      remoteNodeMayNeedToLoad = cacheConfiguration.locking().writeSkewCheck() && cacheMode.isClustered();
+      isWriteSkewConfigured = cacheConfiguration.locking().writeSkewCheck() && cacheMode.isClustered();
    }
 
    @Override
-   protected boolean isPrimaryOwner(Object key) {
-      return remoteNodeMayNeedToLoad && ((cacheMode.isReplicated() && transport.isCoordinator()) ||
+   protected boolean forceLoad(Object key, Set<Flag> flags) {
+      return isWriteSkewConfigured && ((cacheMode.isReplicated() && transport.isCoordinator()) ||
             (cacheMode.isDistributed() && distributionManager.getPrimaryLocation(key).equals(transport.getAddress())));
    }
 }

--- a/core/src/test/java/org/infinispan/atomic/ClusteredAtomicMapPassivationTest.java
+++ b/core/src/test/java/org/infinispan/atomic/ClusteredAtomicMapPassivationTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.atomic;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.loaders.dummy.DummyInMemoryCacheStore;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.annotations.Test;
+
+import javax.transaction.TransactionManager;
+
+import java.util.concurrent.Callable;
+
+import static org.infinispan.test.TestingUtil.withTx;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * Test atomic map operations in a clustered environment where passivation
+ * has been configured.
+ *
+ * @author Galder Zamarreño
+ * @since 5.1
+ */
+@Test(groups = "functional", testName = "atomic.ClusteredAtomicMapPassivationTest")
+public class ClusteredAtomicMapPassivationTest extends MultipleCacheManagersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(
+            CacheMode.REPL_SYNC, true);
+      builder.loaders().passivation(true)
+                  .addCacheLoader().cacheLoader(new DummyInMemoryCacheStore());
+      createClusteredCaches(2, "atomic", builder);
+   }
+
+   public void testEviction() throws Exception {
+      final Cache<String, Object> cache1 = cache(0, "atomic");
+      final Cache<String, Object> cache2 = cache(1, "atomic");
+      TransactionManager tm1 = cache1.getAdvancedCache().getTransactionManager();
+
+      withTx(tm1, new Callable<Void>() {
+         @Override
+         public Void call() throws Exception {
+            // Add atomic map in first node
+            AtomicMap<String, String> map = AtomicMapLookup.getAtomicMap(
+                  cache1, "map");
+            map.put("key1", "value1");
+            map.put("key2", "value2");
+            return null;
+         }
+      });
+
+      // From second node, passivate the map
+      cache2.evict("map");
+
+      withTx(tm1, new Callable<Void>() {
+         @Override
+         public Void call() throws Exception {
+            // Modify atomic map from first node
+            AtomicMap<String, String> map = AtomicMapLookup.getAtomicMap(
+                  cache1, "map");
+            map.put("key1", "new_value1");
+            assertTrue(map.containsKey("key2"));
+            assertEquals("value2", map.get("key2"));
+            return null;
+         }
+      });
+
+      // Lookup entry from second node and verify it has all the data
+      AtomicMap<String, String> map = AtomicMapLookup.getAtomicMap(cache2, "map");
+      assertTrue(map.containsKey("key1"));
+      assertTrue(map.containsKey("key2"));
+      assertEquals("new_value1", map.get("key1"));
+      assertEquals("value2", map.get("key2"));
+   }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2095

I admit that my solution is debatable, but I think it's the simplest and safest option while avoiding instanceof calls to figure out what the put call is really putting.

By assigning a flag to all delta writes, such as atomic map writes, interceptors such as the clustered activation interceptor can decide more precisely whether to load the previous value or not, which can be used to merge atomic maps.

5.1.x branch: `t_2095_5`
