### PR TITLE
ISPN-1959 Reduce size of distribution bundle

### DIFF
--- a/cli/cli-client/src/main/resources/ispn-cli.bat
+++ b/cli/cli-client/src/main/resources/ispn-cli.bat
@@ -1,14 +1,13 @@
 @echo off
 
 setlocal enabledelayedexpansion
+set ISPN_HOME=%~dp0
+set ISPN_HOME="%ISPN_HOME%.."
 
-set LIB=
-for %%f in (..\modules\cli-client\lib\*.jar) do set LIB=!LIB!;%%f
-rem echo libs: %LIB%
-
-set CP=%LIB%
-set CP=..\modules\cli-client\infinispan-cli-client.jar;%CP%
+set /p CP=<%ISPN_HOME%\modules\cli-client\runtime-classpath.txt
+set CP=%CP::=;%
+set CP=%CP:$ISPN_HOME=!ISPN_HOME!%
+set CP=%ISPN_HOME%\modules\cli-client\infinispan-cli-client.jar;%CP%
+rem echo libs: %CP%
 
 java -classpath "%CP%" org.infinispan.cli.Main %*
-
-:fileEnd

--- a/cli/cli-client/src/main/resources/ispn-cli.sh
+++ b/cli/cli-client/src/main/resources/ispn-cli.sh
@@ -2,7 +2,8 @@
 
 source "`dirname "$0"`/functions.sh"
 
