### PR TITLE
ISPN-2237 Fix JDK detection in concurrent map factory

### DIFF
--- a/core/src/main/java/org/infinispan/util/concurrent/ConcurrentMapFactory.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/ConcurrentMapFactory.java
@@ -93,7 +93,7 @@ public class ConcurrentMapFactory {
       boolean allowExperimentalMap = Boolean.getBoolean("infinispan.unsafe.allow_jdk8_chm");
 
       try {
-         Class.forName("com.sun.unsafe.Unsafe");
+         Class.forName("sun.misc.Unsafe");
          sunIncompatibleJvm = false;
       } catch (ClassNotFoundException e) {
          sunIncompatibleJvm = true;

--- a/core/src/test/java/org/infinispan/test/fwk/SuiteResourcesAndLogTest.java
+++ b/core/src/test/java/org/infinispan/test/fwk/SuiteResourcesAndLogTest.java
@@ -54,6 +54,7 @@ public class SuiteResourcesAndLogTest {
       log("sun.cpu.endian = " + System.getProperty("sun.cpu.endian"));
       log("protocol.stack = " + System.getProperty("protocol.stack"));
       log("infinispan.test.jgroups.protocol = " + System.getProperty("infinispan.test.jgroups.protocol"));
+      log("infinispan.unsafe.allow_jdk8_chm = " + System.getProperty("infinispan.unsafe.allow_jdk8_chm"));
       String preferIpV4 = System.getProperty("java.net.preferIPv4Stack");
       log("java.net.preferIPv4Stack = " + preferIpV4);
       log("java.net.preferIPv6Stack = " + System.getProperty("java.net.preferIPv6Stack"));

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1276,6 +1276,10 @@
                      <name>java.net.preferIPv4Stack</name>
                      <value>true</value>
                   </property>
+                  <property>
+                     <name>infinispan.unsafe.allow_jdk8_chm</name>
+                     <value>true</value>
+                  </property>
                </systemProperties>
                <trimStackTrace>false</trimStackTrace>
                <properties>


### PR DESCRIPTION
http://lists.jboss.org/pipermail/infinispan-dev/2012-September/011169.html
- Also enable infinispan.unsafe.allow_jdk8_chm by default when running the testsuite in order to detect issues with the backported JDK8 CHM.
