### PR TITLE
ISPN-2216 Upgrade to JGroups 3.0.13.Final

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -143,7 +143,7 @@
       <version.jclouds>1.1.0</version.jclouds>
       <version.jetty>6.1.25</version.jetty>
       <version.jgoodies.forms>1.0.5</version.jgoodies.forms>
-      <version.jgroups>3.0.11.Final</version.jgroups>
+      <version.jgroups>3.0.13.Final</version.jgroups>
       <version.jsap>2.1</version.jsap>
       <version.json>20090211</version.json>
       <version.jstl>1.2</version.jstl>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2216

Only for the 5.1.x branch.
