### PR TITLE
ISPN-2311 Make Loaders and Stores more fluent

### DIFF
--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/AbstractJdbcCacheStoreConfiguration.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/AbstractJdbcCacheStoreConfiguration.java
@@ -18,56 +18,26 @@
  */
 package org.infinispan.loaders.jdbc.configuration;
 
-import org.infinispan.configuration.cache.AbstractLockSupportCacheStoreConfiguration;
+import org.infinispan.configuration.cache.AbstractLockSupportStoreConfiguration;
 import org.infinispan.configuration.cache.AsyncStoreConfiguration;
 import org.infinispan.configuration.cache.SingletonStoreConfiguration;
 import org.infinispan.util.TypedProperties;
 
-public abstract class AbstractJdbcCacheStoreConfiguration extends AbstractLockSupportCacheStoreConfiguration {
+public abstract class AbstractJdbcCacheStoreConfiguration extends AbstractLockSupportStoreConfiguration {
 
-   private final String driverClass;
-   private final String connectionUrl;
-   private final String userName;
-   private final String password;
-   private final String connectionFactoryClass;
-   private final String datasource;
+   private final ConnectionFactoryConfiguration connectionFactory;
 
-   AbstractJdbcCacheStoreConfiguration(String driverClass, String connectionUrl, String userName, String password,
-         String connectionFactoryClass, String datasource, long lockAcquistionTimeout,
+   AbstractJdbcCacheStoreConfiguration(ConnectionFactoryConfiguration connectionFactory, long lockAcquistionTimeout,
          int lockConcurrencyLevel, boolean purgeOnStartup, boolean purgeSynchronously, int purgerThreads,
          boolean fetchPersistentState, boolean ignoreModifications, TypedProperties properties,
          AsyncStoreConfiguration async, SingletonStoreConfiguration singletonStore) {
       super(lockAcquistionTimeout, lockConcurrencyLevel, purgeOnStartup, purgeSynchronously, purgerThreads,
             fetchPersistentState, ignoreModifications, properties, async, singletonStore);
-      this.driverClass = driverClass;
-      this.connectionUrl = connectionUrl;
-      this.userName = userName;
-      this.password = password;
-      this.connectionFactoryClass = connectionFactoryClass;
-      this.datasource = datasource;
+      this.connectionFactory = connectionFactory;
    }
 
-   public String driverClass() {
-      return driverClass;
+   public ConnectionFactoryConfiguration connectionFactory() {
+      return connectionFactory;
    }
 
-   public String connectionUrl() {
-      return connectionUrl;
-   }
-
-   public String userName() {
-      return userName;
-   }
-
-   public String password() {
-      return password;
-   }
-
-   public String connectionFactoryClass() {
-      return connectionFactoryClass;
-   }
-
-   public String datasource() {
-      return datasource;
-   }
 }

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/AbstractJdbcCacheStoreConfigurationBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/AbstractJdbcCacheStoreConfigurationBuilder.java
@@ -18,109 +18,59 @@
  */
 package org.infinispan.loaders.jdbc.configuration;
 
-import java.sql.Driver;
-
+import java.lang.reflect.Constructor;
 import org.infinispan.config.ConfigurationException;
-import org.infinispan.configuration.cache.AbstractLockSupportCacheStoreConfigurationBuilder;
+import org.infinispan.configuration.ConfigurationUtils;
+import org.infinispan.configuration.cache.AbstractLockSupportStoreConfigurationBuilder;
 import org.infinispan.configuration.cache.LoadersConfigurationBuilder;
 import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactory;
-import org.infinispan.loaders.jdbc.connectionfactory.ManagedConnectionFactory;
-import org.infinispan.loaders.jdbc.connectionfactory.PooledConnectionFactory;
 
-public abstract class AbstractJdbcCacheStoreConfigurationBuilder<T extends AbstractJdbcCacheStoreConfiguration, S extends AbstractJdbcCacheStoreConfigurationBuilder<T, S>>
-      extends AbstractLockSupportCacheStoreConfigurationBuilder<T, S> {
-   protected String driverClass;
-   protected String connectionUrl;
-   protected String username;
-   protected String password;
-   protected String datasource;
-   protected String connectionFactoryClass;
+public abstract class AbstractJdbcCacheStoreConfigurationBuilder<T extends AbstractJdbcCacheStoreConfiguration, S extends AbstractJdbcCacheStoreConfigurationBuilder<T, S>> extends
+      AbstractLockSupportStoreConfigurationBuilder<T, S> implements JdbcCacheStoreConfigurationChildBuilder<S> {
+
+   protected ConnectionFactoryConfigurationBuilder<ConnectionFactoryConfiguration> connectionFactory;
 
    public AbstractJdbcCacheStoreConfigurationBuilder(LoadersConfigurationBuilder builder) {
       super(builder);
    }
 
-   /**
-    * The class name of a JDBC driver to use with the built-in connection pooling
-    */
-   public S driverClass(String driverClass) {
-      this.driverClass = driverClass;
-      return self();
+   @Override
+   public PooledConnectionFactoryConfigurationBuilder<S> connectionPool() {
+      return connectionFactory(PooledConnectionFactoryConfigurationBuilder.class);
+   }
+
+   @Override
+   public ManagedConnectionFactoryConfigurationBuilder<S> dataSource() {
+      return connectionFactory(ManagedConnectionFactoryConfigurationBuilder.class);
+   }
+
+   @Override
+   public SimpleConnectionFactoryConfigurationBuilder<S> simpleConnection() {
+      return connectionFactory(SimpleConnectionFactoryConfigurationBuilder.class);
    }
 
    /**
-    * The class of JDBC driver to use with the built-in connection pooling
+    * Use the specified {@link ConnectionFactory} to handle connection to the database
     */
-   public S driverClass(Class<? extends Driver> klass) {
-      this.driverClass = klass.getName();
-      return self();
-   }
-
-   /**
-    * The JDBC URL to use with the built-in connection pooling
-    */
-   public S connectionUrl(String connectionUrl) {
-      this.connectionUrl = connectionUrl;
-      return self();
-   }
-
-   /**
-    * The username used to connect with the built-in connection pooling
-    */
-   public S username(String userName) {
-      this.username = userName;
-      return self();
-   }
-
-   /**
-    * The password used to connect with the built-in connection pooling
-    */
-   public S password(String password) {
-      this.password = password;
-      return self();
-   }
-
-   /**
-    * The JNDI name of a container-managed datasource
-    */
-   public S datasource(String datasource) {
-      this.datasource = datasource;
-      return self();
-   }
-
-   /**
-    * The class name of a {@link ConnectionFactory} to use to handle connections to a database. If
-    * unspecified, a suitable one will be chosen based on the other parametes (i.e.
-    * {@link ManagedConnectionFactory} if a datasource is specified or
-    * {@link PooledConnectionFactory} if a connectionUrl is specified)
-    */
-   public S connectionFactoryClass(String connectionFactoryClass) {
-      this.connectionFactoryClass = connectionFactoryClass;
-      return self();
-   }
-
-   /**
-    * The class of a {@link ConnectionFactory} to use to handle connections to a database. If
-    * unspecified, a suitable one will be chosen based on the other parametes (i.e.
-    * {@link ManagedConnectionFactory} if a datasource is specified or
-    * {@link PooledConnectionFactory} if a connectionUrl is specified)
-    */
-   public S connectionFactoryClass(Class<? extends ConnectionFactory> klass) {
-      this.connectionFactoryClass = klass.getName();
-      return self();
+   public <C extends ConnectionFactoryConfigurationBuilder<?>> C connectionFactory(Class<C> klass) {
+      if (connectionFactory != null) {
+         throw new IllegalStateException("A ConnectionFactory has already been configured for this store");
+      }
+      try {
+         Constructor<C> constructor = klass.getDeclaredConstructor(AbstractJdbcCacheStoreConfigurationBuilder.class);
+         C builder = constructor.newInstance(this);
+         this.connectionFactory = (ConnectionFactoryConfigurationBuilder<ConnectionFactoryConfiguration>) builder;
+         return builder;
+      } catch (Exception e) {
+         throw new ConfigurationException("Could not instantiate loader configuration builder '" + klass.getName() + "'", e);
+      }
    }
 
    @Override
    public void validate() {
       super.validate();
-      if (datasource != null && connectionUrl != null) {
-         throw new ConfigurationException("Cannot specify both a datasource and a connection URL");
-      }
-      if (connectionFactoryClass == null) {
-         if (datasource != null)
-            connectionFactoryClass = ManagedConnectionFactory.class.getName();
-         else
-            connectionFactoryClass = PooledConnectionFactory.class.getName();
+      if (connectionFactory == null) {
+         throw new ConfigurationException("A ConnectionFactory has not been specified for the Store");
       }
    }
 
@@ -130,12 +80,9 @@ public abstract class AbstractJdbcCacheStoreConfigurationBuilder<T extends Abstr
     * open a bug and add the ID here
     */
    protected S readInternal(AbstractJdbcCacheStoreConfiguration template) {
-      this.connectionFactoryClass(template.connectionFactoryClass());
-      this.connectionUrl(template.connectionUrl());
-      this.datasource(template.datasource());
-      this.driverClass(template.driverClass());
-      this.password(template.password());
-      this.username(template.userName());
+      Class<? extends ConnectionFactoryConfigurationBuilder<?>> cfb = (Class<? extends ConnectionFactoryConfigurationBuilder<?>>) ConfigurationUtils.builderFor(template.connectionFactory());
+      connectionFactory(cfb);
+      connectionFactory.read(template.connectionFactory());
 
       // LockSupportStore-specific configuration
       lockAcquistionTimeout = template.lockAcquistionTimeout();

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/AbstractJdbcCacheStoreConfigurationChildBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/AbstractJdbcCacheStoreConfigurationChildBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.loaders.jdbc.configuration;
+
+import org.infinispan.configuration.cache.AbstractLockSupportStoreConfigurationChildBuilder;
+
+/**
+ * AbstractJdbcCacheStoreConfigurationChildBuilder.
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public abstract class AbstractJdbcCacheStoreConfigurationChildBuilder<S extends AbstractJdbcCacheStoreConfigurationBuilder<?, S>>
+      extends AbstractLockSupportStoreConfigurationChildBuilder<S> implements JdbcCacheStoreConfigurationChildBuilder<S> {
+
+   private AbstractJdbcCacheStoreConfigurationBuilder<?, S> builder;
+
+   protected AbstractJdbcCacheStoreConfigurationChildBuilder(AbstractJdbcCacheStoreConfigurationBuilder<?, S> builder) {
+      super(builder);
+      this.builder = builder;
+   }
+
+   @Override
+   public PooledConnectionFactoryConfigurationBuilder<S> connectionPool() {
+      return builder.connectionPool();
+   }
+
+   @Override
+   public ManagedConnectionFactoryConfigurationBuilder<S> dataSource() {
+      return builder.dataSource();
+   }
+
+   @Override
+   public SimpleConnectionFactoryConfigurationBuilder<S> simpleConnection() {
+      return builder.simpleConnection();
+   }
+
+}

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/Attribute.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/Attribute.java
@@ -32,10 +32,9 @@ public enum Attribute {
    UNKNOWN(null),
 
    BATCH_SIZE("batchSize"),
-   CONNECTION_FACTORY_CLASS("connectionFactoryClass"),
    CONNECTION_URL("connectionUrl"),
    CREATE_ON_START("createOnStart"),
-   DATASOURCE("datasource"),
+   JNDI_URL("jndiUrl"),
    DRIVER_CLASS("driverClass"),
    DROP_ON_EXIT("dropOnExit"),
    FETCH_SIZE("fetchSize"),

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/ConnectionFactoryConfiguration.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/ConnectionFactoryConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.loaders.jdbc.configuration;
+
+import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactory;
+
+/**
+ * ConnectionFactoryConfiguration.
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public interface ConnectionFactoryConfiguration {
+   Class<? extends ConnectionFactory> connectionFactoryClass();
+}

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/ConnectionFactoryConfigurationBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/ConnectionFactoryConfigurationBuilder.java
@@ -16,23 +16,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  * MA  02110-1301, USA.
  */
-package org.infinispan.configuration.cache;
+package org.infinispan.loaders.jdbc.configuration;
 
-import java.util.concurrent.TimeUnit;
+import org.infinispan.configuration.Builder;
 
-/**
- * LockSupportCacheStoreConfigurationBuilder is an interface which should be implemented by all cache store builders which support locking
- *
- * @author Tristan Tarrant
- * @since 5.2
- */
-public interface LockSupportCacheStoreConfigurationBuilder<T extends StoreConfiguration, S extends LockSupportCacheStoreConfigurationBuilder<T, S>> extends StoreConfigurationBuilder<T, S> {
-
-   S lockAcquistionTimeout(long lockAcquistionTimeout);
-
-   S lockAcquistionTimeout(
-         long lockAcquistionTimeout, TimeUnit unit);
-
-   S lockConcurrencyLevel(int lockConcurrencyLevel);
+public interface ConnectionFactoryConfigurationBuilder<T extends ConnectionFactoryConfiguration> extends Builder<T> {
 
 }

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/Element.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/Element.java
@@ -39,6 +39,10 @@ public enum Element {
     BINARY_KEYED_JDBC_STORE("binaryKeyedJdbcStore"),
     MIXED_KEYED_JDBC_STORE("mixedKeyedJdbcStore"),
 
+    CONNECTION_POOL("connectionPool"),
+    DATA_SOURCE("dataSource"),
+    SIMPLE_CONNECTION("simpleConnection"),
+
     BINARY_KEYED_TABLE("binaryKeyedTable"),
     STRING_KEYED_TABLE("stringKeyedTable"),
 

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcBinaryCacheStoreConfiguration.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcBinaryCacheStoreConfiguration.java
@@ -27,18 +27,15 @@ import org.infinispan.loaders.jdbc.binary.JdbcBinaryCacheStoreConfig;
 import org.infinispan.util.TypedProperties;
 
 @BuiltBy(JdbcBinaryCacheStoreConfigurationBuilder.class)
-public class JdbcBinaryCacheStoreConfiguration extends AbstractJdbcCacheStoreConfiguration implements LegacyLoaderAdapter<JdbcBinaryCacheStoreConfig>{
+public class JdbcBinaryCacheStoreConfiguration extends AbstractJdbcCacheStoreConfiguration implements LegacyLoaderAdapter<JdbcBinaryCacheStoreConfig> {
 
    private final TableManipulationConfiguration table;
 
-   JdbcBinaryCacheStoreConfiguration(TableManipulationConfiguration table, String driverClass,
-         String connectionUrl, String userName, String password, String connectionFactoryClass,
-         String datasourceJndiLocation, long lockAcquistionTimeout, int lockConcurrencyLevel, boolean purgeOnStartup,
-         boolean purgeSynchronously, int purgerThreads, boolean fetchPersistentState, boolean ignoreModifications,
-         TypedProperties properties, AsyncStoreConfiguration async, SingletonStoreConfiguration singletonStore) {
-      super(driverClass, connectionUrl, userName, password, connectionFactoryClass, datasourceJndiLocation,
-            lockAcquistionTimeout, lockConcurrencyLevel, purgeOnStartup, purgeSynchronously, purgerThreads,
-            fetchPersistentState, ignoreModifications, properties, async, singletonStore);
+   JdbcBinaryCacheStoreConfiguration(TableManipulationConfiguration table, ConnectionFactoryConfiguration connectionFactory, long lockAcquistionTimeout, int lockConcurrencyLevel,
+         boolean purgeOnStartup, boolean purgeSynchronously, int purgerThreads, boolean fetchPersistentState, boolean ignoreModifications, TypedProperties properties,
+         AsyncStoreConfiguration async, SingletonStoreConfiguration singletonStore) {
+      super(connectionFactory, lockAcquistionTimeout, lockConcurrencyLevel, purgeOnStartup, purgeSynchronously, purgerThreads, fetchPersistentState, ignoreModifications,
+            properties, async, singletonStore);
       this.table = table;
    }
 
@@ -52,13 +49,8 @@ public class JdbcBinaryCacheStoreConfiguration extends AbstractJdbcCacheStoreCon
       // StoreConfiguration
       LegacyConfigurationAdaptor.adapt(this, config);
 
-      // AbstractJdbcCacheStoreConfiguration
-      config.setConnectionFactoryClass(connectionFactoryClass());
-      config.setConnectionUrl(connectionUrl());
-      config.setDatasourceJndiLocation(datasource());
-      config.setDriverClass(driverClass());
-      config.setUserName(userName());
-      config.setPassword(password());
+      // ConnectionFactory
+      ((LegacyConnectionFactoryAdaptor) connectionFactory()).adapt(config);
 
       // TableManipulation
       config.setCreateTableOnStart(table.createOnStart());
@@ -79,14 +71,9 @@ public class JdbcBinaryCacheStoreConfiguration extends AbstractJdbcCacheStoreCon
 
    @Override
    public String toString() {
-      return "JdbcBinaryBasedCacheStoreConfiguration [table=" + table + ", driverClass()=" + driverClass()
-            + ", connectionUrl()=" + connectionUrl() + ", userName()=" + userName() + ", password()=" + password()
-            + ", connectionFactoryClass()=" + connectionFactoryClass() + ", datasourceJndiLocation()="
-            + datasource() + ", lockAcquistionTimeout()=" + lockAcquistionTimeout()
-            + ", lockConcurrencyLevel()=" + lockConcurrencyLevel() + ", async()=" + async() + ", singletonStore()="
-            + singletonStore() + ", purgeOnStartup()=" + purgeOnStartup() + ", purgeSynchronously()="
-            + purgeSynchronously() + ", purgerThreads()=" + purgerThreads() + ", fetchPersistentState()="
-            + fetchPersistentState() + ", ignoreModifications()=" + ignoreModifications() + ", properties()="
-            + properties() + "]";
+      return "JdbcBinaryCacheStoreConfiguration [table=" + table + ", connectionFactory()=" + connectionFactory() + ", lockAcquistionTimeout()=" + lockAcquistionTimeout()
+            + ", lockConcurrencyLevel()=" + lockConcurrencyLevel() + ", async()=" + async() + ", singletonStore()=" + singletonStore() + ", purgeOnStartup()=" + purgeOnStartup()
+            + ", purgeSynchronously()=" + purgeSynchronously() + ", purgerThreads()=" + purgerThreads() + ", fetchPersistentState()=" + fetchPersistentState()
+            + ", ignoreModifications()=" + ignoreModifications() + ", properties()=" + properties() + "]";
    }
 }

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcBinaryCacheStoreConfigurationBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcBinaryCacheStoreConfigurationBuilder.java
@@ -23,11 +23,11 @@ import org.infinispan.util.TypedProperties;
 
 public class JdbcBinaryCacheStoreConfigurationBuilder extends
       AbstractJdbcCacheStoreConfigurationBuilder<JdbcBinaryCacheStoreConfiguration, JdbcBinaryCacheStoreConfigurationBuilder> {
-   protected final TableManipulationConfigurationBuilder table;
+   protected final BinaryTableManipulationConfigurationBuilder table;
 
    public JdbcBinaryCacheStoreConfigurationBuilder(LoadersConfigurationBuilder builder) {
       super(builder);
-      this.table = new TableManipulationConfigurationBuilder(this);
+      this.table = new BinaryTableManipulationConfigurationBuilder(this);
    }
 
    @Override
@@ -38,7 +38,7 @@ public class JdbcBinaryCacheStoreConfigurationBuilder extends
    /**
     * Allows configuration of table-specific parameters such as column names and types
     */
-   public TableManipulationConfigurationBuilder table() {
+   public BinaryTableManipulationConfigurationBuilder table() {
       return table;
    }
 
@@ -49,10 +49,8 @@ public class JdbcBinaryCacheStoreConfigurationBuilder extends
 
    @Override
    public JdbcBinaryCacheStoreConfiguration create() {
-      return new JdbcBinaryCacheStoreConfiguration(table.create(), driverClass, connectionUrl, username, password,
-            connectionFactoryClass, datasource, lockAcquistionTimeout, lockConcurrencyLevel,
-            purgeOnStartup, purgeSynchronously, purgerThreads, fetchPersistentState, ignoreModifications,
-            TypedProperties.toTypedProperties(properties), async.create(), singletonStore.create());
+      return new JdbcBinaryCacheStoreConfiguration(table.create(), connectionFactory.create(), lockAcquistionTimeout, lockConcurrencyLevel, purgeOnStartup, purgeSynchronously,
+            purgerThreads, fetchPersistentState, ignoreModifications, TypedProperties.toTypedProperties(properties), async.create(), singletonStore.create());
    }
 
    @Override
@@ -61,5 +59,28 @@ public class JdbcBinaryCacheStoreConfigurationBuilder extends
       this.table.read(template.table());
 
       return this;
+   }
+
+   public class BinaryTableManipulationConfigurationBuilder extends
+         TableManipulationConfigurationBuilder<JdbcBinaryCacheStoreConfigurationBuilder, BinaryTableManipulationConfigurationBuilder> {
+
+      BinaryTableManipulationConfigurationBuilder(AbstractJdbcCacheStoreConfigurationBuilder<?, JdbcBinaryCacheStoreConfigurationBuilder> builder) {
+         super(builder);
+      }
+
+      @Override
+      public PooledConnectionFactoryConfigurationBuilder<JdbcBinaryCacheStoreConfigurationBuilder> connectionPool() {
+         return JdbcBinaryCacheStoreConfigurationBuilder.this.connectionPool();
+      }
+
+      @Override
+      public ManagedConnectionFactoryConfigurationBuilder<JdbcBinaryCacheStoreConfigurationBuilder> dataSource() {
+         return JdbcBinaryCacheStoreConfigurationBuilder.this.dataSource();
+      }
+
+      @Override
+      public BinaryTableManipulationConfigurationBuilder self() {
+         return this;
+      }
    }
 }

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcCacheStoreConfigurationChildBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcCacheStoreConfigurationChildBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.loaders.jdbc.configuration;
+
+import org.infinispan.configuration.cache.LockSupportStoreConfigurationChildBuilder;
+
+/**
+ * JdbcCacheStoreConfigurationChildBuilder.
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public interface JdbcCacheStoreConfigurationChildBuilder<S extends AbstractJdbcCacheStoreConfigurationBuilder<?, S>> extends LockSupportStoreConfigurationChildBuilder<S> {
+
+   /**
+    * Configures a connection pool to be used by this JDBC Cache Store to handle connections to the database
+    */
+   PooledConnectionFactoryConfigurationBuilder<S> connectionPool();
+
+   /**
+    * Configures a DataSource to be used by this JDBC Cache Store to handle connections to the database
+    */
+   ManagedConnectionFactoryConfigurationBuilder<S> dataSource();
+
+
+   /**
+    * Configures this JDBC Cache Store to use a single connection to the database
+    */
+   SimpleConnectionFactoryConfigurationBuilder<S> simpleConnection();
+
+   /**
+    * Use the specified {@link ConnectionFactory} to handle connections to the database
+    */
+   //<C extends ConnectionFactoryConfigurationBuilder<?>> C connectionFactory(Class<C> klass);
+
+}

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcCacheStoreConfigurationParser52.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcCacheStoreConfigurationParser52.java
@@ -95,7 +95,7 @@ public class JdbcCacheStoreConfigurationParser52 implements ConfigurationParser<
             break;
          }
          default: {
-            Parser52.parseCommonStoreChildren(reader, builder);
+            parseCommonJdbcStoreElements(reader, element, builder);
             break;
          }
          }
@@ -116,7 +116,7 @@ public class JdbcCacheStoreConfigurationParser52 implements ConfigurationParser<
             break;
          }
          default: {
-            Parser52.parseCommonStoreChildren(reader, builder);
+            parseCommonJdbcStoreElements(reader, element, builder);
             break;
          }
          }
@@ -124,19 +124,49 @@ public class JdbcCacheStoreConfigurationParser52 implements ConfigurationParser<
       loadersBuilder.addStore(builder);
    }
 
-   private void parseCommonJdbcStoreAttributes(XMLExtendedStreamReader reader,
-         AbstractJdbcCacheStoreConfigurationBuilder<?, ?> builder) throws XMLStreamException {
+   private void parseCommonJdbcStoreElements(XMLExtendedStreamReader reader, Element element, AbstractJdbcCacheStoreConfigurationBuilder<?, ?> builder) throws XMLStreamException {
+      switch (element) {
+      case CONNECTION_POOL: {
+         parseConnectionPoolAttributes(reader, builder.connectionPool());
+         break;
+      }
+      case DATA_SOURCE: {
+         parseDataSourceAttributes(reader, builder.dataSource());
+         break;
+      }
+      case SIMPLE_CONNECTION: {
+         parseSimpleConnectionAttributes(reader, builder.simpleConnection());
+         break;
+      }
+      default: {
+         Parser52.parseCommonStoreChildren(reader, builder);
+         break;
+      }
+      }
+   }
+
+   private void parseCommonJdbcStoreAttributes(XMLExtendedStreamReader reader, AbstractJdbcCacheStoreConfigurationBuilder<?, ?> builder) throws XMLStreamException {
+      for (int i = 0; i < reader.getAttributeCount(); i++) {
+         Parser52.parseCommonStoreAttributes(reader, i, builder);
+      }
+   }
+
+   private void parseDataSourceAttributes(XMLExtendedStreamReader reader,
+         ManagedConnectionFactoryConfigurationBuilder<?> builder) throws XMLStreamException {
+      String jndiUrl = ParseUtils.requireSingleAttribute(reader, Attribute.JNDI_URL.getLocalName());
+      builder.jndiUrl(jndiUrl);
+      ParseUtils.requireNoContent(reader);
+   }
+
+   private void parseConnectionPoolAttributes(XMLExtendedStreamReader reader,
+         PooledConnectionFactoryConfigurationBuilder<?> builder) throws XMLStreamException {
       for (int i = 0; i < reader.getAttributeCount(); i++) {
          ParseUtils.requireNoNamespaceAttribute(reader, i);
          String value = replaceProperties(reader.getAttributeValue(i));
          Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
          switch (attribute) {
-         case CONNECTION_FACTORY_CLASS: {
-            builder.connectionFactoryClass(value);
-            break;
-         }
-         case DATASOURCE: {
-            builder.datasource(value);
+         case CONNECTION_URL: {
+            builder.driverClass(value);
             break;
          }
          case DRIVER_CLASS: {
@@ -152,11 +182,42 @@ public class JdbcCacheStoreConfigurationParser52 implements ConfigurationParser<
             break;
          }
          default: {
-            Parser52.parseCommonStoreAttributes(reader, i, builder);
-            break;
+            throw ParseUtils.unexpectedAttribute(reader, i);
          }
          }
       }
+      ParseUtils.requireNoContent(reader);
+   }
+
+   private void parseSimpleConnectionAttributes(XMLExtendedStreamReader reader,
+         SimpleConnectionFactoryConfigurationBuilder<?> builder) throws XMLStreamException {
+      for (int i = 0; i < reader.getAttributeCount(); i++) {
+         ParseUtils.requireNoNamespaceAttribute(reader, i);
+         String value = replaceProperties(reader.getAttributeValue(i));
+         Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+         switch (attribute) {
+         case CONNECTION_URL: {
+            builder.driverClass(value);
+            break;
+         }
+         case DRIVER_CLASS: {
+            builder.driverClass(value);
+            break;
+         }
+         case PASSWORD: {
+            builder.password(value);
+            break;
+         }
+         case USERNAME: {
+            builder.username(value);
+            break;
+         }
+         default: {
+            throw ParseUtils.unexpectedAttribute(reader, i);
+         }
+         }
+      }
+      ParseUtils.requireNoContent(reader);
    }
 
    private void parseMixedKeyedJdbcStore(XMLExtendedStreamReader reader, LoadersConfigurationBuilder loadersBuilder)
@@ -175,7 +236,7 @@ public class JdbcCacheStoreConfigurationParser52 implements ConfigurationParser<
             break;
          }
          default: {
-            Parser52.parseCommonStoreChildren(reader, builder);
+            parseCommonJdbcStoreElements(reader, element, builder);
             break;
          }
          }

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcMixedCacheStoreConfiguration.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcMixedCacheStoreConfiguration.java
@@ -34,22 +34,18 @@ import org.infinispan.util.TypedProperties;
  * @since 5.2
  */
 @BuiltBy(JdbcMixedCacheStoreConfigurationBuilder.class)
-public class JdbcMixedCacheStoreConfiguration extends AbstractJdbcCacheStoreConfiguration implements
-      LegacyLoaderAdapter<JdbcMixedCacheStoreConfig> {
+public class JdbcMixedCacheStoreConfiguration extends AbstractJdbcCacheStoreConfiguration implements LegacyLoaderAdapter<JdbcMixedCacheStoreConfig> {
 
    private final TableManipulationConfiguration binaryTable;
    private final TableManipulationConfiguration stringTable;
    private final String key2StringMapper;
 
-   protected JdbcMixedCacheStoreConfiguration(String key2StringMapper, TableManipulationConfiguration binaryTable,
-         TableManipulationConfiguration stringTable, String driverClass, String connectionUrl, String userName,
-         String password, String connectionFactoryClass, String datasourceJndiLocation, long lockAcquistionTimeout,
-         int lockConcurrencyLevel, boolean purgeOnStartup, boolean purgeSynchronously, int purgerThreads,
-         boolean fetchPersistentState, boolean ignoreModifications, TypedProperties properties,
-         AsyncStoreConfiguration async, SingletonStoreConfiguration singletonStore) {
-      super(driverClass, connectionUrl, userName, password, connectionFactoryClass, datasourceJndiLocation,
-            lockAcquistionTimeout, lockConcurrencyLevel, purgeOnStartup, purgeSynchronously, purgerThreads,
-            fetchPersistentState, ignoreModifications, properties, async, singletonStore);
+   protected JdbcMixedCacheStoreConfiguration(String key2StringMapper, TableManipulationConfiguration binaryTable, TableManipulationConfiguration stringTable,
+         ConnectionFactoryConfiguration connectionFactory, long lockAcquistionTimeout, int lockConcurrencyLevel, boolean purgeOnStartup, boolean purgeSynchronously,
+         int purgerThreads, boolean fetchPersistentState, boolean ignoreModifications, TypedProperties properties, AsyncStoreConfiguration async,
+         SingletonStoreConfiguration singletonStore) {
+      super(connectionFactory, lockAcquistionTimeout, lockConcurrencyLevel, purgeOnStartup, purgeSynchronously, purgerThreads, fetchPersistentState, ignoreModifications,
+            properties, async, singletonStore);
       this.key2StringMapper = key2StringMapper;
       this.binaryTable = binaryTable;
       this.stringTable = stringTable;
@@ -74,13 +70,8 @@ public class JdbcMixedCacheStoreConfiguration extends AbstractJdbcCacheStoreConf
       // StoreConfiguration
       LegacyConfigurationAdaptor.adapt(this, config);
 
-      // AbstractJdbcCacheStoreConfiguration
-      config.setConnectionFactoryClass(connectionFactoryClass());
-      config.setConnectionUrl(connectionUrl());
-      config.setDatasourceJndiLocation(datasource());
-      config.setDriverClass(driverClass());
-      config.setUserName(userName());
-      config.setPassword(password());
+      // ConnectionFactory
+      ((LegacyConnectionFactoryAdaptor) connectionFactory()).adapt(config);
 
       // JdbcStringBasedCacheStoreConfiguration
       config.setKey2StringMapperClass(key2StringMapper);
@@ -111,16 +102,10 @@ public class JdbcMixedCacheStoreConfiguration extends AbstractJdbcCacheStoreConf
 
    @Override
    public String toString() {
-      return "JdbcMixedCacheStoreConfiguration [binaryTable=" + binaryTable + ", stringTable=" + stringTable
-            + ", key2StringMapper=" + key2StringMapper + ", getDriverClass()=" + driverClass()
-            + ", getConnectionUrl()=" + connectionUrl() + ", getUserName()=" + userName() + ", getPassword()="
-            + password() + ", getConnectionFactoryClass()=" + connectionFactoryClass()
-            + ", getDatasourceJndiLocation()=" + datasource() + ", lockAcquistionTimeout()="
-            + lockAcquistionTimeout() + ", lockConcurrencyLevel()=" + lockConcurrencyLevel() + ", async()=" + async()
-            + ", singletonStore()=" + singletonStore() + ", purgeOnStartup()=" + purgeOnStartup()
-            + ", purgeSynchronously()=" + purgeSynchronously() + ", purgerThreads()=" + purgerThreads()
-            + ", fetchPersistentState()=" + fetchPersistentState() + ", ignoreModifications()=" + ignoreModifications()
-            + ", properties()=" + properties() + "]";
+      return "JdbcMixedCacheStoreConfiguration [binaryTable=" + binaryTable + ", stringTable=" + stringTable + ", key2StringMapper=" + key2StringMapper + ", connectionFactory()="
+            + connectionFactory() + ", lockAcquistionTimeout()=" + lockAcquistionTimeout() + ", lockConcurrencyLevel()=" + lockConcurrencyLevel() + ", async()=" + async()
+            + ", singletonStore()=" + singletonStore() + ", purgeOnStartup()=" + purgeOnStartup() + ", purgeSynchronously()=" + purgeSynchronously() + ", purgerThreads()="
+            + purgerThreads() + ", fetchPersistentState()=" + fetchPersistentState() + ", ignoreModifications()=" + ignoreModifications() + ", properties()=" + properties() + "]";
    }
 
 }

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcMixedCacheStoreConfigurationChildBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcMixedCacheStoreConfigurationChildBuilder.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.loaders.jdbc.configuration;
+
+import org.infinispan.loaders.jdbc.configuration.JdbcMixedCacheStoreConfigurationBuilder.MixedTableManipulationConfigurationBuilder;
+import org.infinispan.loaders.keymappers.DefaultTwoWayKey2StringMapper;
+import org.infinispan.loaders.keymappers.Key2StringMapper;
+
+public interface JdbcMixedCacheStoreConfigurationChildBuilder<S extends AbstractJdbcCacheStoreConfigurationBuilder<?, S>> extends JdbcCacheStoreConfigurationChildBuilder<S> {
+
+   /**
+    * Allows configuration of table-specific parameters such as column names and types for the table
+    * used to store entries with binary keys
+    */
+   MixedTableManipulationConfigurationBuilder binaryTable();
+
+   /**
+    * Allows configuration of table-specific parameters such as column names and types for the table
+    * used to store entries with string keys
+    */
+   MixedTableManipulationConfigurationBuilder stringTable();
+
+   /**
+    * The class name of a {@link Key2StringMapper} to use for mapping keys to strings suitable for
+    * storage in a database table. Defaults to {@link DefaultTwoWayKey2StringMapper}
+    */
+   JdbcMixedCacheStoreConfigurationChildBuilder<S> key2StringMapper(String key2StringMapper);
+
+   /**
+    * The class of a {@link Key2StringMapper} to use for mapping keys to strings suitable for
+    * storage in a database table. Defaults to {@link DefaultTwoWayKey2StringMapper}
+    */
+   JdbcMixedCacheStoreConfigurationChildBuilder<S> key2StringMapper(Class<? extends Key2StringMapper> klass);
+
+}

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcStringBasedCacheStoreConfiguration.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcStringBasedCacheStoreConfiguration.java
@@ -27,19 +27,16 @@ import org.infinispan.loaders.jdbc.stringbased.JdbcStringBasedCacheStoreConfig;
 import org.infinispan.util.TypedProperties;
 
 @BuiltBy(JdbcStringBasedCacheStoreConfigurationBuilder.class)
-public class JdbcStringBasedCacheStoreConfiguration extends AbstractJdbcCacheStoreConfiguration implements LegacyLoaderAdapter<JdbcStringBasedCacheStoreConfig>{
+public class JdbcStringBasedCacheStoreConfiguration extends AbstractJdbcCacheStoreConfiguration implements LegacyLoaderAdapter<JdbcStringBasedCacheStoreConfig> {
 
    private final String key2StringMapper;
    private final TableManipulationConfiguration table;
 
-   protected JdbcStringBasedCacheStoreConfiguration(String key2StringMapper, TableManipulationConfiguration table,
-         String driverClass, String connectionUrl, String userName, String password, String connectionFactoryClass,
-         String datasourceJndiLocation, long lockAcquistionTimeout, int lockConcurrencyLevel, boolean purgeOnStartup,
-         boolean purgeSynchronously, int purgerThreads, boolean fetchPersistentState, boolean ignoreModifications,
-         TypedProperties properties, AsyncStoreConfiguration async, SingletonStoreConfiguration singletonStore) {
-      super(driverClass, connectionUrl, userName, password, connectionFactoryClass, datasourceJndiLocation,
-            lockAcquistionTimeout, lockConcurrencyLevel, purgeOnStartup, purgeSynchronously, purgerThreads,
-            fetchPersistentState, ignoreModifications, properties, async, singletonStore);
+   protected JdbcStringBasedCacheStoreConfiguration(String key2StringMapper, TableManipulationConfiguration table, ConnectionFactoryConfiguration connectionFactory,
+         long lockAcquistionTimeout, int lockConcurrencyLevel, boolean purgeOnStartup, boolean purgeSynchronously, int purgerThreads, boolean fetchPersistentState,
+         boolean ignoreModifications, TypedProperties properties, AsyncStoreConfiguration async, SingletonStoreConfiguration singletonStore) {
+      super(connectionFactory, lockAcquistionTimeout, lockConcurrencyLevel, purgeOnStartup, purgeSynchronously, purgerThreads, fetchPersistentState, ignoreModifications,
+            properties, async, singletonStore);
       this.key2StringMapper = key2StringMapper;
       this.table = table;
    }
@@ -59,13 +56,8 @@ public class JdbcStringBasedCacheStoreConfiguration extends AbstractJdbcCacheSto
       // StoreConfiguration
       LegacyConfigurationAdaptor.adapt(this, config);
 
-      // AbstractJdbcCacheStoreConfiguration
-      config.setConnectionFactoryClass(connectionFactoryClass());
-      config.setConnectionUrl(connectionUrl());
-      config.setDatasourceJndiLocation(datasource());
-      config.setDriverClass(driverClass());
-      config.setUserName(userName());
-      config.setPassword(password());
+      // ConnectionFactory
+      ((LegacyConnectionFactoryAdaptor) connectionFactory()).adapt(config);
 
       // JdbcStringBasedCacheStoreConfiguration
       config.setKey2StringMapperClass(key2StringMapper);
@@ -84,20 +76,15 @@ public class JdbcStringBasedCacheStoreConfiguration extends AbstractJdbcCacheSto
       config.setTimestampColumnType(table.timestampColumnType());
       config.setTableNamePrefix(table.tableNamePrefix());
 
-      return config ;
+      return config;
    }
 
    @Override
    public String toString() {
-      return "JdbcStringBasedCacheStoreConfiguration [key2StringMapper=" + key2StringMapper + ", table=" + table
-            + ", driverClass()=" + driverClass() + ", connectionUrl()=" + connectionUrl() + ", userName()="
-            + userName() + ", password()=" + password() + ", connectionFactoryClass()=" + connectionFactoryClass()
-            + ", datasourceJndiLocation()=" + datasource() + ", lockAcquistionTimeout()="
-            + lockAcquistionTimeout() + ", lockConcurrencyLevel()=" + lockConcurrencyLevel() + ", async()=" + async()
-            + ", singletonStore()=" + singletonStore() + ", purgeOnStartup()=" + purgeOnStartup()
-            + ", purgeSynchronously()=" + purgeSynchronously() + ", purgerThreads()=" + purgerThreads()
-            + ", fetchPersistentState()=" + fetchPersistentState() + ", ignoreModifications()=" + ignoreModifications()
-            + ", properties()=" + properties() + "]";
+      return "JdbcStringBasedCacheStoreConfiguration [key2StringMapper=" + key2StringMapper + ", table=" + table + ", connectionFactory()=" + connectionFactory()
+            + ", lockAcquistionTimeout()=" + lockAcquistionTimeout() + ", lockConcurrencyLevel()=" + lockConcurrencyLevel() + ", async()=" + async() + ", singletonStore()="
+            + singletonStore() + ", purgeOnStartup()=" + purgeOnStartup() + ", purgeSynchronously()=" + purgeSynchronously() + ", purgerThreads()=" + purgerThreads()
+            + ", fetchPersistentState()=" + fetchPersistentState() + ", ignoreModifications()=" + ignoreModifications() + ", properties()=" + properties() + "]";
    }
 
 }

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcStringBasedCacheStoreConfigurationBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcStringBasedCacheStoreConfigurationBuilder.java
@@ -31,15 +31,14 @@ import org.infinispan.util.TypedProperties;
  * @author Tristan Tarrant
  * @since 5.2
  */
-public class JdbcStringBasedCacheStoreConfigurationBuilder
-      extends
+public class JdbcStringBasedCacheStoreConfigurationBuilder extends
       AbstractJdbcCacheStoreConfigurationBuilder<JdbcStringBasedCacheStoreConfiguration, JdbcStringBasedCacheStoreConfigurationBuilder> {
    private String key2StringMapper = DefaultTwoWayKey2StringMapper.class.getName();
-   private TableManipulationConfigurationBuilder table;
+   private StringTableManipulationConfigurationBuilder table;
 
    public JdbcStringBasedCacheStoreConfigurationBuilder(LoadersConfigurationBuilder builder) {
       super(builder);
-      table = new TableManipulationConfigurationBuilder(this);
+      table = new StringTableManipulationConfigurationBuilder(this);
    }
 
    @Override
@@ -48,8 +47,8 @@ public class JdbcStringBasedCacheStoreConfigurationBuilder
    }
 
    /**
-    * The class name of a {@link Key2StringMapper} to use for mapping keys to strings suitable for storage in a database table.
-    * Defaults to {@link DefaultTwoWayKey2StringMapper}
+    * The class name of a {@link Key2StringMapper} to use for mapping keys to strings suitable for
+    * storage in a database table. Defaults to {@link DefaultTwoWayKey2StringMapper}
     */
    public JdbcStringBasedCacheStoreConfigurationBuilder key2StringMapper(String key2StringMapper) {
       this.key2StringMapper = key2StringMapper;
@@ -57,8 +56,8 @@ public class JdbcStringBasedCacheStoreConfigurationBuilder
    }
 
    /**
-    * The class of a {@link Key2StringMapper} to use for mapping keys to strings suitable for storage in a database table.
-    * Defaults to {@link DefaultTwoWayKey2StringMapper}
+    * The class of a {@link Key2StringMapper} to use for mapping keys to strings suitable for
+    * storage in a database table. Defaults to {@link DefaultTwoWayKey2StringMapper}
     */
    public JdbcStringBasedCacheStoreConfigurationBuilder key2StringMapper(Class<? extends Key2StringMapper> klass) {
       this.key2StringMapper = klass.getName();
@@ -68,7 +67,7 @@ public class JdbcStringBasedCacheStoreConfigurationBuilder
    /**
     * Allows configuration of table-specific parameters such as column names and types
     */
-   public TableManipulationConfigurationBuilder table() {
+   public StringTableManipulationConfigurationBuilder table() {
       return table;
    }
 
@@ -78,10 +77,8 @@ public class JdbcStringBasedCacheStoreConfigurationBuilder
 
    @Override
    public JdbcStringBasedCacheStoreConfiguration create() {
-      return new JdbcStringBasedCacheStoreConfiguration(key2StringMapper, table.create(), driverClass, connectionUrl,
-            username, password, connectionFactoryClass, datasource, lockAcquistionTimeout, lockConcurrencyLevel,
-            purgeOnStartup, purgeSynchronously, purgerThreads, fetchPersistentState, ignoreModifications,
-            TypedProperties.toTypedProperties(properties), async.create(), singletonStore.create());
+      return new JdbcStringBasedCacheStoreConfiguration(key2StringMapper, table.create(), connectionFactory.create(), lockAcquistionTimeout, lockConcurrencyLevel, purgeOnStartup,
+            purgeSynchronously, purgerThreads, fetchPersistentState, ignoreModifications, TypedProperties.toTypedProperties(properties), async.create(), singletonStore.create());
    }
 
    @Override
@@ -90,6 +87,28 @@ public class JdbcStringBasedCacheStoreConfigurationBuilder
       this.key2StringMapper = template.key2StringMapper();
       this.table.read(template.table());
       return this;
+   }
+
+   public class StringTableManipulationConfigurationBuilder extends TableManipulationConfigurationBuilder<JdbcStringBasedCacheStoreConfigurationBuilder, StringTableManipulationConfigurationBuilder> {
+
+      StringTableManipulationConfigurationBuilder(AbstractJdbcCacheStoreConfigurationBuilder<?, JdbcStringBasedCacheStoreConfigurationBuilder> builder) {
+         super(builder);
+      }
+
+      @Override
+      public StringTableManipulationConfigurationBuilder self() {
+         return this;
+      }
+
+      @Override
+      public PooledConnectionFactoryConfigurationBuilder<JdbcStringBasedCacheStoreConfigurationBuilder> connectionPool() {
+         return JdbcStringBasedCacheStoreConfigurationBuilder.this.connectionPool();
+      }
+
+      @Override
+      public ManagedConnectionFactoryConfigurationBuilder<JdbcStringBasedCacheStoreConfigurationBuilder> dataSource() {
+         return JdbcStringBasedCacheStoreConfigurationBuilder.this.dataSource();
+      }
    }
 
 }

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/LegacyConnectionFactoryAdaptor.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/LegacyConnectionFactoryAdaptor.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.loaders.jdbc.configuration;
+
+import org.infinispan.loaders.jdbc.AbstractJdbcCacheStoreConfig;
+
+/**
+ * LegacyConnectionFactoryAdaptor.
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+@Deprecated
+public interface LegacyConnectionFactoryAdaptor {
+   void adapt(AbstractJdbcCacheStoreConfig config);
+}

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/ManagedConnectionFactoryConfiguration.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/ManagedConnectionFactoryConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.loaders.jdbc.configuration;
+
+import org.infinispan.configuration.BuiltBy;
+import org.infinispan.loaders.jdbc.AbstractJdbcCacheStoreConfig;
+import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactory;
+import org.infinispan.loaders.jdbc.connectionfactory.ManagedConnectionFactory;
+
+/**
+ * ManagedConnectionFactoryConfiguration.
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+@BuiltBy(ManagedConnectionFactoryConfigurationBuilder.class)
+public class ManagedConnectionFactoryConfiguration implements ConnectionFactoryConfiguration, LegacyConnectionFactoryAdaptor {
+   private final String jndiUrl;
+
+   ManagedConnectionFactoryConfiguration(String jndiUrl) {
+      this.jndiUrl = jndiUrl;
+   }
+
+   public String jndiUrl() {
+      return jndiUrl;
+   }
+
+   @Override
+   public Class<? extends ConnectionFactory> connectionFactoryClass() {
+      return ManagedConnectionFactory.class;
+   }
+
+   @Override
+   public void adapt(AbstractJdbcCacheStoreConfig config) {
+      config.setConnectionFactoryClass(connectionFactoryClass().getName());
+      config.setDatasourceJndiLocation(jndiUrl);
+   }
+
+   @Override
+   public String toString() {
+      return "ManagedConnectionFactoryConfiguration [jndiUrl=" + jndiUrl + "]";
+   }
+
+}

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/ManagedConnectionFactoryConfigurationBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/ManagedConnectionFactoryConfigurationBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.loaders.jdbc.configuration;
+
+import org.infinispan.config.ConfigurationException;
+
+/**
+ * ManagedConnectionFactoryConfigurationBuilder.
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public class ManagedConnectionFactoryConfigurationBuilder<S extends AbstractJdbcCacheStoreConfigurationBuilder<?, S>> extends AbstractJdbcCacheStoreConfigurationChildBuilder<S>
+      implements ConnectionFactoryConfigurationBuilder<ManagedConnectionFactoryConfiguration> {
+
+   public ManagedConnectionFactoryConfigurationBuilder(AbstractJdbcCacheStoreConfigurationBuilder<?, S> builder) {
+      super(builder);
+   }
+
+   private String jndiUrl;
+
+   public void jndiUrl(String jndiUrl) {
+      this.jndiUrl = jndiUrl;
+   }
+
+   @Override
+   public void validate() {
+      throw new ConfigurationException("The jndiUrl has not been specified");
+   }
+
+   @Override
+   public ManagedConnectionFactoryConfiguration create() {
+      return new ManagedConnectionFactoryConfiguration(jndiUrl);
+   }
+
+   @Override
+   public ManagedConnectionFactoryConfigurationBuilder<S> read(ManagedConnectionFactoryConfiguration template) {
+      this.jndiUrl = template.jndiUrl();
+      return this;
+   }
+
+}

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/PooledConnectionFactoryConfiguration.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/PooledConnectionFactoryConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.loaders.jdbc.configuration;
+
+import org.infinispan.configuration.BuiltBy;
+import org.infinispan.loaders.jdbc.AbstractJdbcCacheStoreConfig;
+import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactory;
+import org.infinispan.loaders.jdbc.connectionfactory.PooledConnectionFactory;
+
+@BuiltBy(PooledConnectionFactoryConfigurationBuilder.class)
+public class PooledConnectionFactoryConfiguration implements ConnectionFactoryConfiguration, LegacyConnectionFactoryAdaptor {
+   private final String connectionUrl;
+   private final String driverClass;
+   private final String username;
+   private final String password;
+
+   PooledConnectionFactoryConfiguration(String connectionUrl, String driverClass, String username, String password) {
+      this.connectionUrl = connectionUrl;
+      this.driverClass = driverClass;
+      this.username = username;
+      this.password = password;
+   }
+
+   public String connectionUrl() {
+      return connectionUrl;
+   }
+
+   public String driverClass() {
+      return driverClass;
+   }
+
+   public String username() {
+      return username;
+   }
+
+   public String password() {
+      return password;
+   }
+
+   @Override
+   public Class<? extends ConnectionFactory> connectionFactoryClass() {
+      return PooledConnectionFactory.class;
+   }
+
+   @Override
+   public void adapt(AbstractJdbcCacheStoreConfig config) {
+      config.setConnectionFactoryClass(connectionFactoryClass().getName());
+      config.setConnectionUrl(connectionUrl);
+      config.setDriverClass(driverClass);
+      config.setUserName(username);
+      config.setPassword(password);
+   }
+
+   @Override
+   public String toString() {
+      return "PooledConnectionFactoryConfiguration [connectionUrl=" + connectionUrl + ", driverClass=" + driverClass + ", username=" + username + ", password=" + password + "]";
+   }
+
+}

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/PooledConnectionFactoryConfigurationBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/PooledConnectionFactoryConfigurationBuilder.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.loaders.jdbc.configuration;
+
+import java.sql.Driver;
+
+import org.infinispan.config.ConfigurationException;
+
+/**
+ * PooledConnectionFactoryConfigurationBuilder.
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public class PooledConnectionFactoryConfigurationBuilder<S extends AbstractJdbcCacheStoreConfigurationBuilder<?, S>> extends AbstractJdbcCacheStoreConfigurationChildBuilder<S>
+      implements ConnectionFactoryConfigurationBuilder<PooledConnectionFactoryConfiguration> {
+
+   protected PooledConnectionFactoryConfigurationBuilder(AbstractJdbcCacheStoreConfigurationBuilder<?, S> builder) {
+      super(builder);
+   }
+
+   private String connectionUrl;
+   private String driverClass;
+   private String username;
+   private String password;
+
+   public PooledConnectionFactoryConfigurationBuilder<S> connectionUrl(String connectionUrl) {
+      this.connectionUrl = connectionUrl;
+      return this;
+   }
+
+   public PooledConnectionFactoryConfigurationBuilder<S> driverClass(Class<? extends Driver> driverClass) {
+      this.driverClass = driverClass.getName();
+      return this;
+   }
+
+   public PooledConnectionFactoryConfigurationBuilder<S> driverClass(String driverClass) {
+      this.driverClass = driverClass;
+      return this;
+   }
+
+   public PooledConnectionFactoryConfigurationBuilder<S> username(String username) {
+      this.username = username;
+      return this;
+   }
+
+   public PooledConnectionFactoryConfigurationBuilder<S> password(String password) {
+      this.password = password;
+      return this;
+   }
+
+   @Override
+   public void validate() {
+      if (connectionUrl == null) {
+         throw new ConfigurationException("Missing connectionUrl parameter");
+      }
+   }
+
+   @Override
+   public PooledConnectionFactoryConfiguration create() {
+      return new PooledConnectionFactoryConfiguration(connectionUrl, driverClass, username, password);
+   }
+
+   @Override
+   public PooledConnectionFactoryConfigurationBuilder<S> read(PooledConnectionFactoryConfiguration template) {
+      this.connectionUrl = template.connectionUrl();
+      this.driverClass = template.driverClass();
+      this.username = template.username();
+      this.password = template.password();
+      return this;
+   }
+
+}

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/SimpleConnectionFactoryConfiguration.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/SimpleConnectionFactoryConfiguration.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.loaders.jdbc.configuration;
+
+import org.infinispan.configuration.Builder;
+import org.infinispan.configuration.BuiltBy;
+import org.infinispan.loaders.jdbc.AbstractJdbcCacheStoreConfig;
+import org.infinispan.loaders.jdbc.connectionfactory.ConnectionFactory;
+import org.infinispan.loaders.jdbc.connectionfactory.SimpleConnectionFactory;
+
+/**
+ * SimpleConnectionFactoryConfiguration.
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+@BuiltBy(SimpleConnectionFactoryConfigurationBuilder.class)
+public class SimpleConnectionFactoryConfiguration implements ConnectionFactoryConfiguration, LegacyConnectionFactoryAdaptor {
+   private final String connectionUrl;
+   private final String driverClass;
+   private final String username;
+   private final String password;
+
+   SimpleConnectionFactoryConfiguration(String connectionUrl, String driverClass, String username, String password) {
+      this.connectionUrl = connectionUrl;
+      this.driverClass = driverClass;
+      this.username = username;
+      this.password = password;
+   }
+
+   public String connectionUrl() {
+      return connectionUrl;
+   }
+
+   public String driverClass() {
+      return driverClass;
+   }
+
+   public String username() {
+      return username;
+   }
+
+   public String password() {
+      return password;
+   }
+
+   @Override
+   public Class<? extends ConnectionFactory> connectionFactoryClass() {
+      return SimpleConnectionFactory.class;
+   }
+
+   @Override
+   public void adapt(AbstractJdbcCacheStoreConfig config) {
+      config.setConnectionFactoryClass(connectionFactoryClass().getName());
+      config.setConnectionUrl(connectionUrl);
+      config.setDriverClass(driverClass);
+      config.setUserName(username);
+      config.setPassword(password);
+   }
+
+   @Override
+   public String toString() {
+      return "SimpleConnectionFactoryConfiguration [connectionUrl=" + connectionUrl + ", driverClass=" + driverClass + ", username=" + username + ", password=" + password + "]";
+   }
+}

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/SimpleConnectionFactoryConfigurationBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/SimpleConnectionFactoryConfigurationBuilder.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.loaders.jdbc.configuration;
+
+import java.sql.Driver;
+
+import org.infinispan.config.ConfigurationException;
+
+/**
+ * SimpleConnectionFactoryBuilder.
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public class SimpleConnectionFactoryConfigurationBuilder<S extends AbstractJdbcCacheStoreConfigurationBuilder<?, S>> extends AbstractJdbcCacheStoreConfigurationChildBuilder<S>
+      implements ConnectionFactoryConfigurationBuilder<SimpleConnectionFactoryConfiguration> {
+
+   private String connectionUrl;
+   private String driverClass;
+   private String username;
+   private String password;
+
+   public SimpleConnectionFactoryConfigurationBuilder(AbstractJdbcCacheStoreConfigurationBuilder<?, S> builder) {
+      super(builder);
+   }
+
+   public SimpleConnectionFactoryConfigurationBuilder<S> connectionUrl(String connectionUrl) {
+      this.connectionUrl = connectionUrl;
+      return this;
+   }
+
+   public SimpleConnectionFactoryConfigurationBuilder<S> driverClass(Class<? extends Driver> driverClass) {
+      this.driverClass = driverClass.getName();
+      return this;
+   }
+
+   public SimpleConnectionFactoryConfigurationBuilder<S> driverClass(String driverClass) {
+      this.driverClass = driverClass;
+      return this;
+   }
+
+   public SimpleConnectionFactoryConfigurationBuilder<S> username(String username) {
+      this.username = username;
+      return this;
+   }
+
+   public SimpleConnectionFactoryConfigurationBuilder<S> password(String password) {
+      this.password = password;
+      return this;
+   }
+
+   @Override
+   public void validate() {
+      if (connectionUrl == null) {
+         throw new ConfigurationException("A connectionUrl has not been specified");
+      }
+   }
+
+   @Override
+   public SimpleConnectionFactoryConfiguration create() {
+      return new SimpleConnectionFactoryConfiguration(connectionUrl, driverClass, username, password);
+   }
+
+   @Override
+   public SimpleConnectionFactoryConfigurationBuilder<S> read(SimpleConnectionFactoryConfiguration template) {
+      this.connectionUrl = template.connectionUrl();
+      this.driverClass = template.driverClass();
+      this.username = template.username();
+      this.password = template.password();
+
+      return this;
+   }
+
+}

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/TableManipulationConfigurationBuilder.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/TableManipulationConfigurationBuilder.java
@@ -19,9 +19,7 @@
 package org.infinispan.loaders.jdbc.configuration;
 
 import org.infinispan.configuration.Builder;
-import org.infinispan.configuration.cache.AbstractStoreConfiguration;
-import org.infinispan.configuration.cache.AbstractStoreConfigurationBuilder;
-import org.infinispan.configuration.cache.AbstractStoreConfigurationChildBuilder;
+import org.infinispan.configuration.Self;
 import org.infinispan.loaders.jdbc.TableManipulation;
 
 /**
@@ -30,9 +28,8 @@ import org.infinispan.loaders.jdbc.TableManipulation;
  * @author Tristan Tarrant
  * @since 5.2
  */
-public class TableManipulationConfigurationBuilder extends
-      AbstractStoreConfigurationChildBuilder<TableManipulationConfiguration> {
-
+public abstract class TableManipulationConfigurationBuilder<B extends AbstractJdbcCacheStoreConfigurationBuilder<?, B>, S extends TableManipulationConfigurationBuilder<B, S>> extends
+      AbstractJdbcCacheStoreConfigurationChildBuilder<B> implements Builder<TableManipulationConfiguration>, Self<S> {
    private int batchSize = TableManipulation.DEFAULT_BATCH_SIZE;
    private int fetchSize = TableManipulation.DEFAULT_FETCH_SIZE;
    private boolean createOnStart = true;
@@ -46,102 +43,102 @@ public class TableManipulationConfigurationBuilder extends
    private String timestampColumnName;
    private String timestampColumnType;
 
-   TableManipulationConfigurationBuilder(
-         AbstractStoreConfigurationBuilder<? extends AbstractStoreConfiguration, ?> builder) {
+   TableManipulationConfigurationBuilder(AbstractJdbcCacheStoreConfigurationBuilder<?, B> builder) {
       super(builder);
    }
 
    /**
-    * When doing repetitive DB inserts (e.g. on {@link org.infinispan.loaders.CacheStore#fromStream(java.io.ObjectInput)}
-    * this will be batched according to this parameter. This is an optional parameter, and if it is not specified it
-    * will be defaulted to {@link #DEFAULT_BATCH_SIZE}.
+    * When doing repetitive DB inserts (e.g. on
+    * {@link org.infinispan.loaders.CacheStore#fromStream(java.io.ObjectInput)} this will be batched
+    * according to this parameter. This is an optional parameter, and if it is not specified it will
+    * be defaulted to {@link #DEFAULT_BATCH_SIZE}.
     */
-   public TableManipulationConfigurationBuilder batchSize(int batchSize) {
+   public S batchSize(int batchSize) {
       this.batchSize = batchSize;
-      return this;
+      return self();
    }
 
    /**
-    * For DB queries (e.g. {@link org.infinispan.loaders.CacheStore#toStream(java.io.ObjectOutput)} ) the fetch size
-    * will be set on {@link java.sql.ResultSet#setFetchSize(int)}. This is optional parameter, if not specified will be
-    * defaulted to {@link #DEFAULT_FETCH_SIZE}.
+    * For DB queries (e.g. {@link org.infinispan.loaders.CacheStore#toStream(java.io.ObjectOutput)}
+    * ) the fetch size will be set on {@link java.sql.ResultSet#setFetchSize(int)}. This is optional
+    * parameter, if not specified will be defaulted to {@link #DEFAULT_FETCH_SIZE}.
     */
-   public TableManipulationConfigurationBuilder fetchSize(int fetchSize) {
+   public S fetchSize(int fetchSize) {
       this.fetchSize = fetchSize;
-      return this;
+      return self();
    }
 
    /**
-    * Sets the prefix for the name of the table where the data will be stored. "_<cache name>" will be appended
-    * to this prefix in order to enforce unique table names for each cache.
+    * Sets the prefix for the name of the table where the data will be stored. "_<cache name>" will
+    * be appended to this prefix in order to enforce unique table names for each cache.
     */
-   public TableManipulationConfigurationBuilder tableNamePrefix(String tableNamePrefix) {
+   public S tableNamePrefix(String tableNamePrefix) {
       this.tableNamePrefix = tableNamePrefix;
-      return this;
+      return self();
    }
 
    /**
     * Determines whether database tables should be created by the store on startup
     */
-   public TableManipulationConfigurationBuilder createOnStart(boolean createOnStart) {
+   public S createOnStart(boolean createOnStart) {
       this.createOnStart = createOnStart;
-      return this;
+      return self();
    }
 
    /**
     * Determines whether database tables should be dropped by the store on shutdown
     */
-   public TableManipulationConfigurationBuilder dropOnExit(boolean dropOnExit) {
+   public S dropOnExit(boolean dropOnExit) {
       this.dropOnExit = dropOnExit;
-      return this;
+      return self();
    }
 
    /**
     * The name of the database column used to store the keys
     */
-   public TableManipulationConfigurationBuilder idColumnName(String idColumnName) {
+   public S idColumnName(String idColumnName) {
       this.idColumnName = idColumnName;
-      return this;
+      return self();
    }
 
    /**
     * The type of the database column used to store the keys
     */
-   public TableManipulationConfigurationBuilder idColumnType(String idColumnType) {
+   public S idColumnType(String idColumnType) {
       this.idColumnType = idColumnType;
-      return this;
+      return self();
    }
 
    /**
     * The name of the database column used to store the entries
     */
-   public TableManipulationConfigurationBuilder dataColumnName(String dataColumnName) {
+   public S dataColumnName(String dataColumnName) {
       this.dataColumnName = dataColumnName;
-      return this;
+      return self();
    }
 
    /**
     * The type of the database column used to store the entries
     */
-   public TableManipulationConfigurationBuilder dataColumnType(String dataColumnType) {
+   public S dataColumnType(String dataColumnType) {
       this.dataColumnType = dataColumnType;
-      return this;
+      return self();
    }
 
    /**
     * The name of the database column used to store the timestamps
     */
-   public TableManipulationConfigurationBuilder timestampColumnName(String timestampColumnName) {
+   public S timestampColumnName(String timestampColumnName) {
       this.timestampColumnName = timestampColumnName;
-      return this;
+      return self();
    }
 
    /**
     * The type of the database column used to store the timestamps
     */
-   public TableManipulationConfigurationBuilder timestampColumnType(String timestampColumnType) {
+   public S timestampColumnType(String timestampColumnType) {
       this.timestampColumnType = timestampColumnType;
-      return this;
+      return self();
    }
 
    @Override
@@ -150,8 +147,8 @@ public class TableManipulationConfigurationBuilder extends
 
    @Override
    public TableManipulationConfiguration create() {
-      return new TableManipulationConfiguration(idColumnName, idColumnType, tableNamePrefix, cacheName, dataColumnName,
-            dataColumnType, timestampColumnName, timestampColumnType, fetchSize, batchSize, createOnStart, dropOnExit);
+      return new TableManipulationConfiguration(idColumnName, idColumnType, tableNamePrefix, cacheName, dataColumnName, dataColumnType, timestampColumnName, timestampColumnType,
+            fetchSize, batchSize, createOnStart, dropOnExit);
    }
 
    @Override
@@ -171,7 +168,4 @@ public class TableManipulationConfigurationBuilder extends
 
       return this;
    }
-
-
-
 }

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/as/JdbcCacheStoreConfigurationParserAS7.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/as/JdbcCacheStoreConfigurationParserAS7.java
@@ -138,7 +138,7 @@ public class JdbcCacheStoreConfigurationParserAS7 implements ConfigurationParser
          Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
          switch (attribute) {
          case DATASOURCE: {
-            builder.datasource(value);
+            builder.dataSource().jndiUrl(value);
             break;
          }
          default: {

--- a/cachestore/jdbc/src/main/resources/schema/infinispan-cachestore-jdbc-config-5.2.xsd
+++ b/cachestore/jdbc/src/main/resources/schema/infinispan-cachestore-jdbc-config-5.2.xsd
@@ -111,24 +111,23 @@
   <xs:complexType name="jdbcStore" abstract="true">
     <xs:complexContent>
       <xs:extension base="config:lockSupportStore">
-        <xs:attribute name="connectionFactoryClass" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>
-              The class name of a connection factory to use
-            </xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="connectionUrl" type="xs:string">
+        <xs:sequence>
+          <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element ref="connectionPool" />
+            <xs:element ref="dataSource" />
+            <xs:element ref="singleConnection" />
+          </xs:choice>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  
+  <xs:complexType name="connectionPool">
+    <xs:complexContent>
+      <xs:attribute name="connectionUrl" type="xs:string">
           <xs:annotation>
             <xs:documentation>
               A JDBC driver-specific connection URL
-            </xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="datasource" type="xs:string">
-          <xs:annotation>
-            <xs:documentation>
-              The address of a datasource to use when connecting
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
@@ -153,7 +152,51 @@
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  
+  <xs:complexType name="dataSource">
+    <xs:complexContent>
+      <xs:attribute name="jndiUrl" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>
+              The address of a datasource to use when connecting
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+    </xs:complexContent>
+  </xs:complexType>
+  
+  <xs:complexType name="singleConnection">
+    <xs:complexContent>
+      <xs:attribute name="connectionUrl" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>
+              A JDBC driver-specific connection URL
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="driverClass" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>
+              The class name of the driver used for connecting to the database.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="password" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>
+              The password to use when connecting via connectionUrl
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="username" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>
+              The username to use when connecting via connectionUrl
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
     </xs:complexContent>
   </xs:complexType>
 

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/configuration/XmlFileParsingTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/configuration/XmlFileParsingTest.java
@@ -50,6 +50,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
             "   <default>\n" +
             "     <loaders>\n" +
             "       <stringKeyedJdbcStore xmlns=\"urn:infinispan:config:jdbc:5.2\" >\n" +
+            "         <connectionPool connectionUrl=\"jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=-1\" username=\"dbuser\" password=\"dbpass\" />\n" +
             "         <stringKeyedTable prefix=\"entry\" fetchSize=\"34\" batchSize=\"99\">\n" +
             "           <idColumn name=\"id\" type=\"VARCHAR\" />\n" +
             "           <dataColumn name=\"datum\" type=\"BINARY\" />\n" +
@@ -74,6 +75,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
             "   <default>\n" +
             "     <loaders>\n" +
             "       <binaryKeyedJdbcStore xmlns=\"urn:infinispan:config:jdbc:5.2\" ignoreModifications=\"true\">\n" +
+            "         <simpleConnection connectionUrl=\"jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=-1\" username=\"dbuser\" password=\"dbpass\" />\n" +
             "         <binaryKeyedTable prefix=\"bucket\" fetchSize=\"34\" batchSize=\"99\">\n" +
             "           <idColumn name=\"id\" type=\"BINARY\" />\n" +
             "           <dataColumn name=\"datum\" type=\"BINARY\" />\n" +
@@ -101,6 +103,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
             "   <default>\n" +
             "     <loaders>\n" +
             "       <mixedKeyedJdbcStore xmlns=\"urn:infinispan:config:jdbc:5.2\" >\n" +
+            "         <dataSource jndiUrl=\"java:MyDataSource\" />\n" +
             "         <stringKeyedTable prefix=\"entry\" fetchSize=\"34\" batchSize=\"99\">\n" +
             "           <idColumn name=\"id\" type=\"VARCHAR\" />\n" +
             "           <dataColumn name=\"datum\" type=\"BINARY\" />\n" +

--- a/cachestore/jdbc/src/test/resources/configs/managed/binary-managed-connection-factory.xml
+++ b/cachestore/jdbc/src/test/resources/configs/managed/binary-managed-connection-factory.xml
@@ -67,9 +67,8 @@
             concurrencyLevel="500" useLockStriping="false"/>
       <loaders>
          <binaryKeyedJdbcStore fetchPersistentState="false"
-                 ignoreModifications="false" purgeOnStartup="false"
-                 connectionFactoryClass="org.infinispan.loaders.jdbc.connectionfactory.ManagedConnectionFactory"
-                 datasource="java:/BinaryStoreWithManagedConnectionTest/DS">
+                 ignoreModifications="false" purgeOnStartup="false">
+            <dataSource jndiUrl="java:/BinaryStoreWithManagedConnectionTest/DS" />
             <binaryKeyedTable prefix="ISPN_BUCKET_TABLE" createOnStart="true" dropOnExit="true">
                <idColumn name="ID_COLUMN" type="VARCHAR(255)" />
                <dataColumn name="DATA_COLUMN" type="BINARY" />

--- a/cachestore/jdbc/src/test/resources/configs/managed/mixed-managed-connection-factory.xml
+++ b/cachestore/jdbc/src/test/resources/configs/managed/mixed-managed-connection-factory.xml
@@ -66,9 +66,8 @@
             writeSkewCheck="false"
             concurrencyLevel="500" useLockStriping="false"/>
       <loaders>
-         <mixedKeyedJdbcStore fetchPersistentState="false" ignoreModifications="false" purgeOnStartup="false"
-            connectionFactoryClass="org.infinispan.loaders.jdbc.connectionfactory.ManagedConnectionFactory"
-            datasource="java:/MixedStoreWithManagedConnectionTest/DS" >
+         <mixedKeyedJdbcStore fetchPersistentState="false" ignoreModifications="false" purgeOnStartup="false">
+            <dataSource jndiUrl="java:/MixedStoreWithManagedConnectionTest/DS" />
             <stringKeyedTable prefix="ISPN_MIXED_STR_TABLE" createOnStart="true" dropOnExit="true">
                <idColumn name="ID_COLUMN" type="VARCHAR(255)" />
                <dataColumn name="DATA_COLUMN" type="BINARY" />

--- a/cachestore/jdbc/src/test/resources/configs/managed/str-managed-connection-factory.xml
+++ b/cachestore/jdbc/src/test/resources/configs/managed/str-managed-connection-factory.xml
@@ -66,9 +66,8 @@
             writeSkewCheck="false"
             concurrencyLevel="500" useLockStriping="false"/>
       <loaders>
-         <stringKeyedJdbcStore xmlns="urn:infinispan:config:jdbc:5.2" fetchPersistentState="false" ignoreModifications="false" purgeOnStartup="false"
-            connectionFactoryClass="org.infinispan.loaders.jdbc.connectionfactory.ManagedConnectionFactory" 
-            datasource="java:/StringStoreWithManagedConnectionTest/DS">
+         <stringKeyedJdbcStore xmlns="urn:infinispan:config:jdbc:5.2" fetchPersistentState="false" ignoreModifications="false" purgeOnStartup="false">
+            <dataSource jndiUrl="java:/StringStoreWithManagedConnectionTest/DS" />
             <stringKeyedTable prefix="ISPN_STRING_TABLE" createOnStart="true" dropOnExit="true">
                <idColumn name="ID_COLUMN" type="VARCHAR(255)" />
                <dataColumn name="DATA_COLUMN" type="BINARY" />

--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/AbstractRemoteCacheStoreConfigurationChildBuilder.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/AbstractRemoteCacheStoreConfigurationChildBuilder.java
@@ -28,7 +28,7 @@ import org.infinispan.marshall.Marshaller;
  * @author Tristan Tarrant
  * @since 5.2
  */
-public abstract class AbstractRemoteCacheStoreConfigurationChildBuilder<T> extends AbstractStoreConfigurationChildBuilder<T> implements RemoteCacheStoreConfigurationChildBuilder {
+public abstract class AbstractRemoteCacheStoreConfigurationChildBuilder<S> extends AbstractStoreConfigurationChildBuilder<S> implements RemoteCacheStoreConfigurationChildBuilder<S> {
    private final RemoteCacheStoreConfigurationBuilder builder;
 
    protected AbstractRemoteCacheStoreConfigurationChildBuilder(RemoteCacheStoreConfigurationBuilder builder) {

--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/ConnectionPoolConfigurationBuilder.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/ConnectionPoolConfigurationBuilder.java
@@ -18,6 +18,8 @@
  */
 package org.infinispan.loaders.remote.configuration;
 
+import org.infinispan.configuration.Builder;
+
 /**
  *
  * ConnectionPoolConfigurationBuilder. Specified connection pooling properties for the HotRod client
@@ -25,7 +27,8 @@ package org.infinispan.loaders.remote.configuration;
  * @author Tristan Tarrant
  * @since 5.2
  */
-public class ConnectionPoolConfigurationBuilder extends AbstractRemoteCacheStoreConfigurationChildBuilder<ConnectionPoolConfiguration> {
+public class ConnectionPoolConfigurationBuilder extends AbstractRemoteCacheStoreConfigurationChildBuilder<RemoteCacheStoreConfigurationBuilder> implements
+      Builder<ConnectionPoolConfiguration> {
    private ExhaustedAction exhaustedAction = ExhaustedAction.WAIT;
    private int maxActive = -1;
    private int maxTotal = -1;
@@ -40,7 +43,8 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteCacheStore
    }
 
    /**
-    * Specifies what happens when asking for a connection from a server's pool, and that pool is exhausted.
+    * Specifies what happens when asking for a connection from a server's pool, and that pool is
+    * exhausted.
     */
    public ConnectionPoolConfigurationBuilder exhaustedAction(ExhaustedAction exhaustedAction) {
       this.exhaustedAction = exhaustedAction;
@@ -131,8 +135,7 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteCacheStore
 
    @Override
    public ConnectionPoolConfiguration create() {
-      return new ConnectionPoolConfiguration(exhaustedAction, maxActive, maxTotal, maxIdle, minIdle,
-            timeBetweenEvictionRuns, minEvictableIdleTime, testWhileIdle);
+      return new ConnectionPoolConfiguration(exhaustedAction, maxActive, maxTotal, maxIdle, minIdle, timeBetweenEvictionRuns, minEvictableIdleTime, testWhileIdle);
    }
 
    @Override

--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/ExecutorFactoryConfigurationBuilder.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/ExecutorFactoryConfigurationBuilder.java
@@ -20,6 +20,7 @@ package org.infinispan.loaders.remote.configuration;
 
 import java.util.Properties;
 
+import org.infinispan.configuration.Builder;
 import org.infinispan.executors.DefaultExecutorFactory;
 import org.infinispan.executors.ExecutorFactory;
 import org.infinispan.util.TypedProperties;
@@ -27,7 +28,7 @@ import org.infinispan.util.TypedProperties;
 /**
  * Configures executor factory.
  */
-public class ExecutorFactoryConfigurationBuilder extends AbstractRemoteCacheStoreConfigurationChildBuilder<ExecutorFactoryConfiguration> {
+public class ExecutorFactoryConfigurationBuilder extends AbstractRemoteCacheStoreConfigurationChildBuilder<RemoteCacheStoreConfigurationBuilder> implements Builder<ExecutorFactoryConfiguration> {
 
    private ExecutorFactory factory = new DefaultExecutorFactory();
    private Properties properties;
@@ -62,7 +63,7 @@ public class ExecutorFactoryConfigurationBuilder extends AbstractRemoteCacheStor
     *           property value
     * @return previous value if exists, null otherwise
     */
-   public ExecutorFactoryConfigurationBuilder addProperty(String key, String value) {
+   public ExecutorFactoryConfigurationBuilder addExecutorProperty(String key, String value) {
       this.properties.put(key, value);
       return this;
    }
@@ -74,7 +75,7 @@ public class ExecutorFactoryConfigurationBuilder extends AbstractRemoteCacheStor
     *           Properties
     * @return this ExecutorFactoryConfig
     */
-   public ExecutorFactoryConfigurationBuilder withProperties(Properties props) {
+   public ExecutorFactoryConfigurationBuilder withExecutorProperties(Properties props) {
       this.properties = props;
       return this;
    }

--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/RemoteCacheStoreConfigurationBuilder.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/RemoteCacheStoreConfigurationBuilder.java
@@ -39,7 +39,7 @@ import org.infinispan.util.TypedProperties;
  */
 public class RemoteCacheStoreConfigurationBuilder extends
       AbstractStoreConfigurationBuilder<RemoteCacheStoreConfiguration, RemoteCacheStoreConfigurationBuilder> implements
-      RemoteCacheStoreConfigurationChildBuilder {
+      RemoteCacheStoreConfigurationChildBuilder<RemoteCacheStoreConfigurationBuilder> {
    private final ExecutorFactoryConfigurationBuilder asyncExecutorFactory;
    private String balancingStrategy = RoundRobinBalancingStrategy.class.getName();
    private final ConnectionPoolConfigurationBuilder connectionPool;

--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/RemoteCacheStoreConfigurationChildBuilder.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/RemoteCacheStoreConfigurationChildBuilder.java
@@ -22,7 +22,7 @@ import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 import org.infinispan.configuration.cache.StoreConfigurationChildBuilder;
 import org.infinispan.marshall.Marshaller;
 
-public interface RemoteCacheStoreConfigurationChildBuilder extends StoreConfigurationChildBuilder {
+public interface RemoteCacheStoreConfigurationChildBuilder<S> extends StoreConfigurationChildBuilder<S> {
 
    /**
     * Adds a new remote server

--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/RemoteCacheStoreConfigurationParser52.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/RemoteCacheStoreConfigurationParser52.java
@@ -122,7 +122,7 @@ public class RemoteCacheStoreConfigurationParser52 implements ConfigurationParse
          Element element = Element.forName(reader.getLocalName());
          switch (element) {
          case PROPERTIES: {
-            builder.withProperties(Parser52.parseProperties(reader));
+            builder.withExecutorProperties(Parser52.parseProperties(reader));
             break;
          }
          default: {

--- a/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/RemoteServerConfigurationBuilder.java
+++ b/cachestore/remote/src/main/java/org/infinispan/loaders/remote/configuration/RemoteServerConfigurationBuilder.java
@@ -18,7 +18,10 @@
  */
 package org.infinispan.loaders.remote.configuration;
 
-public class RemoteServerConfigurationBuilder extends AbstractRemoteCacheStoreConfigurationChildBuilder<RemoteServerConfiguration> {
+import org.infinispan.configuration.Builder;
+
+public class RemoteServerConfigurationBuilder extends AbstractRemoteCacheStoreConfigurationChildBuilder<RemoteCacheStoreConfigurationBuilder> implements
+      Builder<RemoteServerConfiguration> {
    private String host;
    private int port = 11222;
 
@@ -52,6 +55,5 @@ public class RemoteServerConfigurationBuilder extends AbstractRemoteCacheStoreCo
 
       return this;
    }
-
 
 }

--- a/core/src/main/java/org/infinispan/configuration/BuiltBy.java
+++ b/core/src/main/java/org/infinispan/configuration/BuiltBy.java
@@ -31,5 +31,6 @@ import java.lang.annotation.RetentionPolicy;
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface BuiltBy {
-   Class<? extends Builder<?>> value();
+   @SuppressWarnings("rawtypes")
+   Class<? extends Builder> value();
 }

--- a/core/src/main/java/org/infinispan/configuration/ConfigurationUtils.java
+++ b/core/src/main/java/org/infinispan/configuration/ConfigurationUtils.java
@@ -16,28 +16,26 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  * MA  02110-1301, USA.
  */
-package org.infinispan.configuration.cache;
+package org.infinispan.configuration;
+
+import org.infinispan.config.ConfigurationException;
 
 /**
- * LockSupportStoreConfiguration.
+ * ConfigurationUtils. Contains utility methods used in configuration
  *
  * @author Tristan Tarrant
  * @since 5.2
  */
-public interface LockSupportCacheStoreConfiguration extends StoreConfiguration {
+public final class ConfigurationUtils {
 
-   /**
-    * The timeout in milliseconds before giving up on acquiring a lock
-    *
-    * @return
-    */
-   long lockAcquistionTimeout();
+   private ConfigurationUtils() {}
 
-   /**
-    * This value determines the number of threads that can concurrently access the lock container
-    *
-    * @return
-    */
-   int lockConcurrencyLevel();
-
+   @SuppressWarnings("unchecked")
+   public static <B> Class<? extends Builder<B>> builderFor(B built) {
+      BuiltBy builtBy = built.getClass().getAnnotation(BuiltBy.class);
+      if (builtBy == null) {
+         throw new ConfigurationException("Missing BuiltBy annotation for configuration bean " + built.getClass().getName());
+      }
+      return (Class<? extends Builder<B>>) builtBy.value();
+   }
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractClusteringConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractClusteringConfigurationChildBuilder.java
@@ -18,7 +18,7 @@
  */
 package org.infinispan.configuration.cache;
 
-abstract class AbstractClusteringConfigurationChildBuilder<T> extends AbstractConfigurationChildBuilder<T> implements ClusteringConfigurationChildBuilder {
+abstract class AbstractClusteringConfigurationChildBuilder extends AbstractConfigurationChildBuilder implements ClusteringConfigurationChildBuilder {
 
    private final ClusteringConfigurationBuilder clusteringBuilder;
 
@@ -31,17 +31,17 @@ abstract class AbstractClusteringConfigurationChildBuilder<T> extends AbstractCo
    public AsyncConfigurationBuilder async() {
       return clusteringBuilder.async();
    }
-   
+
    @Override
    public HashConfigurationBuilder hash() {
       return clusteringBuilder.hash();
    }
-   
+
    @Override
    public L1ConfigurationBuilder l1() {
       return clusteringBuilder.l1();
    }
-   
+
    @Override
    public StateTransferConfigurationBuilder stateTransfer() {
       return clusteringBuilder.stateTransfer();
@@ -51,9 +51,9 @@ abstract class AbstractClusteringConfigurationChildBuilder<T> extends AbstractCo
    public SyncConfigurationBuilder sync() {
       return clusteringBuilder.sync();
    }
-   
+
    protected ClusteringConfigurationBuilder getClusteringBuilder() {
       return clusteringBuilder;
    }
-   
+
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractConfigurationChildBuilder.java
@@ -18,9 +18,7 @@
  */
 package org.infinispan.configuration.cache;
 
-import org.infinispan.configuration.Builder;
-
-abstract class AbstractConfigurationChildBuilder<T> implements ConfigurationChildBuilder, Builder<T> {
+abstract class AbstractConfigurationChildBuilder implements ConfigurationChildBuilder {
 
    private final ConfigurationBuilder builder;
 

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractCustomInterceptorsConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractCustomInterceptorsConfigurationChildBuilder.java
@@ -18,17 +18,17 @@
  */
 package org.infinispan.configuration.cache;
 
-public abstract class AbstractCustomInterceptorsConfigurationChildBuilder<T> extends AbstractConfigurationChildBuilder<T> {
+public abstract class AbstractCustomInterceptorsConfigurationChildBuilder extends AbstractConfigurationChildBuilder {
 
    private final CustomInterceptorsConfigurationBuilder customInterceptorsBuilder;
-   
+
    protected AbstractCustomInterceptorsConfigurationChildBuilder(CustomInterceptorsConfigurationBuilder builder) {
       super(builder.getBuilder());
-      this.customInterceptorsBuilder = builder; 
+      this.customInterceptorsBuilder = builder;
    }
-   
+
    protected CustomInterceptorsConfigurationBuilder getCustomInterceptorsBuilder() {
       return customInterceptorsBuilder;
    }
-   
+
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractLoaderConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractLoaderConfigurationBuilder.java
@@ -26,7 +26,7 @@ import java.util.Properties;
  * rather than delegate to existing ones.
  */
 public abstract class AbstractLoaderConfigurationBuilder<T extends LoaderConfiguration, S extends AbstractLoaderConfigurationBuilder<T, S>> extends
-      AbstractLoadersConfigurationChildBuilder<T> implements LoaderConfigurationBuilder<T, S> {
+      AbstractLoadersConfigurationChildBuilder implements LoaderConfigurationBuilder<T, S> {
    protected Properties properties = new Properties();
 
    public AbstractLoaderConfigurationBuilder(LoadersConfigurationBuilder builder) {
@@ -58,5 +58,4 @@ public abstract class AbstractLoaderConfigurationBuilder<T extends LoaderConfigu
       this.properties = props;
       return self();
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractLoaderConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractLoaderConfigurationChildBuilder.java
@@ -18,18 +18,32 @@
  */
 package org.infinispan.configuration.cache;
 
+import java.util.Properties;
+
 /**
  *
- * AbstractLoaderConfigurationChildBuilder.
+ * AbstractLoaderConfigurationChildBuilder delegates {@link LoaderConfigurationChildBuilder} methods to a specified {@link LoaderConfigurationBuilder}
  *
  * @author Pete Muir
  * @author Tristan Tarrant
  * @since 5.1
  */
-public abstract class AbstractLoaderConfigurationChildBuilder<T> extends AbstractLoadersConfigurationChildBuilder<T> {
+public abstract class AbstractLoaderConfigurationChildBuilder<S> extends AbstractLoadersConfigurationChildBuilder implements LoaderConfigurationChildBuilder<S> {
 
-   AbstractLoaderConfigurationChildBuilder(LoadersConfigurationBuilder builder) {
-      super(builder);
+   private final LoaderConfigurationBuilder<? extends AbstractLoaderConfiguration, ? extends LoaderConfigurationBuilder<?,?>> builder;
+
+   protected AbstractLoaderConfigurationChildBuilder(LoaderConfigurationBuilder<? extends AbstractLoaderConfiguration, ? extends LoaderConfigurationBuilder<?,?>> builder) {
+      super(builder.loaders());
+      this.builder = builder;
    }
 
+   @Override
+   public S addProperty(String key, String value) {
+      return (S)builder.addProperty(key, value);
+   }
+
+   @Override
+   public S withProperties(Properties p) {
+      return (S)builder.withProperties(p);
+   }
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractLoadersConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractLoadersConfigurationChildBuilder.java
@@ -18,7 +18,14 @@
  */
 package org.infinispan.configuration.cache;
 
-public abstract class AbstractLoadersConfigurationChildBuilder<T> extends AbstractConfigurationChildBuilder<T> implements LoadersConfigurationChildBuilder {
+/**
+ *
+ * AbstractLoadersConfigurationChildBuilder.
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public abstract class AbstractLoadersConfigurationChildBuilder extends AbstractConfigurationChildBuilder implements LoadersConfigurationChildBuilder {
    protected AbstractLoadersConfigurationChildBuilder(LoadersConfigurationBuilder builder) {
       super(builder.getBuilder());
    }

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractLockSupportStoreConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractLockSupportStoreConfiguration.java
@@ -27,12 +27,12 @@ import org.infinispan.util.TypedProperties;
  * @author Galder Zamarreño
  * @since 5.1
  */
-public abstract class AbstractLockSupportCacheStoreConfiguration extends AbstractStoreConfiguration implements LockSupportCacheStoreConfiguration {
+public abstract class AbstractLockSupportStoreConfiguration extends AbstractStoreConfiguration implements LockSupportStoreConfiguration {
 
    private final int lockConcurrencyLevel;
    private final long lockAcquistionTimeout;
 
-   protected AbstractLockSupportCacheStoreConfiguration(long lockAcquistionTimeout,
+   protected AbstractLockSupportStoreConfiguration(long lockAcquistionTimeout,
          int lockConcurrencyLevel, boolean purgeOnStartup, boolean purgeSynchronously,
          int purgerThreads, boolean fetchPersistentState, boolean ignoreModifications,
          TypedProperties properties, AsyncStoreConfiguration async,
@@ -59,7 +59,7 @@ public abstract class AbstractLockSupportCacheStoreConfiguration extends Abstrac
       if (o == null || getClass() != o.getClass()) return false;
       if (!super.equals(o)) return false;
 
-      AbstractLockSupportCacheStoreConfiguration that = (AbstractLockSupportCacheStoreConfiguration) o;
+      AbstractLockSupportStoreConfiguration that = (AbstractLockSupportStoreConfiguration) o;
 
       if (lockAcquistionTimeout != that.lockAcquistionTimeout) return false;
       if (lockConcurrencyLevel != that.lockConcurrencyLevel) return false;

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractLockSupportStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractLockSupportStoreConfigurationBuilder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.configuration.cache;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * AbstractLockSupportCacheStoreConfigurationBuilder.
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public abstract class AbstractLockSupportStoreConfigurationBuilder<T extends LockSupportStoreConfiguration, S extends AbstractLockSupportStoreConfigurationBuilder<T, S>> extends
+      AbstractStoreConfigurationBuilder<T, S> implements LockSupportStoreConfigurationBuilder<T, S> {
+
+   protected long lockAcquistionTimeout;
+   protected int lockConcurrencyLevel;
+
+   public AbstractLockSupportStoreConfigurationBuilder(LoadersConfigurationBuilder builder) {
+      super(builder);
+   }
+
+   @Override
+   public S lockAcquistionTimeout(long lockAcquistionTimeout) {
+      this.lockAcquistionTimeout = lockAcquistionTimeout;
+      return self();
+   }
+
+   @Override
+   public S lockAcquistionTimeout(long lockAcquistionTimeout, TimeUnit unit) {
+      return lockAcquistionTimeout(unit.toMillis(lockAcquistionTimeout));
+   }
+
+   @Override
+   public S lockConcurrencyLevel(int lockConcurrencyLevel) {
+      this.lockConcurrencyLevel = lockConcurrencyLevel;
+      return self();
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractLockSupportStoreConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractLockSupportStoreConfigurationChildBuilder.java
@@ -22,35 +22,36 @@ package org.infinispan.configuration.cache;
 import java.util.concurrent.TimeUnit;
 
 /**
- * AbstractLockSupportCacheStoreConfigurationBuilder.
+ *
+ * AbstractLockSupportStoreConfigurationChildBuilder delegates {@link LockSupportStoreConfigurationChildBuilder} methods
+ * to a specified {@link LockSupportStoreConfigurationBuilder}
  *
  * @author Tristan Tarrant
  * @since 5.2
  */
-public abstract class AbstractLockSupportCacheStoreConfigurationBuilder<T extends StoreConfiguration, S extends AbstractLockSupportCacheStoreConfigurationBuilder<T, S>> extends
-      AbstractStoreConfigurationBuilder<T, S> implements LockSupportCacheStoreConfigurationBuilder<T, S> {
+public abstract class AbstractLockSupportStoreConfigurationChildBuilder<S>
+      extends AbstractStoreConfigurationChildBuilder<S> implements LockSupportStoreConfigurationChildBuilder<S> {
 
-   protected long lockAcquistionTimeout;
-   protected int lockConcurrencyLevel;
+   private final LockSupportStoreConfigurationBuilder<? extends AbstractLockSupportStoreConfiguration, ? extends LockSupportStoreConfigurationBuilder<?, ?>> builder;
 
-   public AbstractLockSupportCacheStoreConfigurationBuilder(LoadersConfigurationBuilder builder) {
+   public AbstractLockSupportStoreConfigurationChildBuilder(
+         AbstractLockSupportStoreConfigurationBuilder<? extends AbstractLockSupportStoreConfiguration, ? extends LockSupportStoreConfigurationBuilder<?, ?>> builder) {
       super(builder);
+      this.builder = builder;
    }
 
    @Override
    public S lockAcquistionTimeout(long lockAcquistionTimeout) {
-      this.lockAcquistionTimeout = lockAcquistionTimeout;
-      return self();
+      return (S) builder.lockAcquistionTimeout(lockAcquistionTimeout);
    }
 
    @Override
    public S lockAcquistionTimeout(long lockAcquistionTimeout, TimeUnit unit) {
-      return lockAcquistionTimeout(unit.toMillis(lockAcquistionTimeout));
+      return (S) builder.lockAcquistionTimeout(lockAcquistionTimeout, unit);
    }
 
    @Override
    public S lockConcurrencyLevel(int lockConcurrencyLevel) {
-      this.lockConcurrencyLevel = lockConcurrencyLevel;
-      return self();
+      return (S) builder.lockConcurrencyLevel(lockConcurrencyLevel);
    }
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractModuleConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractModuleConfigurationBuilder.java
@@ -24,7 +24,7 @@ package org.infinispan.configuration.cache;
  * @author Tristan Tarrant
  * @since 5.2
  */
-public abstract class AbstractModuleConfigurationBuilder<T> extends AbstractConfigurationChildBuilder<T> {
+public abstract class AbstractModuleConfigurationBuilder extends AbstractConfigurationChildBuilder {
 
    protected AbstractModuleConfigurationBuilder(ConfigurationBuilder builder) {
       super(builder);

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractStoreConfigurationBuilder.java
@@ -31,8 +31,8 @@ public abstract class AbstractStoreConfigurationBuilder<T extends StoreConfigura
 
    private static final Log log = LogFactory.getLog(LegacyStoreConfigurationBuilder.class);
 
-   protected final AsyncStoreConfigurationBuilder async;
-   protected final SingletonStoreConfigurationBuilder singletonStore;
+   protected final AsyncStoreConfigurationBuilder<S> async;
+   protected final SingletonStoreConfigurationBuilder<S> singletonStore;
    protected boolean fetchPersistentState = false;
    protected boolean ignoreModifications = false;
    protected boolean purgeOnStartup = false;
@@ -41,8 +41,8 @@ public abstract class AbstractStoreConfigurationBuilder<T extends StoreConfigura
 
    public AbstractStoreConfigurationBuilder(LoadersConfigurationBuilder builder) {
       super(builder);
-      this.async = new AsyncStoreConfigurationBuilder(builder);
-      this.singletonStore = new SingletonStoreConfigurationBuilder(builder);
+      this.async = new AsyncStoreConfigurationBuilder(this);
+      this.singletonStore = new SingletonStoreConfigurationBuilder(this);
    }
 
    /**
@@ -50,7 +50,7 @@ public abstract class AbstractStoreConfigurationBuilder<T extends StoreConfigura
     * writes to the cache store, giving you 'write-behind' caching.
     */
    @Override
-   public AsyncStoreConfigurationBuilder async() {
+   public AsyncStoreConfigurationBuilder<S> async() {
       return async;
    }
 
@@ -61,7 +61,7 @@ public abstract class AbstractStoreConfigurationBuilder<T extends StoreConfigura
     * CacheStore implementation. It always delegates reads to the real CacheStore.
     */
    @Override
-   public SingletonStoreConfigurationBuilder singletonStore() {
+   public SingletonStoreConfigurationBuilder<S> singletonStore() {
       return singletonStore;
    }
 

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractStoreConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractStoreConfigurationChildBuilder.java
@@ -18,23 +18,55 @@
  */
 package org.infinispan.configuration.cache;
 
-public abstract class AbstractStoreConfigurationChildBuilder<T> extends AbstractLoaderConfigurationChildBuilder<T> implements StoreConfigurationChildBuilder {
+/**
+*
+* AbstractStoreConfigurationChildBuilder delegates {@link StoreConfigurationChildBuilder} methods to a specified {@link StoreConfigurationBuilder}
+*
+* @author Tristan Tarrant
+* @since 5.2
+*/
+public abstract class AbstractStoreConfigurationChildBuilder<S> extends AbstractLoaderConfigurationChildBuilder<S> implements StoreConfigurationChildBuilder<S> {
 
-   private final StoreConfigurationBuilder<? extends AbstractStoreConfiguration, ? extends StoreConfigurationBuilder<?,?>> storeConfigurationBuilder;
+   private final StoreConfigurationBuilder<? extends AbstractStoreConfiguration, ? extends StoreConfigurationBuilder<?, ?>> builder;
 
    protected AbstractStoreConfigurationChildBuilder(AbstractStoreConfigurationBuilder<? extends AbstractStoreConfiguration, ?> builder) {
-      super(builder.loaders());
-      this.storeConfigurationBuilder = builder;
+      super(builder);
+      this.builder = builder;
    }
 
    @Override
-   public AsyncStoreConfigurationBuilder async() {
-      return storeConfigurationBuilder.async();
+   public AsyncStoreConfigurationBuilder<S> async() {
+      return (AsyncStoreConfigurationBuilder<S>) builder.async();
    }
 
    @Override
-   public SingletonStoreConfigurationBuilder singletonStore() {
-      return storeConfigurationBuilder.singletonStore();
+   public SingletonStoreConfigurationBuilder<S> singletonStore() {
+      return (SingletonStoreConfigurationBuilder<S>) builder.singletonStore();
+   }
+
+   @Override
+   public S fetchPersistentState(boolean b) {
+      return (S) builder.fetchPersistentState(b);
+   }
+
+   @Override
+   public S ignoreModifications(boolean b) {
+      return (S) builder.ignoreModifications(b);
+   }
+
+   @Override
+   public S purgeOnStartup(boolean b) {
+      return (S) builder.purgeOnStartup(b);
+   }
+
+   @Override
+   public S purgerThreads(int i) {
+      return (S) builder.purgerThreads(i);
+   }
+
+   @Override
+   public S purgeSynchronously(boolean b) {
+      return (S) builder.purgeSynchronously(b);
    }
 
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractTransportConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractTransportConfigurationChildBuilder.java
@@ -18,15 +18,15 @@
  */
 package org.infinispan.configuration.cache;
 
-public abstract class AbstractTransportConfigurationChildBuilder<T> extends AbstractConfigurationChildBuilder<T> implements TransactionConfigurationChildBuilder {
+public abstract class AbstractTransportConfigurationChildBuilder extends AbstractConfigurationChildBuilder implements TransactionConfigurationChildBuilder {
 
    private final TransactionConfigurationBuilder transactionConfigurationBuilder;
-   
+
    protected AbstractTransportConfigurationChildBuilder(TransactionConfigurationBuilder builder) {
       super(builder.getBuilder());
       this.transactionConfigurationBuilder = builder;
    }
-   
+
    @Override
    public RecoveryConfigurationBuilder recovery() {
       return transactionConfigurationBuilder.recovery();

--- a/core/src/main/java/org/infinispan/configuration/cache/AsyncConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AsyncConfigurationBuilder.java
@@ -21,6 +21,7 @@ package org.infinispan.configuration.cache;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.config.ConfigurationException;
+import org.infinispan.configuration.Builder;
 import org.infinispan.remoting.ReplicationQueue;
 import org.infinispan.remoting.ReplicationQueueImpl;
 
@@ -30,7 +31,7 @@ import org.infinispan.remoting.ReplicationQueueImpl;
  * exclusive with synchronous configuration.
  *
  */
-public class AsyncConfigurationBuilder extends AbstractClusteringConfigurationChildBuilder<AsyncConfiguration> {
+public class AsyncConfigurationBuilder extends AbstractClusteringConfigurationChildBuilder implements Builder<AsyncConfiguration> {
 
    private boolean asyncMarshalling = false;
    private ReplicationQueue replicationQueue = new ReplicationQueueImpl();

--- a/core/src/main/java/org/infinispan/configuration/cache/AsyncStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AsyncStoreConfigurationBuilder.java
@@ -20,6 +20,8 @@ package org.infinispan.configuration.cache;
 
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.configuration.Builder;
+
 /**
  * Configuration for the async cache store. If enabled, this provides you with asynchronous writes
  * to the cache store, giving you 'write-behind' caching.
@@ -27,7 +29,7 @@ import java.util.concurrent.TimeUnit;
  * @author pmuir
  *
  */
-public class AsyncStoreConfigurationBuilder extends AbstractLoaderConfigurationChildBuilder<AsyncStoreConfiguration> {
+public class AsyncStoreConfigurationBuilder<S> extends AbstractStoreConfigurationChildBuilder<S> implements Builder<AsyncStoreConfiguration> {
 
    private boolean enabled = false;
    private long flushLockTimeout = 1;
@@ -35,24 +37,24 @@ public class AsyncStoreConfigurationBuilder extends AbstractLoaderConfigurationC
    private long shutdownTimeout = TimeUnit.SECONDS.toMillis(25);
    private int threadPoolSize = 1;
 
-   AsyncStoreConfigurationBuilder(LoadersConfigurationBuilder builder) {
+   AsyncStoreConfigurationBuilder(AbstractStoreConfigurationBuilder<? extends AbstractStoreConfiguration, ?> builder) {
       super(builder);
    }
 
    /**
     * If true, all modifications to this cache store happen asynchronously, on a separate thread.
     */
-   public AsyncStoreConfigurationBuilder enable() {
+   public AsyncStoreConfigurationBuilder<S> enable() {
       this.enabled = true;
       return this;
    }
 
-   public AsyncStoreConfigurationBuilder disable() {
+   public AsyncStoreConfigurationBuilder<S> disable() {
       this.enabled = false;
       return this;
    }
 
-   public AsyncStoreConfigurationBuilder enabled(boolean enabled) {
+   public AsyncStoreConfigurationBuilder<S> enabled(boolean enabled) {
       this.enabled = enabled;
       return this;
    }
@@ -61,7 +63,7 @@ public class AsyncStoreConfigurationBuilder extends AbstractLoaderConfigurationC
     * Timeout to acquire the lock which guards the state to be flushed to the cache store
     * periodically. The timeout can be adjusted for a running cache.
     */
-   public AsyncStoreConfigurationBuilder flushLockTimeout(long l) {
+   public AsyncStoreConfigurationBuilder<S> flushLockTimeout(long l) {
       this.flushLockTimeout = l;
       return this;
    }
@@ -70,7 +72,7 @@ public class AsyncStoreConfigurationBuilder extends AbstractLoaderConfigurationC
     * Timeout to acquire the lock which guards the state to be flushed to the cache store
     * periodically. The timeout can be adjusted for a running cache.
     */
-   public AsyncStoreConfigurationBuilder flushLockTimeout(long l, TimeUnit unit) {
+   public AsyncStoreConfigurationBuilder<S> flushLockTimeout(long l, TimeUnit unit) {
       return flushLockTimeout(unit.toMillis(l));
    }
 
@@ -80,7 +82,7 @@ public class AsyncStoreConfigurationBuilder extends AbstractLoaderConfigurationC
     * behaves like a synchronous store for that period, blocking until the queue can accept more
     * elements.
     */
-   public AsyncStoreConfigurationBuilder modificationQueueSize(int i) {
+   public AsyncStoreConfigurationBuilder<S> modificationQueueSize(int i) {
       this.modificationQueueSize = i;
       return this;
    }
@@ -90,7 +92,7 @@ public class AsyncStoreConfigurationBuilder extends AbstractLoaderConfigurationC
     * modifications still need to be applied; you likely want to set a very large timeout to make
     * sure to not loose data
     */
-   public AsyncStoreConfigurationBuilder shutdownTimeout(long l) {
+   public AsyncStoreConfigurationBuilder<S> shutdownTimeout(long l) {
       this.shutdownTimeout = l;
       return this;
    }
@@ -100,14 +102,14 @@ public class AsyncStoreConfigurationBuilder extends AbstractLoaderConfigurationC
     * modifications still need to be applied; you likely want to set a very large timeout to make
     * sure to not loose data
     */
-   public AsyncStoreConfigurationBuilder shutdownTimeout(long l, TimeUnit unit) {
+   public AsyncStoreConfigurationBuilder<S> shutdownTimeout(long l, TimeUnit unit) {
       return shutdownTimeout(unit.toMillis(l));
    }
 
    /**
     * Size of the thread pool whose threads are responsible for applying the modifications.
     */
-   public AsyncStoreConfigurationBuilder threadPoolSize(int i) {
+   public AsyncStoreConfigurationBuilder<S> threadPoolSize(int i) {
       this.threadPoolSize = i;
       return this;
    }
@@ -124,7 +126,7 @@ public class AsyncStoreConfigurationBuilder extends AbstractLoaderConfigurationC
    }
 
    @Override
-   public AsyncStoreConfigurationBuilder read(AsyncStoreConfiguration template) {
+   public AsyncStoreConfigurationBuilder<S> read(AsyncStoreConfiguration template) {
       this.enabled = template.enabled();
       this.flushLockTimeout = template.flushLockTimeout();
       this.modificationQueueSize = template.modificationQueueSize();

--- a/core/src/main/java/org/infinispan/configuration/cache/BackupConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/BackupConfigurationBuilder.java
@@ -26,7 +26,7 @@ import org.infinispan.configuration.Builder;
  * @author Mircea.Markus@jboss.com
  * @since 5.2
  */
-public class BackupConfigurationBuilder extends AbstractConfigurationChildBuilder<BackupConfiguration> {
+public class BackupConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<BackupConfiguration> {
 
    private String site;
 

--- a/core/src/main/java/org/infinispan/configuration/cache/BackupForBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/BackupForBuilder.java
@@ -27,7 +27,7 @@ import org.infinispan.configuration.Builder;
  * @author Mircea Markus
  * @since 5.2
  */
-public class BackupForBuilder extends AbstractConfigurationChildBuilder<BackupForConfiguration> {
+public class BackupForBuilder extends AbstractConfigurationChildBuilder implements Builder<BackupForConfiguration> {
    private String remoteCache;
    private String remoteSite;
 

--- a/core/src/main/java/org/infinispan/configuration/cache/ClusteringConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ClusteringConfigurationBuilder.java
@@ -18,14 +18,16 @@
  */
 package org.infinispan.configuration.cache;
 
+import org.infinispan.configuration.Builder;
+
 /**
  * Defines clustered characteristics of the cache.
  *
  * @author pmuir
  *
  */
-public class ClusteringConfigurationBuilder extends AbstractConfigurationChildBuilder<ClusteringConfiguration> implements
-      ClusteringConfigurationChildBuilder {
+public class ClusteringConfigurationBuilder extends AbstractConfigurationChildBuilder implements
+      ClusteringConfigurationChildBuilder, Builder<ClusteringConfiguration> {
 
    private CacheMode cacheMode = CacheMode.LOCAL;
    private final AsyncConfigurationBuilder asyncConfigurationBuilder;

--- a/core/src/main/java/org/infinispan/configuration/cache/ConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ConfigurationBuilder.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 import org.infinispan.config.ConfigurationException;
 import org.infinispan.configuration.Builder;
-import org.infinispan.configuration.BuiltBy;
+import org.infinispan.configuration.ConfigurationUtils;
 
 public class ConfigurationBuilder implements ConfigurationChildBuilder {
 
@@ -173,13 +173,14 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder {
       }
    }
 
+   @Override
    public SitesConfigurationBuilder sites() {
       return sites;
    }
 
    @SuppressWarnings("unchecked")
    public void validate() {
-      for (AbstractConfigurationChildBuilder<?> validatable:
+      for (Builder<?> validatable:
             asList(clustering, dataContainer, deadlockDetection, eviction, expiration, indexing,
                    invocationBatching, jmxStatistics, loaders, locking, storeAsBinary, transaction,
                    versioning, unsafe, sites)) {
@@ -231,11 +232,7 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder {
       this.versioning.read(template.versioning());
 
       for (Object c : template.modules().values()) {
-         BuiltBy builtBy = c.getClass().getAnnotation(BuiltBy.class);
-         if (builtBy==null) {
-            throw new ConfigurationException("Missing BuiltBy annotation for configuration bean "+c.getClass().getName());
-         }
-         Builder<Object> builder = (Builder<Object>) this.addModule(builtBy.value());
+         Builder<Object> builder = this.addModule(ConfigurationUtils.builderFor(c));
          builder.read(c);
       }
 

--- a/core/src/main/java/org/infinispan/configuration/cache/CustomInterceptorsConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/CustomInterceptorsConfigurationBuilder.java
@@ -22,13 +22,15 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.infinispan.configuration.Builder;
+
 /**
  * Configures custom interceptors to be added to the cache.
  *
  * @author pmuir
  *
  */
-public class CustomInterceptorsConfigurationBuilder extends AbstractConfigurationChildBuilder<CustomInterceptorsConfiguration> {
+public class CustomInterceptorsConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<CustomInterceptorsConfiguration> {
 
    private List<InterceptorConfigurationBuilder> interceptorBuilders = new LinkedList<InterceptorConfigurationBuilder>();
 

--- a/core/src/main/java/org/infinispan/configuration/cache/DataContainerConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/DataContainerConfigurationBuilder.java
@@ -20,6 +20,7 @@ package org.infinispan.configuration.cache;
 
 import java.util.Properties;
 
+import org.infinispan.configuration.Builder;
 import org.infinispan.container.DataContainer;
 import org.infinispan.util.TypedProperties;
 
@@ -29,7 +30,7 @@ import org.infinispan.util.TypedProperties;
  * @author pmuir
  *
  */
-public class DataContainerConfigurationBuilder extends AbstractConfigurationChildBuilder<DataContainerConfiguration> {
+public class DataContainerConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<DataContainerConfiguration> {
 
    // No default here. DataContainerFactory figures out default.
    private DataContainer dataContainer;

--- a/core/src/main/java/org/infinispan/configuration/cache/DeadlockDetectionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/DeadlockDetectionConfigurationBuilder.java
@@ -20,10 +20,12 @@ package org.infinispan.configuration.cache;
 
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.configuration.Builder;
+
 /**
  * Configures deadlock detection.
  */
-public class DeadlockDetectionConfigurationBuilder extends AbstractConfigurationChildBuilder<DeadlockDetectionConfiguration> {
+public class DeadlockDetectionConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<DeadlockDetectionConfiguration> {
 
    private boolean enabled = false;
    private long spinDuration = TimeUnit.MILLISECONDS.toMillis(100);

--- a/core/src/main/java/org/infinispan/configuration/cache/EvictionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/EvictionConfigurationBuilder.java
@@ -19,6 +19,7 @@
 package org.infinispan.configuration.cache;
 
 import org.infinispan.config.ConfigurationException;
+import org.infinispan.configuration.Builder;
 import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.eviction.EvictionThreadPolicy;
 import org.infinispan.util.logging.Log;
@@ -27,7 +28,7 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * Controls the eviction settings for the cache.
  */
-public class EvictionConfigurationBuilder extends AbstractConfigurationChildBuilder<EvictionConfiguration> {
+public class EvictionConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<EvictionConfiguration> {
 
    private static final Log log = LogFactory.getLog(EvictionConfigurationBuilder.class);
 

--- a/core/src/main/java/org/infinispan/configuration/cache/ExpirationConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ExpirationConfigurationBuilder.java
@@ -20,10 +20,12 @@ package org.infinispan.configuration.cache;
 
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.configuration.Builder;
+
 /**
  * Controls the default expiration settings for entries in the cache.
  */
-public class ExpirationConfigurationBuilder extends AbstractConfigurationChildBuilder<ExpirationConfiguration> {
+public class ExpirationConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<ExpirationConfiguration> {
 
    private long lifespan = -1L;
    private long maxIdle = -1L;

--- a/core/src/main/java/org/infinispan/configuration/cache/FileCacheStoreConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/FileCacheStoreConfiguration.java
@@ -32,7 +32,7 @@ import org.infinispan.util.TypedProperties;
  * @since 5.1
  */
 @BuiltBy(FileCacheStoreConfigurationBuilder.class)
-public class FileCacheStoreConfiguration extends AbstractLockSupportCacheStoreConfiguration implements LegacyLoaderAdapter<FileCacheStoreConfig>{
+public class FileCacheStoreConfiguration extends AbstractLockSupportStoreConfiguration implements LegacyLoaderAdapter<FileCacheStoreConfig>{
 
    private final String location;
    private final long fsyncInterval;

--- a/core/src/main/java/org/infinispan/configuration/cache/FileCacheStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/FileCacheStoreConfigurationBuilder.java
@@ -32,7 +32,7 @@ import org.infinispan.util.TypedProperties;
  * @author Galder Zamarreño
  * @since 5.1
  */
-public class FileCacheStoreConfigurationBuilder extends AbstractLockSupportCacheStoreConfigurationBuilder<FileCacheStoreConfiguration, FileCacheStoreConfigurationBuilder> {
+public class FileCacheStoreConfigurationBuilder extends AbstractLockSupportStoreConfigurationBuilder<FileCacheStoreConfiguration, FileCacheStoreConfigurationBuilder> {
 
    private String location = "Infinispan-FileCacheStore";
    private long fsyncInterval = TimeUnit.SECONDS.toMillis(1);

--- a/core/src/main/java/org/infinispan/configuration/cache/GroupsConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/GroupsConfigurationBuilder.java
@@ -18,6 +18,7 @@
  */
 package org.infinispan.configuration.cache;
 
+import org.infinispan.configuration.Builder;
 import org.infinispan.distribution.group.Group;
 import org.infinispan.distribution.group.Grouper;
 
@@ -30,7 +31,7 @@ import java.util.List;
  * @author pmuir
  *
  */
-public class GroupsConfigurationBuilder extends AbstractClusteringConfigurationChildBuilder<GroupsConfiguration> {
+public class GroupsConfigurationBuilder extends AbstractClusteringConfigurationChildBuilder implements Builder<GroupsConfiguration> {
 
    private boolean enabled = false;
    private List<Grouper<?>> groupers = new LinkedList<Grouper<?>>();

--- a/core/src/main/java/org/infinispan/configuration/cache/HashConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/HashConfigurationBuilder.java
@@ -20,6 +20,7 @@ package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.hash.Hash;
 import org.infinispan.commons.hash.MurmurHash3;
+import org.infinispan.configuration.Builder;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.distribution.ch.ConsistentHashFactory;
 import org.infinispan.util.logging.Log;
@@ -31,7 +32,7 @@ import org.infinispan.util.logging.LogFactory;
  * @author pmuir
  *
  */
-public class HashConfigurationBuilder extends AbstractClusteringConfigurationChildBuilder<HashConfiguration> {
+public class HashConfigurationBuilder extends AbstractClusteringConfigurationChildBuilder implements Builder<HashConfiguration> {
    private static final Log log = LogFactory.getLog(HashConfigurationBuilder.class);
 
    private ConsistentHashFactory consistentHashFactory;

--- a/core/src/main/java/org/infinispan/configuration/cache/IndexingConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/IndexingConfigurationBuilder.java
@@ -21,6 +21,7 @@ package org.infinispan.configuration.cache;
 import java.util.Map;
 import java.util.Properties;
 
+import org.infinispan.configuration.Builder;
 import org.infinispan.util.TypedProperties;
 import org.infinispan.util.Util;
 import org.infinispan.util.logging.Log;
@@ -29,7 +30,7 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * Configures indexing of entries in the cache for searching.
  */
-public class IndexingConfigurationBuilder extends AbstractConfigurationChildBuilder<IndexingConfiguration>{
+public class IndexingConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<IndexingConfiguration>{
 
    private static final Log log = LogFactory.getLog(IndexingConfigurationBuilder.class);
 

--- a/core/src/main/java/org/infinispan/configuration/cache/InterceptorConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/InterceptorConfigurationBuilder.java
@@ -19,13 +19,14 @@
 package org.infinispan.configuration.cache;
 
 import org.infinispan.config.ConfigurationException;
+import org.infinispan.configuration.Builder;
 import org.infinispan.configuration.cache.InterceptorConfiguration.Position;
 import org.infinispan.interceptors.base.CommandInterceptor;
 
 /**
  * This builder defines details of a specific custom interceptor.
  */
-public class InterceptorConfigurationBuilder extends AbstractCustomInterceptorsConfigurationChildBuilder<InterceptorConfiguration> {
+public class InterceptorConfigurationBuilder extends AbstractCustomInterceptorsConfigurationChildBuilder implements Builder<InterceptorConfiguration> {
 
    private Class<? extends CommandInterceptor> after;
    private Class<? extends CommandInterceptor> before;

--- a/core/src/main/java/org/infinispan/configuration/cache/InvocationBatchingConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/InvocationBatchingConfigurationBuilder.java
@@ -20,7 +20,9 @@ package org.infinispan.configuration.cache;
 
 import static org.infinispan.transaction.TransactionMode.NON_TRANSACTIONAL;
 
-public class InvocationBatchingConfigurationBuilder extends AbstractConfigurationChildBuilder<InvocationBatchingConfiguration> {
+import org.infinispan.configuration.Builder;
+
+public class InvocationBatchingConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<InvocationBatchingConfiguration> {
 
    boolean enabled = false;
 

--- a/core/src/main/java/org/infinispan/configuration/cache/JMXStatisticsConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/JMXStatisticsConfigurationBuilder.java
@@ -18,13 +18,15 @@
  */
 package org.infinispan.configuration.cache;
 
+import org.infinispan.configuration.Builder;
+
 /**
  * Determines whether statistics are gather and reported.
  *
  * @author pmuir
  *
  */
-public class JMXStatisticsConfigurationBuilder extends AbstractConfigurationChildBuilder<JMXStatisticsConfiguration> {
+public class JMXStatisticsConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<JMXStatisticsConfiguration> {
 
    private boolean enabled = false;
 

--- a/core/src/main/java/org/infinispan/configuration/cache/L1ConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/L1ConfigurationBuilder.java
@@ -19,6 +19,7 @@
 package org.infinispan.configuration.cache;
 
 import org.infinispan.config.ConfigurationException;
+import org.infinispan.configuration.Builder;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -29,7 +30,7 @@ import java.util.concurrent.TimeUnit;
  * this element is ignored.
  */
 
-public class L1ConfigurationBuilder extends AbstractClusteringConfigurationChildBuilder<L1Configuration> {
+public class L1ConfigurationBuilder extends AbstractClusteringConfigurationChildBuilder implements Builder<L1Configuration> {
 
    private static final Log log = LogFactory.getLog(L1ConfigurationBuilder.class);
 

--- a/core/src/main/java/org/infinispan/configuration/cache/LegacyConfigurationAdaptor.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LegacyConfigurationAdaptor.java
@@ -551,8 +551,8 @@ public class LegacyConfigurationAdaptor {
       legacy.getSingletonStoreConfig().pushStateTimeout(config.singletonStore().pushStateTimeout());
       legacy.getSingletonStoreConfig().pushStateWhenCoordinator(config.singletonStore().pushStateWhenCoordinator());
 
-      if (config instanceof LockSupportCacheStoreConfiguration) {
-         LockSupportCacheStoreConfiguration lockConfig = (LockSupportCacheStoreConfiguration) config;
+      if (config instanceof LockSupportStoreConfiguration) {
+         LockSupportStoreConfiguration lockConfig = (LockSupportStoreConfiguration) config;
          LockSupportCacheStoreConfig lockLegacy = (LockSupportCacheStoreConfig) legacy;
          lockLegacy.setLockAcquistionTimeout(lockConfig.lockAcquistionTimeout());
          lockLegacy.setLockConcurrencyLevel(lockConfig.lockConcurrencyLevel());

--- a/core/src/main/java/org/infinispan/configuration/cache/LegacyStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LegacyStoreConfigurationBuilder.java
@@ -31,8 +31,7 @@ import org.infinispan.util.TypedProperties;
  *
  * @since 5.2
  */
-public class LegacyStoreConfigurationBuilder extends AbstractStoreConfigurationBuilder<LegacyStoreConfiguration, LegacyStoreConfigurationBuilder> implements
-      StoreConfigurationChildBuilder {
+public class LegacyStoreConfigurationBuilder extends AbstractStoreConfigurationBuilder<LegacyStoreConfiguration, LegacyStoreConfigurationBuilder> {
 
    private CacheLoader cacheStore; // TODO: in 6.0, as we deprecate the cacheLoader() method, narrow this type to CacheStore
 

--- a/core/src/main/java/org/infinispan/configuration/cache/LoaderConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LoaderConfigurationBuilder.java
@@ -18,8 +18,6 @@
  */
 package org.infinispan.configuration.cache;
 
-import java.util.Properties;
-
 import org.infinispan.configuration.Builder;
 import org.infinispan.configuration.Self;
 
@@ -29,24 +27,6 @@ import org.infinispan.configuration.Self;
  * @author Tristan Tarrant
  * @since 5.2
  */
-public interface LoaderConfigurationBuilder<T extends LoaderConfiguration, S extends LoaderConfigurationBuilder<T,S>> extends Builder<T>, ConfigurationChildBuilder, Self<S> {
-
-   /**
-    * <p>
-    * Defines a single property. Can be used multiple times to define all needed properties, but the
-    * full set is overridden by {@link #withProperties(Properties)}.
-    * </p>
-    * <p>
-    * These properties are passed directly to the cache store.
-    * </p>
-    */
-   S addProperty(String key, String value);
-
-   /**
-    * Properties passed to the cache store or loader
-    * @param p
-    * @return
-    */
-   S withProperties(Properties p);
+public interface LoaderConfigurationBuilder<T extends LoaderConfiguration, S extends LoaderConfigurationBuilder<T,S>> extends Builder<T>, LoaderConfigurationChildBuilder<S>, Self<S> {
 
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/LoaderConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LoaderConfigurationChildBuilder.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.configuration.cache;
+
+import java.util.Properties;
+
+/**
+ * LoaderConfigurationBuilder is an interface which should be implemented by all cache loader builders
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public interface LoaderConfigurationChildBuilder<S> extends ConfigurationChildBuilder {
+
+   /**
+    * <p>
+    * Defines a single property. Can be used multiple times to define all needed properties, but the
+    * full set is overridden by {@link #withProperties(Properties)}.
+    * </p>
+    * <p>
+    * These properties are passed directly to the cache store.
+    * </p>
+    */
+   S addProperty(String key, String value);
+
+   /**
+    * Properties passed to the cache store or loader
+    * @param p
+    * @return
+    */
+   S withProperties(Properties p);
+
+}

--- a/core/src/main/java/org/infinispan/configuration/cache/LoadersConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LoadersConfigurationBuilder.java
@@ -25,13 +25,13 @@ import java.util.List;
 
 import org.infinispan.config.ConfigurationException;
 import org.infinispan.configuration.Builder;
-import org.infinispan.configuration.BuiltBy;
+import org.infinispan.configuration.ConfigurationUtils;
 
 /**
  * Configuration for cache loaders and stores.
  *
  */
-public class LoadersConfigurationBuilder extends AbstractConfigurationChildBuilder<LoadersConfiguration> {
+public class LoadersConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<LoadersConfiguration> {
 
    private boolean passivation = false;
    private boolean preload = false;
@@ -238,11 +238,7 @@ public class LoadersConfigurationBuilder extends AbstractConfigurationChildBuild
    @Override
    public LoadersConfigurationBuilder read(LoadersConfiguration template) {
       for (LoaderConfiguration c : template.cacheLoaders()) {
-         BuiltBy builtBy = c.getClass().getAnnotation(BuiltBy.class);
-         if (builtBy==null) {
-            throw new ConfigurationException("Missing BuiltBy annotation for configuration bean "+c.getClass().getName());
-         }
-         Class<? extends LoaderConfigurationBuilder<?, ?>> builderClass = (Class<? extends LoaderConfigurationBuilder<?, ?>>) builtBy.value();
+         Class<? extends LoaderConfigurationBuilder<?, ?>> builderClass = (Class<? extends LoaderConfigurationBuilder<?, ?>>) ConfigurationUtils.builderFor(c);
          Builder<Object> builder = (Builder<Object>) this.addLoader(builderClass);
          builder.read(c);
       }

--- a/core/src/main/java/org/infinispan/configuration/cache/LockSupportStoreConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LockSupportStoreConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.configuration.cache;
+
+/**
+ * LockSupportStoreConfiguration.
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public interface LockSupportStoreConfiguration extends StoreConfiguration {
+
+   /**
+    * The timeout in milliseconds before giving up on acquiring a lock
+    *
+    * @return
+    */
+   long lockAcquistionTimeout();
+
+   /**
+    * This value determines the number of threads that can concurrently access the lock container
+    *
+    * @return
+    */
+   int lockConcurrencyLevel();
+
+}

--- a/core/src/main/java/org/infinispan/configuration/cache/LockSupportStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LockSupportStoreConfigurationBuilder.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.configuration.cache;
+
+/**
+ * LockSupportCacheStoreConfigurationBuilder is an interface which should be implemented by all cache store builders which support locking
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public interface LockSupportStoreConfigurationBuilder<T extends LockSupportStoreConfiguration, S extends LockSupportStoreConfigurationBuilder<T, S>> extends StoreConfigurationBuilder<T, S>, LockSupportStoreConfigurationChildBuilder<S> {
+
+}

--- a/core/src/main/java/org/infinispan/configuration/cache/LockSupportStoreConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LockSupportStoreConfigurationChildBuilder.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.configuration.cache;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * LockSupportCacheStoreConfigurationBuilder is an interface which should be implemented by all cache store builders which support locking
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+public interface LockSupportStoreConfigurationChildBuilder<S> extends StoreConfigurationChildBuilder<S> {
+
+   S lockAcquistionTimeout(long lockAcquistionTimeout);
+
+   S lockAcquistionTimeout(
+         long lockAcquistionTimeout, TimeUnit unit);
+
+   S lockConcurrencyLevel(int lockConcurrencyLevel);
+
+}

--- a/core/src/main/java/org/infinispan/configuration/cache/LockingConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LockingConfigurationBuilder.java
@@ -19,6 +19,7 @@
 package org.infinispan.configuration.cache;
 
 import org.infinispan.config.ConfigurationException;
+import org.infinispan.configuration.Builder;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.util.concurrent.IsolationLevel;
 
@@ -30,7 +31,7 @@ import java.util.concurrent.TimeUnit;
  * @author pmuir
  *
  */
-public class LockingConfigurationBuilder extends AbstractConfigurationChildBuilder<LockingConfiguration> {
+public class LockingConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<LockingConfiguration> {
 
    private int concurrencyLevel = 32;
    IsolationLevel isolationLevel = IsolationLevel.READ_COMMITTED;

--- a/core/src/main/java/org/infinispan/configuration/cache/RecoveryConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/RecoveryConfigurationBuilder.java
@@ -18,13 +18,15 @@
  */
 package org.infinispan.configuration.cache;
 
+import org.infinispan.configuration.Builder;
+
 /**
  * Defines recovery configuration for the cache.
  *
  * @author pmuir
  *
  */
-public class RecoveryConfigurationBuilder extends AbstractTransportConfigurationChildBuilder<RecoveryConfiguration> {
+public class RecoveryConfigurationBuilder extends AbstractTransportConfigurationChildBuilder implements Builder<RecoveryConfiguration> {
 
    private boolean enabled = true;
    private String recoveryInfoCacheName = "__recoveryInfoCacheName__";

--- a/core/src/main/java/org/infinispan/configuration/cache/SingletonStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/SingletonStoreConfigurationBuilder.java
@@ -20,6 +20,8 @@ package org.infinispan.configuration.cache;
 
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.configuration.Builder;
+
 /**
  * SingletonStore is a delegating cache store used for situations when only one
  * instance in a cluster should interact with the underlying store. The coordinator of the cluster will be responsible for
@@ -29,20 +31,20 @@ import java.util.concurrent.TimeUnit;
  * @author pmuir
  *
  */
-public class SingletonStoreConfigurationBuilder extends AbstractLoaderConfigurationChildBuilder<SingletonStoreConfiguration> {
+public class SingletonStoreConfigurationBuilder<S> extends AbstractStoreConfigurationChildBuilder<S> implements Builder<SingletonStoreConfiguration> {
 
    private boolean enabled = false;
    private long pushStateTimeout = TimeUnit.SECONDS.toMillis(10);
    private boolean pushStateWhenCoordinator = true;
 
-   SingletonStoreConfigurationBuilder(LoadersConfigurationBuilder builder) {
+   SingletonStoreConfigurationBuilder(AbstractStoreConfigurationBuilder<? extends AbstractStoreConfiguration, ?> builder) {
       super(builder);
    }
 
    /**
     * Enable the singleton store cache store
     */
-   public SingletonStoreConfigurationBuilder enable() {
+   public SingletonStoreConfigurationBuilder<S> enable() {
       this.enabled = true;
       return this;
    }
@@ -50,7 +52,7 @@ public class SingletonStoreConfigurationBuilder extends AbstractLoaderConfigurat
    /**
     * If true, the singleton store cache store is enabled.
     */
-   public SingletonStoreConfigurationBuilder enabled(boolean enabled) {
+   public SingletonStoreConfigurationBuilder<S> enabled(boolean enabled) {
       this.enabled = enabled;
       return this;
    }
@@ -58,7 +60,7 @@ public class SingletonStoreConfigurationBuilder extends AbstractLoaderConfigurat
    /**
     * Enable the singleton store cache store
     */
-   public SingletonStoreConfigurationBuilder disable() {
+   public SingletonStoreConfigurationBuilder<S> disable() {
       this.enabled = false;
       return this;
    }
@@ -67,7 +69,7 @@ public class SingletonStoreConfigurationBuilder extends AbstractLoaderConfigurat
     * If pushStateWhenCoordinator is true, this property sets the maximum number of milliseconds
     * that the process of pushing the in-memory state to the underlying cache loader should take.
     */
-   public SingletonStoreConfigurationBuilder pushStateTimeout(long l) {
+   public SingletonStoreConfigurationBuilder<S> pushStateTimeout(long l) {
       this.pushStateTimeout = l;
       return this;
    }
@@ -76,7 +78,7 @@ public class SingletonStoreConfigurationBuilder extends AbstractLoaderConfigurat
     * If pushStateWhenCoordinator is true, this property sets the maximum number of milliseconds
     * that the process of pushing the in-memory state to the underlying cache loader should take.
     */
-   public SingletonStoreConfigurationBuilder pushStateTimeout(long l, TimeUnit unit) {
+   public SingletonStoreConfigurationBuilder<S> pushStateTimeout(long l, TimeUnit unit) {
       return pushStateTimeout(unit.toMillis(l));
    }
 
@@ -85,7 +87,7 @@ public class SingletonStoreConfigurationBuilder extends AbstractLoaderConfigurat
     * underlying cache store. This can be very useful in situations where the coordinator crashes
     * and there's a gap in time until the new coordinator is elected.
     */
-   public SingletonStoreConfigurationBuilder pushStateWhenCoordinator(boolean b) {
+   public SingletonStoreConfigurationBuilder<S> pushStateWhenCoordinator(boolean b) {
       this.pushStateWhenCoordinator = b;
       return this;
    }
@@ -100,7 +102,7 @@ public class SingletonStoreConfigurationBuilder extends AbstractLoaderConfigurat
    }
 
    @Override
-   public SingletonStoreConfigurationBuilder read(SingletonStoreConfiguration template) {
+   public SingletonStoreConfigurationBuilder<S> read(SingletonStoreConfiguration template) {
       this.enabled = template.enabled();
       this.pushStateTimeout = template.pushStateTimeout();
       this.pushStateWhenCoordinator = template.pushStateWhenCoordinator();

--- a/core/src/main/java/org/infinispan/configuration/cache/SitesConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/SitesConfigurationBuilder.java
@@ -31,7 +31,7 @@ import java.util.Set;
  * @author Mircea.Markus@jboss.com
  * @since 5.2
  */
-public class SitesConfigurationBuilder extends AbstractConfigurationChildBuilder<SitesConfiguration> {
+public class SitesConfigurationBuilder extends AbstractConfigurationChildBuilder  implements Builder<SitesConfiguration> {
 
    private static final int DEFAULT_BACKUP_COUNT = 2;
 

--- a/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfigurationBuilder.java
@@ -20,6 +20,7 @@
 package org.infinispan.configuration.cache;
 
 import org.infinispan.config.ConfigurationException;
+import org.infinispan.configuration.Builder;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -32,7 +33,7 @@ import java.util.concurrent.TimeUnit;
  * @since 5.1
  */
 public class StateTransferConfigurationBuilder extends
-      AbstractClusteringConfigurationChildBuilder<StateTransferConfiguration> {
+      AbstractClusteringConfigurationChildBuilder implements Builder<StateTransferConfiguration> {
 
    private static final Log log = LogFactory.getLog(StateTransferConfigurationBuilder.class);
 

--- a/core/src/main/java/org/infinispan/configuration/cache/StoreAsBinaryConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StoreAsBinaryConfigurationBuilder.java
@@ -18,6 +18,8 @@
  */
 package org.infinispan.configuration.cache;
 
+import org.infinispan.configuration.Builder;
+
 /**
  * Controls whether when stored in memory, keys and values are stored as references to their original objects, or in
  * a serialized, binary format.  There are benefits to both approaches, but often if used in a clustered mode,
@@ -29,7 +31,7 @@ package org.infinispan.configuration.cache;
  * <p />
  * @see StoreAsBinaryConfiguration
  */
-public class StoreAsBinaryConfigurationBuilder extends AbstractConfigurationChildBuilder<StoreAsBinaryConfiguration> {
+public class StoreAsBinaryConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<StoreAsBinaryConfiguration> {
 
    private boolean enabled = false;
    private boolean storeKeysAsBinary = true;

--- a/core/src/main/java/org/infinispan/configuration/cache/StoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StoreConfigurationBuilder.java
@@ -24,52 +24,7 @@ package org.infinispan.configuration.cache;
  * @author Tristan Tarrant
  * @since 5.2
  */
-public interface StoreConfigurationBuilder<T extends StoreConfiguration, S extends StoreConfigurationBuilder<T, S>> extends LoaderConfigurationBuilder<T, S> {
+public interface StoreConfigurationBuilder<T extends StoreConfiguration, S extends StoreConfigurationBuilder<T, S>> extends LoaderConfigurationBuilder<T, S>, StoreConfigurationChildBuilder<S> {
 
-   /**
-    * Configuration for the async cache loader. If enabled, this provides you with asynchronous
-    * writes to the cache store, giving you 'write-behind' caching.
-    */
-   AsyncStoreConfigurationBuilder async();
 
-   /**
-    * SingletonStore is a delegating cache store used for situations when only one instance in a
-    * cluster should interact with the underlying store. The coordinator of the cluster will be
-    * responsible for the underlying CacheStore. SingletonStore is a simply facade to a real
-    * CacheStore implementation. It always delegates reads to the real CacheStore.
-    */
-   SingletonStoreConfigurationBuilder singletonStore();
-
-   /**
-    * If true, fetch persistent state when joining a cluster. If multiple cache stores are chained,
-    * only one of them can have this property enabled. Persistent state transfer with a shared cache
-    * store does not make sense, as the same persistent store that provides the data will just end
-    * up receiving it. Therefore, if a shared cache store is used, the cache will not allow a
-    * persistent state transfer even if a cache store has this property set to true. Finally,
-    * setting it to true only makes sense if in a clustered environment, and only 'replication' and
-    * 'invalidation' cluster modes are supported.
-    */
-   S fetchPersistentState(boolean b);
-
-   /**
-    * If true, any operation that modifies the cache (put, remove, clear, store...etc) won't be
-    * applied to the cache store. This means that the cache store could become out of sync with the
-    * cache.
-    */
-   S ignoreModifications(boolean b);
-
-   /**
-    * If true, purges this cache store when it starts up.
-    */
-   S purgeOnStartup(boolean b);
-
-   /**
-    * The number of threads to use when purging asynchronously.
-    */
-   S purgerThreads(int i);
-
-   /**
-    * If true, CacheStore#purgeExpired() call will be done synchronously
-    */
-   S purgeSynchronously(boolean b);
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/StoreConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StoreConfigurationChildBuilder.java
@@ -18,10 +18,53 @@
  */
 package org.infinispan.configuration.cache;
 
-public interface StoreConfigurationChildBuilder extends ConfigurationChildBuilder {
+public interface StoreConfigurationChildBuilder<S> extends LoaderConfigurationChildBuilder<S> {
 
-   AsyncStoreConfigurationBuilder async();
-   
-   SingletonStoreConfigurationBuilder singletonStore();
-   
+   /**
+    * Configuration for the async cache store. If enabled, this provides you with asynchronous
+    * writes to the cache store, giving you 'write-behind' caching.
+    */
+   AsyncStoreConfigurationBuilder<S> async();
+
+   /**
+    * SingletonStore is a delegating cache store used for situations when only one instance in a
+    * cluster should interact with the underlying store. The coordinator of the cluster will be
+    * responsible for the underlying CacheStore. SingletonStore is a simply facade to a real
+    * CacheStore implementation. It always delegates reads to the real CacheStore.
+    */
+   SingletonStoreConfigurationBuilder<S> singletonStore();
+
+   /**
+    * If true, fetch persistent state when joining a cluster. If multiple cache stores are chained,
+    * only one of them can have this property enabled. Persistent state transfer with a shared cache
+    * store does not make sense, as the same persistent store that provides the data will just end
+    * up receiving it. Therefore, if a shared cache store is used, the cache will not allow a
+    * persistent state transfer even if a cache store has this property set to true. Finally,
+    * setting it to true only makes sense if in a clustered environment, and only 'replication' and
+    * 'invalidation' cluster modes are supported.
+    */
+   S fetchPersistentState(boolean b);
+
+   /**
+    * If true, any operation that modifies the cache (put, remove, clear, store...etc) won't be
+    * applied to the cache store. This means that the cache store could become out of sync with the
+    * cache.
+    */
+   S ignoreModifications(boolean b);
+
+   /**
+    * If true, purges this cache store when it starts up.
+    */
+   S purgeOnStartup(boolean b);
+
+   /**
+    * The number of threads to use when purging asynchronously.
+    */
+   S purgerThreads(int i);
+
+   /**
+    * If true, CacheStore#purgeExpired() call will be done synchronously
+    */
+   S purgeSynchronously(boolean b);
+
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/SyncConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/SyncConfigurationBuilder.java
@@ -20,12 +20,14 @@ package org.infinispan.configuration.cache;
 
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.configuration.Builder;
+
 /**
  * If configured all communications are synchronous, in that whenever a thread sends a message sent
  * over the wire, it blocks until it receives an acknowledgment from the recipient. SyncConfig is
  * mutually exclusive with the AsyncConfig.
  */
-public class SyncConfigurationBuilder extends AbstractClusteringConfigurationChildBuilder<SyncConfiguration> {
+public class SyncConfigurationBuilder extends AbstractClusteringConfigurationChildBuilder implements Builder<SyncConfiguration> {
 
    private long replTimeout = TimeUnit.SECONDS.toMillis(15);
 

--- a/core/src/main/java/org/infinispan/configuration/cache/TakeOfflineConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TakeOfflineConfigurationBuilder.java
@@ -25,7 +25,7 @@ import org.infinispan.configuration.Builder;
  * @author Mircea Markus
  * @since 5.2
  */
-public class TakeOfflineConfigurationBuilder extends AbstractConfigurationChildBuilder<TakeOfflineConfiguration> {
+public class TakeOfflineConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<TakeOfflineConfiguration>{
 
    private int afterFailures = 0;
    private long minTimeToWait = 0;

--- a/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
@@ -18,6 +18,7 @@
  */
 package org.infinispan.configuration.cache;
 
+import org.infinispan.configuration.Builder;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
 import org.infinispan.transaction.lookup.GenericTransactionManagerLookup;
@@ -33,7 +34,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author pmuir
  */
-public class TransactionConfigurationBuilder extends AbstractConfigurationChildBuilder<TransactionConfiguration> {
+public class TransactionConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<TransactionConfiguration> {
 
    private boolean autoCommit = true;
    private long cacheStopTimeout = TimeUnit.SECONDS.toMillis(30);

--- a/core/src/main/java/org/infinispan/configuration/cache/UnsafeConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/UnsafeConfigurationBuilder.java
@@ -18,6 +18,8 @@
  */
 package org.infinispan.configuration.cache;
 
+import org.infinispan.configuration.Builder;
+
 /**
  * Controls certain tuning parameters that may break some of Infinispan's public API contracts in exchange for better
  * performance in some cases.
@@ -25,7 +27,7 @@ package org.infinispan.configuration.cache;
  * Use with care, only after thoroughly reading and understanding the documentation about a specific feature.
  * <p />
  */
-public class UnsafeConfigurationBuilder extends AbstractConfigurationChildBuilder<UnsafeConfiguration> {
+public class UnsafeConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<UnsafeConfiguration> {
 
    private boolean unreliableReturnValues = false;
 

--- a/core/src/main/java/org/infinispan/configuration/cache/VersioningConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/VersioningConfigurationBuilder.java
@@ -19,7 +19,9 @@
 
 package org.infinispan.configuration.cache;
 
-public class VersioningConfigurationBuilder extends AbstractConfigurationChildBuilder<VersioningConfiguration> {
+import org.infinispan.configuration.Builder;
+
+public class VersioningConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<VersioningConfiguration> {
 
    boolean enabled = false;
    VersioningScheme scheme = VersioningScheme.NONE;

--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser52.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser52.java
@@ -643,7 +643,7 @@ public class Parser52 implements ConfigurationParser<ConfigurationBuilderHolder>
     * This method is public static so that it can be reused by custom cache store/loader configuration parsers
     */
    public static void parseLockSupportStoreAttributes(XMLExtendedStreamReader reader, int i,
-         LockSupportCacheStoreConfigurationBuilder<?, ?> builder) throws XMLStreamException {
+         LockSupportStoreConfigurationBuilder<?, ?> builder) throws XMLStreamException {
       ParseUtils.requireNoNamespaceAttribute(reader, i);
       String value = replaceProperties(reader.getAttributeValue(i));
       Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));

--- a/core/src/test/java/org/infinispan/configuration/module/MyModuleConfigurationBuilder.java
+++ b/core/src/test/java/org/infinispan/configuration/module/MyModuleConfigurationBuilder.java
@@ -18,6 +18,7 @@
  */
 package org.infinispan.configuration.module;
 
+import org.infinispan.configuration.Builder;
 import org.infinispan.configuration.cache.AbstractModuleConfigurationBuilder;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 
@@ -28,7 +29,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
  * @author Tristan Tarrant
  * @since 5.2
  */
-public class MyModuleConfigurationBuilder extends AbstractModuleConfigurationBuilder<MyModuleConfiguration> {
+public class MyModuleConfigurationBuilder extends AbstractModuleConfigurationBuilder implements Builder<MyModuleConfiguration> {
    private String attribute;
 
    public MyModuleConfigurationBuilder(ConfigurationBuilder builder) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2311

Make sure the cache stores don't interrupt fluency
Don't carry along unnecessary generics
Introduce more readable API and XML for JDBC connection factory configuration
