### PR TITLE
ISPN-2363 Allow overriding of startServer JMX port via environment variable

### DIFF
--- a/core/src/main/resources/functions.sh
+++ b/core/src/main/resources/functions.sh
@@ -180,12 +180,17 @@ function start() {
   "${START_ARGS[@]}"
 }
 
-# Find port between 2000 and 65000
+# Find port between 2000 and 65000 (can be overridden by ISPN_JMX_PORT)
 function find_tcp_port(){
-  PORT=$(( 2000+( 100+( $(od -An -N2 -i /dev/random) )%(63000) )))
-  while :
-    do
-      (echo >/dev/tcp/localhost/$PORT) &>/dev/null &&  PORT=$(( 2000+( 100+( $(od -An -N2 -i /dev/random) )%(63000) ))) || break
-    done
-  echo "$PORT"
+  if [[ "x${ISPN_JMX_PORT}" == "x" ]]; then
+    PORT=$(( 2000+( 100+( $(od -An -N2 -i /dev/random) )%(63000) )))
+    while :
+      do
+        (echo >/dev/tcp/localhost/$PORT) &>/dev/null &&  PORT=$(( 2000+( 100+( $(od -An -N2 -i /dev/random) )%(63000) ))) || break
+      done
+    echo "$PORT"
+  else
+    echo "$ISPN_JMX_PORT"
+  fi
 }
+


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2363
