### PR TITLE
ISPN-2683 AS7.x modules packaging

### DIFF
--- a/as-modules/build.xml
+++ b/as-modules/build.xml
@@ -1,0 +1,68 @@
+<!--
+  ~ Copyright 2011 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this library; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA
+  -->
+<project name="as-modules" basedir="." default="clean">
+
+   <property name="output.dir" value="${project.build.directory}/infinispan-as-modules" />
+
+   <import file="lib.xml" />
+
+   <target name="clean">
+      <delete dir="${output.dir}" />
+   </target>
+
+   <target name="copy-files">
+      <!-- Copy the resource files -->
+      <copy todir="${output.dir}">
+         <fileset dir="${basedir}/src/main/resources">
+            <include name="**/*.txt" />
+         </fileset>
+      </copy>
+   </target>
+
+   <!-- These modules are for JDG-specific functionality -->
+   <target name="modules">
+   
+      <filterset id="module-filter">
+         <filter token="infinispan.slot" value="${infinispan.slot}" />
+         <filter token="jgroups.slot" value="${jgroups.slot}" />
+      </filterset>
+
+      <module-def name="org.infinispan" slot="${infinispan.slot}">
+         <maven-resource group="org.infinispan" artifact="infinispan-core" />
+      </module-def>
+
+      <module-def name="org.infinispan.cachestore.jdbc" slot="${infinispan.slot}">
+         <maven-resource group="org.infinispan" artifact="infinispan-cachestore-jdbc" />
+      </module-def>
+
+      <module-def name="org.infinispan.cachestore.remote" slot="${infinispan.slot}">
+         <maven-resource group="org.infinispan" artifact="infinispan-cachestore-remote" />
+      </module-def>
+
+      <module-def name="org.infinispan.tree" slot="${infinispan.slot}">
+         <maven-resource group="org.infinispan" artifact="infinispan-tree" />
+      </module-def>
+
+      <module-def name="org.jgroups" slot="${jgroups.slot}">
+         <maven-resource group="org.jgroups" artifact="jgroups" />
+      </module-def>
+   </target>
+
+   <target name="all" depends="clean, copy-files, modules" />
+</project>

