### PR TITLE
ISPN-2291:  Proof of concept implementation:

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/locking/OptimisticLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/OptimisticLockingInterceptor.java
@@ -117,6 +117,7 @@ public class OptimisticLockingInterceptor extends AbstractTxLockingInterceptor {
    
    @Override
    public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
+      try {
       abortIfRemoteTransactionInvalid(ctx, command);
       if (!command.hasModifications() || command.writesToASingleKey()) {
          //optimisation: don't create another LockReorderingVisitor here as it is not needed.
@@ -134,6 +135,11 @@ public class OptimisticLockingInterceptor extends AbstractTxLockingInterceptor {
          }
       }
       return invokeNextAndCommitIf1Pc(ctx, command);
+      }
+      finally {
+         checkLockOnOriginatorLeave( ctx );
+      }
+
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/locking/PessimisticLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/PessimisticLockingInterceptor.java
@@ -302,10 +302,14 @@ public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor 
 
    protected final void lockAndRegisterBackupLock(TxInvocationContext ctx,
          Object key, boolean isLockOwner, long lockTimeout, boolean skipLocking) throws InterruptedException {
-      if (isLockOwner) {
-         lockKeyAndCheckOwnership(ctx, key, lockTimeout, skipLocking);
-      } else if (cdl.localNodeIsOwner(key)) {
-         ctx.getCacheTransaction().addBackupLockForKey(key);
-      }
+      try {
+         if (isLockOwner) {
+            lockKeyAndCheckOwnership(ctx, key, lockTimeout, skipLocking);
+         } else if (cdl.localNodeIsOwner(key)) {
+            ctx.getCacheTransaction().addBackupLockForKey(key);
+         }
+      } finally {
+         checkLockOnOriginatorLeave( ctx );
+      }     
    }
 }

--- a/core/src/main/java/org/infinispan/transaction/LocalTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/LocalTransaction.java
@@ -55,9 +55,6 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
    private Set<Address> remoteLockedNodes;
    private Set<Object> readKeys = null;
 
-   /** mark as volatile as this might be set from the tx thread code on view change*/
-   private volatile boolean isMarkedForRollback;
-
    private final Transaction transaction;
 
    private final boolean implicitTransaction;
@@ -94,14 +91,6 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
 
    public void clearRemoteLocksAcquired() {
       if (remoteLockedNodes != null) remoteLockedNodes.clear();
-   }
-
-   public void markForRollback(boolean markForRollback) {
-      isMarkedForRollback = markForRollback;
-   }
-
-   public final boolean isMarkedForRollback() {
-      return isMarkedForRollback;
    }
 
    public Transaction getTransaction() {

--- a/core/src/main/java/org/infinispan/transaction/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/TransactionTable.java
@@ -245,6 +245,11 @@ public class TransactionTable {
          } catch (Throwable e) {
             log.unableToRollbackGlobalTx(gtx, e);
          }
+         finally {
+            
+            // Remove the remote transaction.
+            remoteTransactions.remove( gtx );
+         }
       }
 
       log.trace("Completed cleaning transactions originating on leavers");
@@ -273,13 +278,14 @@ public class TransactionTable {
       return createRemoteTransaction(globalTx, modifications, currentViewId);
    }
 
+      
    /**
     * Creates and register a {@link RemoteTransaction}. Returns the created transaction.
     *
     * @throws IllegalStateException if an attempt to create a {@link RemoteTransaction} for an already registered id is
     *                               made.
     */
-   public RemoteTransaction createRemoteTransaction(GlobalTransaction globalTx, WriteCommand[] modifications, int topologyId) {
+   public RemoteTransaction createRemoteTransaction(GlobalTransaction globalTx, WriteCommand[] modifications, int topologyId ) {
       RemoteTransaction remoteTransaction = modifications == null ? txFactory.newRemoteTransaction(globalTx, topologyId)
             : txFactory.newRemoteTransaction(modifications, globalTx, topologyId);
       registerRemoteTransaction(globalTx, remoteTransaction);

--- a/core/src/main/java/org/infinispan/transaction/xa/CacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/CacheTransaction.java
@@ -98,4 +98,8 @@ public interface CacheTransaction {
    boolean keyRead(Object key);
 
    void addReadKey(Object key);
+   
+   public void markForRollback(boolean markForRollback);
+
+   public boolean isMarkedForRollback();
 }


### PR DESCRIPTION
1) Do not remove remote transactions if the originator didn't crash to prevent pending locks from losing their txTable context.
2) If originator crashed, set the rollback flag and handle condition after lock acquisition.
