### PR TITLE
ISPN-2440 JGroupsTransport.invokeRemotely throws SuspectExceptions even ...

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -496,7 +496,7 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
       if (broadcast) {
          rsps = dispatcher.broadcastRemoteCommands(rpcCommand, toJGroupsMode(mode), timeout, recipients != null,
                                                    usePriorityQueue, toJGroupsFilter(responseFilter),
-               asyncMarshalling);
+                                                   asyncMarshalling, ignoreLeavers);
       } else {         
          if (jgAddressList == null || !jgAddressList.isEmpty()) {
             boolean singleRecipient = !ignoreLeavers && jgAddressList != null && jgAddressList.size() == 1;
@@ -516,7 +516,7 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
                } else {
                   rsps = dispatcher.invokeRemoteCommands(jgAddressList, rpcCommand, toJGroupsMode(mode), timeout,
                                                          recipients != null, usePriorityQueue, toJGroupsFilter(responseFilter),
-                        asyncMarshalling);
+                                                         asyncMarshalling, ignoreLeavers);
                }
             }
          }


### PR DESCRIPTION
...in SYNCHRONOUS_IGNORE_LEAVERS mode

https://issues.jboss.org/browse/ISPN-2440

Explicitly catch JGroups' SuspectedExceptions and ignore them when the
response mode is SYNCHRONOUS_IGNORE_LEAVERS.

This is a bit of a hack, but it beats casting the NotifyingFuture to a
UnicastRequest to call getResponse() and check the suspected status.
