### PR TITLE
ISPN-2660 Replace non-alphanumeric characters in cache names with an underscore to prevent database naming errors

### DIFF
--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/TableManipulation.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/TableManipulation.java
@@ -379,7 +379,7 @@ public class TableManipulation implements Cloneable {
       if (tableNamePrefix == null || cacheName == null) {
          throw new IllegalStateException("Both tableNamePrefix and cacheName must be non null at this point!");
       }
-      return tableNamePrefix + "_" + cacheName.replace(".", "_");
+      return tableNamePrefix + "_" + cacheName.replaceAll("[^\\p{Alnum}]", "_");
    }
 
    public String getIdentifierQuoteString() {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2660
