### PR TITLE
ISPN-2326 c3p0 not part of the release

### DIFF
--- a/cachestore/cassandra/pom.xml
+++ b/cachestore/cassandra/pom.xml
@@ -52,6 +52,12 @@
          <artifactId>cassandra-all</artifactId>
          <scope>test</scope>
       </dependency>
+      <!-- We need to force the version defined in parent pom for this indirect dependency -->
+      <dependency>
+         <groupId>commons-codec</groupId>
+         <artifactId>commons-codec</artifactId>
+         <scope>runtime</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/cli/cli-server/pom.xml
+++ b/cli/cli-server/pom.xml
@@ -83,11 +83,6 @@
       <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-server-hotrod</artifactId>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>${project.groupId}</groupId>
-         <artifactId>infinispan-server-hotrod</artifactId>
          <type>test-jar</type>
          <scope>test</scope>
       </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -120,6 +120,8 @@
       <version.cdi>1.0-SP4</version.cdi>
       <version.com.intellij.forms_rt>6.0.5</version.com.intellij.forms_rt>
       <version.commons.compress>1.4</version.commons.compress>
+      <version.commons.codec>1.4</version.commons.codec>
+      <version.commons.collections>3.2.1</version.commons.collections>
       <version.commons.dbcp>1.4</version.commons.dbcp>
       <version.commons.pool>1.6</version.commons.pool>
       <version.commons.httpclient>3.1</version.commons.httpclient>
@@ -470,6 +472,16 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>${version.commons.compress}</version>
+         </dependency>
+         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${version.commons.codec}</version>
+         </dependency>
+         <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>${version.commons.collections}</version>
          </dependency>
          <dependency>
             <groupId>org.apache.commons</groupId>
@@ -1523,7 +1535,6 @@
                         <configuration>
                            <includeScope>runtime</includeScope>
                            <excludeScope>test</excludeScope>
-                           <!-- all jar paths are relative to bin dir inside the distribution bundle -->
                            <prefix>$ISPN_HOME/lib</prefix>
                            <outputFile>${project.build.directory}/runtime-classpath.txt</outputFile>
                         </configuration>

--- a/rhq-plugin/pom.xml
+++ b/rhq-plugin/pom.xml
@@ -89,6 +89,13 @@
          <scope>provided</scope>
       </dependency>
 
+      <!-- We need to force the version defined in parent pom for this indirect dependency -->
+      <dependency>
+         <groupId>commons-collections</groupId>
+         <artifactId>commons-collections</artifactId>
+         <scope>runtime</scope>
+      </dependency>
+
       <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -105,12 +105,6 @@
          <artifactId>infinispan-core</artifactId>
          <scope>compile</scope>
       </dependency>
-      <dependency>
-         <groupId>${project.groupId}</groupId>
-         <artifactId>infinispan-core</artifactId>
-         <version>${project.version}</version>
-         <type>test-jar</type>
-      </dependency>
       <!-- Made the RHQ dependency non-transitive in case we only need the remote cache -->
       <dependency>
          <groupId>org.rhq.helpers</groupId>

--- a/src/main/resources/assemblies/all.xml
+++ b/src/main/resources/assemblies/all.xml
@@ -56,6 +56,60 @@
    </formats>
 
    <moduleSets>