-add_classpath "${ISPN_HOME}/modules/cli-client"
+add_classpath ${ISPN_HOME}/modules/cli-client/*.jar
+add_classpath ${ISPN_HOME}/modules/cli-client/runtime-classpath.txt
 
 add_jvm_args $JVM_PARAMS
 

--- a/core/src/main/release/README-Modules.txt
+++ b/core/src/main/release/README-Modules.txt
@@ -1,6 +1,7 @@
-Infinispan requires 'infinispan-core.jar' as well as all libraries in the 'lib' directory to be on your classpath, or
+Infinispan requires 'infinispan-core.jar' as well as all libraries listed in the runtime-classpath.txt file.
+The required libraries are located in the 'lib' directory and must be added to your classpath, or
 packaged with your deployment.
 
 This distribution also ships with a number of optional modules, in the 'modules' directory.  If you wish to use one or
-more of these modules, you will also need the module's jar file and all of its dependencies ('modules/MODULE_NAME/lib')
-to be on your classpath, in addition to the jars mentioned earlier.
+more of these modules, you will also need the module's jar file and all of its dependencies (listed in the corresponding
+runtime-classpath.txt file) to be on your classpath.

--- a/core/src/main/resources/functions.sh
+++ b/core/src/main/resources/functions.sh
@@ -52,6 +52,8 @@ function add_classpath() {
       fi
     elif [[ -f "$E" && "$E" =~ \.([Jj][Aa][Rr]|[Zz][Ii][Pp])$ ]]; then
       CLASSPATH="$CLASSPATH:$E"
+    elif [[ -f "$E" && "$E" =~ /runtime-classpath\.txt$ ]]; then
+      CLASSPATH=$CLASSPATH:`eval echo $(<$E)`
     fi
 
     if [[ "$CLASSPATH" =~ ^: ]]; then

--- a/core/src/main/resources/importConfig.bat
+++ b/core/src/main/resources/importConfig.bat
@@ -1,12 +1,13 @@
 @echo off
 
 setlocal enabledelayedexpansion
+set ISPN_HOME=%~dp0
+set ISPN_HOME="%ISPN_HOME%.."
 
-set LIB=
-for %%f in (..\lib\*.jar) do set LIB=!LIB!;%%f
-rem echo libs: %LIB%
-
-set CP=%LIB%;..\infinispan-core.jar;%CP%
+set /p CP=<%ISPN_HOME%\runtime-classpath.txt
+set CP=%CP::=;%
+set CP=%CP:$ISPN_HOME=!ISPN_HOME!%
+set CP=%ISPN_HOME%\infinispan-core.jar;%CP%
+rem echo libs: %CP%
 
 java -classpath "%CP%" org.infinispan.config.parsing.ConfigFilesConvertor %1 %2 %3 %4 %5 %6
-:fileEnd

--- a/core/src/main/resources/importConfig.sh
+++ b/core/src/main/resources/importConfig.sh
@@ -2,8 +2,9 @@
 
 source "`dirname "$0"`/functions.sh"
 
-add_classpath "${ISPN_HOME}"/*.jar
-add_classpath "${ISPN_HOME}/lib"
+add_classpath ${ISPN_HOME}/*.jar
+add_classpath ${ISPN_HOME}/runtime-classpath.txt
 
-start org.infinispan.config.parsing.ConfigFilesConvertor "$@"
+add_program_args "$@"
 
+start org.infinispan.config.parsing.ConfigFilesConvertor

--- a/demos/distexec/src/main/resources/runPiApproximationDemo.sh
+++ b/demos/distexec/src/main/resources/runPiApproximationDemo.sh
@@ -2,9 +2,8 @@
 
 source "`dirname "$0"`/functions.sh"
 
-add_classpath "${ISPN_HOME}"/*.jar
-add_classpath "${ISPN_HOME}/lib"
-add_classpath "${ISPN_HOME}/modules/demos/distexec"
+add_classpath ${ISPN_HOME}/modules/demos/distexec/*.jar
+add_classpath ${ISPN_HOME}/modules/demos/distexec/runtime-classpath.txt
 
 add_jvm_args $JVM_PARAMS
 add_jvm_args '-Djava.net.preferIPv4Stack=true'

--- a/demos/distexec/src/main/resources/runWordCountDemo.sh
+++ b/demos/distexec/src/main/resources/runWordCountDemo.sh
@@ -2,9 +2,8 @@
 
 source "`dirname "$0"`/functions.sh"
 
-add_classpath "${ISPN_HOME}"/*.jar
-add_classpath "${ISPN_HOME}/lib"
-add_classpath "${ISPN_HOME}/modules/demos/distexec"
+add_classpath ${ISPN_HOME}/modules/demos/distexec/*.jar
+add_classpath ${ISPN_HOME}/modules/demos/distexec/runtime-classpath.txt
 
 add_jvm_args $JVM_PARAMS
 add_jvm_args '-Djava.net.preferIPv4Stack=true'

--- a/demos/ec2/src/main/resources/runEC2Demo-all.sh
+++ b/demos/ec2/src/main/resources/runEC2Demo-all.sh
@@ -2,11 +2,9 @@
 
 source "`dirname "$0"`/functions.sh"
 
-add_classpath "${ISPN_HOME}"/*.jar
-add_classpath "${ISPN_HOME}/etc"
-add_classpath "${ISPN_HOME}/etc/config-sameples/ec2-demo"
-add_classpath "${ISPN_HOME}/lib"
-add_classpath "${ISPN_HOME}/modules/demos/ec2"
+add_classpath ${ISPN_HOME}/etc
+add_classpath ${ISPN_HOME}/etc/config-samples/ec2-demo
+add_classpath ${ISPN_HOME}/modules/demos/ec2/runtime-classpath.txt
 
 add_jvm_args '-Xmx512m'
 add_jvm_args $JVM_PARAMS

--- a/demos/ec2/src/main/resources/runEC2Demo-influenza.sh
+++ b/demos/ec2/src/main/resources/runEC2Demo-influenza.sh
@@ -2,11 +2,9 @@
 
 source "`dirname "$0"`/functions.sh"
 
-add_classpath "${ISPN_HOME}"/*.jar
-add_classpath "${ISPN_HOME}/etc"
-add_classpath "${ISPN_HOME}/etc/config-samples/ec2-demo"
-add_classpath "${ISPN_HOME}/lib"
-add_classpath "${ISPN_HOME}/modules"
+add_classpath ${ISPN_HOME}/etc
+add_classpath ${ISPN_HOME}/etc/config-samples/ec2-demo
+add_classpath ${ISPN_HOME}/modules/demos/ec2/runtime-classpath.txt
 
 if [[ ! -e ${ISPN_HOME}/etc/Amazon-TestData/influenza.dat ]]; then
   gunzip ${ISPN_HOME}/etc/Amazon-TestData/influenza.dat.gz > /dev/null

--- a/demos/ec2/src/main/resources/runEC2Demo-nucleotide.sh
+++ b/demos/ec2/src/main/resources/runEC2Demo-nucleotide.sh
@@ -2,11 +2,9 @@
 
 source "`dirname "$0"`/functions.sh"
 
-add_classpath "${ISPN_HOME}"/*.jar
-add_classpath "${ISPN_HOME}/etc"
-add_classpath "${ISPN_HOME}/etc/config-samples/ec2-demo"
-add_classpath "${ISPN_HOME}/lib"
-add_classpath "${ISPN_HOME}/modules"
+add_classpath ${ISPN_HOME}/etc
+add_classpath ${ISPN_HOME}/etc/config-samples/ec2-demo
+add_classpath ${ISPN_HOME}/modules/demos/ec2/runtime-classpath.txt
 
 if [[ ! -e ${ISPN_HOME}/etc/Amazon-TestData/influenza_na.dat ]]; then
   gunzip ${ISPN_HOME}/etc/Amazon-TestData/influenza_na.dat.gz > /dev/null

--- a/demos/ec2/src/main/resources/runEC2Demo-protein.sh
+++ b/demos/ec2/src/main/resources/runEC2Demo-protein.sh
@@ -2,11 +2,9 @@
 
 source "`dirname "$0"`/functions.sh"
 
-add_classpath "${ISPN_HOME}"/*.jar
-add_classpath "${ISPN_HOME}/etc"
-add_classpath "${ISPN_HOME}/etc/config-samples/ec2-demo"
-add_classpath "${ISPN_HOME}/lib"
-add_classpath "${ISPN_HOME}/modules"
+add_classpath ${ISPN_HOME}/etc
+add_classpath ${ISPN_HOME}/etc/config-samples/ec2-demo
+add_classpath ${ISPN_HOME}/modules/demos/ec2/runtime-classpath.txt
 
 if [[ ! -e ${ISPN_HOME}/etc/Amazon-TestData/influenza_aa.dat ]]; then
   gunzip ${ISPN_HOME}/etc/Amazon-TestData/influenza_aa.dat.gz > /dev/null

--- a/demos/ec2/src/main/resources/runEC2Demo-query.sh
+++ b/demos/ec2/src/main/resources/runEC2Demo-query.sh
@@ -2,11 +2,9 @@
 
 source "`dirname "$0"`/functions.sh"
 
-add_classpath "${ISPN_HOME}"/*.jar
-add_classpath "${ISPN_HOME}/etc"
-add_classpath "${ISPN_HOME}/etc/config-samples/ec2-demo"
-add_classpath "${ISPN_HOME}/lib"
-add_classpath "${ISPN_HOME}/modules"
+add_classpath ${ISPN_HOME}/etc
+add_classpath ${ISPN_HOME}/etc/config-samples/ec2-demo
+add_classpath ${ISPN_HOME}/modules/demos/ec2/runtime-classpath.txt
 
 add_jvm_args '-Xmx512m'
 add_jvm_args $JVM_PARAMS

--- a/demos/ec2/src/main/resources/runEC2Demo-reader.sh
+++ b/demos/ec2/src/main/resources/runEC2Demo-reader.sh
@@ -2,11 +2,9 @@
 
 source "`dirname "$0"`/functions.sh"
 
-add_classpath "${ISPN_HOME}"/*.jar
-add_classpath "${ISPN_HOME}/etc"
-add_classpath "${ISPN_HOME}/etc/config-samples/ec2-demo"
-add_classpath "${ISPN_HOME}/lib"
-add_classpath "${ISPN_HOME}/modules"
+add_classpath ${ISPN_HOME}/etc
+add_classpath ${ISPN_HOME}/etc/config-samples/ec2-demo
+add_classpath ${ISPN_HOME}/modules/demos/ec2/runtime-classpath.txt
 
 add_jvm_args '-Xmx512m'
 add_jvm_args $JVM_PARAMS

--- a/demos/gui/src/main/resources/runGuiDemo.bat
+++ b/demos/gui/src/main/resources/runGuiDemo.bat
@@ -1,29 +1,18 @@
 @echo off
 
-:noenvreset
-set my_classpath=
-for /f "tokens=* delims=" %%f in ('dir /s /b /a-d "..\lib\*.jar"') do (
-		call set my_classpath=%%my_classpath%%;%%~f)
-	)
-set my_classpath=%my_classpath:~1%
+setlocal enabledelayedexpansion
+set ISPN_HOME=%~dp0
+set ISPN_HOME="%ISPN_HOME%.."
 
-set my_classpath=%my_classpath%;..\infinispan-core.jar
-
-for /f "tokens=* delims=" %%f in ('dir /s /b /a-d "..\modules\demos\gui\*.jar"') do (
-                call set my_classpath=%%my_classpath%%;%%~f)
-        )
-set my_classpath=%my_classpath:~1%
-
-for /f "tokens=* delims=" %%f in ('dir /s /b /a-d "..\modules\demos\gui\lib\*.jar"') do (
-                call set my_classpath=%%my_classpath%%;%%~f)
-        )
-set my_classpath=%my_classpath:~1%
+set /p CP=<%ISPN_HOME%\modules\demos\gui\runtime-classpath.txt
+set CP=%CP::=;%
+set CP=%CP:$ISPN_HOME=!ISPN_HOME!%
+set CP=%ISPN_HOME%\modules\demos\gui\infinispan-gui-demo.jar;%CP%
+rem echo libs: %CP%
 
 :test
 set /a "TESTPORT=%RANDOM%+2000"
 netstat -an | findstr ":%TESTPORT% "
 if %ERRORLEVEL%==0 goto test
 
-java -cp "%my_classpath%" -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=%TESTPORT% -Djgroups.bind_addr=127.0.0.1 -Djava.net.preferIPv4Stack=true -Dlog4j.configuration=..\etc\log4j.xml -Dsun.nio.ch.bugLevel="" org.infinispan.demo.InfinispanDemo
-
-
+java -cp "%CP%" -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=%TESTPORT% -Djgroups.bind_addr=127.0.0.1 -Djava.net.preferIPv4Stack=true -Dlog4j.configuration=%ISPN_HOME%\etc\log4j.xml -Dsun.nio.ch.bugLevel="" org.infinispan.demo.InfinispanDemo

--- a/demos/gui/src/main/resources/runGuiDemo.sh
+++ b/demos/gui/src/main/resources/runGuiDemo.sh
@@ -2,9 +2,8 @@
 
 source "`dirname "$0"`/functions.sh"
 
-add_classpath "${ISPN_HOME}"/*.jar
-add_classpath "${ISPN_HOME}/lib"
-add_classpath "${ISPN_HOME}/modules/demos/gui"
+add_classpath ${ISPN_HOME}/modules/demos/gui/*.jar
+add_classpath ${ISPN_HOME}/modules/demos/gui/runtime-classpath.txt
 
 add_jvm_args $JVM_PARAMS
 add_jvm_args '-Djgroups.bind_addr=127.0.0.1'

--- a/demos/lucene-directory-demo/src/main/resources/runLuceneDemo.bat
+++ b/demos/lucene-directory-demo/src/main/resources/runLuceneDemo.bat
@@ -1,27 +1,18 @@
 @echo off
 
-:noenvreset
-set my_classpath=
-for /f "tokens=* delims=" %%f in ('dir /s /b /a-d "..\lib\*.jar"') do (
-		call set my_classpath=%%my_classpath%%;%%~f)
-	)
-set my_classpath=%my_classpath:~1%
+setlocal enabledelayedexpansion
+set ISPN_HOME=%~dp0
+set ISPN_HOME="%ISPN_HOME%.."
 
-set my_classpath=%my_classpath%;..\infinispan-core.jar
-
-for /f "tokens=* delims=" %%f in ('dir /s /b /a-d "..\modules\demos\lucene-directory-demo\*.jar"') do (
-                call set my_classpath=%%my_classpath%%;%%~f)
-        )
-set my_classpath=%my_classpath:~1%
-
-for /f "tokens=* delims=" %%f in ('dir /s /b /a-d "..\modules\demos\lucene-directory-demo\lib\*.jar"') do (
-                call set my_classpath=%%my_classpath%%;%%~f)
-        )
-set my_classpath=%my_classpath:~1%
+set /p CP=<%ISPN_HOME%\modules\demos\lucene-directory-demo\runtime-classpath.txt
+set CP=%CP::=;%
+set CP=%CP:$ISPN_HOME=!ISPN_HOME!%
+set CP=%ISPN_HOME%\modules\demos\lucene-directory-demo\infinispan-lucene-demo.jar;%CP%
+rem echo libs: %CP%
 
 :test
 set /a "TESTPORT=%RANDOM%+2000"
 netstat -an | findstr ":%TESTPORT% "
 if %ERRORLEVEL%==0 goto test
 
-java -cp "%my_classpath%" -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=%TESTPORT% -Djgroups.bind_addr=127.0.0.1 -Djava.net.preferIPv4Stack=true -Dlog4j.configuration=..\etc\log4j.xml -Dsun.nio.ch.bugLevel="" org.infinispan.lucenedemo.DemoDriver
+java -cp "%CP%" -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=%TESTPORT% -Djgroups.bind_addr=127.0.0.1 -Djava.net.preferIPv4Stack=true -Dlog4j.configuration=%ISPN_HOME%\etc\log4j.xml -Dsun.nio.ch.bugLevel="" org.infinispan.lucenedemo.DemoDriver

--- a/demos/lucene-directory-demo/src/main/resources/runLuceneDemo.sh
+++ b/demos/lucene-directory-demo/src/main/resources/runLuceneDemo.sh
@@ -2,9 +2,8 @@
 
 source "`dirname "$0"`/functions.sh"
 
-add_classpath "${ISPN_HOME}"/*.jar
-add_classpath "${ISPN_HOME}/lib"
-add_classpath "${ISPN_HOME}/modules/demos/lucene-directory-demo"
+add_classpath ${ISPN_HOME}/modules/demos/lucene-directory-demo/*.jar
+add_classpath ${ISPN_HOME}/modules/demos/lucene-directory-demo/runtime-classpath.txt
 
 add_jvm_args $JVM_PARAMS
 add_jvm_args '-Djgroups.bind_addr=127.0.0.1'

--- a/demos/nearcache-client/pom.xml
+++ b/demos/nearcache-client/pom.xml
@@ -139,7 +139,6 @@
       <plugins>
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.1.1</version>
             <configuration>
                <!-- No web.xml needed in Java EE 6 -->
                <failOnMissingWebXml>false</failOnMissingWebXml>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -49,11 +49,11 @@
    </developers>
    <mailingLists>
       <mailingList>
-         <name>Infinispan Commit Notificatons</name>
-         <subscribe>https://lists.jboss.org/mailman/listinfo/infinispan-commits</subscribe>
-         <unsubscribe>https://lists.jboss.org/mailman/listinfo/infinispan-commits</unsubscribe>
-         <post>infinispan-commits@lists.jboss.org</post>
-         <archive>http://lists.jboss.org/pipermail/infinispan-commits/</archive>
+         <name>Infinispan Issues</name>
+         <subscribe>https://lists.jboss.org/mailman/listinfo/infinispan-issues</subscribe>
+         <unsubscribe>https://lists.jboss.org/mailman/listinfo/infinispan-issues</unsubscribe>
+         <post>infinispan-issues@lists.jboss.org</post>
+         <archive>http://lists.jboss.org/pipermail/infinispan-issues/</archive>
       </mailingList>
       <mailingList>
          <name>Infinispan Developers</name>
@@ -917,14 +917,14 @@
                <version>${version.maven.bundle}</version>
             </plugin>
             <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-assembly-plugin</artifactId>
-                  <version>2.2-beta-3</version>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-assembly-plugin</artifactId>
+               <version>2.3</version>
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-dependency-plugin</artifactId>
-               <version>2.0</version>
+               <version>2.4</version>
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
@@ -952,7 +952,7 @@
                <artifactId>maven-war-plugin</artifactId>
                <version>2.1.1</version>
                <configuration>
-                  <attachClasses>true</attachClasses>
+                  <attachClasses>false</attachClasses>
                </configuration>
             </plugin>
             <plugin>
@@ -1328,6 +1328,39 @@
       </plugins>
    </reporting>
    <profiles>
+      <profile>
+         <id>distribution</id>
+         <properties>
+            <skipTests>true</skipTests>
+         </properties>
+
+         <build>
+            <plugins>
+               <!-- generate target/runtime-classpath.txt, to be included in bundle -->
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-dependency-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>create-classpath</id>
+                        <phase>package</phase>
+                        <goals>
+                           <goal>build-classpath</goal>
+                        </goals>
+                        <configuration>
+                           <includeScope>runtime</includeScope>
+                           <excludeScope>test</excludeScope>
+                           <!-- all jar paths are relative to bin dir inside the distribution bundle -->
+                           <prefix>$ISPN_HOME/lib</prefix>
+                           <outputFile>${project.build.directory}/runtime-classpath.txt</outputFile>
+                        </configuration>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+
       <profile>
          <id>extras</id>
          <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -82,12 +82,6 @@
    <profiles>
       <profile>
          <id>distribution</id>
-         <activation>
-            <activeByDefault>false</activeByDefault>
-         </activation>
-         <properties>
-            <maven.test.skip.exec>true</maven.test.skip.exec>
-         </properties>
          <build>
             <plugins>
                <plugin>
@@ -102,7 +96,7 @@
                         </goals>
                         <configuration>
                            <quiet>true</quiet>
-                           <!-- In case you anyone needs to trace javadoc issues
+                           <!-- In case anyone needs to trace javadoc issues
                            <additionalJOption>-J-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</additionalJOption>
                            -->
                            <stylesheetfile>${basedir}/src/javadoc/stylesheet.css</stylesheetfile>

--- a/server/core/src/main/resources/startServer.bat
+++ b/server/core/src/main/resources/startServer.bat
@@ -1,25 +1,25 @@
 @echo off
 
 setlocal enabledelayedexpansion
+set ISPN_HOME=%~dp0
+set ISPN_HOME="%ISPN_HOME%.."
 
-set LIB=
-for %%f in (..\lib\*.jar) do set LIB=!LIB!;%%f
-for %%f in (..\modules\memcached\lib\*.jar) do set LIB=!LIB!;%%f
-for %%f in (..\modules\hotrod\lib\*.jar) do set LIB=!LIB!;%%f
-for %%f in (..\modules\websocket\lib\*.jar) do set LIB=!LIB!;%%f
-rem echo libs: %LIB%
-
-set CP=%LIB%;..\infinispan-core.jar;..\modules\core\infinispan-server-memcached.jar;%CP%
-set CP=..\modules\memcached\infinispan-server-memcached.jar;%CP%
-set CP=..\modules\hotrod\infinispan-server-hotrod.jar;%CP%
-set CP=..\modules\websocket\infinispan-server-websocket.jar;%CP%
-set CP=..\modules\cli-server\infinispan-cli-server.jar;%CP%
+set /p CP1=<%ISPN_HOME%\modules\memcached\runtime-classpath.txt
+set /p CP2=<%ISPN_HOME%\modules\hotrod\runtime-classpath.txt
+set /p CP3=<%ISPN_HOME%\modules\websocket\runtime-classpath.txt
+set /p CP4=<%ISPN_HOME%\modules\cli-server\runtime-classpath.txt
+set CP=%CP1%;%CP2%;%CP3%;%CP4%
+set CP=%CP::=;%
+set CP=%CP:$ISPN_HOME=!ISPN_HOME!%
+set CP=%ISPN_HOME%\modules\memcached\infinispan-server-memcached.jar;%CP%
+set CP=%ISPN_HOME%\modules\hotrod\infinispan-server-hotrod.jar;%CP%
+set CP=%ISPN_HOME%\modules\websocket\infinispan-server-websocket.jar;%CP%
+set CP=%ISPN_HOME%\modules\cli-server\infinispan-cli-server.jar;%CP%
+rem echo libs: %CP%
 
 :test
 set /a "TESTPORT=%RANDOM%+2000"
 netstat -an | findstr ":%TESTPORT% "
 if %ERRORLEVEL%==0 goto test
 
-java -classpath "%CP%" -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=%TESTPORT% -Djgroups.bind_addr=127.0.0.1 -Djava.net.preferIPv4Stack=true -Dlog4j.configuration=..\etc\log4j.xml -Dsun.nio.ch.bugLevel="" org.infinispan.server.core.Main %*
-
-:fileEnd
+java -classpath "%CP%" -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=%TESTPORT% -Djgroups.bind_addr=127.0.0.1 -Djava.net.preferIPv4Stack=true -Dlog4j.configuration=%ISPN_HOME%\etc\log4j.xml -Dsun.nio.ch.bugLevel="" org.infinispan.server.core.Main %*

--- a/server/core/src/main/resources/startServer.sh
+++ b/server/core/src/main/resources/startServer.sh
@@ -2,12 +2,14 @@
 
 source "`dirname "$0"`/functions.sh"
 
-add_classpath "${ISPN_HOME}"/*.jar
-add_classpath "${ISPN_HOME}/lib"
-add_classpath "${ISPN_HOME}/modules/memcached"
-add_classpath "${ISPN_HOME}/modules/hotrod"
-add_classpath "${ISPN_HOME}/modules/websocket"
-add_classpath "${ISPN_HOME}/modules/cli-server"
+add_classpath ${ISPN_HOME}/modules/memcached/*.jar
+add_classpath ${ISPN_HOME}/modules/hotrod/*.jar
+add_classpath ${ISPN_HOME}/modules/websocket/*.jar
+add_classpath ${ISPN_HOME}/modules/cli-server/*.jar
+add_classpath ${ISPN_HOME}/modules/memcached/runtime-classpath.txt
+add_classpath ${ISPN_HOME}/modules/hotrod/runtime-classpath.txt
+add_classpath ${ISPN_HOME}/modules/websocket/runtime-classpath.txt
+add_classpath ${ISPN_HOME}/modules/cli-server/runtime-classpath.txt
 
 add_jvm_args $JVM_PARAMS
 add_jvm_args '-Djava.net.preferIPv4Stack=true'

--- a/server/rest/pom.xml
+++ b/server/rest/pom.xml
@@ -55,7 +55,9 @@
          <plugin>
             <artifactId>maven-war-plugin</artifactId>
             <configuration>
-            	<attachClasses>true</attachClasses>
+               <!-- we also pack WEB-INF/classes separately so JDG can use infinispan-server-rest-x.y.z-classes.jar
+               to build a custom server war rather than use the war generated here -->
+               <attachClasses>true</attachClasses>
             </configuration>
          </plugin>
       </plugins>

--- a/src/main/resources/assemblies/all.xml
+++ b/src/main/resources/assemblies/all.xml
@@ -44,22 +44,22 @@
    + doc (release notes, etc from src/main/release)
 -->
 <assembly
-      xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+      xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+      xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
    <id>all</id>
+
+   <baseDirectory>${project.artifactId}-${project.version}-all</baseDirectory>
 
    <formats>
       <format>zip</format>
    </formats>
 
    <moduleSets>
-
+      <!-- Core module -->
       <moduleSet>
          <includeSubModules>false</includeSubModules>
          <includes>
-            <include>org.infinispan:infinispan-api</include>
-            <include>org.infinispan:infinispan-commons</include>
             <include>org.infinispan:infinispan-core</include>
          </includes>
          <sources>
@@ -137,13 +137,21 @@
                   </includes>
                </fileSet>
 
+               <!-- runtime-classpath.txt file -->
+               <fileSet>
+                  <directory>target</directory>
+                  <outputDirectory></outputDirectory>
+                  <lineEnding>keep</lineEnding>
+                  <includes>
+                     <include>runtime-classpath.txt</include>
+                  </includes>
+               </fileSet>
             </fileSets>
 
          </sources>
 
          <binaries>
 
-            <outputDirectory></outputDirectory>
             <outputFileNameMapping>
                ${module.artifactId}.${module.extension}
             </outputFileNameMapping>
@@ -191,7 +199,7 @@
                      <include>**/*.dat.gz</include>
                   </includes>
                </fileSet>
