### PR TITLE
ISPN-2305 Cache callback order changes and concurrent cache hang up

### DIFF
--- a/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
@@ -328,6 +328,10 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
    }
 
    protected synchronized AbstractComponentFactory createComponentFactoryInternal(Class<?> componentClass, String cfClass) {
+      //first check as it might have been created in between by another thread
+      AbstractComponentFactory component = getComponent(cfClass);
+      if (component != null) return component;
+
       //hasn't yet been created.  Create and put in registry
       AbstractComponentFactory cf = instantiateFactory(cfClass);
       if (cf == null)

--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -132,8 +132,10 @@ public final class ComponentRegistry extends AbstractComponentRegistry {
    @Override
    protected final Component lookupComponent(String componentClassName, String name, boolean nameIsFQCN) {
       if (isGlobal(nameIsFQCN ? name : componentClassName)) {
+         log.tracef("Looking up global component %s", componentClassName);
          return globalComponents.lookupComponent(componentClassName, name, nameIsFQCN);
       } else {
+         log.tracef("Looking up local component %s", componentClassName);
          return lookupLocalComponent(componentClassName, name, nameIsFQCN);
       }
    }
@@ -149,8 +151,10 @@ public final class ComponentRegistry extends AbstractComponentRegistry {
    @Override
    protected final <T> T getOrCreateComponent(Class<T> componentClass, String name, boolean nameIsFQCN) {
       if (isGlobal(nameIsFQCN ? name : componentClass.getName())) {
+         log.tracef("Get or create global component %s", componentClass);
          return globalComponents.getOrCreateComponent(componentClass, name, nameIsFQCN);
       } else {
+         log.tracef("Get or create local component %s", componentClass);
          return super.getOrCreateComponent(componentClass, name, nameIsFQCN);
       }
    }

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -674,12 +674,12 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
       globalComponentRegistry.start();
       Configuration c = getConfiguration(cacheName);
 
+      log.tracef("About to wire and start cache %s", cacheName);
       Cache<K, V> cache = new InternalCacheFactory<K, V>().createCache(c, globalComponentRegistry, cacheName);
       cacheWrapper.setCache(cache);
 
       // start the cache-level components
       try {
-         log.tracef("About to start cache %s", cacheName);
          cache.start();
       } finally {
          // allow other threads to access the cache

--- a/core/src/main/java/org/infinispan/transaction/lookup/GenericTransactionManagerLookup.java
+++ b/core/src/main/java/org/infinispan/transaction/lookup/GenericTransactionManagerLookup.java
@@ -109,9 +109,10 @@ public class GenericTransactionManagerLookup implements TransactionManagerLookup
     * @return TransactionManager
     */
    @Override
-   public TransactionManager getTransactionManager() {
-      if (!lookupDone)
+   public synchronized TransactionManager getTransactionManager() {
+      if (!lookupDone) {
          doLookups(configuration.classLoader());
+      }
       if (tm != null)
          return tm;
       if (lookupFailed) {
@@ -179,7 +180,6 @@ public class GenericTransactionManagerLookup implements TransactionManagerLookup
                return;
             }
          }
-         lookupDone = true;
       } finally {
          Util.close(ctx);
       }
@@ -220,6 +220,7 @@ public class GenericTransactionManagerLookup implements TransactionManagerLookup
       catch (Exception ex) {
          log.unableToInvokeWebsphereStaticGetTmMethod(ex, clazz.getName());
       }
+      lookupDone = true;
    }
 
 }

--- a/core/src/main/java/org/infinispan/transaction/lookup/JBossStandaloneJTAManagerLookup.java
+++ b/core/src/main/java/org/infinispan/transaction/lookup/JBossStandaloneJTAManagerLookup.java
@@ -68,7 +68,7 @@ public class JBossStandaloneJTAManagerLookup implements TransactionManagerLookup
    }
 
    @Override
-   public TransactionManager getTransactionManager() throws Exception {
+   public synchronized TransactionManager getTransactionManager() throws Exception {
       TransactionManager tm = (TransactionManager) manager.invoke(null);
       if (log.isInfoEnabled()) log.retrievingTm(tm);
       return tm;

--- a/core/src/main/java/org/infinispan/transaction/lookup/JBossTransactionManagerLookup.java
+++ b/core/src/main/java/org/infinispan/transaction/lookup/JBossTransactionManagerLookup.java
@@ -39,7 +39,7 @@ import javax.transaction.TransactionManager;
 public class JBossTransactionManagerLookup implements TransactionManagerLookup {
 
    @Override
-   public TransactionManager getTransactionManager() throws Exception {
+   public synchronized TransactionManager getTransactionManager() throws Exception {
       String as7Location = "java:jboss/TransactionManager";
 
       InitialContext initialContext = new InitialContext();

--- a/core/src/main/java/org/infinispan/transaction/lookup/TransactionManagerLookup.java
+++ b/core/src/main/java/org/infinispan/transaction/lookup/TransactionManagerLookup.java
@@ -27,6 +27,11 @@ import javax.transaction.TransactionManager;
 /**
  * Factory interface, allows {@link org.infinispan.Cache} to use different transactional systems. Names of implementors of
  * this class can be configured using {@link Configuration#setTransactionManagerLookupClass}.
+ * Thread safety: it is possible for the same instance of this class to be used by multiple caches at the same time e.g.
+ * when the same instance is passed to multiple configurations:
+ * {@link org.infinispan.configuration.cache.TransactionConfigurationBuilder#transactionManagerLookup(TransactionManagerLookup)}.
+ * As infinispan supports parallel cache startup, it might be possible for multiple threads to invoke the
+ * getTransactionManager() method concurrently, so it is highly recommended for instances of this class to be thread safe.
  *
  * @author Bela Ban, Aug 26 2003
  * @since 4.0

--- a/core/src/test/java/org/infinispan/config/TxManagerLookupConfigTest.java
+++ b/core/src/test/java/org/infinispan/config/TxManagerLookupConfigTest.java
@@ -70,7 +70,7 @@ public class TxManagerLookupConfigTest {
    public static class TxManagerLookupA implements TransactionManagerLookup {
 
       @Override
-      public TransactionManager getTransactionManager() throws Exception {
+      public synchronized TransactionManager getTransactionManager() throws Exception {
          return tma;
       }
    }
@@ -78,7 +78,7 @@ public class TxManagerLookupConfigTest {
    public static class TxManagerLookupB implements TransactionManagerLookup {
 
       @Override
-      public TransactionManager getTransactionManager() throws Exception {
+      public synchronized TransactionManager getTransactionManager() throws Exception {
          return tmb;
       }
    }

--- a/core/src/test/java/org/infinispan/tx/recovery/RecoveryDummyTransactionManagerLookup.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/RecoveryDummyTransactionManagerLookup.java
@@ -12,7 +12,7 @@ import javax.transaction.TransactionManager;
 public class RecoveryDummyTransactionManagerLookup implements TransactionManagerLookup {
 
    @Override
-   public TransactionManager getTransactionManager() throws Exception {
+   public synchronized TransactionManager getTransactionManager() throws Exception {
       DummyTransactionManager dtm = new DummyTransactionManager();
       dtm.setUseXaXid(true);
       return dtm;


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2305
Should fix the hanging of the test suite.
- TxManagerLookup can now be invoked by multipel thread at the same time and needs synchronization
- there was a race condition in AbstractComponentRegistry
