### PR TITLE
Upgrade to JGroups 3.2.0.Alpha1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -146,7 +146,7 @@
       <version.jclouds>1.1.0</version.jclouds>
       <version.jetty>6.1.25</version.jetty>
       <version.jgoodies.forms>1.0.5</version.jgoodies.forms>
-      <version.jgroups>3.1.0.Final</version.jgroups>
+      <version.jgroups>3.2.0.Alpha1</version.jgroups>
       <version.jreadline>0.16</version.jreadline>
       <version.jsap>2.1</version.jsap>
       <version.json>20090211</version.json>


### PR DESCRIPTION
This contains some fixes that should stabilize the test suite.
Also RELAY2 which is needed for the x-site code.
