### PR TITLE
Faster FileCacheStore implementation

### DIFF
--- a/core/src/main/java/org/infinispan/loaders/file/FastFileCacheStore.java
+++ b/core/src/main/java/org/infinispan/loaders/file/FastFileCacheStore.java
@@ -22,603 +22,531 @@
  */
 package org.infinispan.loaders.file;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.infinispan.Cache;
 import org.infinispan.config.ConfigurationException;
-import org.infinispan.container.entries.*;
-import org.infinispan.loaders.*;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.entries.InternalCacheValue;
+import org.infinispan.loaders.AbstractCacheStore;
+import org.infinispan.loaders.CacheLoaderConfig;
+import org.infinispan.loaders.CacheLoaderException;
+import org.infinispan.loaders.CacheLoaderMetadata;
+import org.infinispan.loaders.CacheStore;
 import org.infinispan.marshall.StreamingMarshaller;
 
 /**
- * A filesystem-based implementation of a {@link CacheStore}. This file store
- * stores cache values in a single file
- * <tt>&lt;location&gt;/&lt;cache name&gt;.dat</tt>, keys and file positions are
- * kept in memory.
+ * A filesystem-based implementation of a {@link CacheStore}. This file store stores cache values in
+ * a single file <tt>&lt;location&gt;/&lt;cache name&gt;.dat</tt>, keys and file positions are kept
+ * in memory.
  * <p/>
- * Note: this CacheStore implementation keeps keys and file positions in memory!
- * The current implementation needs about 100 bytes per cache entry, plus the
- * memory for the key objects. Use the maxEntries parameter or cache entries
- * that can expire (with purge) to prevent the cache store from growing
- * indefinitely and causing OutOfMemoryExceptions.
+ * Note: this CacheStore implementation keeps keys and file positions in memory! The current
+ * implementation needs about 100 bytes per cache entry, plus the memory for the key objects. Use
+ * the maxEntries parameter or cache entries that can expire (with purge) to prevent the cache store
+ * from growing indefinitely and causing OutOfMemoryExceptions.
  * <p/>
- * This class is fully thread safe, yet allows for concurrent load / store of
- * individual cache entries.
+ * This class is fully thread safe, yet allows for concurrent load / store of individual cache
+ * entries.
  * 
  * @author Karsten Blees
  */
 @CacheLoaderMetadata(configurationClass = FastFileCacheStoreConfig.class)