--- a/as-modules/lib.xml
+++ b/as-modules/lib.xml
@@ -1,0 +1,195 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project name="module-repository-lib" xmlns:artifact="antlib:org.apache.maven.artifact.ant">
+
+    <property name="src.dir" value="src"/>
+    <property name="module.repo.src.dir" value="${src.dir}/main/resources/modules"/>
+    <property name="output.dir" value="target/jboss-as-${jboss.as.release.version}"/>
+    <property name="module.repo.output.dir" value="${output.dir}/modules"/>
+    <property name="module.xml" value="module.xml"/>
+
+    <property name="bundle.repo.output.dir" value="${output.dir}/bundles"/>
+
+    <macrodef name="module-def">
+        <attribute name="name"/>
+        <attribute name="slot" default="main"/>
+        <attribute name="src" default="${module.repo.src.dir}" />
+        <element name="resources" implicit="yes" optional="yes"/>
+
+        <sequential>
+            <echo message="Initializing module -> @{name}"/>
+            <!-- Figure out the correct module path -->
+            <define-module-dir name="@{name}" slot="@{slot}"/>
+
+            <delete dir="${module.repo.output.dir}/${current.module.path}" quiet="true" />
+
+            <!-- Make the module output director -->
+            <mkdir dir="${module.repo.output.dir}/${current.module.path}"/>
+
+            <!-- Copy the module.xml and other stuff to the output director -->
+            <copy todir="${module.repo.output.dir}/${current.module.path}">
+                <filterset begintoken="${" endtoken="}">
+                    <filter token="slot" value="@{slot}" />
+                    <filterset refid="module-filter" />
+                </filterset>
+                <fileset dir="@{src}/${source.module.path}">
+                    <include name="**"/>
+                </fileset>
+            </copy>
+
+            <!-- Process the resource -->
+            <resources/>
+
+            <!-- Some final cleanup -->
+            <replace file="${module.repo.output.dir}/${current.module.path}/${module.xml}">
+                <replacetoken>
+                    <![CDATA[
+        <!-- Insert resources here -->]]></replacetoken>
+                <replacevalue>
+                </replacevalue>
+            </replace>
+
+        </sequential>
+    </macrodef>
+
+    <macrodef name="bundle-def">
+        <attribute name="name"/>
+        <attribute name="slot" default="main"/>
+        <element name="resources" implicit="yes" optional="yes"/>
+
+        <sequential>
+            <echo message="Initializing bundle -> @{name}"/>
+            <!-- Figure out the correct bundle path -->
+            <define-bundle-dir name="@{name}" slot="@{slot}" />
+
+            <!-- Make the bundle output director -->
+            <mkdir dir="${bundle.repo.output.dir}/${current.bundle.path}"/>
+
+            <!-- Process the resource -->
+            <resources/>
+
+        </sequential>
+    </macrodef>
+
+    <macrodef name="maven-bundle" >
+        <attribute name="group"/>
+        <attribute name="artifact"/>
+
+        <sequential>
+            <!-- Copy the jar to the bundle dir -->
+            <copy todir="${bundle.repo.output.dir}/${current.bundle.path}" failonerror="true">
+                <fileset file="${@{group}:@{artifact}:jar}"/>
+                <mapper type="flatten" />
+            </copy>
+        </sequential>
+    </macrodef>
+    
+    <scriptdef name="define-module-dir" language="javascript">
+        <attribute name="name"/>
+        <attribute name="slot"/>
+        <![CDATA[
+            name = attributes.get("name");
+            name = name.replace(".", "/");
+            project.setProperty("source.module.path", name + "/main");
+            project.setProperty("current.module.path", name + "/" + attributes.get("slot"));
+        ]]>
+    </scriptdef>
+
+    <scriptdef name="define-bundle-dir" language="javascript">
+        <attribute name="name"/>
+        <attribute name="slot"/>
+        <![CDATA[
+            name = attributes.get("name");
+            name = name.replace(".", "/");
+            project.setProperty("current.bundle.path", name + "/" + attributes.get("slot"));
+        ]]>
+    </scriptdef>
+    
+    <macrodef name="maven-resource" >
+        <attribute name="group"/>
+        <attribute name="artifact"/>
+
+        <sequential>
+            <!-- Copy the jar to the module dir -->
+            <copy todir="${module.repo.output.dir}/${current.module.path}" failonerror="true">
+                <fileset file="${@{group}:@{artifact}:jar}"/>
+                <mapper type="flatten" />
+            </copy>
+
+            <basename file="${@{group}:@{artifact}:jar}" property="resourcename.@{group}.@{artifact}"/>
+            <!-- Update the resource entry in module.xml -->
+            <define-resource-root path="${resourcename.@{group}.@{artifact}}" />
+            <replace file="${module.repo.output.dir}/${current.module.path}/${module.xml}">
+                <replacefilter token="&lt;!-- Insert resources here --&gt;" value="${current.resource.root}&#10;        &lt;!-- Insert resources here --&gt;"/>
+            </replace>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="maven-resource-with-classifier" >
+        <attribute name="group"/>
+        <attribute name="artifact"/>
+        <attribute name="classifier"/>
+
+        <sequential>
+            <!-- Copy the jar to the module dir -->
+            <copy todir="${module.repo.output.dir}/${current.module.path}" failonerror="true">
+                <fileset file="${@{group}:@{artifact}:jar:@{classifier}}"/>
+                <!-- http://jira.codehaus.org/browse/MANTRUN-159 -->
+                <mapper type="flatten" />
+            </copy>
+
+            <basename file="${@{group}:@{artifact}:jar:@{classifier}}" property="resourcename.@{group}.@{artifact}.@{classifier}"/>
+
+            <!-- Update the resource entry in module.xml -->
+            <define-resource-root path="${resourcename.@{group}.@{artifact}.@{classifier}}"/>
+            <replace file="${module.repo.output.dir}/${current.module.path}/${module.xml}">
+                <replacefilter token="&lt;!-- Insert resources here --&gt;" value="${current.resource.root}&#10;        &lt;!-- Insert resources here --&gt;"/>
+            </replace>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="extract-native-jar" >
+        <attribute name="group"/>
+        <attribute name="artifact"/>
+        <sequential>
+        <unzip src="${@{group}:@{artifact}:jar}" dest="${module.repo.output.dir}/${current.module.path}">
+           <patternset>
+               <include name="lib/**"/>
+           </patternset>
+       </unzip>
+        </sequential>
+    </macrodef>
+
+    <scriptdef name="define-resource-root" language="javascript">
+        <attribute name="path"/>
+        <![CDATA[
+            path = attributes.get("path");
+            root = "<resource-root path=\"" + path + "\"/>";
+            if(path.indexOf('${') != -1) {
+                throw "Module resource root not found, make sure it is listed in build/pom.xml" + path;
+            }
+            project.setProperty("current.resource.root", root);
+        ]]>
+    </scriptdef>
+
+</project>