-               
+
                <fileSet>
                   <directory>src/main/resources/</directory>
                   <outputDirectory>etc</outputDirectory>
@@ -245,12 +253,21 @@
                <fileSet>
                   <directory>src/main/release</directory>
                   <outputDirectory></outputDirectory>
-                  <lineEnding>dos</lineEnding>                  
+                  <lineEnding>dos</lineEnding>
                   <includes>
                      <include>**/*.txt</include>
                   </includes>
                </fileSet>
 
+               <!-- runtime-classpath.txt file -->
+               <fileSet>
+                  <directory>target</directory>
+                  <outputDirectory>modules/${module.basedir.name}</outputDirectory>
+                  <lineEnding>keep</lineEnding>
+                  <includes>
+                     <include>runtime-classpath.txt</include>
+                  </includes>
+               </fileSet>
             </fileSets>
 
          </sources>
@@ -267,8 +284,6 @@
             <dependencySets>
                <dependencySet>
                   <excludes>
-                     <exclude>infinispan-api*</exclude>
-                     <exclude>infinispan-commons*</exclude>
                      <exclude>infinispan-core*</exclude>
                      <exclude>net.jcip:jcip-annotations</exclude>
                      <exclude>org.rhq.helpers:rhq-pluginAnnotations</exclude>
@@ -279,7 +294,7 @@
                   </excludes>
                   <useTransitiveDependencies>true</useTransitiveDependencies>
                   <useTransitiveFiltering>true</useTransitiveFiltering>
-                  <outputDirectory>modules/${module.basedir.name}/lib</outputDirectory>
+                  <outputDirectory>lib</outputDirectory>
                </dependencySet>
             </dependencySets>
 
@@ -363,6 +378,15 @@
                   </includes>
                </fileSet>
 
+               <!-- runtime-classpath.txt file -->
+               <fileSet>
+                  <directory>target</directory>
+                  <outputDirectory>modules/cachestores/${module.basedir.name}</outputDirectory>
+                  <lineEnding>keep</lineEnding>
+                  <includes>
+                     <include>runtime-classpath.txt</include>
+                  </includes>
+               </fileSet>
             </fileSets>
 
          </sources>
@@ -379,8 +403,6 @@
             <dependencySets>
                <dependencySet>
                   <excludes>
-                     <exclude>infinispan-api*</exclude>
-                     <exclude>infinispan-commons*</exclude>
                      <exclude>infinispan-core*</exclude>
                      <exclude>net.jcip:jcip-annotations</exclude>
                      <exclude>org.rhq.helpers:rhq-pluginAnnotations</exclude>
@@ -391,7 +413,7 @@
                   </excludes>
                   <useTransitiveDependencies>true</useTransitiveDependencies>
                   <useTransitiveFiltering>true</useTransitiveFiltering>
-                  <outputDirectory>modules/cachestores/${module.basedir.name}/lib</outputDirectory>
+                  <outputDirectory>lib</outputDirectory>
                </dependencySet>
             </dependencySets>
 
@@ -404,23 +426,6 @@
          <includes>
             <include>org.infinispan:infinispan-server-rest</include>
          </includes>
-
-         <sources>
-            <includeModuleDirectory>false</includeModuleDirectory>
-            <fileSets>
-               <fileSet>
-                  <directory>target</directory>
-                  <outputDirectory>modules/${module.basedir.name}</outputDirectory>
-                  <includes>
-                     <include>*.jar</include>
-                  </includes>
-                  <excludes>
-                     <exclude>*tests.jar</exclude>
-                     <exclude>*sources.jar</exclude>
-                  </excludes>
-               </fileSet>
-            </fileSets>
-         </sources>
 
          <binaries>
             <outputDirectory>modules/${module.basedir.name}</outputDirectory>
@@ -561,13 +566,21 @@
                <!-- EULAs and license files -->
                <fileSet>
                   <directory>src/main/release</directory>
-                  <outputDirectory></outputDirectory>
                   <lineEnding>dos</lineEnding>
                   <includes>
                      <include>**/*.txt</include>
                   </includes>
                </fileSet>
 
