### PR TITLE
ISPN-2186 Ignore cache view commands from an old coordinator.

### DIFF
--- a/core/src/main/java/org/infinispan/cacheviews/CacheViewsManager.java
+++ b/core/src/main/java/org/infinispan/cacheviews/CacheViewsManager.java
@@ -69,11 +69,11 @@ public interface CacheViewsManager {
 
    void handleRequestLeave(Address sender, String cacheName);
 
-   void handlePrepareView(String cacheName, CacheView pendingView, CacheView committedView) throws Exception;
+   void handlePrepareView(Address sender, String cacheName, CacheView pendingView, CacheView committedView) throws Exception;
 
-   void handleCommitView(String cacheName, int viewId);
+   void handleCommitView(Address sender, String cacheName, int viewId);
 
-   void handleRollbackView(String cacheName, int newViewId, int committedViewId);
+   void handleRollbackView(Address sender, String cacheName, int newViewId, int committedViewId);
 
    /**
     * @return The last prepared view id for each cache that's running on this node.

--- a/core/src/main/java/org/infinispan/commands/control/CacheViewControlCommand.java
+++ b/core/src/main/java/org/infinispan/commands/control/CacheViewControlCommand.java
@@ -123,14 +123,14 @@ public class CacheViewControlCommand implements CacheRpcCommand {
                cacheViewsManager.handleRequestLeave(sender, cacheName);
               return null;
             case PREPARE_VIEW:
-               cacheViewsManager.handlePrepareView(cacheName, new CacheView(newViewId, newMembers),
+               cacheViewsManager.handlePrepareView(sender, cacheName, new CacheView(newViewId, newMembers),
                      new CacheView(oldViewId, oldMembers));
                return null;
             case COMMIT_VIEW:
-               cacheViewsManager.handleCommitView(cacheName, newViewId);
+               cacheViewsManager.handleCommitView(sender, cacheName, newViewId);
                return null;
             case ROLLBACK_VIEW:
-               cacheViewsManager.handleRollbackView(cacheName, newViewId, oldViewId);
+               cacheViewsManager.handleRollbackView(sender, cacheName, newViewId, oldViewId);
                return null;
             case RECOVER_VIEW:
                return cacheViewsManager.handleRecoverViews();


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2186
Only for the 5.1.x branch.

Needed for https://issues.jboss.org/browse/JBPAPP-9658.
There's another issue remaining to finish up JBPAPP-9658 - https://issues.jboss.org/browse/AS7-5442 - but that will probably require a fix in JGroups and/or AS7.
