### PR TITLE
ISPN-1583 Avoid delegate advanced caches wrapped parameters

### DIFF
--- a/core/src/test/java/org/infinispan/configuration/ClassResolverConfigTest.java
+++ b/core/src/test/java/org/infinispan/configuration/ClassResolverConfigTest.java
@@ -52,4 +52,12 @@ public class ClassResolverConfigTest extends WithClassLoaderTest {
       super.testReadingWithCorrectClassLoaderAfterReplication();
    }
 
+   @Override
+   @Test(expectedExceptions = AssertionError.class,
+         expectedExceptionsMessageRegExp = "Expected a ClassNotFoundException")
+   public void testReadingWithCorrectClassLoaderAfterReplicationWithDelegateCache() {
+      // Same reason as method above...
+      super.testReadingWithCorrectClassLoaderAfterReplicationWithDelegateCache();
+   }
+
 }


### PR DESCRIPTION
- Such parameters are flags or classloaders.
- By adding an interface that generates wrap objects, abstract delegate implementations can pass on caches with flags or cache loaders while keeping these wrapped.
- This avoid the problem of unwrapping a wrapper while keeping hold of the given flag/classloaders.
