### PR TITLE
Set the initial topologyID to -1

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -162,7 +162,8 @@ public class RemoteCacheManager implements BasicCacheContainer {
    private boolean forceReturnValueDefault = false;
    private ExecutorService asyncExecutorService;
    private final Map<String, RemoteCacheHolder> cacheName2RemoteCache = new HashMap<String, RemoteCacheHolder>();
-   private AtomicInteger topologyId = new AtomicInteger();
+   // Use an invalid topologyID (-1) so we always get a topology update on connection.
+   private AtomicInteger topologyId = new AtomicInteger(-1);
    private ClassLoader classLoader;
    private Codec codec;
 


### PR DESCRIPTION
This causes a topology update on initial connection, potentially cleaning out invalid servers in the server list.
