### PR TITLE
Fix DummyInMemoryCacheStoreConfigurationBuilder#read()

### DIFF
--- a/core/src/test/java/org/infinispan/loaders/dummy/DummyInMemoryCacheStoreConfigurationBuilder.java
+++ b/core/src/test/java/org/infinispan/loaders/dummy/DummyInMemoryCacheStoreConfigurationBuilder.java
@@ -63,6 +63,10 @@ public class DummyInMemoryCacheStoreConfigurationBuilder
 
    @Override
    public DummyInMemoryCacheStoreConfigurationBuilder read(DummyInMemoryCacheStoreConfiguration template) {
+      debug = template.debug();
+      storeName = template.storeName();
+      failKey = template.failKey();
+
       // AbstractStore-specific configuration
       fetchPersistentState = template.fetchPersistentState();
       ignoreModifications = template.ignoreModifications();


### PR DESCRIPTION
Make sure the DummyInMemoryCacheStoreConfigurationBuilder actually copies the config