+
+      <!--
+         Gather all transitive runtime dependencies and place them in lib dir of the zip package (runtime-classpath.txt of each module will reference them from here).
+         This is done in a single moduleSet instead of the 'binaries' section of each module in order to avoid the issue with possibly skipped dependencies or
+         incorrectly resolved versions that is already described in the assembly plugin user guide in relation with multiple moduleSets. This issue appeared in
+         version 2.2 of the plugin and is a documented limitation of the moduleSets mechanism (which might become deprecated in the future). The user guide
+         recommends avoiding moduleSets altogether in favor of dependencySets but that solution does not work in our case because we would not be able to include
+         other files in the distribution (scripts, config files, demo data files, etc). That means we'll continue to live (dangerously) with moduleSets.
+      -->
+      <moduleSet>
+         <includeSubModules>false</includeSubModules>
+         <includes>
+            <include>org.infinispan:infinispan-core</include>
+            <include>org.infinispan:infinispan-rhq-plugin</include>
+            <include>org.infinispan:infinispan-tree</include>
+            <include>org.infinispan:infinispan-query</include>
+            <include>org.infinispan:infinispan-server-memcached</include>
+            <include>org.infinispan:infinispan-server-hotrod</include>
+            <include>org.infinispan:infinispan-server-websocket</include>
+            <include>org.infinispan:infinispan-client-hotrod</include>
+            <include>org.infinispan:infinispan-lucene-directory</include>
+            <include>org.infinispan:infinispan-spring</include>
+            <include>org.infinispan:infinispan-cli-client</include>
+            <include>org.infinispan:infinispan-cli-server</include>
+            <include>org.infinispan:infinispan-cachestore-bdbje</include>
+            <include>org.infinispan:infinispan-cachestore-cassandra</include>
+            <include>org.infinispan:infinispan-cachestore-cloud</include>
+            <include>org.infinispan:infinispan-cachestore-hbase</include>
+            <include>org.infinispan:infinispan-cachestore-jdbc</include>
+            <include>org.infinispan:infinispan-cachestore-jdbm</include>
+            <include>org.infinispan:infinispan-cachestore-remote</include>
+            <include>org.infinispan:infinispan-gui-demo</include>
+            <include>org.infinispan:infinispan-ec2-demo</include>
+            <include>org.infinispan:infinispan-distexec-demo</include>
+            <include>org.infinispan:infinispan-directory-demo</include>
+            <include>org.infinispan:infinispan-nearcache-demo</include>
+            <include>org.infinispan:infinispan-lucene-demo</include>
+            <include>org.infinispan:infinispan-cdi</include>
+         </includes>
+
+         <binaries>
+            <unpack>false</unpack>
+            <outputDirectory>lib</outputDirectory>
+            <dependencySets>
+               <dependencySet>
+                  <useStrictFiltering>true</useStrictFiltering>
+                  <useTransitiveDependencies>true</useTransitiveDependencies>
+                  <useTransitiveFiltering>true</useTransitiveFiltering>
+                  <outputDirectory>lib</outputDirectory>
+               </dependencySet>
+            </dependencySets>
+         </binaries>
+      </moduleSet>
+
       <!-- Core module -->
       <moduleSet>
          <includeSubModules>false</includeSubModules>
@@ -104,7 +158,7 @@
                      <include>**/*.css</include>
                   </includes>
                </fileSet>
-               
+
                <!-- Binary resources -->
                <fileSet>
                   <directory>src/main/release</directory>
@@ -159,30 +213,20 @@
          </sources>
 
          <binaries>
-
             <outputFileNameMapping>
                ${module.artifactId}.${module.extension}
             </outputFileNameMapping>
             <unpack>false</unpack>
-
-            <dependencySets>
-               <dependencySet>
-                  <useTransitiveDependencies>false</useTransitiveDependencies>
-                  <outputDirectory>lib</outputDirectory>
-               </dependencySet>
-            </dependencySets>
-
          </binaries>
       </moduleSet>
 
-      <!-- Rest of modules except demos and cache stores -->
+      <!-- Rest of modules except demos, rest server and cache stores -->
       <moduleSet>
          <includeSubModules>false</includeSubModules>
          <includes>
             <include>org.infinispan:infinispan-rhq-plugin</include>
             <include>org.infinispan:infinispan-tree</include>
             <include>org.infinispan:infinispan-query</include>
-            <include>org.infinispan:infinispan-server-rest</include>
             <include>org.infinispan:infinispan-server-memcached</include>
             <include>org.infinispan:infinispan-server-hotrod</include>
             <include>org.infinispan:infinispan-server-websocket</include>
@@ -234,7 +278,7 @@
                      <include>**/*.css</include>
                   </includes>
                </fileSet>
