### PR TITLE
ISPN-2106 - StateTransferFunctionalTest.testSTWithThirdWritingNonTxCache...

### DIFF
--- a/core/src/main/java/org/infinispan/cacheviews/CacheViewsManagerImpl.java
+++ b/core/src/main/java/org/infinispan/cacheviews/CacheViewsManagerImpl.java
@@ -230,7 +230,8 @@ public class CacheViewsManagerImpl implements CacheViewsManager {
          final CacheViewControlCommand cmd = new CacheViewControlCommand(cacheName,
                CacheViewControlCommand.Type.REQUEST_LEAVE, self);
          // ignore any response from the other members
-         transport.invokeRemotely(members, cmd, ResponseMode.ASYNCHRONOUS, timeout, false, null);
+         // still, the call has to be synchronous or the externalizer table might stop before we serialize the command
+         transport.invokeRemotely(members, cmd, ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS, timeout, false, null);
       } catch (Exception e) {
          log.debugf(e, "%s: Error while leaving cache view", cacheName);
       }


### PR DESCRIPTION
... and testSTWithThirdWritingTxCache failing randomly

https://issues.jboss.org/browse/ISPN-2106

Redesign the serialization to make sure we delay the state transfer and not a random put command.
Wait until the state transfer has ended to check the location of entries.
