### PR TITLE
ISPN-2261 CacheStore Builder API cleanup

### DIFF
--- a/cachestore/bdbje/src/main/java/org/infinispan/loaders/bdbje/configuration/Attribute.java
+++ b/cachestore/bdbje/src/main/java/org/infinispan/loaders/bdbje/configuration/Attribute.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Enumerates the attributes used by the Remote cache store configuration
+ * Enumerates the attributes used by the Bdbje cache store configuration
  *
  * @author Tristan Tarrant
  * @since 5.2

--- a/cachestore/bdbje/src/main/java/org/infinispan/loaders/bdbje/configuration/BdbjeCacheStoreConfigurationBuilder.java
+++ b/cachestore/bdbje/src/main/java/org/infinispan/loaders/bdbje/configuration/BdbjeCacheStoreConfigurationBuilder.java
@@ -48,36 +48,89 @@ public class BdbjeCacheStoreConfigurationBuilder extends
       return this;
    }
 
+   /**
+    * A location on disk where the store can write internal files. This defaults to
+    * <tt>Infinispan-BdbjeCacheStore</tt> in the current working directory.
+    *
+    * @return
+    */
    public BdbjeCacheStoreConfigurationBuilder location(String location) {
       this.location = location;
       return this;
    }
 
+   /**
+    * The length of time, in milliseconds, to wait for locks before timing out and throwing an
+    * exception. By default, this is set to <tt>60000</tt>.
+    *
+    * @param lockAcquistionTimeout
+    * @return
+    */
    public BdbjeCacheStoreConfigurationBuilder lockAcquistionTimeout(long lockAcquistionTimeout) {
       this.lockAcquistionTimeout = lockAcquistionTimeout;
       return this;
    }
 
+   /**
+    * The number of times transaction prepares will attempt to resolve a deadlock before throwing an
+    * exception. By default, this is set to <tt>5</tt>.
+    *
+    * @param maxTxRetries
+    * @return
+    */
    public BdbjeCacheStoreConfigurationBuilder maxTxRetries(int maxTxRetries) {
       this.maxTxRetries = maxTxRetries;
       return this;
    }
 
+   /**
+    * The prefix to add before the cache name to generate the filename of the SleepyCat database
+    * persisting this store. If unspecified, the filename defaults to
+    * <tt>{@link org.infinispan.Cache#getName()} cache#name}</tt>.
+    *
+    * @param cacheDbNamePrefix
+    * @return
+    */
    public BdbjeCacheStoreConfigurationBuilder cacheDbNamePrefix(String cacheDbNamePrefix) {
       this.cacheDbNamePrefix = cacheDbNamePrefix;
       return this;
    }
 
+   /**
+    * The name of the SleepyCat database persisting the class information for objects in this store.
+    * This defaults to <tt>{@link org.infinispan.Cache#getName()} cache#name}_class_catalog</tt>.
+    *
+    * @param catalogDbName
+    * @return
+    */
    public BdbjeCacheStoreConfigurationBuilder catalogDbName(String catalogDbName) {
       this.catalogDbName = catalogDbName;
       return this;
    }
 
+   /**
+    * The prefix to add before the cache name to generate the filename of the SleepyCat database
+    * persisting this store containing the expiration entries. If unspecified, the filename defaults to
+    * <tt>{@link org.infinispan.Cache#getName()} cache#name}_expiry</tt>.
+    *
+    * @param expiryDbPrefix
+    * @return
+    */
    public BdbjeCacheStoreConfigurationBuilder expiryDbPrefix(String expiryDbPrefix) {
       this.expiryDbPrefix = expiryDbPrefix;
       return this;
    }
 
