### PR TITLE
Minor configuration fixes

### DIFF
--- a/cachestore/jdbc/src/main/resources/schema/infinispan-cachestore-jdbc-config-5.2.xsd
+++ b/cachestore/jdbc/src/main/resources/schema/infinispan-cachestore-jdbc-config-5.2.xsd
@@ -1,7 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!-- ~ Copyright 2012 Red Hat, Inc. and/or its affiliates. ~ ~ This is free software; you can redistribute it and/or modify it ~ under the terms of the GNU Lesser General Public License as ~ published by the Free Software Foundation; either version 2.1 of ~ the License, or (at your option) any later 
-  version. ~ ~ This software is distributed in the hope that it will be useful, ~ but WITHOUT ANY WARRANTY; without even the implied warranty of ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU ~ Lesser General Public License for more details. ~ ~ You should have received a copy of the 
-  GNU Lesser General Public ~ License along with this library; if not, write to the Free Software ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA ~ 02110-1301 USA -->
+
+<!--
+  ~ Copyright 2012 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this library; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA
+  -->
 
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" version="1.0" targetNamespace="urn:infinispan:config:jdbc:5.2" xmlns:tns="urn:infinispan:config:jdbc:5.2" xmlns:config="urn:infinispan:config:5.2" xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:import namespace="urn:infinispan:config:5.2" schemaLocation="http://www.infinispan.org/schemas/infinispan-config-5.2.xsd" />

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractLoaderConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractLoaderConfiguration.java
@@ -32,7 +32,7 @@ import org.infinispan.util.TypedProperties;
  */
 public abstract class AbstractLoaderConfiguration extends AbstractTypedPropertiesConfiguration implements LoaderConfiguration {
 
-   AbstractLoaderConfiguration(TypedProperties properties) {
+   protected AbstractLoaderConfiguration(TypedProperties properties) {
       super(properties);
    }
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractStoreConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractStoreConfiguration.java
@@ -33,7 +33,7 @@ public abstract class AbstractStoreConfiguration extends AbstractLoaderConfigura
    private final AsyncStoreConfiguration async;
    private final SingletonStoreConfiguration singletonStore;
 
-   AbstractStoreConfiguration(boolean purgeOnStartup, boolean purgeSynchronously, int purgerThreads, boolean fetchPersistentState,
+   protected AbstractStoreConfiguration(boolean purgeOnStartup, boolean purgeSynchronously, int purgerThreads, boolean fetchPersistentState,
          boolean ignoreModifications, TypedProperties properties, AsyncStoreConfiguration async, SingletonStoreConfiguration singletonStore) {
       super(properties);
       this.purgeOnStartup = purgeOnStartup;

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalConfiguration.java
@@ -119,6 +119,11 @@ public class GlobalConfiguration {
       return shutdown;
    }
 
+   @SuppressWarnings("unchecked")
+   public <T> T module(Class<T> moduleClass) {
+      return (T)modules.get(moduleClass);
+   }
+
    public Map<Class<?>, ?> modules() {
       return modules;
    }


### PR DESCRIPTION
- add a modules(Class<T>) method to GlobalConfiguration to make it consistent with Configuration
- reformat copyright header on infinispan-cachestore-jdbc-5.2.xsd
- make AbstractLoaderConfiguration and AbstractStoreConfiguration constructors protected to ease subclassing
