### PR TITLE
fix for ISPN-2138: Could not execute MapReduce on AS7.1.1 getting java.l...

### DIFF
--- a/core/src/main/java/org/infinispan/commands/read/MapReduceCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/MapReduceCommand.java
@@ -146,6 +146,7 @@ public class MapReduceCommand extends BaseRpcCommand {
             GetKeyValueCommand command = commandsFactory.buildGetKeyValueCommand(key,
                      ctx.getFlags());
             command.setReturnCacheEntry(false);
+            ctx = getInvocationContext(context); 
             Object value = invoker.invoke(ctx, command);
             mapper.map(key, value, collector);
          }

--- a/core/src/main/java/org/infinispan/context/NonTransactionalInvocationContextContainer.java
+++ b/core/src/main/java/org/infinispan/context/NonTransactionalInvocationContextContainer.java
@@ -73,6 +73,7 @@ public class NonTransactionalInvocationContextContainer extends AbstractInvocati
    public NonTxInvocationContext createRemoteInvocationContext(Address origin) {
       NonTxInvocationContext ctx = new NonTxInvocationContext();
       ctx.setOrigin(origin);
+      ctx.setOriginLocal(true);
       ctxHolder.set(ctx);
       return ctx;
    }


### PR DESCRIPTION
not sure that this is the smartest patch but it works :)

setOriginLocal FLAG must be set tu true.
Because of the reset of the InvocationContext FLAG the only solution was to recreate a InvocationContext.

I be open for a better solution.

Cheers 
~Sandro 
