### PR TITLE
fix 'invocation batching not enabled' confusing logging message

### DIFF
--- a/core/src/main/java/org/infinispan/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/CacheImpl.java
@@ -602,7 +602,7 @@ public class CacheImpl<K, V> extends CacheSupport<K, V> implements AdvancedCache
    @Override
    public boolean startBatch() {
       if (!config.isInvocationBatchingEnabled()) {
-         throw new ConfigurationException("Invocation batching not enabled in current configuration!  Please use the <invocationBatching /> element.");
+         throw new ConfigurationException("Invocation batching not enabled in current configuration! Please enable it.");
       }
       return batchContainer.startBatch();
    }
@@ -610,7 +610,7 @@ public class CacheImpl<K, V> extends CacheSupport<K, V> implements AdvancedCache
    @Override
    public void endBatch(boolean successful) {
       if (!config.isInvocationBatchingEnabled()) {
-         throw new ConfigurationException("Invocation batching not enabled in current configuration!  Please use the <invocationBatching /> element.");
+         throw new ConfigurationException("Invocation batching not enabled in current configuration! Please enable it.");
       }
       batchContainer.endBatch(successful);
    }

--- a/core/src/main/java/org/infinispan/batch/AutoBatchSupport.java
+++ b/core/src/main/java/org/infinispan/batch/AutoBatchSupport.java
@@ -38,7 +38,7 @@ public abstract class AutoBatchSupport {
 
    protected static void assertBatchingSupported(Configuration c) {
       if (!c.isInvocationBatchingEnabled())
-         throw new ConfigurationException("Invocation batching not enabled in current configuration!  Please use the <invocationBatching /> element.");
+         throw new ConfigurationException("Invocation batching not enabled in current configuration! Please enable it.");
    }
 
    protected void startAtomic() {


### PR DESCRIPTION
Very silly.

IMHO lets not refer to some XML stanzas unless it is XML paring code. The message is just confusing if you are using programmatic configuration or using directly from JDG/AS7.
