### PR TITLE
ISPN-2371 The global component registry fails to start components

### DIFF
--- a/core/src/main/java/org/infinispan/factories/EmptyConstructorFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EmptyConstructorFactory.java
@@ -47,7 +47,7 @@ import org.infinispan.xsite.BackupReceiverRepositoryImpl;
  * @since 4.0
  */
 @DefaultFactoryFor(classes = {InboundInvocationHandler.class, RemoteCommandsFactory.class, ExternalizerTable.class,
-                              LocalTopologyManager.class, ClusterTopologyManager.class, RebalancePolicy.class, BackupReceiverRepository.class})
+                              RebalancePolicy.class, BackupReceiverRepository.class})
 @Scope(Scopes.GLOBAL)
 public class EmptyConstructorFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
 

--- a/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
@@ -41,6 +41,8 @@ import org.infinispan.manager.EmbeddedCacheManagerStartupException;
 import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifier;
 import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifierImpl;
 import org.infinispan.remoting.transport.Transport;
+import org.infinispan.topology.ClusterTopologyManager;
+import org.infinispan.topology.LocalTopologyManager;
 import org.infinispan.util.ModuleProperties;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -134,6 +136,9 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
          // This is necessary to make sure the transport has been started and is available to other components that
          // may need it.  This is a messy approach though - a proper fix will be in ISPN-1698
          getOrCreateComponent(Transport.class);
+         // These two should not be necessary, but they are here as a workaround for ISPN-2371
+         getOrCreateComponent(LocalTopologyManager.class);
+         getOrCreateComponent(ClusterTopologyManager.class);
 
       } catch (Exception e) {
          throw new CacheException("Unable to construct a GlobalComponentRegistry!", e);

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerFactory.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerFactory.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.infinispan.topology;
+
+import org.infinispan.factories.AbstractComponentFactory;
+import org.infinispan.factories.AutoInstantiableFactory;
+import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.remoting.transport.Transport;
+
+/**
+ * Factory for ClusterTopologyManager implementations
+ *
+ * @author Dan Berindei
+ * @since 5.2
+ */
+@Scope(Scopes.GLOBAL)
+@DefaultFactoryFor(classes = ClusterTopologyManager.class)
+public class ClusterTopologyManagerFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
+
+   @Override
+   @SuppressWarnings("unchecked")
+   public <T> T construct(Class<T> componentType) {
+      if (globalConfiguration.transport().transport() == null)
+         return null;
+
+      return (T) new ClusterTopologyManagerImpl();
+   }
+
+}

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerFactory.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerFactory.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.infinispan.topology;
+
+import org.infinispan.factories.AbstractComponentFactory;
+import org.infinispan.factories.AutoInstantiableFactory;
+import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+
+/**
+ * Factory for ClusterTopologyManager implementations
+ *
+ * @author Dan Berindei
+ * @since 5.2
+ */
+@Scope(Scopes.GLOBAL)
+@DefaultFactoryFor(classes = LocalTopologyManager.class)
+public class LocalTopologyManagerFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
+
+   @Override
+   @SuppressWarnings("unchecked")
+   public <T> T construct(Class<T> componentType) {
+      if (globalConfiguration.transport().transport() == null)
+         return null;
+
+      return (T) new LocalTopologyManagerImpl();
+   }
+
+}


### PR DESCRIPTION
if the components registered in parallel with the regular startup

Workaround for ClusterTopologyManagerImpl/LocalTopologyManagerImpl.

https://issues.jboss.org/browse/ISPN-2371
