### PR TITLE
ISPN-2574 Segment transfer not restarted if the owner fails

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/InboundTransferTask.java
+++ b/core/src/main/java/org/infinispan/statetransfer/InboundTransferTask.java
@@ -90,6 +90,12 @@ public class InboundTransferTask {
       return segments;
    }
 
+   public Set<Integer> getUnfinishedSegments() {
+      Set<Integer> unfinishedSegments = new HashSet<Integer>(segments);
+      unfinishedSegments.removeAll(finishedSegments);
+      return unfinishedSegments;
+   }
+
    public Address getSource() {
       return source;
    }
@@ -167,12 +173,10 @@ public class InboundTransferTask {
 
    @Override
    public String toString() {
-      HashSet<Integer> unfinishedSegments = new HashSet<Integer>(segments);
-      unfinishedSegments.removeAll(finishedSegments);
       return "InboundTransferTask{" +
             "segments=" + segments +
             ", finishedSegments=" + finishedSegments +
-            ", unfinishedSegments=" + unfinishedSegments +
+            ", unfinishedSegments=" + getUnfinishedSegments() +
             ", source=" + source +
             ", isCancelled=" + isCancelled +
             ", topologyId=" + topologyId +

--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -255,6 +255,7 @@ public class StateConsumerImpl implements StateConsumer {
                            log.tracef("Removing inbound transfers for segments %s from source %s for cache %s", inboundTransfer.getSegments(), source, cacheName);
                         }
                         transfersBySegment.keySet().removeAll(inboundTransfer.getSegments());
+                        addedSegments.addAll(inboundTransfer.getUnfinishedSegments());
                      }
                   }
                }


### PR DESCRIPTION
When an InboundTransferTasks is removed because the source has left the cluster we need to restart all unfinished segments from another source.

Please integrate but do not close the issue yet (still need to write a unit test for it).

JIRA: https://issues.jboss.org/browse/ISPN-2574
