### PR TITLE
[ISPN-2447] Upgrade to netty-3.5.9.Final

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -160,7 +160,7 @@
       <version.milyn.smooks>1.2.2</version.milyn.smooks>
       <version.mockito>1.8.5</version.mockito>
       <version.mysql.driver>5.1.19</version.mysql.driver>
-      <version.netty>3.5.8.Final</version.netty>
+      <version.netty>3.5.9.Final</version.netty>
       <version.org.jboss.naming>5.0.6.CR1</version.org.jboss.naming>
       <version.resteasy>2.3.2.Final</version.resteasy>
       <version.rhq.helpers>3.0.4</version.rhq.helpers>


### PR DESCRIPTION
Upgrade to netty-3.5.9.Final because of a possible NPE.

See https://issues.jboss.org/browse/ISPN-2447
