### PR TITLE
ISPN-2263 ConcurrentModificationException during cancellation of outboun...

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/StateProviderImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateProviderImpl.java
@@ -282,8 +282,10 @@ public class StateProviderImpl implements StateProvider {
       synchronized (transfersByDestination) {
          List<OutboundTransferTask> transferTasks = transfersByDestination.get(destination);
          if (transferTasks != null) {
-            for (OutboundTransferTask transferTask : transferTasks) {
-               transferTask.cancelSegments(segments);
+            // get an array copy of the collection to avoid ConcurrentModificationException if the entire task gets cancelled and removeTransfer(transferTask) is called
+            OutboundTransferTask[] tasks = transferTasks.toArray(new OutboundTransferTask[transferTasks.size()]);
+            for (OutboundTransferTask transferTask : tasks) {
+               transferTask.cancelSegments(segments); //this can potentially result in a removeTransfer(transferTask)
             }
          }
       }


### PR DESCRIPTION
...d state transfer

Iteration over the list of outbound tasks that need to be adjusted by cancelling some of the segments could result in a CME if all segments are to be cancelled and the entire tasks gets cancelled and removed consequently. This is easily avoidable by copying the list before iterating it.

Jira: https://issues.jboss.org/browse/ISPN-2263