--- a/as-modules/pom.xml
+++ b/as-modules/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ Copyright 2012 Red Hat, Inc. and/or its affiliates. ~ ~ This is free software; you can redistribute it and/or modify it ~ under the terms of the GNU Lesser General Public License as ~ published by the Free Software Foundation; either version 2.1 of ~ the License, or (at your option) any later 
+   version. ~ ~ This software is distributed in the hope that it will be useful, ~ but WITHOUT ANY WARRANTY; without even the implied warranty of ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU ~ Lesser General Public License for more details. ~ ~ You should have received a copy of the 
+   GNU Lesser General Public ~ License along with this library; if not, write to the Free Software ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA ~ 02110-1301 USA -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+   <parent>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-parent</artifactId>
+      <version>5.2.0-SNAPSHOT</version>
+      <relativePath>../parent/pom.xml</relativePath>
+   </parent>
+
+   <artifactId>infinispan-as-modules</artifactId>
+   <name>Infinispan AS/EAP modules</name>
+   <packaging>pom</packaging>
+
+   <properties>
+      <infinispan.slot>5.2</infinispan.slot>
+      <jgroups.slot>3.2</jgroups.slot>
+   </properties>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-core</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-client-hotrod</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-cachestore-jdbc</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-cachestore-remote</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-tree</artifactId>
+      </dependency>
+   </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>build-dist-dir</id>
+                  <goals>
+                     <goal>run</goal>
+                  </goals>
+                  <phase>package</phase>
+                  <configuration>
+                     <target>
+                        <ant antfile="build.xml" inheritRefs="true">
+                           <target name="all" />
+                        </ant>
+                     </target>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>assemble</id>
+                  <phase>package</phase>
+                  <goals>
+                     <goal>single</goal>
+                  </goals>
+               </execution>
+            </executions>
+            <configuration>
+               <descriptors>
+                  <descriptor>src/main/assembly/dist.xml</descriptor>
+               </descriptors>
+               <finalName>${project.artifactId}-${project.version}</finalName>
+               <outputDirectory>${buildDirectory}/distribution</outputDirectory>
+               <workDirectory>${buildDirectory}/assembly/work</workDirectory>
+               <appendAssemblyId>false</appendAssemblyId>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+</project>

