### PR TITLE
ISPN-2366 Rename state transfer config option 'waitForInitialStateTransf...

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfiguration.java
@@ -30,17 +30,17 @@ public class StateTransferConfiguration {
    private Boolean originalFetchInMemoryState;
    private long timeout;
    private int chunkSize;
-   private boolean waitForInitialStateTransferToComplete;
-   private Boolean originalWaitForInitialStateTransferToComplete;
+   private boolean awaitInitialTransfer;
+   private Boolean originalAwaitInitialTransfer;
 
    StateTransferConfiguration(boolean fetchInMemoryState, Boolean originalFetchInMemoryState, long timeout, int chunkSize,
-                              boolean waitForInitialStateTransferToComplete, Boolean originalWaitForInitialStateTransferToComplete) {
+                              boolean awaitInitialTransfer, Boolean originalAwaitInitialTransfer) {
       this.fetchInMemoryState = fetchInMemoryState;
       this.originalFetchInMemoryState = originalFetchInMemoryState;
       this.timeout = timeout;
       this.chunkSize = chunkSize;
-      this.waitForInitialStateTransferToComplete = waitForInitialStateTransferToComplete;
-      this.originalWaitForInitialStateTransferToComplete = originalWaitForInitialStateTransferToComplete;
+      this.awaitInitialTransfer = awaitInitialTransfer;
+      this.originalAwaitInitialTransfer = originalAwaitInitialTransfer;
    }
 
    /**
@@ -88,19 +88,22 @@ public class StateTransferConfiguration {
    }
 
    /**
-    * If {@code true}, the {@code CacheManager.getCache()} call will not return until state transfer is complete for
-    * this cache on the current node, ie. its {@code DataContainer} has finished receiving the entries it should hold
-    * according to the new {@code ConsistentHash}. This option is only available in clustered mode and the default value is {@code true}.
+    * If {@code true}, this will cause the first call to method {@code CacheManager.getCache()} on the joiner node to
+    * block and wait until the joining is complete and the cache has finished receiving state from neighboring caches
+    * (if fetchInMemoryState is enabled). This option applies to distributed and replicated caches only and is enabled
+    * by default. Please note that setting this to {@code false} will make the cache object available immediately but
+    * any access to keys that should be available locally but are not yet transferred will actually cause a (transparent)
+    * remote access. While this will not have any impact on the logic of your application it might impact performance.
     */
-   public boolean waitForInitialStateTransferToComplete() {
-      return waitForInitialStateTransferToComplete;
+   public boolean awaitInitialTransfer() {
+      return awaitInitialTransfer;
    }
 
    /**
-    * We want to remember if the user didn't configure waitForInitialStateTransferToComplete for the default cache.
+    * We want to remember if the user didn't configure awaitInitialTransfer for the default cache.
     */
-   protected Boolean originalWaitForInitialStateTransferToComplete() {
-      return originalWaitForInitialStateTransferToComplete;
+   protected Boolean originalAwaitInitialTransfer() {
+      return originalAwaitInitialTransfer;
    }
 
    @Override
@@ -110,8 +113,8 @@ public class StateTransferConfiguration {
             ", fetchInMemoryState=" + fetchInMemoryState +
             ", originalFetchInMemoryState=" + originalFetchInMemoryState +
             ", timeout=" + timeout +
-            ", waitForInitialStateTransferToComplete=" + waitForInitialStateTransferToComplete +
-            ", originalWaitForInitialStateTransferToComplete=" + originalWaitForInitialStateTransferToComplete +
+            ", awaitInitialTransfer=" + awaitInitialTransfer +
+            ", originalAwaitInitialTransfer=" + originalAwaitInitialTransfer +
             '}';
    }
 
@@ -127,8 +130,8 @@ public class StateTransferConfiguration {
       if (timeout != that.timeout) return false;
       if (originalFetchInMemoryState != null ? !originalFetchInMemoryState.equals(that.originalFetchInMemoryState) : that.originalFetchInMemoryState != null)
          return false;
-      if (waitForInitialStateTransferToComplete != that.waitForInitialStateTransferToComplete) return false;
-      if (originalWaitForInitialStateTransferToComplete != null ? !originalWaitForInitialStateTransferToComplete.equals(that.originalWaitForInitialStateTransferToComplete) : that.originalWaitForInitialStateTransferToComplete != null)
+      if (awaitInitialTransfer != that.awaitInitialTransfer) return false;
+      if (originalAwaitInitialTransfer != null ? !originalAwaitInitialTransfer.equals(that.originalAwaitInitialTransfer) : that.originalAwaitInitialTransfer != null)
          return false;
 
       return true;
@@ -140,8 +143,8 @@ public class StateTransferConfiguration {
       result = 31 * result + (originalFetchInMemoryState != null ? originalFetchInMemoryState.hashCode() : 0);
       result = 31 * result + (int) (timeout ^ (timeout >>> 32));
       result = 31 * result + chunkSize;
-      result = 31 * result + (waitForInitialStateTransferToComplete ? 1 : 0);
-      result = 31 * result + (originalWaitForInitialStateTransferToComplete != null ? originalWaitForInitialStateTransferToComplete.hashCode() : 0);
+      result = 31 * result + (awaitInitialTransfer ? 1 : 0);
+      result = 31 * result + (originalAwaitInitialTransfer != null ? originalAwaitInitialTransfer.hashCode() : 0);
       return result;
    }
 

--- a/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
@@ -53,7 +53,7 @@ public enum Attribute {
     FACTORY("factory"),
     FETCH_IN_MEMORY_STATE("fetchInMemoryState"),
     FETCH_PERSISTENT_STATE("fetchPersistentState"),
-    WAIT_FOR_INITIAL_STATE_TRANSFER_TO_COMPLETE("waitForInitialStateTransferToComplete"),
+    AWAIT_INITIAL_TRANSFER("awaitInitialTransfer"),
     FLUSH_LOCK_TIMEOUT("flushLockTimeout"),
     FSYNC_INTERVAL("fsyncInterval"),
     FSYNC_MODE("fsyncMode"),

--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser52.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser52.java
@@ -1310,8 +1310,8 @@ public class Parser52 implements ConfigurationParser<ConfigurationBuilderHolder>
             case FETCH_IN_MEMORY_STATE:
                builder.clustering().stateTransfer().fetchInMemoryState(Boolean.parseBoolean(value));
                break;
-            case WAIT_FOR_INITIAL_STATE_TRANSFER_TO_COMPLETE:
-               builder.clustering().stateTransfer().waitForInitialStateTransferToComplete(Boolean.parseBoolean(value));
+            case AWAIT_INITIAL_TRANSFER:
+               builder.clustering().stateTransfer().awaitInitialTransfer(Boolean.parseBoolean(value));
                break;
             case TIMEOUT:
                builder.clustering().stateTransfer().timeout(Long.parseLong(value));

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -206,7 +206,7 @@ public class StateTransferManagerImpl implements StateTransferManager {
    @Start(priority = 1000)
    @SuppressWarnings("unused")
    public void waitForInitialStateTransferToComplete() throws InterruptedException {
-      if (configuration.clustering().stateTransfer().waitForInitialStateTransferToComplete()) {
+      if (configuration.clustering().stateTransfer().awaitInitialTransfer()) {
          if (trace) log.tracef("Waiting for initial state transfer to finish for cache %s on %s", cacheName, rpcManager.getAddress());
          boolean success = initialStateTransferComplete.await(configuration.clustering().stateTransfer().timeout(), TimeUnit.MILLISECONDS);
          if (!success) {

--- a/core/src/main/resources/schema/infinispan-config-5.2.xsd
+++ b/core/src/main/resources/schema/infinispan-config-5.2.xsd
@@ -805,11 +805,13 @@
                     </xs:documentation>
                   </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="waitForInitialStateTransferToComplete" type="xs:boolean">
+                <xs:attribute name="awaitInitialTransfer" type="xs:boolean">
                   <xs:annotation>
                     <xs:documentation>
-                       If true, this will cause the first call to method CacheManager.getCache() on a joiner node to block and wait until the joining is complete and the node has finished receiving state from neighboring caches (if fetchInMemoryState is enabled).
-                       This option applies to distributed and replicated caches only and is enabled by default.
+                       If true, this will cause the first call to method CacheManager.getCache() on the joiner node to block and wait until the joining is complete and the cache has finished
+                       receiving state from neighboring caches (if fetchInMemoryState is enabled). This option applies to distributed and replicated caches only and is enabled by default.
+                       Please note that setting this to false will make the cache object available immediately but any access to keys that should be available locally but are not yet transferred
+                       will actually cause a (transparent) remote access. While this will not have any impact on the logic of your application it might impact performance.
                     </xs:documentation>
                   </xs:annotation>
                 </xs:attribute>

--- a/core/src/test/java/org/infinispan/statetransfer/BaseDistStateTransferConsistencyTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/BaseDistStateTransferConsistencyTest.java
@@ -92,7 +92,7 @@ public abstract class BaseDistStateTransferConsistencyTest extends MultipleCache
       }
 
       builder.clustering().hash().numSegments(10).numOwners(2).l1().disable().onRehash(false).locking().lockAcquisitionTimeout(1000l);
-      builder.clustering().stateTransfer().fetchInMemoryState(true).waitForInitialStateTransferToComplete(false);
+      builder.clustering().stateTransfer().fetchInMemoryState(true).awaitInitialTransfer(false);
 
       createCluster(builder, 3);
       waitForClusterToForm();

--- a/core/src/test/java/org/infinispan/statetransfer/BaseReplStateTransferConsistencyTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/BaseReplStateTransferConsistencyTest.java
@@ -97,7 +97,7 @@ public abstract class BaseReplStateTransferConsistencyTest extends MultipleCache
 
       cacheConfigBuilder.clustering().l1().disable().onRehash(false).locking().lockAcquisitionTimeout(1000l);
       cacheConfigBuilder.clustering().hash().numSegments(10)
-            .stateTransfer().fetchInMemoryState(true).waitForInitialStateTransferToComplete(false);
+            .stateTransfer().fetchInMemoryState(true).awaitInitialTransfer(false);
 
       createCluster(cacheConfigBuilder, 2);
       waitForClusterToForm();


### PR DESCRIPTION
...erToComplete' to 'awaitInitialTransfer'

The previous name introduced in Beta6 was quite horrible, so let's fix this before the final release

Also revised javadoc and XSD documentation to higlight consequences of turning it off.

JIRA: https://issues.jboss.org/browse/ISPN-2366