-public class FastFileCacheStore extends AbstractCacheStore
-{
-	private static final byte[] MAGIC = new byte[]
-	{ 'F', 'C', 'S', '1' };
+public class FastFileCacheStore extends AbstractCacheStore {
+   private static final byte[] MAGIC = new byte[] { 'F', 'C', 'S', '1' };
 
-	private static final int KEYLEN_POS = 4;
+   private static final int KEYLEN_POS = 4;
 
-	private static final int KEY_POS = 4 + 4 + 4 + 8;
+   private static final int KEY_POS = 4 + 4 + 4 + 8;
 
-	private FastFileCacheStoreConfig config;
+   private FastFileCacheStoreConfig config;
 
-	private FileChannel file;
+   private FileChannel file;
 
-	private Map<Object, FileEntry> entries;
+   private Map<Object, FileEntry> entries;
 
-	private SortedSet<FileEntry> freeList;
+   private SortedSet<FileEntry> freeList;
 
-	private long filePos = MAGIC.length;
+   private long filePos = MAGIC.length;
 
-	/** {@inheritDoc} */
-	@Override
-	public Class<? extends CacheLoaderConfig> getConfigurationClass()
-	{
-		return FastFileCacheStoreConfig.class;
-	}
+   /** {@inheritDoc} */
+   @Override
+   public Class<? extends CacheLoaderConfig> getConfigurationClass() {
+      return FastFileCacheStoreConfig.class;
+   }
 
-	/** {@inheritDoc} */
-	@Override
-	public void init(CacheLoaderConfig config, Cache<?, ?> cache,
-		StreamingMarshaller m) throws CacheLoaderException
-	{
-		super.init(config, cache, m);
-		this.config = (FastFileCacheStoreConfig) config;
-	}
+   /** {@inheritDoc} */
+   @Override
+   public void init(CacheLoaderConfig config, Cache<?, ?> cache, StreamingMarshaller m) throws CacheLoaderException {
+      super.init(config, cache, m);
+      this.config = (FastFileCacheStoreConfig) config;
+   }
 
-	/** {@inheritDoc} */
-	@Override
-	public void start() throws CacheLoaderException
-	{
-		super.start();
-		try
-		{
-			// open the data file
-			String location = config.getLocation();
-			if (location == null || location.trim().length() == 0)
-				location = "Infinispan-FileCacheStore";
-			File dir = new File(location);
-			if (!dir.exists() && !dir.mkdirs())
-				throw new ConfigurationException("Directory " + dir.getAbsolutePath()
-					+ " does not exist and cannot be created!");
+   /** {@inheritDoc} */
+   @Override
+   public void start() throws CacheLoaderException {
+      super.start();
+      try {
+         // open the data file
+         String location = config.getLocation();
+         if (location == null || location.trim().length() == 0)
+            location = "Infinispan-FileCacheStore";
+         File dir = new File(location);
+         if (!dir.exists() && !dir.mkdirs())
+            throw new ConfigurationException("Directory " + dir.getAbsolutePath()
+                  + " does not exist and cannot be created!");
 
-			File f = new File(location, cache.getName() + ".dat");
-			file = new RandomAccessFile(f, "rw").getChannel();
+         File f = new File(location, cache.getName() + ".dat");
+         file = new RandomAccessFile(f, "rw").getChannel();
 
-			// initialize data structures
-			// only use LinkedHashMap (LRU) for entries when cache store is bounded
-			final Map entryMap;
-			if (config.getMaxEntries() > 0)
-				entryMap = new LinkedHashMap<Object, FileEntry>(16, 0.75f, true);
-			else
-				entryMap = new HashMap();
-			entries = Collections.synchronizedMap(entryMap);
-			freeList = Collections.synchronizedSortedSet(new TreeSet<FileEntry>());
+         // initialize data structures
+         // only use LinkedHashMap (LRU) for entries when cache store is bounded
+         final Map<Object, FileEntry> entryMap;
+         if (config.getMaxEntries() > 0)
+            entryMap = new LinkedHashMap<Object, FileEntry>(16, 0.75f, true);
+         else
+            entryMap = new HashMap<Object, FileEntry>();
+         entries = Collections.synchronizedMap(entryMap);
+         freeList = Collections.synchronizedSortedSet(new TreeSet<FileEntry>());
 
-			// check file format and read persistent state if enabled for the cache
-			byte[] header = new byte[MAGIC.length];
-			if (file.read(ByteBuffer.wrap(header), 0) == MAGIC.length
-				&& Arrays.equals(MAGIC, header)
-				&& cache.getCacheConfiguration().loaders().preload())
-				preload();
-			else
-				// otherwise (unknown file format or no preload) just reset the file
-				clear();
-		}
-		catch (Exception e)
-		{
-			throw new CacheLoaderException(e);
-		}
-	}
+         // check file format and read persistent state if enabled for the cache
+         byte[] header = new byte[MAGIC.length];
+         if (file.read(ByteBuffer.wrap(header), 0) == MAGIC.length && Arrays.equals(MAGIC, header)
+               && cache.getCacheConfiguration().loaders().preload())
+            preload();
+         else
+            // otherwise (unknown file format or no preload) just reset the file
+            clear();
+      } catch (Exception e) {
+         throw new CacheLoaderException(e);
+      }
+   }
 
-	/** {@inheritDoc} */
-	@Override
-	public void stop() throws CacheLoaderException
-	{
-		try
-		{
-			if (file != null)
-			{
-				// reset state
-				file.close();
-				file = null;
-				entries = null;
-				freeList = null;
-				filePos = MAGIC.length;
-			}
-		}
-		catch (Exception e)
-		{
-			throw new CacheLoaderException(e);
-		}
-		super.stop();
-	}
+   /** {@inheritDoc} */
+   @Override
+   public void stop() throws CacheLoaderException {
+      try {
+         if (file != null) {
+            // reset state
+            file.close();
+            file = null;
+            entries = null;
+            freeList = null;
+            filePos = MAGIC.length;
+         }
+      } catch (Exception e) {
+         throw new CacheLoaderException(e);
+      }
+      super.stop();
+   }
 
-	/**
-	 * Rebuilds the in-memory index from file.
-	 */
-	private void preload() throws Exception
-	{
-		ByteBuffer buf = ByteBuffer.allocate(KEY_POS);
-		for (;;)
-		{
-			// read FileEntry fields from file (size, keyLen etc.)
-			buf.clear().limit(KEY_POS);
-			file.read(buf, filePos);
-			// return if end of file is reached
-			if (buf.remaining() > 0)
-				return;
-			buf.flip();
+   /**
+    * Rebuilds the in-memory index from file.
+    */
+   private void preload() throws Exception {
+      ByteBuffer buf = ByteBuffer.allocate(KEY_POS);
+      for (;;) {
+         // read FileEntry fields from file (size, keyLen etc.)
+         buf.clear().limit(KEY_POS);
+         file.read(buf, filePos);
+         // return if end of file is reached
+         if (buf.remaining() > 0)
+            return;
+         buf.flip();
 
-			// initialize FileEntry from buffer
-			FileEntry fe = new FileEntry(filePos, buf.getInt());
-			fe.keyLen = buf.getInt();
-			fe.dataLen = buf.getInt();
-			fe.expiryTime = buf.getLong();
+         // initialize FileEntry from buffer
+         FileEntry fe = new FileEntry(filePos, buf.getInt());
+         fe.keyLen = buf.getInt();
+         fe.dataLen = buf.getInt();
+         fe.expiryTime = buf.getLong();
 
-			// update file pointer
-			filePos += fe.size;
+         // update file pointer
+         filePos += fe.size;
 
-			// check if the entry is used or free
-			if (fe.keyLen > 0)
-			{
-				// load the key from file
-				if (buf.capacity() < fe.keyLen)
-					buf = ByteBuffer.allocate(fe.keyLen);
+         // check if the entry is used or free
+         if (fe.keyLen > 0) {
+            // load the key from file
+            if (buf.capacity() < fe.keyLen)
+               buf = ByteBuffer.allocate(fe.keyLen);
 
-				buf.clear().limit(fe.keyLen);
-				file.read(buf, fe.offset + KEY_POS);
+            buf.clear().limit(fe.keyLen);
+            file.read(buf, fe.offset + KEY_POS);
 
-				// deserialize key and add to entries map
-				Object key = getMarshaller().objectFromByteBuffer(buf.array(), 0,
-					fe.keyLen);
-				entries.put(key, fe);
-			}
-			else
-			{
-				// add to free list
-				freeList.add(fe);
-			}
-		}
-	}
+            // deserialize key and add to entries map
+            Object key = getMarshaller().objectFromByteBuffer(buf.array(), 0, fe.keyLen);
+            entries.put(key, fe);
+         } else {
+            // add to free list
+            freeList.add(fe);
+         }
+      }
+   }
 
-	/**
-	 * {@inheritDoc}
-	 * <p/>
-	 * The base class implementation calls {@link #load(Object)} for this, we can
-	 * do better because we keep all keys in memory.
-	 */
-	@Override
-	public boolean containsKey(Object key) throws CacheLoaderException
-	{
-		return entries.containsKey(key);
-	}
+   /**
+    * {@inheritDoc}
+    * <p/>
+    * The base class implementation calls {@link #load(Object)} for this, we can do better because
+    * we keep all keys in memory.
+    */
+   @Override
+   public boolean containsKey(Object key) throws CacheLoaderException {
+      return entries.containsKey(key);
+   }
 
-	/**
-	 * Allocates the requested space in the file.
-	 * 
-	 * @param len requested space
-	 * @return allocated file position and length as FileEntry object
-	 */
-	private FileEntry allocate(int len)
-	{
-		synchronized (freeList)
-		{
-			// lookup a free entry of sufficient size
-			SortedSet<FileEntry> candidates = freeList.tailSet(new FileEntry(0, len));
-			for (Iterator<FileEntry> it = candidates.iterator(); it.hasNext();)
-			{
-				FileEntry free = it.next();
-				// ignore entries that are still in use by concurrent readers
-				if (free.isLocked())
-					continue;
+   /**
+    * Allocates the requested space in the file.
+    *
+    * @param len
+    *           requested space
+    * @return allocated file position and length as FileEntry object
+    */
+   private FileEntry allocate(int len) {
+      synchronized (freeList) {
+         // lookup a free entry of sufficient size
+         SortedSet<FileEntry> candidates = freeList.tailSet(new FileEntry(0, len));
+         for (Iterator<FileEntry> it = candidates.iterator(); it.hasNext();) {
+            FileEntry free = it.next();
+            // ignore entries that are still in use by concurrent readers
+            if (free.isLocked())
+               continue;
 
-				// found one, remove from freeList
-				it.remove();
-				return free;
-			}
+            // found one, remove from freeList
+            it.remove();
+            return free;
+         }
 
-			// no appropriate free section available, append at end of file
-			FileEntry fe = new FileEntry(filePos, len);
-			filePos += len;
-			return fe;
-		}
-	}
+         // no appropriate free section available, append at end of file
+         FileEntry fe = new FileEntry(filePos, len);
+         filePos += len;
+         return fe;
+      }
+   }
 
-	private static final byte[] ZERO_INT =
-	{ 0, 0, 0, 0 };
+   private static final byte[] ZERO_INT = { 0, 0, 0, 0 };
 
-	/**
-	 * Frees the space of the specified file entry (for reuse by allocate).
-	 * 
-	 * @param fe FileEntry to free
-	 */
-	private void free(FileEntry fe) throws IOException
-	{
-		if (fe != null)
-		{
-			// invalidate entry on disk (by setting keyLen field to 0)
-			file.write(ByteBuffer.wrap(ZERO_INT), fe.offset + KEYLEN_POS);
-			freeList.add(fe);
-		}
-	}
+   /**
+    * Frees the space of the specified file entry (for reuse by allocate).
+    *
+    * @param fe
+    *           FileEntry to free
+    */
+   private void free(FileEntry fe) throws IOException {
+      if (fe != null) {
+         // invalidate entry on disk (by setting keyLen field to 0)
+         file.write(ByteBuffer.wrap(ZERO_INT), fe.offset + KEYLEN_POS);
+         freeList.add(fe);
+      }
+   }
 
-	/** {@inheritDoc} */
-	@Override
-	public void store(InternalCacheEntry entry) throws CacheLoaderException
-	{
-		try
-		{
-			// serialize cache value
-			byte[] key = getMarshaller().objectToByteBuffer(entry.getKey());
-			byte[] data = getMarshaller().objectToByteBuffer(
-				entry.toInternalCacheValue());
+   /** {@inheritDoc} */
+   @Override
+   public void store(InternalCacheEntry entry) throws CacheLoaderException {
+      try {
+         // serialize cache value
+         byte[] key = getMarshaller().objectToByteBuffer(entry.getKey());
+         byte[] data = getMarshaller().objectToByteBuffer(entry.toInternalCacheValue());
 
-			// allocate file entry and store in cache file
-			int len = KEY_POS + key.length + data.length;
-			FileEntry fe = allocate(len);
-			try
-			{
-				fe.expiryTime = entry.getExpiryTime();
-				fe.keyLen = key.length;
-				fe.dataLen = data.length;
+         // allocate file entry and store in cache file
+         int len = KEY_POS + key.length + data.length;
+         FileEntry fe = allocate(len);
+         try {
+            fe.expiryTime = entry.getExpiryTime();
+            fe.keyLen = key.length;
+            fe.dataLen = data.length;
 
-				ByteBuffer buf = ByteBuffer.allocate(len);
-				buf.putInt(fe.size);
-				buf.putInt(fe.keyLen);
-				buf.putInt(fe.dataLen);
-				buf.putLong(fe.expiryTime);
-				buf.put(key);
-				buf.put(data);
-				buf.flip();
-				file.write(buf, fe.offset);
+            ByteBuffer buf = ByteBuffer.allocate(len);
+            buf.putInt(fe.size);
+            buf.putInt(fe.keyLen);
+            buf.putInt(fe.dataLen);
+            buf.putLong(fe.expiryTime);
+            buf.put(key);
+            buf.put(data);
+            buf.flip();
+            file.write(buf, fe.offset);
 
-				// add the new entry to in-memory index
-				fe = entries.put(entry.getKey(), fe);
+            // add the new entry to in-memory index
+            fe = entries.put(entry.getKey(), fe);
 
-				// if we added an entry, check if we need to evict something
-				if (fe == null)
-					fe = evict();
-			}
-			finally
-			{
-				// in case we replaced or evicted an entry, add to freeList
-				free(fe);
-			}
-		}
-		catch (Exception e)
-		{
-			throw new CacheLoaderException(e);
-		}
-	}
+            // if we added an entry, check if we need to evict something
+            if (fe == null)
+               fe = evict();
+         } finally {
+            // in case we replaced or evicted an entry, add to freeList
+            free(fe);
+         }
+      } catch (Exception e) {
+         throw new CacheLoaderException(e);
+      }
+   }
 
-	/**
-	 * Try to evict an entry if the capacity of the cache store is reached.
-	 * 
-	 * @return FileEntry to evict, or null (if unbounded or capacity is not yet
-	 *         reached)
-	 */
-	private FileEntry evict()
-	{
-		if (config.getMaxEntries() > 0)
-		{
-			synchronized (entries)
-			{
-				if (entries.size() > config.getMaxEntries())
-				{
-					Iterator<FileEntry> it = entries.values().iterator();
-					FileEntry fe = it.next();
-					it.remove();
-					return fe;
-				}
-			}
-		}
-		return null;
-	}
+   /**
+    * Try to evict an entry if the capacity of the cache store is reached.
+    *
+    * @return FileEntry to evict, or null (if unbounded or capacity is not yet reached)
+    */
+   private FileEntry evict() {
+      if (config.getMaxEntries() > 0) {
+         synchronized (entries) {
+            if (entries.size() > config.getMaxEntries()) {
+               Iterator<FileEntry> it = entries.values().iterator();
+               FileEntry fe = it.next();
+               it.remove();
+               return fe;
+            }
+         }
+      }
+      return null;
+   }
 
-	/** {@inheritDoc} */
-	@Override
-	public void clear() throws CacheLoaderException
-	{
-		try
-		{
-			synchronized (entries)
-			{
-				synchronized (freeList)
-				{
-					// wait until all readers are done reading file entries
-					for (FileEntry fe : entries.values())
-						fe.waitUnlocked();
-					for (FileEntry fe : freeList)
-						fe.waitUnlocked();
+   /** {@inheritDoc} */
+   @Override
+   public void clear() throws CacheLoaderException {
+      try {
+         synchronized (entries) {
+            synchronized (freeList) {
+               // wait until all readers are done reading file entries
+               for (FileEntry fe : entries.values())
+                  fe.waitUnlocked();
+               for (FileEntry fe : freeList)
+                  fe.waitUnlocked();
 
-					// clear in-memory state
-					entries.clear();
-					freeList.clear();
+               // clear in-memory state
+               entries.clear();
+               freeList.clear();
 
-					// reset file
-					file.truncate(0);
-					file.write(ByteBuffer.wrap(MAGIC), 0);
-					filePos = MAGIC.length;
-				}
-			}
-		}
-		catch (Exception e)
-		{
-			throw new CacheLoaderException(e);
-		}
-	}
+               // reset file
+               file.truncate(0);
+               file.write(ByteBuffer.wrap(MAGIC), 0);
+               filePos = MAGIC.length;
+            }
+         }
+      } catch (Exception e) {
+         throw new CacheLoaderException(e);
+      }
+   }
 
-	/** {@inheritDoc} */
-	@Override
-	public boolean remove(Object key) throws CacheLoaderException
-	{
-		try
-		{
-			FileEntry fe = entries.remove(key);
-			free(fe);
-			return fe != null;
-		}
-		catch (Exception e)
-		{
-			throw new CacheLoaderException(e);
-		}
-	}
+   /** {@inheritDoc} */
+   @Override
+   public boolean remove(Object key) throws CacheLoaderException {
+      try {
+         FileEntry fe = entries.remove(key);
+         free(fe);
+         return fe != null;
+      } catch (Exception e) {
+         throw new CacheLoaderException(e);
+      }
+   }
 
-	/** {@inheritDoc} */
-	@Override
-	public InternalCacheEntry load(Object key) throws CacheLoaderException
-	{
-		try
-		{
-			final FileEntry fe;
-			final boolean expired;
-			synchronized (entries)
-			{
-				// lookup FileEntry of the key
-				fe = entries.get(key);
-				if (fe == null)
-					return null;
+   /** {@inheritDoc} */
+   @Override
+   public InternalCacheEntry load(Object key) throws CacheLoaderException {
+      try {
+         final FileEntry fe;
+         final boolean expired;
+         synchronized (entries) {
+            // lookup FileEntry of the key
+            fe = entries.get(key);
+            if (fe == null)
+               return null;
 
-				// if expired, remove the entry (within entries monitor)
-				expired = fe.isExpired(System.currentTimeMillis());
-				if (expired)
-					entries.remove(key);
+            // if expired, remove the entry (within entries monitor)
+            expired = fe.isExpired(System.currentTimeMillis());
+            if (expired)
+               entries.remove(key);
 
-				// lock entry for reading before releasing entries monitor
-				fe.lock();
-			}
+            // lock entry for reading before releasing entries monitor
+            fe.lock();
+         }
 
-			final byte[] data;
-			try
-			{
-				// if expired, free the file entry (after releasing entries monitor)
-				if (expired)
-				{
-					free(fe);
-					return null;
-				}
+         final byte[] data;
+         try {
+            // if expired, free the file entry (after releasing entries monitor)
+            if (expired) {
+               free(fe);
+               return null;
+            }
 
-				// load serialized data from disk
-				data = new byte[fe.dataLen];
-				file.read(ByteBuffer.wrap(data), fe.offset + KEY_POS + fe.keyLen);
-			}
-			finally
-			{
-				// no need to keep the lock for deserialization
-				fe.unlock();
-			}
+            // load serialized data from disk
+            data = new byte[fe.dataLen];
+            file.read(ByteBuffer.wrap(data), fe.offset + KEY_POS + fe.keyLen);
+         } finally {
+            // no need to keep the lock for deserialization
+            fe.unlock();
+         }
 
-			// deserialize data and recreate InternalCacheEntry
-			return ((InternalCacheValue) getMarshaller().objectFromByteBuffer(data))
-				.toInternalCacheEntry(key);
-		}
-		catch (Exception e)
-		{
-			throw new CacheLoaderException(e);
-		}
-	}
+         // deserialize data and recreate InternalCacheEntry
+         return ((InternalCacheValue) getMarshaller().objectFromByteBuffer(data)).toInternalCacheEntry(key);
+      } catch (Exception e) {
+         throw new CacheLoaderException(e);
+      }
+   }
 
-	/** {@inheritDoc} */
-	@Override
-	public Set<InternalCacheEntry> loadAll() throws CacheLoaderException
-	{
-		return load(Integer.MAX_VALUE);
-	}
+   /** {@inheritDoc} */
+   @Override
+   public Set<InternalCacheEntry> loadAll() throws CacheLoaderException {
+      return load(Integer.MAX_VALUE);
+   }
 
-	/** {@inheritDoc} */
-	@Override
-	public Set<InternalCacheEntry> load(int numEntries)
-		throws CacheLoaderException
-	{
-		Set<Object> keys = loadAllKeys(null);
-		Set<InternalCacheEntry> result = new HashSet<InternalCacheEntry>();
-		for (Object key : keys)
-		{
-			InternalCacheEntry ice = load(key);
-			if (ice != null)
-			{
-				result.add(ice);
-				if (result.size() > numEntries)
-					return result;
-			}
-		}
-		return result;
-	}
+   /** {@inheritDoc} */
+   @Override
+   public Set<InternalCacheEntry> load(int numEntries) throws CacheLoaderException {
+      Set<Object> keys = loadAllKeys(null);
+      Set<InternalCacheEntry> result = new HashSet<InternalCacheEntry>();
+      for (Object key : keys) {
+         InternalCacheEntry ice = load(key);
+         if (ice != null) {
+            result.add(ice);
+            if (result.size() > numEntries)
+               return result;
+         }
+      }
+      return result;
+   }
 
-	/** {@inheritDoc} */
-	@Override
-	public Set<Object> loadAllKeys(Set<Object> keysToExclude)
-		throws CacheLoaderException
-	{
-		Set<Object> result;
-		synchronized (entries)
-		{
-			result = new HashSet(entries.keySet());
-		}
-		if (keysToExclude != null)
-			result.removeAll(keysToExclude);
-		return result;
-	}
+   /** {@inheritDoc} */
+   @Override
+   public Set<Object> loadAllKeys(Set<Object> keysToExclude) throws CacheLoaderException {
+      Set<Object> result;
+      synchronized (entries) {
+         result = new HashSet<Object>(entries.keySet());
+      }
+      if (keysToExclude != null)
+         result.removeAll(keysToExclude);
+      return result;
+   }
 
-	/** {@inheritDoc} */
-	@Override
-	protected void purgeInternal() throws CacheLoaderException
-	{
-		long now = System.currentTimeMillis();
-		synchronized (entries)
-		{
-			for (Iterator<FileEntry> it = entries.values().iterator(); it.hasNext();)
-			{
-				FileEntry fe = it.next();
-				if (fe.isExpired(now))
-				{
-					it.remove();
-					try
-					{
-						free(fe);
-					}
-					catch (Exception e)
-					{
-						throw new CacheLoaderException(e);
-					}
-				}
-			}
-		}
-	}
+   /** {@inheritDoc} */
+   @Override
+   protected void purgeInternal() throws CacheLoaderException {
+      long now = System.currentTimeMillis();
+      synchronized (entries) {
+         for (Iterator<FileEntry> it = entries.values().iterator(); it.hasNext();) {
+            FileEntry fe = it.next();
+            if (fe.isExpired(now)) {
+               it.remove();
+               try {
+                  free(fe);
+               } catch (Exception e) {
+                  throw new CacheLoaderException(e);
+               }
+            }
+         }
+      }
+   }
 
-	/** {@inheritDoc} */
-	public void fromStream(ObjectInput inputStream) throws CacheLoaderException
-	{
-		// seems that this is never called by Infinispan (except by decorators)
-		throw new UnsupportedOperationException();
-	}
+   /** {@inheritDoc} */
+   public void fromStream(ObjectInput inputStream) throws CacheLoaderException {
+      // seems that this is never called by Infinispan (except by decorators)
+      throw new UnsupportedOperationException();
+   }
 
-	/** {@inheritDoc} */
-	public void toStream(ObjectOutput outputStream) throws CacheLoaderException
-	{
-		// seems that this is never called by Infinispan (except by decorators)
-		throw new UnsupportedOperationException();
-	}
+   /** {@inheritDoc} */
+   public void toStream(ObjectOutput outputStream) throws CacheLoaderException {
+      // seems that this is never called by Infinispan (except by decorators)
+      throw new UnsupportedOperationException();
+   }
 
-	/**
-	 * Helper class to represent an entry in the cache file.
-	 * <p/>
-	 * The format of a FileEntry on disk is as follows:
-	 * <ul>
-	 * <li>4 bytes: {@link #size}</li>
-	 * <li>4 bytes: {@link #keyLen}, 0 if the block is unused</li>
-	 * <li>4 bytes: {@link #dataLen}</li>
-	 * <li>8 bytes: {@link #expiryTime}</li>
-	 * <li>{@link #keyLen} bytes: serialized key</li>
-	 * <li>{@link #dataLen} bytes: serialized data</li>
-	 * </ul>
-	 */
-	private static class FileEntry implements Comparable
-	{
-		/**
-		 * File offset of this block.
-		 */
-		private final long offset;
+   /**
+    * Helper class to represent an entry in the cache file.
+    * <p/>
+    * The format of a FileEntry on disk is as follows:
+    * <ul>
+    * <li>4 bytes: {@link #size}</li>
+    * <li>4 bytes: {@link #keyLen}, 0 if the block is unused</li>
+    * <li>4 bytes: {@link #dataLen}</li>
+    * <li>8 bytes: {@link #expiryTime}</li>
+    * <li>{@link #keyLen} bytes: serialized key</li>
+    * <li>{@link #dataLen} bytes: serialized data</li>
+    * </ul>
+    */
+   private static class FileEntry implements Comparable<Object> {
+      /**
+       * File offset of this block.
+       */
+      private final long offset;
 
-		/**
-		 * Total size of this block.
-		 */
-		private final int size;
+      /**
+       * Total size of this block.
+       */
+      private final int size;
 
-		/**
-		 * Size of serialized key.
-		 */
-		private int keyLen;
+      /**
+       * Size of serialized key.
+       */
+      private int keyLen;
 
-		/**
-		 * Size of serialized data.
-		 */
-		private int dataLen;
+      /**
+       * Size of serialized data.
+       */
+      private int dataLen;
 
-		/**
-		 * Time stamp when the entry will expire (i.e. will be collected by purge).
-		 */
-		private long expiryTime = -1;
+      /**
+       * Time stamp when the entry will expire (i.e. will be collected by purge).
+       */
+      private long expiryTime = -1;
 
-		/**
-		 * Number of current readers.
-		 */
-		private transient int readers = 0;
+      /**
+       * Number of current readers.
+       */
+      private transient int readers = 0;
 
-		private FileEntry(long offset, int size)
-		{
-			this.offset = offset;
-			this.size = size;
-		}
+      private FileEntry(long offset, int size) {
+         this.offset = offset;
+         this.size = size;
+      }
 
-		private synchronized boolean isLocked()
-		{
-			return readers > 0;
-		}
+      private synchronized boolean isLocked() {
+         return readers > 0;
+      }
 
-		private synchronized void lock()
-		{
-			readers++;
-		}
+      private synchronized void lock() {
+         readers++;
+      }
 
-		private synchronized void unlock()
-		{
-			readers--;
-			if (readers == 0)
-				notifyAll();
-		}
+      private synchronized void unlock() {
+         readers--;
+         if (readers == 0)
+            notifyAll();
+      }
 
-		private synchronized void waitUnlocked()
-		{
-			while (readers > 0)
-			{
-				try
-				{
-					wait();
-				}
-				catch (InterruptedException e)
-				{
-					// ignore, we don't expect anyone to interrupt us
-				}
-			}
-		}
+      private synchronized void waitUnlocked() {
+         while (readers > 0) {
+            try {
+               wait();
+            } catch (InterruptedException e) {
+               // ignore, we don't expect anyone to interrupt us
+            }
+         }
+      }
 
-		private boolean isExpired(long now)
-		{
-			return expiryTime > 0 && expiryTime < now;
-		}
+      private boolean isExpired(long now) {
+         return expiryTime > 0 && expiryTime < now;
+      }
 
-		/** {@inheritDoc} */
-		public int compareTo(Object o)
-		{
-			if (!(o instanceof FileEntry))
-				throw new ClassCastException();
-			if (this == o)
-				return 0;
-			FileEntry fe = (FileEntry) o;
-			int diff = size - fe.size;
-			return (diff != 0) ? diff : offset > fe.offset ? 1 : -1;
-		}
-	}
+      /** {@inheritDoc} */
+      public int compareTo(Object o) {
+         if (!(o instanceof FileEntry))
+            throw new ClassCastException();
+         if (this == o)
+            return 0;
+         FileEntry fe = (FileEntry) o;
+         int diff = size - fe.size;
+         return (diff != 0) ? diff : offset > fe.offset ? 1 : -1;
+      }
+   }
 }

--- a/core/src/main/java/org/infinispan/loaders/file/FastFileCacheStoreConfig.java
+++ b/core/src/main/java/org/infinispan/loaders/file/FastFileCacheStoreConfig.java
@@ -28,60 +28,50 @@ import org.infinispan.loaders.AbstractCacheStoreConfig;
  * Configures {@link FastFileCacheStore}.
  * <p/>
  * <ul>
- * <li><tt>location</tt> - a location on disk where the store can write internal
- * files. This defaults to <tt>Infinispan-FileCacheStore</tt> in the current
- * working directory.</li>
- * <li><tt>maxEntries</tt> - maximum number of entries allowed in the cache
- * store. If more entries are added, the least recently used (LRU) entry is
- * removed.</li>
+ * <li><tt>location</tt> - a location on disk where the store can write internal files. This
+ * defaults to <tt>Infinispan-FileCacheStore</tt> in the current working directory.</li>
+ * <li><tt>maxEntries</tt> - maximum number of entries allowed in the cache store. If more entries
+ * are added, the least recently used (LRU) entry is removed.</li>
  * </ul>
  * 
  * @author Karsten Blees
  */
-public class FastFileCacheStoreConfig extends AbstractCacheStoreConfig
-{
-	private static final long serialVersionUID = 1L;
+public class FastFileCacheStoreConfig extends AbstractCacheStoreConfig {
+   private static final long serialVersionUID = 1L;
 
-	private String location = "Infinispan-FileCacheStore";
+   private String location = "Infinispan-FileCacheStore";
 
-	private int maxEntries = -1;
+   private int maxEntries = -1;
 
-	public FastFileCacheStoreConfig()
-	{
-		setCacheLoaderClassName(FastFileCacheStore.class.getName());
-	}
+   public FastFileCacheStoreConfig() {
+      setCacheLoaderClassName(FastFileCacheStore.class.getName());
+   }
 
-	public String getLocation()
-	{
-		return location;
-	}
+   public String getLocation() {
+      return location;
+   }
 
-	public void setLocation(String location)
-	{
-		testImmutability("location");
-		this.location = location;
-	}
+   public void setLocation(String location) {
+      testImmutability("location");
+      this.location = location;
+   }
 
-	public FastFileCacheStoreConfig location(String location)
-	{
-		setLocation(location);
-		return this;
-	}
+   public FastFileCacheStoreConfig location(String location) {
+      setLocation(location);
+      return this;
+   }
 
-	public int getMaxEntries()
-	{
-		return maxEntries;
-	}
+   public int getMaxEntries() {
+      return maxEntries;
+   }
 
-	public void setMaxEntries(int maxEntries)
-	{
-		testImmutability("maxEntries");
-		this.maxEntries = maxEntries;
-	}
+   public void setMaxEntries(int maxEntries) {
+      testImmutability("maxEntries");
+      this.maxEntries = maxEntries;
+   }
 
-	public FastFileCacheStoreConfig maxEntries(int maxEntries)
-	{
-		setMaxEntries(maxEntries);
-		return this;
-	}
+   public FastFileCacheStoreConfig maxEntries(int maxEntries) {
+      setMaxEntries(maxEntries);
+      return this;
+   }
 }


### PR DESCRIPTION
Hi Infinispan dev team,

I recently tried to switch from Ehcache to Infinispan (mostly due to Ehcache's ingenuous 'probabilistic' (i.e. random) eviction algorithms).

However, unfortunately, I found Infinispan's FileCacheStore to be so horribly slow that is is unusable. Looking at the code, the theoretical 4 million open files per FileCacheStore prevent use in a production environment anyway.

So, I went ahead and wrote my own version, which manages cache values in a single file and keeps keys and file positions in memory. This version is ~1500 [1] to ~5000 [2] times faster than the original.

[1] with Long keys increasing in 1k steps (i.e. original FileCacheStore stores 1 entry per bucket, 1 file per entry)
[2] with adjacent Long keys (i.e. original FileCacheStore stores 1k entries per bucket, 1 file per 1k entries)

I make this code available in the hope that it may be useful to someone, or probably even included in a future release.

Cheers,
Karsten
