### PR TITLE
ISPN-2385 ReceiveBufferSize should be set on the child channel

### DIFF
--- a/server/core/src/main/scala/org/infinispan/server/core/transport/NettyTransport.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/transport/NettyTransport.scala
@@ -99,7 +99,7 @@ class NettyTransport(server: ProtocolServer, encoder: ChannelDownstreamHandler,
       if (sendBufSize > 0)
          bootstrap.setOption("child.sendBufferSize", sendBufSize) // Sets server side send buffer
       if (recvBufSize > 0)
-         bootstrap.setOption("receiveBufferSize", recvBufSize) // Sets server side receive buffer
+         bootstrap.setOption("child.receiveBufferSize", recvBufSize) // Sets server side receive buffer
 
       val ch = bootstrap.bind(address)
       serverChannels.add(ch)


### PR DESCRIPTION
At the moment receiveBufferSize is set on the "acceptor" channel which is not what you want. It should be set on the child channel. This commit fix it.
