### PR TITLE
ISPN-2557 IllegalStateException "Segments [a,b, c] are not owned by Node...

### DIFF
--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -817,4 +817,12 @@ public interface Log extends BasicLogger {
    @LogMessage(level = WARN)
    @Message(value = "Failed to request segments %s of cache %s from node %s (node will not be retried)", id=210)
    void failedToRequestSegments(Collection<Integer> segments, String cacheName, Address source);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Transactions were requested by node %s with topology %d, older than the local topology (%d)", id=211)
+   void transactionsRequestedByNodeWithOlderTopology(Address node, int requestTopologyId, int localTopologyId);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Segments were requested by node %s with topology %d, older than the local topology (%d)", id=212)
+   void segmentsRequestedByNodeWithOlderTopology(Address node, int requestTopologyId, int localTopologyId);
 }


### PR DESCRIPTION
...X" in StateProviderImpl
- In StateProviderImpl.getTransactionsForSegments() and StateProviderImpl.startOutboundTransfer() if requestTopologyId > topologyId we should wait for the topology AND refresh the CacheTopology object we are using. The latter part was missing.
- Extracted the code that checks current topology and waits for a higher topology if needed into a separate method

JIRA: https://issues.jboss.org/browse/ISPN-2557
