### PR TITLE
Fix broken build

### DIFF
--- a/spring/src/test/java/org/infinispan/spring/mock/MockTransportFactory.java
+++ b/spring/src/test/java/org/infinispan/spring/mock/MockTransportFactory.java
@@ -71,11 +71,6 @@ public final class MockTransportFactory implements TransportFactory {
    }
 
    @Override
-   public Transport getTransport(byte[] key, boolean isWrite) {
-      return null;
-   }
-
-   @Override
    public boolean isTcpNoDelay() {
       return false;
    }


### PR DESCRIPTION
Remove MockTransportFactory.getTransport(..) method as it is no longer present in parent interface.
This change was introduced with ISPN-2655.
