### PR TITLE
ISPN-2545 Explicitly add the slf4j-log4j12 implementation to the test deps

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -788,6 +788,12 @@
             <scope>test</scope>
          </dependency>
          <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${version.slf4j}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <version>${version.spring}</version>
@@ -1019,6 +1025,11 @@
                <groupId>i18nlog</groupId>
             </exclusion>
          </exclusions>
+      </dependency>
+      <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+          <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.testng</groupId>


### PR DESCRIPTION
ISPN-2545 Explicitly add the slf4j-log4j12 implementation to the test dependencies to avoid issues with IBM JDK. This has no adverse effect.
https://issues.jboss.org/browse/ISPN-2545