-               
+
                <!-- Binary resources -->
                <fileSet>
                   <directory>src/main/release</directory>
@@ -278,32 +322,12 @@
 
          </sources>
 
-         <!-- All modules except core and Webapp modules -->
          <binaries>
-
             <outputDirectory>modules/${module.basedir.name}</outputDirectory>
             <outputFileNameMapping>
                ${module.artifactId}.${module.extension}
             </outputFileNameMapping>
             <unpack>false</unpack>
-
-            <dependencySets>
-               <dependencySet>
-                  <excludes>
-                     <exclude>infinispan-core*</exclude>
-                     <exclude>net.jcip:jcip-annotations</exclude>
-                     <exclude>org.rhq.helpers:rhq-pluginAnnotations</exclude>
-                     <exclude>org.infinispan:infinispan-core</exclude>
-                     <exclude>org.infinispan:infinispan-server-rest</exclude>
-                     <exclude>org.infinispan:infinispan-gridfs-webdav</exclude>
-                     <exclude>log4j:log4j</exclude>
-                  </excludes>
-                  <useTransitiveDependencies>true</useTransitiveDependencies>
-                  <useTransitiveFiltering>true</useTransitiveFiltering>
-                  <outputDirectory>lib</outputDirectory>
-               </dependencySet>
-            </dependencySets>
-
          </binaries>
       </moduleSet>
 
@@ -361,7 +385,7 @@
                      <include>**/*.css</include>
                   </includes>
                </fileSet>
-               
+
                <!-- Binary resources -->
                <fileSet>
                   <directory>src/main/release</directory>
@@ -405,56 +429,12 @@
 
          </sources>
 
-         <!-- All modules except core and Webapp modules -->
          <binaries>
-
             <outputDirectory>modules/cachestores/${module.basedir.name}</outputDirectory>
             <outputFileNameMapping>
                ${module.artifactId}.${module.extension}
             </outputFileNameMapping>
             <unpack>false</unpack>
-
-            <dependencySets>
-               <dependencySet>
-                  <excludes>
-                     <exclude>infinispan-core*</exclude>
-                     <exclude>net.jcip:jcip-annotations</exclude>
-                     <exclude>org.rhq.helpers:rhq-pluginAnnotations</exclude>
-                     <exclude>org.infinispan:infinispan-core</exclude>
-                     <exclude>org.infinispan:infinispan-server-rest</exclude>
-                     <exclude>org.infinispan:infinispan-gridfs-webdav</exclude>
-                     <exclude>log4j:log4j</exclude>
-                  </excludes>
-                  <useTransitiveDependencies>true</useTransitiveDependencies>
-                  <useTransitiveFiltering>true</useTransitiveFiltering>
-                  <outputDirectory>lib</outputDirectory>
-               </dependencySet>
-            </dependencySets>
-
-         </binaries>
-      </moduleSet>
-
-      <!-- REST server war -->
-      <moduleSet>
-         <includeSubModules>false</includeSubModules>
-         <includes>
-            <include>org.infinispan:infinispan-server-rest</include>
-         </includes>
-
-         <binaries>
-            <outputDirectory>modules/${module.basedir.name}</outputDirectory>
-            <outputFileNameMapping>
-               ${module.artifactId}.${module.extension}
-            </outputFileNameMapping>
-            <unpack>false</unpack>
-            <dependencySets>
-               <dependencySet>
-                  <includes>
-                     <include>NONEXISTENT_DEPENDENCY*</include>
-                  </includes>
-                  <outputDirectory>modules/${module.basedir.name}</outputDirectory>
-               </dependencySet>
-            </dependencySets>
          </binaries>
       </moduleSet>
 
@@ -490,14 +470,6 @@
                ${module.artifactId}.${module.extension}
             </outputFileNameMapping>
             <unpack>false</unpack>
-            <dependencySets>
-               <dependencySet>
-                  <includes>
-                     <include>NONEXISTENT_DEPENDENCY*</include>
-                  </includes>
-                  <outputDirectory>modules/demos/${module.basedir.name}</outputDirectory>
-               </dependencySet>
-            </dependencySets>
          </binaries>
       </moduleSet>
 
@@ -554,7 +526,7 @@
                      <include>**/*.css</include>
                   </includes>
                </fileSet>
