### PR TITLE
ISPN-2338 Transactions should be transferred during rehashing regardless...

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -182,12 +182,11 @@ public class StateConsumerImpl implements StateConsumer {
       stateTransferLock.setTopologyId(cacheTopology.getTopologyId());
 
       try {
-         Set<Integer> addedSegments = null;
+         Set<Integer> addedSegments;
          if (previousCh == null) {
             // we start fresh, without any data, so we need to pull everything we own according to writeCh
-            if (fetchEnabled) {
-               addedSegments = getOwnedSegments(cacheTopology.getWriteConsistentHash());
-            }
+
+            addedSegments = getOwnedSegments(cacheTopology.getWriteConsistentHash());
          } else {
             Set<Integer> previousSegments = getOwnedSegments(previousCh);
             Set<Integer> newSegments = getOwnedSegments(cacheTopology.getWriteConsistentHash());
@@ -203,22 +202,20 @@ public class StateConsumerImpl implements StateConsumer {
             }
             discardSegments(removedSegments);
 
-            if (fetchEnabled) {
-               Set<Integer> currentSegments = getOwnedSegments(cacheTopology.getReadConsistentHash());
-               addedSegments = new HashSet<Integer>(newSegments);
-               addedSegments.removeAll(currentSegments);
+            Set<Integer> currentSegments = getOwnedSegments(cacheTopology.getReadConsistentHash());
+            addedSegments = new HashSet<Integer>(newSegments);
+            addedSegments.removeAll(currentSegments);
 
-               // check if any of the existing transfers should be restarted from a different source because the initial source is no longer a member
-               Set<Address> members = new HashSet<Address>(cacheTopology.getReadConsistentHash().getMembers());
-               synchronized (this) {
-                  for (Address source : transfersBySource.keySet()) {
-                     if (!members.contains(source)) {
-                        List<InboundTransferTask> inboundTransfers = transfersBySource.remove(source);
-                        if (inboundTransfers != null) {
-                           for (InboundTransferTask inboundTransfer : inboundTransfers) {
-                              // these segments will be restarted if they are still in new write CH
-                              transfersBySegment.keySet().removeAll(inboundTransfer.getSegments());
-                           }
+            // check if any of the existing transfers should be restarted from a different source because the initial source is no longer a member
+            Set<Address> members = new HashSet<Address>(cacheTopology.getReadConsistentHash().getMembers());
+            synchronized (this) {
+               for (Address source : transfersBySource.keySet()) {
+                  if (!members.contains(source)) {
+                     List<InboundTransferTask> inboundTransfers = transfersBySource.remove(source);
+                     if (inboundTransfers != null) {
+                        for (InboundTransferTask inboundTransfer : inboundTransfers) {
+                           // these segments will be restarted if they are still in new write CH
+                           transfersBySegment.keySet().removeAll(inboundTransfer.getSegments());
                         }
                      }
                   }
@@ -431,11 +428,15 @@ public class StateConsumerImpl implements StateConsumer {
             }
 
             // if requesting the segments fails we need to retry from another source
-            if (!inboundTransfer.requestSegments()) {
-               log.errorf("Failed to request segments %s from node %s (node will be blacklisted)", segmentsFromSource, source);
-               failedSegments.addAll(segmentsFromSource);
-               blacklistedSources.add(source);
-               removeTransfer(inboundTransfer);  // will be retried from another source
+            if (fetchEnabled) {
+               if (!inboundTransfer.requestSegments()) {
+                  log.errorf("Failed to request segments %s from node %s (node will be blacklisted)", segmentsFromSource, source);
+                  failedSegments.addAll(segmentsFromSource);
+                  blacklistedSources.add(source);
+                  removeTransfer(inboundTransfer);  // will be retried from another source
+               }
+            } else {
+               removeTransfer(inboundTransfer);  // we consider it complete
             }
          }
 

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
@@ -124,6 +124,7 @@ public class StateTransferInterceptor extends CommandInterceptor {   //todo [ani
                prepareCommand = commandFactory.buildPrepareCommand(ctx.getGlobalTransaction(), ctx.getModifications(), false);
             }
             commandFactory.initializeReplicableCommand(prepareCommand, true);
+            prepareCommand.setOrigin(ctx.getOrigin());
             prepareCommand.perform(null);
          }
       }

--- a/core/src/test/java/org/infinispan/tx/ParticipantFailsAfterPrepareTest.java
+++ b/core/src/test/java/org/infinispan/tx/ParticipantFailsAfterPrepareTest.java
@@ -43,7 +43,7 @@ import static org.testng.Assert.assertEquals;
 /**
  * @author Mircea Markus
  */
-@Test(groups = "functional", testName = "tx.ParticipantFailsAfterPrepareTest", enabled = false, description = "Temporary disabled : https://issues.jboss.org/browse/ISPN-2249")
+@Test(groups = "functional", testName = "tx.ParticipantFailsAfterPrepareTest")
 public class ParticipantFailsAfterPrepareTest extends MultipleCacheManagersTest {
 
    @Override
@@ -73,7 +73,7 @@ public class ParticipantFailsAfterPrepareTest extends MultipleCacheManagersTest 
          }
       }
 
-      System.out.println("indexToKill = " + indexToKill);
+      log.debug("indexToKill = " + indexToKill);
       assert indexToKill > 0;
 
       Address toKill = address(indexToKill);
@@ -83,6 +83,7 @@ public class ParticipantFailsAfterPrepareTest extends MultipleCacheManagersTest 
       participants = getAliveParticipants(indexToKill);
 
       TestingUtil.blockUntilViewsReceived(60000, false, participants);
+      TestingUtil.waitForRehashToComplete(participants);
 
       //one of the participants must not have a prepare on it
       boolean noLocks = false;


### PR DESCRIPTION
... of fetchInMemoryState or isFetchPersistentState being false
- Fix ParticipantFailsAfterPrepareTest: TestingUtil.waitForRehashToComplete(..) is required after killing a participant
- Fix NPE originating in StateTransferInterceptorImpl.visitCommitCommand because of null origin of the created PrepareCommand
- Fix StateConsumerImpl to request transactions even if it does not request segments

JIRA: https://issues.jboss.org/browse/ISPN-2338
