### PR TITLE
ISPN-2030 ViewChangedEvent.getOldMembers() and getNewMembers() should never be null

### DIFF
--- a/cdi/extension/src/main/java/org/infinispan/cdi/event/cachemanager/ViewChangedAdapter.java
+++ b/cdi/extension/src/main/java/org/infinispan/cdi/event/cachemanager/ViewChangedAdapter.java
@@ -29,6 +29,7 @@ import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
 import org.infinispan.remoting.transport.Address;
 
 import javax.enterprise.event.Event;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -51,12 +52,12 @@ public class ViewChangedAdapter extends AbstractAdapter<ViewChangedEvent> {
 
       @Override
       public List<Address> getNewMembers() {
-         return null;
+         return Collections.emptyList();
       }
 
       @Override
       public List<Address> getOldMembers() {
-         return null;
+         return Collections.emptyList();
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/event/EventImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/event/EventImpl.java
@@ -26,6 +26,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.Util;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -87,6 +88,9 @@ public class EventImpl implements CacheStartedEvent, CacheStoppedEvent, ViewChan
 
    @Override
    public List<Address> getNewMembers() {
+      if(newMembers == null){
+         Collections.emptyList();
+      }
       return newMembers;
    }
 
@@ -100,6 +104,9 @@ public class EventImpl implements CacheStartedEvent, CacheStoppedEvent, ViewChan
 
    @Override
    public List<Address> getOldMembers() {
+      if(oldMembers == null){
+         Collections.emptyList();
+      }
       return this.oldMembers;
    }
 

--- a/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/event/ViewChangedEvent.java
+++ b/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/event/ViewChangedEvent.java
@@ -34,10 +34,13 @@ import java.util.List;
  */
 public interface ViewChangedEvent extends Event {
    /**
-    * @return the new view associated with this view change.
+    * @return the new view associated with this view change. List cannot be null.
     */
    List<Address> getNewMembers();
 
+   /**
+    * @return the old view associated with this view change. List cannot be null.
+    */
    List<Address> getOldMembers();
 
    Address getLocalAddress();


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2030