+               <!-- runtime-classpath.txt file -->
+               <fileSet>
+                  <directory>target</directory>
+                  <outputDirectory>modules/demos/${module.basedir.name}</outputDirectory>
+                  <lineEnding>keep</lineEnding>
+                  <includes>
+                     <include>runtime-classpath.txt</include>
+                  </includes>
+               </fileSet>
             </fileSets>
 
          </sources>
@@ -584,8 +597,6 @@
             <dependencySets>
                <dependencySet>
                   <excludes>
-                     <exclude>infinispan-api*</exclude>
-                     <exclude>infinispan-commons*</exclude>
                      <exclude>infinispan-core*</exclude>
                      <exclude>net.jcip:jcip-annotations</exclude>
                      <exclude>org.rhq.helpers:rhq-pluginAnnotations</exclude>
@@ -596,7 +607,7 @@
                   </excludes>
                   <useTransitiveDependencies>true</useTransitiveDependencies>
                   <useTransitiveFiltering>true</useTransitiveFiltering>
-                  <outputDirectory>modules/demos/${module.basedir.name}/lib</outputDirectory>
+                  <outputDirectory>lib</outputDirectory>
                </dependencySet>
             </dependencySets>
 
@@ -648,6 +659,15 @@
                   </includes>
                </fileSet>
 
