### PR TITLE
ISPN-2231 - SyncReplTest#testMixingSyncAndAsyncOnSameTransport() looks t...

### DIFF
--- a/core/src/test/java/org/infinispan/replication/SyncReplTest.java
+++ b/core/src/test/java/org/infinispan/replication/SyncReplTest.java
@@ -33,9 +33,7 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 
@@ -203,6 +201,9 @@ public class SyncReplTest extends MultipleCacheManagersTest {
 
          // check that the replication call was sync
          cache1.put("k", "v");
+         verify(mockTransport).invokeRemotely((List<Address>) anyObject(),
+                                              (CacheRpcCommand) anyObject(), eq(ResponseMode.SYNCHRONOUS), anyLong(),
+                                              anyBoolean(), (ResponseFilter) anyObject());
 
          // resume to test for async
          asyncRpcManager = (RpcManagerImpl) TestingUtil.extractComponent(asyncCache1, RpcManager.class);
@@ -217,7 +218,9 @@ public class SyncReplTest extends MultipleCacheManagersTest {
                            anyBoolean(), (ResponseFilter) anyObject())).thenReturn(emptyResponses);
 
          asyncCache1.put("k", "v");
-         // check that the replication call was async
+         verify(mockTransport).invokeRemotely((List<Address>) anyObject(),
+                                               (CacheRpcCommand) anyObject(), eq(ResponseMode.ASYNCHRONOUS), anyLong(),
+                                               anyBoolean(), (ResponseFilter) anyObject());
       } finally {
          // replace original transport
          if (rpcManager != null)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2231

The test was incomplete as it didn't run verification phase in order to make sure that the RPC methods were invoked with appropriate params