+   /**
+    * The name of the SleepyCat properties file containing <tt>je.*</tt> properties to initialize
+    * the JE environment. Defaults to null, no properties are passed in to the JE engine if this is
+    * null or empty. The file specified needs to be available on the classpath, or must be an
+    * absolute path to a valid properties file. Refer to SleepyCat JE Environment configuration
+    * documentation for details.
+    *
+    * @param environmentPropertiesFile
+    * @return
+    */
    public BdbjeCacheStoreConfigurationBuilder environmentPropertiesFile(String environmentPropertiesFile) {
       this.environmentPropertiesFile = environmentPropertiesFile;
       return this;
@@ -93,6 +146,7 @@ public class BdbjeCacheStoreConfigurationBuilder extends
 
    @Override
    public BdbjeCacheStoreConfigurationBuilder read(BdbjeCacheStoreConfiguration template) {
+
       this.location = template.location();
       this.lockAcquistionTimeout = template.lockAcquisitionTimeout();
       this.maxTxRetries = template.maxTxRetries();
@@ -100,6 +154,16 @@ public class BdbjeCacheStoreConfigurationBuilder extends
       this.catalogDbName = template.catalogDbName();
       this.expiryDbPrefix = template.expiryDbPrefix();
       this.environmentPropertiesFile = template.environmentPropertiesFile();
+
+      // AbstractStore-specific configuration
+      fetchPersistentState = template.fetchPersistentState();
+      ignoreModifications = template.ignoreModifications();
+      properties = template.properties();
+      purgeOnStartup = template.purgeOnStartup();
+      purgeSynchronously = template.purgeSynchronously();
+      async.read(template.async());
+      singletonStore.read(template.singletonStore());
+
       return this;
    }
 

--- a/cachestore/bdbje/src/main/java/org/infinispan/loaders/bdbje/configuration/BdbjeCacheStoreConfigurationParser52.java
+++ b/cachestore/bdbje/src/main/java/org/infinispan/loaders/bdbje/configuration/BdbjeCacheStoreConfigurationParser52.java
@@ -34,7 +34,7 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
 
 /**
  *
- * JdbcCacheStoreConfigurationParser52.
+ * BdbjeCacheStoreConfigurationParser52.
  *
  * @author Tristan Tarrant
  * @since 5.2

--- a/cachestore/bdbje/src/main/java/org/infinispan/loaders/bdbje/configuration/Element.java
+++ b/cachestore/bdbje/src/main/java/org/infinispan/loaders/bdbje/configuration/Element.java
@@ -25,10 +25,10 @@ package org.infinispan.loaders.bdbje.configuration;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.infinispan.loaders.file.FileCacheStore;
+import org.infinispan.loaders.bdbje.BdbjeCacheStore;
 
 /**
- * An enumeration of all the recognized XML element local names for the {@link FileCacheStore}
+ * An enumeration of all the recognized XML element local names for the {@link BdbjeCacheStore}
  *
  * @author Tristan Tarrant
  * @since 5.2

--- a/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/configuration/ConfigurationTest.java
+++ b/cachestore/bdbje/src/test/java/org/infinispan/loaders/bdbje/configuration/ConfigurationTest.java
@@ -28,18 +28,30 @@ public class ConfigurationTest {
 
    public void testBdbjeCacheStoreConfigurationAdaptor() {
       ConfigurationBuilder b = new ConfigurationBuilder();
-      b.loaders().addStore(BdbjeCacheStoreConfigurationBuilder.class).location("/tmp/bdbje").cacheDbNamePrefix("myprefix").catalogDbName("mycatalog").async().enable();
+      b.loaders().addStore(BdbjeCacheStoreConfigurationBuilder.class).location("/tmp/bdbje").cacheDbNamePrefix("myprefix").catalogDbName("mycatalog").fetchPersistentState(true).async().enable();
       Configuration configuration = b.build();
-      BdbjeCacheStoreConfiguration store = (BdbjeCacheStoreConfiguration) configuration.loaders().cacheLoaders()
-            .get(0);
+      BdbjeCacheStoreConfiguration store = (BdbjeCacheStoreConfiguration) configuration.loaders().cacheLoaders().get(0);
       assert store.location().equals("/tmp/bdbje");
       assert store.cacheDbNamePrefix().equals("myprefix");
       assert store.catalogDbName().equals("mycatalog");
+      assert store.fetchPersistentState();
+      assert store.async().enabled();
+
+      b = new ConfigurationBuilder();
+      b.loaders().addStore(BdbjeCacheStoreConfigurationBuilder.class).read(store);
+      Configuration configuration2 = b.build();
+      BdbjeCacheStoreConfiguration store2 = (BdbjeCacheStoreConfiguration) configuration2.loaders().cacheLoaders().get(0);
+      assert store2.location().equals("/tmp/bdbje");
+      assert store2.cacheDbNamePrefix().equals("myprefix");
+      assert store2.catalogDbName().equals("mycatalog");
+      assert store2.fetchPersistentState();
+      assert store2.async().enabled();
 
       BdbjeCacheStoreConfig legacy = store.adapt();
       assert legacy.getLocation().equals("/tmp/bdbje");
       assert legacy.getCacheDbNamePrefix().equals("myprefix");
       assert legacy.getCatalogDbName().equals("mycatalog");
+      assert legacy.isFetchPersistentState();
       assert legacy.getAsyncStoreConfig().isEnabled();
    }
 }

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/AbstractJdbcCacheStoreConfigurationBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/AbstractJdbcCacheStoreConfigurationBuilder.java
@@ -24,8 +24,11 @@ import org.infinispan.config.ConfigurationException;
 import org.infinispan.configuration.cache.AbstractLockSupportCacheStoreConfigurationBuilder;
 import org.infinispan.configuration.cache.LoadersConfigurationBuilder;
 import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactory;
+import org.infinispan.loaders.jdbc.connectionfactory.ManagedConnectionFactory;
+import org.infinispan.loaders.jdbc.connectionfactory.PooledConnectionFactory;
 
-public abstract class AbstractJdbcCacheStoreConfigurationBuilder<T extends AbstractJdbcCacheStoreConfiguration, S extends AbstractJdbcCacheStoreConfigurationBuilder<T, S>> extends AbstractLockSupportCacheStoreConfigurationBuilder<T, S> {
+public abstract class AbstractJdbcCacheStoreConfigurationBuilder<T extends AbstractJdbcCacheStoreConfiguration, S extends AbstractJdbcCacheStoreConfigurationBuilder<T, S>>
+      extends AbstractLockSupportCacheStoreConfigurationBuilder<T, S> {
    protected String driverClass;
    protected String connectionUrl;
    protected String username;
@@ -37,41 +40,71 @@ public abstract class AbstractJdbcCacheStoreConfigurationBuilder<T extends Abstr
       super(builder);
    }
 
+   /**
+    * The class name of a JDBC driver to use with the built-in connection pooling
+    */
    public S driverClass(String driverClass) {
       this.driverClass = driverClass;
       return self();
    }
 
+   /**
+    * The class of JDBC driver to use with the built-in connection pooling
+    */
    public S driverClass(Class<? extends Driver> klass) {
       this.driverClass = klass.getName();
       return self();
    }
 
+   /**
+    * The JDBC URL to use with the built-in connection pooling
+    */
    public S connectionUrl(String connectionUrl) {
       this.connectionUrl = connectionUrl;
       return self();
    }
 
+   /**
+    * The username used to connect with the built-in connection pooling
+    */
    public S username(String userName) {
       this.username = userName;
       return self();
    }
 
+   /**
+    * The password used to connect with the built-in connection pooling
+    */
    public S password(String password) {
       this.password = password;
       return self();
    }
 
+   /**
+    * The JNDI name of a container-managed datasource
+    */
    public S datasource(String datasource) {
       this.datasource = datasource;
       return self();
    }
 
+   /**
+    * The class name of a {@link ConnectionFactory} to use to handle connections to a database. If
+    * unspecified, a suitable one will be chosen based on the other parametes (i.e.
+    * {@link ManagedConnectionFactory} if a datasource is specified or
+    * {@link PooledConnectionFactory} if a connectionUrl is specified)
+    */
    public S connectionFactoryClass(String connectionFactoryClass) {
       this.connectionFactoryClass = connectionFactoryClass;
       return self();
    }
 
+   /**
+    * The class of a {@link ConnectionFactory} to use to handle connections to a database. If
+    * unspecified, a suitable one will be chosen based on the other parametes (i.e.
+    * {@link ManagedConnectionFactory} if a datasource is specified or
+    * {@link PooledConnectionFactory} if a connectionUrl is specified)
+    */
    public S connectionFactoryClass(Class<? extends ConnectionFactory> klass) {
       this.connectionFactoryClass = klass.getName();
       return self();
@@ -83,12 +116,18 @@ public abstract class AbstractJdbcCacheStoreConfigurationBuilder<T extends Abstr
       if (datasource != null && connectionUrl != null) {
          throw new ConfigurationException("Cannot specify both a datasource and a connection URL");
       }
+      if (connectionFactoryClass == null) {
+         if (datasource != null)
+            connectionFactoryClass = ManagedConnectionFactory.class.getName();
+         else
+            connectionFactoryClass = PooledConnectionFactory.class.getName();
+      }
    }
 
    /*
-    * TODO: we should really be using inheritance here, but because of a javac bug it won't let me invoke
-    * super.read() from subclasses complaining that abstract methods cannot be invoked. Will open a bug
-    * and add the ID here
+    * TODO: we should really be using inheritance here, but because of a javac bug it won't let me
+    * invoke super.read() from subclasses complaining that abstract methods cannot be invoked. Will
+    * open a bug and add the ID here
     */
    protected S readInternal(AbstractJdbcCacheStoreConfiguration template) {
       this.connectionFactoryClass(template.connectionFactoryClass());
@@ -97,6 +136,17 @@ public abstract class AbstractJdbcCacheStoreConfigurationBuilder<T extends Abstr
       this.driverClass(template.driverClass());
       this.password(template.password());
       this.username(template.userName());
+
+      // LockSupportStore-specific configuration
+      lockAcquistionTimeout = template.lockAcquistionTimeout();
+      lockConcurrencyLevel = template.lockConcurrencyLevel();
+
+      // AbstractStore-specific configuration
+      fetchPersistentState = template.fetchPersistentState();
+      ignoreModifications = template.ignoreModifications();
+      properties = template.properties();
+      purgeOnStartup = template.purgeOnStartup();
+      purgeSynchronously = template.purgeSynchronously();
       this.async.read(template.async());
       this.singletonStore.read(template.singletonStore());
 

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/Element.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/Element.java
@@ -25,10 +25,8 @@ package org.infinispan.loaders.jdbc.configuration;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.infinispan.loaders.file.FileCacheStore;
-
 /**
- * An enumeration of all the recognized XML element local names for the {@link FileCacheStore}
+ * An enumeration of all the recognized XML element local names for the JDBC cache stores
  *
  * @author Tristan Tarrant
  * @since 5.2

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcBinaryCacheStoreConfigurationBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcBinaryCacheStoreConfigurationBuilder.java
@@ -35,6 +35,9 @@ public class JdbcBinaryCacheStoreConfigurationBuilder extends
       return this;
    }
 
+   /**
+    * Allows configuration of table-specific parameters such as column names and types
+    */
    public TableManipulationConfigurationBuilder table() {
       return table;
    }

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcMixedCacheStoreConfigurationBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcMixedCacheStoreConfigurationBuilder.java
@@ -47,10 +47,18 @@ public class JdbcMixedCacheStoreConfigurationBuilder
       return this;
    }
 
+   /**
+    * Allows configuration of table-specific parameters such as column names and types
+    * for the table used to store entries with binary keys
+    */
    public TableManipulationConfigurationBuilder binaryTable() {
       return binaryTable;
    }
 
+   /**
+    * Allows configuration of table-specific parameters such as column names and types
+    * for the table used to store entries with string keys
+    */
    public TableManipulationConfigurationBuilder stringTable() {
       return stringTable;
    }

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcStringBasedCacheStoreConfigurationBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcStringBasedCacheStoreConfigurationBuilder.java
@@ -47,16 +47,27 @@ public class JdbcStringBasedCacheStoreConfigurationBuilder
       return this;
    }
 