--- a/as-modules/src/main/assembly/dist.xml
+++ b/as-modules/src/main/assembly/dist.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2009 Red Hat Inc. and/or its affiliates and other
+  ~ contributors as indicated by the @author tags. All rights reserved.
+  ~ See the copyright.txt in the distribution for a full listing of
+  ~ individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>as-modules</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <baseDirectory>/</baseDirectory>
+
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}/infinispan-as-modules</directory>
+      <outputDirectory />
+      <includes>
+        <include>**/**</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/as-modules/src/main/resources/modules/org/infinispan/cachestore/jdbc/main/module.xml
+++ b/as-modules/src/main/resources/modules/org/infinispan/cachestore/jdbc/main/module.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="org.infinispan.cachestore.jdbc" slot="${slot}">
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="javax.transaction.api"/>
+        <module name="org.apache.commons.pool"/>
+        <module name="org.infinispan" slot="${slot}"/>
+        <module name="org.jboss.logging"/>
+    </dependencies>
+</module>

--- a/as-modules/src/main/resources/modules/org/infinispan/cachestore/remote/main/module.xml
+++ b/as-modules/src/main/resources/modules/org/infinispan/cachestore/remote/main/module.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="org.infinispan.cachestore.remote" slot="${slot}">
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="javax.transaction.api"/>
+        <module name="org.infinispan" slot="${slot}"/>
+        <module name="org.infinispan.client.hotrod" slot="${slot}" export="true"/>
+        <module name="org.jboss.logging"/>
+    </dependencies>
+</module>

--- a/as-modules/src/main/resources/modules/org/infinispan/client/hotrod/main/module.xml
+++ b/as-modules/src/main/resources/modules/org/infinispan/client/hotrod/main/module.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="org.infinispan.client.hotrod" slot="${slot}">
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="org.apache.commons.pool"/>
+        <module name="org.infinispan" slot="${slot}"/>
+        <module name="org.jboss.logging"/>
+    </dependencies>
+</module>

--- a/as-modules/src/main/resources/modules/org/infinispan/main/module.xml
+++ b/as-modules/src/main/resources/modules/org/infinispan/main/module.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="org.infinispan" slot="${slot}">
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="javax.transaction.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="net.jcip"/>
+        <module name="org.apache.xerces" services="import"/>
+        <module name="org.jboss.jandex"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.marshalling"/>
+        <module name="org.jboss.marshalling.river" services="import"/>
+        <module name="org.jboss.staxmapper" />
+        <module name="org.jgroups" slot="${jgroups.slot}"/>
+        <module name="sun.jdk"/>
+    </dependencies>
+</module>

--- a/as-modules/src/main/resources/modules/org/infinispan/tree/main/module.xml
+++ b/as-modules/src/main/resources/modules/org/infinispan/tree/main/module.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="org.infinispan.tree" slot="${slot}">
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="org.infinispan" slot="${slot}"/>
+    </dependencies>
+</module>

--- a/as-modules/src/main/resources/modules/org/jgroups/main/module.xml
+++ b/as-modules/src/main/resources/modules/org/jgroups/main/module.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.1" name="org.jgroups" slot="${slot}">
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+    </dependencies>
+</module>

--- a/bin/release.py
+++ b/bin/release.py
@@ -328,11 +328,12 @@ def release():
   prettyprint("Step 5: Complete", Levels.INFO)
   
   prettyprint("Step 6: Uploading Artifacts", Levels.INFO)
-  do_task(upload_artifacts, [base_dir, version], async_processes)    
+  do_task(upload_artifacts, [base_dir, version], async_processes)
+  do_task(upload_artifacts, [base_dir % "as-modules", version], async_processes)
   prettyprint("Step 6: Complete", Levels.INFO)
   
   prettyprint("Step 7: Uploading to configuration XML schema", Levels.INFO)
-  do_task(upload_schema, [base_dir, version], async_processes)    
+  do_task(upload_schema, [base_dir, version], async_processes)
   prettyprint("Step 7: Complete", Levels.INFO)
 
   prettyprint("Step 8: Uploading to configuration documentation", Levels.INFO)

--- a/integrationtests/as-integration/pom.xml
+++ b/integrationtests/as-integration/pom.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-parent</artifactId>
+      <version>5.2.0-SNAPSHOT</version>
+      <relativePath>../../parent/pom.xml</relativePath>
+   </parent>
+
+   <artifactId>infinispan-as-module-integrationtests</artifactId>
+   <name>Integration tests: AS Module Integration Tests</name>
+   <description>Integration tests: AS Module Integration Tests</description>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-core</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-cachestore-jdbc</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-query</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-tree</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.jboss.arquillian.junit</groupId>
+         <artifactId>arquillian-junit-container</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.jboss.shrinkwrap.resolver</groupId>
+         <artifactId>shrinkwrap-resolver-depchain</artifactId>
+         <type>pom</type>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.jboss.shrinkwrap.resolver</groupId>
+         <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+         <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.jboss.as</groupId>
+         <artifactId>jboss-as-arquillian-container-managed</artifactId>
+         <version>${version.jboss.as}</version>
+         <scope>test</scope>
+      </dependency>
+   </dependencies>
+
+   <build>
+      <testResources>
+         <testResource>
+            <filtering>true</filtering>
+            <directory>src/test/resources</directory>
+         </testResource>
+      </testResources>
+
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <configuration>
+               <skip>true</skip>
+            </configuration>
+         </plugin>
+
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+               <!-- Force use of JUnit, since TestNG+Arquillian break in wonderful ways -->
+               <testNGArtifactName>none:none</testNGArtifactName>
+            </configuration>
+            <executions>
+               <execution>
+                  <goals>
+                     <goal>integration-test</goal>
+                     <goal>verify</goal>
+                  </goals>
+                  <configuration>
+                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+
+
+         <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>unpack</id>
+                  <phase>pre-integration-test</phase>
+                  <goals>
+                     <goal>unpack</goal>
+                  </goals>
+                  <configuration>
+                     <artifactItems>
+                        <artifactItem>
+                           <groupId>org.jboss.as</groupId>
+                           <artifactId>jboss-as-dist</artifactId>
+                           <version>${version.jboss.as}</version>
+                           <type>zip</type>
+                           <overWrite>false</overWrite>
+                           <outputDirectory>${project.build.directory}</outputDirectory>
+                        </artifactItem>
+                        <artifactItem>
+                           <groupId>org.infinispan</groupId>
+                           <artifactId>infinispan-as-modules</artifactId>
+                           <version>${project.version}</version>
+                           <type>zip</type>
+                           <overWrite>false</overWrite>
+                           <outputDirectory>${project.build.directory}/jboss-as-${version.jboss.as}</outputDirectory>
+                        </artifactItem>
+                     </artifactItems>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+               <!-- Copy the AS configuration files so we can use our custom configurations -->
+               <execution>
+                  <id>configure-as-node</id>
+                  <phase>pre-integration-test</phase>
+                  <goals>
+                     <goal>copy-resources</goal>
+                  </goals>
+                  <configuration>
+                     <outputDirectory>${basedir}/target/jboss-as-${version.jboss.as}</outputDirectory>
+                     <overwrite>true</overwrite>
+                     <resources>
+                        <resource>
+                           <directory>${basedir}/src/as7config</directory>
+                        </resource>
+                     </resources>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+      </plugins>
+   </build>
+
+</project>

--- a/integrationtests/as-integration/src/as7config/standalone/configuration/application-roles.properties
+++ b/integrationtests/as-integration/src/as7config/standalone/configuration/application-roles.properties
@@ -1,0 +1,1 @@
+guest=guest

--- a/integrationtests/as-integration/src/as7config/standalone/configuration/application-users.properties
+++ b/integrationtests/as-integration/src/as7config/standalone/configuration/application-users.properties
@@ -1,0 +1,2 @@
+#Test password for guest is "password"
+guest=3437456520927d113b17d471d630e0d6

--- a/integrationtests/as-integration/src/as7config/standalone/configuration/standalone-test.xml
+++ b/integrationtests/as-integration/src/as7config/standalone/configuration/standalone-test.xml
@@ -1,0 +1,306 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<server xmlns="urn:jboss:domain:1.2">
+    <extensions>
+        <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
+        <extension module="org.jboss.as.connector"/>
+        <extension module="org.jboss.as.deployment-scanner"/>
+        <extension module="org.jboss.as.ee"/>
+        <extension module="org.jboss.as.ejb3"/>
+        <extension module="org.jboss.as.jaxrs"/>
+        <extension module="org.jboss.as.jdr"/>
+        <extension module="org.jboss.as.jmx"/>
+        <extension module="org.jboss.as.jpa"/>
+        <extension module="org.jboss.as.logging"/>
+        <extension module="org.jboss.as.mail"/>
+        <extension module="org.jboss.as.naming"/>
+        <extension module="org.jboss.as.osgi"/>
+        <extension module="org.jboss.as.pojo"/>
+        <extension module="org.jboss.as.remoting"/>
+        <extension module="org.jboss.as.sar"/>
+        <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
+        <extension module="org.jboss.as.transactions"/>
+        <extension module="org.jboss.as.web"/>
+        <extension module="org.jboss.as.webservices"/>
+        <extension module="org.jboss.as.weld"/>
+    </extensions>
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                    <properties path="mgmt-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket-binding native="management-native"/>
+            </native-interface>
+            <http-interface security-realm="ManagementRealm">
+                <socket-binding http="management-http"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:logging:1.1">
+            <console-handler name="CONSOLE">
+                <level name="INFO"/>
+                <formatter>
+                    <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                </formatter>
+            </console-handler>
+            <periodic-rotating-file-handler name="FILE">
+                <formatter>
+                    <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="server.log"/>
+                <suffix value=".yyyy-MM-dd"/>
+                <append value="true"/>
+            </periodic-rotating-file-handler>
+            <logger category="com.arjuna">
+                <level name="WARN"/>
+            </logger>
+            <logger category="org.apache.tomcat.util.modeler">
+                <level name="WARN"/>
+            </logger>
+            <logger category="sun.rmi">
+                <level name="WARN"/>
+            </logger>
+            <logger category="jacorb">
+                <level name="WARN"/>
+            </logger>
+            <logger category="jacorb.config">
+                <level name="ERROR"/>
+            </logger>
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                    <handler name="FILE"/>
+                </handlers>
+            </root-logger>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:datasources:1.0">
+            <datasources>
+                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</connection-url>
+                    <driver>h2</driver>
+                    <security>
+                        <user-name>sa</user-name>
+                        <password>sa</password>
+                    </security>
+                </datasource>
+                <drivers>
+                    <driver name="h2" module="com.h2database.h2">
+                        <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
+                    </driver>
+                </drivers>
+            </datasources>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:deployment-scanner:1.1">
+            <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:ee:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:ejb3:1.2">
+            <session-bean>
+                <stateless>
+                    <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
+                </stateless>
+                <stateful default-access-timeout="5000" cache-ref="simple"/>
+                <singleton default-access-timeout="5000"/>
+            </session-bean>
+            <pools>
+                <bean-instance-pools>
+                    <strict-max-pool name="slsb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                    <strict-max-pool name="mdb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                </bean-instance-pools>
+            </pools>
+            <caches>
+                <cache name="simple" aliases="NoPassivationCache"/>
+                <cache name="passivating" passivation-store-ref="file" aliases="SimpleStatefulCache"/>
+            </caches>
+            <passivation-stores>
+                <file-passivation-store name="file"/>
+            </passivation-stores>
+            <async thread-pool-name="default"/>
+            <timer-service thread-pool-name="default">
+                <data-store path="timer-service-data" relative-to="jboss.server.data.dir"/>
+            </timer-service>
+            <remote connector-ref="remoting-connector" thread-pool-name="default"/>
+            <thread-pools>
+                <thread-pool name="default">
+                    <max-threads count="10"/>
+                    <keepalive-time time="100" unit="milliseconds"/>
+                </thread-pool>
+            </thread-pools>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:infinispan:1.2" default-cache-container="hibernate">
+            <cache-container name="hibernate" default-cache="local-query">
+                <local-cache name="entity">
+                    <transaction mode="NON_XA"/>
+                    <eviction strategy="LRU" max-entries="10000"/>
+                    <expiration max-idle="100000"/>
+                </local-cache>
+                <local-cache name="local-query">
+                    <transaction mode="NONE"/>
+                    <eviction strategy="LRU" max-entries="10000"/>
+                    <expiration max-idle="100000"/>
+                </local-cache>
+                <local-cache name="timestamps">
+                    <transaction mode="NONE"/>
+                    <eviction strategy="NONE"/>
+                </local-cache>
+            </cache-container>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:jca:1.1">
+            <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
+            <bean-validation enabled="true"/>
+            <default-workmanager>
+                <short-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </short-running-threads>
+                <long-running-threads>
+                    <core-threads count="50"/>
+                    <queue-length count="50"/>
+                    <max-threads count="50"/>
+                    <keepalive-time time="10" unit="seconds"/>
+                </long-running-threads>
+            </default-workmanager>
+            <cached-connection-manager/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.1">
+            <show-model value="true"/>
+            <remoting-connector/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jpa:1.0">
+            <jpa default-datasource=""/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:mail:1.0">
+            <mail-session jndi-name="java:jboss/mail/Default">
+                <smtp-server outbound-socket-binding-ref="mail-smtp"/>
+            </mail-session>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:naming:1.1"/>
+        <subsystem xmlns="urn:jboss:domain:osgi:1.2" activation="lazy">
+            <properties>
+                <!-- Specifies the beginning start level of the framework -->
+                <property name="org.osgi.framework.startlevel.beginning">1</property>
+            </properties>
+            <capabilities>
+                <!-- modules registered with the OSGi layer on startup -->
+                <capability name="javax.servlet.api:v25"/>
+                <capability name="javax.transaction.api"/>
+                <!-- bundles started in startlevel 1 -->
+                <capability name="org.apache.felix.log" startlevel="1"/>
+                <capability name="org.jboss.osgi.logging" startlevel="1"/>
+                <capability name="org.apache.felix.configadmin" startlevel="1"/>
+                <capability name="org.jboss.as.osgi.configadmin" startlevel="1"/>
+            </capabilities>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:remoting:1.1">
+            <connector name="remoting-connector" socket-binding="remoting" security-realm="ApplicationRealm"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:resource-adapters:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:security:1.1">
+            <security-domains>
+                <security-domain name="other" cache-type="default">
+                    <authentication>
+                        <login-module code="Remoting" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <login-module code="RealmUsersRoles" flag="required">
+                            <module-option name="usersProperties" value="${jboss.server.config.dir}/application-users.properties"/>
+                            <module-option name="rolesProperties" value="${jboss.server.config.dir}/application-roles.properties"/>
+                            <module-option name="realm" value="ApplicationRealm"/>
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                    </authentication>
+                </security-domain>
+                <security-domain name="jboss-web-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+                <security-domain name="jboss-ejb-policy" cache-type="default">
+                    <authorization>
+                        <policy-module code="Delegating" flag="required"/>
+                    </authorization>
+                </security-domain>
+            </security-domains>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
+        <subsystem xmlns="urn:jboss:domain:transactions:1.1">
+            <core-environment>
+                <process-id>
+                    <uuid/>
+                </process-id>
+            </core-environment>
+            <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
+            <coordinator-environment default-timeout="300"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
+            <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
+            <virtual-server name="default-host" enable-welcome-root="true">
+                <alias name="localhost"/>
+                <alias name="example.com"/>
+            </virtual-server>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:webservices:1.1">
+            <modify-wsdl-address>true</modify-wsdl-address>
+            <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
+            <endpoint-config name="Standard-Endpoint-Config"/>
+            <endpoint-config name="Recording-Endpoint-Config">
+                <pre-handler-chain name="recording-handlers" protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM">
+                    <handler name="RecordingHandler" class="org.jboss.ws.common.invocation.RecordingServerHandler"/>
+                </pre-handler-chain>
+            </endpoint-config>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:weld:1.0"/>
+    </profile>
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.bind.address:127.0.0.1}"/>
+        </interface>
+        <!-- TODO - only show this if the jacorb subsystem is added  -->
+        <interface name="unsecure">
+            <!--
+              ~  Used for IIOP sockets in the standard configuration.
+              ~                  To secure JacORB you need to setup SSL 
+              -->
+            <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
+        </interface>
+    </interfaces>
+    <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
+        <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
+        <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="ajp" port="8009"/>
+        <socket-binding name="http" port="8080"/>
+        <socket-binding name="https" port="8443"/>
+        <socket-binding name="osgi-http" interface="management" port="8090"/>
+        <socket-binding name="remoting" port="4447"/>
+        <socket-binding name="txn-recovery-environment" port="4712"/>
+        <socket-binding name="txn-status-manager" port="4713"/>
+        <outbound-socket-binding name="mail-smtp">
+            <remote-destination host="localhost" port="25"/>
+        </outbound-socket-binding>
+    </socket-binding-group>
+</server>

--- a/integrationtests/as-integration/src/test/java/org/infinispan/test/integration/as/InfinispanCacheStoreJdbcIT.java
+++ b/integrationtests/as-integration/src/test/java/org/infinispan/test/integration/as/InfinispanCacheStoreJdbcIT.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.test.integration.as;
+
+import static org.junit.Assert.assertEquals;
+
+import org.infinispan.Cache;
+import org.infinispan.Version;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.loaders.jdbc.configuration.JdbcStringBasedCacheStoreConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test the Infinispan JDBC CacheStore AS module integration
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+@RunWith(Arquillian.class)
+public class InfinispanCacheStoreJdbcIT {
+
+   @Deployment
+   public static Archive<?> deployment() {
+      WebArchive archive = ShrinkWrap.create(WebArchive.class, "jdbc.war").addClass(InfinispanCacheStoreJdbcIT.class).add(manifest(), "META-INF/MANIFEST.MF");
+      return archive;
+   }
+
+   private static Asset manifest() {
+      String manifest = Descriptors.create(ManifestDescriptor.class)
+            .attribute("Dependencies", "org.infinispan:" + Version.MAJOR_MINOR + " services, org.infinispan.cachestore.jdbc:" + Version.MAJOR_MINOR + " services").exportAsString();
+      return new StringAsset(manifest);
+   }
+
+   @Test
+   public void testCacheManager() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.loaders().addStore(JdbcStringBasedCacheStoreConfigurationBuilder.class)
+         .table()
+            .tableNamePrefix("ISPN")
+            .idColumnName("K")
+            .idColumnType("VARCHAR(255)")
+            .dataColumnName("V")
+            .dataColumnType("BLOB")
+            .timestampColumnName("T")
+            .timestampColumnType("BIGINT")
+         .dataSource().jndiUrl("java:jboss/datasources/ExampleDS");
+
+      EmbeddedCacheManager cm = new DefaultCacheManager(builder.build());
+      Cache<String, String> cache = cm.getCache();
+      cache.put("a", "a");
+      assertEquals("a", cache.get("a"));
+      cm.stop();
+   }
+
+}

--- a/integrationtests/as-integration/src/test/java/org/infinispan/test/integration/as/InfinispanCoreIT.java
+++ b/integrationtests/as-integration/src/test/java/org/infinispan/test/integration/as/InfinispanCoreIT.java
@@ -1,0 +1,72 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.test.integration.as;
+
+import org.infinispan.Cache;
+import org.infinispan.Version;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.junit.Assert.*;
+
+/**
+ * Test the Infinispan AS module integration
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+@RunWith(Arquillian.class)
+public class InfinispanCoreIT {
+
+   @Deployment
+   public static Archive<?> deployment() {
+      WebArchive archive = ShrinkWrap
+            .create(WebArchive.class, "simple.war")
+            .addClass(InfinispanCoreIT.class)
+            .add(manifest(), "META-INF/MANIFEST.MF");
+      return archive;
+   }
+
+   private static Asset manifest() {
+      String manifest = Descriptors.create(ManifestDescriptor.class).attribute("Dependencies", "org.infinispan:" + Version.MAJOR_MINOR + " services").exportAsString();
+      return new StringAsset(manifest);
+   }
+
+   @Test
+   public void testCacheManager() {
+      EmbeddedCacheManager cm = new DefaultCacheManager();
+      Cache<String, String> cache = cm.getCache();
+      cache.put("a", "a");
+      assertEquals("a", cache.get("a"));
+      cm.stop();
+   }
+
+}

--- a/integrationtests/as-integration/src/test/java/org/infinispan/test/integration/as/InfinispanTreeIT.java
+++ b/integrationtests/as-integration/src/test/java/org/infinispan/test/integration/as/InfinispanTreeIT.java
@@ -1,0 +1,79 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.test.integration.as;
+
+import org.infinispan.Cache;
+import org.infinispan.Version;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.tree.Fqn;
+import org.infinispan.tree.Node;
+import org.infinispan.tree.TreeCache;
+import org.infinispan.tree.TreeCacheFactory;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test the Infinispan AS module integration
+ *
+ * @author Tristan Tarrant
+ * @since 5.2
+ */
+@RunWith(Arquillian.class)
+public class InfinispanTreeIT {
+
+   @Deployment
+   public static Archive<?> deployment() {
+      WebArchive archive = ShrinkWrap.create(WebArchive.class, "simple.war").addClass(InfinispanTreeIT.class).add(manifest(), "META-INF/MANIFEST.MF");
+      return archive;
+   }
+
+   private static Asset manifest() {
+      String manifest = Descriptors.create(ManifestDescriptor.class)
+            .attribute("Dependencies", "org.infinispan:" + Version.MAJOR_MINOR + " service, org.infinispan.tree:" + Version.MAJOR_MINOR + " services").exportAsString();
+      return new StringAsset(manifest);
+   }
+
+   @Test
+   public void testCacheManager() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.transaction().invocationBatching().enable();
+      EmbeddedCacheManager cm = new DefaultCacheManager(builder.build());
+      Cache<String, String> cache = cm.getCache();
+      TreeCacheFactory tcf = new TreeCacheFactory();
+      TreeCache<String, String> tree = tcf.createTreeCache(cache);
+      Fqn leafFqn = Fqn.fromElements("branch", "leaf");
+      Node<String, String> leaf = tree.getRoot().addChild(leafFqn);
+      leaf.put("fruit", "orange");
+      cm.stop();
+   }
+
+}

