### PR TITLE
ISPN-2134 Convert TreeCache tests to new cache config API

### DIFF
--- a/tree/src/test/java/org/infinispan/api/tree/BaseNodeMoveAPITest.java
+++ b/tree/src/test/java/org/infinispan/api/tree/BaseNodeMoveAPITest.java
@@ -43,6 +43,7 @@ import org.infinispan.util.Util;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.testng.annotations.Test;
 
 import javax.transaction.*;
 import java.util.Random;
@@ -55,6 +56,7 @@ import static org.testng.AssertJUnit.*;
  *
  * @author <a href="mailto:manik AT jboss DOT org">Manik Surtani</a>
  */
+@Test(groups = "functional", testName = "api.tree.BaseNodeMoveAPITest")
 public abstract class BaseNodeMoveAPITest extends SingleCacheManagerTest {
    protected final Log log = LogFactory.getLog(getClass());
 

--- a/tree/src/test/java/org/infinispan/api/tree/FlagTest.java
+++ b/tree/src/test/java/org/infinispan/api/tree/FlagTest.java
@@ -24,7 +24,8 @@ package org.infinispan.api.tree;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
-import org.infinispan.config.Configuration;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.Flag;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.tree.Fqn;
@@ -48,9 +49,9 @@ public class FlagTest extends MultipleCacheManagersTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      Configuration c = getDefaultClusteredConfig(Configuration.CacheMode.INVALIDATION_SYNC, true);
-      c.setInvocationBatchingEnabled(true);
-      createClusteredCaches(2, "invalidatedFlagCache", c);
+      ConfigurationBuilder cb = getDefaultClusteredCacheConfig(CacheMode.INVALIDATION_SYNC, true);
+      cb.invocationBatching().enable();
+      createClusteredCaches(2, "invalidatedFlagCache", cb);
       cache1 = cache(0, "invalidatedFlagCache");
       cache2 = cache(1, "invalidatedFlagCache");
       TreeCacheFactory tcf = new TreeCacheFactory();

--- a/tree/src/test/java/org/infinispan/api/tree/LazyDeserializationTreeCacheTest.java
+++ b/tree/src/test/java/org/infinispan/api/tree/LazyDeserializationTreeCacheTest.java
@@ -22,7 +22,7 @@
  */
 package org.infinispan.api.tree;
 
-import org.infinispan.config.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -38,10 +38,10 @@ public class LazyDeserializationTreeCacheTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       // start a single cache instance
-      Configuration c = getDefaultStandaloneConfig(true);
-      c.setInvocationBatchingEnabled(true);
-      c.setUseLazyDeserialization(true);
-      return TestCacheManagerFactory.createCacheManager(c);
+      ConfigurationBuilder cb = getDefaultStandaloneCacheConfig(true);
+      cb.invocationBatching().enable()
+            .storeAsBinary().enable();
+      return TestCacheManagerFactory.createCacheManager(cb);
    }
 
    public void testStartTreeCache() {

--- a/tree/src/test/java/org/infinispan/api/tree/NodeAPITest.java
+++ b/tree/src/test/java/org/infinispan/api/tree/NodeAPITest.java
@@ -22,7 +22,7 @@
  */
 package org.infinispan.api.tree;
 
-import org.infinispan.config.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -57,9 +57,9 @@ public class NodeAPITest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       // start a single cache instance
-      Configuration c = getDefaultStandaloneConfig(true);
-      c.setInvocationBatchingEnabled(true);
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(c);
+      ConfigurationBuilder cb = getDefaultStandaloneCacheConfig(true);
+      cb.invocationBatching().enable();
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(cb);
       cache = new TreeCacheImpl<Object, Object>(cm.getCache());
       tm = cache.getCache().getAdvancedCache().getTransactionManager();
       return cm;

--- a/tree/src/test/java/org/infinispan/api/tree/NodeMoveAPIOptimisticTest.java
+++ b/tree/src/test/java/org/infinispan/api/tree/NodeMoveAPIOptimisticTest.java
@@ -39,7 +39,7 @@ public class NodeMoveAPIOptimisticTest extends BaseNodeMoveAPITest {
    @Override
    protected ConfigurationBuilder createConfigurationBuilder() {
       ConfigurationBuilder cb = new ConfigurationBuilder();
-      cb.clustering().invocationBatching().enable()
+      cb.invocationBatching().enable()
             .locking().lockAcquisitionTimeout(1000)
             .isolationLevel(IsolationLevel.REPEATABLE_READ)
             .transaction().lockingMode(LockingMode.OPTIMISTIC)

--- a/tree/src/test/java/org/infinispan/api/tree/NodeMoveAPIPessimisticTest.java
+++ b/tree/src/test/java/org/infinispan/api/tree/NodeMoveAPIPessimisticTest.java
@@ -38,7 +38,7 @@ public class NodeMoveAPIPessimisticTest extends BaseNodeMoveAPITest {
    @Override
    protected ConfigurationBuilder createConfigurationBuilder() {
       ConfigurationBuilder cb = new ConfigurationBuilder();
-      cb.clustering().invocationBatching().enable()
+      cb.invocationBatching().enable()
             .locking().lockAcquisitionTimeout(1000)
             .isolationLevel(IsolationLevel.REPEATABLE_READ)
             .transaction().lockingMode(LockingMode.PESSIMISTIC);

--- a/tree/src/test/java/org/infinispan/api/tree/NodeReplicatedMoveTest.java
+++ b/tree/src/test/java/org/infinispan/api/tree/NodeReplicatedMoveTest.java
@@ -30,7 +30,8 @@
 package org.infinispan.api.tree;
 
 import org.infinispan.Cache;
-import org.infinispan.config.Configuration;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.tree.Fqn;
@@ -54,10 +55,10 @@ public class NodeReplicatedMoveTest extends MultipleCacheManagersTest {
    TransactionManager tm1;
 
    protected void createCacheManagers() throws Throwable {
-      Configuration c = getDefaultClusteredConfig(Configuration.CacheMode.REPL_SYNC, true);
-      c.setInvocationBatchingEnabled(true);
+      ConfigurationBuilder cb = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
+      cb.invocationBatching().enable();
 
-      createClusteredCaches(2, "replSync", c);
+      createClusteredCaches(2, "replSync", cb);
 
       Cache c1 = cache(0, "replSync");
       Cache c2 = cache(1, "replSync");

--- a/tree/src/test/java/org/infinispan/api/tree/SyncReplTest.java
+++ b/tree/src/test/java/org/infinispan/api/tree/SyncReplTest.java
@@ -31,8 +31,9 @@
 package org.infinispan.api.tree;
 
 import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.Flag;
-import org.infinispan.config.Configuration;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.tree.Fqn;
 import org.infinispan.tree.Node;
@@ -52,10 +53,10 @@ public class SyncReplTest extends MultipleCacheManagersTest {
    private TreeCache<Object, Object> cache1, cache2;
 
    protected void createCacheManagers() throws Throwable {
-      Configuration c = getDefaultClusteredConfig(Configuration.CacheMode.REPL_SYNC);
-      c.setInvocationBatchingEnabled(true);
+      ConfigurationBuilder cb = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
+      cb.invocationBatching().enable();
 
-      createClusteredCaches(2, "replSync", c);
+      createClusteredCaches(2, "replSync", cb);
 
       Cache c1 = cache(0, "replSync");
       Cache c2 = cache(1, "replSync");

--- a/tree/src/test/java/org/infinispan/api/tree/SyncReplTxTest.java
+++ b/tree/src/test/java/org/infinispan/api/tree/SyncReplTxTest.java
@@ -31,7 +31,8 @@
 package org.infinispan.api.tree;
 
 import org.infinispan.Cache;
-import org.infinispan.config.Configuration;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.tree.Fqn;
 import org.infinispan.tree.Node;
@@ -52,13 +53,13 @@ import javax.transaction.TransactionManager;
  */
 @Test(groups = "functional", testName = "api.tree.SyncReplTxTest")
 public class SyncReplTxTest extends MultipleCacheManagersTest {
-   TreeCache<Object, Object> cache1, cache2;
+   private TreeCache<Object, Object> cache1, cache2;
 
    protected void createCacheManagers() throws Throwable {
-      Configuration c = getDefaultClusteredConfig(Configuration.CacheMode.REPL_SYNC, true);
-      c.setInvocationBatchingEnabled(true);
+      ConfigurationBuilder cb = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
+      cb.invocationBatching().enable();
 
-      createClusteredCaches(2, "replSync", c);
+      createClusteredCaches(2, "replSync", cb);
 
       Cache c1 = cache(0, "replSync");
       Cache c2 = cache(1, "replSync");

--- a/tree/src/test/java/org/infinispan/api/tree/TreeCacheAPITest.java
+++ b/tree/src/test/java/org/infinispan/api/tree/TreeCacheAPITest.java
@@ -25,7 +25,6 @@ package org.infinispan.api.tree;
 import org.infinispan.Cache;
 import org.infinispan.atomic.AtomicMap;
 import org.infinispan.atomic.AtomicMapLookup;
-import org.infinispan.config.Configuration;
 import org.infinispan.config.ConfigurationException;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
@@ -66,9 +65,9 @@ public class TreeCacheAPITest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       // start a single cache instance
-      Configuration c = new Configuration();
-      c.setInvocationBatchingEnabled(true);
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(c);
+      ConfigurationBuilder cb = new ConfigurationBuilder();
+      cb.invocationBatching().enable();
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(cb);
 
       Cache flatcache = cm.getCache();
       cache = new TreeCacheImpl<String, String>(flatcache);

--- a/tree/src/test/java/org/infinispan/loaders/TreeCacheWithJdbmLoaderTest.java
+++ b/tree/src/test/java/org/infinispan/loaders/TreeCacheWithJdbmLoaderTest.java
@@ -19,10 +19,9 @@
 
 package org.infinispan.loaders;
 
-import org.infinispan.loaders.jdbm.JdbmCacheStoreConfig;
+import org.infinispan.configuration.cache.LoaderConfigurationBuilder;
+import org.infinispan.loaders.jdbm.JdbmCacheStore;
 import org.infinispan.test.TestingUtil;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -40,20 +39,21 @@ public class TreeCacheWithJdbmLoaderTest extends TreeCacheWithLoaderTest {
    private String tmpDirectory;
 
    @Override
-   protected CacheStoreConfig getCacheStoreCfg() {
-      JdbmCacheStoreConfig cfg = new JdbmCacheStoreConfig();
-      cfg.setLocation(tmpDirectory);
-      cfg.setPurgeSynchronously(true); // for more accurate unit testing
-      return cfg;
+   protected void addCacheStore(LoaderConfigurationBuilder cb) {
+      cb.cacheLoader(new JdbmCacheStore())
+            .addProperty("location", tmpDirectory)
+            .purgeSynchronously(true); // for more accurate unit testing
    }
 
-   @BeforeClass
-   protected void setUpTempDir() {
+   @Override
+   protected void setup() throws Exception {
       tmpDirectory = TestingUtil.tmpDirectory(this);
+      super.setup();
    }
 
-   @AfterClass(alwaysRun = true)
-   protected void clearTempDir() {
+   @Override
+   protected void teardown() {
+      super.teardown();
       TestingUtil.recursiveFileRemove(tmpDirectory);
       new File(tmpDirectory).mkdirs();
    }

--- a/tree/src/test/java/org/infinispan/loaders/TreeCacheWithLoaderTest.java
+++ b/tree/src/test/java/org/infinispan/loaders/TreeCacheWithLoaderTest.java
@@ -22,7 +22,8 @@
  */
 package org.infinispan.loaders;
 
-import org.infinispan.config.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.LoaderConfigurationBuilder;
 import org.infinispan.loaders.dummy.DummyInMemoryCacheStore;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -48,19 +49,18 @@ public class TreeCacheWithLoaderTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       // start a single cache instance
-      Configuration c = getDefaultStandaloneConfig(true).fluent()
-            .invocationBatching()
-            .loaders()
-               .addCacheLoader(getCacheStoreCfg())
-            .build();
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(c);
+      ConfigurationBuilder cb = getDefaultStandaloneCacheConfig(true);
+      cb.invocationBatching().enable();
+      addCacheStore(cb.loaders().addCacheLoader());
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(cb);
       cache = new TreeCacheImpl<String, String>(cm.getCache());
       store = extractCacheStore();
       return cm;
    }
 
-   protected CacheStoreConfig getCacheStoreCfg() {
-      return new DummyInMemoryCacheStore.Cfg(getClass().getName());
+   protected void addCacheStore(LoaderConfigurationBuilder cb) {
+      cb.cacheLoader(new DummyInMemoryCacheStore())
+            .addProperty("storeName", getClass().getName());
    }
 
    public void testPersistence() throws CacheLoaderException {

--- a/tree/src/test/java/org/infinispan/profiling/TreeProfileTest.java
+++ b/tree/src/test/java/org/infinispan/profiling/TreeProfileTest.java
@@ -23,7 +23,8 @@
 package org.infinispan.profiling;
 
 import org.infinispan.Cache;
-import org.infinispan.config.Configuration;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.profiling.testinternals.FqnGenerator;
 import org.infinispan.profiling.testinternals.Generator;
@@ -82,13 +83,13 @@ public class TreeProfileTest {
 
    @BeforeMethod
    public void setUp() {
-      Configuration cfg = new Configuration();
-      cfg.setInvocationBatchingEnabled(true);
-      cfg.setCacheMode(Configuration.CacheMode.LOCAL);
-      cfg.setConcurrencyLevel(2000);
-      cfg.setLockAcquisitionTimeout(120000);
-      cfg.setIsolationLevel(IsolationLevel.READ_COMMITTED);
-      cacheContainer = TestCacheManagerFactory.createCacheManager(cfg);
+      ConfigurationBuilder cb = new ConfigurationBuilder();
+      cb.invocationBatching().enable()
+            .clustering().cacheMode(CacheMode.LOCAL)
+            .locking().concurrencyLevel(2000)
+            .lockAcquisitionTimeout(120000)
+            .isolationLevel(IsolationLevel.READ_COMMITTED);
+      cacheContainer = TestCacheManagerFactory.createCacheManager(cb);
       Cache c = cacheContainer.getCache();
       cache = new TreeCacheImpl<String, Object>(c);
    }
@@ -270,7 +271,7 @@ public class TreeProfileTest {
 
       public void run() {
          Fqn fqn = Generator.getRandomElement(fqns);
-         long d = 0, st = 0;
+         long d = 0, st;
          try {
             switch (mode) {
                case PUT:

--- a/tree/src/test/java/org/infinispan/tx/TransactionManagerLookupTreeTest.java
+++ b/tree/src/test/java/org/infinispan/tx/TransactionManagerLookupTreeTest.java
@@ -22,7 +22,7 @@
  */
 package org.infinispan.tx;
 
-import org.infinispan.config.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -38,10 +38,10 @@ public class TransactionManagerLookupTreeTest extends TransactionManagerLookupTe
    protected void doTest(TransactionManagerLookup tml) {
       EmbeddedCacheManager ecm = null;
       try {
-         Configuration c = new Configuration();
-         c.setTransactionManagerLookup(tml);
-         c.setInvocationBatchingEnabled(true);
-         ecm = TestCacheManagerFactory.createCacheManager(c);
+         ConfigurationBuilder cb = new ConfigurationBuilder();
+         cb.transaction().transactionManagerLookup(tml)
+               .invocationBatching().enable();
+         ecm = TestCacheManagerFactory.createCacheManager(cb);
          TreeCache<Object, Object> tc = new TreeCacheFactory().createTreeCache(ecm.<Object, Object>getCache());
          tc.put("/a/b/c", "k", "v");
          assert "v".equals(tc.get("/a/b/c", "k"));


### PR DESCRIPTION
Replace all usages of the deprecated config API in tests.

Jira issue: https://issues.jboss.org/browse/ISPN-2134
