### PR TITLE
ISPN-2352 Make a safe, deep copy of the Sort when iterating

### DIFF
--- a/query/src/main/java/org/infinispan/query/clustered/commandworkers/CQKillLazyIterator.java
+++ b/query/src/main/java/org/infinispan/query/clustered/commandworkers/CQKillLazyIterator.java
@@ -37,8 +37,8 @@ public class CQKillLazyIterator extends ClusteredQueryCommandWorker{
    public QueryResponse perform() {
       getQueryBox().kill(lazyQueryId);
       
-      // FIXME not a good idea...
-      return null;
+      // Not ideal, but more sane
+      return new QueryResponse(null);
    }
 
 }

--- a/query/src/main/java/org/infinispan/query/impl/ComponentRegistryUtils.java
+++ b/query/src/main/java/org/infinispan/query/impl/ComponentRegistryUtils.java
@@ -39,8 +39,12 @@ public class ComponentRegistryUtils {
    }
 
    public static <T> T getComponent(Cache<?, ?> cache, Class<T> class1) {
+      return getComponent(cache, class1, class1.getName());
+   }
+
+   public static <T> T getComponent(Cache<?, ?> cache, Class<T> class1, String name) {
       ComponentRegistry componentRegistry = cache.getAdvancedCache().getComponentRegistry();
-      T component = componentRegistry.getComponent(class1);
+      T component = componentRegistry.getComponent(class1, name);
       if (component == null) {
          throw new IllegalArgumentException("Indexing was not enabled on this cache. " + class1 + " not found in registry");
       }

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
@@ -124,17 +124,19 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       Sort sort = new Sort(sortField);
       cacheQuery.sort(sort);
 
-      ResultIterator iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
-      assert cacheQuery.getResultSize() == 4 : cacheQuery.getResultSize();
+      for (int i = 0; i < 2; i ++) {
+         ResultIterator iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
+         assert cacheQuery.getResultSize() == 4 : cacheQuery.getResultSize();
 
-      int previousAge = 0;
-      while (iterator.hasNext()) {
-         Person person = (Person) iterator.next();
-         assert person.getAge() > previousAge;
-         previousAge = person.getAge();
+         int previousAge = 0;
+         while (iterator.hasNext()) {
+            Person person = (Person) iterator.next();
+            assert person.getAge() > previousAge;
+            previousAge = person.getAge();
+         }
+
+         iterator.close();
       }
-
-      iterator.close();
    }
 
    public void testLazyNonOrdered() throws ParseException {


### PR DESCRIPTION
Not sure if this is the right way to solve it. It should be reviewed by Sanne.

This avoids sort fields being reversed when multiple iterators created from a single cache query, by making deep safe copies when the iterator is created.
