### PR TITLE
ISPN-2413 RHQ plugin improvements

### DIFF
--- a/rhq-plugin/src/main/java/org/infinispan/rhq/CacheManagerComponent.java
+++ b/rhq-plugin/src/main/java/org/infinispan/rhq/CacheManagerComponent.java
@@ -41,6 +41,7 @@ import org.rhq.core.domain.measurement.MeasurementDataTrait;
 import org.rhq.core.domain.measurement.MeasurementReport;
 import org.rhq.core.domain.measurement.MeasurementScheduleRequest;
 import org.rhq.core.pluginapi.inventory.ResourceContext;
+import org.rhq.plugins.jmx.JMXServerComponent;
 import org.rhq.plugins.jmx.MBeanResourceComponent;
 import org.rhq.plugins.jmx.ObjectNameQueryUtility;
 
@@ -50,9 +51,9 @@ import org.rhq.plugins.jmx.ObjectNameQueryUtility;
  * @author Heiko W. Rupp
  * @author Galder Zamarreño
  */
-public class CacheManagerComponent extends MBeanResourceComponent<MBeanResourceComponent<?>> {
+public class CacheManagerComponent extends MBeanResourceComponent<JMXServerComponent<?>> {
    private static final Log log = LogFactory.getLog(CacheManagerComponent.class);
-   protected ResourceContext<MBeanResourceComponent<?>> context;
+   protected ResourceContext<JMXServerComponent<?>> context;
    private String cacheManagerPattern;
 
    /**
@@ -85,7 +86,7 @@ public class CacheManagerComponent extends MBeanResourceComponent<MBeanResourceC
     * Start the resource connection
     */
    @Override
-   public void start(ResourceContext<MBeanResourceComponent<?>> context) {
+   public void start(ResourceContext<JMXServerComponent<?>> context) {
       // TODO: Call super.start() ?
       this.context = context;
       this.cacheManagerPattern = "*:" + CacheManagerDiscovery.CACHE_MANAGER_JMX_GROUP + ",name=" + ObjectName.quote(context.getResourceKey()) + ",*";

--- a/rhq-plugin/src/main/java/org/infinispan/rhq/CacheManagerDiscovery.java
+++ b/rhq-plugin/src/main/java/org/infinispan/rhq/CacheManagerDiscovery.java
@@ -47,7 +47,7 @@ import org.rhq.plugins.jmx.ObjectNameQueryUtility;
  */
 public class CacheManagerDiscovery extends MBeanResourceDiscoveryComponent<JMXComponent<?>> implements ManualAddFacet<JMXComponent<?>>{
    private static final Log log = LogFactory.getLog(CacheManagerDiscovery.class);
-   public static final String CACHE_MANAGER_JMX_GROUP = "type=CacheManager";
+   public static final String CACHE_MANAGER_JMX_GROUP = "type=CacheManager,component=CacheManager";
 
    protected static final String CACHE_MANAGER_OBJECTS = "*:" + CACHE_MANAGER_JMX_GROUP + ",*";
 

--- a/tools/src/main/java/org/infinispan/tools/rhq/RhqPluginXmlGenerator.java
+++ b/tools/src/main/java/org/infinispan/tools/rhq/RhqPluginXmlGenerator.java
@@ -108,20 +108,29 @@ public class RhqPluginXmlGenerator {
       Props root = new Props();
       root.setPluginName("Infinispan");
       root.setPluginDescription("Supports management and monitoring of Infinispan");
+      root.setManualAddOfResourceType(true);
       root.setName("Infinispan Cache Manager");
       root.setPkg("org.infinispan.rhq");
       root.setDependsOnJmxPlugin(true);
       root.setDiscoveryClass("CacheManagerDiscovery");
       root.setComponentClass("CacheManagerComponent");
       root.setSingleton(false);
+
       root.setCategory(ResourceCategory.SERVICE);
       Set<TypeKey> servers = new HashSet<TypeKey>();
       servers.add(new TypeKey("JMX Server", "JMX"));
       servers.add(new TypeKey("JBossAS Server", "JBossAS"));
       servers.add(new TypeKey("JBossAS Server", "JBossAS5"));
-      servers.add(new TypeKey("JBossAS7 Standalone Server", "jboss-as-7"));
-      servers.add(new TypeKey("Profile", "jboss-as-7"));
       root.setRunsInsides(servers);
+
+
+      SimpleProperty pc = new SimpleProperty("name");
+      pc.setType("string");
+      pc.setDescription("Name");
+      pc.setDefaultValue("Infinispan Cache Manager");
+      pc.setReadOnly(true);
+      root.getSimpleProps().add(pc);
+
       populateMetricsAndOperations(globalClasses, root, false);
 
       Props cache = new Props();
@@ -141,7 +150,7 @@ public class RhqPluginXmlGenerator {
       String targetMetaInfDir = "../../../target/classes/META-INF";
       new File(targetMetaInfDir).mkdirs();
 
-      pg.createFile(root, "descriptor", "rhq-plugin.xml", metaInfDir);
+      pg.createFile(root, "ispnDescriptor", "rhq-plugin.xml", metaInfDir);
       copyFile(new File(metaInfDir + "/rhq-plugin.xml"), new File(targetMetaInfDir + "/rhq-plugin.xml"));
 
       return true;

--- a/tools/src/main/resources/ispnDescriptor.ftl
+++ b/tools/src/main/resources/ispnDescriptor.ftl
@@ -1,0 +1,47 @@
+<#--
+/*
+ * RHQ Management Platform
+ * Copyright (C) 2005-2008 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+-->
+<#-- @ftlvariable name="props" type="org.rhq.helpers.pluginGen.Props" -->
+<?xml version="1.0"?>
+<plugin name="${props.pluginName}"
+        displayName="${props.pluginName}Plugin"
+        description="${props.pluginDescription}"
+<#if props.usePluginLifecycleListenerApi>
+        pluginLifecycleListener="${props.componentClass}"
+</#if>
+        package="${props.pkg}"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="urn:xmlns:rhq-plugin"
+        xmlns:c="urn:xmlns:rhq-configuration">
+
+<#if props.dependsOnJmxPlugin>
+   <depends plugin="JMX" useClasses="true"/>
+</#if>
+
+   <${props.category.lowerName} <#include "ispnDescriptorMain.ftl"/>
+
+   <#-- Those are the embedded children -->
+   <#list props.children as props>
+       <${props.category.lowerName} <#include "./ispnDescriptorMain.ftl"/>
+       </${props.category.lowerName}>
+   </#list>
+   </${props.category.lowerName}>
+
+</plugin>

--- a/tools/src/main/resources/ispnDescriptorMain.ftl
+++ b/tools/src/main/resources/ispnDescriptorMain.ftl
@@ -1,0 +1,104 @@
+<#--
+/*
+ * RHQ Management Platform
+ * Copyright (C) 2005-2011 Red Hat, Inc.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+-->
+<#-- @ftlvariable name="props" type="org.rhq.helpers.pluginGen.Props" -->
+<#--
+    This file contains the body of the descriptor for a single
+    platform/server/service. It is called by descriptor.ftl
+
+-->
+name="${props.name}"
+            discovery="${props.discoveryClass}"
+            class="${props.componentClass}"
+            <#if props.singleton>singleton="true"</#if>
+            <#if props.manualAddOfResourceType>supportsManualAdd="true"</#if>
+            <#if props.createChildren && props.deleteChildren>createDeletePolicy="both"<#elseif props.createChildren && !props.deleteChildren>createDeletePolicy="create-only"<#elseif !props.createChildren && props.deleteChildren>createDeletePolicy="delete-only"<#else > <#-- Dont mention it, as 'neither' is default --></#if>
+          >
+
+          <#if props.runsInsides?has_content>
+            <runs-inside>
+              <#list props.runsInsides as typeKey>
+                <parent-resource-type name="${typeKey.name}" plugin="${typeKey.pluginName}"/>
+              </#list>
+            </runs-inside>
+          </#if>
+
+          <#if props.simpleProps?has_content>
+            <plugin-configuration>
+                <#list props.simpleProps as simpleProps>
+                <c:simple-property name="${simpleProps.name}" <#if simpleProps.description??>description="${simpleProps.description}"</#if> <#if simpleProps.type??>type="${simpleProps.type}"</#if> <#if simpleProps.defaultValue??>default="${simpleProps.defaultValue}"</#if> <#if simpleProps.readOnly>readOnly="true"</#if>/>
+                </#list>
+                <!-- The template section is only for manual resource additions, and default parameters and the ones presented to the user. -->
+                <#list props.templates as templates>
+                <c:template name="${templates.name}" description="${templates.description}">
+                  <#list templates.simpleProps as innerSimpleProps>
+                  <c:simple-property name="${innerSimpleProps.name}" displayName="${innerSimpleProps.displayName}"
+                                     defaultValue="${innerSimpleProps.defaultValue}"/>
+                  </#list>
+                </c:template>
+                </#list>
+            </plugin-configuration>
+         </#if>
+
+     <#if props.hasOperations>
+        <#if props.operations?has_content>
+           <#list props.operations as operation>
+           <operation name="${operation.name}" displayName="${operation.displayName}" description="${operation.description}">
+              <#if operation.params?has_content>
+              <parameters>
+              <#list operation.params as param>
+                 <c:simple-property name="${param.name}" <#if param.description??>description="${param.description}"</#if>/>
+              </#list>
+              </parameters>
+              </#if>
+              <#if operation.result??>
+              <results>
+                 <c:simple-property name="${operation.result.name}" />
+              </results>
+              </#if>
+           </operation>
+           </#list>
+        <#else>
+           <operation name="dummyOperation">
+              <!-- TODO supply parameters and return values -->
+           </operation>
+        </#if>
+     </#if>
+
+     <#if props.hasMetrics>
+        <#if props.metrics?has_content>
+           <#list props.metrics as metric>
+           <metric property="${metric.property}" displayName="${metric.displayName}" displayType="${metric.displayType}" units="${metric.units}" dataType="${metric.dataType}"
+                   description="${metric.description}" />
+           </#list>
+        <#else>
+           <metric property="dummyMetric" displayName="Dummy display name"/>
+        </#if>
+     </#if>
+
+        <#if props.events>
+            <event name="${props.name}DummyEvent"/>
+        </#if>
+        <#if props.resourceConfiguration>
+            <resource-configuration>
+                <!-- TODO supply your configuration parameters -->
+                <c:simple-property name="dummy"/>
+            </resource-configuration>
+        </#if>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2413

Set the RHQ plugin to accept manual configuration

  Workaround the fact that the RHQ UI wants at least one plugin
  property (by using a read-only dummy property)

  Fix parent ClassCastException on CacheManagers

  Narrow the MBean query to avoid picking up unwanted MBeans
