### PR TITLE
ISPN-2400 ReceiveBufferSize has no effect in WebSocketServer

### DIFF
--- a/server/websocket/src/main/java/org/infinispan/server/websocket/WebSocketServer.java
+++ b/server/websocket/src/main/java/org/infinispan/server/websocket/WebSocketServer.java
@@ -102,7 +102,7 @@ public class WebSocketServer extends AbstractProtocolServer {
       // Bind and start to accept incoming connections.
       bootstrap.setOption("child.tcpNoDelay", tcpNoDelay);
       if (sendBufSize > 0) bootstrap.setOption("child.sendBufferSize", sendBufSize);
-      if (recvBufSize > 0) bootstrap.setOption("receiveBufferSize", recvBufSize);
+      if (recvBufSize > 0) bootstrap.setOption("child.receiveBufferSize", recvBufSize);
 
       bootstrap.bind(address);
    }


### PR DESCRIPTION
The receiveBufferSize option must be set on the child channel to give the expected result
