### PR TITLE
ISPN-2291: Moved the BaseRpcManager lock handling into the Replication a...

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/base/BaseRpcInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/base/BaseRpcInterceptor.java
@@ -60,18 +60,6 @@ public abstract class BaseRpcInterceptor extends CommandInterceptor {
       cacheName = componentRegistry.getCacheName();
    }
 
-   @Override
-   public Object visitLockControlCommand(TxInvocationContext ctx, LockControlCommand command) throws Throwable {
-      Object retVal = invokeNextInterceptor(ctx, command);
-      if (ctx.isOriginLocal()) {
-         //unlock will happen async as it is a best effort
-         boolean sync = !command.isUnlock();
-         ((LocalTxInvocationContext) ctx).remoteLocksAcquired(rpcManager.getTransport().getMembers());
-         rpcManager.broadcastRpcCommand(command, sync, false);
-      }
-      return retVal;
-   }
-
    protected final boolean isSynchronous(FlagAffectedCommand command) {
       if (command.hasFlag(Flag.FORCE_SYNCHRONOUS))
          return true;

--- a/core/src/main/java/org/infinispan/interceptors/xsite/BaseBackupInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/xsite/BaseBackupInterceptor.java
@@ -45,6 +45,9 @@ public class BaseBackupInterceptor extends BaseRpcInterceptor {
    
    protected boolean isTxFromRemoteSite(GlobalTransaction gtx) {
       LocalTransaction remoteTx = txTable.getLocalTransaction(gtx);
+      if( remoteTx == null )
+         return false;
+      
       return remoteTx.isFromRemoteSite();
    }
    


### PR DESCRIPTION
...nd the Invalidation interceptors.  This prevents the LockControlCommand from being broadcast to all nodes (and possibly resulting in stale locks) when xsite is enabled
