### PR TITLE
ISPN-2300 Revert changed flag for entries where conditional ops failed

### DIFF
--- a/core/src/main/java/org/infinispan/commands/write/PutKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/PutKeyValueCommand.java
@@ -90,6 +90,8 @@ public class PutKeyValueCommand extends AbstractDataWriteCommand {
 
       Object entryValue = e.getValue();
       if (entryValue != null && putIfAbsent && !e.isRemoved()) {
+         // Revert assumption that new value is to be committed
+         e.setChanged(false);
          successful = false;
          return entryValue;
       } else {

--- a/core/src/main/java/org/infinispan/commands/write/ReplaceCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/ReplaceCommand.java
@@ -72,7 +72,11 @@ public class ReplaceCommand extends AbstractDataWriteCommand {
       if (e != null) {
          if (ctx.isOriginLocal()) {
             //ISPN-514
-            if (e.isNull() || e.getValue() == null) return returnValue(null, false, ctx);
+            if (e.isNull() || e.getValue() == null) {
+               // Revert assumption that new value is to be committed
+               e.setChanged(false);
+               return returnValue(null, false, ctx);
+            }
          }
 
          if (oldValue == null || oldValue.equals(e.getValue())) {
@@ -81,7 +85,8 @@ public class ReplaceCommand extends AbstractDataWriteCommand {
             e.setMaxIdle(maxIdleTimeMillis);
             return returnValue(old, true, ctx);
          }
-         return returnValue(null, false, ctx);
+         // Revert assumption that new value is to be committed
+         e.setChanged(false);
       }
 
       return returnValue(null, false, ctx);

--- a/core/src/main/java/org/infinispan/container/entries/AbstractInternalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/AbstractInternalCacheEntry.java
@@ -53,6 +53,11 @@ public abstract class AbstractInternalCacheEntry implements InternalCacheEntry {
    }
 
    @Override
+   public void setChanged(boolean changed) {
+      // no-op
+   }
+
+   @Override
    public final void setCreated(boolean created) {
       // no-op
    }
@@ -69,6 +74,11 @@ public abstract class AbstractInternalCacheEntry implements InternalCacheEntry {
 
    @Override
    public final void setValid(boolean valid) {
+      // no-op
+   }
+
+   @Override
+   public void setLoaded(boolean loaded) {
       // no-op
    }
 
@@ -99,6 +109,11 @@ public abstract class AbstractInternalCacheEntry implements InternalCacheEntry {
 
    @Override
    public final boolean isValid() {
+      return false;
+   }
+
+   @Override
+   public boolean isLoaded() {
       return false;
    }
 

--- a/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
@@ -71,6 +71,11 @@ public interface CacheEntry extends Map.Entry<Object, Object>, Versioned {
    boolean isValid();
 
    /**
+    * @return true if the entry was loaded from a cache store.
+    */
+   boolean isLoaded();
+
+   /**
     * Retrieves the key to this entry
     *
     * @return a key
@@ -131,6 +136,8 @@ public interface CacheEntry extends Map.Entry<Object, Object>, Versioned {
     */
    void rollback();
 
+   void setChanged(boolean changed);
+
    void setCreated(boolean created);
 
    void setRemoved(boolean removed);
@@ -138,6 +145,8 @@ public interface CacheEntry extends Map.Entry<Object, Object>, Versioned {
    void setEvicted(boolean evicted);
 
    void setValid(boolean valid);
+
+   void setLoaded(boolean loaded);
 
    /**
     * @return true if this entry is a placeholder for the sake of acquiring a lock; and false if it is a real entry. 

--- a/core/src/main/java/org/infinispan/container/entries/RepeatableReadEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/RepeatableReadEntry.java
@@ -46,7 +46,7 @@ public class RepeatableReadEntry extends ReadCommittedEntry {
       if (isChanged()) return; // already copied
 
       // mark entry as changed.
-      setChanged();
+      setChanged(true);
 
       if (localModeWriteSkewCheck) {
          performLocalWriteSkewCheck(container, false);

--- a/core/src/main/java/org/infinispan/interceptors/CacheLoaderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheLoaderInterceptor.java
@@ -216,6 +216,7 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
          entry.setMaxIdle(loadedEntry.getMaxIdle());
          // TODO shouldn't we also be setting last used and created timestamps?
          entry.setValid(true);
+         entry.setLoaded(true); // mark the entry as loaded from the store
 
          sendNotification(key, value, false, ctx);
       }

--- a/core/src/main/java/org/infinispan/interceptors/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/EntryWrappingInterceptor.java
@@ -367,7 +367,7 @@ public class EntryWrappingInterceptor extends CommandInterceptor {
          return false;
       }
 
-      if (entry.isChanged()) {
+      if (entry.isChanged() || entry.isLoaded()) {
          log.tracef("About to commit entry %s", entry);
          commitContextEntry(entry, ctx, skipOwnershipCheck);
 

--- a/core/src/main/java/org/infinispan/util/Immutables.java
+++ b/core/src/main/java/org/infinispan/util/Immutables.java
@@ -604,6 +604,11 @@ public class Immutables {
       }
 
       @Override
+      public boolean isLoaded() {
+         return entry.isLoaded();
+      }
+
+      @Override
       public void rollback() {
          throw new UnsupportedOperationException();
       }
@@ -619,12 +624,22 @@ public class Immutables {
       }
 
       @Override
+      public void setChanged(boolean changed) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
       public void setEvicted(boolean evicted) {
          entry.setEvicted(evicted);
       }
 
       @Override
       public void setValid(boolean valid) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void setLoaded(boolean loaded) {
          throw new UnsupportedOperationException();
       }
 

--- a/core/src/test/java/org/infinispan/container/versioning/SimpleConditionalOperationsWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/SimpleConditionalOperationsWriteSkewTest.java
@@ -1,0 +1,94 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.infinispan.container.versioning;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.VersioningScheme;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+@Test(groups = "functional", testName = "api.SimpleConditionalOperationsWriteSkewTest")
+public class SimpleConditionalOperationsWriteSkewTest extends MultipleCacheManagersTest {
+
+   protected ConfigurationBuilder getConfig() {
+      ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
+      dcc.transaction().locking().writeSkewCheck(true);
+      dcc.transaction().locking().isolationLevel(IsolationLevel.REPEATABLE_READ);
+      dcc.transaction().versioning().enable().scheme(VersioningScheme.SIMPLE);
+      return dcc;
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder dcc = getConfig();
+      createCluster(dcc, 2);
+      waitForClusterToForm();
+   }
+
+   public void testReplaceFromMainOwner() throws Throwable {
+      Object k = getKeyForCache(0);
+      cache(0).put(k, "0");
+      tm(0).begin();
+      cache(0).put("kkk", "vvv");
+      cache(0).replace(k, "v1", "v2");
+      tm(0).commit();
+
+      assertEquals(advancedCache(0).getDataContainer().get(k).getValue(), "0");
+      assertEquals(advancedCache(1).getDataContainer().get(k).getValue(), "0");
+
+      log.trace("here is the interesting replace.");
+      cache(0).replace(k, "0", "1");
+      assertEquals(advancedCache(0).getDataContainer().get(k).getValue(), "1");
+      assertEquals(advancedCache(1).getDataContainer().get(k).getValue(), "1");
+   }
+
+   public void testRemoveFromMainOwner() {
+      Object k = getKeyForCache(0);
+      cache(0).put(k, "0");
+      cache(0).remove(k, "1");
+
+      assertEquals(advancedCache(0).getDataContainer().get(k).getValue(), "0");
+      assertEquals(advancedCache(1).getDataContainer().get(k).getValue(), "0");
+
+      cache(0).remove(k, "0");
+      assertNull(advancedCache(0).getDataContainer().get(k));
+      assertNull(advancedCache(1).getDataContainer().get(k));
+   }
+
+   public void testPutIfAbsentFromMainOwner() {
+      Object k = getKeyForCache(0);
+      cache(0).put(k, "0");
+      cache(0).putIfAbsent(k, "1");
+
+      assertEquals(advancedCache(0).getDataContainer().get(k).getValue(), "0");
+      assertEquals(advancedCache(1).getDataContainer().get(k).getValue(), "0");
+
+      cache(0).remove(k);
+
+      cache(0).putIfAbsent(k, "1");
+      assertEquals(advancedCache(0).getDataContainer().get(k).getValue(), "1");
+      assertEquals(advancedCache(1).getDataContainer().get(k).getValue(), "1");
+   }
+}

--- a/core/src/test/java/org/infinispan/container/versioning/VersionedConditionalOperationsTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/VersionedConditionalOperationsTest.java
@@ -1,0 +1,159 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.container.versioning;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.VersioningScheme;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNull;
+
+/**
+ * This test checks behaivour of versioned caches
+ * when executing conditional operations.
+ *
+ * @author Pedro Ruivo
+ * @since 5.2
+ */
+@Test(testName = "container.versioning.VersionedConditionalOperationsTest", groups = "functional")
+public class VersionedConditionalOperationsTest extends MultipleCacheManagersTest {
+
+   protected static final String KEY_1 = "key_1";
+   protected static final String KEY_2 = "key_2";
+   protected static final String VALUE_1 = "value_1";
+   protected static final String VALUE_2 = "value_2";
+   protected static final String VALUE_3 = "value_3";
+   protected static final String VALUE_4 = "value_4";
+
+   protected final int clusterSize;
+   protected final CacheMode mode;
+   protected final boolean syncCommit;
+
+   public VersionedConditionalOperationsTest() {
+      this(2, CacheMode.REPL_SYNC, false);
+   }
+
+   protected VersionedConditionalOperationsTest(
+         int clusterSize, CacheMode mode, boolean syncCommit) {
+      this.clusterSize = clusterSize;
+      this.mode = mode;
+      this.syncCommit = syncCommit;
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(mode, true);
+      dcc.transaction().syncCommitPhase(syncCommit).syncRollbackPhase(syncCommit);
+      dcc.locking().isolationLevel(IsolationLevel.REPEATABLE_READ).writeSkewCheck(true);
+      dcc.versioning().enable().scheme(VersioningScheme.SIMPLE);
+      createCluster(dcc, clusterSize);
+      waitForClusterToForm();
+   }
+
+   public void testPutIfAbsent() {
+      assertEmpty(KEY_1, KEY_2);
+
+      cache(1).put(KEY_1, VALUE_1);
+      assertCacheValue(1, KEY_1, VALUE_1);
+
+      cache(0).putIfAbsent(KEY_1, VALUE_2);
+      assertCacheValue(0, KEY_1, VALUE_1);
+
+      cache(1).put(KEY_1, VALUE_3);
+      assertCacheValue(1, KEY_1, VALUE_3);
+
+      cache(0).putIfAbsent(KEY_1, VALUE_4);
+      assertCacheValue(0, KEY_1, VALUE_3);
+
+      cache(0).putIfAbsent(KEY_2, VALUE_1);
+      assertCacheValue(0, KEY_2, VALUE_1);
+
+      assertNoTransactions();
+   }
+
+   public void testRemoveIfPresent() {
+      assertEmpty(KEY_1);
+
+      cache(0).put(KEY_1, VALUE_1);
+      cache(1).put(KEY_1, VALUE_2);
+      assertCacheValue(1, KEY_1, VALUE_2);
+
+      cache(0).remove(KEY_1, VALUE_1);
+      assertCacheValue(0, KEY_1, VALUE_2);
+
+      cache(0).remove(KEY_1, VALUE_2);
+      assertCacheValue(0, KEY_1, null);
+
+      assertNoTransactions();
+   }
+
+   public void testReplaceWithOldVal() {
+      assertEmpty(KEY_1);
+
+      cache(1).put(KEY_1, VALUE_1);
+      assertCacheValue(1, KEY_1, VALUE_1);
+
+      cache(0).put(KEY_1, VALUE_2);
+      assertCacheValue(0, KEY_1, VALUE_2);
+
+      cache(0).replace(KEY_1, VALUE_3, VALUE_4);
+      assertCacheValue(0, KEY_1, VALUE_2);
+
+      cache(0).replace(KEY_1, VALUE_2, VALUE_4);
+      assertCacheValue(0, KEY_1, VALUE_4);
+
+      assertNoTransactions();
+   }
+
+   protected void assertEmpty(Object... keys) {
+      for (Cache cache : caches()) {
+         for (Object key : keys) {
+            assertNull(cache.get(key));
+         }
+      }
+   }
+
+   //originatorIndex == cache which executed the transaction
+   protected void assertCacheValue(int originatorIndex, Object key, Object value) {
+      for (int index = 0; index < caches().size(); ++index) {
+         if ((index == originatorIndex && mode.isSynchronous()) ||
+               (index != originatorIndex && syncCommit)) {
+            assertEquals(index, key, value);
+         } else {
+            assertEventuallyEquals(index, key, value);
+         }
+      }
+
+   }
+
+   private void assertEquals(int index, Object key, Object value) {
+      assert value == null
+            ? value == cache(index).get(key)
+            : value.equals(cache(index).get(key));
+   }
+}

--- a/core/src/test/java/org/infinispan/loaders/CacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/loaders/CacheLoaderFunctionalTest.java
@@ -273,7 +273,7 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
       // make sure we have no stale locks!!
       assertNoLocks(cache);
 
-      assert cache.size() == 3 : "Expected the cache to contain 3 elements but contained " + cache.size();
+      assert cache.size() == 3 : "Expected the cache to contain 3 elements but contained " + cache.entrySet();
 
       for (int i = 1; i < 5; i++) cache.evict("k" + i);
       // make sure we have no stale locks!!


### PR DESCRIPTION
- Changed cache entry flagged was overloaded to mean that both that a
  new entry had to be stored in the cache, and that a entry loaded from
  the cache store had to be stored in the cache.
- Changed now represents a change, so a cache entry whose value in
  memory is going to change as a direct result of the cache operation,
  i.e. when the conditional operation succeeds.
- Loaded means that a entry was loaded from the cache store and needs
  to be stored in the cache, i.e. when a conditional operation requires
  comparing the old value which is present in the cache store, and if
  the condition fails, the value in the cache store still needs updating
  in the cache.
