### PR TITLE
ISPN-2112 Wait for 10 seconds for views to be installed

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
@@ -107,7 +107,7 @@ public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
       assert manager(1).getCache() != null;
       assert manager(2).getCache() != null;
 
-      blockUntilViewReceived(manager(0).getCache(), 3, 10000);
+      blockUntilViewReceived(manager(0).getCache(), 3);
       blockUntilCacheStatusAchieved(manager(0).getCache(), ComponentStatus.RUNNING, 10000);
       blockUntilCacheStatusAchieved(manager(1).getCache(), ComponentStatus.RUNNING, 10000);
       blockUntilCacheStatusAchieved(manager(2).getCache(), ComponentStatus.RUNNING, 10000);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
@@ -37,7 +37,7 @@ public abstract class MultiHotRodServersTest extends MultipleCacheManagersTest {
       // Verify that default caches should be started
       for (int i = 0; i < num; i++) assert manager(i).getCache() != null;
       // Block until views have been received
-      blockUntilViewReceived(manager(0).getCache(), num, 10000);
+      blockUntilViewReceived(manager(0).getCache(), num);
       // Verify that caches running
       for (int i = 0; i < num; i++) {
          blockUntilCacheStatusAchieved(

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -396,6 +396,17 @@ public class TestingUtil {
       blockUntilViewReceived(cache, groupSize, timeout, true);
    }
 
+   /**
+    * Loops, continually calling {@link #areCacheViewsComplete(Cache[])} until
+    * it either returns true or a default timeout has elapsed.
+    *
+    * @param groupSize number of caches expected in the group
+    */
+   public static void blockUntilViewReceived(Cache cache, int groupSize) {
+      // Default 10 seconds
+      blockUntilViewReceived(cache, groupSize, 10000, true);
+   }
+
    public static void blockUntilViewReceived(Cache cache, int groupSize, long timeout, boolean barfIfTooManyMembersInView) {
       long failTime = System.currentTimeMillis() + timeout;
 

--- a/core/src/test/java/org/infinispan/tx/StaleLockRecoveryTest.java
+++ b/core/src/test/java/org/infinispan/tx/StaleLockRecoveryTest.java
@@ -71,7 +71,7 @@ public class StaleLockRecoveryTest extends MultipleCacheManagersTest {
       assertLocked(c2, "k");
 
       cacheManagers.get(0).stop();
-      TestingUtil.blockUntilViewReceived(c2, 1, 1000);
+      TestingUtil.blockUntilViewReceived(c2, 1);
 
       EmbeddedCacheManager cacheManager = c2.getCacheManager();
       assert cacheManager.getMembers().size() == 1;

--- a/core/src/test/java/org/infinispan/tx/exception/TxAndRemoteTimeoutExceptionTest.java
+++ b/core/src/test/java/org/infinispan/tx/exception/TxAndRemoteTimeoutExceptionTest.java
@@ -77,7 +77,7 @@ public class TxAndRemoteTimeoutExceptionTest extends MultipleCacheManagersTest {
       txTable0 = TestingUtil.getTransactionTable(cache(0));
       txTable1 = TestingUtil.getTransactionTable(cache(1));
       tm = cache(0).getAdvancedCache().getTransactionManager();
-      TestingUtil.blockUntilViewReceived(cache(0), 2, 10000);
+      TestingUtil.blockUntilViewReceived(cache(0), 2);
    }
 
    protected Configuration getDefaultConfig() {

--- a/lucene-directory/src/test/java/org/infinispan/lucene/profiling/DynamicTopologyStressTest.java
+++ b/lucene-directory/src/test/java/org/infinispan/lucene/profiling/DynamicTopologyStressTest.java
@@ -102,7 +102,7 @@ public class DynamicTopologyStressTest extends MultipleCacheManagersTest {
          Cache<Object, Object> cache = readers[i].getCache();
          discardPerNode[i] = TestingUtil.getDiscardForCache(cache);
          TestingUtil.setDelayForCache(cache, 1, 1);
-         TestingUtil.blockUntilViewReceived(cache, i + 1, 1000);
+         TestingUtil.blockUntilViewReceived(cache, i + 1);
       }
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2112
- Some of the methods were just waiting for 1 second for the cluster view to be installed, which in CI environments could be too short. 10 seconds should do fine for all except in individual cases.