+   /**
+    * The class name of a {@link Key2StringMapper} to use for mapping keys to strings suitable for storage in a database table.
+    * Defaults to {@link DefaultTwoWayKey2StringMapper}
+    */
    public JdbcStringBasedCacheStoreConfigurationBuilder key2StringMapper(String key2StringMapper) {
       this.key2StringMapper = key2StringMapper;
       return this;
    }
 
+   /**
+    * The class of a {@link Key2StringMapper} to use for mapping keys to strings suitable for storage in a database table.
+    * Defaults to {@link DefaultTwoWayKey2StringMapper}
+    */
    public JdbcStringBasedCacheStoreConfigurationBuilder key2StringMapper(Class<? extends Key2StringMapper> klass) {
       this.key2StringMapper = klass.getName();
       return this;
    }
 
+   /**
+    * Allows configuration of table-specific parameters such as column names and types
+    */
    public TableManipulationConfigurationBuilder table() {
       return table;
    }

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/TableManipulationConfigurationBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/TableManipulationConfigurationBuilder.java
@@ -51,61 +51,94 @@ public class TableManipulationConfigurationBuilder extends
       super(builder);
    }
 
+   /**
+    * When doing repetitive DB inserts (e.g. on {@link org.infinispan.loaders.CacheStore#fromStream(java.io.ObjectInput)}
+    * this will be batched according to this parameter. This is an optional parameter, and if it is not specified it
+    * will be defaulted to {@link #DEFAULT_BATCH_SIZE}.
+    */
    public TableManipulationConfigurationBuilder batchSize(int batchSize) {
       this.batchSize = batchSize;
       return this;
    }
 
+   /**
+    * For DB queries (e.g. {@link org.infinispan.loaders.CacheStore#toStream(java.io.ObjectOutput)} ) the fetch size
+    * will be set on {@link java.sql.ResultSet#setFetchSize(int)}. This is optional parameter, if not specified will be
+    * defaulted to {@link #DEFAULT_FETCH_SIZE}.
+    */
    public TableManipulationConfigurationBuilder fetchSize(int fetchSize) {
       this.fetchSize = fetchSize;
       return this;
    }
 
+   /**
+    * Sets the prefix for the name of the table where the data will be stored. "_<cache name>" will be appended
+    * to this prefix in order to enforce unique table names for each cache.
+    */
    public TableManipulationConfigurationBuilder tableNamePrefix(String tableNamePrefix) {
       this.tableNamePrefix = tableNamePrefix;
       return this;
    }
 
+   /**
+    * Determines whether database tables should be created by the store on startup
+    */
    public TableManipulationConfigurationBuilder createOnStart(boolean createOnStart) {
       this.createOnStart = createOnStart;
       return this;
    }
 
+   /**
+    * Determines whether database tables should be dropped by the store on shutdown
+    */
    public TableManipulationConfigurationBuilder dropOnExit(boolean dropOnExit) {
       this.dropOnExit = dropOnExit;
       return this;
    }
 
-   public TableManipulationConfigurationBuilder cacheName(String cacheName) {
-      this.cacheName = cacheName;
-      return this;
-   }
-
+   /**
+    * The name of the database column used to store the keys
+    */
    public TableManipulationConfigurationBuilder idColumnName(String idColumnName) {
       this.idColumnName = idColumnName;
       return this;
    }
 
+   /**
+    * The type of the database column used to store the keys
+    */
    public TableManipulationConfigurationBuilder idColumnType(String idColumnType) {
       this.idColumnType = idColumnType;
       return this;
    }
 
+   /**
+    * The name of the database column used to store the entries
+    */
    public TableManipulationConfigurationBuilder dataColumnName(String dataColumnName) {
       this.dataColumnName = dataColumnName;
       return this;
    }
 
+   /**
+    * The type of the database column used to store the entries
+    */
    public TableManipulationConfigurationBuilder dataColumnType(String dataColumnType) {
       this.dataColumnType = dataColumnType;
       return this;
    }
 
+   /**
+    * The name of the database column used to store the timestamps
+    */
    public TableManipulationConfigurationBuilder timestampColumnName(String timestampColumnName) {
       this.timestampColumnName = timestampColumnName;
       return this;
    }
 
