### PR TITLE
ISPN-2258 StateTransferManager is not exposed as JMX MBean

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -37,6 +37,7 @@ import org.infinispan.distribution.group.GroupingConsistentHash;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
+import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.topology.CacheJoinInfo;
@@ -50,6 +51,7 @@ import org.infinispan.util.logging.LogFactory;
  * @author anistor@redhat.com
  * @since 5.2
  */
+@MBean(objectName = "StateTransferManager", description = "Component that handles state transfer")
 public class StateTransferManagerImpl implements StateTransferManager {
 
    private static final Log log = LogFactory.getLog(StateTransferManagerImpl.class);


### PR DESCRIPTION
Add `@MBean` annotation to StateTransferManagerImpl to expose it as MBean as it used to be before NBST.

JIRA: https://issues.jboss.org/browse/ISPN-2258