--- a/integrationtests/as-integration/src/test/resources/arquillian.xml
+++ b/integrationtests/as-integration/src/test/resources/arquillian.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <engine>
+        <property name="deploymentExportPath">target/</property>
+    </engine>
+
+    <container qualifier="jboss" default="true">
+        <protocol type="jmx-as7">
+            <property name="executionType">REMOTE</property>
+        </protocol>
+        <configuration>
+            <property name="jbossHome">${basedir}/target/jboss-as-${version.jboss.as}</property>
+            <!-- Needed for JMS tests -->
+            <property name="serverConfig">standalone-test.xml</property>
+            <!-- To debug the Arquillian managed application server: -->
+            <!-- property name="javaVmArguments">-Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=y -Xmx512m -XX:MaxPermSize=128m</property -->
+        </configuration>
+    </container>
+
+</arquillian>

--- a/integrationtests/as-integration/src/test/resources/log4j.properties
+++ b/integrationtests/as-integration/src/test/resources/log4j.properties
@@ -1,0 +1,24 @@
+### direct log messages to stdout ###
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} (%t) %5p %c{1}:%L - %m%n
+
+### direct messages to file hibernate.log ###
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.File=hibernate.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} (%t) %5p %c{1}:%L - %m%n
+
+### direct messages to socket - chainsaw ###
+log4j.appender.socket=org.apache.log4j.net.SocketAppender
+log4j.appender.socket.remoteHost=localhost
+log4j.appender.socket.port=4560
+log4j.appender.socket.locationInfo=true
+
+### set log levels - for more verbose logging change 'info' to 'debug' ###
+
+log4j.rootLogger=warn, stdout
+log4j.logger.org.jboss=info
+
+log4j.logger.org.infinispan=info

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -97,6 +97,7 @@
    <properties>
       <buildDirectory>target</buildDirectory>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
       <defaultTestGroup>functional,unit,arquillian</defaultTestGroup>
       <testNGListener>org.infinispan.test.fwk.UnitTestTestNGListener</testNGListener>
       <infinispan.test.parallel.threads>20</infinispan.test.parallel.threads>