-               
+
                <!-- Binary resources -->
                <fileSet>
                   <directory>src/main/release</directory>
@@ -598,32 +570,58 @@
 
          </sources>
 
-         <!-- All modules except core and Webapp modules -->
          <binaries>
-
             <outputDirectory>modules/demos/${module.basedir.name}</outputDirectory>
             <outputFileNameMapping>
                ${module.artifactId}.${module.extension}
             </outputFileNameMapping>
             <unpack>false</unpack>
+         </binaries>
+      </moduleSet>
 
-            <dependencySets>
-               <dependencySet>
-                  <excludes>
-                     <exclude>infinispan-core*</exclude>
-                     <exclude>net.jcip:jcip-annotations</exclude>
-                     <exclude>org.rhq.helpers:rhq-pluginAnnotations</exclude>
-                     <exclude>org.infinispan:infinispan-core</exclude>
-                     <exclude>org.infinispan:infinispan-server-rest</exclude>
-                     <exclude>org.infinispan:infinispan-gridfs-webdav</exclude>
-                     <exclude>log4j:log4j</exclude>
-                  </excludes>
-                  <useTransitiveDependencies>true</useTransitiveDependencies>
-                  <useTransitiveFiltering>true</useTransitiveFiltering>
-                  <outputDirectory>lib</outputDirectory>
-               </dependencySet>
-            </dependencySets>
+      <!-- REST server war -->
+      <moduleSet>
+         <includeSubModules>false</includeSubModules>
+         <includes>
+            <include>org.infinispan:infinispan-server-rest</include>
+         </includes>
 
+         <sources>
+            <includeModuleDirectory>false</includeModuleDirectory>
+
+            <fileSets>
+               <!-- Executable resources -->
+               <fileSet>
+                  <directory>src/main/release</directory>
+                  <outputDirectory></outputDirectory>
+                  <lineEnding>unix</lineEnding>
+                  <includes>
+                     <include>**/*.sh</include>
+                     <include>**/*.py</include>
+                     <include>**/*.rb</include>
+                  </includes>
+                  <fileMode>0755</fileMode>
+               </fileSet>
+
+               <fileSet>
+                  <directory>src/main/release</directory>
+                  <outputDirectory></outputDirectory>
+                  <lineEnding>dos</lineEnding>
+                  <includes>
+                     <include>**/*.cmd</include>
+                     <include>**/*.bat</include>
+                  </includes>
+                  <fileMode>0644</fileMode>
+               </fileSet>
+            </fileSets>
+         </sources>
+
+         <binaries>
+            <outputDirectory>modules/${module.basedir.name}</outputDirectory>
+            <outputFileNameMapping>
+               ${module.artifactId}.${module.extension}
+            </outputFileNameMapping>
+            <unpack>false</unpack>
          </binaries>
       </moduleSet>
 
@@ -675,7 +673,7 @@
                      <include>**/*.css</include>
                   </includes>
                </fileSet>
-               
+
                <!-- Binary resources -->
                <fileSet>
                   <directory>src/main/release</directory>
@@ -733,32 +731,12 @@
             </fileSets>
          </sources>
 
-         <!-- All modules except core and Webapp modules -->
          <binaries>
-
             <outputDirectory>modules/cdi</outputDirectory>
             <outputFileNameMapping>
                ${module.artifactId}.${module.extension}
             </outputFileNameMapping>
             <unpack>false</unpack>