+   /**
+    * The type of the database column used to store the timestamps
+    */
    public TableManipulationConfigurationBuilder timestampColumnType(String timestampColumnType) {
       this.timestampColumnType = timestampColumnType;
       return this;

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/configuration/ConfigurationTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/configuration/ConfigurationTest.java
@@ -21,25 +21,217 @@ package org.infinispan.loaders.jdbc.configuration;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.loaders.jdbc.binary.JdbcBinaryCacheStoreConfig;
+import org.infinispan.loaders.jdbc.connectionfactory.ManagedConnectionFactory;
 import org.infinispan.loaders.jdbc.connectionfactory.PooledConnectionFactory;
+import org.infinispan.loaders.jdbc.mixed.JdbcMixedCacheStoreConfig;
+import org.infinispan.loaders.jdbc.stringbased.JdbcStringBasedCacheStoreConfig;
 import org.testng.annotations.Test;
 
 @Test(groups = "unit", testName = "loaders.jdbc.configuration.ConfigurationTest")
 public class ConfigurationTest {
 
+   private static final String JDBC_URL = "jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=-1";
+
+   public void testImplicitPooledConnectionFactory() {
+      ConfigurationBuilder b = new ConfigurationBuilder();
+      b.loaders().addStore(JdbcBinaryCacheStoreConfigurationBuilder.class)
+         .connectionUrl(JDBC_URL);
+      Configuration configuration = b.build();
+      JdbcBinaryCacheStoreConfiguration store = (JdbcBinaryCacheStoreConfiguration) configuration.loaders().cacheLoaders().get(0);
+      assert store.connectionFactoryClass().equals(PooledConnectionFactory.class.getName());
+   }
+
+   public void testImplicitManagedConnectionFactory() {
+      ConfigurationBuilder b = new ConfigurationBuilder();
+      b.loaders().addStore(JdbcBinaryCacheStoreConfigurationBuilder.class)
+         .datasource("java:jboss/datasources/ExampleDS");
+      Configuration configuration = b.build();
+      JdbcBinaryCacheStoreConfiguration store = (JdbcBinaryCacheStoreConfiguration) configuration.loaders().cacheLoaders().get(0);
+      assert store.connectionFactoryClass().equals(ManagedConnectionFactory.class.getName());
+   }
+
    public void testJdbcBinaryCacheStoreConfigurationAdaptor() {
       ConfigurationBuilder b = new ConfigurationBuilder();
       b.loaders().addStore(JdbcBinaryCacheStoreConfigurationBuilder.class)
-         .connectionUrl("jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=-1")
+         .connectionUrl(JDBC_URL)
          .connectionFactoryClass(PooledConnectionFactory.class)
+         .fetchPersistentState(true)
+         .lockConcurrencyLevel(32)
          .table()
+            .tableNamePrefix("BINARY_")
             .idColumnName("id").idColumnType("VARCHAR")
             .dataColumnName("datum").dataColumnType("BINARY")
-            .timestampColumnName("version").timestampColumnType("BIGINT");
+            .timestampColumnName("version").timestampColumnType("BIGINT")
+         .async().enable();
       Configuration configuration = b.build();
       JdbcBinaryCacheStoreConfiguration store = (JdbcBinaryCacheStoreConfiguration) configuration.loaders().cacheLoaders().get(0);
+      assert store.connectionUrl().equals(JDBC_URL);
+      assert store.table().tableNamePrefix().equals("BINARY_");
+      assert store.table().idColumnName().equals("id");
+      assert store.table().idColumnType().equals("VARCHAR");
+      assert store.table().dataColumnName().equals("datum");
+      assert store.table().dataColumnType().equals("BINARY");
+      assert store.table().timestampColumnName().equals("version");
+      assert store.table().timestampColumnType().equals("BIGINT");
+      assert store.fetchPersistentState();
+      assert store.lockConcurrencyLevel() == 32;
+      assert store.async().enabled();
 
-      JdbcBinaryCacheStoreConfig cacheStoreConfig = store.adapt();
-      assert cacheStoreConfig.getConnectionFactoryConfig().getConnectionUrl().equals("jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=-1");
+      b = new ConfigurationBuilder();
+      b.loaders().addStore(JdbcBinaryCacheStoreConfigurationBuilder.class).read(store);
+      Configuration configuration2 = b.build();
+      JdbcBinaryCacheStoreConfiguration store2 = (JdbcBinaryCacheStoreConfiguration) configuration2.loaders().cacheLoaders().get(0);
+      assert store2.connectionUrl().equals(JDBC_URL);
+      assert store2.table().tableNamePrefix().equals("BINARY_");
+      assert store2.table().idColumnName().equals("id");
+      assert store2.table().idColumnType().equals("VARCHAR");
+      assert store2.table().dataColumnName().equals("datum");
+      assert store2.table().dataColumnType().equals("BINARY");
+      assert store2.table().timestampColumnName().equals("version");
+      assert store2.table().timestampColumnType().equals("BIGINT");
+      assert store2.fetchPersistentState();
+      assert store2.lockConcurrencyLevel() == 32;
+      assert store2.async().enabled();
+
+      JdbcBinaryCacheStoreConfig legacy = store.adapt();
+      assert legacy.getConnectionFactoryConfig().getConnectionUrl().equals(JDBC_URL);
+      assert legacy.getTableManipulation().getTableNamePrefix().equals("BINARY_");
+      assert legacy.getTableManipulation().getIdColumnName().equals("id");
+      assert legacy.getTableManipulation().getIdColumnType().equals("VARCHAR");
+      assert legacy.getTableManipulation().getDataColumnName().equals("datum");
+      assert legacy.getTableManipulation().getDataColumnType().equals("BINARY");
+      assert legacy.getTableManipulation().getTimestampColumnName().equals("version");
+      assert legacy.getTableManipulation().getTimestampColumnType().equals("BIGINT");
+      assert legacy.isFetchPersistentState();
+      assert legacy.getLockConcurrencyLevel() == 32;
+      assert legacy.getAsyncStoreConfig().isEnabled();
+   }
+
+   public void testJdbcMixedCacheStoreConfigurationAdaptor() {
+      ConfigurationBuilder b = new ConfigurationBuilder();
+      JdbcMixedCacheStoreConfigurationBuilder mixedBuilder = b.loaders().addStore(JdbcMixedCacheStoreConfigurationBuilder.class)
+         .connectionUrl(JDBC_URL)
+         .connectionFactoryClass(PooledConnectionFactory.class)
+         .fetchPersistentState(true)
+         .lockConcurrencyLevel(32);
+      mixedBuilder.async().enable();
+
+      mixedBuilder.binaryTable()
+         .tableNamePrefix("BINARY_")
+         .idColumnName("id").idColumnType("VARCHAR")
+         .dataColumnName("datum").dataColumnType("BINARY")
+         .timestampColumnName("version").timestampColumnType("BIGINT");
+
+      mixedBuilder.stringTable()
+         .tableNamePrefix("STRINGS_")
+         .idColumnName("id").idColumnType("VARCHAR")
+         .dataColumnName("datum").dataColumnType("BINARY")
+         .timestampColumnName("version").timestampColumnType("BIGINT");
+
+      Configuration configuration = b.build();
+      JdbcMixedCacheStoreConfiguration store = (JdbcMixedCacheStoreConfiguration) configuration.loaders().cacheLoaders().get(0);
+      assert store.connectionUrl().equals(JDBC_URL);
+      assert store.binaryTable().tableNamePrefix().equals("BINARY_");
+      assert store.binaryTable().idColumnName().equals("id");
+      assert store.binaryTable().idColumnType().equals("VARCHAR");
+      assert store.binaryTable().dataColumnName().equals("datum");
+      assert store.binaryTable().dataColumnType().equals("BINARY");
+      assert store.binaryTable().timestampColumnName().equals("version");
+      assert store.binaryTable().timestampColumnType().equals("BIGINT");
+      assert store.stringTable().tableNamePrefix().equals("STRINGS_");
+      assert store.stringTable().idColumnName().equals("id");
+      assert store.stringTable().idColumnType().equals("VARCHAR");
+      assert store.stringTable().dataColumnName().equals("datum");
+      assert store.stringTable().dataColumnType().equals("BINARY");
+      assert store.stringTable().timestampColumnName().equals("version");
+      assert store.stringTable().timestampColumnType().equals("BIGINT");
+      assert store.fetchPersistentState();
+      assert store.lockConcurrencyLevel() == 32;
+      assert store.async().enabled();
+
+      b = new ConfigurationBuilder();
+      b.loaders().addStore(JdbcMixedCacheStoreConfigurationBuilder.class).read(store);
+      Configuration configuration2 = b.build();
+      JdbcMixedCacheStoreConfiguration store2 = (JdbcMixedCacheStoreConfiguration) configuration2.loaders().cacheLoaders().get(0);
+      assert store2.connectionUrl().equals(JDBC_URL);
+      assert store2.binaryTable().idColumnName().equals("id");
+      assert store2.binaryTable().idColumnType().equals("VARCHAR");
+      assert store2.binaryTable().dataColumnName().equals("datum");
+      assert store2.binaryTable().dataColumnType().equals("BINARY");
+      assert store2.binaryTable().timestampColumnName().equals("version");
+      assert store2.binaryTable().timestampColumnType().equals("BIGINT");
+      assert store2.stringTable().tableNamePrefix().equals("STRINGS_");
+      assert store2.stringTable().idColumnName().equals("id");
+      assert store2.stringTable().idColumnType().equals("VARCHAR");
+      assert store2.stringTable().dataColumnName().equals("datum");
+      assert store2.stringTable().dataColumnType().equals("BINARY");
+      assert store2.stringTable().timestampColumnName().equals("version");
+      assert store2.stringTable().timestampColumnType().equals("BIGINT");
+      assert store2.fetchPersistentState();
+      assert store2.lockConcurrencyLevel() == 32;
+      assert store2.async().enabled();
+
+      JdbcMixedCacheStoreConfig legacy = store.adapt();
+      assert legacy.getConnectionFactoryConfig().getConnectionUrl().equals(JDBC_URL);
+      assert legacy.isFetchPersistentState();
+      assert legacy.getLockConcurrencyLevel() == 32;
+      assert legacy.getAsyncStoreConfig().isEnabled();
+   }
+
+   public void testJdbcStringCacheStoreConfigurationAdaptor() {
+      ConfigurationBuilder b = new ConfigurationBuilder();
+      b.loaders().addStore(JdbcStringBasedCacheStoreConfigurationBuilder.class)
+         .connectionUrl(JDBC_URL)
+         .connectionFactoryClass(PooledConnectionFactory.class)
+         .fetchPersistentState(true)
+         .lockConcurrencyLevel(32)
+         .table()
+            .tableNamePrefix("STRINGS_")
+            .idColumnName("id").idColumnType("VARCHAR")
+            .dataColumnName("datum").dataColumnType("BINARY")
+            .timestampColumnName("version").timestampColumnType("BIGINT")
+         .async().enable();
+      Configuration configuration = b.build();
+      JdbcStringBasedCacheStoreConfiguration store = (JdbcStringBasedCacheStoreConfiguration) configuration.loaders().cacheLoaders().get(0);
+      assert store.connectionUrl().equals(JDBC_URL);
+      assert store.table().tableNamePrefix().equals("STRINGS_");
+      assert store.table().idColumnName().equals("id");
+      assert store.table().idColumnType().equals("VARCHAR");
+      assert store.table().dataColumnName().equals("datum");
+      assert store.table().dataColumnType().equals("BINARY");
+      assert store.table().timestampColumnName().equals("version");
+      assert store.table().timestampColumnType().equals("BIGINT");
+      assert store.fetchPersistentState();
+      assert store.lockConcurrencyLevel() == 32;
+      assert store.async().enabled();
+
+      b = new ConfigurationBuilder();
+      b.loaders().addStore(JdbcStringBasedCacheStoreConfigurationBuilder.class).read(store);
+      Configuration configuration2 = b.build();
+      JdbcStringBasedCacheStoreConfiguration store2 = (JdbcStringBasedCacheStoreConfiguration) configuration2.loaders().cacheLoaders().get(0);
+      assert store2.connectionUrl().equals(JDBC_URL);
+      assert store2.table().tableNamePrefix().equals("STRINGS_");
+      assert store2.table().idColumnName().equals("id");
+      assert store2.table().idColumnType().equals("VARCHAR");
+      assert store2.table().dataColumnName().equals("datum");
+      assert store2.table().dataColumnType().equals("BINARY");
+      assert store2.table().timestampColumnName().equals("version");
+      assert store2.table().timestampColumnType().equals("BIGINT");
+      assert store2.fetchPersistentState();
+      assert store2.lockConcurrencyLevel() == 32;
+      assert store2.async().enabled();
+
+      JdbcStringBasedCacheStoreConfig legacy = store.adapt();
+      assert legacy.getConnectionFactoryConfig().getConnectionUrl().equals(JDBC_URL);
+      assert legacy.getTableManipulation().getTableNamePrefix().equals("STRINGS_");
+      assert legacy.getTableManipulation().getIdColumnName().equals("id");
+      assert legacy.getTableManipulation().getIdColumnType().equals("VARCHAR");
+      assert legacy.getTableManipulation().getDataColumnName().equals("datum");
+      assert legacy.getTableManipulation().getDataColumnType().equals("BINARY");
+      assert legacy.getTableManipulation().getTimestampColumnName().equals("version");
+      assert legacy.getTableManipulation().getTimestampColumnType().equals("BIGINT");
+      assert legacy.isFetchPersistentState();
+      assert legacy.getLockConcurrencyLevel() == 32;
+      assert legacy.getAsyncStoreConfig().isEnabled();
    }
 }

--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/AbstractRemoteCacheStoreConfigurationChildBuilder.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/AbstractRemoteCacheStoreConfigurationChildBuilder.java
@@ -18,16 +18,21 @@
  */
 package org.infinispan.loaders.remote.configuration;
 
+import org.infinispan.client.hotrod.impl.transport.TransportFactory;
+import org.infinispan.configuration.cache.AbstractStoreConfigurationChildBuilder;
+import org.infinispan.marshall.Marshaller;
+
 /**
  * AbstractRemoteCacheStoreConfigurationChildBuilder.
  *
  * @author Tristan Tarrant
  * @since 5.2
  */
-public class AbstractRemoteCacheStoreConfigurationChildBuilder implements RemoteCacheStoreConfigurationChildBuilder {
+public abstract class AbstractRemoteCacheStoreConfigurationChildBuilder<T> extends AbstractStoreConfigurationChildBuilder<T> implements RemoteCacheStoreConfigurationChildBuilder {
    private final RemoteCacheStoreConfigurationBuilder builder;
 
    protected AbstractRemoteCacheStoreConfigurationChildBuilder(RemoteCacheStoreConfigurationBuilder builder) {
+      super(builder);
       this.builder = builder;
    }
 
@@ -72,6 +77,11 @@ public class AbstractRemoteCacheStoreConfigurationChildBuilder implements Remote
    }
 
    @Override
+   public RemoteCacheStoreConfigurationBuilder marshaller(Class<? extends Marshaller> marshaller) {
+      return builder.marshaller(marshaller);
+   }
+
+   @Override
    public RemoteCacheStoreConfigurationBuilder pingOnStartup(boolean pingOnStartup) {
       return builder.pingOnStartup(pingOnStartup);
    }
@@ -98,6 +108,11 @@ public class AbstractRemoteCacheStoreConfigurationChildBuilder implements Remote
 
    @Override
    public RemoteCacheStoreConfigurationBuilder transportFactory(String transportFactory) {
+      return builder.transportFactory(transportFactory);
+   }
+
+   @Override
+   public RemoteCacheStoreConfigurationBuilder transportFactory(Class<? extends TransportFactory> transportFactory) {
       return builder.transportFactory(transportFactory);
    }
 

--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/ConnectionPoolConfigurationBuilder.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/ConnectionPoolConfigurationBuilder.java
@@ -18,10 +18,14 @@
  */
 package org.infinispan.loaders.remote.configuration;
 
-import org.infinispan.configuration.Builder;
-
-public class ConnectionPoolConfigurationBuilder extends AbstractRemoteCacheStoreConfigurationChildBuilder implements
-      Builder<ConnectionPoolConfiguration> {
+/**
+ *
+ * ConnectionPoolConfigurationBuilder. Specified connection pooling properties for the HotRod client
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public class ConnectionPoolConfigurationBuilder extends AbstractRemoteCacheStoreConfigurationChildBuilder<ConnectionPoolConfiguration> {
    private ExhaustedAction exhaustedAction = ExhaustedAction.WAIT;
    private int maxActive = -1;
    private int maxTotal = -1;
@@ -35,41 +39,87 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteCacheStore
       super(builder);
    }
 
+   /**
+    * Specifies what happens when asking for a connection from a server's pool, and that pool is exhausted.
+    */
    public ConnectionPoolConfigurationBuilder exhaustedAction(ExhaustedAction exhaustedAction) {
       this.exhaustedAction = exhaustedAction;
       return this;
    }
 
+   /**
+    * Controls the maximum number of connections per server that are allocated (checked out to
+    * client threads, or idle in the pool) at one time. When non-positive, there is no limit to the
+    * number of connections per server. When maxActive is reached, the connection pool for that
+    * server is said to be exhausted. The default setting for this parameter is -1, i.e. there is no
+    * limit.
+    */
    public ConnectionPoolConfigurationBuilder maxActive(int maxActive) {
       this.maxActive = maxActive;
       return this;
    }
 
+   /**
+    * Sets a global limit on the number persistent connections that can be in circulation within the
+    * combined set of servers. When non-positive, there is no limit to the total number of
+    * persistent connections in circulation. When maxTotal is exceeded, all connections pools are
+    * exhausted. The default setting for this parameter is -1 (no limit).
+    */
    public ConnectionPoolConfigurationBuilder maxTotal(int maxTotal) {
       this.maxTotal = maxTotal;
       return this;
    }
 
+   /**
+    * Controls the maximum number of idle persistent connections, per server, at any time. When
+    * negative, there is no limit to the number of connections that may be idle per server. The
+    * default setting for this parameter is -1.
+    */
    public ConnectionPoolConfigurationBuilder maxIdle(int maxIdle) {
       this.maxIdle = maxIdle;
       return this;
    }
 
+   /**
+    * Sets a target value for the minimum number of idle connections (per server) that should always
+    * be available. If this parameter is set to a positive number and timeBetweenEvictionRunsMillis
+    * > 0, each time the idle connection eviction thread runs, it will try to create enough idle
+    * instances so that there will be minIdle idle instances available for each server. The default
+    * setting for this parameter is 1.
+    */
    public ConnectionPoolConfigurationBuilder minIdle(int minIdle) {
       this.minIdle = minIdle;
       return this;
    }
 
+   /**
+    * Indicates how long the eviction thread should sleep before "runs" of examining idle
+    * connections. When non-positive, no eviction thread will be launched. The default setting for
+    * this parameter is 2 minutes.
+    */
    public ConnectionPoolConfigurationBuilder timeBetweenEvictionRuns(long timeBetweenEvictionRuns) {
       this.timeBetweenEvictionRuns = timeBetweenEvictionRuns;
       return this;
    }
 
+   /**
+    * Specifies the minimum amount of time that an connection may sit idle in the pool before it is
+    * eligible for eviction due to idle time. When non-positive, no connection will be dropped from
+    * the pool due to idle time alone. This setting has no effect unless
+    * timeBetweenEvictionRunsMillis > 0. The default setting for this parameter is 1800000(30
+    * minutes).
+    */
    public ConnectionPoolConfigurationBuilder minEvictableIdleTime(long minEvictableIdleTime) {
       this.minEvictableIdleTime = minEvictableIdleTime;
       return this;
    }
 
+   /**
+    * Indicates whether or not idle connections should be validated by sending an TCP packet to the
+    * server, during idle connection eviction runs. Connections that fail to validate will be
+    * dropped from the pool. This setting has no effect unless timeBetweenEvictionRunsMillis > 0.
+    * The default setting for this parameter is true.
+    */
    public ConnectionPoolConfigurationBuilder testWhileIdle(boolean testWhileIdle) {
       this.testWhileIdle = testWhileIdle;
       return this;
@@ -81,8 +131,8 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteCacheStore
 
    @Override
    public ConnectionPoolConfiguration create() {
-      return new ConnectionPoolConfiguration(exhaustedAction, maxActive, maxTotal, maxIdle, minIdle, timeBetweenEvictionRuns,
-            minEvictableIdleTime, testWhileIdle);
+      return new ConnectionPoolConfiguration(exhaustedAction, maxActive, maxTotal, maxIdle, minIdle,
+            timeBetweenEvictionRuns, minEvictableIdleTime, testWhileIdle);
    }
 
    @Override

--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/Element.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/Element.java
@@ -25,10 +25,10 @@ package org.infinispan.loaders.remote.configuration;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.infinispan.loaders.file.FileCacheStore;
+import org.infinispan.loaders.remote.RemoteCacheStore;
 
 /**
- * An enumeration of all the recognized XML element local names for the {@link FileCacheStore}
+ * An enumeration of all the recognized XML element local names for the {@link RemoteCacheStore}
  *
  * @author Tristan Tarrant
  * @since 5.2

--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/ExecutorFactoryConfigurationBuilder.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/ExecutorFactoryConfigurationBuilder.java
@@ -20,7 +20,6 @@ package org.infinispan.loaders.remote.configuration;
 
 import java.util.Properties;
 
-import org.infinispan.configuration.Builder;
 import org.infinispan.executors.DefaultExecutorFactory;
 import org.infinispan.executors.ExecutorFactory;
 import org.infinispan.util.TypedProperties;
@@ -28,7 +27,7 @@ import org.infinispan.util.TypedProperties;
 /**
  * Configures executor factory.
  */
-public class ExecutorFactoryConfigurationBuilder extends AbstractRemoteCacheStoreConfigurationChildBuilder implements Builder<ExecutorFactoryConfiguration> {
+public class ExecutorFactoryConfigurationBuilder extends AbstractRemoteCacheStoreConfigurationChildBuilder<ExecutorFactoryConfiguration> {
 
    private ExecutorFactory factory = new DefaultExecutorFactory();
    private Properties properties;

--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/RemoteCacheStoreConfigurationBuilder.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/RemoteCacheStoreConfigurationBuilder.java
@@ -23,14 +23,16 @@ import java.util.List;
 
 import org.infinispan.api.BasicCacheContainer;
 import org.infinispan.client.hotrod.impl.ConfigurationProperties;
+import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 import org.infinispan.client.hotrod.impl.transport.tcp.RoundRobinBalancingStrategy;
 import org.infinispan.configuration.cache.AbstractStoreConfigurationBuilder;
 import org.infinispan.configuration.cache.LoadersConfigurationBuilder;
 import org.infinispan.loaders.remote.RemoteCacheStore;
+import org.infinispan.marshall.Marshaller;
 import org.infinispan.util.TypedProperties;
 
 /**
- * RemoteCacheStoreConfigurationBuilde. Configures a {@link RemoteCacheStore}
+ * RemoteCacheStoreConfigurationBuilder. Configures a {@link RemoteCacheStore}
  *
  * @author Tristan Tarrant
  * @since 5.2
@@ -106,6 +108,12 @@ public class RemoteCacheStoreConfigurationBuilder extends
    }
 
    @Override
+   public RemoteCacheStoreConfigurationBuilder marshaller(Class<? extends Marshaller> marshaller) {
+      this.marshaller = marshaller.getName();
+      return this;
+   }
+
+   @Override
    public RemoteCacheStoreConfigurationBuilder pingOnStartup(boolean pingOnStartup) {
       this.pingOnStartup = pingOnStartup;
       return this;
@@ -138,6 +146,12 @@ public class RemoteCacheStoreConfigurationBuilder extends
    @Override
    public RemoteCacheStoreConfigurationBuilder transportFactory(String transportFactory) {
       this.transportFactory = transportFactory;
+      return this;
+   }
+
+   @Override
+   public RemoteCacheStoreConfigurationBuilder transportFactory(Class<? extends TransportFactory> transportFactory) {
+      this.transportFactory = transportFactory.getName();
       return this;
    }
 
@@ -183,6 +197,18 @@ public class RemoteCacheStoreConfigurationBuilder extends
       this.tcpNoDelay = template.tcpNoDelay();
       this.transportFactory = template.transportFactory();
       this.valueSizeEstimate = template.valueSizeEstimate();
+      for(RemoteServerConfiguration server : template.servers()) {
+         this.addServer().host(server.host()).port(server.port());
+      }
+
+      // AbstractStore-specific configuration
+      fetchPersistentState = template.fetchPersistentState();
+      ignoreModifications = template.ignoreModifications();
+      properties = template.properties();
+      purgeOnStartup = template.purgeOnStartup();
+      purgeSynchronously = template.purgeSynchronously();
+      async.read(template.async());
+      singletonStore.read(template.singletonStore());
       return this;
    }
 

--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/RemoteCacheStoreConfigurationChildBuilder.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/RemoteCacheStoreConfigurationChildBuilder.java
@@ -18,36 +18,104 @@
  */
 package org.infinispan.loaders.remote.configuration;
 
-public interface RemoteCacheStoreConfigurationChildBuilder {
+import org.infinispan.client.hotrod.impl.transport.TransportFactory;
+import org.infinispan.configuration.cache.StoreConfigurationChildBuilder;
+import org.infinispan.marshall.Marshaller;
 
+public interface RemoteCacheStoreConfigurationChildBuilder extends StoreConfigurationChildBuilder {
+
+   /**
+    * Adds a new remote server
+    */
    RemoteServerConfigurationBuilder addServer();
 
+   /**
+    * Configuration for the executor service used for asynchronous work on the Transport, including
+    * asynchronous marshalling and Cache 'async operations' such as Cache.putAsync().
+    */
    ExecutorFactoryConfigurationBuilder asyncExecutorFactory();
 
+   /**
+    * For replicated (vs distributed) Hot Rod server clusters, the client balances requests to the
+    * servers according to this strategy.
+    */
    RemoteCacheStoreConfigurationBuilder balancingStrategy(String balancingStrategy);
 
+   /**
+    * Configures the connection pool
+    */
    ConnectionPoolConfigurationBuilder connectionPool();
 
+   /**
+    * This property defines the maximum socket connect timeout before giving up connecting to the
+    * server.
+    */
    RemoteCacheStoreConfigurationBuilder connectionTimeout(long connectionTimeout);
 
+   /**
+    * Whether or not to implicitly FORCE_RETURN_VALUE for all calls.
+    */
    RemoteCacheStoreConfigurationBuilder forceReturnValues(boolean forceReturnValues);
 
+   /**
+    * The class name of the driver used for connecting to the database.
+    */
    RemoteCacheStoreConfigurationBuilder keySizeEstimate(int keySizeEstimate);
 
+   /**
+    * Allows you to specify a custom {@link org.infinispan.marshall.Marshaller} implementation to
+    * serialize and deserialize user objects.
+    */
    RemoteCacheStoreConfigurationBuilder marshaller(String marshaller);
 
+   /**
+    * Allows you to specify a custom {@link org.infinispan.marshall.Marshaller} implementation to
+    * serialize and deserialize user objects.
+    */
+   RemoteCacheStoreConfigurationBuilder marshaller(Class<? extends Marshaller> marshaller);
+
+   /**
+    * If true, a ping request is sent to a back end server in order to fetch cluster's topology.
+    */
    RemoteCacheStoreConfigurationBuilder pingOnStartup(boolean pingOnStartup);
 
+   /**
+    * This property defines the protocol version that this client should use. Defaults to 1.1. Other
+    * valid values include 1.0.
+    */
    RemoteCacheStoreConfigurationBuilder protocolVersion(String protocolVersion);
 
+   /**
+    * The name of the remote cache in the remote infinispan cluster, to which to connect to. If
+    * unspecified, the default cache will be used
+    */
    RemoteCacheStoreConfigurationBuilder remoteCacheName(String remoteCacheName);
 
+   /**
+    * This property defines the maximum socket read timeout in milliseconds before giving up waiting
+    * for bytes from the server. Defaults to 60000 (1 minute)
+    */
    RemoteCacheStoreConfigurationBuilder socketTimeout(long socketTimeout);
 
+   /**
+    * Affects TCP NODELAY on the TCP stack. Defaults to enabled
+    */
    RemoteCacheStoreConfigurationBuilder tcpNoDelay(boolean tcpNoDelay);
 
+   /**
+    * Controls which transport to use. Currently only the TcpTransport is supported.
+    */
    RemoteCacheStoreConfigurationBuilder transportFactory(String transportFactory);
 
+   /**
+    * Controls which transport to use. Currently only the TcpTransport is supported.
+    */
+   RemoteCacheStoreConfigurationBuilder transportFactory(Class<? extends TransportFactory> transportFactory);
+
+   /**
+    * This hint allows sizing of byte buffers when serializing and deserializing values, to minimize
+    * array resizing.
+    */
    RemoteCacheStoreConfigurationBuilder valueSizeEstimate(int valueSizeEstimate);
 
 }

--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/RemoteServerConfigurationBuilder.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/RemoteServerConfigurationBuilder.java
@@ -18,9 +18,7 @@
  */
 package org.infinispan.loaders.remote.configuration;
 
-import org.infinispan.configuration.Builder;
-
-public class RemoteServerConfigurationBuilder extends AbstractRemoteCacheStoreConfigurationChildBuilder implements Builder<RemoteServerConfiguration> {
+public class RemoteServerConfigurationBuilder extends AbstractRemoteCacheStoreConfigurationChildBuilder<RemoteServerConfiguration> {
    private String host;
    private int port = 11222;
 

--- a/cachestore/remote/src/main/resources/schema/infinispan-cachestore-remote-config-5.2.xsd
+++ b/cachestore/remote/src/main/resources/schema/infinispan-cachestore-remote-config-5.2.xsd
@@ -93,7 +93,7 @@
         <xs:attribute name="protocolVersion" type="xs:string" default="1.1">
           <xs:annotation>
             <xs:documentation>
-              This property defines the protocol version that this client should use. Other valid values include 1.0.
+              This property defines the protocol version that this client should use. Defaults to 1.1. Other valid values include 1.0.
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
@@ -108,14 +108,14 @@
         <xs:attribute name="socketTimeout" type="xs:int" default="60000">
           <xs:annotation>
             <xs:documentation>
-              This property defines the protocol version that this client should use. Other valid values include 1.0.
+              This property defines the maximum socket read timeout in milliseconds before giving up waiting for bytes from the server. Defaults to 60000 (1 minute)
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="tcpNoDelay" type="xs:boolean" default="true">
           <xs:annotation>
             <xs:documentation>
-              This property defines the protocol version that this client should use. Other valid values include 1.0.
+              Affects TCP NODELAY on the TCP stack. Defaults to enabled
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
@@ -129,7 +129,7 @@
         <xs:attribute name="valueSizeEstimate" type="xs:int" default="512">
           <xs:annotation>
             <xs:documentation>
-              his hint allows sizing of byte buffers when serializing and deserializing values, to minimize array resizing.
+              This hint allows sizing of byte buffers when serializing and deserializing values, to minimize array resizing.
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>

--- a/cachestore/remote/src/test/java/org/infinispan/loaders/remote/configuration/ConfigurationTest.java
+++ b/cachestore/remote/src/test/java/org/infinispan/loaders/remote/configuration/ConfigurationTest.java
@@ -24,23 +24,54 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.loaders.remote.RemoteCacheStoreConfig;
 import org.testng.annotations.Test;
 
-@Test(groups = "unit", testName = "loaders.jdbc.configuration.ConfigurationTest")
+@Test(groups = "unit", testName = "loaders.remote.configuration.ConfigurationTest")
 public class ConfigurationTest {
 
    public void testRemoteCacheStoreConfigurationAdaptor() {
       ConfigurationBuilder b = new ConfigurationBuilder();
-      b.loaders().addStore(RemoteCacheStoreConfigurationBuilder.class).remoteCacheName("RemoteCache").addServer()
-            .host("one").port(12111).addServer().host("two").connectionPool().maxActive(10).minIdle(5)
-            .exhaustedAction(ExhaustedAction.EXCEPTION).minEvictableIdleTime(10000);
+      b.loaders().addStore(RemoteCacheStoreConfigurationBuilder.class)
+         .remoteCacheName("RemoteCache")
+         .fetchPersistentState(true)
+         .addServer()
+            .host("one").port(12111)
+         .addServer()
+            .host("two")
+         .connectionPool()
+            .maxActive(10)
+            .minIdle(5)
+            .exhaustedAction(ExhaustedAction.EXCEPTION)
+            .minEvictableIdleTime(10000)
+         .async().enable();
       Configuration configuration = b.build();
-      RemoteCacheStoreConfiguration store = (RemoteCacheStoreConfiguration) configuration.loaders().cacheLoaders()
-            .get(0);
+      RemoteCacheStoreConfiguration store = (RemoteCacheStoreConfiguration) configuration.loaders().cacheLoaders().get(0);
+      assert store.remoteCacheName().equals("RemoteCache");
       assert store.servers().size() == 2;
+      assert store.connectionPool().maxActive() == 10;
+      assert store.connectionPool().minIdle() == 5;
       assert store.connectionPool().exhaustedAction() == ExhaustedAction.EXCEPTION;
-      RemoteCacheStoreConfig cacheStoreConfig = store.adapt();
-      assert "RemoteCache".equals(cacheStoreConfig.getRemoteCacheName());
-      assert "one:12111;two:11222".equals(cacheStoreConfig.getHotRodClientProperties().get(
+      assert store.connectionPool().minEvictableIdleTime() == 10000;
+      assert store.fetchPersistentState();
+      assert store.async().enabled();
+
+      b = new ConfigurationBuilder();
+      b.loaders().addStore(RemoteCacheStoreConfigurationBuilder.class).read(store);
+      Configuration configuration2 = b.build();
+      RemoteCacheStoreConfiguration store2 = (RemoteCacheStoreConfiguration) configuration2.loaders().cacheLoaders().get(0);
+      assert store2.remoteCacheName().equals("RemoteCache");
+      assert store2.servers().size() == 2;
+      assert store2.connectionPool().maxActive() == 10;
+      assert store2.connectionPool().minIdle() == 5;
+      assert store2.connectionPool().exhaustedAction() == ExhaustedAction.EXCEPTION;
+      assert store2.connectionPool().minEvictableIdleTime() == 10000;
+      assert store2.fetchPersistentState();
+      assert store2.async().enabled();
+
+      RemoteCacheStoreConfig legacy = store.adapt();
+      assert "RemoteCache".equals(legacy.getRemoteCacheName());
+      assert "one:12111;two:11222".equals(legacy.getHotRodClientProperties().get(
             ConfigurationProperties.SERVER_LIST));
-      assert cacheStoreConfig.getTypedProperties().getIntProperty("whenExhaustedAction", -1) == 0;
+      assert legacy.getTypedProperties().getIntProperty("whenExhaustedAction", -1) == 0;
+      assert legacy.isFetchPersistentState();
+      assert legacy.asyncStore().isEnabled();
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2261

JdbcCacheStore
- Fix builder read() method and enhance test cases
- implicitly select a connectionFactory based on parameters
- JavaDocs

BdbjeCacheStore
- Fix builder read() method and enhance test case
- Fix the JavaDocs

RemoteCacheStore
- Fix the hierarchy of the AbstractRemoteCacheStoreChildBuilder so that we don't break the fluent configurability
- Fix builder read() method and enhance test case
- Fix the JavaDocs
