### PR TITLE
ISPN-2452 Remove scope from parent dependency definition

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -209,7 +209,6 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>infinispan-cdi</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
          </dependency>
          <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
- Child pom.xml files should define which scope to use a dependency for.
