### PR TITLE
ISPN-2290 Fix cache MBean leak when cache statistics disabled

### DIFF
--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreVamTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/mixed/JdbcMixedCacheStoreVamTest.java
@@ -27,7 +27,6 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.StreamingMarshaller;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/NonStringKeyPreloadTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/NonStringKeyPreloadTest.java
@@ -23,6 +23,8 @@
 package org.infinispan.loaders.jdbc.stringbased;
 
 import static junit.framework.Assert.assertEquals;
+import static org.infinispan.test.TestingUtil.clearCacheLoader;
+import static org.infinispan.test.TestingUtil.withCacheManager;
 
 import java.sql.Connection;
 
@@ -37,9 +39,8 @@ import org.infinispan.loaders.jdbc.TableManipulation;
 import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactory;
 import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactoryConfig;
 import org.infinispan.loaders.jdbc.connectionfactory.PooledConnectionFactory;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractInfinispanTest;
-import org.infinispan.test.TestingUtil;
+import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.UnitTestDatabaseManager;
 import org.testng.annotations.Test;
@@ -57,70 +58,83 @@ public class NonStringKeyPreloadTest extends AbstractInfinispanTest {
       String mapperName = PersonKey2StringMapper.class.getName();
       Configuration cfg = createCacheStoreConfig(mapperName, false, true);
 
-      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createCacheManager(cfg);
-      try {
-         cacheManager.getCache();
-         assert false : " Preload with Key2StringMapper is not supported. Specify an TwoWayKey2StringMapper if you want to support it (or disable preload).";
-      } catch (CacheException ce) {
-         //expected
-      } finally {
-         cacheManager.stop();
-      }
+      withCacheManager(new CacheManagerCallable(
+            TestCacheManagerFactory.createCacheManager(cfg)) {
+         @Override
+         public void call() {
+            try {
+               cm.getCache();
+               assert false : " Preload with Key2StringMapper is not supported. Specify an TwoWayKey2StringMapper if you want to support it (or disable preload).";
+            } catch (CacheException e) {
+               // Expected
+            }
+         }
+      });
    }
 
    public void testPreloadWithTwoWayKey2StringMapper() throws Exception {
       String mapperName = TwoWayPersonKey2StringMapper.class.getName();
       Configuration config = createCacheStoreConfig(mapperName, true, true);
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(config);
-      Cache<Object, Object> cache = cm.getCache();
-      Person mircea = new Person("Markus", "Mircea", 30);
-      cache.put(mircea, "me");
-      Person dan = new Person("Dan", "Dude", 30);
-      cache.put(dan, "mate");
-      cache.stop();
-      cm.stop();
+      final Person mircea = new Person("Markus", "Mircea", 30);
+      final Person dan = new Person("Dan", "Dude", 30);
+      withCacheManager(new CacheManagerCallable(
+            TestCacheManagerFactory.createCacheManager(config)) {
+         @Override
+         public void call() {
+            Cache<Object, Object> cache = cm.getCache();
+            cache.put(mircea, "me");
+            cache.put(dan, "mate");
+         }
+      });
 
-      cm = TestCacheManagerFactory.createCacheManager(config);
-      try {
-         cache = cm.getCache();
-         assert cache.containsKey(mircea);
-         assert cache.containsKey(dan);
-      } finally {
-         TestingUtil.clearCacheLoader(cache);
-         cache.stop();
-         cm.stop();
-      }
+      withCacheManager(new CacheManagerCallable(
+            TestCacheManagerFactory.createCacheManager(config)) {
+         @Override
+         public void call() {
+            Cache<Object, Object> cache = null;
+            try {
+               cache = cm.getCache();
+               assert cache.containsKey(mircea);
+               assert cache.containsKey(dan);
+            } finally {
+               clearCacheLoader(cache);
+            }
+         }
+      });
    }
    public void testPreloadWithTwoWayKey2StringMapperAndBoundedCache() throws Exception {
       String mapperName = TwoWayPersonKey2StringMapper.class.getName();
       Configuration config = createCacheStoreConfig(mapperName, true, true);
       config.setEvictionStrategy(EvictionStrategy.LRU);
       config.setEvictionMaxEntries(3);
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(config);
-      AdvancedCache<Object, Object> cache = cm.getCache().getAdvancedCache();
-      for (int i = 0; i < 10; i++) {
-         Person p = new Person("name" + i, "surname" + i, 30);
-         cache.put(p, "" + i);
-      }
-      cache.stop();
-      cm.stop();
-
-      cm = TestCacheManagerFactory.createCacheManager(config);
-      try {
-         cache = cm.getCache().getAdvancedCache();
-         assertEquals(3, cache.size());
-         int found = 0;
-         for (int i = 0; i < 10; i++) {
-            Person p = new Person("name" + i, "surname" + i, 30);
-            if (cache.getDataContainer().containsKey(p)) {
-               found++;
+      withCacheManager(new CacheManagerCallable(
+            TestCacheManagerFactory.createCacheManager(config)) {
+         @Override
+         public void call() {
+            AdvancedCache<Object, Object> cache = cm.getCache().getAdvancedCache();
+            for (int i = 0; i < 10; i++) {
+               Person p = new Person("name" + i, "surname" + i, 30);
+               cache.put(p, "" + i);
             }
          }
-         assertEquals(3, found);
-      } finally {
-         cache.stop();
-         cm.stop();
-      }
+      });
+
+      withCacheManager(new CacheManagerCallable(
+            TestCacheManagerFactory.createCacheManager(config)) {
+         @Override
+         public void call() {
+            AdvancedCache<Object, Object> cache = cm.getCache().getAdvancedCache();
+            assertEquals(3, cache.size());
+            int found = 0;
+            for (int i = 0; i < 10; i++) {
+               Person p = new Person("name" + i, "surname" + i, 30);
+               if (cache.getDataContainer().containsKey(p)) {
+                  found++;
+               }
+            }
+            assertEquals(3, found);
+         }
+      });
    }
 
    static Configuration createCacheStoreConfig(String mapperName, boolean wrap, boolean preload) {

--- a/core/src/main/java/org/infinispan/jmx/CacheJmxRegistration.java
+++ b/core/src/main/java/org/infinispan/jmx/CacheJmxRegistration.java
@@ -78,7 +78,6 @@ public class CacheJmxRegistration extends AbstractJmxRegistration {
    public void start() {
       if (cache == null)
          throw new IllegalStateException("The cache should had been injected before a call to this method");
-      Configuration config = cache.getCacheConfiguration();
       Set<Component> components = cache.getComponentRegistry().getRegisteredComponents();
       nonCacheComponents = getNonCacheComponents(components);
       if (registerMBeans(components, cache.getCacheManager().getCacheManagerConfiguration())) {

--- a/core/src/main/java/org/infinispan/jmx/JmxUtil.java
+++ b/core/src/main/java/org/infinispan/jmx/JmxUtil.java
@@ -70,7 +70,8 @@ public class JmxUtil {
       String configJmxDomain = cfg.globalJmxStatistics().domain();
       if (!jmxDomain.equals(configJmxDomain) && !cfg.globalJmxStatistics().allowDuplicateDomains()) {
          log.cacheManagerAlreadyRegistered(configJmxDomain);
-         throw new JmxDomainConflictException(String.format("Domain already registered %s", configJmxDomain));
+         throw new JmxDomainConflictException(String.format(
+               "Domain already registered %s when trying to register: %s", configJmxDomain, groupName));
       }
       return jmxDomain;
    }

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -751,10 +751,9 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
    }
 
    private void unregisterCacheMBean(Cache<?, ?> cache) {
-      if (cache.getCacheConfiguration().jmxStatistics().enabled()) {
-         cache.getAdvancedCache().getComponentRegistry().getComponent(CacheJmxRegistration.class)
-                 .unregisterCacheMBean();
-      }
+      // Unregister cache mbean regardless of jmx statistics setting
+      cache.getAdvancedCache().getComponentRegistry().getComponent(CacheJmxRegistration.class)
+              .unregisterCacheMBean();
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/jmx/CacheMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheMBeanTest.java
@@ -23,17 +23,22 @@
 package org.infinispan.jmx;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
+import org.infinispan.Cache;
 import org.infinispan.CacheException;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.SingleCacheManagerTest;
 import static org.infinispan.test.TestingUtil.*;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -134,4 +139,26 @@ public class CacheMBeanTest extends SingleCacheManagerTest {
          otherContainer.stop();
       }
    }
+
+   public void testAvoidLeakOfCacheMBeanWhenCacheStatisticsDisabled(Method m) {
+      final String jmxDomain = "jmx_" + m.getName();
+      withCacheManager(new CacheManagerCallable(
+            TestCacheManagerFactory.createCacheManagerEnforceJmxDomain(jmxDomain, false, false)) {
+         @Override
+         public void call() {
+            try {
+               cm.getCache();
+               ObjectName cacheObjectName = getCacheObjectName(jmxDomain);
+               assertTrue(cacheObjectName + " should be registered",
+                     server.isRegistered(cacheObjectName));
+               TestingUtil.killCacheManagers(cm);
+               assertFalse(cacheObjectName + " should NOT be registered",
+                     server.isRegistered(cacheObjectName));
+            } catch (Exception e) {
+               throw new RuntimeException(e);
+            }
+         }
+      });
+   }
+
 }

--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -75,7 +75,6 @@ import org.jgroups.util.UUID;
  */
 public class TestCacheManagerFactory {
 
-
    private static AtomicInteger jmxDomainPostfix = new AtomicInteger();
 
    public static final String MARSHALLER = LegacyKeySupportSystemProperties.getProperty("infinispan.test.marshaller.class", "infinispan.marshaller.class");
@@ -611,12 +610,6 @@ public class TestCacheManagerFactory {
    static void testFinished(String testName) {
       perThreadCacheManagers.get().checkManagersClosed(testName);
       perThreadCacheManagers.get().unsetTestName();
-   }
-
-   public static DefaultCacheManager createCacheManager(org.infinispan.configuration.cache.Configuration config) {
-      GlobalConfigurationBuilder globalConfigBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
-      TestCacheManagerFactory.amendGlobalConfiguration(globalConfigBuilder, new TransportFlags());
-      return new DefaultCacheManager(globalConfigBuilder.build(), config);
    }
 
    private static class PerThreadCacheManagers {

--- a/lucene-directory/src/test/java/org/infinispan/lucene/DynamicBufferSizeTest.java
+++ b/lucene-directory/src/test/java/org/infinispan/lucene/DynamicBufferSizeTest.java
@@ -31,7 +31,6 @@ import junit.framework.Assert;
 
 import org.apache.lucene.store.Directory;
 import org.infinispan.configuration.cache.CacheMode;
-import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -51,11 +50,9 @@ public class DynamicBufferSizeTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder builder = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
-      Configuration configuration = builder
-            .clustering().cacheMode(CacheMode.LOCAL)
-            .invocationBatching().enable()
-            .build();
-      return TestCacheManagerFactory.createCacheManager(configuration);
+      builder.clustering().cacheMode(CacheMode.LOCAL)
+            .invocationBatching().enable();
+      return TestCacheManagerFactory.createCacheManager(builder);
    }
    
    @Test

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCacheTest.java
@@ -64,7 +64,6 @@ public class LocalCacheTest extends SingleCacheManagerTest {
    protected Person person3;
    protected Person person4;
    protected Person person5;
-   protected Person person6;
    protected AnotherGrassEater anotherGrassEater;
    protected QueryParser queryParser;
    protected String key1 = "Navin";
@@ -333,7 +332,7 @@ public class LocalCacheTest extends SingleCacheManagerTest {
             .addProperty("hibernate.search.default.directory_provider", "ram")
             .addProperty("hibernate.search.lucene_version", "LUCENE_CURRENT");
       enhanceConfig(cfg);
-      return TestCacheManagerFactory.createCacheManager(cfg.build());
+      return TestCacheManagerFactory.createCacheManager(cfg);
    }
    
    public void testEntityDiscovery() {
@@ -350,7 +349,7 @@ public class LocalCacheTest extends SingleCacheManagerTest {
 
    /**
     * Verifies if the indexing interceptor is aware of a specific list of types.
-    * @param cache
+    * @param cache the cache containing the indexes
     * @param types vararg listing the types the indexing engine should know
     */
    private void assertIndexingKnows(Cache<Object, Object> cache, Class... types) {

--- a/query/src/test/java/org/infinispan/query/blackbox/QueryCacheRestartTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/QueryCacheRestartTest.java
@@ -61,7 +61,7 @@ public class QueryCacheRestartTest extends AbstractInfinispanTest {
       builder.indexing().enable().indexLocalOnly(localOnly)
             .addProperty("hibernate.search.default.directory_provider", "ram")
             .addProperty("hibernate.search.lucene_version", "LUCENE_CURRENT");
-      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager(builder.build())) {
+      withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.createCacheManager(builder)) {
          @Override
          public void call() {
             Cache<Object,Object> cache = cm.getCache();

--- a/query/src/test/java/org/infinispan/query/config/DefaultCacheInheritancePreventedTest.java
+++ b/query/src/test/java/org/infinispan/query/config/DefaultCacheInheritancePreventedTest.java
@@ -21,15 +21,17 @@ package org.infinispan.query.config;
 import java.io.IOException;
 
 import org.infinispan.Cache;
-import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.query.Search;
 import org.infinispan.query.SearchManager;
 import org.infinispan.query.backend.LocalQueryInterceptor;
 import org.infinispan.query.backend.QueryInterceptor;
 import org.infinispan.query.impl.ComponentRegistryUtils;
-import org.infinispan.test.TestingUtil;
+import org.infinispan.test.CacheManagerCallable;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.infinispan.test.TestingUtil.withCacheManager;
 
 /**
  * Similar to QueryParsingTest but that one only looks at the configuration; in this case we check the components are actually
@@ -38,36 +40,36 @@ import org.testng.annotations.Test;
  * @author Sanne Grinovero
  * @since 5.2
  */
-@Test(groups = "unit", testName = "config.parsing.QueryParsingTest")
+@Test(groups = "unit", testName = "query.config.QueryParsingTest")
 public class DefaultCacheInheritancePreventedTest {
 
    @Test
    public void verifyIndexDisabledCorrectly() throws IOException {
-      DefaultCacheManager cacheManager = new DefaultCacheManager("configuration-parsing-test-enbledInDefault.xml");
-      try {
-         assertIndexingEnabled(cacheManager.getCache(), true, QueryInterceptor.class);
-         assertIndexingEnabled(cacheManager.getCache("simple"), true, QueryInterceptor.class);
-         assertIndexingEnabled(cacheManager.getCache("not-searchable"), false, QueryInterceptor.class);
-         assertIndexingEnabled(cacheManager.getCache("memory-searchable"), true, QueryInterceptor.class);
-         assertIndexingEnabled(cacheManager.getCache("disk-searchable"), true, LocalQueryInterceptor.class);
-      }
-      finally {
-         TestingUtil.killCacheManagers(cacheManager);
-      }
+      withCacheManager(new CacheManagerCallable(
+            TestCacheManagerFactory.fromXml("configuration-parsing-test-enbledInDefault.xml")) {
+         @Override
+         public void call() {
+            assertIndexingEnabled(cm.getCache(), true, QueryInterceptor.class);
+            assertIndexingEnabled(cm.getCache("simple"), true, QueryInterceptor.class);
+            assertIndexingEnabled(cm.getCache("not-searchable"), false, QueryInterceptor.class);
+            assertIndexingEnabled(cm.getCache("memory-searchable"), true, QueryInterceptor.class);
+            assertIndexingEnabled(cm.getCache("disk-searchable"), true, LocalQueryInterceptor.class);
+         }
+      });
    }
 
    @Test
    public void verifyIndexEnabledCorrectly() throws IOException {
-      DefaultCacheManager cacheManager = new DefaultCacheManager("configuration-parsing-test.xml");
-      try {
-         assertIndexingEnabled(cacheManager.getCache(), false, QueryInterceptor.class);
-         assertIndexingEnabled(cacheManager.getCache("simple"), false, QueryInterceptor.class);
-         assertIndexingEnabled(cacheManager.getCache("memory-searchable"), true, QueryInterceptor.class);
-         assertIndexingEnabled(cacheManager.getCache("disk-searchable"), true, LocalQueryInterceptor.class);
-      }
-      finally {
-         TestingUtil.killCacheManagers(cacheManager);
-      }
+      withCacheManager(new CacheManagerCallable(
+            TestCacheManagerFactory.fromXml("configuration-parsing-test.xml")) {
+         @Override
+         public void call() {
+            assertIndexingEnabled(cm.getCache(), false, QueryInterceptor.class);
+            assertIndexingEnabled(cm.getCache("simple"), false, QueryInterceptor.class);
+            assertIndexingEnabled(cm.getCache("memory-searchable"), true, QueryInterceptor.class);
+            assertIndexingEnabled(cm.getCache("disk-searchable"), true, LocalQueryInterceptor.class);
+         }
+      });
    }
 
    /**

--- a/query/src/test/java/org/infinispan/query/tx/TransactionalQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/tx/TransactionalQueryTest.java
@@ -24,7 +24,6 @@ package org.infinispan.query.tx;
 
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
-import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -32,14 +31,13 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import javax.transaction.TransactionManager;
+import java.util.concurrent.Callable;
+
 import static org.infinispan.query.helper.TestQueryHelperFactory.*;
+import static org.infinispan.test.TestingUtil.withTx;
 
 @Test(groups = "functional", testName = "query.tx.TransactionalQueryTest")
 public class TransactionalQueryTest extends SingleCacheManagerTest {
-   protected EmbeddedCacheManager m_cacheManager;
-   private Cache<String, Session> m_cache;
-   private TransactionManager m_transactionManager;
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
@@ -50,36 +48,45 @@ public class TransactionalQueryTest extends SingleCacheManagerTest {
             .indexLocalOnly(false)
             .addProperty("hibernate.search.default.directory_provider", "ram")
             .addProperty("hibernate.search.lucene_version", "LUCENE_CURRENT");
-      m_cacheManager = TestCacheManagerFactory.createCacheManager(cfg);
-      m_cache = m_cacheManager.getCache();
-      m_transactionManager = m_cache.getAdvancedCache().getTransactionManager();
-      return m_cacheManager;
+      return TestCacheManagerFactory.createCacheManager(cfg);
    }
 
    @BeforeMethod
    public void initialize() throws Exception {
       // Initialize the cache
-      m_transactionManager.begin();
-      for (int i = 0; i < 100; i++) {
-         m_cache.put(String.valueOf(i), new Session(String.valueOf(i)));
-      }
-      m_transactionManager.commit();
+      withTx(tm(), new Callable<Void>() {
+         @Override
+         public Void call() throws Exception {
+            for (int i = 0; i < 100; i++) {
+               cache.put(String.valueOf(i), new Session(String.valueOf(i)));
+            }
+            return null;
+         }
+      });
    }
 
    public void run() throws Exception {
       // Verify querying works
-      createCacheQuery(m_cache, "", "Id:2?");
+      createCacheQuery(cache, "", "Id:2?");
 
       // Remove something that exists
-      m_transactionManager.begin();
-      m_cache.remove("50");
-      m_transactionManager.commit();
+      withTx(tm(), new Callable<Void>() {
+         @Override
+         public Void call() throws Exception {
+            cache.remove("50");
+            return null;
+         }
+      });
 
       // Remove something that doesn't exist with a transaction
       // This also fails without using a transaction
-      m_transactionManager.begin();
-      m_cache.remove("200");
-      m_transactionManager.commit();
+      withTx(tm(), new Callable<Void>() {
+         @Override
+         public Void call() throws Exception {
+            cache.remove("200");
+            return null;
+         }
+      });
    }
 
    @Indexed(index = "SessionIndex")

--- a/query/src/test/resources/configuration-parsing-test-enbledInDefault.xml
+++ b/query/src/test/resources/configuration-parsing-test-enbledInDefault.xml
@@ -3,6 +3,10 @@
     xsi:schemaLocation="urn:infinispan:config:5.2 http://www.infinispan.org/schemas/infinispan-config-5.2.xsd"
     xmlns="urn:infinispan:config:5.2">
 
+    <global>
+        <globalJmxStatistics allowDuplicateDomains="true" />
+    </global>
+
     <default>
         <indexing enabled="true">
             <properties>

--- a/query/src/test/resources/configuration-parsing-test.xml
+++ b/query/src/test/resources/configuration-parsing-test.xml
@@ -3,6 +3,10 @@
     xsi:schemaLocation="urn:infinispan:config:5.2 http://www.infinispan.org/schemas/infinispan-config-5.2.xsd"
     xmlns="urn:infinispan:config:5.2">
 
+    <global>
+        <globalJmxStatistics allowDuplicateDomains="true" />
+    </global>
+
     <default>
         <indexing enabled="false" />
     </default>

--- a/server/core/src/test/scala/org/infinispan/server/core/AbstractProtocolServerTest.scala
+++ b/server/core/src/test/scala/org/infinispan/server/core/AbstractProtocolServerTest.scala
@@ -25,11 +25,12 @@ package org.infinispan.server.core
 import org.testng.annotations.Test
 import java.util.Properties
 import org.infinispan.server.core.Main._
-import org.infinispan.manager.{DefaultCacheManager, EmbeddedCacheManager}
+import org.infinispan.manager.EmbeddedCacheManager
 import org.testng.Assert._
 import java.lang.reflect.Method
 import org.infinispan.util.TypedProperties
 import test.Stoppable
+import org.infinispan.test.fwk.TestCacheManagerFactory
 
 /**
  * Abstract protocol server test.
@@ -40,82 +41,82 @@ import test.Stoppable
 @Test(groups = Array("functional"), testName = "server.core.AbstractProtocolServerTest")
 class AbstractProtocolServerTest {
 
-   def testValidateNegativeMasterThreads {
+   def testValidateNegativeMasterThreads() {
       val p = new Properties
       p.setProperty(PROP_KEY_MASTER_THREADS, "-1")
       expectIllegalArgument(p, createServer)
    }
 
-   def testValidateNegativeWorkerThreads {
+   def testValidateNegativeWorkerThreads() {
       val p = new Properties
       p.setProperty(PROP_KEY_WORKER_THREADS, "-1")
       expectIllegalArgument(p, createServer)
    }
 
-   def testValidateNegativeIdleTimeout {
+   def testValidateNegativeIdleTimeout() {
       val p = new Properties
       p.setProperty(PROP_KEY_IDLE_TIMEOUT, "-1")
       expectIllegalArgument(p, createServer)
    }
 
-   def testValidateIllegalTcpNoDelay {
+   def testValidateIllegalTcpNoDelay() {
       val p = new Properties
       p.setProperty(PROP_KEY_TCP_NO_DELAY, "blah")
       expectIllegalArgument(p, createServer)
    }
 
-   def testValidateNegativeSendBufSize {
+   def testValidateNegativeSendBufSize() {
       val p = new Properties
       p.setProperty(PROP_KEY_SEND_BUF_SIZE, "-1")
       expectIllegalArgument(p, createServer)
    }
 
-   def testValidateNegativeRecvBufSize {
+   def testValidateNegativeRecvBufSize() {
       val p = new Properties
       p.setProperty(PROP_KEY_RECV_BUF_SIZE, "-1")
       expectIllegalArgument(p, createServer)
    }
 
    def testHostPropertySubstitution(m: Method) {
-      var host = "1.2.3.4";
+      var host = "1.2.3.4"
       var p = new Properties
-      p.setProperty(PROP_KEY_HOST, host);
+      p.setProperty(PROP_KEY_HOST, host)
       Stoppable.useServer(createServer) { server =>
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             assertEquals(server.getHost, host)
          }
 
          host = "${" + m.getName + "-myhost:5.6.7.8}"
          p = new Properties
-         p.setProperty(PROP_KEY_HOST, host);
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         p.setProperty(PROP_KEY_HOST, host)
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             assertEquals(server.getHost, "5.6.7.8")
          }
 
          host = "${" + m.getName + "-myhost:9.10.11.12}"
-         System.setProperty(m.getName + "-myhost", "13.14.15.16");
+         System.setProperty(m.getName + "-myhost", "13.14.15.16")
          p = new Properties
-         p.setProperty(PROP_KEY_HOST, host);
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         p.setProperty(PROP_KEY_HOST, host)
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             assertEquals(server.getHost, "13.14.15.16")
          }
 
          host = "${" + m.getName + "-otherhost}"
          p = new Properties
-         p.setProperty(PROP_KEY_HOST, host);
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         p.setProperty(PROP_KEY_HOST, host)
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             assertEquals(server.getHost, host)
          }
 
          host = "${" + m.getName + "-otherhost}"
-         System.setProperty(m.getName + "-otherhost", "17.18.19.20");
+         System.setProperty(m.getName + "-otherhost", "17.18.19.20")
          p = new Properties
-         p.setProperty(PROP_KEY_HOST, host);
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         p.setProperty(PROP_KEY_HOST, host)
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             assertEquals(server.getHost, "17.18.19.20")
          }
@@ -125,43 +126,43 @@ class AbstractProtocolServerTest {
    def testPortPropertySubstitution(m: Method) {
       var port = "123"
       var p = new Properties
-      p.setProperty(PROP_KEY_PORT, port);
+      p.setProperty(PROP_KEY_PORT, port)
       Stoppable.useServer(createServer) { server =>
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             assertEquals(server.getPort, port.toInt)
          }
 
          port = "${" + m.getName + "-myport:567}"
          p = new Properties
-         p.setProperty(PROP_KEY_PORT, port);
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         p.setProperty(PROP_KEY_PORT, port)
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             assertEquals(server.getPort, 567)
          }
 
          port = "${" + m.getName + "-myport:891}"
-         System.setProperty(m.getName + "-myport", "234");
+         System.setProperty(m.getName + "-myport", "234")
          p = new Properties
-         p.setProperty(PROP_KEY_PORT, port);
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         p.setProperty(PROP_KEY_PORT, port)
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             assertEquals(server.getPort, 234)
          }
 
          port = "${" + m.getName + "-otherport}"
          p = new Properties
-         p.setProperty(PROP_KEY_PORT, port);
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         p.setProperty(PROP_KEY_PORT, port)
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             assertEquals(server.getPort, 12345)
          }
 
          port = "${" + m.getName + "-otherport}"
-         System.setProperty(m.getName + "-otherport", "5567");
+         System.setProperty(m.getName + "-otherport", "5567")
          p = new Properties
-         p.setProperty(PROP_KEY_PORT, port);
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         p.setProperty(PROP_KEY_PORT, port)
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             assertEquals(server.getPort, 5567)
          }
@@ -171,9 +172,9 @@ class AbstractProtocolServerTest {
    def testTcpNoDelayPropertySubstitution(m: Method) {
       var tcpNoDelay = "true"
       var p = new Properties
-      p.setProperty(PROP_KEY_TCP_NO_DELAY, tcpNoDelay);
+      p.setProperty(PROP_KEY_TCP_NO_DELAY, tcpNoDelay)
       Stoppable.useServer(createServer) { server =>
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             assertEquals(server.asInstanceOf[MockProtocolServer]
                     .tcpNoDelay, tcpNoDelay.toBoolean)
@@ -181,35 +182,35 @@ class AbstractProtocolServerTest {
 
          tcpNoDelay = "${" + m.getName + "-mytcpnodelay:false}"
          p = new Properties
-         p.setProperty(PROP_KEY_TCP_NO_DELAY, tcpNoDelay);
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         p.setProperty(PROP_KEY_TCP_NO_DELAY, tcpNoDelay)
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             assertEquals(server.asInstanceOf[MockProtocolServer].tcpNoDelay, false)
          }
 
          tcpNoDelay = "${" + m.getName + "-mytcpnodelay:true}"
-         System.setProperty(m.getName + "-mytcpnodelay", "false");
+         System.setProperty(m.getName + "-mytcpnodelay", "false")
          p = new Properties
-         p.setProperty(PROP_KEY_TCP_NO_DELAY, tcpNoDelay);
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         p.setProperty(PROP_KEY_TCP_NO_DELAY, tcpNoDelay)
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             assertEquals(server.asInstanceOf[MockProtocolServer].tcpNoDelay, false)
          }
 
          tcpNoDelay = "${" + m.getName + "-othertcpnodelay}"
          p = new Properties
-         p.setProperty(PROP_KEY_TCP_NO_DELAY, tcpNoDelay);
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         p.setProperty(PROP_KEY_TCP_NO_DELAY, tcpNoDelay)
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             // Boolean.parseBoolean() returning false to anything other than true, no exception thrown
             assertEquals(server.asInstanceOf[MockProtocolServer].tcpNoDelay, false)
          }
 
          tcpNoDelay = "${" + m.getName + "-othertcpnodelay}"
-         System.setProperty(m.getName + "-othertcpnodelay", "true");
+         System.setProperty(m.getName + "-othertcpnodelay", "true")
          p = new Properties
-         p.setProperty(PROP_KEY_PORT, tcpNoDelay);
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         p.setProperty(PROP_KEY_PORT, tcpNoDelay)
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
             assertEquals(server.asInstanceOf[MockProtocolServer].tcpNoDelay, true)
          }
@@ -218,7 +219,7 @@ class AbstractProtocolServerTest {
 
    private def expectIllegalArgument(p: Properties, server: ProtocolServer) {
       try {
-         Stoppable.useCacheManager(new DefaultCacheManager()) { cm =>
+         Stoppable.useCacheManager(TestCacheManagerFactory.createCacheManager) { cm =>
             server.start(p, cm)
          }
       } catch {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2290
- Make tests more resilient to failures.
- Make sure all cache managers are created via the factory.
- Use withCacheManager() where possible to provide better guarantees that cache manager will be closed properly.
- Added a test for the cache MBean registration leak.
