### PR TITLE
ISPN-2632 Added asymmetric cluster tests for Hot Rod server/clients

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientAsymmetricClusterTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientAsymmetricClusterTest.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.client.hotrod;
+
+import org.infinispan.client.hotrod.exceptions.HotRodClientException;
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Tests behaviour of Hot Rod clients with asymmetric clusters.
+ *
+ * @author Galder Zamarreño
+ * @since 5.2
+ */
+@Test(groups = "functional", testName = "client.hotrod.ClientAsymmetricClusterTest")
+public class ClientAsymmetricClusterTest extends MultiHotRodServersTest {
+
+   private static final String CACHE_NAME = "asymmetricCache";
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(
+            CacheMode.REPL_SYNC, false);
+
+      createHotRodServers(2, builder);
+
+      // Define replicated cache in only one of the nodes
+      manager(0).defineConfiguration(CACHE_NAME, builder.build());
+   }
+
+   @Test(expectedExceptions = HotRodClientException.class,
+         expectedExceptionsMessageRegExp = ".*CacheNotFoundException.*")
+   public void test000() {
+      RemoteCacheManager client0 = client(0);
+      RemoteCache<Object, Object> cache0 = client0.getCache(CACHE_NAME);
+      cache0.put(1, "v1");
+      assertEquals("v1", cache0.get(1));
+      cache0.put(2, "v1");
+      assertEquals("v1", cache0.get(2));
+      cache0.put(3, "v1");
+      assertEquals("v1", cache0.get(3));
+   }
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExpiryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExpiryTest.java
@@ -28,7 +28,7 @@ public class ExpiryTest extends MultiHotRodServersTest {
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
       builder.expiration().lifespan(2000L).maxIdle(3000L);
-      createHotRodServers(1, builder.build());
+      createHotRodServers(1, builder);
    }
 
    public void testGlobalExpiry(Method m) throws Exception {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodAsyncReplicationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodAsyncReplicationTest.java
@@ -40,7 +40,7 @@ public class HotRodAsyncReplicationTest extends MultiHotRodServersTest {
       builder.clustering().async().replQueueInterval(1000L).useReplQueue(true);
       builder.eviction().maxEntries(3);
 
-      createHotRodServers(2, builder.build());
+      createHotRodServers(2, builder);
    }
 
    public void testPutKeyValue(Method m) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/PingOnStartupTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/PingOnStartupTest.java
@@ -47,7 +47,7 @@ public class PingOnStartupTest extends MultiHotRodServersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
-      createHotRodServers(2, builder.build());
+      createHotRodServers(2, builder);
    }
 
    public void testTopologyFetched() {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
@@ -4,7 +4,7 @@ import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.TestHelper;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.configuration.cache.Configuration;
-import org.infinispan.configuration.cache.LegacyConfigurationAdaptor;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
@@ -32,9 +32,9 @@ public abstract class MultiHotRodServersTest extends MultipleCacheManagersTest {
    protected List<HotRodServer> servers = new ArrayList<HotRodServer>();
    protected List<RemoteCacheManager> clients = new ArrayList<RemoteCacheManager>();
 
-   protected void createHotRodServers(int num, Configuration defaultCfg) {
+   protected void createHotRodServers(int num, ConfigurationBuilder defaultBuilder) {
       // Start Hot Rod servers
-      for (int i = 0; i < num; i++) addHotRodServer(defaultCfg);
+      for (int i = 0; i < num; i++) addHotRodServer(defaultBuilder);
       // Verify that default caches should be started
       for (int i = 0; i < num; i++) assert manager(i).getCache() != null;
       // Block until views have been received
@@ -45,13 +45,15 @@ public abstract class MultiHotRodServersTest extends MultipleCacheManagersTest {
                manager(i).getCache(), ComponentStatus.RUNNING, 10000);
       }
 
+      Configuration defaultCfg = defaultBuilder.build();
       if (defaultCfg.clustering().cacheMode().isSynchronous()) {
          // Do a put and verify that is present in other nodes
          cache(0).put("k","v");
          for (int i = 0; i < num; i++) assertEquals("v", cache(i).get("k"));
       } else {
          // It must be asynchronous
-         for (int i = 1; i < num; i++) replListener(cache(i)).expect(PutKeyValueCommand.class);
+         for (int i = 1; i < num; i++)
+            replListener(cache(i)).expect(PutKeyValueCommand.class);
          cache(0).put("k","v");
          for (int i = 1; i < num; i++) {
             replListener(cache(i)).waitForRpc();
@@ -79,15 +81,15 @@ public abstract class MultiHotRodServersTest extends MultipleCacheManagersTest {
       // Correct order is to stop servers first
       try {
          for (HotRodServer server : servers)
-            server.stop();
+            HotRodClientTestingUtil.killServers(server);
       } finally {
          // And then the caches and cache managers
          super.destroy();
       }
    }
 
-   private HotRodServer addHotRodServer(Configuration cfg) {
-      EmbeddedCacheManager cm = addClusterEnabledCacheManager(LegacyConfigurationAdaptor.adapt(cfg));
+   private HotRodServer addHotRodServer(ConfigurationBuilder builder) {
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder);
       HotRodServer server = TestHelper.startHotRodServer(cm);
       servers.add(server);
       return server;

--- a/core/src/main/java/org/infinispan/configuration/cache/AsyncConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AsyncConfigurationBuilder.java
@@ -34,7 +34,7 @@ import org.infinispan.remoting.ReplicationQueueImpl;
 public class AsyncConfigurationBuilder extends AbstractClusteringConfigurationChildBuilder implements Builder<AsyncConfiguration> {
 
    private boolean asyncMarshalling = false;
-   private ReplicationQueue replicationQueue = new ReplicationQueueImpl();
+   private ReplicationQueue replicationQueue;
    private long replicationQueueInterval = TimeUnit.SECONDS.toMillis(5);
    private int replicationQueueMaxElements = 1000;
    private boolean useReplicationQueue = false;

--- a/core/src/main/java/org/infinispan/configuration/cache/LegacyConfigurationAdaptor.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LegacyConfigurationAdaptor.java
@@ -65,10 +65,15 @@ public class LegacyConfigurationAdaptor {
          legacy.clustering()
             .async()
                .asyncMarshalling(config.clustering().async().asyncMarshalling())
-               .replQueueClass(config.clustering().async().replQueue().getClass())
                .replQueueInterval(config.clustering().async().replQueueInterval())
                .replQueueMaxElements(config.clustering().async().replQueueMaxElements())
                .useReplQueue(config.clustering().async().useReplQueue());
+
+
+         ReplicationQueue replQueue = config.clustering().async().replQueue();
+         if (replQueue != null) {
+            legacy.clustering().async().replQueueClass(replQueue.getClass());
+         }
       }
 
       if (config.clustering().hash().hash() != null) {

--- a/core/src/main/java/org/infinispan/factories/ReplicationQueueFactory.java
+++ b/core/src/main/java/org/infinispan/factories/ReplicationQueueFactory.java
@@ -22,8 +22,10 @@
  */
 package org.infinispan.factories;
 
+import org.infinispan.configuration.cache.ClusteringConfiguration;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.remoting.ReplicationQueue;
+import org.infinispan.remoting.ReplicationQueueImpl;
 
 /**
  * Factory for ReplicationQueue.
@@ -36,8 +38,10 @@ public class ReplicationQueueFactory extends EmptyConstructorNamedCacheFactory i
    @Override
    @SuppressWarnings("unchecked")
    public <T> T construct(Class<T> componentType) {
-      if ((!configuration.clustering().cacheMode().isSynchronous()) && configuration.clustering().async().useReplQueue()) {
-         return componentType.cast(configuration.clustering().async().replQueue());
+      ClusteringConfiguration clustering = configuration.clustering();
+      if ((!clustering.cacheMode().isSynchronous()) && clustering.async().useReplQueue()) {
+         ReplicationQueue replQueue = clustering.async().replQueue();
+         return replQueue != null ? componentType.cast(replQueue) : (T) new ReplicationQueueImpl();
       } else {
          return null;
       }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
@@ -26,7 +26,6 @@ import org.infinispan.server.core._
 import transport._
 import OperationStatus._
 import org.infinispan.manager.EmbeddedCacheManager
-import org.infinispan.server.hotrod.ProtocolFlag._
 import org.infinispan.server.core.transport.ExtendedChannelBuffer._
 import java.nio.channels.ClosedChannelException
 import org.infinispan.Cache
@@ -107,15 +106,16 @@ class HotRodDecoder(cacheManager: EmbeddedCacheManager, transport: NettyTranspor
             "Remote requests are not allowed to topology cache. Do no send remote requests to cache '%s'".format(HotRodServer.ADDRESS_CACHE_NAME),
             header.version, header.messageId)
 
-      var seenForFirstTime = false;
+      var seenForFirstTime = false
       // Try to avoid calling cacheManager.getCacheNames() if possible, since this creates a lot of unnecessary garbage
       if (server.isCacheNameKnown(cacheName)) {
          if (!(cacheManager.getCacheNames contains cacheName)) {
+            isError = true // Mark it as error so that the rest of request is ignored
             throw new CacheNotFoundException(
                "Cache with name '%s' not found amongst the configured caches".format(cacheName),
                header.version, header.messageId)
          } else {
-            seenForFirstTime = true;
+            seenForFirstTime = true
          }
       }
 

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRod11DistributionTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRod11DistributionTest.scala
@@ -19,15 +19,14 @@
 
 package org.infinispan.server.hotrod
 
-import org.infinispan.config.Configuration
 import org.infinispan.test.AbstractCacheTest._
-import org.infinispan.config.Configuration.CacheMode
 import java.lang.reflect.Method
 import test.HotRodTestingUtil._
 import org.testng.Assert._
 import test.HotRodClient
 import org.infinispan.server.hotrod.OperationStatus._
 import org.testng.annotations.Test
+import org.infinispan.configuration.cache.{CacheMode, ConfigurationBuilder}
 
 /**
  * Tests Hot Rod distribution mode using Hot Rod's 1.1 protocol.
@@ -40,9 +39,9 @@ class HotRod11DistributionTest extends HotRodMultiNodeTest {
 
    override protected def cacheName = "distributedVersion11"
 
-   override protected def createCacheConfig: Configuration = {
-      val cfg = getDefaultClusteredConfig(CacheMode.DIST_SYNC)
-      cfg.fluent().l1().disable() // Disable L1 explicitly
+   override protected def createCacheConfig: ConfigurationBuilder = {
+      val cfg = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false)
+      cfg.clustering().l1().disable() // Disable L1 explicitly
       cfg
    }
 

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRod11StorageOnlyNodesTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRod11StorageOnlyNodesTest.scala
@@ -19,17 +19,16 @@
 
 package org.infinispan.server.hotrod
 
-import org.infinispan.config.Configuration
 import org.infinispan.test.AbstractCacheTest._
-import org.infinispan.config.Configuration.CacheMode
 import java.lang.reflect.Method
 import test.HotRodTestingUtil._
 import org.testng.Assert._
-import test.{HotRodMagicKeyGenerator, HotRodClient}
+import test.HotRodMagicKeyGenerator
 import org.infinispan.server.hotrod.OperationStatus._
 import org.testng.annotations.Test
 import org.infinispan.test.TestingUtil
 import org.infinispan.server.core.test.ServerTestingUtil
+import org.infinispan.configuration.cache.{CacheMode, ConfigurationBuilder}
 
 /**
  * Tests Hot Rod distribution mode when some of the cache managers do not have HotRod servers running.
@@ -42,9 +41,9 @@ class HotRod11StorageOnlyNodesTest extends HotRodMultiNodeTest {
 
    override protected def cacheName = "distributed"
 
-   override protected def createCacheConfig: Configuration = {
-      val cfg = getDefaultClusteredConfig(CacheMode.DIST_SYNC)
-      cfg.fluent().l1().disable() // Disable L1 explicitly
+   override protected def createCacheConfig: ConfigurationBuilder = {
+      val cfg = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false)
+      cfg.clustering().l1().disable() // Disable L1 explicitly
       cfg
    }
 
@@ -65,7 +64,7 @@ class HotRod11StorageOnlyNodesTest extends HotRodMultiNodeTest {
 
       val newCacheManager = addClusterEnabledCacheManager()
       try {
-         newCacheManager.defineConfiguration(cacheName, createCacheConfig)
+         newCacheManager.defineConfiguration(cacheName, createCacheConfig.build())
          newCacheManager.getCache(cacheName)
          TestingUtil.blockUntilViewsReceived(50000, true, manager(0), manager(1), manager(2))
          TestingUtil.waitForRehashToComplete(cache(0, cacheName), cache(1, cacheName), cache(2, cacheName))

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodAsymmetricClusterTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodAsymmetricClusterTest.scala
@@ -1,0 +1,46 @@
+package org.infinispan.server.hotrod
+
+import org.infinispan.configuration.cache.{CacheMode, ConfigurationBuilder}
+import org.infinispan.test.AbstractCacheTest._
+import org.testng.annotations.Test
+import java.lang.reflect.Method
+import test.HotRodTestingUtil._
+import org.infinispan.server.hotrod.OperationStatus._
+
+/**
+ * Tests behaviour of Hot Rod servers with asymmetric clusters
+ *
+ * @author Galder Zamarreño
+ * @since 5.2
+ */
+@Test(groups = Array("functional"), testName = "server.hotrod.HotRodAsymmetricClusterTest")
+class HotRodAsymmetricClusterTest extends HotRodMultiNodeTest {
+
+  protected def cacheName: String = "asymmetricCache"
+
+  protected def createCacheConfig: ConfigurationBuilder =
+     getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false)
+
+  @Test(enabled = false)
+  override def createCacheManagers() {
+     for (i <- 0 until 2) {
+        val cm = super.addClusterEnabledCacheManager()
+        if (i == 0) {
+           cm.defineConfiguration(cacheName, createCacheConfig.build())
+        }
+     }
+  }
+
+   protected def protocolVersion: Byte = 12
+
+   def testPutInCacheDefinedNode(m: Method) {
+      val resp = clients.head.put(k(m) , 0, 0, v(m))
+      assertStatus(resp, Success)
+   }
+
+   def testPutInNonCacheDefinedNode(m: Method) {
+      val resp = clients.tail.head.put(k(m) , 0, 0, v(m))
+      assertStatus(resp, ParseError)
+   }
+
+}

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDistributionTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDistributionTest.scala
@@ -23,17 +23,13 @@
 package org.infinispan.server.hotrod
 
 import org.testng.annotations.Test
-import org.infinispan.config.Configuration.CacheMode
-import org.infinispan.config.Configuration
 import java.lang.reflect.Method
 import org.infinispan.server.hotrod.OperationStatus._
 import test.HotRodTestingUtil._
 import org.testng.Assert._
 import org.infinispan.test.AbstractCacheTest._
-import test.{TestHashDistAware10Response, HotRodClient}
-
-// Do not remove, otherwise getDefaultClusteredConfig is not found
-import scala.collection.JavaConversions._
+import test.HotRodClient
+import org.infinispan.configuration.cache.{CacheMode, ConfigurationBuilder}
 
 /**
  * Tests Hot Rod logic when interacting with distributed caches, particularly logic to do with
@@ -47,9 +43,9 @@ class HotRodDistributionTest extends HotRodMultiNodeTest {
 
    override protected def cacheName: String = "hotRodDistSync"
 
-   override protected def createCacheConfig: Configuration = {
-      val cfg = getDefaultClusteredConfig(CacheMode.DIST_SYNC)
-      cfg.fluent().l1().disable() // Disable L1 explicitly
+   override protected def createCacheConfig: ConfigurationBuilder = {
+      val cfg = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false)
+      cfg.clustering().l1().disable() // Disable L1 explicitly
       cfg
    }
 

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodProxyTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodProxyTest.scala
@@ -27,9 +27,8 @@ import test.HotRodTestingUtil._
 import org.infinispan.server.hotrod.OperationStatus._
 import org.testng.annotations.Test
 import org.testng.Assert._
-import org.infinispan.config.Configuration
 import org.infinispan.test.AbstractCacheTest._
-import collection.JavaConversions._
+import org.infinispan.configuration.cache.{CacheMode, ConfigurationBuilder}
 
 /**
  * Tests Hot Rod instances that are behind a proxy.
@@ -47,9 +46,9 @@ class HotRodProxyTest extends HotRodMultiNodeTest {
 
    override protected def cacheName: String = "hotRodProxy"
 
-   override protected def createCacheConfig: Configuration = {
-      val config = getDefaultClusteredConfig(Configuration.CacheMode.REPL_SYNC)
-      config.setFetchInMemoryState(true)
+   override protected def createCacheConfig: ConfigurationBuilder = {
+      val config = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false)
+      config.clustering().stateTransfer().fetchInMemoryState(true)
       config
    }
 
@@ -61,7 +60,7 @@ class HotRodProxyTest extends HotRodMultiNodeTest {
    override protected def startTestHotRodServer(cacheManager: EmbeddedCacheManager, port: Int) =
       startHotRodServer(cacheManager, port, proxyHost2, proxyPort2)
 
-   def testTopologyWithProxiesReturned {
+   def testTopologyWithProxiesReturned() {
       val resp = clients.head.ping(2, 0)
       assertStatus(resp, Success)
       val topoResp = resp.asTopologyAwareResponse


### PR DESCRIPTION
Do not close JIRA. This commit just adds some tests that put expectations around asymmetric cluster behaviour for Hot Rod servers and clients.

This also includes a fix for the replication queue configuration issue that was noticed as part of ISPN-2335.
