### PR TITLE
ISPN-2388 - Use UTF-8 when convert CharSequence to ChannelBuffer

### DIFF
--- a/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolDecoder.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolDecoder.scala
@@ -35,6 +35,8 @@ import org.infinispan.util.ClusterIdGenerator
 import logging.Log
 import java.lang.StringBuilder
 import org.jboss.netty.handler.codec.replay.ReplayingDecoder
+import org.jboss.netty.buffer.ChannelBuffers
+import org.jboss.netty.util.CharsetUtil
 
 /**
  * Common abstract decoder for Memcached and Hot Rod protocols.
@@ -173,8 +175,7 @@ abstract class AbstractProtocolDecoder[K, V <: CacheValue](transport: NettyTrans
                // We only expect Lists of ChannelBuffer instances, so don't worry about type erasure
                case l: List[ChannelBuffer] => l.foreach(ch.write(_))
                case a: Array[Byte] => ch.write(wrappedBuffer(a))
-               case sb: StringBuilder => ch.write(wrappedBuffer(sb.toString.getBytes))
-               case s: String => ch.write(wrappedBuffer(s.getBytes))
+               case cs: CharSequence => ch.write(ChannelBuffers.copiedBuffer(cs, CharsetUtil.UTF_8))
                case _ => ch.write(response)
             }
          }
@@ -272,7 +273,7 @@ abstract class AbstractProtocolDecoder[K, V <: CacheValue](transport: NettyTrans
       if (errorResponse != null) {
          errorResponse match {
             case a: Array[Byte] => ch.write(wrappedBuffer(a))
-            case sb: StringBuilder => ch.write(wrappedBuffer(sb.toString.getBytes))
+            case cs: CharSequence => ch.write(ChannelBuffers.copiedBuffer(cs, CharsetUtil.UTF_8))
             case null => // ignore
             case _ => ch.write(errorResponse)
          }

--- a/server/core/src/main/scala/org/infinispan/server/core/transport/ExtendedChannelBuffer.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/transport/ExtendedChannelBuffer.scala
@@ -24,6 +24,7 @@
 package org.infinispan.server.core.transport
 
 import org.jboss.netty.buffer.{ChannelBuffers, ChannelBuffer}
+import org.jboss.netty.util.CharsetUtil
 
 object ExtendedChannelBuffer {
 
@@ -52,7 +53,7 @@ object ExtendedChannelBuffer {
     */
    def readString(bf: ChannelBuffer): String = {
       val bytes = readRangedBytes(bf)
-      if (!bytes.isEmpty) new String(bytes, "UTF8") else ""
+      if (!bytes.isEmpty) new String(bytes, CharsetUtil.UTF_8) else ""
    }
 
    def writeUnsignedShort(i: Int, bf: ChannelBuffer) = bf.writeShort(i)
@@ -64,6 +65,6 @@ object ExtendedChannelBuffer {
       bf.writeBytes(src)
    }
 
-   def writeString(msg: String, bf: ChannelBuffer) = writeRangedBytes(msg.getBytes(), bf)
+   def writeString(msg: String, bf: ChannelBuffer) = writeRangedBytes(msg.getBytes(CharsetUtil.UTF_8), bf)
 
 }


### PR DESCRIPTION
Use the Charset when convert CharSequence to ChannelBuffer to not depend on default Charset of the actual platform
