### PR TITLE
ISPN-2494 Transactiontable.cleanupCompletedTransactions fills debug logf...

### DIFF
--- a/core/src/main/java/org/infinispan/transaction/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/TransactionTable.java
@@ -523,29 +523,31 @@ public class TransactionTable {
    }
 
    public void cleanupCompletedTransactions() {
-      try {
-         log.debugf("About to cleanup completed transaction. Initial size is %d", completedTransactions.size());
-         //this iterator is weekly consistent and will never throw ConcurrentModificationException
-         Iterator<Map.Entry<GlobalTransaction, Long>> iterator = completedTransactions.entrySet().iterator();
-         long timeout = configuration.transaction().completedTxTimeout();
+      if (!completedTransactions.isEmpty()) {
+         try {
+            log.tracef("About to cleanup completed transaction. Initial size is %d", completedTransactions.size());
+            //this iterator is weekly consistent and will never throw ConcurrentModificationException
+            Iterator<Map.Entry<GlobalTransaction, Long>> iterator = completedTransactions.entrySet().iterator();
+            long timeout = configuration.transaction().completedTxTimeout();
 
-         int removedEntries = 0;
-         long beginning = System.nanoTime();
-         while (iterator.hasNext()) {
-            Map.Entry<GlobalTransaction, Long> e = iterator.next();
-            long ageNanos = System.nanoTime() - e.getValue();
-            if (TimeUnit.NANOSECONDS.toMillis(ageNanos) >= timeout) {
-               iterator.remove();
-               removedEntries++;
+            int removedEntries = 0;
+            long beginning = System.nanoTime();
+            while (iterator.hasNext()) {
+               Map.Entry<GlobalTransaction, Long> e = iterator.next();
+               long ageNanos = System.nanoTime() - e.getValue();
+               if (TimeUnit.NANOSECONDS.toMillis(ageNanos) >= timeout) {
+                  iterator.remove();
+                  removedEntries++;
+               }
             }
-         }
-         long duration = System.nanoTime() - beginning;
+            long duration = System.nanoTime() - beginning;
 
-         log.debugf("Finished cleaning up completed transactions. %d transactions were removed, total duration was %d millis, " +
-                         "current number of completed transactions is %d", removedEntries, TimeUnit.NANOSECONDS.toMillis(duration),
-                    completedTransactions.size());
-      } catch (Exception e) {
-         log.errorf(e, "Failed to cleanup completed transactions: %s", e.getMessage());
+            log.tracef("Finished cleaning up completed transactions. %d transactions were removed, total duration was %d millis, " +
+                  "current number of completed transactions is %d", removedEntries, TimeUnit.NANOSECONDS.toMillis(duration),
+                  completedTransactions.size());
+         } catch (Exception e) {
+            log.errorf(e, "Failed to cleanup completed transactions: %s", e.getMessage());
+         }
       }
    }
 }


### PR DESCRIPTION
...ile rapidly
- Do not execute or log anything if the scheduled task wakes up and there are no completed transactions to clean up
- Switch logging to trace instead of debug level

JIRA: https://issues.jboss.org/browse/ISPN-2494
