### PR TITLE
ISPN-2102 JDBC cacheloader test failing frequently: assertNoLocksHeld

### DIFF
--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/logging/Log.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/logging/Log.java
@@ -49,7 +49,7 @@ public interface Log extends org.infinispan.util.logging.Log {
 
    @LogMessage(level = ERROR)
    @Message(value = "Failed clearing cache store", id = 8001)
-   void failedClearingJdbcCacheStore(@Cause SQLException e);
+   void failedClearingJdbcCacheStore(@Cause Exception e);
 
    @LogMessage(level = ERROR)
    @Message(value = "I/O failure while integrating state into store", id = 8002)

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/binary/JdbcBinaryCacheStoreTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/binary/JdbcBinaryCacheStoreTest.java
@@ -81,12 +81,6 @@ public class JdbcBinaryCacheStoreTest extends BaseCacheStoreTest {
       jdbcBucketCacheStore.stop();
    }
 
-   @Test(enabled = false, description = "See ISPN-2102")
-   @Override
-   public void testPurgeExpired() throws Exception {
-      super.testPurgeExpired();
-   }
-
    public void testPurgeExpiredAllCodepaths() throws CacheLoaderException {
       FixedHashKey k1 = new FixedHashKey(1, "a");
       FixedHashKey k2 = new FixedHashKey(1, "b");


### PR DESCRIPTION
Make sure all locks are released during JdbcBinaryCacheStore.purgeInternal() in all situations
