### PR TITLE
ISPN-2128 infinispan-gridfs-webdav should contain log4j dependency

### DIFF
--- a/demos/gridfs-webdav/pom.xml
+++ b/demos/gridfs-webdav/pom.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
@@ -49,6 +49,10 @@
          <groupId>javax.servlet</groupId>
          <artifactId>servlet-api</artifactId>
          <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>log4j</groupId>
+         <artifactId>log4j</artifactId>
       </dependency>
    </dependencies>
 </project>


### PR DESCRIPTION
- add log4j dependency explicitly to infinispan-gridfs-webdav pom to pack it in war (otherwise log4j is marked optional by parent)

Jira issue: https://issues.jboss.org/browse/ISPN-2128
