### PR TITLE
ISPN-2387 ClusteredGetCommand should not be a VisitableCommand

### DIFF
--- a/core/src/main/java/org/infinispan/commands/AbstractVisitor.java
+++ b/core/src/main/java/org/infinispan/commands/AbstractVisitor.java
@@ -29,7 +29,6 @@ import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.read.KeySetCommand;
 import org.infinispan.commands.read.SizeCommand;
 import org.infinispan.commands.read.ValuesCommand;
-import org.infinispan.commands.remote.ClusteredGetCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
@@ -185,11 +184,6 @@ public abstract class AbstractVisitor implements Visitor {
    
    @Override
    public Object visitDistributedExecuteCommand(InvocationContext ctx, DistributedExecuteCommand<?> command) throws Throwable {
-      return handleDefault(ctx, command);
-   }
-
-   @Override
-   public Object visitClusteredGetCommand(InvocationContext ctx, ClusteredGetCommand command) throws Throwable {
       return handleDefault(ctx, command);
    }
 }

--- a/core/src/main/java/org/infinispan/commands/Visitor.java
+++ b/core/src/main/java/org/infinispan/commands/Visitor.java
@@ -29,7 +29,6 @@ import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.read.KeySetCommand;
 import org.infinispan.commands.read.SizeCommand;
 import org.infinispan.commands.read.ValuesCommand;
-import org.infinispan.commands.remote.ClusteredGetCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
@@ -79,8 +78,6 @@ public interface Visitor {
    Object visitValuesCommand(InvocationContext ctx, ValuesCommand command) throws Throwable;
 
    Object visitEntrySetCommand(InvocationContext ctx, EntrySetCommand command) throws Throwable;
-
-   Object visitClusteredGetCommand(InvocationContext ctx, ClusteredGetCommand command) throws Throwable;
 
    // tx commands
 


### PR DESCRIPTION
- Remove it from Visitor and AbstractVisitor

Master only.
Jira: https://issues.jboss.org/browse/ISPN-2387