-
-            <dependencySets>
-               <dependencySet>
-                  <excludes>
-                     <exclude>infinispan-core*</exclude>
-                     <exclude>net.jcip:jcip-annotations</exclude>
-                     <exclude>org.rhq.helpers:rhq-pluginAnnotations</exclude>
-                     <exclude>org.infinispan:infinispan-core</exclude>
-                     <exclude>org.infinispan:infinispan-server-rest</exclude>
-                     <exclude>org.infinispan:infinispan-gridfs-webdav</exclude>
-                     <exclude>log4j:log4j</exclude>
-                  </excludes>
-                  <useTransitiveDependencies>true</useTransitiveDependencies>
-                  <useTransitiveFiltering>true</useTransitiveFiltering>
-                  <outputDirectory>lib</outputDirectory>
-               </dependencySet>
-            </dependencySets>
-
          </binaries>
       </moduleSet>
 

--- a/src/main/resources/assemblies/bin.xml
+++ b/src/main/resources/assemblies/bin.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source
   ~ Copyright 2009 Red Hat Inc. and/or its affiliates and other
@@ -50,6 +52,47 @@
    </formats>
 
    <moduleSets>
+
+      <!--
+         Gather all transitive runtime dependencies and place them in lib dir of the zip package (runtime-classpath.txt of each module will reference them from here).
+         This is done in a single moduleSet instead of the 'binaries' section of each module in order to avoid the issue with possibly skipped dependencies or
+         incorrectly resolved versions that is already described in the assembly plugin user guide in relation with multiple moduleSets. This issue appeared in
+         version 2.2 of the plugin and is a documented limitation of the moduleSets mechanism (which might become deprecated in the future). The user guide
+         recommends avoiding moduleSets altogether in favor of dependencySets but that solution does not work in our case because we would not be able to include
+         other files in the distribution (scripts, config files, demo data files, etc). That means we'll continue to live (dangerously) with moduleSets.
+      -->
+      <moduleSet>
+         <includeSubModules>false</includeSubModules>
+         <includes>
+            <include>org.infinispan:infinispan-core</include>
+            <include>org.infinispan:infinispan-rhq-plugin</include>
+            <include>org.infinispan:infinispan-tree</include>
+            <include>org.infinispan:infinispan-query</include>
+            <include>org.infinispan:infinispan-server-memcached</include>
+            <include>org.infinispan:infinispan-server-hotrod</include>
+            <include>org.infinispan:infinispan-server-websocket</include>
+            <include>org.infinispan:infinispan-client-hotrod</include>
+            <include>org.infinispan:infinispan-lucene-directory</include>
+            <include>org.infinispan:infinispan-cli-client</include>
+            <include>org.infinispan:infinispan-cli-server</include>
+            <include>org.infinispan:infinispan-gui-demo</include>
+            <include>org.infinispan:infinispan-cdi</include>
+         </includes>
+
+         <binaries>
+            <unpack>false</unpack>
+            <outputDirectory>lib</outputDirectory>
+            <dependencySets>
+               <dependencySet>
+                  <useStrictFiltering>true</useStrictFiltering>
+                  <useTransitiveDependencies>true</useTransitiveDependencies>
+                  <useTransitiveFiltering>true</useTransitiveFiltering>
+                  <outputDirectory>lib</outputDirectory>
+               </dependencySet>
+            </dependencySets>
+         </binaries>
+      </moduleSet>
+
       <!-- Core module -->
       <moduleSet>
          <includeSubModules>false</includeSubModules>
