### PR TITLE
ISPN-2384 Avoid losing entries with concurrent passivation/activation

### DIFF
--- a/core/src/main/java/org/infinispan/eviction/ActivationManager.java
+++ b/core/src/main/java/org/infinispan/eviction/ActivationManager.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.eviction;
+
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+
+/**
+ * Controls activation of cache entries that have been passivated.
+ *
+ * @author Galder Zamarreño
+ * @since 5.2
+ */
+@Scope(Scopes.NAMED_CACHE)
+public interface ActivationManager {
+
+   /**
+    * Remove key and associated value from cache store
+    * and update the activation counter.
+    *
+    * @param key Key to remove
+    */
+   void activate(Object key);
+
+   /**
+    * Get number of activations executed.
+    *
+    * @return A long representing the number of activations
+    */
+   long getActivationCount();
+
+}

--- a/core/src/main/java/org/infinispan/eviction/ActivationManagerImpl.java
+++ b/core/src/main/java/org/infinispan/eviction/ActivationManagerImpl.java
@@ -1,0 +1,138 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.eviction;
+
+import org.infinispan.config.ConfigurationException;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.jmx.annotations.MBean;
+import org.infinispan.jmx.annotations.ManagedAttribute;
+import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.loaders.CacheLoaderException;
+import org.infinispan.loaders.CacheLoaderManager;
+import org.infinispan.loaders.CacheStore;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.rhq.helpers.pluginAnnotations.agent.MeasurementType;
+import org.rhq.helpers.pluginAnnotations.agent.Metric;
+import org.rhq.helpers.pluginAnnotations.agent.Operation;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Concrete implementation of activation logic manager.
+ *
+ * @author Galder Zamarreño
+ * @since 5.2
+ */
+@MBean(objectName = "Activation",
+      description = "Component that handles activating entries that have been passivated to a CacheStore by loading them into memory.")
+public class ActivationManagerImpl implements ActivationManager {
+
+   private static final Log log = LogFactory.getLog(ActivationManagerImpl.class);
+   private static final boolean trace = log.isTraceEnabled();
+
+   private final AtomicLong activations = new AtomicLong(0);
+   private CacheLoaderManager clm;
+   private CacheStore store;
+   private Configuration cfg;
+   private boolean enabled;
+
+   @ManagedAttribute(description = "Enables or disables the gathering of statistics by this component", writable = true)
+   private boolean statisticsEnabled = false;
+
+   @Inject
+   public void inject(CacheLoaderManager clm, Configuration cfg) {
+      this.clm = clm;
+      this.cfg = cfg;
+   }
+
+   @Start(priority = 10) // Just before the passivation manager
+   public void start() {
+      enabled = clm.isUsingPassivation() && !clm.isShared();
+      if (enabled) {
+         store = clm.getCacheStore();
+         if (store == null)
+            throw new ConfigurationException(
+                  "Passivation can only be used with a CacheLoader that implements CacheStore!");
+
+         statisticsEnabled = cfg.jmxStatistics().enabled();
+      }
+   }
+
+   @Override
+   public void activate(Object key) {
+      if (enabled) {
+         try {
+            if (store.remove(key) && statisticsEnabled) {
+               activations.incrementAndGet();
+            }
+         } catch (CacheLoaderException e) {
+            log.unableToRemoveEntryAfterActivation(key, e);
+         }
+      } else {
+         if (trace)
+            log.trace("Don't remove entry from shared cache store after activation.");
+      }
+   }
+
+   @Override
+   public long getActivationCount() {
+      return activations.get();
+   }
+
+   @ManagedAttribute(description = "Number of activation events")
+   @Metric(displayName = "Number of cache entries activated",
+         measurementType = MeasurementType.TRENDSUP)
+   @SuppressWarnings("unused")
+   public String getActivations() {
+      if (!statisticsEnabled)
+         return "N/A";
+
+      return String.valueOf(getActivationCount());
+   }
+
+   @ManagedOperation(description = "Resets statistics gathered by this component")
+   @Operation(displayName = "Reset statistics")
+   public void resetStatistics() {
+      activations.set(0);
+   }
+
+   /**
+    * Disables a cache loader of a given type, where type is the fully qualified class name of a {@link org.infinispan.loaders.CacheLoader} implementation.
+    *
+    * If the given type cannot be found, this is a no-op.  If more than one cache loader of the same type is configured,
+    * all cache loaders of the given type are disabled.
+    *
+    * @param loaderType fully qualified class name of the cache loader type to disable
+    */
+   @ManagedOperation(description = "Disable all cache loaders of a given type, where type is a fully qualified class name of the cache loader to disable")
+   @Operation(displayName = "Disable all cache loaders of a given type, where type is a fully qualified class name of the cache loader to disable")
+   @SuppressWarnings("unused")
+   public void disableCacheLoader(String loaderType) {
+      if (enabled) clm.disableCacheStore(loaderType);
+   }
+
+}

