### PR TITLE
ISPN-2215 Put back the ping on startup check on getCache()

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -515,13 +515,15 @@ public class RemoteCacheManager implements BasicCacheContainer {
             RemoteCacheImpl<K, V> result = new RemoteCacheImpl<K, V>(this, cacheName);
             RemoteCacheHolder rcc = new RemoteCacheHolder(result, forceReturnValueOverride == null ? forceReturnValueDefault : forceReturnValueOverride);
             startRemoteCache(rcc);
-            // If ping not successful assume that the cache does not exist
-            // Default cache is always started, so don't do for it
-            if (!cacheName.equals(BasicCacheContainer.DEFAULT_CACHE_NAME) &&
-                  ping(result) == PingResult.CACHE_DOES_NOT_EXIST) {
-               return null;
+            if (config.getPingOnStartup()) {
+               // If ping not successful assume that the cache does not exist
+               // Default cache is always started, so don't do for it
+               if (!cacheName.equals(BasicCacheContainer.DEFAULT_CACHE_NAME) &&
+                     ping(result) == PingResult.CACHE_DOES_NOT_EXIST) {
+                  return null;
+               }
             }
-            // If cache is not defined in server
+            // If ping on startup is disabled, or cache is defined in server
             cacheName2RemoteCache.put(cacheName, rcc);
             return result;
          } else {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/PingOnStartupTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/PingOnStartupTest.java
@@ -94,7 +94,21 @@ public class PingOnStartupTest extends MultiHotRodServersTest {
       });
    }
 
-   public void testGetCacheWithPingOnStartupDisabled() throws Exception {
+   public void testGetCacheWithPingOnStartupDisabledSingleNode() throws Exception {
+      Properties props = new Properties();
+      props.put("infinispan.client.hotrod.server_list", "boomoo:12345");
+      props.put("infinispan.client.hotrod.ping_on_startup", "false");
+
+      withRemoteCacheManager(new RemoteCacheManagerCallable(
+            new RemoteCacheManager(props)) {
+         @Override
+         public void call() throws Exception {
+            rcm.getCache();
+         }
+      });
+   }
+
+   public void testGetCacheWithPingOnStartupDisabledMultipleNodes() throws Exception {
       Properties props = new Properties();
       HotRodServer hotRodServer2 = server(1);
       props.put("infinispan.client.hotrod.server_list",


### PR DESCRIPTION
Added a test that specifically addresses the situation where single node
in the server list is not available and ping on startup is disabled.
