### PR TITLE
ISPN-2252 mvn deploy -Pdistribution doesn't uploads the sources

### DIFF
--- a/bin/utils.py
+++ b/bin/utils.py
@@ -370,7 +370,7 @@ class DryRunUploader(DryRun):
 
 def maven_build_distribution(version):
   """Builds the distribution in the current working dir"""
-  mvn_commands = [["clean"], ["install", "-Pjmxdoc"],["install", "-Pgenerate-schema-doc"], ["deploy", "-Pdistribution"]]
+  mvn_commands = [["clean"], ["install", "-Pjmxdoc"],["install", "-Pgenerate-schema-doc"], ["deploy", "-Pdistribution,extras"]]
     
   for c in mvn_commands:
     c.append("-Dmaven.test.skip.exec=true")

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1356,6 +1356,39 @@
    </reporting>
    <profiles>
       <profile>
+         <id>distribution</id>
+         <properties>
+            <skipTests>true</skipTests>
+         </properties>
+
+         <build>
+            <plugins>
+               <!-- generate target/runtime-classpath.txt, to be included in bundle -->
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-dependency-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>create-classpath</id>
+                        <phase>package</phase>
+                        <goals>
+                           <goal>build-classpath</goal>
+                        </goals>
+                        <configuration>
+                           <includeScope>runtime</includeScope>
+                           <excludeScope>test</excludeScope>
+                           <!-- all jar paths are relative to bin dir inside the distribution bundle -->
+                           <prefix>$ISPN_HOME/lib</prefix>
+                           <outputFile>${project.build.directory}/runtime-classpath.txt</outputFile>
+                        </configuration>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+
+      <profile>
          <id>extras</id>
          <activation>
             <activeByDefault>true</activeByDefault>

--- a/pom.xml
+++ b/pom.xml
@@ -162,25 +162,6 @@ pageTracker._trackPageview();
                      <attach>false</attach>
                   </configuration>
                </plugin>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-dependency-plugin</artifactId>
-                  <executions>
-                  <execution>
-                     <id>create-classpath</id>
-                     <phase>package</phase>
-                     <goals>
-                       <goal>build-classpath</goal>
-                     </goals>
-                     <configuration>
-                       <includeScope>runtime</includeScope>
-                       <excludeScope>test</excludeScope>
-                       <prefix>$ISPN_HOME/lib</prefix>
-                       <outputFile>${project.build.directory}/runtime-classpath.txt</outputFile>
-                    </configuration>
-                  </execution>
-                </executions>
-              </plugin>
             </plugins>
          </build>
       </profile>


### PR DESCRIPTION
- Revert previous POM fix as it was no longer generating runtime-classpath.txt for modules and this breaks the demos from the distribution.
- Modify utils.py script to include 'extras' profile together with 'distribution'. This should solve the issue with the missing source jars.

JIRA: https://issues.jboss.org/browse/ISPN-2252