+               <!-- runtime-classpath.txt file -->
+               <fileSet>
+                  <directory>target</directory>
+                  <outputDirectory></outputDirectory>
+                  <lineEnding>keep</lineEnding>
+                  <includes>
+                     <include>runtime-classpath.txt</include>
+                  </includes>
+               </fileSet>
             </fileSets>
 
          </sources>
@@ -662,6 +682,18 @@
          </includes>
          <sources>
             <includeModuleDirectory>false</includeModuleDirectory>
+
+            <fileSets>
+               <!-- runtime-classpath.txt file -->
+               <fileSet>
+                  <directory>target</directory>
+                  <lineEnding>keep</lineEnding>
+                  <outputDirectory>modules/cdi</outputDirectory>
+                  <includes>
+                     <include>runtime-classpath.txt</include>
+                  </includes>
+               </fileSet>
+            </fileSets>
          </sources>
 
          <!-- All modules except core and Webapp modules -->
@@ -676,8 +708,6 @@
             <dependencySets>
                <dependencySet>
                   <excludes>
-                     <exclude>infinispan-api*</exclude>
-                     <exclude>infinispan-commons*</exclude>
                      <exclude>infinispan-core*</exclude>
                      <exclude>net.jcip:jcip-annotations</exclude>
                      <exclude>org.rhq.helpers:rhq-pluginAnnotations</exclude>
