### PR TITLE
ISPN-2117 Protect against cache manager being left open

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -924,7 +924,7 @@
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-pmd-plugin</artifactId>
                <!-- See also reporting plugins -->
-               <version>2.6</version>
+               <version>2.7.1</version>
                <configuration>
                   <minimumTokens>100</minimumTokens>
                   <targetJdk>1.6</targetJdk>
@@ -1296,18 +1296,18 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-pmd-plugin</artifactId>
             <!-- Needs to be re-defined and configured in pluginManagement section -->
-            <version>2.6</version>
+            <version>2.7.1</version>
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-report-plugin</artifactId>
-            <version>2.4.3-JBOSS</version>
+            <version>2.12</version>
          </plugin>
          <!-- Findbugs report -->
          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>findbugs-maven-plugin</artifactId>
-            <version>2.3</version>
+            <version>2.5</version>
             <configuration>
                <onlyAnalyze>org.infinispan.*</onlyAnalyze>
                <xmlOutput>true</xmlOutput>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2117

I don't understand how the cache manager could leak. I tried to test exceptions happening at different stages after cache manager was created, but could not find any obvious leak.

So, instead what I've done is guarantee that the cache manager in the test is stopped in a safe way, and make sure the cache manager created is killed safely too.

`5.1.x` branch too: `t_2117_5`
