### PR TITLE
ISPN-2274 Configuration builders for DummyInMemoryCacheStore 

### DIFF
--- a/core/src/test/java/org/infinispan/loaders/dummy/DummyInMemoryCacheStoreConfiguration.java
+++ b/core/src/test/java/org/infinispan/loaders/dummy/DummyInMemoryCacheStoreConfiguration.java
@@ -1,0 +1,74 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.loaders.dummy;
+
+import org.infinispan.configuration.BuiltBy;
+import org.infinispan.configuration.cache.AbstractStoreConfiguration;
+import org.infinispan.configuration.cache.AsyncStoreConfiguration;
+import org.infinispan.configuration.cache.LegacyConfigurationAdaptor;
+import org.infinispan.configuration.cache.LegacyLoaderAdapter;
+import org.infinispan.configuration.cache.SingletonStoreConfiguration;
+import org.infinispan.loaders.dummy.DummyInMemoryCacheStore.Cfg;
+import org.infinispan.util.TypedProperties;
+
+@BuiltBy(DummyInMemoryCacheStoreConfigurationBuilder.class)
+public class DummyInMemoryCacheStoreConfiguration extends AbstractStoreConfiguration implements
+      LegacyLoaderAdapter<DummyInMemoryCacheStore.Cfg> {
+
+   private final boolean debug;
+   private final String storeName;
+   private final Object failKey;
+
+   protected DummyInMemoryCacheStoreConfiguration(boolean debug, String storeName, Object failKey,
+         boolean purgeOnStartup, boolean purgeSynchronously, int purgerThreads, boolean fetchPersistentState,
+         boolean ignoreModifications, TypedProperties properties, AsyncStoreConfiguration async,
+         SingletonStoreConfiguration singletonStore) {
+      super(purgeOnStartup, purgeSynchronously, purgerThreads, fetchPersistentState, ignoreModifications, properties,
+            async, singletonStore);
+      this.debug = debug;
+      this.storeName = storeName;
+      this.failKey = failKey;
+   }
+
+   public boolean debug() {
+      return debug;
+   }
+
+   public String storeName() {
+      return storeName;
+   }
+
+   public Object failKey() {
+      return failKey;
+   }
+
+   @Override
+   public Cfg adapt() {
+      Cfg config = new Cfg();
+
+      LegacyConfigurationAdaptor.adapt(this, config);
+
+      config.debug(debug);
+      config.storeName(storeName);
+      config.failKey(failKey);
+
+      return config;
+   }
+
+}

--- a/core/src/test/java/org/infinispan/loaders/dummy/DummyInMemoryCacheStoreConfigurationBuilder.java
+++ b/core/src/test/java/org/infinispan/loaders/dummy/DummyInMemoryCacheStoreConfigurationBuilder.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.loaders.dummy;
+
+import org.infinispan.configuration.cache.AbstractStoreConfigurationBuilder;
+import org.infinispan.configuration.cache.LoadersConfigurationBuilder;
+import org.infinispan.util.TypedProperties;
+
+public class DummyInMemoryCacheStoreConfigurationBuilder
+      extends
+      AbstractStoreConfigurationBuilder<DummyInMemoryCacheStoreConfiguration, DummyInMemoryCacheStoreConfigurationBuilder> {
+
+   private boolean debug;
+   private String storeName;
+   private Object failKey;
+
+   public DummyInMemoryCacheStoreConfigurationBuilder(LoadersConfigurationBuilder builder) {
+      super(builder);
+   }
+
+   @Override
+   public DummyInMemoryCacheStoreConfigurationBuilder self() {
+      return this;
+   }
+
+   public DummyInMemoryCacheStoreConfigurationBuilder debug(boolean debug) {
+      this.debug = debug;
+      return this;
+   }
+
+   public DummyInMemoryCacheStoreConfigurationBuilder storeName(String storeName) {
+      this.storeName = storeName;
+      return this;
+   }
+
+   public DummyInMemoryCacheStoreConfigurationBuilder failKey(Object failKey) {
+      this.failKey = failKey;
+      return this;
+   }
+
+   @Override
+   public DummyInMemoryCacheStoreConfiguration create() {
+      return new DummyInMemoryCacheStoreConfiguration(debug, storeName, failKey, purgeOnStartup, purgeSynchronously, purgerThreads,
+            fetchPersistentState, ignoreModifications, TypedProperties.toTypedProperties(properties), async.create(),
+            singletonStore.create());
+   }
+
+   @Override
+   public DummyInMemoryCacheStoreConfigurationBuilder read(DummyInMemoryCacheStoreConfiguration template) {
+      // AbstractStore-specific configuration
+      fetchPersistentState = template.fetchPersistentState();
+      ignoreModifications = template.ignoreModifications();
+      properties = template.properties();
+      purgeOnStartup = template.purgeOnStartup();
+      purgeSynchronously = template.purgeSynchronously();
+      async.read(template.async());
+      singletonStore.read(template.singletonStore());
+
+      return this;
+   }
+
+}