@@ -688,7 +718,7 @@
                   </excludes>
                   <useTransitiveDependencies>true</useTransitiveDependencies>
                   <useTransitiveFiltering>true</useTransitiveFiltering>
-                  <outputDirectory>modules/cdi/lib</outputDirectory>
+                  <outputDirectory>lib</outputDirectory>
                </dependencySet>
             </dependencySets>
 

--- a/src/main/resources/assemblies/bin.xml
+++ b/src/main/resources/assemblies/bin.xml
@@ -38,21 +38,22 @@
    + doc (release notes, etc from src/main/release)
 -->
 <assembly
-      xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+      xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+      xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
    <id>bin</id>
+
+   <baseDirectory>${project.artifactId}-${project.version}-bin</baseDirectory>
 
    <formats>
       <format>zip</format>
    </formats>
 
    <moduleSets>
+      <!-- Core module -->
       <moduleSet>
          <includeSubModules>false</includeSubModules>
          <includes>
-            <include>org.infinispan:infinispan-api</include>
-            <include>org.infinispan:infinispan-commons</include>
             <include>org.infinispan:infinispan-core</include>
          </includes>
          <sources>
@@ -129,12 +130,20 @@
                      <include>**/*.txt</include>
                   </includes>
                </fileSet>
-            </fileSets>
 
+               <!-- runtime-classpath.txt file -->
+               <fileSet>
+                  <directory>target</directory>
+                  <outputDirectory></outputDirectory>
+                  <lineEnding>keep</lineEnding>
+                  <includes>
+                     <include>runtime-classpath.txt</include>
+                  </includes>
+               </fileSet>
+            </fileSets>
          </sources>
 
          <binaries>
-            <outputDirectory></outputDirectory>
             <unpack>false</unpack>
             <outputFileNameMapping>
                ${module.artifactId}.${module.extension}
@@ -143,7 +152,7 @@
             <dependencySets>
                <dependencySet>
                   <useTransitiveDependencies>false</useTransitiveDependencies>
-                  <outputDirectory>/lib</outputDirectory>
+                  <outputDirectory>lib</outputDirectory>
                </dependencySet>
             </dependencySets>
 
@@ -208,7 +217,7 @@
                   <includes>
                      <include>**/*.html</include>
                   </includes>
