### PR TITLE
ISPN-2426 putForExternalRead() does not unlock if entry already exists

### DIFF
--- a/core/src/main/java/org/infinispan/container/EntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/EntryFactoryImpl.java
@@ -154,8 +154,11 @@ public class EntryFactoryImpl implements EntryFactory {
       } else {
          InternalCacheEntry ice = (icEntry == null ? getFromContainer(key) : icEntry);
          // A putForExternalRead is putIfAbsent, so if key present, do nothing
-         if (ice != null && ctx.hasFlag(Flag.PUT_FOR_EXTERNAL_READ))
+         if (ice != null && ctx.hasFlag(Flag.PUT_FOR_EXTERNAL_READ)) {
+            // make sure we record this! Null value since this is a forced lock on the key
+            ctx.putLookedUpEntry(key, null);
             return null;
+         }
 
          mvccEntry = ice != null ?
              wrapInternalCacheEntryForPut(ctx, key, ice) :

--- a/core/src/test/java/org/infinispan/api/APINonTxTest.java
+++ b/core/src/test/java/org/infinispan/api/APINonTxTest.java
@@ -39,6 +39,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.infinispan.test.TestingUtil.assertNoLocks;
+
 /**
  * @author Mircea Markus
  * @since 5.1
@@ -347,4 +349,13 @@ public class APINonTxTest extends SingleCacheManagerTest {
       cache.put("hello", null);
    }
 
+   public void testPutIfAbsentLockCleanup() {
+      assertNoLocks(cache);
+      cache.put("key", "value");
+      assertNoLocks(cache);
+      // This call should fail.
+      cache.putForExternalRead("key", "value2");
+      assertNoLocks(cache);
+      assert cache.get("key").equals("value");
+   }
 }


### PR DESCRIPTION
5.1.x version of https://issues.jboss.org/browse/ISPN-2426
