### PR TITLE
ISPN-2450 Fix parallel execution of test suite by upgrading TestNG to 6.7

### DIFF
--- a/cdi/extension/pom.xml
+++ b/cdi/extension/pom.xml
@@ -42,7 +42,6 @@
    <properties>
       <!-- version of slf4j needed by Weld -->
       <version.slf4j>1.5.10</version.slf4j>
-      <version.testng.arquillian>5.14.10</version.testng.arquillian>
    </properties>
 
    <developers>
@@ -98,7 +97,7 @@
       <dependency>
          <groupId>org.testng</groupId>
          <artifactId>testng</artifactId>
-         <version>${version.testng.arquillian}</version>
+         <version>${version.testng}</version>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -170,7 +170,7 @@
       <version.solder>3.1.0.Final</version.solder>
       <version.spring>3.1.0.RELEASE</version.spring>
       <version.spymemcached>2.5</version.spymemcached>
-      <version.testng>5.14.10</version.testng>
+      <version.testng>6.7</version.testng>
       <version.webdav.servlet>2.0.1</version.webdav.servlet>
       <version.weld>1.1.4.Final</version.weld>
       <version.xsom>20081112</version.xsom>


### PR DESCRIPTION
This is for master.  It could/should be backported to branch `5.1.x` as well ...

See https://issues.jboss.org/browse/ISPN-2450
