### PR TITLE
ISPN-2701 Disable ConfigurationOverridesTest, InfinispanContainerCacheMa...

### DIFF
--- a/spring/src/test/java/org/infinispan/spring/ConfigurationOverridesTest.java
+++ b/spring/src/test/java/org/infinispan/spring/ConfigurationOverridesTest.java
@@ -48,10 +48,10 @@ import org.testng.annotations.Test;
  * @author <a href="mailto:olaf DOT bergner AT gmx DOT de">Olaf Bergner</a>
  *
  */
-@Test(groups = "unit", testName = "spring.ConfigurationOverridesTest")
+@Test(groups = "unit", testName = "spring.ConfigurationOverridesTest",
+      enabled = false, description = "Disabled temporarily, see https://issues.jboss.org/browse/ISPN-2701")
 public class ConfigurationOverridesTest {
 
-   @Test
    public final void configurationOverridesShouldOverrideDeadlockSpinDetectionDurationPropIfExplicitlySet() throws Exception {
       final long expectedDeadlockSpinDetectionDuration = 100000L;
 
@@ -68,7 +68,6 @@ public class ConfigurationOverridesTest {
                   configuration.deadlockDetection().spinDuration());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideEnableDeadlockDetectionPropIfExplicitlySet()
          throws Exception {
       final boolean expectedEnableDeadlockDetection = true;
@@ -86,7 +85,6 @@ public class ConfigurationOverridesTest {
                   configuration.deadlockDetection().enabled());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideUseLockStripingPropIfExplicitlySet()
          throws Exception {
       final boolean expectedUseLockStriping = true;
@@ -104,7 +102,6 @@ public class ConfigurationOverridesTest {
                   configuration.locking().useLockStriping());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideUnsafeUnreliableReturnValuesPropIfExplicitlySet()
          throws Exception {
       final boolean expectedUnsafeUnreliableReturnValues = true;
@@ -123,7 +120,6 @@ public class ConfigurationOverridesTest {
                   configuration.unsafe().unreliableReturnValues());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideRehashRpcTimeoutPropIfExplicitlySet()
          throws Exception {
       final long expectedRehashRpcTimeout = 100000L;
@@ -141,7 +137,6 @@ public class ConfigurationOverridesTest {
                   configuration.clustering().stateTransfer().timeout());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideWriteSkewCheckPropIfExplicitlySet()
          throws Exception {
       final boolean expectedWriteSkewCheck = true;
@@ -159,7 +154,6 @@ public class ConfigurationOverridesTest {
                   configuration.locking().writeSkewCheck());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideConcurrencyLevelPropIfExplicitlySet()
          throws Exception {
       final int expectedConcurrencyLevel = 10000;
@@ -177,7 +171,6 @@ public class ConfigurationOverridesTest {
                   configuration.locking().concurrencyLevel());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideReplQueueMaxElementsPropIfExplicitlySet()
          throws Exception {
       final int expectedReplQueueMaxElements = 10000;
@@ -195,7 +188,6 @@ public class ConfigurationOverridesTest {
                   configuration.clustering().async().replQueueMaxElements());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideReplQueueIntervalPropIfExplicitlySet()
          throws Exception {
       final long expectedReplQueueInterval = 10000L;
@@ -213,7 +205,6 @@ public class ConfigurationOverridesTest {
                   configuration.clustering().async().replQueueInterval());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideReplQueueClassPropIfExplicitlySet()
          throws Exception {
       final String expectedReplQueueClass = "repl.queue.Class";//FIXME create one
@@ -231,7 +222,6 @@ public class ConfigurationOverridesTest {
                   configuration.clustering().async().replQueue().getClass());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideExposeJmxStatisticsPropIfExplicitlySet() throws Exception {
       final boolean expectedExposeJmxStatistics = true;
 
@@ -248,7 +238,6 @@ public class ConfigurationOverridesTest {
                   configuration.jmxStatistics().enabled());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideInvocationBatchingEnabledPropIfExplicitlySet()
          throws Exception {
       final boolean expectedInvocationBatchingEnabled = true;
@@ -266,7 +255,6 @@ public class ConfigurationOverridesTest {
                   configuration.invocationBatching().enabled());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideFetchInMemoryStatePropIfExplicitlySet()
          throws Exception {
       final boolean expectedFetchInMemoryState = true;
@@ -284,7 +272,6 @@ public class ConfigurationOverridesTest {
                   configuration.clustering().stateTransfer().fetchInMemoryState());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideAlwaysProvideInMemoryStatePropIfExplicitlySet()
          throws Exception {
       final boolean expectedAlwaysProvideInMemoryState = true;
@@ -302,7 +289,6 @@ public class ConfigurationOverridesTest {
                   configuration.clustering().stateTransfer().fetchInMemoryState());//FIXME
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideLockAcquisitionTimeoutPropIfExplicitlySet()
          throws Exception {
       final long expectedLockAcquisitionTimeout = 1000000L;
@@ -320,7 +306,6 @@ public class ConfigurationOverridesTest {
                   configuration.locking().lockAcquisitionTimeout());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideSyncReplTimeoutPropIfExplicitlySet()
          throws Exception {
       final long expectedSyncReplTimeout = 100000L;
@@ -338,7 +323,6 @@ public class ConfigurationOverridesTest {
                   configuration.clustering().stateTransfer().timeout());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideCacheModeStringPropIfExplicitlySet()
          throws Exception {
       final String expectedCacheModeString = CacheMode.LOCAL.name();
@@ -356,7 +340,6 @@ public class ConfigurationOverridesTest {
                   configuration.clustering().cacheModeString());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideEvictionWakeUpIntervalPropIfExplicitlySet()
          throws Exception {
       final long expectedExpirationWakeUpInterval = 100000L;
@@ -374,7 +357,6 @@ public class ConfigurationOverridesTest {
                   configuration.expiration().wakeUpInterval());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideEvictionStrategyPropIfExplicitlySet()
          throws Exception {
       final EvictionStrategy expectedEvictionStrategy = EvictionStrategy.LIRS;
@@ -392,7 +374,6 @@ public class ConfigurationOverridesTest {
                   configuration.eviction().strategy());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideEvictionStrategyClassPropIfExplicitlySet()
          throws Exception {
       final String expectedEvictionStrategyClass = "LRU";
@@ -410,7 +391,6 @@ public class ConfigurationOverridesTest {
                   configuration.eviction().strategy());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideEvictionThreadPolicyPropIfExplicitlySet()
          throws Exception {
       final EvictionThreadPolicy expectedEvictionThreadPolicy = EvictionThreadPolicy.PIGGYBACK;
@@ -428,7 +408,6 @@ public class ConfigurationOverridesTest {
                   configuration.eviction().threadPolicy());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideEvictionThreadPolicyClassPropIfExplicitlySet()
          throws Exception {
       final String expectedEvictionThreadPolicyClass = "PIGGYBACK";
@@ -446,7 +425,6 @@ public class ConfigurationOverridesTest {
                   configuration.eviction().threadPolicy());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideEvictionMaxEntriesPropIfExplicitlySet()
          throws Exception {
       final int expectedEvictionMaxEntries = 1000000;
@@ -464,7 +442,6 @@ public class ConfigurationOverridesTest {
                   configuration.eviction().maxEntries());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideExpirationLifespanPropIfExplicitlySet()
          throws Exception {
       final long expectedExpirationLifespan = 1000000L;
@@ -482,7 +459,6 @@ public class ConfigurationOverridesTest {
                   configuration.expiration().lifespan());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideExpirationMaxIdlePropIfExplicitlySet()
          throws Exception {
       final long expectedExpirationMaxIdle = 100000L;
@@ -500,7 +476,6 @@ public class ConfigurationOverridesTest {
                   configuration.expiration().maxIdle());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideTransactionManagerLookupClassPropIfExplicitlySet()
          throws Exception {
       final String expectedTransactionManagerLookupClass = "expected.transaction.manager.lookup.Class";
@@ -518,7 +493,6 @@ public class ConfigurationOverridesTest {
                   configuration.transaction().transactionManagerLookup());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideTransactionManagerLookupPropIfExplicitlySet()
          throws Exception {
       final TransactionManagerLookup expectedTransactionManagerLookup = new JBossTransactionManagerLookup();
@@ -536,7 +510,6 @@ public class ConfigurationOverridesTest {
                   configuration.transaction().transactionManagerLookup());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideCacheLoaderManagerConfigPropIfExplicitlySet()
          throws Exception {
       final CacheLoaderManagerConfig expectedCacheLoaderManagerConfig = new CacheLoaderManagerConfig();
@@ -554,7 +527,6 @@ public class ConfigurationOverridesTest {
                   configuration.loaders().cacheLoaders());//FIXME
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideSyncCommitPhasePropIfExplicitlySet()
          throws Exception {
       final boolean expectedSyncCommitPhase = true;
@@ -572,7 +544,6 @@ public class ConfigurationOverridesTest {
                   configuration.transaction().syncCommitPhase());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideSyncRollbackPhasePropIfExplicitlySet()
          throws Exception {
       final boolean expectedSyncRollbackPhase = true;
@@ -590,7 +561,6 @@ public class ConfigurationOverridesTest {
                   configuration.transaction().syncRollbackPhase());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideUseEagerLockingPropIfExplicitlySet()
          throws Exception {
 
@@ -609,7 +579,6 @@ public class ConfigurationOverridesTest {
                   configuration.transaction().lockingMode());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideUseReplQueuePropIfExplicitlySet() throws Exception {
       final boolean expectedUseReplQueue = true;
 
@@ -626,7 +595,6 @@ public class ConfigurationOverridesTest {
                   configuration.clustering().async().useReplQueue());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideIsolationLevelPropIfExplicitlySet()
          throws Exception {
       final IsolationLevel expectedIsolationLevel = IsolationLevel.SERIALIZABLE;
@@ -644,7 +612,6 @@ public class ConfigurationOverridesTest {
                   configuration.locking().isolationLevel());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideStateRetrievalTimeoutPropIfExplicitlySet()
          throws Exception {
       final long expectedStateRetrievalTimeout = 1000000L;
@@ -662,7 +629,6 @@ public class ConfigurationOverridesTest {
                   configuration.clustering().stateTransfer().timeout());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideStateRetrievalChunkSizePropIfExplicitlySet()
          throws Exception {
       final int expectedStateRetrievalChunkSize = 123456;
@@ -681,7 +647,6 @@ public class ConfigurationOverridesTest {
                   configuration.clustering().stateTransfer().chunkSize());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideIsolationLevelClassPropIfExplicitlySet()
          throws Exception {
       final String expectedIsolationLevelClass = "REPEATABLE_READ";
@@ -698,7 +663,6 @@ public class ConfigurationOverridesTest {
                   IsolationLevel.REPEATABLE_READ, configuration.locking().isolationLevel());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideUseLazyDeserializationPropIfExplicitlySet()
          throws Exception {
       final boolean expectedUseLazyDeserialization = true;
@@ -715,7 +679,6 @@ public class ConfigurationOverridesTest {
                   expectedUseLazyDeserialization, configuration.storeAsBinary().enabled());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideL1CacheEnabledPropIfExplicitlySet()
          throws Exception {
       final boolean expectedL1CacheEnabled = true;
@@ -732,7 +695,6 @@ public class ConfigurationOverridesTest {
                   expectedL1CacheEnabled, configuration.clustering().l1().enabled());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideL1LifespanPropIfExplicitlySet()
          throws Exception {
       final long expectedL1Lifespan = 2300446L;
@@ -749,7 +711,6 @@ public class ConfigurationOverridesTest {
                   expectedL1Lifespan, configuration.clustering().l1().lifespan());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideL1OnRehashPropIfExplicitlySet()
          throws Exception {
       final boolean expectedL1OnRehash = true;
@@ -766,7 +727,6 @@ public class ConfigurationOverridesTest {
                   expectedL1OnRehash, configuration.clustering().l1().onRehash());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideConsistentHashClassPropIfExplicitlySet()
          throws Exception {
       final String expectedConsistentHashClass = "expected.consistent.hash.Class";
@@ -783,7 +743,6 @@ public class ConfigurationOverridesTest {
                   expectedConsistentHashClass, configuration.clustering().hash().consistentHashFactory().getClass().getName());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideNumOwnersPropIfExplicitlySet()
          throws Exception {
       final int expectedNumOwners = 675443;
@@ -800,7 +759,6 @@ public class ConfigurationOverridesTest {
                   expectedNumOwners, configuration.clustering().hash().numOwners());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideRehashEnabledPropIfExplicitlySet()
          throws Exception {
       final boolean expectedRehashEnabled = true;
@@ -817,7 +775,6 @@ public class ConfigurationOverridesTest {
                   expectedRehashEnabled, configuration.clustering().stateTransfer().fetchInMemoryState());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideRehashWaitTimePropIfExplicitlySet()
          throws Exception {
       final long expectedRehashWaitTime = 1232778L;
@@ -834,7 +791,6 @@ public class ConfigurationOverridesTest {
                   expectedRehashWaitTime, configuration.clustering().stateTransfer().timeout());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideUseAsyncMarshallingPropIfExplicitlySet()
          throws Exception {
       final boolean expectedUseAsyncMarshalling = true;
@@ -851,7 +807,6 @@ public class ConfigurationOverridesTest {
                   expectedUseAsyncMarshalling, configuration.clustering().async().asyncMarshalling());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideIndexingEnabledPropIfExplicitlySet()
          throws Exception {
       final boolean expectedIndexingEnabled = true;
@@ -868,7 +823,6 @@ public class ConfigurationOverridesTest {
                   expectedIndexingEnabled, configuration.indexing().enabled());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideIndexLocalOnlyPropIfExplicitlySet()
          throws Exception {
       final boolean expectedIndexLocalOnly = true;
@@ -885,7 +839,6 @@ public class ConfigurationOverridesTest {
                   expectedIndexLocalOnly, configuration.indexing().indexLocalOnly());
    }
 
-   @Test
    public final void configurationOverridesShouldOverrideCustomInterceptorsPropIfExplicitlySet()
          throws Exception {
       final CustomInterceptorConfig customInterceptor = new CustomInterceptorConfig();

--- a/spring/src/test/java/org/infinispan/spring/config/InfinispanContainerCacheManagerDefinitionTest.java
+++ b/spring/src/test/java/org/infinispan/spring/config/InfinispanContainerCacheManagerDefinitionTest.java
@@ -35,7 +35,8 @@ import org.testng.annotations.Test;
 /**
  * @author Marius Bogoevici
  */
-@Test(groups = "functional", testName = "spring.config.InfinispanContainerCacheManagerDefinitionTest")
+@Test(groups = "functional", testName = "spring.config.InfinispanContainerCacheManagerDefinitionTest",
+      enabled = false, description = "Disabled temporarily, see https://issues.jboss.org/browse/ISPN-2701")
 @ContextConfiguration
 public class InfinispanContainerCacheManagerDefinitionTest extends AbstractTestNGSpringContextTests {
 
@@ -45,10 +46,8 @@ public class InfinispanContainerCacheManagerDefinitionTest extends AbstractTestN
     @Autowired @Qualifier("cacheManager2")
     private CacheManager containerCacheManager2;
 
-    @Test
     public void testContainerCacheManagerExists() {
        Assert.assertNotNull(containerCacheManager);
        Assert.assertNotNull(containerCacheManager2);
     }
-
 }

--- a/spring/src/test/java/org/infinispan/spring/config/InfinispanEmbeddedCacheManagerDefinitionTest.java
+++ b/spring/src/test/java/org/infinispan/spring/config/InfinispanEmbeddedCacheManagerDefinitionTest.java
@@ -36,7 +36,8 @@ import org.testng.annotations.Test;
  * @author Marius Bogoevici
  */
 
-@Test(groups = "functional", testName = "spring.config.InfinispanEmbeddedCacheManagerDefinitionTest")
+@Test(groups = "functional", testName = "spring.config.InfinispanEmbeddedCacheManagerDefinitionTest",
+      enabled = false, description = "Disabled temporarily, see https://issues.jboss.org/browse/ISPN-2701")
 @ContextConfiguration
 public class InfinispanEmbeddedCacheManagerDefinitionTest extends AbstractTestNGSpringContextTests {
 
@@ -46,7 +47,6 @@ public class InfinispanEmbeddedCacheManagerDefinitionTest extends AbstractTestNG
     @Autowired @Qualifier("withConfigFile")
     private CacheManager embeddedCacheManagerWithConfigFile;
 
-    @Test
     public void testEmbeddedCacheManagerExists() {
        Assert.assertNotNull(embeddedCacheManager);
        Assert.assertNotNull(embeddedCacheManagerWithConfigFile);


### PR DESCRIPTION
...nagerDefinitionTest and InfinispanEmbeddedCacheManagerDefinitionTest temporarily.

Because these tests are broken, see https://issues.jboss.org/browse/ISPN-2701
