### PR TITLE
ISPN-2409 DefaultExecutorService failoverExecution does not rethrow the root cause of the failure

### DIFF
--- a/core/src/main/java/org/infinispan/distexec/DefaultExecutorService.java
+++ b/core/src/main/java/org/infinispan/distexec/DefaultExecutorService.java
@@ -957,19 +957,26 @@ public class DefaultExecutorService extends AbstractExecutorService implements D
                try {
                   response = failoverExecution(e, timeout, unit);
                } catch (Exception failedOver) {
-                  throw new ExecutionException(failedOver);
+                  throw wrapIntoExecutionException(failedOver);
                }
             } else {
-               throw new ExecutionException(e);
+               throw wrapIntoExecutionException(e);
             }
          }
          return response;
       }
+      
+      protected ExecutionException wrapIntoExecutionException(Exception e){
+         if (e instanceof ExecutionException) {
+            return (ExecutionException) e;
+         } else {
+            return new ExecutionException(e);
+         }
+      }
 
 
       private V failoverExecution(final Exception cause, long timeout, TimeUnit unit)
-               throws ExecutionException {
-         V response = null;
+               throws Exception {
          final List<Address> executionCandidates = executionCandidates(getOwningTask());
          FailoverContext fc = new FailoverContext() {
             @Override
@@ -988,25 +995,16 @@ public class DefaultExecutorService extends AbstractExecutorService implements D
             }
 
             @Override
-            public Exception cause() {
+            public Throwable cause() {
                return cause;
             }
          };
 
-         try {
-            Address target = getOwningTask().getTaskFailoverPolicy().failover(fc);
-            DistributedTaskPart<V> part = createDistributedTaskPart(owningTask, distCommand,
-                     getInputKeys(), target, failedOverCount);
-            part.execute();
-            response = part.get(timeout, unit);
-            if (response == null)
-               throw new ExecutionException("Failover execution failed", new Exception(
-                        "Failover execution failed", cause));
-         } catch (Exception e2) {
-            throw new ExecutionException("Failover execution failed", new Exception(
-                     "Failover execution failed", e2));
-         }
-         return response;
+         Address target = getOwningTask().getTaskFailoverPolicy().failover(fc);
+         DistributedTaskPart<V> part = createDistributedTaskPart(owningTask, distCommand,
+                  getInputKeys(), target, failedOverCount);
+         part.execute();
+         return part.get(timeout, unit);
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/distexec/FailoverContext.java
+++ b/core/src/main/java/org/infinispan/distexec/FailoverContext.java
@@ -48,15 +48,17 @@ public interface FailoverContext {
    List<Address> executionCandidates();
 
    /**
-    * Returns the Exception which was the cause of the task failure. This includes both system
+    * Returns the Throwable which was the cause of the task failure. This includes both system
     * exception related to Infinispan transient failures (node crash, transient errors etc) as well
-    * as application level exceptions. Exception will contain the full chain of Exceptions. If
-    * clients are interested in root cause of the Exception they can use appropriate
-    * {@link Exception#getCause()} API to recursively traverse the Exception chain.
+    * as application level exceptions. Returned Throwable will most likely contain the chain of
+    * Exceptions that interested clients can inspect and, if desired, find the root cause of the
+    * returned Throwable
     * 
-    * @return the Exception that caused task failure on the particular Infinispan node
+    * @see {@link Throwable#getCause()} API to recursively traverse the Exception chain
+    * 
+    * @return the Throwable that caused task failure on the particular Infinispan node
     */
-   Exception cause();
+   Throwable cause();
 
    /**
     * Returns a list of input keys for this task. Note that this method does not return all of the

--- a/core/src/test/java/org/infinispan/distexec/BasicDistributedExecutorTest.java
+++ b/core/src/test/java/org/infinispan/distexec/BasicDistributedExecutorTest.java
@@ -371,7 +371,6 @@ public class BasicDistributedExecutorTest extends AbstractCacheTest {
       }
    }
 
-   @Test(expectedExceptions = ExecutionException.class)
    public void testDistributedCallableRandomFailoverPolicy() throws Exception {
       Configuration config = TestCacheManagerFactory.getDefaultConfiguration(true, Configuration.CacheMode.REPL_SYNC);
       EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createClusteredCacheManager(config);
@@ -396,13 +395,18 @@ public class BasicDistributedExecutorTest extends AbstractCacheTest {
          Future<Integer> val = des.submit(task, new String[] {"key1"});
 
          val.get();
-      } finally {
+         throw new IllegalStateException("Should have raised exception");
+      } catch (Exception e){
+         assert e instanceof ExecutionException;
+         boolean duplicateEEInChain = e.getCause() instanceof ExecutionException;
+         AssertJUnit.assertEquals(false, duplicateEEInChain);
+      }
+      finally {
          des.shutdownNow();
          TestingUtil.killCacheManagers(cacheManager);
       }
    }
 
-   @Test(expectedExceptions = ExecutionException.class)
    public void testDistributedCallableRandomFailoverPolicyWith2Nodes() throws Exception {
       Configuration config = TestCacheManagerFactory.getDefaultConfiguration(true, Configuration.CacheMode.REPL_SYNC);
       EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createClusteredCacheManager(config);
@@ -429,7 +433,14 @@ public class BasicDistributedExecutorTest extends AbstractCacheTest {
 
          Future<Integer> val = des.submit(task, new String[] {"key1"});
          val.get();
-      } finally {
+         throw new IllegalStateException("Should have thrown exception");
+      }  catch (Exception e){
+         assert e instanceof ExecutionException;
+         ExecutionException ee = (ExecutionException)e;
+         boolean duplicateEEInChain = ee.getCause() instanceof ExecutionException;
+         AssertJUnit.assertEquals(false, duplicateEEInChain);
+      }
+      finally {
          des.shutdownNow();
          TestingUtil.killCacheManagers(cacheManager, cacheManager1);
       }
@@ -492,7 +503,6 @@ public class BasicDistributedExecutorTest extends AbstractCacheTest {
       }
    }
 
-   @Test(expectedExceptions = ExecutionException.class)
    public void testDistributedCallableCustomFailoverPolicy() throws Exception {
       Configuration config = TestCacheManagerFactory.getDefaultConfiguration(true, Configuration.CacheMode.REPL_SYNC);
       EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createClusteredCacheManager(config);
@@ -527,7 +537,14 @@ public class BasicDistributedExecutorTest extends AbstractCacheTest {
 
          Future<Integer> val = des.submit(task, new String[] {"key1"});
          val.get();
-      } finally {
+         throw new IllegalStateException("Should have thrown exception");
+      } catch (Exception e) {
+         assert e instanceof ExecutionException;
+         ExecutionException ee = (ExecutionException) e;
+         boolean duplicateEEInChain = ee.getCause() instanceof ExecutionException;
+         AssertJUnit.assertEquals(false, duplicateEEInChain);
+      }
+      finally {
          des.shutdownNow();
          TestingUtil.killCacheManagers(cacheManager);
       }


### PR DESCRIPTION
Master only. See JIRA for details. 

_Note_ although this one looks simple, lets not rush until we have an agreement this is the best approach. The default logic of getting a root cause is in protected method so clients can customize if a need arises. Although I doubt it.  
