### PR TITLE
ISPN-2434 Backwards compatbile ctor for ConfigurationBuilderHolder

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/parsing/ConfigurationBuilderHolder.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/ConfigurationBuilderHolder.java
@@ -33,6 +33,10 @@ public class ConfigurationBuilderHolder {
    private final Map<Class<? extends ConfigurationParser<?>>, ParserContext> parserContexts;
    private final ClassLoader classLoader;
 
+   public ConfigurationBuilderHolder() {
+      this(Thread.currentThread().getContextClassLoader());
+   }
+
    public ConfigurationBuilderHolder(ClassLoader classLoader) {
       this.globalConfigurationBuilder = new GlobalConfigurationBuilder();
       this.defaultConfigurationBuilder = new ConfigurationBuilder();


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2434

So that class can be instantiated from both 5.1.x and 5.2.x codebase.
