### PR TITLE
ISPN-2523 Fix race condition in BDB store transaction prepare

### DIFF
--- a/cachestore/bdbje/src/main/java/org/infinispan/loaders/bdbje/BdbjeCacheStore.java
+++ b/cachestore/bdbje/src/main/java/org/infinispan/loaders/bdbje/BdbjeCacheStore.java
@@ -310,7 +310,7 @@ public class BdbjeCacheStore extends AbstractCacheStore {
          Transaction txn = currentTransaction.getTransaction();
          if (trace) log.tracef("transaction %s == sleepycat transaction %s", tx, txn);
          txnMap.put(tx, txn);
-         ReflectionUtil.setValue(currentTransaction, "localTrans", new ThreadLocal());
+         ((ThreadLocal)ReflectionUtil.getValue(currentTransaction, "localTrans")).remove();
       } catch (Exception e) {
          throw convertToCacheLoaderException("Problem preparing transaction", e);
       }


### PR DESCRIPTION
Currently the prepare method creates a transaction and then clears all of them. This leads to NPE if two prepares are run concurrently (one thread can clear transaction for another). The fix makes it clear only own transaction
