### PR TITLE
ISPN-2611 + ISPN-2745 Drop rhq-pluginAnnotations and rhq-pluginGen / Add missing ops

### DIFF
--- a/core/src/main/java/org/infinispan/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/CacheImpl.java
@@ -59,6 +59,8 @@ import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.SurvivesRestarts;
 import org.infinispan.interceptors.InterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
+import org.infinispan.jmx.annotations.DataType;
+import org.infinispan.jmx.annotations.DisplayType;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
@@ -83,10 +85,6 @@ import org.infinispan.util.concurrent.NotifyingFutureAdaptor;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.rhq.helpers.pluginAnnotations.agent.DataType;
-import org.rhq.helpers.pluginAnnotations.agent.DisplayType;
-import org.rhq.helpers.pluginAnnotations.agent.Metric;
-import org.rhq.helpers.pluginAnnotations.agent.Operation;
 
 import javax.transaction.InvalidTransactionException;
 import javax.transaction.SystemException;
@@ -311,8 +309,10 @@ public class CacheImpl<K, V> extends CacheSupport<K, V> implements AdvancedCache
    }
 
    @Override
-   @ManagedOperation(description = "Clears the cache.")
-   @Operation(displayName = "Clears the cache.")
+   @ManagedOperation(
+         description = "Clears the cache.",
+         displayName = "Clears the cache."
+   )
    public final void clear() {
       clear(null, null);
    }
@@ -551,8 +551,10 @@ public class CacheImpl<K, V> extends CacheSupport<K, V> implements AdvancedCache
    }
 
    @Override
-   @ManagedOperation(description = "Starts the cache.")
-   @Operation(displayName = "Starts cache.")
+   @ManagedOperation(
+         description = "Starts the cache.",
+         displayName = "Starts cache."
+   )
    public void start() {
       componentRegistry.start();
       defaultLifespan = config.expiration().lifespan();
@@ -566,8 +568,10 @@ public class CacheImpl<K, V> extends CacheSupport<K, V> implements AdvancedCache
    }
 
    @Override
-   @ManagedOperation(description = "Stops the cache.")
-   @Operation(displayName = "Stops cache.")
+   @ManagedOperation(
+         description = "Stops the cache.",
+         displayName = "Stops cache."
+   )
    public void stop() {
       stop(null);
    }
@@ -631,8 +635,12 @@ public class CacheImpl<K, V> extends CacheSupport<K, V> implements AdvancedCache
     * Returns String representation of ComponentStatus enumeration in order to avoid class not found exceptions in JMX
     * tools that don't have access to infinispan classes.
     */
-   @ManagedAttribute(description = "Returns the cache status")
-   @Metric(displayName = "Cache status", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Returns the cache status",
+         displayName = "Cache status",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY
+   )
    public String getCacheStatus() {
       return getStatus().toString();
    }
@@ -661,8 +669,12 @@ public class CacheImpl<K, V> extends CacheSupport<K, V> implements AdvancedCache
    /**
     * Returns the cache name. If this is the default cache, it returns a more friendly name.
     */
-   @ManagedAttribute(description = "Returns the cache name")
-   @Metric(displayName = "Cache name", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Returns the cache name",
+         displayName = "Cache name",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY
+   )
    public String getCacheName() {
       String name = getName().equals(CacheContainer.DEFAULT_CACHE_NAME) ? "Default Cache" : getName();
       return name + "(" + getConfiguration().getCacheModeString().toLowerCase() + ")";
@@ -671,8 +683,12 @@ public class CacheImpl<K, V> extends CacheSupport<K, V> implements AdvancedCache
    /**
     * Returns the cache configuration as XML string.
     */
-   @ManagedAttribute(description = "Returns the cache configuration as XML string")
-   @Metric(displayName = "Cache configuration (XML)", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Returns the cache configuration as XML string",
+         displayName = "Cache configuration (XML)",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY
+   )
    public String getConfigurationAsXmlString() {
       return getConfiguration().toXmlString();
    }

--- a/core/src/main/java/org/infinispan/distribution/DistributionManagerImpl.java
+++ b/core/src/main/java/org/infinispan/distribution/DistributionManagerImpl.java
@@ -36,6 +36,7 @@ import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.jmx.annotations.Parameter;
 import org.infinispan.statetransfer.StateTransferManager;
 import org.infinispan.remoting.responses.ClusteredGetResponseValidityFilter;
 import org.infinispan.remoting.responses.Response;
@@ -49,9 +50,6 @@ import org.infinispan.util.Immutables;
 import org.infinispan.util.InfinispanCollections;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.rhq.helpers.pluginAnnotations.agent.Operation;
-import org.rhq.helpers.pluginAnnotations.agent.Parameter;
-
 import java.util.*;
 
 /**
@@ -180,18 +178,22 @@ public class DistributionManagerImpl implements DistributionManager {
       return getWriteConsistentHash();
    }
 
+   @Override
    public ConsistentHash getReadConsistentHash() {
       return stateTransferManager.getCacheTopology().getReadConsistentHash();
    }
 
+   @Override
    public ConsistentHash getWriteConsistentHash() {
       return stateTransferManager.getCacheTopology().getWriteConsistentHash();
    }
 
    // TODO Move these methods to the StateTransferManager interface so we can eliminate the dependency
    @Override
-   @ManagedOperation(description = "Determines whether a given key is affected by an ongoing rehash, if any.")
-   @Operation(displayName = "Could key be affected by rehash?")
+   @ManagedOperation(
+         description = "Determines whether a given key is affected by an ongoing rehash, if any.",
+         displayName = "Could key be affected by rehash?"
+   )
    public boolean isAffectedByRehash(@Parameter(name = "key", description = "Key to check") Object key) {
       return stateTransferManager.isStateTransferInProgressForKey(key);
    }
@@ -221,14 +223,18 @@ public class DistributionManagerImpl implements DistributionManager {
       return Immutables.immutableListConvert(an);
    }
 
-   @ManagedOperation(description = "Tells you whether a given key is local to this instance of the cache.  Only works with String keys.")
-   @Operation(displayName = "Is key local?")
+   @ManagedOperation(
+         description = "Tells you whether a given key is local to this instance of the cache.  Only works with String keys.",
+         displayName = "Is key local?"
+   )
    public boolean isLocatedLocally(@Parameter(name = "key", description = "Key to query") String key) {
       return getLocality(key).isLocal();
    }
 
-   @ManagedOperation(description = "Locates an object in a cluster.  Only works with String keys.")
-   @Operation(displayName = "Locate key")
+   @ManagedOperation(
+         description = "Locates an object in a cluster.  Only works with String keys.",
+         displayName = "Locate key"
+   )
    public List<String> locateKey(@Parameter(name = "key", description = "Key to locate") String key) {
       List<String> l = new LinkedList<String>();
       for (Address a : locate(key)) l.add(a.toString());

--- a/core/src/main/java/org/infinispan/eviction/ActivationManagerImpl.java
+++ b/core/src/main/java/org/infinispan/eviction/ActivationManagerImpl.java
@@ -30,15 +30,12 @@ import org.infinispan.factories.annotations.Start;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.jmx.annotations.MeasurementType;
 import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.loaders.CacheLoaderManager;
 import org.infinispan.loaders.CacheStore;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.rhq.helpers.pluginAnnotations.agent.MeasurementType;
-import org.rhq.helpers.pluginAnnotations.agent.Metric;
-import org.rhq.helpers.pluginAnnotations.agent.Operation;
-
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -103,10 +100,11 @@ public class ActivationManagerImpl implements ActivationManager {
       return activations.get();
    }
 
-   @ManagedAttribute(description = "Number of activation events")
-   @Metric(displayName = "Number of cache entries activated",
-         measurementType = MeasurementType.TRENDSUP)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(
+         description = "Number of activation events",
+         displayName = "Number of cache entries activated",
+         measurementType = MeasurementType.TRENDSUP
+   )
    public String getActivations() {
       if (!statisticsEnabled)
          return "N/A";
@@ -114,8 +112,10 @@ public class ActivationManagerImpl implements ActivationManager {
       return String.valueOf(getActivationCount());
    }
 
-   @ManagedOperation(description = "Resets statistics gathered by this component")
-   @Operation(displayName = "Reset statistics")
+   @ManagedOperation(
+         description = "Resets statistics gathered by this component",
+         displayName = "Reset statistics"
+   )
    public void resetStatistics() {
       activations.set(0);
    }

--- a/core/src/main/java/org/infinispan/interceptors/CacheLoaderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheLoaderInterceptor.java
@@ -38,9 +38,12 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.interceptors.base.JmxStatsCommandInterceptor;
+import org.infinispan.jmx.annotations.DisplayType;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.jmx.annotations.MeasurementType;
+import org.infinispan.jmx.annotations.Parameter;
 import org.infinispan.loaders.CacheLoader;
 import org.infinispan.loaders.CacheLoaderManager;
 import org.infinispan.loaders.CacheStore;
@@ -49,10 +52,6 @@ import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.util.InfinispanCollections;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.rhq.helpers.pluginAnnotations.agent.DisplayType;
-import org.rhq.helpers.pluginAnnotations.agent.MeasurementType;
-import org.rhq.helpers.pluginAnnotations.agent.Metric;
-import org.rhq.helpers.pluginAnnotations.agent.Operation;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -235,28 +234,38 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
       }
    }
 
-   @ManagedAttribute(description = "Number of entries loaded from cache store")
-   @Metric(displayName = "Number of cache store loads", measurementType = MeasurementType.TRENDSUP)
+   @ManagedAttribute(
+         description = "Number of entries loaded from cache store",
+         displayName = "Number of cache store loads",
+         measurementType = MeasurementType.TRENDSUP
+   )
    public long getCacheLoaderLoads() {
       return cacheLoads.get();
    }
 
-   @ManagedAttribute(description = "Number of entries that did not exist in cache store")
-   @Metric(displayName = "Number of cache store load misses", measurementType = MeasurementType.TRENDSUP)
+   @ManagedAttribute(
+         description = "Number of entries that did not exist in cache store",
+         displayName = "Number of cache store load misses",
+         measurementType = MeasurementType.TRENDSUP
+   )
    public long getCacheLoaderMisses() {
       return cacheMisses.get();
    }
 
    @Override
-   @ManagedOperation(description = "Resets statistics gathered by this component")
-   @Operation(displayName = "Reset Statistics")
+   @ManagedOperation(
+         description = "Resets statistics gathered by this component",
+         displayName = "Reset Statistics"
+   )
    public void resetStatistics() {
       cacheLoads.set(0);
       cacheMisses.set(0);
    }
 
-   @ManagedAttribute(description = "Returns a collection of cache loader types which configured and enabled")
-   @Metric(displayName = "Returns a collection of cache loader types which configured and enabled", displayType = DisplayType.DETAIL)
+   @ManagedAttribute(
+         description = "Returns a collection of cache loader types which configured and enabled",
+         displayName = "Returns a collection of cache loader types which configured and enabled",
+         displayType = DisplayType.DETAIL)
    /**
     * This method returns a collection of cache loader types (fully qualified class names) that are configured and enabled.
     */
@@ -275,8 +284,10 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
          return InfinispanCollections.emptySet();
       }
    }
