### PR TITLE
ISPN-2495 Replication on startup not reliable

### DIFF
--- a/core/src/main/java/org/infinispan/loaders/CacheLoaderManagerImpl.java
+++ b/core/src/main/java/org/infinispan/loaders/CacheLoaderManagerImpl.java
@@ -60,14 +60,12 @@ import org.infinispan.loaders.decorators.ReadOnlyStore;
 import org.infinispan.loaders.decorators.SingletonStore;
 import org.infinispan.loaders.decorators.SingletonStoreConfig;
 import org.infinispan.marshall.StreamingMarshaller;
-import org.infinispan.statetransfer.StateTransferManager;
 import org.infinispan.util.InfinispanCollections;
 import org.infinispan.util.Util;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 public class CacheLoaderManagerImpl implements CacheLoaderManager {
-   private static final Log log = LogFactory.getLog(CacheLoaderManagerImpl.class);
 
    Configuration configuration;
    LoadersConfiguration clmConfig;
@@ -76,19 +74,17 @@ public class CacheLoaderManagerImpl implements CacheLoaderManager {
    CacheLoader loader;
    InvocationContextContainer icc;
    TransactionManager transactionManager;
-   StateTransferManager stateTransferManager;
+   private static final Log log = LogFactory.getLog(CacheLoaderManagerImpl.class);
 
    @Inject
    public void inject(AdvancedCache<Object, Object> cache,
                       @ComponentName(CACHE_MARSHALLER) StreamingMarshaller marshaller,
-                      Configuration configuration, InvocationContextContainer icc,
-                      TransactionManager transactionManager, StateTransferManager stateTransferManager) {
+                      Configuration configuration, InvocationContextContainer icc, TransactionManager transactionManager) {
       this.cache = cache;
       this.m = marshaller;
       this.configuration = configuration;
       this.icc = icc;
       this.transactionManager = transactionManager;
-      this.stateTransferManager = stateTransferManager;
    }
 
    @Override
@@ -210,19 +206,12 @@ public class CacheLoaderManagerImpl implements CacheLoaderManager {
 
    /**
     * Performs a preload on the cache based on the cache loader preload configs used when configuring the cache.
-    * The preload will happen only on the first node to start this cache in a cluster - the other nodes
-    * will receive this data via state transfer.
     */
    @Override
    @Start(priority = 56)
    public void preload() {
       if (loader != null) {
          if (clmConfig.preload()) {
-            // Don't preload anything if we're not the first member to start up
-            if (stateTransferManager != null && !stateTransferManager.isLocalNodeFirst()) {
-               log.debugf("We are not the first node to join cache %s, skipping preload", cache.getName());
-               return;
-            }
             long start = 0;
             boolean debugTiming = log.isDebugEnabled();
             if (debugTiming) {
@@ -251,7 +240,7 @@ public class CacheLoaderManagerImpl implements CacheLoaderManager {
                   .withFlags(flags.toArray(new Flag[]{}));
 
             for (InternalCacheEntry e : state)
-               flaggedCache.putIfAbsent(e.getKey(), e.getValue(),
+               flaggedCache.put(e.getKey(), e.getValue(),
                      e.getLifespan(), MILLISECONDS, e.getMaxIdle(), MILLISECONDS);
 
             if (debugTiming) {

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
@@ -37,6 +37,7 @@ import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.topology.CacheTopology;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.RemoteTransaction;
 import org.infinispan.transaction.WriteSkewHelper;
@@ -230,7 +231,10 @@ public class StateTransferInterceptor extends CommandInterceptor {   //todo [ani
       // set the topology id if it was not set before (ie. this is local command)
       // TODO Make tx commands extend FlagAffectedCommand so we can use CACHE_MODE_LOCAL in StaleTransactionCleanupService
       if (command.getTopologyId() == -1) {
-         command.setTopologyId(stateTransferManager.getCacheTopology().getTopologyId());
+         CacheTopology cacheTopology = stateTransferManager.getCacheTopology();
+         if (cacheTopology != null) {
+            command.setTopologyId(cacheTopology.getTopologyId());
+         }
       }
 
       // remote/forwarded command

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -96,7 +96,8 @@ public class StateTransferManagerImpl implements StateTransferManager {
       this.localTopologyManager = localTopologyManager;
    }
 
-   @Start(priority = 50)
+   // needs to be AFTER the DistributionManager and *after* the cache loader manager (if any) inits and preloads
+   @Start(priority = 60)
    @Override
    public void start() throws Exception {
       if (trace) {
@@ -259,7 +260,7 @@ public class StateTransferManagerImpl implements StateTransferManager {
       // forward commands with older topology ids to their new targets
       // but we need to make sure we have the latest topology
       CacheTopology cacheTopology = getCacheTopology();
-      int localTopologyId = cacheTopology.getTopologyId();
+      int localTopologyId = cacheTopology != null ? cacheTopology.getTopologyId() : -1;
       // if it's a tx/lock/write command, forward it to the new owners
       log.tracef("CommandTopologyId=%s, localTopologyId=%s", cmdTopologyId, localTopologyId);
 

--- a/core/src/main/java/org/infinispan/transaction/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/TransactionTable.java
@@ -312,9 +312,6 @@ public class TransactionTable {
       LocalTransaction current = localTransactions.get(transaction);
       if (current == null) {
          Address localAddress = rpcManager != null ? rpcManager.getTransport().getAddress() : null;
-         if (rpcManager != null && currentTopologyId < 0) {
-            throw new IllegalStateException("Cannot create transactions if topology id is not known yet!");
-         }
          GlobalTransaction tx = txFactory.newGlobalTransaction(localAddress, false);
          current = txFactory.newLocalTransaction(transaction, tx, ctx.isImplicitTransaction(), currentTopologyId);
          log.tracef("Created a new local transaction: %s", current);

--- a/core/src/test/java/org/infinispan/distribution/DistCacheStorePreloadTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistCacheStorePreloadTest.java
@@ -76,10 +76,13 @@ public class DistCacheStorePreloadTest extends BaseDistCacheStoreTest {
       EmbeddedCacheManager cm2 = cacheManagers.get(1);
       cm2.defineConfiguration(cacheName, buildConfiguration().build());
       c2 = cache(1, cacheName);
-      waitForClusterToForm(cacheName);
-      caches.add(c2);
+      waitForClusterToForm();
 
       DataContainer dc2 = c2.getAdvancedCache().getDataContainer();
-      assertEquals("No keys should be preloaded on the second cache", 0, dc2.size());
+      assertEquals("Expected all the cache store entries to be preloaded on the second cache", NUM_KEYS, dc2.size());
+
+      for (int i = 0; i < NUM_KEYS; i++) {
+         assertOwnershipAndNonOwnership("k" + i, true);
+      }
    }
 }

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferCacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferCacheLoaderFunctionalTest.java
@@ -23,14 +23,21 @@
 package org.infinispan.statetransfer;
 
 import org.infinispan.Cache;
-import org.infinispan.config.CacheLoaderManagerConfig;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.loaders.CacheLoader;
 import org.infinispan.loaders.CacheLoaderManager;
-import org.infinispan.loaders.CacheStoreConfig;
-import org.infinispan.loaders.dummy.DummyInMemoryCacheStore;
+import org.infinispan.loaders.dummy.DummyInMemoryCacheStoreConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import static org.testng.Assert.assertEquals;
 
 @Test(groups = "functional", testName = "statetransfer.StateTransferCacheLoaderFunctionalTest", enabled = true)
 public class StateTransferCacheLoaderFunctionalTest extends StateTransferFunctionalTest {
@@ -47,13 +54,14 @@ public class StateTransferCacheLoaderFunctionalTest extends StateTransferFunctio
 
    @Override
    protected EmbeddedCacheManager createCacheManager() {
+      configurationBuilder.loaders().clearCacheLoaders();
       // increment the DIMCS store id
-      CacheLoaderManagerConfig clmc = new CacheLoaderManagerConfig();
-      CacheStoreConfig clc = new DummyInMemoryCacheStore.Cfg("store number " + id++);
-      clmc.addCacheLoaderConfig(clc);
-      clc.setFetchPersistentState(true);
-      clmc.setShared(sharedCacheLoader.get());
-      config.setCacheLoaderManagerConfig(clmc);
+      DummyInMemoryCacheStoreConfigurationBuilder dimcs = new DummyInMemoryCacheStoreConfigurationBuilder(configurationBuilder.loaders());
+      dimcs.storeName("store number " + id++);
+      dimcs.fetchPersistentState(true);
+      configurationBuilder.loaders().addLoader(dimcs);
+      configurationBuilder.loaders().shared(sharedCacheLoader.get()).preload(true);
+
       return super.createCacheManager();
    }
 
@@ -102,8 +110,8 @@ public class StateTransferCacheLoaderFunctionalTest extends StateTransferFunctio
 
          // starting the second cache would initialize an in-memory state transfer but not a persistent one since the loader is shared
          Cache<Object, Object> c2 = createCacheManager().getCache(cacheName);
-
          TestingUtil.blockUntilViewsReceived(60000, c1, c2);
+         TestingUtil.waitForRehashToComplete(c1, c2);
 
          verifyInitialDataOnLoader(c1);
          verifyInitialData(c1);
@@ -114,4 +122,76 @@ public class StateTransferCacheLoaderFunctionalTest extends StateTransferFunctio
          sharedCacheLoader.set(false);
       }
    }
+
+   public void testInitialSlowPreload() throws Exception {
+      // Test for ISPN-2495
+      // Preload on cache on node 1 is slow and unfinished at the point, where cache on node 2 starts.
+      // Node 2 requests state, got answer that no entries available. Since node 2 is not coordinator,
+      // preload is ignored. At the end, node 1 contains REPL cache with all entries, node 2 has same cache without entries.
+      try {
+         sharedCacheLoader.set(true);
+         EmbeddedCacheManager cm1 = createCacheManager();
+         Cache<Object, Object> cache1 = cm1.getCache(cacheName);
+         verifyNoDataOnLoader(cache1);
+         verifyNoData(cache1);
+
+         // write initial data
+         cache1.put("A", new DelayedUnmarshal());
+         cache1.put("B", new DelayedUnmarshal());
+         cache1.put("C", new DelayedUnmarshal());
+         assertEquals(cache1.size(), 3);
+         cm1.stop();
+
+         // this cache is only used to start networking
+         final ConfigurationBuilder defaultConfigurationBuilder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
+
+         // now lets start cm and shortly after another cache manager
+         final EmbeddedCacheManager cm2 = super.createCacheManager();
+         cm2.defineConfiguration("initialCache", defaultConfigurationBuilder.build());
+         cm2.startCaches("initialCache");
+
+         EmbeddedCacheManager cm3 = super.createCacheManager();
+         cm3.defineConfiguration("initialCache", defaultConfigurationBuilder.build());
+         cm3.startCaches("initialCache");
+
+         // networking is started and cluster has 2 members
+         TestingUtil.blockUntilViewsReceived(60000, cm2.getCache("initialCache"), cm3.getCache("initialCache"));
+
+         // now fork start of "slow" cache
+         Thread worker = new Thread(){
+            @Override
+            public void run() {
+               cm2.startCaches(cacheName);
+            }
+         };
+         worker.start();
+         // lets wait a bit, cache is started pon cm2, but preload is not finished
+         TestingUtil.sleepThread(1000);
+
+         // uncomment this to see failing test
+         worker.join();
+
+         // at this point node is not alone, so preload is not used
+         // the start of the cache must be blocked until state transfer is finished
+         cm3.startCaches(cacheName);
+         assertEquals(cm3.getCache(cacheName).size(), 3);
+      } finally {
+         sharedCacheLoader.set(false);
+      }
+   }
+
+   public static class DelayedUnmarshal implements Serializable {
+
+      private static final long serialVersionUID = 1L;
+
+      private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+         TestingUtil.sleepThread(2000);
+         in.defaultReadObject();
+      }
+
+      private void writeObject(ObjectOutputStream out) throws IOException {
+         out.defaultWriteObject();
+      }
+   }
+
 }

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferReplicationQueueTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferReplicationQueueTest.java
@@ -174,8 +174,8 @@ public class StateTransferReplicationQueueTest extends MultipleCacheManagersTest
                if (tx) tm.begin();
                cache.put("test" + c, new PojoValue(c));
                cache.remove("test" + c);
-               c++;
                if (tx) tm.commit();
+               c++;
                if (c % 1000 == 0) TestingUtil.sleepThread(1); // Slow it down a bit
             }
             catch (Exception e) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2495
- Extended functional tests for state transfer with loaders.
- Revert "ISPN-1586 Move the preload after the join, and only
  preload if we are the first node"
- After rebalance, remove entries from any segment that the
  local node doesn't own (e.g. the entries it has preloaded).
