### PR TITLE
Backward compatibility for users that user Parser, so they could upgrade...

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
@@ -1,0 +1,14 @@
+package org.infinispan.configuration.parsing;
+
+/**
+ * This class is here just for backward compatibility
+ * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
+ * @deprecated use {@link ParserRegistry}
+ */
+@Deprecated
+public class Parser extends ParserRegistry {
+
+    public Parser(ClassLoader classLoader) {
+        super(classLoader);
+    }
+}


### PR DESCRIPTION
... to newer version without need to change code and recompile

This issue prevents AS7 to use latest version of infinispan as it needs Parser class.
In long term this is could/should be removed but it should be present at least until 5.2.0.FINAL is released.

Currently this issue blocks "release" of CapeDwarf. as we have catch 22, capedwarf needs new 5.2.x infinispan, but AS cannot include it as there is no non-snapshot release available.
and capedwarf distro cannot just override infinispan that is part of AS, becouse of this issue.

for more info, you can also ping @alesj
