### PR TITLE
ISPN-2300 Fix conditional operations to work with versioned caches

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/VersionedEntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/VersionedEntryWrappingInterceptor.java
@@ -92,6 +92,13 @@ public class VersionedEntryWrappingInterceptor extends EntryWrappingInterceptor 
    protected void commitContextEntry(CacheEntry entry, InvocationContext ctx, boolean skipOwnershipCheck) {
       if (ctx.isInTxScope() && !isFromStateTransfer(ctx)) {
          EntryVersion version = ((TxInvocationContext) ctx).getCacheTransaction().getUpdatedEntryVersions().get(entry.getKey());
+
+         // If no updated version (i.e. cos it's written first time, or
+         // it's loaded from cache store via activation or loading), set
+         // the version to the entries own version.
+         if (version == null)
+            version = entry.getVersion();
+
          cdl.commitEntry(entry, version, skipOwnershipCheck, ctx);
       } else {
          // This could be a state transfer call!

--- a/core/src/test/java/org/infinispan/container/versioning/VersionedConditionalOperationsTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/VersionedConditionalOperationsTest.java
@@ -1,0 +1,136 @@
+package org.infinispan.container.versioning;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.VersioningScheme;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNull;
+
+/**
+ * This test checks behaivour of versioned caches
+ * when executing conditional operations.
+ *
+ * @author Pedro Ruivo
+ * @since 5.2
+ */
+@Test(testName = "container.versioning.VersionedConditionalOperationsTest", groups = "functional")
+public class VersionedConditionalOperationsTest extends MultipleCacheManagersTest {
+
+   protected static final String KEY_1 = "key_1";
+   protected static final String KEY_2 = "key_2";
+   protected static final String VALUE_1 = "value_1";
+   protected static final String VALUE_2 = "value_2";
+   protected static final String VALUE_3 = "value_3";
+   protected static final String VALUE_4 = "value_4";
+
+   protected final int clusterSize;
+   protected final CacheMode mode;
+   protected final boolean syncCommit;
+
+   public VersionedConditionalOperationsTest() {
+      this(2, CacheMode.REPL_SYNC, false);
+   }
+
+   protected VersionedConditionalOperationsTest(
+         int clusterSize, CacheMode mode, boolean syncCommit) {
+      this.clusterSize = clusterSize;
+      this.mode = mode;
+      this.syncCommit = syncCommit;
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(mode, true);
+      dcc.transaction().syncCommitPhase(syncCommit).syncRollbackPhase(syncCommit);
+      dcc.locking().isolationLevel(IsolationLevel.REPEATABLE_READ).writeSkewCheck(true);
+      dcc.versioning().enable().scheme(VersioningScheme.SIMPLE);
+      createCluster(dcc, clusterSize);
+      waitForClusterToForm();
+   }
+
+   public void testPutIfAbsent() {
+      assertEmpty(KEY_1, KEY_2);
+
+      cache(1).put(KEY_1, VALUE_1);
+      assertCacheValue(1, KEY_1, VALUE_1);
+
+      cache(0).putIfAbsent(KEY_1, VALUE_2);
+      assertCacheValue(0, KEY_1, VALUE_1);
+
+      cache(1).put(KEY_1, VALUE_3);
+      assertCacheValue(1, KEY_1, VALUE_3);
+
+      cache(0).putIfAbsent(KEY_1, VALUE_4);
+      assertCacheValue(0, KEY_1, VALUE_3);
+
+      cache(0).putIfAbsent(KEY_2, VALUE_1);
+      assertCacheValue(0, KEY_2, VALUE_1);
+
+      assertNoTransactions();
+   }
+
+   public void testRemoveIfPresent() {
+      assertEmpty(KEY_1);
+
+      cache(0).put(KEY_1, VALUE_1);
+      cache(1).put(KEY_1, VALUE_2);
+      assertCacheValue(1, KEY_1, VALUE_2);
+
+      cache(0).remove(KEY_1, VALUE_1);
+      assertCacheValue(0, KEY_1, VALUE_2);
+
+      cache(0).remove(KEY_1, VALUE_2);
+      assertCacheValue(0, KEY_1, null);
+
+      assertNoTransactions();
+   }
+
+   public void testReplaceWithOldVal() {
+      assertEmpty(KEY_1);
+
+      cache(1).put(KEY_1, VALUE_1);
+      assertCacheValue(1, KEY_1, VALUE_1);
+
+      cache(0).put(KEY_1, VALUE_2);
+      assertCacheValue(0, KEY_1, VALUE_2);
+
+      cache(0).replace(KEY_1, VALUE_3, VALUE_4);
+      assertCacheValue(0, KEY_1, VALUE_2);
+
+      cache(0).replace(KEY_1, VALUE_2, VALUE_4);
+      assertCacheValue(0, KEY_1, VALUE_4);
+
+      assertNoTransactions();
+   }
+
+   protected void assertEmpty(Object... keys) {
+      for (Cache cache : caches()) {
+         for (Object key : keys) {
+            assertNull(cache.get(key));
+         }
+      }
+   }
+
+   //originatorIndex == cache which executed the transaction
+   protected void assertCacheValue(int originatorIndex, Object key, Object value) {
+      for (int index = 0; index < caches().size(); ++index) {
+         if ((index == originatorIndex && mode.isSynchronous()) ||
+               (index != originatorIndex && syncCommit)) {
+            assertEquals(index, key, value);
+         } else {
+            assertEventuallyEquals(index, key, value);
+         }
+      }
+
+   }
+
+   private void assertEquals(int index, Object key, Object value) {
+      assert value == null
+            ? value == cache(index).get(key)
+            : value.equals(cache(index).get(key));
+   }
+}


### PR DESCRIPTION
As explained in https://issues.jboss.org/browse/ISPN-2300, other fixes were considered including Pedro's but none except the one submitted managed to pass the entire core/ testsuite. So, if you're gonna suggest an alternative fix, make sure you test it before :)
