### PR TITLE
ISPN-2105 - KeyAffinityServiceShutdownTest.testSimpleShutdown randomly fails

### DIFF
--- a/core/src/test/java/org/infinispan/affinity/BaseKeyAffinityServiceTest.java
+++ b/core/src/test/java/org/infinispan/affinity/BaseKeyAffinityServiceTest.java
@@ -93,7 +93,7 @@ public abstract class BaseKeyAffinityServiceTest extends BaseDistFunctionalTest 
 
    protected void assertEventualFullCapacity(List<Address> addresses) throws InterruptedException {
       Map<Address, BlockingQueue<Object>> blockingQueueMap = keyAffinityService.getAddress2KeysMapping();
-      long maxWaitTime = 20 * 60 * 1000; // No more than 20 minutes per address since any more is ridiculous!
+      long maxWaitTime = 60 * 1000; // No more than 1 minute per address since any more is ridiculous!
       for (Address addr : addresses) {
          BlockingQueue<Object> queue = blockingQueueMap.get(addr);
          long giveupTime = System.currentTimeMillis() + maxWaitTime;
@@ -103,6 +103,9 @@ public abstract class BaseKeyAffinityServiceTest extends BaseDistFunctionalTest 
       }
       assertEquals(keyAffinityService.getMaxNumberOfKeys(), keyAffinityService.existingKeyCount.get());
       assertEquals(addresses.size() * 100, keyAffinityService.existingKeyCount.get());
+
+      // give the worker thread some time to shut down
+      Thread.sleep(200);
       assertEquals(false, keyAffinityService.isKeyGeneratorThreadActive());
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2105

The KeyAffinityService generator thread only stops after it has filled the queue,
so there is a small interval of time where the queue is full but the thread is
still active.
