### PR TITLE
fix UnitTestTestNGListener to use XmlTest#getXmlClasses instead of XmlTest#getClasses

### DIFF
--- a/core/src/test/java/org/infinispan/test/fwk/UnitTestTestNGListener.java
+++ b/core/src/test/java/org/infinispan/test/fwk/UnitTestTestNGListener.java
@@ -108,7 +108,7 @@ public class UnitTestTestNGListener implements ITestListener, IInvokedMethodList
    public void onStart(ITestContext arg0) {
       String fullName = arg0.getName();
       String simpleName = fullName.substring(fullName.lastIndexOf('.') + 1);
-      Class testClass = arg0.getCurrentXmlTest().getClasses().get(0).getSupportClass();
+      Class testClass = arg0.getCurrentXmlTest().getXmlClasses().get(0).getSupportClass();
       if (!simpleName.equals(testClass.getSimpleName())) {
          log.warnf("Wrong test name %s for class %s", simpleName, testClass.getSimpleName());
       }
@@ -116,7 +116,7 @@ public class UnitTestTestNGListener implements ITestListener, IInvokedMethodList
    }
 
    public void onFinish(ITestContext arg0) {
-      Class testClass = arg0.getCurrentXmlTest().getClasses().get(0).getSupportClass();
+      Class testClass = arg0.getCurrentXmlTest().getXmlClasses().get(0).getSupportClass();
       TestCacheManagerFactory.testFinished(testClass.getSimpleName());
    }
 


### PR DESCRIPTION
Master only. Simple fix to use getXmlClasses instead of recently added getClasses. Use of getClasses breaks infinispan-cdi project which uses older testng library (needed for arquillian compatibility) 
