### PR TITLE
ISPN-2249 Fix and re-enable HotRod tests that were failing because of NBST

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
@@ -60,8 +60,7 @@ import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.*;
  * @author Mircea.Markus@jboss.com
  * @since 4.1
  */
-@Test(groups = "functional", testName = "client.hotrod.CSAIntegrationTest",
-      enabled = false, description = "Temporary disabled : https://issues.jboss.org/browse/ISPN-2249")
+@Test(groups = "functional", testName = "client.hotrod.CSAIntegrationTest")
 public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
 
    private HotRodServer hotRodServer1;

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRod11DistributionTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRod11DistributionTest.scala
@@ -35,8 +35,7 @@ import org.testng.annotations.Test
  * @author Galder Zamarreño
  * @since 5.1
  */
-@Test(groups = Array("functional"), testName = "server.hotrod.HotRod11DistributionTest", enabled = false,
-      description = "Temporary disabled : https://issues.jboss.org/browse/ISPN-2249")
+@Test(groups = Array("functional"), testName = "server.hotrod.HotRod11DistributionTest")
 class HotRod11DistributionTest extends HotRodMultiNodeTest {
 
    override protected def cacheName = "distributedVersion11"

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDistributionTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDistributionTest.scala
@@ -42,8 +42,7 @@ import scala.collection.JavaConversions._
  * @author Galder Zamarreño
  * @since 4.1
  */
-@Test(groups = Array("functional"), testName = "server.hotrod.HotRodDistributionTest", enabled = false,
-      description = "Temporary disabled : https://issues.jboss.org/browse/ISPN-2249")
+@Test(groups = Array("functional"), testName = "server.hotrod.HotRodDistributionTest")
 class HotRodDistributionTest extends HotRodMultiNodeTest {
 
    override protected def cacheName: String = "hotRodDistSync"

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodReplicationTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodReplicationTest.scala
@@ -177,7 +177,7 @@ class HotRodReplicationTest extends HotRodMultiNodeTest {
       assertEquals(hashTopologyResp.members.size, 2)
       servers.map(_.getAddress).foreach(
          addr => assertTrue(hashTopologyResp.members.exists(_ == addr)))
-      assertHashIds(hashTopologyResp.hashIds, servers, cacheName)
+      assertReplicatedHashIds(hashTopologyResp.hashIds, servers, cacheName)
 
       assertEquals(hashTopologyResp.numOwners, 0)
       assertEquals(hashTopologyResp.hashFunction, 0)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2249

HotRodTestingUtil was trying to ignore the order of the owners for each
segment, but it didn't work properly.

The others were intermittent failures that I believe were fixed with
ISPN-2262.
