### PR TITLE
ISPN-2232 Make sure local query caches can also be registered

### DIFF
--- a/query/src/main/java/org/infinispan/query/CommandInitializer.java
+++ b/query/src/main/java/org/infinispan/query/CommandInitializer.java
@@ -27,6 +27,7 @@ import org.infinispan.Cache;
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commands.module.ModuleCommandInitializer;
 import org.infinispan.query.backend.QueryInterceptor;
+import org.infinispan.query.impl.ComponentRegistryUtils;
 
 /**
  * Initializes query module remote commands
@@ -46,7 +47,7 @@ public final class CommandInitializer implements ModuleCommandInitializer {
       SearchManager searchManager = Search.getSearchManager(cache);
       SearchFactory searchFactory = searchManager.getSearchFactory();
       searchFactoryImplementor = (SearchFactoryImplementor) searchFactory;
-      queryInterceptor = cache.getAdvancedCache().getComponentRegistry().getComponent(QueryInterceptor.class);
+      queryInterceptor = ComponentRegistryUtils.getQueryInterceptor(cache);
    }
 
    @Override

--- a/query/src/main/java/org/infinispan/query/SearchManagerImpl.java
+++ b/query/src/main/java/org/infinispan/query/SearchManagerImpl.java
@@ -29,6 +29,7 @@ import org.hibernate.search.SearchFactory;
 import org.hibernate.search.query.dsl.EntityContext;
 import org.hibernate.search.spi.SearchFactoryIntegrator;
 import org.infinispan.AdvancedCache;
+import org.infinispan.query.backend.LocalQueryInterceptor;
 import org.infinispan.query.backend.QueryInterceptor;
 import org.infinispan.query.clustered.ClusteredCacheQueryImpl;
 import org.infinispan.query.impl.CacheQueryImpl;
@@ -54,7 +55,7 @@ class SearchManagerImpl implements SearchManager {
       }
       this.cache = cache;
       this.searchFactory = ComponentRegistryUtils.getComponent(cache, SearchFactoryIntegrator.class);
-      this.queryInterceptor = ComponentRegistryUtils.getComponent(cache, QueryInterceptor.class);
+      this.queryInterceptor = ComponentRegistryUtils.getQueryInterceptor(cache);
    }
 
    /* (non-Javadoc)

--- a/query/src/main/java/org/infinispan/query/backend/KeyTransformationHandler.java
+++ b/query/src/main/java/org/infinispan/query/backend/KeyTransformationHandler.java
@@ -242,7 +242,8 @@ public class KeyTransformationHandler {
     * @return a KeyTransformationHandler instance
     */
    public static KeyTransformationHandler getInstance(AdvancedCache<?, ?> cache) {
-      QueryInterceptor queryInterceptor = ComponentRegistryUtils.getComponent(cache, QueryInterceptor.class);
+      QueryInterceptor queryInterceptor = ComponentRegistryUtils.getQueryInterceptor(cache);
       return queryInterceptor.getKeyTransformationHandler();
    }
+
 }

--- a/query/src/main/java/org/infinispan/query/impl/ComponentRegistryUtils.java
+++ b/query/src/main/java/org/infinispan/query/impl/ComponentRegistryUtils.java
@@ -24,9 +24,14 @@ package org.infinispan.query.impl;
 
 import org.infinispan.Cache;
 import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.query.backend.LocalQueryInterceptor;
+import org.infinispan.query.backend.QueryInterceptor;
 
 /**
+ * Component registry utilities
+ *
  * @author Marko Luksa
+ * @author Galder Zamarreño
  */
 public class ComponentRegistryUtils {
 
@@ -41,4 +46,11 @@ public class ComponentRegistryUtils {
       }
       return component;
    }
+
+   public static QueryInterceptor getQueryInterceptor(Cache<?, ?> cache) {
+      Class<? extends QueryInterceptor> queryType = cache.getCacheConfiguration().indexing().indexLocalOnly()
+            ? LocalQueryInterceptor.class : QueryInterceptor.class;
+      return getComponent(cache, queryType);
+   }
+
 }

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -80,7 +80,8 @@ public class LifecycleManager extends AbstractModuleLifecycle {
       QueryInterceptor queryInterceptor = cr.getComponent(QueryInterceptor.class);
       if (queryInterceptor == null) {
          queryInterceptor = buildQueryInterceptor(cfg, searchFactory);
-         cr.registerComponent(queryInterceptor, QueryInterceptor.class);
+         // Interceptor registration not needed, core configuration handling
+         // already does it for all custom interceptors
 
          ConfigurationBuilder builder = new ConfigurationBuilder();
          InterceptorConfigurationBuilder interceptorBuilder =


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2232
- This can be achieved making sure the correct type is given when the query interceptor is retrieved from the component registry.
- This avoids the need for unnecessary query interceptor registration because the custom interceptor chain handling already takes care of that, and with local indexing, you'd have QueryInterceptor.class component registered unnecessarily.