-               </fileSet>               
+               </fileSet>
 
                <fileSet>
                   <directory>src/main/resources</directory>
@@ -230,6 +239,16 @@
                      <include>**/*.txt</include>
                   </includes>
                </fileSet>
+
+               <!-- runtime-classpath.txt file -->
+               <fileSet>
+                  <directory>target</directory>
+                  <outputDirectory>modules/${module.basedir.name}</outputDirectory>
+                  <lineEnding>keep</lineEnding>
+                  <includes>
+                     <include>runtime-classpath.txt</include>
+                  </includes>
+               </fileSet>
             </fileSets>
          </sources>
 
@@ -242,8 +261,6 @@
             <dependencySets>
                <dependencySet>
                   <excludes>
-                     <exclude>infinispan-api*</exclude>
-                     <exclude>infinispan-commons*</exclude>
                      <exclude>infinispan-core*</exclude>
                      <exclude>net.jcip:jcip-annotations</exclude>
                      <exclude>org.rhq.helpers:rhq-pluginAnnotations</exclude>
@@ -252,7 +269,7 @@
                   </excludes>
                   <useTransitiveDependencies>true</useTransitiveDependencies>
                   <useTransitiveFiltering>true</useTransitiveFiltering>
-                  <outputDirectory>modules/${module.basedir.name}/lib</outputDirectory>
+                  <outputDirectory>lib</outputDirectory>
                </dependencySet>
             </dependencySets>
 
@@ -340,6 +357,15 @@
                   </includes>
                </fileSet>
 
+               <!-- runtime-classpath.txt file -->
+               <fileSet>
+                  <directory>target</directory>
+                  <outputDirectory>modules/demos/${module.basedir.name}</outputDirectory>
+                  <lineEnding>keep</lineEnding>
+                  <includes>
+                     <include>runtime-classpath.txt</include>
+                  </includes>
+               </fileSet>
             </fileSets>
 
          </sources>
@@ -356,8 +382,6 @@
             <dependencySets>
                <dependencySet>
                   <excludes>
-                     <exclude>infinispan-api*</exclude>
-                     <exclude>infinispan-commons*</exclude>
                      <exclude>infinispan-core*</exclude>
                      <exclude>net.jcip:jcip-annotations</exclude>
                      <exclude>org.rhq.helpers:rhq-pluginAnnotations</exclude>
@@ -368,13 +392,14 @@
                   </excludes>
                   <useTransitiveDependencies>true</useTransitiveDependencies>
                   <useTransitiveFiltering>true</useTransitiveFiltering>
-                  <outputDirectory>modules/demos/${module.basedir.name}/lib</outputDirectory>
+                  <outputDirectory>lib</outputDirectory>
                </dependencySet>
             </dependencySets>
 
          </binaries>
       </moduleSet>
 
+      <!-- REST server war -->
       <moduleSet>
          <includeSubModules>false</includeSubModules>
          <includes>
@@ -444,6 +469,15 @@
                   </includes>
                </fileSet>
 
+               <!-- runtime-classpath.txt file -->
+               <fileSet>
+                  <directory>target</directory>
+                  <outputDirectory></outputDirectory>
+                  <lineEnding>keep</lineEnding>
+                  <includes>
+                     <include>runtime-classpath.txt</include>
+                  </includes>
+               </fileSet>
             </fileSets>
 
          </sources>
@@ -458,6 +492,18 @@
          </includes>
          <sources>
             <includeModuleDirectory>false</includeModuleDirectory>
+
+            <fileSets>
+               <!-- runtime-classpath.txt file -->
+               <fileSet>
+                  <directory>target</directory>
+                  <lineEnding>keep</lineEnding>
+                  <outputDirectory>modules/cdi</outputDirectory>
+                  <includes>
+                     <include>runtime-classpath.txt</include>
+                  </includes>
+               </fileSet>
+            </fileSets>
          </sources>
 
          <!-- All modules except core and Webapp modules -->
@@ -472,8 +518,6 @@
             <dependencySets>
                <dependencySet>
                   <excludes>
-                     <exclude>infinispan-api*</exclude>
-                     <exclude>infinispan-commons*</exclude>
                      <exclude>infinispan-core*</exclude>
                      <exclude>net.jcip:jcip-annotations</exclude>
                      <exclude>org.rhq.helpers:rhq-pluginAnnotations</exclude>
@@ -484,7 +528,7 @@
                   </excludes>
                   <useTransitiveDependencies>true</useTransitiveDependencies>
                   <useTransitiveFiltering>true</useTransitiveFiltering>
-                  <outputDirectory>modules/cdi/lib</outputDirectory>
+                  <outputDirectory>lib</outputDirectory>
                </dependencySet>
             </dependencySets>
 

--- a/src/main/resources/assemblies/rest-server.xml
+++ b/src/main/resources/assemblies/rest-server.xml
@@ -21,13 +21,19 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<assembly>
+<assembly
+      xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
    <id>server-rest</id>
    <formats>
       <format>zip</format>
    </formats>
 
    <includeBaseDirectory>true</includeBaseDirectory>
+   <baseDirectory>${project.artifactId}-${project.version}-server-rest</baseDirectory>
+
    <fileSets>
       <fileSet>
          <directory>server/rest/target</directory>

--- a/src/main/resources/assemblies/src.xml
+++ b/src/main/resources/assemblies/src.xml
@@ -27,30 +27,36 @@
    subversion checkout.
 -->
 <assembly
-        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <id>src</id>
     <formats>
         <format>zip</format>
     </formats>
 
     <includeBaseDirectory>true</includeBaseDirectory>
+    <baseDirectory>${project.artifactId}-${project.version}-src</baseDirectory>
+
     <fileSets>
         <fileSet>
             <excludes>
                 <exclude>**/target/**</exclude>
                 <exclude>**/output/**</exclude>
                 <exclude>**/test-output/**</exclude>
+                <exclude>**/out/**</exclude>
                 <exclude>**/jbossdb/**</exclude>
                 <exclude>**/testFiles/**</exclude>
                 <exclude>**/*.jdb</exclude>
                 <exclude>**/*.iml</exclude>
                 <exclude>**/*.ipr</exclude>
                 <exclude>**/*.iws</exclude>
+                <exclude>**/.idea/**</exclude>
                 <exclude>**/*.log</exclude>
                 <exclude>**/*.lck</exclude>
                 <exclude>**/*-BdbjeCacheStore/**</exclude>
+                <exclude>**/ObjectStore/**</exclude>
+                <exclude>**/PutObjectStoreDirHere/**</exclude>
                 <exclude>**/coretarget/**</exclude>
                 <exclude>**/.git/**</exclude>
             </excludes>


### PR DESCRIPTION
- add all runtime dependencies to a global lib dir inside the bundle so we avoid jar duplication and reduce the total size
- for each infinispan module a runtime-classpath.txt file is generated and placed beside the jar
- all bat and sh script in bin folder were updated to reflect these runtime classpath changes
- exclude some unwanted folders from src bundle: ObjectStore, out, .idea ...
- rename top folder inside zip bundle to be the same as zip name (used to be project name for all bundles without the src/bin/all suffix)
- fix POM so tests are not executed while 'distribution' profile is active
- 'all' and 'bin' bundles contained two unwanted 'main' and 'test' folders (were CDI sources)
- no longer produce most "*-classes.jar" artifacts attached to WARs, except for rest server WAR (JDG seems to use *-classes.jar rather than the war)

Jira issue: https://issues.jboss.org/browse/ISPN-1959