@@ -110,7 +111,7 @@
       <version.aesh>0.24</version.aesh>
       <version.antlr>3.4</version.antlr>
       <version.apacheds.jdbm>1.5.7</version.apacheds.jdbm>
-      <version.arquillian>1.0.0.Final</version.arquillian>
+      <version.arquillian>1.0.3.Final</version.arquillian>
       <version.arquillian.container.weld>1.0.0.CR3</version.arquillian.container.weld>
       <version.avro>1.3.3</version.avro>
       <version.bdbje>5.0.34</version.bdbje>
@@ -139,6 +140,7 @@
       <version.javax.persistence>1.0</version.javax.persistence>
       <version.javax.servlet>2.5</version.javax.servlet>
       <version.jboss.marshalling>1.3.15.GA</version.jboss.marshalling>
+      <version.jboss.as>7.1.1.Final</version.jboss.as>
       <version.jbossjta>4.16.3.Final</version.jbossjta>
       <version.osgi>4.3.0</version.osgi>
       <version.jboss.logging>3.1.1.GA</version.jboss.logging>
@@ -167,11 +169,13 @@
       <version.rhq.helpers>3.0.4</version.rhq.helpers>
       <version.rhq>4.2.0</version.rhq>
       <version.scala>2.10.0</version.scala>
