### PR TITLE
ISPN-2471 BatchAsyncCacheStoreTest fails randomly

### DIFF
--- a/core/src/main/java/org/infinispan/loaders/decorators/AsyncStore.java
+++ b/core/src/main/java/org/infinispan/loaders/decorators/AsyncStore.java
@@ -666,7 +666,7 @@ public class AsyncStore extends AbstractDelegatingStore {
                   }
 
                   // if this is the last state to process, wait for background threads, then quit
-                  if (s.stopped) {
+                  if (s.stopped && s.modifications.isEmpty()) {
                      s.workerThreads.await();
                      return;
                   }


### PR DESCRIPTION
AsyncStore.AsyncStoreCoordinator.run() termination condition should also check if all queued modifications are processed before terminating.

JIRA: https://issues.jboss.org/browse/ISPN-2471
