### PR TITLE
ISPN-2104 Add methods with java.util.concurrent.TimeUnit for specifying ...

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/AsyncConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AsyncConfigurationBuilder.java
@@ -85,6 +85,14 @@ public class AsyncConfigurationBuilder extends AbstractClusteringConfigurationCh
    }
 
    /**
+    * If useReplQueue is set to true, this attribute controls how often the asynchronous thread used
+    * to flush the replication queue runs.
+    */
+   public AsyncConfigurationBuilder replQueueInterval(long interval, TimeUnit unit) {
+      return replQueueInterval(unit.toMillis(interval));
+   }
+
+   /**
     * If useReplQueue is set to true, this attribute can be used to trigger flushing of the queue
     * when it reaches a specific threshold.
     */

--- a/core/src/main/java/org/infinispan/configuration/cache/AsyncLoaderConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AsyncLoaderConfigurationBuilder.java
@@ -67,6 +67,14 @@ public class AsyncLoaderConfigurationBuilder extends AbstractLoaderConfiguration
    }
 
    /**
+    * Timeout to acquire the lock which guards the state to be flushed to the cache store
+    * periodically. The timeout can be adjusted for a running cache.
+    */
+   public AsyncLoaderConfigurationBuilder flushLockTimeout(long l, TimeUnit unit) {
+      return flushLockTimeout(unit.toMillis(l));
+   }
+
+   /**
     * Sets the size of the modification queue for the async store. If updates are made at a rate
     * that is faster than the underlying cache store can process this queue, then the async store
     * behaves like a synchronous store for that period, blocking until the queue can accept more
@@ -85,6 +93,15 @@ public class AsyncLoaderConfigurationBuilder extends AbstractLoaderConfiguration
    public AsyncLoaderConfigurationBuilder shutdownTimeout(long l) {
       this.shutdownTimeout = l;
       return this;
+   }
+
+   /**
+    * Timeout to stop the cache store. When the store is stopped it's possible that some
+    * modifications still need to be applied; you likely want to set a very large timeout to make
+    * sure to not loose data
+    */
+   public AsyncLoaderConfigurationBuilder shutdownTimeout(long l, TimeUnit unit) {
+      return shutdownTimeout(unit.toMillis(l));
    }
 
    /**

--- a/core/src/main/java/org/infinispan/configuration/cache/DeadlockDetectionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/DeadlockDetectionConfigurationBuilder.java
@@ -42,6 +42,14 @@ public class DeadlockDetectionConfigurationBuilder extends AbstractConfiguration
    }
    
    /**
+    * Time period that determines how often is lock acquisition attempted within maximum time
+    * allowed to acquire a particular lock
+    */
+   public DeadlockDetectionConfigurationBuilder spinDuration(long l, TimeUnit unit) {
+      return spinDuration(unit.toMillis(l));
+   }
+
+   /**
     * Enable deadlock detection
     */
    public DeadlockDetectionConfigurationBuilder enable() {

--- a/core/src/main/java/org/infinispan/configuration/cache/ExpirationConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ExpirationConfigurationBuilder.java
@@ -46,6 +46,16 @@ public class ExpirationConfigurationBuilder extends AbstractConfigurationChildBu
    }
 
    /**
+    * Maximum lifespan of a cache entry, after which the entry is expired cluster-wide, in
+    * milliseconds. -1 means the entries never expire.
+    *
+    * Note that this can be overridden on a per-entry basis by using the Cache API.
+    */
+   public ExpirationConfigurationBuilder lifespan(long l, TimeUnit unit) {
+      return lifespan(unit.toMillis(l));
+   }
+
+   /**
     * Maximum idle time a cache entry will be maintained in the cache, in milliseconds. If the idle
     * time is exceeded, the entry will be expired cluster-wide. -1 means the entries never expire.
     * 
@@ -54,6 +64,16 @@ public class ExpirationConfigurationBuilder extends AbstractConfigurationChildBu
    public ExpirationConfigurationBuilder maxIdle(long l) {
       this.maxIdle = l;
       return this;
+   }
+
+   /**
+    * Maximum idle time a cache entry will be maintained in the cache, in milliseconds. If the idle
+    * time is exceeded, the entry will be expired cluster-wide. -1 means the entries never expire.
+    *
+    * Note that this can be overridden on a per-entry basis by using the Cache API.
+    */
+   public ExpirationConfigurationBuilder maxIdle(long l, TimeUnit unit) {
+      return maxIdle(unit.toMillis(l));
    }
 
    /**
@@ -94,6 +114,15 @@ public class ExpirationConfigurationBuilder extends AbstractConfigurationChildBu
    public ExpirationConfigurationBuilder wakeUpInterval(long l) {
       this.wakeUpInterval = l;
       return this;
+   }
+
+   /**
+    * Interval (in milliseconds) between subsequent runs to purge expired entries from memory and
+    * any cache stores. If you wish to disable the periodic eviction process altogether, set
+    * wakeupInterval to -1.
+    */
+   public ExpirationConfigurationBuilder wakeUpInterval(long l, TimeUnit unit) {
+      return wakeUpInterval(unit.toMillis(l));
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/FileCacheStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/FileCacheStoreConfigurationBuilder.java
@@ -62,6 +62,10 @@ public class FileCacheStoreConfigurationBuilder extends AbstractLoaderConfigurat
       return this;
    }
 
