### PR TITLE
ISPN-2167 Fixed issue where array offset and size were not used when cal...

### DIFF
--- a/core/src/test/java/org/infinispan/marshall/TestObjectStreamMarshaller.java
+++ b/core/src/test/java/org/infinispan/marshall/TestObjectStreamMarshaller.java
@@ -104,9 +104,7 @@ public class TestObjectStreamMarshaller extends AbstractMarshaller implements St
 
    @Override
    public Object objectFromByteBuffer(byte[] buf, int offset, int length) throws IOException, ClassNotFoundException {
-      byte[] newBytes = new byte[length];
-      System.arraycopy(buf, offset, newBytes, 0, length);
-      return objectFromObjectStream(new ObjectInputStream(new ByteArrayInputStream(buf)));
+      return objectFromObjectStream(new ObjectInputStream(new ByteArrayInputStream(buf, offset, length)));
    }
 
    @Override


### PR DESCRIPTION
As you can see from diff the code is passing in the original byte array instead of the copied version.  Looking at the issue though there is really no need to copy the array when you could just pass it in with the offset and length as the commit has.  This way is doesn't needlessly copy the data again.
