### PR TITLE
ISPN-2658 Update serialized count MarshalledValue test

### DIFF
--- a/core/src/test/java/org/infinispan/marshall/MarshalledValueTest.java
+++ b/core/src/test/java/org/infinispan/marshall/MarshalledValueTest.java
@@ -449,7 +449,13 @@ public class MarshalledValueTest extends MultipleCacheManagersTest {
       cache2.put(key, "2");
 
       // Deserialization only occurs when the cache2.put occurs, not during transport thread execution.
-      assertSerializationCounts(4, 1);
+      // Serialized 5 times:
+      //    twice when cache1 is stored, one to check if the type can be serialized, 2nd to replicate.
+      //    twice when cache1 is stored, one to check if the type can be serialized, 2nd to replicate.
+      //    the final time is when in the 1st node it compares the received
+      //    value and the one in the cache, whose comparison happens in
+      //    serialized mode since serializing is cheaper than deserializing.
+      assertSerializationCounts(5, 1);
    }
 
    public void testReturnValueDeserialization() { 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2658
- The test used to pass due to lack of clearing between test methods and in fact even in older releases, if you run the test method individually, it would fail. So, the test was passing due to the effect of other test methods.
- The test has now been changed with the correct expectations.