+      <version.shrinkwrapResolver>2.0.0-alpha-6</version.shrinkwrapResolver>
       <version.slf4j>1.6.4</version.slf4j>
       <version.solder>3.1.0.Final</version.solder>
       <version.spring>3.1.0.RELEASE</version.spring>
       <version.spymemcached>2.5</version.spymemcached>
-      <version.testng>6.7</version.testng>
+      <version.testng>6.8</version.testng>
+      <version.testng.arquillian>6.5.2</version.testng.arquillian>
       <version.webdav.servlet>2.0.1</version.webdav.servlet>
       <version.weld>1.1.8.Final</version.weld>
       <version.xstream>1.4.1</version.xstream>
@@ -182,12 +186,14 @@
       <version.maven.bundle>2.3.7</version.maven.bundle>
       <version.maven.source>2.2.1</version.maven.source>
       <version.maven.scala>2.15.2</version.maven.scala>
+      <version.maven.surefire>2.12.4</version.maven.surefire>
       <version.jacoco>0.5.10.201208310627</version.jacoco>
       <version.asm>3.3.1</version.asm>
       <reportTitle>Infinispan JaCoCo Report</reportTitle>
       <dir.ispn>../</dir.ispn>
       <dir.report>../jacoco-html</dir.report>
    </properties>