-   @ManagedOperation(description = "Disable all cache loaders of a given type, where type is a fully qualified class name of the cache loader to disable")
-   @Operation(displayName = "Disable all cache loaders of a given type")
+   @ManagedOperation(
+         description = "Disable all cache loaders of a given type, where type is a fully qualified class name of the cache loader to disable",
+         displayName = "Disable all cache loaders of a given type"
+   )
    /**
     * Disables a cache loader of a given type, where type is the fully qualified class name of a {@link CacheLoader} implementation.
     *
@@ -285,7 +296,7 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
     *
     * @param loaderType fully qualified class name of the cache loader type to disable
     */
-   public void disableCacheLoader(String loaderType) {
+   public void disableCacheLoader(@Parameter(name="loaderType", description="Fully qualified class name of a CacheLoader implementation") String loaderType) {
       if (enabled) clm.disableCacheStore(loaderType);
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/CacheMgmtInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheMgmtInterceptor.java
@@ -31,16 +31,14 @@ import org.infinispan.container.DataContainer;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.interceptors.base.JmxStatsCommandInterceptor;
+import org.infinispan.jmx.annotations.DisplayType;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.jmx.annotations.MeasurementType;
+import org.infinispan.jmx.annotations.Units;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.rhq.helpers.pluginAnnotations.agent.DisplayType;
-import org.rhq.helpers.pluginAnnotations.agent.MeasurementType;
-import org.rhq.helpers.pluginAnnotations.agent.Metric;
-import org.rhq.helpers.pluginAnnotations.agent.Operation;
-import org.rhq.helpers.pluginAnnotations.agent.Units;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -147,44 +145,71 @@ public class CacheMgmtInterceptor extends JmxStatsCommandInterceptor {
       return retval;
    }
 
-   @ManagedAttribute(description = "Number of cache attribute hits")
-   @Metric(displayName = "Number of cache hits", measurementType = MeasurementType.TRENDSUP, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Number of cache attribute hits",
+         displayName = "Number of cache hits",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY)
    public long getHits() {
       return hits.get();
    }
 
-   @ManagedAttribute(description = "Number of cache attribute misses")
-   @Metric(displayName = "Number of cache misses", measurementType = MeasurementType.TRENDSUP, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Number of cache attribute misses",
+         displayName = "Number of cache misses",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
    public long getMisses() {
       return misses.get();
    }
 
-   @ManagedAttribute(description = "Number of cache removal hits")
-   @Metric(displayName = "Number of cache removal hits", measurementType = MeasurementType.TRENDSUP, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Number of cache removal hits",
+         displayName = "Number of cache removal hits",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
    public long getRemoveHits() {
       return removeHits.get();
    }
 
-   @ManagedAttribute(description = "Number of cache removals where keys were not found")
-   @Metric(displayName = "Number of cache removal misses", measurementType = MeasurementType.TRENDSUP, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Number of cache removals where keys were not found",
+         displayName = "Number of cache removal misses",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
    public long getRemoveMisses() {
       return removeMisses.get();
    }
 
-   @ManagedAttribute(description = "number of cache attribute put operations")
-   @Metric(displayName = "Number of cache puts" , measurementType = MeasurementType.TRENDSUP, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "number of cache attribute put operations",
+         displayName = "Number of cache puts" ,
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
    public long getStores() {
       return stores.get();
    }
 
-   @ManagedAttribute(description = "Number of cache eviction operations")
-   @Metric(displayName = "Number of cache evictions", measurementType = MeasurementType.TRENDSUP, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Number of cache eviction operations",
+         displayName = "Number of cache evictions",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
    public long getEvictions() {
       return evictions.get();
    }
 
-   @ManagedAttribute(description = "Percentage hit/(hit+miss) ratio for the cache")
-   @Metric(displayName = "Hit ratio", units = Units.PERCENTAGE, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Percentage hit/(hit+miss) ratio for the cache",
+         displayName = "Hit ratio",
+         units = Units.PERCENTAGE,
+         displayType = DisplayType.SUMMARY
+   )
    @SuppressWarnings("unused")
    public double getHitRatio() {
       long hitsL = hits.get();
@@ -196,8 +221,12 @@ public class CacheMgmtInterceptor extends JmxStatsCommandInterceptor {
       return (hitsL / total);
    }
 
-   @ManagedAttribute(description = "read/writes ratio for the cache")
-   @Metric(displayName = "Read/write ratio", units = Units.PERCENTAGE, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "read/writes ratio for the cache",
+         displayName = "Read/write ratio",
+         units = Units.PERCENTAGE,
+         displayType = DisplayType.SUMMARY
+   )
    @SuppressWarnings("unused")
    public double getReadWriteRatio() {
       if (stores.get() == 0)
@@ -205,8 +234,12 @@ public class CacheMgmtInterceptor extends JmxStatsCommandInterceptor {
       return (((double) (hits.get() + misses.get()) / (double) stores.get()));
    }
 
-   @ManagedAttribute(description = "Average number of milliseconds for a read operation on the cache")
-   @Metric(displayName = "Average read time", units = Units.MILLISECONDS, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Average number of milliseconds for a read operation on the cache",
+         displayName = "Average read time",
+         units = Units.MILLISECONDS,
+         displayType = DisplayType.SUMMARY
+   )
    @SuppressWarnings("unused")
    public long getAverageReadTime() {
       long total = hits.get() + misses.get();
@@ -215,8 +248,12 @@ public class CacheMgmtInterceptor extends JmxStatsCommandInterceptor {
       return (hitTimes.get() + missTimes.get()) / total;
    }
 
-   @ManagedAttribute(description = "Average number of milliseconds for a write operation in the cache")
-   @Metric(displayName = "Average write time", units = Units.MILLISECONDS, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Average number of milliseconds for a write operation in the cache",
+         displayName = "Average write time",
+         units = Units.MILLISECONDS,
+         displayType = DisplayType.SUMMARY
+   )
    @SuppressWarnings("unused")
    public long getAverageWriteTime() {
       if (stores.get() == 0)
@@ -224,28 +261,42 @@ public class CacheMgmtInterceptor extends JmxStatsCommandInterceptor {
       return (storeTimes.get()) / stores.get();
    }
 
-   @ManagedAttribute(description = "Number of entries currently in the cache")
-   @Metric(displayName = "Number of current cache entries", displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Number of entries currently in the cache",
+         displayName = "Number of current cache entries",
+         displayType = DisplayType.SUMMARY
+   )
    public int getNumberOfEntries() {
       return dataContainer.size();
    }
 
-   @ManagedAttribute(description = "Number of seconds since cache started")
-   @Metric(displayName = "Seconds since cache started", units = Units.SECONDS, measurementType = MeasurementType.TRENDSUP, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Number of seconds since cache started",
+         displayName = "Seconds since cache started",
+         units = Units.SECONDS,
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
    public long getElapsedTime() {
       return TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startNanoseconds.get());
    }
 
-   @ManagedAttribute(description = "Number of seconds since the cache statistics were last reset")
-   @Metric(displayName = "Seconds since cache statistics were reset", units = Units.SECONDS, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Number of seconds since the cache statistics were last reset",
+         displayName = "Seconds since cache statistics were reset",
+         units = Units.SECONDS,
+         displayType = DisplayType.SUMMARY
+   )
    @SuppressWarnings("unused")
    public long getTimeSinceReset() {
       return TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - resetNanoseconds.get());
    }
 
    @Override
-   @ManagedOperation(description = "Resets statistics gathered by this component")
-   @Operation(displayName = "Reset Statistics (Statistics)")
+   @ManagedOperation(
+         description = "Resets statistics gathered by this component",
+         displayName = "Reset Statistics (Statistics)"
+   )
    public void resetStatistics() {
       hits.set(0);
       misses.set(0);

--- a/core/src/main/java/org/infinispan/interceptors/CacheStoreInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheStoreInterceptor.java
@@ -45,6 +45,7 @@ import org.infinispan.interceptors.base.JmxStatsCommandInterceptor;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.jmx.annotations.MeasurementType;
 import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.loaders.CacheLoaderManager;
 import org.infinispan.loaders.CacheStore;
@@ -56,9 +57,6 @@ import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.concurrent.ConcurrentMapFactory;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.rhq.helpers.pluginAnnotations.agent.MeasurementType;
-import org.rhq.helpers.pluginAnnotations.agent.Metric;
-import org.rhq.helpers.pluginAnnotations.agent.Operation;
 
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
@@ -381,15 +379,20 @@ public class CacheStoreInterceptor extends JmxStatsCommandInterceptor {
    }
 
    @Override
-   @ManagedOperation(description = "Resets statistics gathered by this component")
-   @Operation(displayName = "Reset statistics")
+   @ManagedOperation(
+         description = "Resets statistics gathered by this component",
+         displayName = "Reset statistics"
+   )
    public void resetStatistics() {
       cacheStores.set(0);
    }
 
-   @ManagedAttribute(description = "number of cache loader stores")
-   @Metric(displayName = "Number of cache stores", measurementType = MeasurementType.TRENDSUP)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(
+         description = "number of cache loader stores",
+         displayName = "Number of cache stores",
+         measurementType = MeasurementType.TRENDSUP
+   )
+
    public long getCacheLoaderStores() {
       return cacheStores.get();
    }

--- a/core/src/main/java/org/infinispan/interceptors/InvalidationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/InvalidationInterceptor.java
@@ -22,6 +22,14 @@
  */
 package org.infinispan.interceptors;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.transaction.Transaction;
+
 import org.infinispan.commands.AbstractVisitor;
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.FlagAffectedCommand;
@@ -41,26 +49,17 @@ import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.interceptors.base.BaseRpcInterceptor;
+import org.infinispan.jmx.annotations.DataType;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.jmx.annotations.MeasurementType;
+import org.infinispan.jmx.annotations.Parameter;
 import org.infinispan.util.InfinispanCollections;
 import org.infinispan.util.concurrent.NotifyingFutureImpl;
 import org.infinispan.util.concurrent.NotifyingNotifiableFuture;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.rhq.helpers.pluginAnnotations.agent.DataType;
-import org.rhq.helpers.pluginAnnotations.agent.MeasurementType;
-import org.rhq.helpers.pluginAnnotations.agent.Metric;
-import org.rhq.helpers.pluginAnnotations.agent.Operation;
-import org.rhq.helpers.pluginAnnotations.agent.Parameter;
-
-import javax.transaction.Transaction;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 
 
 /**
@@ -161,7 +160,7 @@ public class InvalidationInterceptor extends BaseRpcInterceptor {
       }
       return retVal;
    }
-   
+
    private Object handleInvalidate(InvocationContext ctx, WriteCommand command, Object... keys) throws Throwable {
       Object retval = invokeNextInterceptor(ctx, command);
       if (command.isSuccessful() && !ctx.isInTxScope()) {
@@ -258,24 +257,34 @@ public class InvalidationInterceptor extends BaseRpcInterceptor {
       return false;
    }
 
-   @ManagedOperation(description = "Resets statistics gathered by this component")
-   @Operation(displayName = "Reset statistics")
+   @ManagedOperation(
+         description = "Resets statistics gathered by this component",
+         displayName = "Reset statistics"
+   )
    public void resetStatistics() {
       invalidations.set(0);
    }
 
-   @Metric(displayName = "Statistics enabled", dataType = DataType.TRAIT)
+   @ManagedAttribute(
+         displayName = "Statistics enabled",
+         dataType = DataType.TRAIT
+   )
    public boolean getStatisticsEnabled() {
       return this.statisticsEnabled;
    }
 
-   @Operation(displayName = "Enable/disable statistics")
+   @ManagedAttribute(
+         displayName = "Enable/disable statistics"
+   )
    public void setStatisticsEnabled(@Parameter(name = "enabled", description = "Whether statistics should be enabled or disabled (true/false)") boolean enabled) {
       this.statisticsEnabled = enabled;
    }
 
-   @ManagedAttribute(description = "Number of invalidations")
-   @Metric(displayName = "Number of invalidations", measurementType = MeasurementType.TRENDSUP)
+   @ManagedAttribute(
+         description = "Number of invalidations",
+         displayName = "Number of invalidations",
+         measurementType = MeasurementType.TRENDSUP
+   )
    public long getInvalidations() {
       return invalidations.get();
    }

--- a/core/src/main/java/org/infinispan/interceptors/PassivationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/PassivationInterceptor.java
@@ -31,12 +31,9 @@ import org.infinispan.interceptors.base.JmxStatsCommandInterceptor;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.jmx.annotations.MeasurementType;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.rhq.helpers.pluginAnnotations.agent.MeasurementType;
-import org.rhq.helpers.pluginAnnotations.agent.Metric;
-import org.rhq.helpers.pluginAnnotations.agent.Operation;
-
 /**
  * Writes evicted entries back to the store on the way in through the CacheStore
  *
@@ -44,7 +41,7 @@ import org.rhq.helpers.pluginAnnotations.agent.Operation;
  */
 @MBean(objectName = "Passivation", description = "Component that handles passivating entries to a CacheStore on eviction.")
 public class PassivationInterceptor extends JmxStatsCommandInterceptor {
-   
+
 
    PassivationManager passivator;
    DataContainer dataContainer;
@@ -70,14 +67,17 @@ public class PassivationInterceptor extends JmxStatsCommandInterceptor {
    }
 
    @Override
-   @ManagedOperation(description = "Resets statistics gathered by this component")
-   @Operation(displayName = "Reset statistics")
+   @ManagedOperation(
+         description = "Resets statistics gathered by this component", displayName = "Reset statistics")
    public void resetStatistics() {
       passivator.resetPassivationCount();
    }
 
-   @ManagedAttribute(description = "Number of passivation events")
-   @Metric(displayName = "Number of cache passivations", measurementType = MeasurementType.TRENDSUP)   
+   @ManagedAttribute(
+         description = "Number of passivation events",
+         displayName = "Number of cache passivations",
+         measurementType = MeasurementType.TRENDSUP
+   )
    public String getPassivations() {
       if (!getStatisticsEnabled()) return "N/A";
       return String.valueOf(passivator.getPassivationCount());

--- a/core/src/main/java/org/infinispan/jmx/annotations/DataType.java
+++ b/core/src/main/java/org/infinispan/jmx/annotations/DataType.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.jmx.annotations;
+
+public enum DataType {
+   MEASUREMENT, TRAIT, CALLTIME;
+
+   @Override
+   public String toString() {
+      return this.name().toLowerCase();
+   }
+
+}

--- a/core/src/main/java/org/infinispan/jmx/annotations/DisplayType.java
+++ b/core/src/main/java/org/infinispan/jmx/annotations/DisplayType.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.jmx.annotations;
+
+public enum DisplayType {
+   SUMMARY, DETAIL;
+
+   @Override
+   public String toString() {
+      return this.name().toLowerCase();
+   }
+
+}

--- a/core/src/main/java/org/infinispan/jmx/annotations/ManagedAttribute.java
+++ b/core/src/main/java/org/infinispan/jmx/annotations/ManagedAttribute.java
@@ -42,4 +42,14 @@ public @interface ManagedAttribute {
    String description() default "";
 
    boolean writable() default false;
+
+   String displayName() default "";
+
+   DataType dataType() default DataType.MEASUREMENT;
+
+   DisplayType displayType() default DisplayType.DETAIL;
+
+   MeasurementType measurementType() default MeasurementType.DYNAMIC;
+
+   Units units() default Units.NONE;
 }

--- a/core/src/main/java/org/infinispan/jmx/annotations/ManagedOperation.java
+++ b/core/src/main/java/org/infinispan/jmx/annotations/ManagedOperation.java
@@ -39,4 +39,6 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD})
 public @interface ManagedOperation {
    String description() default "";
+   String displayName() default "";
+   String name() default "";
 }

--- a/core/src/main/java/org/infinispan/jmx/annotations/MeasurementType.java
+++ b/core/src/main/java/org/infinispan/jmx/annotations/MeasurementType.java
@@ -1,0 +1,23 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.jmx.annotations;
+
+public enum MeasurementType {
+   DYNAMIC, TRENDSUP, TRENDSDOWN;
+}

--- a/core/src/main/java/org/infinispan/jmx/annotations/Parameter.java
+++ b/core/src/main/java/org/infinispan/jmx/annotations/Parameter.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.jmx.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.CLASS)
+public @interface Parameter {
+   String name() default "";
+   String description() default "";
+}
+

--- a/core/src/main/java/org/infinispan/jmx/annotations/Units.java
+++ b/core/src/main/java/org/infinispan/jmx/annotations/Units.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.jmx.annotations;
+
+public enum Units {
+   NONE, MILLISECONDS, SECONDS, PERCENTAGE;
+
+   @Override
+   public String toString() {
+      return this.name().toLowerCase();
+   }
+
+}

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -43,9 +43,12 @@ import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.jmx.CacheJmxRegistration;
 import org.infinispan.jmx.CacheManagerJmxRegistration;
+import org.infinispan.jmx.annotations.DataType;
+import org.infinispan.jmx.annotations.DisplayType;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.jmx.annotations.Parameter;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.lifecycle.Lifecycle;
 import org.infinispan.loaders.CacheLoaderManager;
@@ -59,11 +62,6 @@ import org.infinispan.util.InfinispanCollections;
 import org.infinispan.util.concurrent.ConcurrentMapFactory;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.rhq.helpers.pluginAnnotations.agent.DataType;
-import org.rhq.helpers.pluginAnnotations.agent.DisplayType;
-import org.rhq.helpers.pluginAnnotations.agent.Metric;
-import org.rhq.helpers.pluginAnnotations.agent.Operation;
-import org.rhq.helpers.pluginAnnotations.agent.Parameter;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -534,7 +532,6 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
     * @return a cache instance identified by cacheName
     */
    @Override
-   @SuppressWarnings("unchecked")
    public <K, V> Cache<K, V> getCache(String cacheName) {
       assertIsNotTerminated();
       if (cacheName == null)
@@ -833,15 +830,12 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
       return isRunning(DEFAULT_CACHE_NAME);
    }
 
-   @ManagedAttribute(description = "The status of the cache manager instance.")
-   @Metric(displayName = "Cache manager status", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(description = "The status of the cache manager instance.", displayName = "Cache manager status", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
    public String getCacheManagerStatus() {
       return getStatus().toString();
    }
 
-   @ManagedAttribute(description = "The defined cache names and their statuses.  The default cache is not included in this representation.")
-   @Metric(displayName = "List of defined caches", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(description = "The defined cache names and their statuses.  The default cache is not included in this representation.", displayName = "List of defined caches", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
    public String getDefinedCacheNames() {
       StringBuilder result = new StringBuilder("[");
       for (String cacheName : getCacheNames()) {
@@ -852,23 +846,17 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
       return result.toString();
    }
 
-   @ManagedAttribute(description = "The total number of defined caches, excluding the default cache.")
-   @Metric(displayName = "Number of caches defined", displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(description = "The total number of defined caches, excluding the default cache.", displayName = "Number of caches defined", displayType = DisplayType.SUMMARY)
    public String getDefinedCacheCount() {
       return String.valueOf(this.configurationOverrides.keySet().size());
    }
 
-   @ManagedAttribute(description = "The total number of created caches, including the default cache.")
-   @Metric(displayName = "Number of caches created", displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(description = "The total number of created caches, including the default cache.", displayName = "Number of caches created", displayType = DisplayType.SUMMARY)
    public String getCreatedCacheCount() {
       return String.valueOf(this.caches.keySet().size());
    }
 
-   @ManagedAttribute(description = "The total number of running caches, including the default cache.")
-   @Metric(displayName = "Number of running caches", displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(description = "The total number of running caches, including the default cache.", displayName = "Number of running caches", displayType = DisplayType.SUMMARY)
    public String getRunningCacheCount() {
       int running = 0;
       for (CacheWrapper cachew : caches.values()) {
@@ -879,42 +867,32 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
       return String.valueOf(running);
    }
 
-   @ManagedAttribute(description = "Infinispan version.")
-   @Metric(displayName = "Infinispan version", displayType = DisplayType.SUMMARY, dataType = DataType.TRAIT)
+   @ManagedAttribute(description = "Infinispan version.", displayName = "Infinispan version", displayType = DisplayType.SUMMARY, dataType = DataType.TRAIT)
    public String getVersion() {
       return Version.printVersion();
    }
 
-   @ManagedAttribute(description = "The name of this cache manager")
-   @Metric(displayName = "Cache manager name", displayType = DisplayType.SUMMARY, dataType = DataType.TRAIT)
+   @ManagedAttribute(description = "The name of this cache manager", displayName = "Cache manager name", displayType = DisplayType.SUMMARY, dataType = DataType.TRAIT)
    public String getName() {
       return globalConfiguration.globalJmxStatistics().cacheManagerName();
    }
 
-   @ManagedOperation(description = "Starts the default cache associated with this cache manager")
-   @Operation(displayName = "Starts the default cache")
-   @SuppressWarnings("unused")
+   @ManagedOperation(description = "Starts the default cache associated with this cache manager", displayName = "Starts the default cache")
    public void startCache() {
       getCache();
    }
 
-   @ManagedOperation(description = "Starts a named cache from this cache manager")
-   @Operation(name = "startCacheWithCacheName", displayName = "Starts a cache with the given name")
-   @SuppressWarnings("unused")
+   @ManagedOperation(description = "Starts a named cache from this cache manager", name = "startCacheWithCacheName", displayName = "Starts a cache with the given name")
    public void startCache(@Parameter(name = "cacheName", description = "Name of cache to start") String cacheName) {
       getCache(cacheName);
    }
 
-   @ManagedAttribute(description = "The network address associated with this instance")
-   @Metric(displayName = "Network address", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(description = "The network address associated with this instance", displayName = "Network address", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
    public String getNodeAddress() {
       return getLogicalAddressString();
    }
 
-   @ManagedAttribute(description = "The physical network addresses associated with this instance")
-   @Metric(displayName = "Physical network addresses", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(description = "The physical network addresses associated with this instance", displayName = "Physical network addresses", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
    public String getPhysicalAddresses() {
       Transport t = getTransport();
       if (t == null) return "local";
@@ -922,9 +900,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
       return address == null ? "local" : address.toString();
    }
 
-   @ManagedAttribute(description = "List of members in the cluster")
-   @Metric(displayName = "Cluster members", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(description = "List of members in the cluster", displayName = "Cluster members", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
    public String getClusterMembers() {
       Transport t = getTransport();
       if (t == null) return "local";
@@ -932,9 +908,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
       return addressList.toString();
    }
 
-   @ManagedAttribute(description = "Size of the cluster in number of nodes")
-   @Metric(displayName = "Cluster size", displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(description = "Size of the cluster in number of nodes", displayName = "Cluster size", displayType = DisplayType.SUMMARY)
    public int getClusterSize() {
       Transport t = getTransport();
       if (t == null) return 1;
@@ -944,8 +918,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
    /**
     * {@inheritDoc}
     */
-   @ManagedAttribute(description = "Cluster name")
-   @Metric(displayName = "Cluster name", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(description = "Cluster name", displayName = "Cluster name", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
    @Override
    public String getClusterName() {
       return globalConfiguration.transport().clusterName();

--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
@@ -33,9 +33,14 @@ import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
+import org.infinispan.jmx.annotations.DataType;
+import org.infinispan.jmx.annotations.DisplayType;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.jmx.annotations.MeasurementType;
+import org.infinispan.jmx.annotations.Parameter;
+import org.infinispan.jmx.annotations.Units;
 import org.infinispan.statetransfer.StateTransferManager;
 import org.infinispan.remoting.ReplicationQueue;
 import org.infinispan.remoting.RpcException;
@@ -48,13 +53,6 @@ import org.infinispan.util.InfinispanCollections;
 import org.infinispan.util.concurrent.NotifyingNotifiableFuture;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.rhq.helpers.pluginAnnotations.agent.DataType;
-import org.rhq.helpers.pluginAnnotations.agent.DisplayType;
-import org.rhq.helpers.pluginAnnotations.agent.MeasurementType;
-import org.rhq.helpers.pluginAnnotations.agent.Metric;
-import org.rhq.helpers.pluginAnnotations.agent.Operation;
-import org.rhq.helpers.pluginAnnotations.agent.Parameter;
-import org.rhq.helpers.pluginAnnotations.agent.Units;
 
 import java.text.NumberFormat;
 import java.util.Collection;
@@ -122,15 +120,13 @@ public class RpcManagerImpl implements RpcManager {
       statisticsEnabled = configuration.jmxStatistics().enabled();
    }
 
-   @ManagedAttribute(description = "Retrieves the committed view.")
-   @Metric(displayName = "Committed view", dataType = DataType.TRAIT)
+   @ManagedAttribute(description = "Retrieves the committed view.", displayName = "Committed view", dataType = DataType.TRAIT)
    public String getCommittedViewAsString() {
       return localTopologyManager == null ? "N/A" : String.valueOf(localTopologyManager.getCacheTopology(cacheName)
             .getCurrentCH());
    }
 
-   @ManagedAttribute(description = "Retrieves the pending view.")
-   @Metric(displayName = "Pending view", dataType = DataType.TRAIT)
+   @ManagedAttribute(description = "Retrieves the pending view.", displayName = "Pending view", dataType = DataType.TRAIT)
    public String getPendingViewAsString() {
       return localTopologyManager == null ? "N/A" : String.valueOf(localTopologyManager.getCacheTopology(cacheName)
             .getPendingCH());
@@ -332,19 +328,17 @@ public class RpcManagerImpl implements RpcManager {
          }
       }
    }
-   
+
    // -------------------------------------------- JMX information -----------------------------------------------
 
-   @ManagedOperation(description = "Resets statistics gathered by this component")
-   @Operation(displayName = "Reset statistics")
+   @ManagedOperation(description = "Resets statistics gathered by this component", displayName = "Reset statistics")
    public void resetStatistics() {
       replicationCount.set(0);
       replicationFailures.set(0);
       totalReplicationTime.set(0);
    }
 
-   @ManagedAttribute(description = "Number of successful replications")
-   @Metric(displayName = "Number of successful replications", measurementType = MeasurementType.TRENDSUP, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(description = "Number of successful replications", displayName = "Number of successful replications", measurementType = MeasurementType.TRENDSUP, displayType = DisplayType.SUMMARY)
    public long getReplicationCount() {
       if (!isStatisticsEnabled()) {
          return -1;
@@ -352,8 +346,7 @@ public class RpcManagerImpl implements RpcManager {
       return replicationCount.get();
    }
 
-   @ManagedAttribute(description = "Number of failed replications")
-   @Metric(displayName = "Number of failed replications", measurementType = MeasurementType.TRENDSUP, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(description = "Number of failed replications", displayName = "Number of failed replications", measurementType = MeasurementType.TRENDSUP, displayType = DisplayType.SUMMARY)
    public long getReplicationFailures() {
       if (!isStatisticsEnabled()) {
          return -1;
@@ -361,12 +354,12 @@ public class RpcManagerImpl implements RpcManager {
       return replicationFailures.get();
    }
 
-   @Metric(displayName = "Statistics enabled", dataType = DataType.TRAIT)
+   @ManagedAttribute(displayName = "Statistics enabled", dataType = DataType.TRAIT)
    public boolean isStatisticsEnabled() {
       return statisticsEnabled;
    }
 
-   @Operation(displayName = "Enable/disable statistics")
+   @ManagedOperation(displayName = "Enable/disable statistics")
    public void setStatisticsEnabled(@Parameter(name = "enabled", description = "Whether statistics should be enabled or disabled (true/false)") boolean statisticsEnabled) {
       this.statisticsEnabled = statisticsEnabled;
    }
@@ -380,8 +373,7 @@ public class RpcManagerImpl implements RpcManager {
       return NumberFormat.getInstance().format(ration) + "%";
    }
 
-   @ManagedAttribute(description = "Successful replications as a ratio of total replications in numeric double format")
-   @Metric(displayName = "Successful replication ratio", units = Units.PERCENTAGE, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(description = "Successful replications as a ratio of total replications in numeric double format", displayName = "Successful replication ratio", units = Units.PERCENTAGE, displayType = DisplayType.SUMMARY)
    public double getSuccessRatioFloatingPoint() {
       if (replicationCount.get() == 0 || !statisticsEnabled) return 0;
       return calculateSuccessRatio();
@@ -392,8 +384,7 @@ public class RpcManagerImpl implements RpcManager {
       return replicationCount.get() / totalCount;
    }
 
-   @ManagedAttribute(description = "The average time spent in the transport layer, in milliseconds")
-   @Metric(displayName = "Average time spent in the transport layer", units = Units.MILLISECONDS, displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(description = "The average time spent in the transport layer, in milliseconds", displayName = "Average time spent in the transport layer", units = Units.MILLISECONDS, displayType = DisplayType.SUMMARY)
    public long getAverageReplicationTime() {
       if (replicationCount.get() == 0) {
          return 0;
@@ -411,6 +402,7 @@ public class RpcManagerImpl implements RpcManager {
       return t != null ? t.getAddress() : null;
    }
 
+   @Override
    public int getTopologyId() {
       CacheTopology cacheTopology = stateTransferManager.getCacheTopology();
       return cacheTopology != null ? cacheTopology.getTopologyId() : -1;

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManager.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManager.java
@@ -26,11 +26,10 @@ package org.infinispan.statetransfer;
 import org.infinispan.commands.TopologyAffectedCommand;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.jmx.annotations.DataType;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.topology.CacheTopology;
-import org.rhq.helpers.pluginAnnotations.agent.DataType;
-import org.rhq.helpers.pluginAnnotations.agent.Metric;
 
 import java.util.Set;
 
@@ -46,15 +45,13 @@ import java.util.Set;
 public interface StateTransferManager {
 
    //todo [anistor] this is inaccurate. this node does not hold state yet in current implementation
-   @ManagedAttribute(description = "If true, the node has successfully joined the grid and is considered to hold state.  If false, the join process is still in progress.")
-   @Metric(displayName = "Is join completed?", dataType = DataType.TRAIT)
+   @ManagedAttribute(description = "If true, the node has successfully joined the grid and is considered to hold state.  If false, the join process is still in progress.", displayName = "Is join completed?", dataType = DataType.TRAIT)
    boolean isJoinComplete();
 
    /**
     * Checks if an inbound state transfer is in progress.
     */
-   @ManagedAttribute(description = "Checks whether there is a pending inbound state transfer on this cluster member.")
-   @Metric(displayName = "Is state transfer in progress?", dataType = DataType.TRAIT)
+   @ManagedAttribute(description = "Checks whether there is a pending inbound state transfer on this cluster member.", displayName = "Is state transfer in progress?", dataType = DataType.TRAIT)
    boolean isStateTransferInProgress();
 
    /**

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAdminOperations.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAdminOperations.java
@@ -26,6 +26,7 @@ package org.infinispan.transaction.xa.recovery;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.jmx.annotations.Parameter;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -82,35 +83,44 @@ public class RecoveryAdminOperations {
    }
 
    @ManagedOperation(description = "Forces the commit of an in-doubt transaction")
-   public String forceCommit(long internalID) {
+   public String forceCommit(@Parameter(name = "internalId", description = "The internal identifier of the transaction") long internalId) {
       if (log.isTraceEnabled())
-         log.tracef("Forces the commit of an in-doubt transaction: %s", internalID);
-      return completeBasedOnInternalId(internalID, true);
+         log.tracef("Forces the commit of an in-doubt transaction: %s", internalId);
+      return completeBasedOnInternalId(internalId, true);
    }
 
-   @ManagedOperation(description = "Forces the commit of an in-doubt transaction")
-   public String forceCommit(int formatId, byte[] globalTxId, byte[] branchQualifier) {
+   @ManagedOperation(description = "Forces the commit of an in-doubt transaction", name="forceCommitByXid")
+   public String forceCommit(
+         @Parameter(name = "formatId", description = "The formatId of the transaction") int formatId,
+         @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId,
+         @Parameter(name = "branchQualifier", description = "The branchQualifier of the transaction") byte[] branchQualifier) {
       return completeBasedOnXid(formatId, globalTxId, branchQualifier, true);
    }
 
    @ManagedOperation(description = "Forces the rollback of an in-doubt transaction")
-   public String forceRollback(long internalId) {
+   public String forceRollback(@Parameter(name = "internalId", description = "The internal identifier of the transaction") long internalId) {
       return completeBasedOnInternalId(internalId, false);
    }
 
-   @ManagedOperation(description = "Forces the rollback of an in-doubt transaction")
-   public String forceRollback(int formatId, byte[] globalTxId, byte[] branchQualifier) {
+   @ManagedOperation(description = "Forces the rollback of an in-doubt transaction", name="forceRollbackByXid")
+   public String forceRollback(
+         @Parameter(name = "formatId", description = "The formatId of the transaction") int formatId,
+         @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId,
+         @Parameter(name = "branchQualifier", description = "The branchQualifier of the transaction") byte[] branchQualifier) {
       return completeBasedOnXid(formatId, globalTxId, branchQualifier, false);
    }
 
-   @ManagedOperation(description = "Removes recovery info for the given transaction.")
-   public String forget(int formatId, byte[] globalTxId, byte[] branchQualifier) {
+   @ManagedOperation(description = "Removes recovery info for the given transaction.", name="forgetByXid")
+   public String forget(
+         @Parameter(name = "formatId", description = "The formatId of the transaction") int formatId,
+         @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId,
+         @Parameter(name = "branchQualifier", description = "The branchQualifier of the transaction") byte[] branchQualifier) {
       recoveryManager.removeRecoveryInformationFromCluster(null, new SerializableXid(branchQualifier, globalTxId, formatId), true, null);
       return "Recovery info removed.";
    }
 
    @ManagedOperation(description = "Removes recovery info for the given transaction.")
-   public String forget(long internalId) {
+   public String forget(@Parameter(name = "internalId", description = "The internal identifier of the transaction") long internalId) {
       recoveryManager.removeRecoveryInformationFromCluster(null, internalId, true);
       return "Recovery info removed.";
    }

--- a/core/src/main/java/org/infinispan/upgrade/RollingUpgradeManager.java
+++ b/core/src/main/java/org/infinispan/upgrade/RollingUpgradeManager.java
@@ -26,11 +26,10 @@ import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.jmx.annotations.Parameter;
 import org.infinispan.util.Util;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.rhq.helpers.pluginAnnotations.agent.Operation;
-
 import java.util.HashSet;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -56,16 +55,20 @@ public class RollingUpgradeManager {
       this.cache = cache;
    }
 
-   @ManagedOperation(description = "Dumps the global known keyset to a well-known key for retrieval by the upgrade process")
-   @Operation(displayName = "Dumps the global known keyset")
+   @ManagedOperation(
+         description = "Dumps the global known keyset to a well-known key for retrieval by the upgrade process",
+         displayName = "Dumps the global known keyset"
+   )
    public void recordKnownGlobalKeyset() {
       for (SourceMigrator m : sourceMigrators)
          m.recordKnownGlobalKeyset();
    }
 
-   @ManagedOperation(description = "Synchronizes data from the old cluster to this using the specified migrator")
-   @Operation(displayName = "Synchronizes data from the old cluster to this using the specified migrator")
-   public long synchronizeData(String migratorName) throws Exception {
+   @ManagedOperation(
+         description = "Synchronizes data from the old cluster to this using the specified migrator",
+         displayName = "Synchronizes data from the old cluster to this using the specified migrator"
+   )
+   public long synchronizeData(@Parameter(name="migratorName", description="The name of the migrator to use") String migratorName) throws Exception {
       TargetMigrator migrator = getMigrator(migratorName);
       long start = System.currentTimeMillis();
       long count = migrator.synchronizeData(cache);
@@ -74,9 +77,11 @@ public class RollingUpgradeManager {
 
    }
 
-   @ManagedOperation(description = "Disconnects the target cluster from the source cluster according to the specified migrator")
-   @Operation(displayName = "Disconnects the target cluster from the source cluster")
-   public void disconnectSource(String migratorName) throws Exception {
+   @ManagedOperation(
+         description = "Disconnects the target cluster from the source cluster according to the specified migrator",
+         displayName = "Disconnects the target cluster from the source cluster"
+   )
+   public void disconnectSource(@Parameter(name="migratorName", description="The name of the migrator to use") String migratorName) throws Exception {
       TargetMigrator migrator = getMigrator(migratorName);
       migrator.disconnectSource(cache);
    }

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/DeadlockDetectingLockManager.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/DeadlockDetectingLockManager.java
@@ -27,12 +27,10 @@ import org.infinispan.factories.annotations.Start;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.jmx.annotations.MeasurementType;
 import org.infinispan.transaction.xa.DldGlobalTransaction;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.rhq.helpers.pluginAnnotations.agent.MeasurementType;
-import org.rhq.helpers.pluginAnnotations.agent.Metric;
-import org.rhq.helpers.pluginAnnotations.agent.Operation;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -128,7 +126,7 @@ public class DeadlockDetectingLockManager extends LockManagerImpl {
    }
 
    private boolean isSameKeyDeadlock(Object key, DldGlobalTransaction thisTx, DldGlobalTransaction lockOwnerTx) {
-      boolean iHaveRemoteLock = !thisTx.isRemote(); //this relies on the fact that when DLD is enabled a lock is first acquired remotely and then locally 
+      boolean iHaveRemoteLock = !thisTx.isRemote(); //this relies on the fact that when DLD is enabled a lock is first acquired remotely and then locally
       boolean otherHasLocalLock = lockOwnerTx.isRemote();
 
       //if we are here then 1) the other tx has a lock on this local key AND 2) I have a lock on the same key remotely
@@ -146,7 +144,7 @@ public class DeadlockDetectingLockManager extends LockManagerImpl {
       boolean localLockOwner = !lockOwnerTx.isRemote();
       if (localLockOwner) {
          // I've already acquired lock on this key before replicating here, so this mean we are in deadlock. This assumes the fact that
-         // if trying to acquire a remote lock, a tx first acquires a local lock. 
+         // if trying to acquire a remote lock, a tx first acquires a local lock.
          if (thisTx.hasLockAtOrigin(lockOwnerTx.getRemoteLockIntention())) {
             if (trace)
                log.tracef("Same key deadlock detected: lock owner tries to acquire lock remotely on %s but we have it!", key);
@@ -169,34 +167,29 @@ public class DeadlockDetectingLockManager extends LockManagerImpl {
    }
 
 
-   @ManagedAttribute (description = "Total number of local detected deadlocks")
-   @Metric(displayName = "Number of total detected deadlocks", measurementType = MeasurementType.TRENDSUP)
+   @ManagedAttribute (description = "Total number of local detected deadlocks", displayName = "Number of total detected deadlocks", measurementType = MeasurementType.TRENDSUP)
    public long getTotalNumberOfDetectedDeadlocks() {
       return localTxStopped.get() + remoteTxStopped.get();
    }
 
-   @ManagedOperation(description = "Resets statistics gathered by this component")
-   @Operation(displayName = "Reset statistics")
+   @ManagedOperation(description = "Resets statistics gathered by this component", displayName = "Reset statistics")
    public void resetStatistics() {
       localTxStopped.set(0);
       remoteTxStopped.set(0);
-      cannotRunDld.set(0); 
+      cannotRunDld.set(0);
    }
 
-   @ManagedAttribute(description = "Number of remote transaction that were roll backed due to deadlocks")
-   @Metric(displayName = "Number of remote transaction that were roll backed due to deadlocks", measurementType = MeasurementType.TRENDSUP)
+   @ManagedAttribute(description = "Number of remote transaction that were roll backed due to deadlocks", displayName = "Number of remote transaction that were roll backed due to deadlocks", measurementType = MeasurementType.TRENDSUP)
    public long getDetectedRemoteDeadlocks() {
       return remoteTxStopped.get();
    }
 
-   @ManagedAttribute (description = "Number of local transaction that were roll backed due to deadlocks")
-   @Metric(displayName = "Number of local transaction that were roll backed due to deadlocks", measurementType = MeasurementType.TRENDSUP)
+   @ManagedAttribute (description = "Number of local transaction that were roll backed due to deadlocks", displayName = "Number of local transaction that were roll backed due to deadlocks", measurementType = MeasurementType.TRENDSUP)
    public long getDetectedLocalDeadlocks() {
       return localTxStopped.get();
    }
 
-   @ManagedAttribute(description = "Number of situations when we try to determine a deadlock and the other lock owner is NOT a transaction. In this scenario we cannot run the deadlock detection mechanism")
-   @Metric(displayName = "Number of unsolvable deadlock situations", measurementType = MeasurementType.TRENDSUP)
+   @ManagedAttribute(description = "Number of situations when we try to determine a deadlock and the other lock owner is NOT a transaction. In this scenario we cannot run the deadlock detection mechanism", displayName = "Number of unsolvable deadlock situations", measurementType = MeasurementType.TRENDSUP)
    public long getOverlapWithNotDeadlockAwareLockOwners() {
       return cannotRunDld.get();
    }
@@ -213,8 +206,7 @@ public class DeadlockDetectingLockManager extends LockManagerImpl {
    }
 
 
-   @ManagedAttribute(description = "Number of locally originated transactions that were interrupted as a deadlock situation was detected")
-   @Metric(displayName = "Number of interrupted local transactions", measurementType = MeasurementType.TRENDSUP)
+   @ManagedAttribute(description = "Number of locally originated transactions that were interrupted as a deadlock situation was detected", displayName = "Number of interrupted local transactions", measurementType = MeasurementType.TRENDSUP)
    @Deprecated
    public static long getLocallyInterruptedTransactions() {
       return -1;

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/LockManagerImpl.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/LockManagerImpl.java
@@ -26,6 +26,7 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.jmx.annotations.DataType;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.marshall.MarshalledValue;
@@ -34,8 +35,6 @@ import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.concurrent.locks.containers.*;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.rhq.helpers.pluginAnnotations.agent.DataType;
-import org.rhq.helpers.pluginAnnotations.agent.Metric;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -150,21 +149,18 @@ public class LockManagerImpl implements LockManager {
       return entry == null || entry.isChanged() || entry.isNull() || entry.isLockPlaceholder();
    }
 
-   @ManagedAttribute(description = "The concurrency level that the MVCC Lock Manager has been configured with.")
-   @Metric(displayName = "Concurrency level", dataType = DataType.TRAIT)
+   @ManagedAttribute(description = "The concurrency level that the MVCC Lock Manager has been configured with.", displayName = "Concurrency level", dataType = DataType.TRAIT)
    public int getConcurrencyLevel() {
       return configuration.locking().concurrencyLevel();
    }
 
    @Override
-   @ManagedAttribute(description = "The number of exclusive locks that are held.")
-   @Metric(displayName = "Number of locks held")
+   @ManagedAttribute(description = "The number of exclusive locks that are held.", displayName = "Number of locks held")
    public int getNumberOfLocksHeld() {
       return lockContainer.getNumLocksHeld();
    }
 
-   @ManagedAttribute(description = "The number of exclusive locks that are available.")
-   @Metric(displayName = "Number of locks available")
+   @ManagedAttribute(description = "The number of exclusive locks that are available.", displayName = "Number of locks available")
    public int getNumberOfLocksAvailable() {
       return lockContainer.size() - lockContainer.getNumLocksHeld();
    }

--- a/core/src/main/java/org/infinispan/xsite/XSiteAdminOperations.java
+++ b/core/src/main/java/org/infinispan/xsite/XSiteAdminOperations.java
@@ -23,13 +23,13 @@ import org.infinispan.Cache;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.jmx.annotations.Parameter;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.responses.SuccessfulResponse;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.rhq.helpers.pluginAnnotations.agent.Operation;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -64,9 +64,8 @@ public class XSiteAdminOperations {
       this.cache = cache;
    }
 
-   @Operation(displayName = "Check whether the given backup site is offline or not.")
-   @ManagedOperation(description = "Check whether the given backup site is offline or not.")
-   public String siteStatus(String site) {
+   @ManagedOperation(description = "Check whether the given backup site is offline or not.", displayName = "Check whether the given backup site is offline or not.")
+   public String siteStatus(@Parameter(name = "site", description = "The name of the backup site") String site) {
       //also consider local node
       OfflineStatus offlineStatus = backupSender.getOfflineStatus(site);
       if (offlineStatus == null)
@@ -112,8 +111,7 @@ public class XSiteAdminOperations {
       return "Site appears online on nodes:" + online + " and offline on nodes: " + offline;
    }
 
-   @Operation(displayName = "Returns the the status(offline/online) of all the configured backup sites.")
-   @ManagedOperation(description = "Returns the the status(offline/online) of all the configured backup sites.")
+   @ManagedOperation(description = "Returns the the status(offline/online) of all the configured backup sites.", displayName = "Returns the the status(offline/online) of all the configured backup sites.")
    public String status() {
       //also consider local node
       Map<String, Boolean> localNodeStatus = backupSender.status();
@@ -167,9 +165,8 @@ public class XSiteAdminOperations {
       return resultStr.toString();
    }
 
-   @Operation(displayName = "Takes this site offline in all nodes in the cluster.")
-   @ManagedOperation(description = "Takes this site offline in all nodes in the cluster.")
-   public String takeSiteOffline(String site) {
+   @ManagedOperation(description = "Takes this site offline in all nodes in the cluster.",displayName = "Takes this site offline in all nodes in the cluster.")
+   public String takeSiteOffline(@Parameter(name = "site", description = "The name of the backup site") String site) {
       OfflineStatus offlineStatus = backupSender.getOfflineStatus(site);
       if (offlineStatus == null)
          return incorrectSiteName(site);
@@ -185,43 +182,44 @@ public class XSiteAdminOperations {
       return returnFailureOrSuccess(failed, prefix);
    }
 
-   @Operation(displayName = "Amends the values for 'TakeOffline.afterFailures' on all the nodes in the cluster.")
-   @ManagedOperation(description = "Amends the values for 'afterFailures' for the 'TakeOffline' functionality on all the nodes in the cluster.")
-   public String setTakeOfflineAfterFailures(String site, int afterFailures) {
+   @ManagedOperation(description = "Amends the values for 'afterFailures' for the 'TakeOffline' functionality on all the nodes in the cluster.", displayName = "Amends the values for 'TakeOffline.afterFailures' on all the nodes in the cluster.")
+   public String setTakeOfflineAfterFailures(
+         @Parameter(name = "site", description = "The name of the backup site") String site,
+         @Parameter(name = "afterFailures", description = "The number of failures after which the site will be taken offline") int afterFailures) {
       return takeOffline(site, afterFailures, null);
    }
 
-   @Operation(displayName = "Amends the values for 'TakeOffline.minTimeToWait' on all the nodes in the cluster.")
-   @ManagedOperation(description = "Amends the values for 'minTimeToWait' for the 'TakeOffline' functionality on all the nodes in the cluster.")
-   public String setTakeOfflineMinTimeToWait(String site, long minTimeToWait) {
+   @ManagedOperation(description = "Amends the values for 'minTimeToWait' for the 'TakeOffline' functionality on all the nodes in the cluster.", displayName = "Amends the values for 'TakeOffline.minTimeToWait' on all the nodes in the cluster.")
+   public String setTakeOfflineMinTimeToWait(
+         @Parameter(name = "site", description = "The name of the backup site") String site,
+         @Parameter(name = "minTimeToWait", description = "The minimum amount of time in milliseconds to wait before taking a site offline") long minTimeToWait) {
       return takeOffline(site, null, minTimeToWait);
    }
 
-   @Operation(displayName = "Amends the values for 'TakeOffline' functionality on all the nodes in the cluster.")
-   @ManagedOperation(description = "Amends the values for 'TakeOffline' functionality on all the nodes in the cluster.")
-   public String amendTakeOffline(String site, int afterFailures, long minTimeToWait) {
+   @ManagedOperation(description = "Amends the values for 'TakeOffline' functionality on all the nodes in the cluster.", displayName = "Amends the values for 'TakeOffline' functionality on all the nodes in the cluster.")
+   public String amendTakeOffline(
+         @Parameter(name = "site", description = "The name of the backup site") String site,
+         @Parameter(name = "afterFailures", description = "The number of failures after which the site will be taken offline") int afterFailures,
+         @Parameter(name = "minTimeToWait", description = "The minimum amount of time in milliseconds to wait before taking a site offline") long minTimeToWait) {
       return takeOffline(site, afterFailures, minTimeToWait);
    }
 
-   @Operation(displayName = "Returns the value of the 'minTimeToWait' for the 'TakeOffline' functionality.")
-   @ManagedOperation(description = "Returns the value of the 'minTimeToWait' for the 'TakeOffline' functionality.")
-   public String getTakeOfflineMinTimeToWait(String site) {
+   @ManagedOperation(description = "Returns the value of the 'minTimeToWait' for the 'TakeOffline' functionality.", displayName = "Returns the value of the 'minTimeToWait' for the 'TakeOffline' functionality.")
+   public String getTakeOfflineMinTimeToWait(@Parameter(name = "site", description = "The name of the backup site") String site) {
       OfflineStatus offlineStatus = backupSender.getOfflineStatus(site);
       if (offlineStatus == null) return incorrectSiteName(site);
       return String.valueOf(offlineStatus.getTakeOffline().minTimeToWait());
    }
 
-   @Operation(displayName = "Returns the value of the 'afterFailures' for the 'TakeOffline' functionality.")
-   @ManagedOperation(description = "Returns the value of the 'afterFailures' for the 'TakeOffline' functionality.")
-   public String getTakeOfflineAfterFailures(String site) {
+   @ManagedOperation(description = "Returns the value of the 'afterFailures' for the 'TakeOffline' functionality.", displayName = "Returns the value of the 'afterFailures' for the 'TakeOffline' functionality.")
+   public String getTakeOfflineAfterFailures(@Parameter(name = "site", description = "The name of the backup site") String site) {
       OfflineStatus offlineStatus = backupSender.getOfflineStatus(site);
       if (offlineStatus == null) return incorrectSiteName(site);
       return String.valueOf(offlineStatus.getTakeOffline().afterFailures());
    }
 
-   @Operation(displayName = "Brings the given site back online on all the cluster.")
-   @ManagedOperation(description = "Brings the given site back online on all the cluster.")
-   public String bringSiteOnline(String site) {
+   @ManagedOperation(description = "Brings the given site back online on all the cluster.", displayName = "Brings the given site back online on all the cluster.")
+   public String bringSiteOnline(@Parameter(name = "site", description = "The name of the backup site") String site) {
       OfflineStatus offlineStatus = backupSender.getOfflineStatus(site);
       if (offlineStatus == null)
          return "Incorrect site name: " + offlineStatus;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -168,7 +168,6 @@
       <version.netty>3.6.1.Final</version.netty>
       <version.org.jboss.naming>5.0.6.CR1</version.org.jboss.naming>
       <version.resteasy>2.3.2.Final</version.resteasy>
-      <version.rhq.helpers>3.0.4</version.rhq.helpers>
       <version.rhq>4.2.0</version.rhq>
       <version.scala>2.10.0</version.scala>
       <version.shrinkwrapResolver>2.0.0-alpha-6</version.shrinkwrapResolver>
@@ -768,16 +767,6 @@
             <version>${version.rhq}</version>
          </dependency>
          <dependency>
-            <groupId>org.rhq.helpers</groupId>
-            <artifactId>rhq-pluginAnnotations</artifactId>
-            <version>${version.rhq.helpers}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.rhq.helpers</groupId>
-            <artifactId>rhq-pluginGen</artifactId>
-            <version>${version.rhq.helpers}</version>
-         </dependency>
-         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${version.scala}</version>
@@ -1015,22 +1004,6 @@
          <artifactId>jboss-logging-processor</artifactId>
          <version>${version.jboss.logging.processor}</version>
          <scope>provided</scope>
-      </dependency>
-      <!-- As of v3.0.4, the RHQ annotations have a retention policy of COMPILE,
-           which means they are no longer required at runtime. However, 
-           because of a Sun compiler bug http://bugs.sun.com/view_bug.do?bug_id=6550655
-           it still needs to be present when using the Infinispan artifacts. This
-           doesn't happen when using Java 7. Please add exclusions accordingly
-           if you don't want to pull this in -->
-      <dependency>
-         <groupId>org.rhq.helpers</groupId>
-         <artifactId>rhq-pluginAnnotations</artifactId>
-         <exclusions>
-            <exclusion>
-               <artifactId>i18nlog</artifactId>
-               <groupId>i18nlog</groupId>
-            </exclusion>
-         </exclusions>
       </dependency>
       <dependency>
           <groupId>org.slf4j</groupId>

--- a/query/src/main/java/org/infinispan/query/MassIndexer.java
+++ b/query/src/main/java/org/infinispan/query/MassIndexer.java
@@ -1,36 +1,35 @@
-/* 
- * JBoss, Home of Professional Open Source 
+/*
+ * JBoss, Home of Professional Open Source
  * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
- * as indicated by the @author tag. All rights reserved. 
- * See the copyright.txt in the distribution for a 
+ * as indicated by the @author tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
- * This copyrighted material is made available to anyone wishing to use, 
- * modify, copy, or redistribute it subject to the terms and conditions 
- * of the GNU Lesser General Public License, v. 2.1. 
- * This program is distributed in the hope that it will be useful, but WITHOUT A 
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
- * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
- * You should have received a copy of the GNU Lesser General Public License, 
- * v.2.1 along with this distribution; if not, write to the Free Software 
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  * MA  02110-1301, USA.
  */
 package org.infinispan.query;
 
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedOperation;
-import org.rhq.helpers.pluginAnnotations.agent.Operation;
 
 /**
  * Component to rebuild the indexes from the existing data.
  * This process starts by removing all existing indexes, and then a distributed
  * task is executed to rebuild the indexes. This task can take a long time to run,
  * depending on data size, used CacheLoaders, indexing complexity.
- * 
+ *
  * While reindexing is being performed queries should not be executed as they
  * will very likely miss many or all results.
- * 
+ *
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
  */
 @MBean(objectName = "MassIndexer",
@@ -39,8 +38,7 @@ public interface MassIndexer {
 
    //TODO Add more parameters here, like timeout when it will be implemented
    //(see ISPN-1313, and ISPN-1042 for task cancellation)
-   @ManagedOperation(description = "Starts rebuilding the index")
-   @Operation(displayName = "Rebuild index")
+   @ManagedOperation(description = "Starts rebuilding the index", displayName = "Rebuild index")
    void start();
 
 }

--- a/rhq-plugin/pom.xml
+++ b/rhq-plugin/pom.xml
@@ -133,6 +133,12 @@
          <artifactId>infinispan-server-core</artifactId>
          <scope>provided</scope>
       </dependency>
+      
+      <dependency>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>infinispan-query</artifactId>
+         <scope>provided</scope>
+      </dependency>
 
       <dependency>
          <groupId>${project.groupId}</groupId>

--- a/server/core/src/main/scala/org/infinispan/server/core/transport/Transport.java
+++ b/server/core/src/main/scala/org/infinispan/server/core/transport/Transport.java
@@ -21,12 +21,11 @@ package org.infinispan.server.core.transport;
 
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.jmx.annotations.DataType;
+import org.infinispan.jmx.annotations.DisplayType;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
-import org.rhq.helpers.pluginAnnotations.agent.DataType;
-import org.rhq.helpers.pluginAnnotations.agent.DisplayType;
-import org.rhq.helpers.pluginAnnotations.agent.MeasurementType;
-import org.rhq.helpers.pluginAnnotations.agent.Metric;
+import org.infinispan.jmx.annotations.MeasurementType;
 
 /**
  * Server transport abstraction
@@ -38,78 +37,98 @@ import org.rhq.helpers.pluginAnnotations.agent.Metric;
 @MBean(objectName = "Transport",
        description = "Transport component manages read and write operations to/from server.")
 public interface Transport {
-   
+
    void start();
-   
+
    void stop();
 
-   @ManagedAttribute(description = "Returns the total number of bytes written " +
-         "by the server back to clients which includes both protocol and user information.")
-   @Metric(displayName = "Number of total number of bytes written",
-           measurementType = MeasurementType.TRENDSUP,
-           displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Returns the total number of bytes written " +
+         "by the server back to clients which includes both protocol and user information.",
+         displayName = "Number of total number of bytes written",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
    String getTotalBytesWritten();
 
    @ManagedAttribute(description = "Returns the total number of bytes read " +
-         "by the server from clients which includes both protocol and user information.")
-   @Metric(displayName = "Number of total number of bytes read",
-           measurementType = MeasurementType.TRENDSUP,
-           displayType = DisplayType.SUMMARY)
+         "by the server from clients which includes both protocol and user information.",
+         displayName = "Number of total number of bytes read",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
    String getTotalBytesRead();
 
-   @ManagedAttribute(description = "Returns the host to which the transport binds.")
-   @Metric(displayName = "Host name", dataType = DataType.TRAIT,
-           displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(
+         description = "Returns the host to which the transport binds.",
+         displayName = "Host name",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY)
    String getHostName();
 
-   @ManagedAttribute(description = "Returns the port to which the transport binds.")
-   @Metric(displayName = "Port", dataType = DataType.TRAIT,
-           displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(
+         description = "Returns the port to which the transport binds.",
+         displayName = "Port",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY
+   )
    String getPort();
 
-   @ManagedAttribute(description = "Returns the number of worker threads.")
-   @Metric(displayName = "Number of worker threads", dataType = DataType.TRAIT,
-           displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(
+         description = "Returns the number of worker threads.",
+         displayName = "Number of worker threads",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY
+   )
    String getNumberWorkerThreads();
 
-   @ManagedAttribute(description = "Returns the idle timeout.")
-   @Metric(displayName = "Idle timeout", dataType = DataType.TRAIT,
-           displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(
+         description = "Returns the idle timeout.",
+         displayName = "Idle timeout",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY
+   )
    String getIdleTimeout();
 
-   @ManagedAttribute(description = "Returns whether TCP no delay was configured or not.")
-   @Metric(displayName = "TCP no delay", dataType = DataType.TRAIT,
-           displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(
+         description = "Returns whether TCP no delay was configured or not.",
+         displayName = "TCP no delay",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY
+   )
    String getTcpNoDelay();
 
-   @ManagedAttribute(description = "Returns the send buffer size.")
-   @Metric(displayName = "Send buffer size", dataType = DataType.TRAIT,
-           displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(
+         description = "Returns the send buffer size.",
+         displayName = "Send buffer size",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY
+   )
    String getSendBufferSize();
 
-   @ManagedAttribute(description = "Returns the receive buffer size.")
-   @Metric(displayName = "Receive buffer size", dataType = DataType.TRAIT,
-           displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(
+         description = "Returns the receive buffer size.",
+         displayName = "Receive buffer size",
+         dataType = DataType.TRAIT,
+         displayType = DisplayType.SUMMARY
+   )
    String getReceiveBufferSize();
 
-   @ManagedAttribute(description = "Returns a count of active connections this server.")
-   @Metric(displayName = "Local active connections",
-         dataType = DataType.MEASUREMENT, displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+   @ManagedAttribute(
+         description = "Returns a count of active connections this server.",
+         displayName = "Local active connections",
+         dataType = DataType.MEASUREMENT, displayType = DisplayType.SUMMARY
+   )
    Integer getNumberOfLocalConnections();
 
-   @ManagedAttribute(description = "Returns a count of active connections in the cluster. " +
+   @ManagedAttribute(
+         description = "Returns a count of active connections in the cluster. " +
          "This operation will make remote calls to aggregate results, " +
-         "so latency might have an impact on the speed of calculation of this attribute.")
-   @Metric(displayName = "Cluster-wide number of active connections",
-         dataType = DataType.MEASUREMENT, displayType = DisplayType.SUMMARY)
-   @SuppressWarnings("unused")
+         "so latency might have an impact on the speed of calculation of this attribute.",
+         displayName = "Cluster-wide number of active connections",
+         dataType = DataType.MEASUREMENT,
+         displayType = DisplayType.SUMMARY
+   )
    Integer getNumberOfGlobalConnections();
 
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodSourceMigrator.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodSourceMigrator.scala
@@ -32,7 +32,6 @@ import org.infinispan.jmx.annotations.{ManagedOperation, MBean}
 import org.infinispan.util.ByteArrayKey
 import org.infinispan.server.core.{Operation, CacheValue}
 import org.infinispan.Cache
-import org.rhq.helpers.pluginAnnotations.agent.Operation
 import org.infinispan.server.core.Operation
 import org.infinispan.distexec.{DistributedCallable, DefaultExecutorService}
 import java.nio.charset.Charset

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -107,11 +107,6 @@
       </dependency>
       <!-- Made the RHQ dependency non-transitive in case we only need the remote cache -->
       <dependency>
-         <groupId>org.rhq.helpers</groupId>
-         <artifactId>rhq-pluginAnnotations</artifactId>
-         <scope>provided</scope>
-      </dependency>
-      <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-client-hotrod</artifactId>
          <scope>compile</scope>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -56,10 +56,11 @@
          <artifactId>infinispan-server-core</artifactId>
          <scope>provided</scope>
       </dependency>
-
+      
       <dependency>
-         <groupId>org.rhq.helpers</groupId>
-         <artifactId>rhq-pluginGen</artifactId>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>infinispan-query</artifactId>
+         <scope>provided</scope>
       </dependency>
 
       <dependency>

--- a/tools/src/main/resources/META-INF/rhq-plugin.xslt
+++ b/tools/src/main/resources/META-INF/rhq-plugin.xslt
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet xmlns="urn:xmlns:rhq-plugin" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:c="urn:xmlns:rhq-configuration" xmlns:xslt="http://xml.apache.org/xslt" version="1.0">
+   <xsl:output method="xml" indent="yes" version="1.0" encoding="UTF-8" omit-xml-declaration="no" standalone="yes" xslt:indent-amount="4"/>
+
+   <xsl:template match="/plugin">
+      <plugin name="Infinispan" displayName="Infinispan Plugin" description="Supports management and monitoring of Infinispan" package="org.infinispan.rhq" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:xmlns:rhq-plugin" xmlns:c="urn:xmlns:rhq-configuration">
+         <depends plugin="JMX" useClasses="true" />
+         <xsl:apply-templates select="cacheManager" />
+      </plugin>
+   </xsl:template>
+
+   <xsl:template match="cacheManager">
+      <service name="Infinispan Cache Manager" discovery="CacheManagerDiscovery" class="CacheManagerComponent" supportsManualAdd="true">
+         <runs-inside>
+            <parent-resource-type name="JBossAS Server" plugin="JBossAS" />
+            <parent-resource-type name="JBossAS Server" plugin="JBossAS5" />
+            <parent-resource-type name="JMX Server" plugin="JMX" />
+         </runs-inside>
+         <plugin-configuration>
+            <c:simple-property name="name" description="Name" type="string" default="Infinispan Cache Manager" readOnly="true" />
+         </plugin-configuration>
+         <xsl:apply-templates select="operation" />
+         <xsl:apply-templates select="metric" />
+         <xsl:apply-templates select="/plugin/cache" />
+      </service>
+   </xsl:template>
+
+   <xsl:template match="/plugin/cache">
+      <service name="Infinispan Cache" discovery="CacheDiscovery" class="CacheComponent">
+         <xsl:apply-templates select="operation" />
+         <xsl:apply-templates select="metric" />
+      </service>
+   </xsl:template>
+
+   <xsl:template match="operation">
+      <xsl:copy>
+         <xsl:apply-templates select="@*|node()" />
+      </xsl:copy>
+   </xsl:template>
+
+   <xsl:template match="metric">
+      <xsl:copy>
+         <xsl:apply-templates select="@*|node()" />
+      </xsl:copy>
+   </xsl:template>
+
+   <xsl:template match="@*|node()">
+      <xsl:copy>
+         <xsl:apply-templates select="@*|node()" />
+      </xsl:copy>
+   </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
ISPN-2611 Drop rhq-pluginAnnotations and rhq-pluginGen
- just use the existing Infinispan JMX annotations augmented with a few extra attributes
- use a simple XSL transform to generate the rhq-plugin.xml descriptor
  ISPN-2745 Add missing operations and parameter names/descriptions
- RecoveryAdmin operations were not included by the RHQ plugin
- Force the use of the @Parameter annotations to describe operation parameters
