### PR TITLE
ISPN-2361 AbstractTxLockingInterceptor.lockKeyAndCheckOwnership() anomal...

### DIFF
--- a/core/src/main/java/org/infinispan/transaction/xa/CacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/CacheTransaction.java
@@ -79,6 +79,14 @@ public interface CacheTransaction {
    void notifyOnTransactionFinished();
 
    /**
+    * Checks if this transaction holds a lock on the given key and then waits until the transaction completes or until
+    * the timeout expires and returns <code>true</code> if the transaction is complete or <code>false</code> otherwise.
+    * If the key is not locked or if the transaction is already completed it returns <code>true</code> immediately.
+    * <p/>
+    * This method is subject to spurious returns in a way similar to {@link java.lang.Object#wait()}. It can sometimes return
+    * before the specified time has elapsed and without guaranteeing that this transaction is complete. The caller is
+    * responsible to call the method again if transaction completion was not reached and the time budget was not spent.
+    *
     * @see org.infinispan.interceptors.locking.AbstractTxLockingInterceptor#lockKeyAndCheckOwnership(org.infinispan.context.InvocationContext, Object)
     */
    boolean waitForLockRelease(Object key, long lockAcquisitionTimeout) throws InterruptedException;


### PR DESCRIPTION
...ies: can wait indefinitelly or it can wait too little due to spurious wakeups

JIRA: https://issues.jboss.org/browse/ISPN-2361
- Extract the check for pending transactions from AbstractTxLockingInterceptor.lockKeyAndCheckOwnership() into a separate method that is called for both local and for remote transactions - this eliminates duplication.
- Execute AbstractCacheTransaction.waitForLockRelease() in a loop in order the cope with spurious wakeups.
- Change waiting time termination condition to avoid waiting with 0 timeout (indefinitelly).
- Add CacheTransaction.waitForLockRelease() javadoc documenting the spurious return issue.