+   
    <dependencyManagement>
       <dependencies>
          <dependency>
@@ -290,6 +296,11 @@
          <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>infinispan-tools</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>infinispan-tree</artifactId>
             <version>${project.version}</version>
          </dependency>
          <dependency>
@@ -597,6 +608,13 @@
             <artifactId>arquillian-weld-ee-embedded-1.1</artifactId>
             <version>${version.arquillian.container.weld}</version>
             <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-bom</artifactId>
+            <version>${version.shrinkwrapResolver}</version>
+            <type>pom</type>
+            <scope>import</scope>
          </dependency>
          <dependency>
             <groupId>org.jboss.spec.javax.transaction</groupId>
@@ -1117,6 +1135,11 @@
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-failsafe-plugin</artifactId>
+               <version>${version.maven.surefire}</version>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-javadoc-plugin</artifactId>
                <version>2.9</version>
             </plugin>
@@ -1135,7 +1158,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-plugin</artifactId>
-               <version>2.12.4</version>
+               <version>${version.maven.surefire}</version>
             </plugin>
             <plugin>
                <artifactId>maven-war-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
       <relativePath>parent/pom.xml</relativePath>
    </parent>
 
-   <groupId>org.infinispan</groupId>
    <artifactId>infinispan</artifactId>
 
    <name>Infinispan Distribution</name>
@@ -78,7 +77,9 @@
       <module>demos/nearcache-client</module>
       <module>cdi/extension</module>
       <module>cdi/tck-runner</module>
+      <module>as-modules</module>
       <module>integrationtests/luceneintegration</module>
+      <module>integrationtests/as-integration</module>
    </modules>
 
    <profiles>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2683

This currently contains: core, cachestore-jdbc, cachestore-remote, hotrod-client, tree and jgroups.
The modules are packaged in a 5.2 slot as not to overwrite the AS's own instance of Infinispan (which obviously is used internally for clustering + caching)