+   public FileCacheStoreConfigurationBuilder fsyncInterval(long fsyncInterval, TimeUnit unit) {
+      return fsyncInterval(unit.toMillis(fsyncInterval));
+   }
+
    public FileCacheStoreConfigurationBuilder fsyncMode(FsyncMode fsyncMode) {
       this.fsyncMode = fsyncMode;
       return this;
@@ -106,6 +110,10 @@ public class FileCacheStoreConfigurationBuilder extends AbstractLoaderConfigurat
    public FileCacheStoreConfigurationBuilder lockAcquistionTimeout(long lockAcquistionTimeout) {
       this.lockAcquistionTimeout = lockAcquistionTimeout;
       return this;
+   }
+
+   public FileCacheStoreConfigurationBuilder lockAcquistionTimeout(long lockAcquistionTimeout, TimeUnit unit) {
+      return lockAcquistionTimeout(unit.toMillis(lockAcquistionTimeout));
    }
 
    public FileCacheStoreConfigurationBuilder lockConcurrencyLevel(int lockConcurrencyLevel) {

--- a/core/src/main/java/org/infinispan/configuration/cache/L1ConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/L1ConfigurationBuilder.java
@@ -74,11 +74,25 @@ public class L1ConfigurationBuilder extends AbstractClusteringConfigurationChild
    }
 
    /**
+    * Maximum lifespan of an entry placed in the L1 cache.
+    */
+   public L1ConfigurationBuilder lifespan(long lifespan, TimeUnit unit) {
+      return lifespan(unit.toMillis(lifespan));
+   }
+
+   /**
     * How often the L1 requestors map is cleaned up of stale items
     */
    public L1ConfigurationBuilder cleanupTaskFrequency(long frequencyMillis) {
       this.cleanupTaskFrequency = frequencyMillis;
       return this;
+   }
+
+   /**
+    * How often the L1 requestors map is cleaned up of stale items
+    */
+   public L1ConfigurationBuilder cleanupTaskFrequency(long frequencyMillis, TimeUnit unit) {
+      return cleanupTaskFrequency(unit.toMillis(frequencyMillis));
    }
 
    /**

--- a/core/src/main/java/org/infinispan/configuration/cache/LockingConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LockingConfigurationBuilder.java
@@ -72,6 +72,13 @@ public class LockingConfigurationBuilder extends AbstractConfigurationChildBuild
    }
 
    /**
+    * Maximum time to attempt a particular lock acquisition
+    */
+   public LockingConfigurationBuilder lockAcquisitionTimeout(long l, TimeUnit unit) {
+      return lockAcquisitionTimeout(unit.toMillis(l));
+   }
+
+   /**
     * If true, a pool of shared locks is maintained for all entries that need to be locked.
     * Otherwise, a lock is created per entry in the cache. Lock striping helps control memory
     * footprint but may reduce concurrency in the system.

--- a/core/src/main/java/org/infinispan/configuration/cache/SingletonStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/SingletonStoreConfigurationBuilder.java
@@ -73,6 +73,14 @@ public class SingletonStoreConfigurationBuilder extends AbstractLoaderConfigurat
    }
 
    /**
+    * If pushStateWhenCoordinator is true, this property sets the maximum number of milliseconds
+    * that the process of pushing the in-memory state to the underlying cache loader should take.
+    */
+   public SingletonStoreConfigurationBuilder pushStateTimeout(long l, TimeUnit unit) {
+      return pushStateTimeout(unit.toMillis(l));
+   }
+
+   /**
     * If true, when a node becomes the coordinator, it will transfer in-memory state to the
     * underlying cache store. This can be very useful in situations where the coordinator crashes
     * and there's a gap in time until the new coordinator is elected.

--- a/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfigurationBuilder.java
@@ -75,6 +75,14 @@ public class StateTransferConfigurationBuilder extends
       return this;
    }
 
+   /**
+    * This is the maximum amount of time - in milliseconds - to wait for state from neighboring
+    * caches, before throwing an exception and aborting startup.
+    */
+   public StateTransferConfigurationBuilder timeout(long l, TimeUnit unit) {
+      return timeout(unit.toMillis(l));
+   }
+
    @Override
    void validate() {
       // certain combinations are illegal, such as state transfer + invalidation

--- a/core/src/main/java/org/infinispan/configuration/cache/SyncConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/SyncConfigurationBuilder.java
@@ -42,6 +42,14 @@ public class SyncConfigurationBuilder extends AbstractClusteringConfigurationChi
       return this;
    }
 
+   /**
+    * This is the timeout used to wait for an acknowledgment when making a remote call, after which
+    * the call is aborted and an exception is thrown.
+    */
+   public SyncConfigurationBuilder replTimeout(long l, TimeUnit unit) {
+      return replTimeout(unit.toMillis(l));
+   }
+
    @Override
    void validate() {
       

--- a/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
@@ -85,6 +85,19 @@ public class TransactionConfigurationBuilder extends AbstractConfigurationChildB
    }
 
    /**
+    * If there are any ongoing transactions when a cache is stopped, Infinispan waits for ongoing
+    * remote and local transactions to finish. The amount of time to wait for is defined by the
+    * cache stop timeout. It is recommended that this value does not exceed the transaction timeout
+    * because even if a new transaction was started just before the cache was stopped, this could
+    * only last as long as the transaction timeout allows it.
+    * <p/>
+    * This configuration property may be adjusted at runtime
+    */
+   public TransactionConfigurationBuilder cacheStopTimeout(long l, TimeUnit unit) {
+      return cacheStopTimeout(unit.toMillis(l));
+   }
+
+   /**
     * Only has effect for DIST mode and when useEagerLocking is set to true. When this is enabled,
     * then only one node is locked in the cluster, disregarding numOwners config. On the opposite,
     * if this is false, then on all cache.lock() calls numOwners RPCs are being performed. The node

--- a/core/src/main/java/org/infinispan/configuration/global/TransportConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/TransportConfigurationBuilder.java
@@ -99,6 +99,16 @@ public class TransportConfigurationBuilder extends AbstractGlobalConfigurationBu
    }
 
    /**
+    * Timeout for coordinating cluster formation when nodes join or leave the cluster.
+    *
+    * @param distributedSyncTimeout
+    * @return
+    */
+   public TransportConfigurationBuilder distributedSyncTimeout(long distributedSyncTimeout, TimeUnit unit) {
+      return distributedSyncTimeout(unit.toMillis(distributedSyncTimeout));
+   }
+
+   /**
     * Class that represents a network transport. Must implement
     * org.infinispan.remoting.transport.Transport
     *


### PR DESCRIPTION
...expiration intervals

Overload all methods that take a long millis value to also accept a TimeUnit and perform the conversion to millis internally.

See jira issue: https://issues.jboss.org/browse/ISPN-2104