@@ -98,7 +141,7 @@
                      <include>**/*.css</include>
                   </includes>
                </fileSet>
-               
+
                <!-- Binary resources -->
                <fileSet>
                   <directory>src/main/release</directory>
@@ -149,38 +192,31 @@
                   </includes>
                </fileSet>
             </fileSets>
-            
+
          </sources>
 
          <binaries>
-            <unpack>false</unpack>
             <outputFileNameMapping>
                ${module.artifactId}.${module.extension}
             </outputFileNameMapping>
-
-            <dependencySets>
-               <dependencySet>
-                  <useTransitiveDependencies>false</useTransitiveDependencies>
-                  <outputDirectory>lib</outputDirectory>
-               </dependencySet>
-            </dependencySets>
-
+            <unpack>false</unpack>
          </binaries>
       </moduleSet>
 
+      <!-- Rest of modules except demos, rest server and cache stores -->
       <moduleSet>
          <includeSubModules>false</includeSubModules>
          <includes>
-            <include>org.infinispan:infinispan-cli-client</include>
-            <include>org.infinispan:infinispan-cli-server</include>
             <include>org.infinispan:infinispan-rhq-plugin</include>
             <include>org.infinispan:infinispan-tree</include>
             <include>org.infinispan:infinispan-query</include>
-            <include>org.infinispan:infinispan-lucene-directory</include>
             <include>org.infinispan:infinispan-server-memcached</include>
             <include>org.infinispan:infinispan-server-hotrod</include>
             <include>org.infinispan:infinispan-server-websocket</include>
             <include>org.infinispan:infinispan-client-hotrod</include>
+            <include>org.infinispan:infinispan-lucene-directory</include>
+            <include>org.infinispan:infinispan-cli-client</include>
+            <include>org.infinispan:infinispan-cli-server</include>
          </includes>
          <sources>
             <includeModuleDirectory>false</includeModuleDirectory>
@@ -224,7 +260,7 @@
                      <include>**/*.css</include>
                   </includes>
                </fileSet>
-               
+
                <!-- Binary resources -->
                <fileSet>
                   <directory>src/main/release</directory>
@@ -270,25 +306,10 @@
 
          <binaries>
             <outputDirectory>modules/${module.basedir.name}</outputDirectory>
-            <unpack>false</unpack>
             <outputFileNameMapping>
                ${module.artifactId}.${module.extension}
             </outputFileNameMapping>
-            <dependencySets>
-               <dependencySet>
-                  <excludes>
-                     <exclude>infinispan-core*</exclude>
-                     <exclude>net.jcip:jcip-annotations</exclude>
-                     <exclude>org.rhq.helpers:rhq-pluginAnnotations</exclude>
-                     <exclude>javax.transaction:jta</exclude>
-                     <exclude>log4j:log4j</exclude>
-                  </excludes>
-                  <useTransitiveDependencies>true</useTransitiveDependencies>
-                  <useTransitiveFiltering>true</useTransitiveFiltering>
-                  <outputDirectory>lib</outputDirectory>
-               </dependencySet>
-            </dependencySets>
-
+            <unpack>false</unpack>
          </binaries>
       </moduleSet>
 
@@ -384,32 +405,12 @@
 
          </sources>
 
-         <!-- All modules except core and Webapp modules -->
          <binaries>
-
             <outputDirectory>modules/demos/${module.basedir.name}</outputDirectory>
             <outputFileNameMapping>
                ${module.artifactId}.${module.extension}
             </outputFileNameMapping>
             <unpack>false</unpack>
-
-            <dependencySets>
-               <dependencySet>
-                  <excludes>
-                     <exclude>infinispan-core*</exclude>
-                     <exclude>net.jcip:jcip-annotations</exclude>
-                     <exclude>org.rhq.helpers:rhq-pluginAnnotations</exclude>
-                     <exclude>org.infinispan:infinispan-core</exclude>
-                     <exclude>org.infinispan:infinispan-server-rest</exclude>
-                     <exclude>org.infinispan:infinispan-gridfs-webdav</exclude>
-                     <exclude>log4j:log4j</exclude>
-                  </excludes>
-                  <useTransitiveDependencies>true</useTransitiveDependencies>
-                  <useTransitiveFiltering>true</useTransitiveFiltering>
-                  <outputDirectory>lib</outputDirectory>
-               </dependencySet>
-            </dependencySets>
-
          </binaries>
       </moduleSet>
 
@@ -420,21 +421,42 @@
             <include>org.infinispan:infinispan-server-rest</include>
          </includes>
 
