### PR TITLE
 ISPN-2474 Remove L1 entries whose owners changed on topology changes

### DIFF
--- a/core/src/test/java/org/infinispan/affinity/BaseFilterKeyAffinityServiceTest.java
+++ b/core/src/test/java/org/infinispan/affinity/BaseFilterKeyAffinityServiceTest.java
@@ -66,7 +66,7 @@ public abstract class BaseFilterKeyAffinityServiceTest extends BaseKeyAffinitySe
 
    protected void testAddNewServer() throws Exception {
       EmbeddedCacheManager cm = addClusterEnabledCacheManager();
-      cm.defineConfiguration(cacheName, configuration);
+      cm.defineConfiguration(cacheName, configuration.build());
       Cache<Object, String> cache = cm.getCache(cacheName);
       caches.add(cache);
       waitForClusterToResize();

--- a/core/src/test/java/org/infinispan/affinity/KeyAffinityServiceTest.java
+++ b/core/src/test/java/org/infinispan/affinity/KeyAffinityServiceTest.java
@@ -87,7 +87,7 @@ public class KeyAffinityServiceTest extends BaseKeyAffinityServiceTest {
    @Test (dependsOnMethods = "testConcurrentConsumptionOfKeys")
    public void testServerAdded() throws InterruptedException {
       EmbeddedCacheManager cm = addClusterEnabledCacheManager();
-      cm.defineConfiguration(cacheName, configuration);
+      cm.defineConfiguration(cacheName, configuration.build());
       Cache<Object, String> cache = cm.getCache(cacheName);
       caches.add(cache);
       waitForClusterToResize();

--- a/core/src/test/java/org/infinispan/distribution/BaseDistCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistCacheStoreTest.java
@@ -24,7 +24,9 @@ package org.infinispan.distribution;
 
 import org.infinispan.config.CacheLoaderManagerConfig;
 import org.infinispan.config.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.loaders.dummy.DummyInMemoryCacheStore;
+import org.infinispan.loaders.dummy.DummyInMemoryCacheStoreConfigurationBuilder;
 
 /**
  * DistSyncCacheStoreTest.
@@ -37,17 +39,16 @@ public abstract class BaseDistCacheStoreTest extends BaseDistFunctionalTest {
    protected boolean preload;
 
    @Override
-   protected Configuration buildConfiguration() {
-      Configuration cfg = super.buildConfiguration();
-      CacheLoaderManagerConfig clmc = new CacheLoaderManagerConfig();
-      clmc.setShared(shared);
+   protected ConfigurationBuilder buildConfiguration() {
+      ConfigurationBuilder cfg = super.buildConfiguration();
+      cfg.loaders().shared(shared);
       if (shared) {
-         clmc.addCacheLoaderConfig(new DummyInMemoryCacheStore.Cfg(getClass().getSimpleName()));
+         cfg.loaders().addStore(new DummyInMemoryCacheStoreConfigurationBuilder(cfg.loaders())
+               .storeName(getClass().getSimpleName()));
       } else {
-         clmc.addCacheLoaderConfig(new DummyInMemoryCacheStore.Cfg());
+         cfg.loaders().addStore(new DummyInMemoryCacheStoreConfigurationBuilder(cfg.loaders()));
       }
-      clmc.setPreload(preload);
-      cfg.setCacheLoaderManagerConfig(clmc);
+      cfg.loaders().preload(preload);
       return cfg;
    }
 }

--- a/core/src/test/java/org/infinispan/distribution/DistCacheStorePreloadTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistCacheStorePreloadTest.java
@@ -74,7 +74,7 @@ public class DistCacheStorePreloadTest extends BaseDistCacheStoreTest {
 
       addClusterEnabledCacheManager();
       EmbeddedCacheManager cm2 = cacheManagers.get(1);
-      cm2.defineConfiguration(cacheName, buildConfiguration());
+      cm2.defineConfiguration(cacheName, buildConfiguration().build());
       c2 = cache(1, cacheName);
       waitForClusterToForm(cacheName);
       caches.add(c2);

--- a/core/src/test/java/org/infinispan/distribution/SingleOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/SingleOwnerTest.java
@@ -26,6 +26,7 @@ package org.infinispan.distribution;
 import org.infinispan.Cache;
 import org.infinispan.CacheException;
 import org.infinispan.config.Configuration;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.concurrent.IsolationLevel;
@@ -50,16 +51,16 @@ public class SingleOwnerTest extends BaseDistFunctionalTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       cacheName = "dist";
-      configuration = getDefaultClusteredConfig(sync ? Configuration.CacheMode.DIST_SYNC : Configuration.CacheMode.DIST_ASYNC, tx);
+      configuration = getDefaultClusteredCacheConfig(sync ? CacheMode.DIST_SYNC : CacheMode.DIST_ASYNC, tx);
       if (!testRetVals) {
-         configuration.setUnsafeUnreliableReturnValues(true);
+         configuration.unsafe().unreliableReturnValues(true);
          // we also need to use repeatable read for tests to work when we dont have reliable return values, since the
          // tests repeatedly queries changes
-         configuration.setIsolationLevel(IsolationLevel.REPEATABLE_READ);
+         configuration.locking().isolationLevel(IsolationLevel.REPEATABLE_READ);
       }
-      configuration.setSyncReplTimeout(3, TimeUnit.SECONDS);
-      configuration.setNumOwners(1);
-      configuration.setLockAcquisitionTimeout(45, TimeUnit.SECONDS);
+      configuration.clustering().sync().replTimeout(3, TimeUnit.SECONDS);
+      configuration.clustering().hash().numOwners(1);
+      configuration.locking().lockAcquisitionTimeout(45, TimeUnit.SECONDS);
       caches = createClusteredCaches(2, cacheName, configuration);
 
       c1 = caches.get(0);

--- a/core/src/test/java/org/infinispan/distribution/rehash/ConcurrentJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/ConcurrentJoinTest.java
@@ -48,7 +48,7 @@ public class ConcurrentJoinTest extends RehashTestBase {
 
       for (int i = 0; i < NUM_JOINERS; i++) {
          EmbeddedCacheManager joinerManager = addClusterEnabledCacheManager(new TransportFlags().withFD(false));
-         joinerManager.defineConfiguration(cacheName, configuration);
+         joinerManager.defineConfiguration(cacheName, configuration.build());
          joinerManagers.add(joinerManager);
          joiners.set(i, null);
       }

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashCompletedOnJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashCompletedOnJoinTest.java
@@ -52,7 +52,7 @@ public class RehashCompletedOnJoinTest extends BaseDistFunctionalTest {
       log.infof("Initialized with keys %s", keys);
       
       EmbeddedCacheManager joinerManager = addClusterEnabledCacheManager();
-      joinerManager.defineConfiguration(cacheName, configuration);
+      joinerManager.defineConfiguration(cacheName, configuration.build());
       Cache joiner = joinerManager.getCache(cacheName);
       DistributionManager dmi = joiner.getAdvancedCache().getDistributionManager();
       assert dmi.isJoinComplete();

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashWithL1Test.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashWithL1Test.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package org.infinispan.distribution.rehash;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TransportFlags;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+
+/**
+ * Tests rehashing with distributed caches with L1 enabled.
+ *
+ * @author Galder Zamarreño
+ * @since 5.2
+ */
+@Test(groups = "functional", testName = "RayTest")
+public class RehashWithL1Test extends MultipleCacheManagersTest {
+
+   ConfigurationBuilder builder;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      // Enable rehashing explicitly
+      builder.clustering().stateTransfer().fetchInMemoryState(true)
+            .hash().l1().enable();
+      createClusteredCaches(2, builder);
+   }
+
+   public void testPutWithRehashAndCacheClear() throws Exception {
+      Future<Void> node3Join = null;
+      int opCount = 100;
+      for (int i = 0; i < opCount; i++) {
+         cache(0).put("k" + i, "some data");
+         if (i == (opCount / 2)) {
+            node3Join = fork(new Callable<Void>() {
+               @Override
+               public Void call() throws Exception {
+                  EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder,
+                        new TransportFlags().withMerge(true));
+                  cm.getCache();
+                  return null;
+               }
+            });
+         }
+         Thread.sleep(10);
+      }
+
+      if (node3Join == null) throw new Exception("Node 3 not joined");
+      node3Join.get();
+
+      for (int i = 0; i < opCount; i++) {
+         cache(0).remove("k" + i);
+         Thread.sleep(10);
+      }
+
+      for (int i = 0; i < opCount; i++) {
+         String key = "k" + i;
+         assertFalse(cache(0).containsKey(key));
+         assertFalse("Key: " + key + " is present in cache at " + cache(1),
+               cache(1).containsKey(key));
+         assertFalse("Key: " + key + " is present in cache at " + cache(2),
+               cache(2).containsKey(key));
+      }
+
+      assertEquals(0, cache(0).size());
+      assertEquals(0, cache(1).size());
+      assertEquals(0, cache(2).size());
+   }
+
+}

--- a/core/src/test/java/org/infinispan/distribution/rehash/SingleJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/SingleJoinTest.java
@@ -38,7 +38,7 @@ public class SingleJoinTest extends RehashTestBase {
 
    void performRehashEvent(boolean offline) {
       joinerManager = addClusterEnabledCacheManager(new TransportFlags().withFD(true));
-      joinerManager.defineConfiguration(cacheName, configuration);
+      joinerManager.defineConfiguration(cacheName, configuration.build());
       joiner = joinerManager.getCache(cacheName);
    }
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/WorkDuringJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/WorkDuringJoinTest.java
@@ -68,7 +68,7 @@ public class WorkDuringJoinTest extends BaseDistFunctionalTest {
 
    Address startNewMember() {
       joinerManager = addClusterEnabledCacheManager();
-      joinerManager.defineConfiguration(cacheName, configuration);
+      joinerManager.defineConfiguration(cacheName, configuration.build());
       joiner = joinerManager.getCache(cacheName);
       return manager(joiner).getAddress();
    }

--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -454,8 +454,6 @@ public class TestCacheManagerFactory {
       markAsTransactional(transactional, builder);
       //don't changed the tx lookup.
       if (useCustomTxLookup) updateTransactionSupport(transactional, builder);
-      // reduce the number of hash segments
-      builder.clustering().hash().numSegments(12);
       return builder;
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2474

Don't write an entry to L1 at all if the key owners changed between the
read CH and the write CH (because the pending CH may not contain any of
the read CH owners).

I also enhanced L1OnRehashTest and I made some other small changes to the test suite.
