### PR TITLE
ISPN-2099 - Upgrade jboss-logging to avoid troubles with pom.xml

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -137,9 +137,9 @@
       <version.jboss.marshalling>1.3.11.GA</version.jboss.marshalling>
       <version.jbossjta>4.16.3.Final</version.jbossjta>
       <version.osgi>4.3.0</version.osgi>
-      <version.jboss.logging>3.1.0.GA</version.jboss.logging>
+      <version.jboss.logging>3.1.1.GA</version.jboss.logging>
       <version.jboss.logging.processor>1.0.3.Final</version.jboss.logging.processor>
-      <version.jboss.logmanager>1.2.0.GA</version.jboss.logmanager>
+      <version.jboss.logmanager>1.3.1.Final</version.jboss.logmanager>
       <version.jboss.spec>1.0.0.Final</version.jboss.spec>
       <version.jcipannotations>1.0</version.jcipannotations>
       <version.jclouds>1.1.0</version.jclouds>


### PR DESCRIPTION
Upgrade jboss logging versions in parent/pom.xml:
-   version.jboss.logging: from 3.1.0.GA to 3.1.1.GA
-   version.jboss.logmanager: from 1.2.0.GA to 1.3.1.Final

Fixes issue https://issues.jboss.org/browse/ISPN-2099.