--- a/core/src/test/java/org/infinispan/loaders/dummy/DummyInMemoryCacheStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/loaders/dummy/DummyInMemoryCacheStoreFunctionalTest.java
@@ -22,6 +22,7 @@
  */
 package org.infinispan.loaders.dummy;
 
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.loaders.BaseCacheStoreFunctionalTest;
 import org.infinispan.loaders.CacheStoreConfig;
 import org.testng.annotations.AfterClass;
@@ -37,10 +38,11 @@ public class DummyInMemoryCacheStoreFunctionalTest extends BaseCacheStoreFunctio
 
    @Override
    protected CacheStoreConfig createCacheStoreConfig() throws Exception {
-      DummyInMemoryCacheStore.Cfg cfg = new DummyInMemoryCacheStore.Cfg()
-         .storeName(getClass().getName())
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      DummyInMemoryCacheStoreConfigurationBuilder loader = builder.loaders().addLoader(DummyInMemoryCacheStoreConfigurationBuilder.class);
+      loader.storeName(getClass().getName())
          .purgeOnStartup(false)
-         .purgeSynchronously(true); // for more accurate unit testing
-      return cfg;
+         .purgeSynchronously(true);
+      return loader.create().adapt();
    }
 }

--- a/core/src/test/java/org/infinispan/loaders/dummy/DummyInMemoryCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/dummy/DummyInMemoryCacheStoreTest.java
@@ -22,6 +22,7 @@
  */
 package org.infinispan.loaders.dummy;
 
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.loaders.BaseCacheStoreTest;
 import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.loaders.CacheStore;
@@ -33,10 +34,12 @@ public class DummyInMemoryCacheStoreTest extends BaseCacheStoreTest {
    @Override
    protected CacheStore createCacheStore() throws CacheLoaderException {
       DummyInMemoryCacheStore cl = new DummyInMemoryCacheStore();
-      DummyInMemoryCacheStore.Cfg cfg = new DummyInMemoryCacheStore.Cfg()
-         .storeName(DummyInMemoryCacheStoreTest.class.getName());
-      cfg.setPurgeSynchronously(true);
-      cl.init(cfg, getCache(), getMarshaller());
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      DummyInMemoryCacheStoreConfigurationBuilder loader = builder.loaders().addLoader(DummyInMemoryCacheStoreConfigurationBuilder.class);
+      loader
+         .storeName(getClass().getName())
+         .purgeSynchronously(true);
+      cl.init( loader.create().adapt(), getCache(), getMarshaller());
       cl.start();
       return cl;
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2274
A small pull request. Migrating the testsuite (and in particular the BaseCacheStoreTest hierarchy) will be performed as part of https://issues.jboss.org/browse/ISPN-2266 and as soon as https://issues.jboss.org/browse/ISPN-1524 is complete
