### PR TITLE
ISPN-2146 Switch to maven-surefire-plugin ver. 2.12.2 in order to fix sure...

### DIFF
--- a/cdi/tck-runner/pom.xml
+++ b/cdi/tck-runner/pom.xml
@@ -109,7 +109,6 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.9</version>
             <configuration>
                <forkMode>once</forkMode>
                 <properties>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -957,7 +957,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-plugin</artifactId>
-               <version>2.13-SNAPSHOT</version>
+               <version>2.12.2</version>
             </plugin>
             <plugin>
                <artifactId>maven-war-plugin</artifactId>
@@ -1323,7 +1323,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-report-plugin</artifactId>
-            <version>2.13-SNASPHOT</version>
+            <version>2.12.2</version>
          </plugin>
          <!-- Findbugs report -->
          <plugin>
@@ -1499,7 +1499,6 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
-                  <version>2.4.3-JBOSS</version>
                   <configuration>
                      <parallel>tests</parallel>
                      <threadCount>${infinispan.test.parallel.threads}</threadCount>


### PR DESCRIPTION
...fire bug SUREFIRE-879

There will be no stable release of maven-surefire-plugin 2.13 soon so instead we can switch to 2.12.2 which also contains the fix for SUREFIRE-879.

Jira issue: https://issues.jboss.org/browse/ISPN-2146