+         <sources>
+            <includeModuleDirectory>false</includeModuleDirectory>
+
+            <fileSets>
+               <!-- Executable resources -->
+               <fileSet>
+                  <directory>src/main/release</directory>
+                  <outputDirectory></outputDirectory>
+                  <lineEnding>unix</lineEnding>
+                  <includes>
+                     <include>**/*.sh</include>
+                     <include>**/*.py</include>
+                     <include>**/*.rb</include>
+                  </includes>
+                  <fileMode>0755</fileMode>
+               </fileSet>
+
+               <fileSet>
+                  <directory>src/main/release</directory>
+                  <outputDirectory></outputDirectory>
+                  <lineEnding>dos</lineEnding>
+                  <includes>
+                     <include>**/*.cmd</include>
+                     <include>**/*.bat</include>
+                  </includes>
+                  <fileMode>0644</fileMode>
+               </fileSet>
+            </fileSets>
+         </sources>
+
          <binaries>
             <outputDirectory>modules/${module.basedir.name}</outputDirectory>
-            <unpack>false</unpack>
             <outputFileNameMapping>
                ${module.artifactId}.${module.extension}
             </outputFileNameMapping>
-            <dependencySets>
-               <dependencySet>
-                  <includes>
-                     <include>NONEXISTENT_DEPENDENCY*</include>
-                  </includes>
-                  <outputDirectory>modules/${module.basedir.name}</outputDirectory>
-               </dependencySet>
-            </dependencySets>
-
+            <unpack>false</unpack>
          </binaries>
       </moduleSet>
 
@@ -486,7 +508,7 @@
                      <include>**/*.css</include>
                   </includes>
                </fileSet>
-               
+
                <!-- Binary resources -->
                <fileSet>
                   <directory>src/main/release</directory>
@@ -544,32 +566,12 @@
             </fileSets>
          </sources>
 
-         <!-- All modules except core and Webapp modules -->
          <binaries>
-
             <outputDirectory>modules/cdi</outputDirectory>
             <outputFileNameMapping>
                ${module.artifactId}.${module.extension}
             </outputFileNameMapping>
             <unpack>false</unpack>
-
-            <dependencySets>
-               <dependencySet>
-                  <excludes>
-                     <exclude>infinispan-core*</exclude>
-                     <exclude>net.jcip:jcip-annotations</exclude>
-                     <exclude>org.rhq.helpers:rhq-pluginAnnotations</exclude>
-                     <exclude>org.infinispan:infinispan-core</exclude>
-                     <exclude>org.infinispan:infinispan-server-rest</exclude>
-                     <exclude>org.infinispan:infinispan-gridfs-webdav</exclude>
-                     <exclude>log4j:log4j</exclude>
-                  </excludes>
-                  <useTransitiveDependencies>true</useTransitiveDependencies>
-                  <useTransitiveFiltering>true</useTransitiveFiltering>
-                  <outputDirectory>lib</outputDirectory>
-               </dependencySet>
-            </dependencySets>
-
          </binaries>
       </moduleSet>
 


### PR DESCRIPTION
This solves: https://issues.jboss.org/browse/ISPN-2326
- c3p0 dependency was ignored by maven assembly plugin because this dependency is referenced by multiple modules, in multiple scopes (including test scope). The processing order of modules (and their dependencies) becomes important because only the first one is considered, so if that happens to have 'test' scope it won't make it into the distro.  This is a consequence of a broader issue/limitation that is already documented in the plugin user guide and to overcome it we should avoid multiple moduleSets (not doable). The current solution consists of adding a FIRST moduleSet that aggregates all jar deps in 'proper' order and removing dependency processing from existing moduleSets.
- Made some trivial changes in bin.xml assembly to reduce the amount of text differences to all.xml (bin.xml is a subset of all.xml and any irrelevant differences should go away to simplify maintaining them in parallel)
- Force dependency resolution for commons-codec and commons-collections to use a global common version (otherwise they would diverge)
- Remove some duplicated dependencies in spring/pom.xml and cli-server/pom.xml.
