### PR TITLE
ISPN-2711 NPE in StateConsumerImpl.addUpdatedKey and isKeyUpdated

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -160,9 +160,11 @@ public class StateConsumerImpl implements StateConsumer {
     */
    @Override
    public void addUpdatedKey(Object key) {
-      if (updatedKeys != null) {
+      // grab a copy of the reference to prevent issues if another thread calls stopApplyingState() between null check and actual usage
+      final Set<Object> localUpdatedKeys = updatedKeys;
+      if (localUpdatedKeys != null) {
          if (cacheTopology.getWriteConsistentHash().isKeyLocalToNode(rpcManager.getAddress(), key)) {
-            updatedKeys.add(key);
+            localUpdatedKeys.add(key);
          }
       }
    }
@@ -175,7 +177,9 @@ public class StateConsumerImpl implements StateConsumer {
     */
    @Override
    public boolean isKeyUpdated(Object key) {
-      return updatedKeys == null || updatedKeys.contains(key);
+      // grab a copy of the reference to prevent issues if another thread calls stopApplyingState() between null check and actual usage
+      final Set<Object> localUpdatedKeys = updatedKeys;
+      return localUpdatedKeys == null || localUpdatedKeys.contains(key);
    }
 
    @Inject


### PR DESCRIPTION
updatedKeys can be set to null by another thread that calls stopApplyingState() between the initial null check and the actual access leading to NPE. To guard against this it is enough to grab a local copy of the reference.

JIRA: https://issues.jboss.org/browse/ISPN-2711
