### PR TITLE
ISPN-2629 Dist Exec testsuite fails in case of TopologyAware nodes

### DIFF
--- a/core/src/test/java/org/infinispan/distexec/DistributedExecutorTest.java
+++ b/core/src/test/java/org/infinispan/distexec/DistributedExecutorTest.java
@@ -67,7 +67,7 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
    }
 
    protected String cacheName() {
-      return CACHE_NAME;
+      return "DistributedExecutorTest-DIST_SYNC";
    }
 
    protected CacheMode getCacheMode() {
@@ -193,8 +193,9 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
 
    public void testTaskCancellation() throws Exception {
       DistributedExecutorService des = createDES(getCache());
-      List<Address> members = new ArrayList<Address>(getCache().getAdvancedCache().getRpcManager()
-               .getTransport().getMembers());
+      List<Address> cacheMembers = getCache().getAdvancedCache().getRpcManager().getMembers();
+      List<Address> members = new ArrayList<Address>(cacheMembers);
+      AssertJUnit.assertEquals(caches(cacheName()).size(), members.size());
       members.remove(getCache().getAdvancedCache().getRpcManager().getAddress());
       
       DistributedTaskBuilder<Integer> tb = des.createDistributedTaskBuilder( new LongRunningCallable());
@@ -226,8 +227,9 @@ public class DistributedExecutorTest extends LocalDistributedExecutorTest {
    @Test(expectedExceptions = CancellationException.class)
    public void testCancelAndGet() throws Exception {
       DistributedExecutorService des = createDES(getCache());
-      List<Address> members = new ArrayList<Address>(getCache().getAdvancedCache().getRpcManager()
-               .getTransport().getMembers());
+      List<Address> cacheMembers = getCache().getAdvancedCache().getRpcManager().getMembers();
+      List<Address> members = new ArrayList<Address>(cacheMembers);
+      AssertJUnit.assertEquals(caches(cacheName()).size(), members.size());
       members.remove(getCache().getAdvancedCache().getRpcManager().getAddress());
       
       DistributedTaskBuilder<Integer> tb = des.createDistributedTaskBuilder( new LongRunningCallable());

--- a/core/src/test/java/org/infinispan/distexec/DistributedExecutorWithTopologyAwareNodesTest.java
+++ b/core/src/test/java/org/infinispan/distexec/DistributedExecutorWithTopologyAwareNodesTest.java
@@ -1,0 +1,64 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tag. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.distexec;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Tests dist.exec module using topology aware addresses.
+ * 
+ * @author anna.manukyan
+ * @since 5.2
+ */
+@Test(groups = "functional", testName = "distexec.DistributedExecutorWithTopologyAwareNodesTest")
+public class DistributedExecutorWithTopologyAwareNodesTest extends DistributedExecutorTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+
+      GlobalConfigurationBuilder globalConfigurationBuilder = GlobalConfigurationBuilder
+               .defaultClusteredBuilder();
+      globalConfigurationBuilder.transport().machineId("a").rackId("b").siteId("test1");
+
+      EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(
+               globalConfigurationBuilder, builder);
+      cm1.defineConfiguration(cacheName(), builder.build());
+      cacheManagers.add(cm1);
+
+      globalConfigurationBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      globalConfigurationBuilder.transport().machineId("b").rackId("b").siteId("test2");
+      EmbeddedCacheManager cm2 = TestCacheManagerFactory.createClusteredCacheManager(
+               globalConfigurationBuilder, builder);
+
+      cm2.defineConfiguration(cacheName(), builder.build());
+      cacheManagers.add(cm2);
+
+      waitForClusterToForm(cacheName());
+   }
+   
+   protected String cacheName() {
+      return "DistributedExecutorWithTopologyAwareNodesTest";
+   }
+}

--- a/core/src/test/java/org/infinispan/distexec/LocalDistributedExecutorTest.java
+++ b/core/src/test/java/org/infinispan/distexec/LocalDistributedExecutorTest.java
@@ -27,7 +27,6 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "distexec.LocalDistributedExecutorTest")
 public class LocalDistributedExecutorTest extends MultipleCacheManagersTest {
    
-   public static String CACHE_NAME = "DistributedExecutorTest-DIST_SYNC";
    private DistributedExecutorService cleanupService;
    
    public LocalDistributedExecutorTest() {
@@ -54,7 +53,7 @@ public class LocalDistributedExecutorTest extends MultipleCacheManagersTest {
    }
 
    protected String cacheName() {
-      return CACHE_NAME;
+      return "LocalDistributedExecutorTest";
    }
 
    protected Cache<Object, Object> getCache() {

--- a/core/src/test/java/org/infinispan/distexec/ReplSyncDistributedExecutorTest.java
+++ b/core/src/test/java/org/infinispan/distexec/ReplSyncDistributedExecutorTest.java
@@ -65,7 +65,7 @@ public class ReplSyncDistributedExecutorTest extends DistributedExecutorTest {
     */
    public void testTaskCancellation() throws Exception {
       DistributedExecutorService des = createDES(getCache());
-      List<Address> l = getCache().getAdvancedCache().getRpcManager().getTransport().getMembers();
+      List<Address> l = getCache().getAdvancedCache().getRpcManager().getMembers();
       List<Address> members = new ArrayList<Address>(l);
       members.remove(getCache().getAdvancedCache().getRpcManager().getAddress());
 


### PR DESCRIPTION
Master only. No change to core/src except a few cancellation tests that did not use RpcManager#getMembers but instead used Transport#getMembers. Introduction of a new test using TopologyAwareAddress and dist.exec
