### PR TITLE
ISPN-1174 Fix async cache store consistency issues with some operations

### DIFF
--- a/core/src/main/java/org/infinispan/container/entries/AbstractInternalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/AbstractInternalCacheEntry.java
@@ -34,6 +34,7 @@ import org.infinispan.container.versioning.EntryVersion;
 public abstract class AbstractInternalCacheEntry implements InternalCacheEntry {
 
    protected Object key;
+   private boolean evicted;
 
    protected AbstractInternalCacheEntry() {
    }
@@ -64,7 +65,7 @@ public abstract class AbstractInternalCacheEntry implements InternalCacheEntry {
 
    @Override
    public final void setEvicted(boolean evicted) {
-      // no-op
+      this.evicted = evicted;
    }
 
    @Override
@@ -94,7 +95,7 @@ public abstract class AbstractInternalCacheEntry implements InternalCacheEntry {
 
    @Override
    public final boolean isEvicted() {
-      return true;
+      return evicted;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/container/entries/InternalNullEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/InternalNullEntry.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.container.entries;
+
+import org.infinispan.container.DataContainer;
+import org.infinispan.container.versioning.EntryVersion;
+import org.infinispan.loaders.decorators.AsyncStore;
+
+/**
+ * Internal null cache entry used to signal that an entry has been removed
+ * but it's in the process of being removed from another component,
+ * i.e. an async cache store.
+ *
+ * This entry helps deal with situations where an eventual removal
+ * is under way.
+ *
+ * @author Galder Zamarreño
+ * @since 5.2
+ */
+public class InternalNullEntry implements InternalCacheEntry {
+
+   private final long asyncProcessorId;
+   private final AsyncStore asyncStore;
+
+   public InternalNullEntry(AsyncStore asyncStore) {
+      this.asyncStore = asyncStore;
+      this.asyncProcessorId = this.asyncStore.getAsyncProcessorId();
+   }
+
+   @Override
+   public boolean isNull() {
+      return false; // not null to avoid cache loader interceptor loading from store
+   }
+
+   @Override
+   public Object getValue() {
+      return this; // set this value to avoid cache loader interceptor
+   }
+
+   @Override
+   public boolean canExpire() {
+      return true;
+   }
+
+   @Override
+   public boolean isExpired(long now) {
+      return asyncStore.getAsyncProcessorId() > asyncProcessorId;
+   }
+
+   @Override
+   public boolean isExpired() {
+      return asyncStore.getAsyncProcessorId() > asyncProcessorId;
+   }
+
+   // Below are non-relevant method implementations
+
+   @Override
+   public boolean isChanged() {
+      return false;
+   }
+
+   @Override
+   public boolean isCreated() {
+      return false;
+   }
+
+   @Override
+   public boolean isRemoved() {
+      return false;
+   }
+
+   @Override
+   public boolean isEvicted() {
+      return false;
+   }
+
+   @Override
+   public boolean isValid() {
+      return false;
+   }
+
+   @Override
+   public Object getKey() {
+      return null;
+   }
+
+   @Override
+   public long getLifespan() {
+      return 0;
+   }
+
+   @Override
+   public long getMaxIdle() {
+      return 0;
+   }
+
+   @Override
+   public void setMaxIdle(long maxIdle) {
+      // Empty
+   }
+
+   @Override
+   public void setLifespan(long lifespan) {
+      // Empty
+   }
+
+   @Override
+   public Object setValue(Object value) {
+      return null;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      return false;
+   }
+
+   @Override
+   public int hashCode() {
+      return 0;
+   }
+
+   @Override
+   public void commit(DataContainer container, EntryVersion newVersion) {
+      // Empty
+   }
+
+   @Override
+   public void rollback() {
+      // Empty
+   }
+
+   @Override
+   public void setCreated(boolean created) {
+      // Empty
+   }
+
+   @Override
+   public void setRemoved(boolean removed) {
+      // Empty
+   }
+
+   @Override
+   public void setEvicted(boolean evicted) {
+      // Empty
+   }
+
+   @Override
+   public void setValid(boolean valid) {
+      // Empty
+   }
+
+   @Override
+   public boolean isLockPlaceholder() {
+      return false;
+   }
+
+   @Override
+   public boolean undelete(boolean doUndelete) {
+      return false;
+   }
+
+   @Override
+   public long getCreated() {
+      return 0;
+   }
+
+   @Override
+   public long getLastUsed() {
+      return 0;
+   }
+
+   @Override
+   public long getExpiryTime() {
+      return 0;
+   }
+
+   @Override
+   public void touch() {
+      // Empty
+   }
+
+   @Override
+   public void touch(long currentTimeMillis) {
+      // Empty
+   }
+
+   @Override
+   public void reincarnate() {
+      // Empty
+   }
+
+   @Override
+   public InternalCacheValue toInternalCacheValue() {
+      return null;
+   }
+
+   @Override
+   public InternalCacheEntry clone() {
+      return null;
+   }
+
+   @Override
+   public EntryVersion getVersion() {
+      return null;
+   }
+
+   @Override
+   public void setVersion(EntryVersion version) {
+      // Empty
+   }
+
+}

--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -64,6 +64,8 @@ public final class ComponentRegistry extends AbstractComponentRegistry {
    private ResponseGenerator responseGenerator;
    private CommandsFactory commandsFactory;
 
+   protected final ClassLoader defaultClassLoader;
+
    @Inject
    public void setCacheManagerNotifier(CacheManagerNotifier cacheManagerNotifier) {
       this.cacheManagerNotifier = cacheManagerNotifier;
@@ -78,7 +80,7 @@ public final class ComponentRegistry extends AbstractComponentRegistry {
     */
    public ComponentRegistry(String cacheName, Configuration configuration, AdvancedCache<?, ?> cache,
                             GlobalComponentRegistry globalComponents, ClassLoader defaultClassLoader) {
-      super(defaultClassLoader); // registers the default classloader
+      this.defaultClassLoader = defaultClassLoader;
       try {
          this.cacheName = cacheName;
          if (cacheName == null) throw new ConfigurationException("Cache name cannot be null!");
@@ -177,7 +179,7 @@ public final class ComponentRegistry extends AbstractComponentRegistry {
    }
 
    private boolean isGlobal(String className) {
-      ComponentMetadata m = ComponentMetadataRepo.findComponentMetadata(className);
+      ComponentMetadata m = getComponentMetadataRepo().findComponentMetadata(className);
       return m != null && m.isGlobalScope();
    }
 
@@ -266,6 +268,11 @@ public final class ComponentRegistry extends AbstractComponentRegistry {
       stateTransferManager = getComponent(StateTransferManager.class);
       responseGenerator = getComponent(ResponseGenerator.class);
       commandsFactory = getLocalComponent(CommandsFactory.class);
+   }
+
+   @Override
+   public ComponentMetadataRepo getComponentMetadataRepo() {
+      return globalComponents.getComponentMetadataRepo();
    }
 
 }

--- a/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
@@ -100,7 +100,7 @@ public class InterceptorChainFactory extends AbstractNamedCacheComponentFactory 
          first = createInterceptor(new InvocationContextInterceptor(), InvocationContextInterceptor.class);
       }
 
-      InterceptorChain interceptorChain = new InterceptorChain(first);
+      InterceptorChain interceptorChain = new InterceptorChain(first, componentRegistry.getComponentMetadataRepo());
 
       // add the interceptor chain to the registry first, since some interceptors may ask for it.
       componentRegistry.registerComponent(interceptorChain, InterceptorChain.class);

--- a/core/src/main/java/org/infinispan/interceptors/CacheLoaderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheLoaderInterceptor.java
@@ -32,6 +32,7 @@ import org.infinispan.configuration.cache.StoreConfiguration;
 import org.infinispan.container.EntryFactory;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.entries.InternalNullEntry;
 import org.infinispan.container.entries.MVCCEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
@@ -173,6 +174,9 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
          } else {
             return false;
          }
+      } else if (e instanceof InternalNullEntry) {
+         ctx.putLookedUpEntry(key, null);
+         return false;
       } else {
          return true;
       }

--- a/core/src/main/java/org/infinispan/interceptors/InterceptorChain.java
+++ b/core/src/main/java/org/infinispan/interceptors/InterceptorChain.java
@@ -61,12 +61,14 @@ public class InterceptorChain {
    private volatile CommandInterceptor firstInChain;
 
    final ReentrantLock lock = new ReentrantLock();
+   final ComponentMetadataRepo componentMetadataRepo;
 
    /**
     * Constructs an interceptor chain having the supplied interceptor as first.
     */
-   public InterceptorChain(CommandInterceptor first) {
+   public InterceptorChain(CommandInterceptor first, ComponentMetadataRepo componentMetadataRepo) {
       this.firstInChain = first;
+      this.componentMetadataRepo = componentMetadataRepo;
    }
 
    @Start
@@ -81,7 +83,7 @@ public class InterceptorChain {
       if ((!ReflectionUtil.getAllMethodsShallow(i, Inject.class).isEmpty() ||
             !ReflectionUtil.getAllMethodsShallow(i, Start.class).isEmpty() ||
             !ReflectionUtil.getAllMethodsShallow(i, Stop.class).isEmpty()) &&
-            ComponentMetadataRepo.findComponentMetadata(i.getName()) == null) {
+            componentMetadataRepo.findComponentMetadata(i.getName()) == null) {
          log.customInterceptorExpectsInjection(i.getName());
       }      
    }

--- a/core/src/main/java/org/infinispan/loaders/CacheLoaderManagerImpl.java
+++ b/core/src/main/java/org/infinispan/loaders/CacheLoaderManagerImpl.java
@@ -350,7 +350,7 @@ public class CacheLoaderManagerImpl implements CacheLoaderManager {
             // async?
             CacheStoreConfig cfg2 = (CacheStoreConfig) cfg;
             if (cfg2.getAsyncStoreConfig().isEnabled()) {
-               tmpStore = new AsyncStore(tmpStore, cfg2.getAsyncStoreConfig());
+               tmpStore = createAsyncStore(tmpStore, cfg2);
                tmpLoader = tmpStore;
             }
 
@@ -372,6 +372,10 @@ public class CacheLoaderManagerImpl implements CacheLoaderManager {
          tmpLoader.init(cfg, cache, m);
       }
       return tmpLoader;
+   }
+
+   protected AsyncStore createAsyncStore(CacheStore tmpStore, CacheStoreConfig cfg2) {
+      return new AsyncStore(tmpStore, cfg2.getAsyncStoreConfig());
    }
 
    void assertNotSingletonAndShared(StoreConfiguration cfg) {

--- a/core/src/test/java/org/infinispan/config/DataContainerTest.java
+++ b/core/src/test/java/org/infinispan/config/DataContainerTest.java
@@ -23,10 +23,10 @@
 package org.infinispan.config;
 
 import org.infinispan.AdvancedCache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.DefaultDataContainer;
 import org.infinispan.container.InternalEntryFactoryImpl;
-import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -79,7 +79,8 @@ public class DataContainerTest {
          AdvancedCache<Object, Object> cache = cm.getCache().getAdvancedCache();
 
          DataContainer ddc = DefaultDataContainer.unBoundedDataContainer(cache.getConfiguration().getConcurrencyLevel());
-         ((DefaultDataContainer) ddc).initialize(null, null,new InternalEntryFactoryImpl());
+         ((DefaultDataContainer) ddc).initialize(null, null,new InternalEntryFactoryImpl(),
+               new ConfigurationBuilder().build(), null);
          QueryableDataContainer.setDelegate(ddc);
 
          // Verify that the default is correctly established
@@ -112,7 +113,8 @@ public class DataContainerTest {
          AdvancedCache<Object, Object> cache = cm.getCache().getAdvancedCache();
 
          DataContainer ddc = DefaultDataContainer.unBoundedDataContainer(cache.getConfiguration().getConcurrencyLevel());
-         ((DefaultDataContainer) ddc).initialize(null, null,new InternalEntryFactoryImpl());
+         ((DefaultDataContainer) ddc).initialize(
+               null, null,new InternalEntryFactoryImpl(), new ConfigurationBuilder().build(), null);
          QueryableDataContainer.setDelegate(ddc);
 
          // Verify that the config is correct

--- a/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
+++ b/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
@@ -22,6 +22,7 @@
  */
 package org.infinispan.container;
 
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.entries.ImmortalCacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.MortalCacheEntry;
@@ -55,7 +56,8 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
 
    protected DataContainer createContainer() {
       DefaultDataContainer dc = new DefaultDataContainer(16);
-      dc.initialize(null, null, new InternalEntryFactoryImpl());
+      dc.initialize(null, null, new InternalEntryFactoryImpl(),
+            new ConfigurationBuilder().build(), null);
       return dc;
    }
 

--- a/core/src/test/java/org/infinispan/interceptors/InterceptorChainTest.java
+++ b/core/src/test/java/org/infinispan/interceptors/InterceptorChainTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.infinispan.factories.components.ComponentMetadataRepo;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -45,7 +46,7 @@ public class InterceptorChainTest {
    private static final Log log = LogFactory.getLog(InterceptorChainTest.class);
 
    public void testConcurrentAddRemove() throws Exception {
-      InterceptorChain ic = new InterceptorChain(new CallInterceptor());
+      InterceptorChain ic = new InterceptorChain(new CallInterceptor(), new ComponentMetadataRepo());
       ic.addInterceptor(new ActivationInterceptor(), 1);
       CyclicBarrier barrier = new CyclicBarrier(4);
       List<Future<Void>> futures = new ArrayList<Future<Void>>(2);

--- a/core/src/test/java/org/infinispan/loaders/decorators/AsyncStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/loaders/decorators/AsyncStoreFunctionalTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.loaders.decorators;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.DataContainer;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.eviction.EvictionStrategy;
+import org.infinispan.factories.AbstractNamedCacheComponentFactory;
+import org.infinispan.factories.AutoInstantiableFactory;
+import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.loaders.CacheLoaderException;
+import org.infinispan.loaders.CacheLoaderManager;
+import org.infinispan.loaders.CacheLoaderManagerImpl;
+import org.infinispan.loaders.CacheStore;
+import org.infinispan.loaders.CacheStoreConfig;
+import org.infinispan.loaders.dummy.DummyInMemoryCacheStore;
+import org.infinispan.loaders.dummy.DummyInMemoryCacheStoreConfigurationBuilder;
+import org.infinispan.loaders.modifications.Modification;
+import org.infinispan.loaders.modifications.Store;
+import org.infinispan.test.CacheManagerCallable;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.infinispan.test.TestingUtil.*;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * Functional tests of the async store when running associated with a cache instance.
+ *
+ * @author Galder Zamarreño
+ * @since 5.2
+ */
+@Test(groups = "functional", testName = "loaders.RemovedEntryFoundAsyncStoreTest")
+public class AsyncStoreFunctionalTest {
+
+   private static final Log log = LogFactory.getLog(AsyncStoreFunctionalTest.class);
+
+   public void testPutAfterPassivation() {
+      ConfigurationBuilder builder = asyncStoreWithEvictionBuilder();
+      builder.loaders().passivation(true);
+
+      withCacheManager(new CacheManagerCallable(
+            TestCacheManagerFactory.createCacheManager(builder)) {
+         @Override
+         public void call() {
+            // Hack the component metadata repository
+            // to inject the custom cache loader manager
+            GlobalComponentRegistry gcr = TestingUtil.extractGlobalComponentRegistry(cm);
+            gcr.getComponentMetadataRepo().injectFactoryForComponent(
+                  CacheLoaderManager.class, CustomCacheLoaderManagerFactory.class);
+
+            Cache<Integer, String> cache = cm.getCache();
+
+            MockAsyncStore cacheStore = getMockAsyncStore(cache);
+            CountDownLatch modApplyLatch = cacheStore.modApplyLatch;
+            CountDownLatch lockedWaitLatch = cacheStore.lockedWaitLatch;
+
+            // Store an entry in the cache
+            cache.put(1, "v1");
+            // Store a second entry to force the previous entry
+            // to be evicted and passivated
+            cache.put(2, "v2");
+
+            try {
+               // Wait for async store to have this modification queued up,
+               // ready to apply it to the cache store...
+               log.trace("Wait for async store to lock keys");
+               lockedWaitLatch.await(60, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+               Thread.currentThread().interrupt();
+            }
+
+            try {
+               // Even though it's in the process of being passivated,
+               // the entry should still be found in memory
+               assertEquals("v1", cache.get(1));
+            } finally {
+               modApplyLatch.countDown();
+            }
+         }
+      });
+   }
+
+   public void testPutAfterEviction() {
+      ConfigurationBuilder builder = asyncStoreWithEvictionBuilder();
+
+      withCacheManager(new CacheManagerCallable(
+            TestCacheManagerFactory.createCacheManager(builder)) {
+         @Override
+         public void call() {
+            // Hack the component metadata repository
+            // to inject the custom cache loader manager
+            GlobalComponentRegistry gcr = TestingUtil.extractGlobalComponentRegistry(cm);
+            gcr.getComponentMetadataRepo().injectFactoryForComponent(
+                  CacheLoaderManager.class, CustomCacheLoaderManagerFactory.class);
+
+            Cache<Integer, String> cache = cm.getCache();
+
+            MockAsyncStore cacheStore = getMockAsyncStore(cache);
+            CountDownLatch modApplyLatch = cacheStore.modApplyLatch;
+            CountDownLatch lockedWaitLatch = cacheStore.lockedWaitLatch;
+
+            // Store an entry in the cache
+            cache.put(1, "v1");
+
+            try {
+               // Wait for async store to have this modification queued up,
+               // ready to apply it to the cache store...
+               log.trace("Wait for async store to lock keys");
+               lockedWaitLatch.await(60, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+               Thread.currentThread().interrupt();
+            }
+
+            // This shouldn't result in k=1 being evicted
+            // because the k=1 put is queued in the async store
+            cache.put(2, "v2");
+
+            try {
+               assertEquals("v1", cache.get(1));
+               assertEquals("v2", cache.get(2));
+            } finally {
+               modApplyLatch.countDown();
+            }
+         }
+      });
+   }
+
+   public void testGetAfterRemove() throws Exception {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.loaders()
+               .addStore(DummyInMemoryCacheStoreConfigurationBuilder.class)
+               .async().enabled(true);
+
+      withCacheManager(new CacheManagerCallable(
+            TestCacheManagerFactory.createCacheManager(builder)) {
+         @Override
+         public void call() {
+            // Hack the component metadata repository
+            // to inject the custom cache loader manager
+            GlobalComponentRegistry gcr = TestingUtil.extractGlobalComponentRegistry(cm);
+            gcr.getComponentMetadataRepo().injectFactoryForComponent(
+                  CacheLoaderManager.class, CustomCacheLoaderManagerFactory.class);
+
+            Cache<Integer, String> cache = cm.getCache();
+
+            MockAsyncStore cacheStore = getMockAsyncStore(cache);
+            CountDownLatch modApplyLatch = cacheStore.modApplyLatch;
+            CountDownLatch lockedWaitLatch = cacheStore.lockedWaitLatch;
+
+            // Store a value first
+            cache.put(1, "skip");
+
+            // Wait until cache store contains the expected key/value pair
+            ((DummyInMemoryCacheStore) cacheStore.getDelegate())
+                  .blockUntilCacheStoreContains(1, "skip", 60000);
+
+            // Remove it from the cache container
+            cache.remove(1);
+
+            try {
+               // Wait for async store to have this modification queued up,
+               // ready to apply it to the cache store...
+               lockedWaitLatch.await(60, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+               Thread.currentThread().interrupt();
+            }
+
+            try {
+               // Even though the remove it's pending,
+               // the entry should not be retrieved
+               assertEquals(null, cache.get(1));
+            } finally {
+               modApplyLatch.countDown();
+            }
+
+            DataContainer dataContainer = TestingUtil.extractComponent(cache, DataContainer.class);
+            dataContainer.purgeExpired();
+
+            Set<Integer> keys = cache.keySet();
+            assertTrue("Keys not empty: " + keys, keys.isEmpty());
+            Set<Map.Entry<Integer, String>> entries = cache.entrySet();
+            assertTrue("Entry set not empty: " + entries, entries.isEmpty());
+            Collection<String> values = cache.values();
+            assertTrue("Values not empty: " + values, values.isEmpty());
+         }
+      });
+   }
+
+   private MockAsyncStore getMockAsyncStore(Cache<Integer, String> cache) {
+      CustomCacheLoaderManager cacheLoaderManager = (CustomCacheLoaderManager)
+            TestingUtil.extractComponent(cache, CacheLoaderManager.class);
+      return (MockAsyncStore)
+            cacheLoaderManager.getCacheStore();
+   }
+
+   private ConfigurationBuilder asyncStoreWithEvictionBuilder() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      // Emulate eviction with direct data container eviction
+      builder.eviction().strategy(EvictionStrategy.LRU).maxEntries(1)
+            .loaders()
+            .addStore(DummyInMemoryCacheStoreConfigurationBuilder.class)
+            .async().enabled(true);
+      return builder;
+   }
+
+   public static class MockAsyncStore extends AsyncStore {
+
+      private static final Log log = LogFactory.getLog(MockAsyncStore.class);
+
+      private final CountDownLatch modApplyLatch;
+      private final CountDownLatch lockedWaitLatch;
+
+      public MockAsyncStore(CountDownLatch modApplyLatch, CountDownLatch lockedWaitLatch,
+            CacheStore delegate, AsyncStoreConfig asyncStoreConfig) {
+         super(delegate, asyncStoreConfig);
+         this.modApplyLatch = modApplyLatch;
+         this.lockedWaitLatch = lockedWaitLatch;
+      }
+
+      @Override
+      protected void applyModificationsSync(ConcurrentMap<Object, Modification> mods)
+            throws CacheLoaderException {
+         try {
+            // Wait for signal to do the modification
+            if (mods.containsKey(1) && !isSkip(mods.get(1))) {
+               log.tracef("Wait to apply modifications: %s", mods);
+               lockedWaitLatch.countDown();
+               modApplyLatch.await(60, TimeUnit.SECONDS);
+               log.tracef("Apply modifications: %s", mods);
+            }
+            super.applyModificationsSync(mods);
+         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+         }
+      }
+
+      private boolean isSkip(Modification mod) {
+         if (mod instanceof Store) {
+            InternalCacheEntry storedEntry = ((Store) mod).getStoredEntry();
+            return storedEntry.getValue().equals("skip");
+         }
+         return false;
+      }
+
+   }
+
+   public static class CustomCacheLoaderManagerFactory
+         extends AbstractNamedCacheComponentFactory implements AutoInstantiableFactory {
+
+      @Override
+      public <T> T construct(Class<T> componentType) {
+         return (T) new CustomCacheLoaderManager();
+      }
+
+   }
+
+   public static class CustomCacheLoaderManager extends CacheLoaderManagerImpl {
+
+      @Override
+      protected AsyncStore createAsyncStore(CacheStore tmpStore, CacheStoreConfig cfg2) {
+         CountDownLatch modApplyLatch = new CountDownLatch(1);
+         CountDownLatch lockedWaitLatch = new CountDownLatch(1);
+         return new MockAsyncStore(modApplyLatch, lockedWaitLatch,
+               tmpStore, cfg2.getAsyncStoreConfig());
+      }
+
+   }
+
+}

--- a/core/src/test/java/org/infinispan/loaders/decorators/AsyncStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/decorators/AsyncStoreTest.java
@@ -60,8 +60,8 @@ import static org.infinispan.test.TestingUtil.k;
 import static org.infinispan.test.TestingUtil.v;
 
 @Test(groups = "unit", testName = "loaders.decorators.AsyncTest", sequential=true)
-public class AsyncTest extends AbstractInfinispanTest {
-   private static final Log log = LogFactory.getLog(AsyncTest.class);
+public class AsyncStoreTest extends AbstractInfinispanTest {
+   private static final Log log = LogFactory.getLog(AsyncStoreTest.class);
    AsyncStore store;
    ExecutorService asyncExecutor;
    DummyInMemoryCacheStore underlying;
@@ -73,7 +73,7 @@ public class AsyncTest extends AbstractInfinispanTest {
       underlying = new DummyInMemoryCacheStore();
       asyncConfig = new AsyncStoreConfig().threadPoolSize(10);
       store = new AsyncStore(underlying, asyncConfig);
-      dummyCfg = new DummyInMemoryCacheStore.Cfg().storeName(AsyncTest.class.getName());
+      dummyCfg = new DummyInMemoryCacheStore.Cfg().storeName(AsyncStoreTest.class.getName());
       store.init(dummyCfg, null, null);
       store.start();
       asyncExecutor = (ExecutorService) TestingUtil.extractField(store, "executor");
@@ -130,7 +130,7 @@ public class AsyncTest extends AbstractInfinispanTest {
       // stop the cache store
       store.stop();
       try {
-         store.remove("blah");
+         store.store(null);
          assert false : "Should have restricted this entry from being made";
       }
       catch (CacheException expected) {

--- a/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolServer.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolServer.scala
@@ -115,7 +115,8 @@ abstract class AbstractProtocolServer(threadNamePrefix: String) extends Protocol
          val jmxDomain = JmxUtil.buildJmxDomain(globalCfg, mbeanServer, groupName)
 
          // Pick up metadata from the component metadata repository
-         val meta = ComponentMetadataRepo.findComponentMetadata(transport.getClass).toManageableComponentMetadata
+         val meta = LifecycleCallbacks.componentMetadataRepo
+                 .findComponentMetadata(transport.getClass).toManageableComponentMetadata
          // And use this metadata when registering the transport as a dynamic MBean
          val dynamicMBean = new ResourceDMBean(transport, meta)
 

--- a/server/core/src/main/scala/org/infinispan/server/core/LifecycleCallbacks.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/LifecycleCallbacks.scala
@@ -28,6 +28,7 @@ import org.infinispan.server.core.ExternalizerIds._
 import org.infinispan.factories.{ComponentRegistry, GlobalComponentRegistry}
 import org.infinispan.configuration.global.GlobalConfiguration
 import org.infinispan.configuration.cache.Configuration
+import org.infinispan.factories.components.ComponentMetadataRepo
 
 /**
  * Module lifecycle callbacks implementation that enables module specific
@@ -38,8 +39,10 @@ import org.infinispan.configuration.cache.Configuration
  */
 class LifecycleCallbacks extends AbstractModuleLifecycle {
 
-   override def cacheManagerStarting(gcr: GlobalComponentRegistry, globalCfg: GlobalConfiguration) =
+   override def cacheManagerStarting(gcr: GlobalComponentRegistry, globalCfg: GlobalConfiguration) {
+      LifecycleCallbacks.componentMetadataRepo = gcr.getComponentMetadataRepo
       addExternalizer(globalCfg)
+   }
 
    override def cacheStarting(cr: ComponentRegistry, cfg: Configuration, cacheName: String) =
       cfg.storeAsBinary().enabled(false)
@@ -47,5 +50,11 @@ class LifecycleCallbacks extends AbstractModuleLifecycle {
    private[core] def addExternalizer(globalCfg : GlobalConfiguration) =
       globalCfg.serialization().advancedExternalizers().put(
          SERVER_CACHE_VALUE, new CacheValue.Externalizer)
+
+}
+
+object LifecycleCallbacks {
+
+   var componentMetadataRepo: ComponentMetadataRepo = _
 
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-1174

Sanne's delayed birthday present :)
- This fix addresses issues related to interaction between remove, eviction (with and without passivation) and async cache store, making sure that the cache returns consistent information.
- To build unit tests I've had to patch internal cache components to behave in a particular way, which has lead me to converting the component metadata repository to a non-static class. This helps enormously in building such unit tests without having to change existing components.

NOTE: A stress test for async stores will be developed in time for CR, see [ISPN-2293](https://issues.jboss.org/browse/ISPN-2293)
