### PR TITLE
[DEFERRED] ISPN-2172 Create a remote context instead of local when applying state

### DIFF
--- a/core/src/main/java/org/infinispan/commands/write/InvalidateL1Command.java
+++ b/core/src/main/java/org/infinispan/commands/write/InvalidateL1Command.java
@@ -115,7 +115,7 @@ public class InvalidateL1Command extends InvalidateCommand {
 
             if (!locality.isLocal()) {
                if (forRehash && config.clustering().l1().onRehash()) {
-                  if (trace) log.trace("Not removing, instead entry will be stored in L1");
+                  if (trace) log.tracef("Not removing key=%s, instead entry will be stored in L1", k);
                   // don't need to do anything here, DistLockingInterceptor.commitEntry() will put the entry in L1
                } else {
                	if (trace) log.tracef("Invalidating key %s.", k);
@@ -151,9 +151,7 @@ public class InvalidateL1Command extends InvalidateCommand {
 
       InvalidateL1Command that = (InvalidateL1Command) o;
 
-      if (forRehash != that.forRehash) return false;
-
-      return true;
+      return forRehash == that.forRehash;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/distribution/L1ManagerImpl.java
+++ b/core/src/main/java/org/infinispan/distribution/L1ManagerImpl.java
@@ -131,6 +131,7 @@ public class L1ManagerImpl implements L1Manager {
    
    @Override
    public void addRequestor(Object key, Address origin) {
+      if (trace) log.tracef("Add %s as L1 requestor for %s", origin, key);
       //we do a plain get first as that's likely to be enough
       ConcurrentMap<Address, Long> as = requestors.get(key);
       long now = System.currentTimeMillis();

--- a/core/src/main/java/org/infinispan/statetransfer/BaseStateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/BaseStateTransferManagerImpl.java
@@ -243,7 +243,9 @@ public abstract class BaseStateTransferManagerImpl implements StateTransferManag
          log.debugf("Applying new state from %s: received %d keys", sender, state.size());
          if (trace) log.tracef("Received keys: %s", keys(state));
          for (InternalCacheEntry e : state) {
-            InvocationContext ctx = icc.createInvocationContext(false, 1);
+            // The put call originates remotely. This helps adding a state pusher
+            // which does not own a key, as L1 requestor if L1 is enabled.
+            InvocationContext ctx = icc.createRemoteInvocationContext(sender);
             // locking not necessary as during rehashing we block all transactions
             ctx.setFlags(CACHE_MODE_LOCAL, SKIP_CACHE_LOAD, SKIP_REMOTE_LOOKUP, SKIP_SHARED_CACHE_STORE, SKIP_LOCKING,
                          SKIP_OWNERSHIP_CHECK);

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashWithL1Test.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashWithL1Test.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.distribution.rehash;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TransportFlags;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+
+/**
+ * Tests rehashing with distributed caches with L1 enabled.
+ *
+ * @author Galder Zamarreño
+ * @since 5.2
+ */
+@Test(groups = "functional", testName = "RayTest")
+public class RehashWithL1Test extends MultipleCacheManagersTest {
+
+   ConfigurationBuilder builder;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      // Enable rehashing explicitly
+      builder.clustering().stateTransfer().fetchInMemoryState(true)
+            .hash().l1().enable();
+      createClusteredCaches(2, builder);
+   }
+
+   public void testPutWithRehashAndCacheClear() throws Exception {
+      Future<Void> node3Join = null;
+      int opCount = 100;
+      for (int i = 0; i < opCount; i++) {
+         cache(0).put("k" + i, "some data");
+         if (i == (opCount / 2)) {
+            node3Join = fork(new Callable<Void>() {
+               @Override
+               public Void call() throws Exception {
+                  EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder,
+                        new TransportFlags().withMerge(true));
+                  cm.getCache();
+                  return null;
+               }
+            });
+         }
+         Thread.sleep(10);
+      }
+
+      if (node3Join == null) throw new Exception("Node 3 not joined");
+      node3Join.get();
+
+      for (int i = 0; i < opCount; i++) {
+         cache(0).remove("k" + i);
+         Thread.sleep(10);
+      }
+
+      for (int i = 0; i < opCount; i++) {
+         String key = "k" + i;
+         assertFalse(cache(0).containsKey(key));
+         assertFalse("Key: " + key + " is present in cache at " + cache(1),
+               cache(1).containsKey(key));
+         assertFalse("Key: " + key + " is present in cache at " + cache(2),
+               cache(2).containsKey(key));
+      }
+
+      assertEquals(0, cache(0).size());
+      assertEquals(0, cache(1).size());
+      assertEquals(0, cache(2).size());
+   }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2172

This helps the distribution interceptor figure out that if the state sender does not a key any more and L1 is enabled, the sender should be recorded as L1 requestor.