--- a/core/src/main/java/org/infinispan/factories/EmptyConstructorNamedCacheFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EmptyConstructorNamedCacheFactory.java
@@ -33,6 +33,8 @@ import org.infinispan.context.NonTransactionalInvocationContextContainer;
 import org.infinispan.context.TransactionalInvocationContextContainer;
 import org.infinispan.distribution.L1Manager;
 import org.infinispan.distribution.L1ManagerImpl;
+import org.infinispan.eviction.ActivationManager;
+import org.infinispan.eviction.ActivationManagerImpl;
 import org.infinispan.eviction.EvictionManager;
 import org.infinispan.eviction.EvictionManagerImpl;
 import org.infinispan.eviction.PassivationManager;
@@ -65,7 +67,8 @@ import static org.infinispan.util.Util.getInstance;
  * @since 4.0
  */
 @DefaultFactoryFor(classes = {CacheNotifier.class, CommandsFactory.class,
-                              CacheLoaderManager.class, InvocationContextContainer.class, PassivationManager.class,
+                              CacheLoaderManager.class, InvocationContextContainer.class,
+                              PassivationManager.class, ActivationManager.class,
                               BatchContainer.class, EvictionManager.class,
                               TransactionCoordinator.class, RecoveryAdminOperations.class, StateTransferLock.class,
                               ClusteringDependentLogic.class, LockContainer.class,
@@ -97,6 +100,8 @@ public class EmptyConstructorNamedCacheFactory extends AbstractNamedCacheCompone
             return (T) new CacheLoaderManagerImpl();
          } else if (componentType.equals(PassivationManager.class)) {
             return (T) new PassivationManagerImpl();
+         } else if (componentType.equals(ActivationManager.class)) {
+            return (T) new ActivationManagerImpl();
          } else if (componentType.equals(BatchContainer.class)) {
             return (T) new BatchContainer();
          } else if (componentType.equals(TransactionCoordinator.class)) {

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -829,4 +829,9 @@ public interface Log extends BasicLogger {
    @LogMessage(level = ERROR)
    @Message(value = "Unable to load %s from any of the following classloaders: %s", id=213)
    void unableToLoadClass(String classname, String classloaders, @Cause Throwable cause);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Unable to remove entry under %s from cache store after activation", id = 214)
+   void unableToRemoveEntryAfterActivation(Object key, @Cause Exception e);
+
 }

--- a/core/src/test/java/org/infinispan/config/DataContainerTest.java
+++ b/core/src/test/java/org/infinispan/config/DataContainerTest.java
@@ -78,7 +78,7 @@ public class DataContainerTest {
          AdvancedCache<Object, Object> cache = cm.getCache().getAdvancedCache();
 
          DataContainer ddc = DefaultDataContainer.unBoundedDataContainer(cache.getConfiguration().getConcurrencyLevel());
-         ((DefaultDataContainer) ddc).initialize(null, null,new InternalEntryFactoryImpl());
+         ((DefaultDataContainer) ddc).initialize(null, null,new InternalEntryFactoryImpl(), null, null);
          QueryableDataContainer.setDelegate(ddc);
 
          // Verify that the default is correctly established
@@ -111,7 +111,7 @@ public class DataContainerTest {
          AdvancedCache<Object, Object> cache = cm.getCache().getAdvancedCache();
 
          DataContainer ddc = DefaultDataContainer.unBoundedDataContainer(cache.getConfiguration().getConcurrencyLevel());
-         ((DefaultDataContainer) ddc).initialize(null, null,new InternalEntryFactoryImpl());
+         ((DefaultDataContainer) ddc).initialize(null, null,new InternalEntryFactoryImpl(), null, null);
          QueryableDataContainer.setDelegate(ddc);
 
          // Verify that the config is correct

--- a/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
+++ b/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
@@ -55,7 +55,7 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
 
    protected DataContainer createContainer() {
       DefaultDataContainer dc = new DefaultDataContainer(16);
-      dc.initialize(null, null, new InternalEntryFactoryImpl());
+      dc.initialize(null, null, new InternalEntryFactoryImpl(), null, null);
       return dc;
    }
 

--- a/core/src/test/java/org/infinispan/eviction/ConcurrentPassivationActivationTest.java
+++ b/core/src/test/java/org/infinispan/eviction/ConcurrentPassivationActivationTest.java
@@ -1,0 +1,148 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.eviction;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.loaders.dummy.DummyInMemoryCacheStoreConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryPassivated;
+import org.infinispan.notifications.cachelistener.event.CacheEntryPassivatedEvent;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Tests behaviour when concurrent passivation/activation operations occur.
+ *
+ * @author Galder Zamarreño
+ * @since 5.2
+ */
+@Test(groups = "functional", testName = "eviction.ConcurrentPassivationActivationTest")
+public class ConcurrentPassivationActivationTest extends SingleCacheManagerTest {
+
+   final CountDownLatch passivateWait = new CountDownLatch(1);
+   final CountDownLatch activationWait = new CountDownLatch(1);
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.eviction().strategy(EvictionStrategy.LRU).maxEntries(1)
+         .jmxStatistics().enable()
+         .loaders()
+            .passivation(true)
+            .addLoader(DummyInMemoryCacheStoreConfigurationBuilder.class);
+
+      return TestCacheManagerFactory.createCacheManager(builder);
+   }
+
+   public void testInMemoryEntryNotLostWithConcurrentActivePassive() throws Exception {
+      ActivationManager activation =
+            TestingUtil.extractComponent(cache, ActivationManager.class);
+
+      PassivationManager passivation =
+            TestingUtil.extractComponent(cache, PassivationManager.class);
+
+      cache.addListener(new SlowPassivator());
+
+      assertEquals(0, activation.getActivationCount());
+      assertEquals(0, passivation.getPassivationCount());
+
+      // 1. Store an entry in the cache
+      cache.put(1, "v1");
+      assertEquals(0, activation.getActivationCount());
+      assertEquals(0, passivation.getPassivationCount());
+
+      ExecutorService exec = Executors.newFixedThreadPool(2);
+
+      // 2. Add another entry and block just after passivation has stored
+      // entry in cache store, but it's still in memory
+      Future<Object> passivatorFuture = exec.submit(new Callable<Object>() {
+         @Override
+         public Object call() throws Exception {
+            // Store a second entry to force the previous entry
+            // to be evicted and passivated
+            log.debug("Store another entry and force previous to be passivated");
+            cache.put(2, "v2");
+            return null;
+         }
+      });
+
+      // 3. Retrieve entry to be passivated from memory
+      // and let it remove it from cache store
+      Future<Object> activatorFuture = exec.submit(new Callable<Object>() {
+         @Override
+         public Object call() throws Exception {
+            // Retrieve first key forcing an activation
+            log.debug("Retrieve entry and force activation");
+            activationWait.await(60, TimeUnit.SECONDS);
+            assertEquals("v1", cache.get(1));
+            return null;
+         }
+      });
+
+      activatorFuture.get(30, TimeUnit.SECONDS);
+      assertEquals(0, activation.getActivationCount());
+      assertEquals(1, passivation.getPassivationCount());
+
+      // 4. With entry stored, then removed, now let the passivator thread
+      // remove the entry from memory
+      passivateWait.countDown();
+
+      // 5. Wait for entry to be removed from memory...
+      passivatorFuture.get(30, TimeUnit.SECONDS);
+
+      // 6. Entry shouldn't be gone
+      assertEquals("v1", cache.get(1));
+      assertEquals(1, activation.getActivationCount());
+      // Second key gets passivated now to make space for the 1st one
+      assertEquals(2, passivation.getPassivationCount());
+   }
+
+   @Listener
+   public class SlowPassivator {
+
+      @CacheEntryPassivated
+      @SuppressWarnings("unused")
+      public void passivate(CacheEntryPassivatedEvent event) throws Exception {
+         if (!event.isPre()) {
+            log.debugf("Entry stored in cache store, wait before removing from memory");
+            activationWait.countDown();
+            passivateWait.await(60, TimeUnit.SECONDS);
+         }
+      }
+
+   }
+
+}

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
 import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 import javax.transaction.Status;
 import javax.transaction.TransactionManager;
@@ -1162,29 +1163,37 @@ public class TestingUtil {
       return jmxDomain + '.' + m.getName();
    }
 
-   public static ObjectName getCacheManagerObjectName(String jmxDomain) throws Exception {
+   public static ObjectName getCacheManagerObjectName(String jmxDomain) {
       return getCacheManagerObjectName(jmxDomain, "DefaultCacheManager");
    }
 
-   public static ObjectName getCacheManagerObjectName(String jmxDomain, String cacheManagerName) throws Exception {
-      return new ObjectName(jmxDomain + ":type=CacheManager,name=" + ObjectName.quote(cacheManagerName) + ",component=CacheManager");
+   public static ObjectName getCacheManagerObjectName(String jmxDomain, String cacheManagerName) {
+      try {
+         return new ObjectName(jmxDomain + ":type=CacheManager,name=" + ObjectName.quote(cacheManagerName) + ",component=CacheManager");
+      } catch (Exception e) {
+         throw new RuntimeException(e);
+      }
    }
 
-   public static ObjectName getCacheObjectName(String jmxDomain) throws Exception {
+   public static ObjectName getCacheObjectName(String jmxDomain) {
       return getCacheObjectName(jmxDomain, CacheContainer.DEFAULT_CACHE_NAME + "(local)");
    }
 
-   public static ObjectName getCacheObjectName(String jmxDomain, String cacheName) throws Exception {
+   public static ObjectName getCacheObjectName(String jmxDomain, String cacheName) {
       return getCacheObjectName(jmxDomain, cacheName, "Cache");
    }
 
-   public static ObjectName getCacheObjectName(String jmxDomain, String cacheName, String component) throws Exception {
+   public static ObjectName getCacheObjectName(String jmxDomain, String cacheName, String component) {
       return getCacheObjectName(jmxDomain, cacheName, component, "DefaultCacheManager");
    }
 
-   public static ObjectName getCacheObjectName(String jmxDomain, String cacheName, String component, String cacheManagerName) throws Exception {
-      return new ObjectName(jmxDomain + ":type=Cache,manager=" + ObjectName.quote(cacheManagerName)
-            + ",name=" + ObjectName.quote(cacheName) + ",component=" + component);
+   public static ObjectName getCacheObjectName(String jmxDomain, String cacheName, String component, String cacheManagerName) {
+      try {
+         return new ObjectName(jmxDomain + ":type=Cache,manager=" + ObjectName.quote(cacheManagerName)
+               + ",name=" + ObjectName.quote(cacheName) + ",component=" + component);
+      } catch (Exception e) {
+         throw new RuntimeException(e);
+      }
    }
 
    public static ObjectName getJGroupsChannelObjectName(String jmxDomain, String clusterName) throws Exception {


### PR DESCRIPTION
REQUIRES CAREFUL REVIEW
- Fixed by making sure that evicting an entry as a result of exciding the given max size is done within the internal hash map segment lock, and make sure activations happen within this lock too.
- This way, concurrent passivation/activation operations will be lined in such way that removing from store (activation) won't happen at the same time as removing entries from memory without providing guarantees that the entry remains in memory.
- Added a unit to replicate this entry loss.
- Activation interceptor still needed to handle environments where eviction happens manually, via cache.evict() calls.
