### PR TITLE
ISPN-2507 @DataRehashed event is not triggered

### DIFF
--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifier.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifier.java
@@ -109,7 +109,7 @@ public interface CacheNotifier extends Listenable {
     */
    void notifyTransactionRegistered(GlobalTransaction globalTransaction, InvocationContext ctx);
 
-   void notifyDataRehashed(Collection<Address> oldView, Collection<Address> newView, int newTopologyId, boolean pre);
+   void notifyDataRehashed(ConsistentHash oldCH, ConsistentHash newCH, int newTopologyId, boolean pre);
 
    void notifyTopologyChanged(ConsistentHash oldConsistentHash, ConsistentHash newConsistentHash, int newTopologyId, boolean pre);
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
@@ -334,12 +334,12 @@ public final class CacheNotifierImpl extends AbstractListenerImpl implements Cac
    }
 
    @Override
-   public void notifyDataRehashed(Collection<Address> oldView, Collection<Address> newView, int newTopologyId, boolean pre) {
+   public void notifyDataRehashed(ConsistentHash oldCH, ConsistentHash newCH, int newTopologyId, boolean pre) {
       if (!dataRehashedListeners.isEmpty()) {
          EventImpl<Object, Object> e = EventImpl.createEvent(cache, DATA_REHASHED);
          e.setPre(pre);
-         e.setMembersAtStart(oldView);
-         e.setMembersAtEnd(newView);
+         e.setConsistentHashAtStart(oldCH);
+         e.setConsistentHashAtEnd(newCH);
          e.setNewTopologyId(newTopologyId);
          for (ListenerInvocation listener : dataRehashedListeners) listener.invoke(e);
       }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/DataRehashed.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/DataRehashed.java
@@ -19,7 +19,7 @@
 
 package org.infinispan.notifications.cachelistener.annotation;
 
-import org.infinispan.config.Configuration;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.notifications.IncorrectListenerException;
 import org.infinispan.notifications.cachelistener.event.DataRehashedEvent;
 import org.infinispan.notifications.cachelistener.event.Event;
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation should be used on methods that need to be notified when a rehash starts or ends.  This is only fired
- * in a {@link Configuration.CacheMode#DIST_SYNC} or {@link Configuration.CacheMode#DIST_ASYNC} configured cache.
+ * in a {@link CacheMode#DIST_SYNC} or {@link CacheMode#DIST_ASYNC} configured cache.
  * <p/>
  * Methods annotated with this annotation should accept a single parameter, a {@link DataRehashedEvent} otherwise a
  * {@link IncorrectListenerException} will be thrown when registering your listener.

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/event/DataRehashedEvent.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/event/DataRehashedEvent.java
@@ -19,6 +19,7 @@
 
 package org.infinispan.notifications.cachelistener.event;
 
+import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.notifications.cachelistener.annotation.DataRehashed;
 import org.infinispan.remoting.transport.Address;
 
@@ -27,7 +28,17 @@ import java.util.Collection;
 /**
  * An event passed in to methods annotated with {@link DataRehashed}.
  *
+ * <p>Note that the {@link #getConsistentHashAtStart()} and {@link #getConsistentHashAtEnd()}
+ * may return different value in the "pre" event notification and in the "post" event notification.
+ * For instance, the <em>end</em> CH in the "pre" notification may be a union of the <em>start</em> and
+ * <em>end</em> CHs in the "post" notification.</p>
+ *
+ * <p>The result of the {@link #getNewTopologyId()} method is not guaranteed to be the same for the "pre"
+ * and the "post" notification, either. However, the "post" value is guaranteed to be greater than or equal to
+ * the "pre" value.</p>
+ *
  * @author Manik Surtani
+ * @author Dan Berindei
  * @since 5.0
  */
 public interface DataRehashedEvent<K, V> extends Event<K, V> {
@@ -41,6 +52,16 @@ public interface DataRehashedEvent<K, V> extends Event<K, V> {
     * @return Retrieves the list of members after rehashing ended.
     */
    Collection<Address> getMembersAtEnd();
+
+   /**
+    * @return The unbalanced consistent hash before the rebalance started.
+    */
+   ConsistentHash getConsistentHashAtStart();
+
+   /**
+    * @return The consistent hash at the end of the rebalance.
+    */
+   ConsistentHash getConsistentHashAtEnd();
 
    /**
     * @return Retrieves the new topology id after rehashing was triggered.

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -233,13 +233,11 @@ public class StateTransferManagerImpl implements StateTransferManager {
 
    @Override
    public boolean isStateTransferInProgress() {
-      // todo [anistor] this returns false until we receive the first rebalance and should actually return true if the cluster has > 1 member
       return stateConsumer.isStateTransferInProgress();
    }
 
    @Override
    public boolean isStateTransferInProgressForKey(Object key) {
-      // todo [anistor] this returns false until we receive the first rebalance and should actually return true if the cluster has > 1 member
       return stateConsumer.isStateTransferInProgressForKey(key);
    }
 

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareConsistentHashFactoryTest.java
@@ -140,7 +140,7 @@ public class TopologyAwareConsistentHashFactoryTest extends AbstractInfinispanTe
       assertAllLocationsWithRebalance(4);
       assertAllLocationsWithRebalance(99);
    }
-   
+
    public void testDifferentMachines2() {
       addNode(testAddresses[0], "m0", null, null);
       addNode(testAddresses[1], "m0", null, null);
@@ -148,6 +148,17 @@ public class TopologyAwareConsistentHashFactoryTest extends AbstractInfinispanTe
       addNode(testAddresses[3], "m1", null, null);
       addNode(testAddresses[4], "m2", null, null);
       addNode(testAddresses[5], "m2", null, null);
+
+      assertAllLocationsWithRebalance(1);
+      assertAllLocationsWithRebalance(2);
+      assertAllLocationsWithRebalance(3);
+      assertAllLocationsWithRebalance(4);
+   }
+
+   public void testDifferentMachines3() {
+      addNode(testAddresses[0], "primary", "primary", "primary");
+      addNode(testAddresses[1], "primary", "primary", "primary");
+      addNode(testAddresses[2], "secondary", "primary", "primary");
 
       assertAllLocationsWithRebalance(1);
       assertAllLocationsWithRebalance(2);

--- a/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
@@ -184,7 +184,7 @@ public class StateConsumerTest {
       // create state provider
       StateConsumerImpl stateConsumer = new StateConsumerImpl();
       stateConsumer.init(cache, pooledExecutorService, stateTransferManager, interceptorChain, icc, configuration, rpcManager, null,
-            commandsFactory, cacheLoaderManager, dataContainer, transactionTable, stateTransferLock);
+            commandsFactory, cacheLoaderManager, dataContainer, transactionTable, stateTransferLock, cacheNotifier);
       stateConsumer.start();
 
       final List<InternalCacheEntry> cacheEntries = new ArrayList<InternalCacheEntry>();
@@ -206,15 +206,15 @@ public class StateConsumerTest {
 
       Set<Integer> seg = new HashSet<Integer>(Arrays.asList(0));
 
-      assertFalse(stateConsumer.isStateTransferInProgress());
+      assertFalse(stateConsumer.hasActiveTransfers());
 
       stateConsumer.onTopologyUpdate(new CacheTopology(1, ch2, null), false);
-      assertTrue(stateConsumer.isStateTransferInProgress());
+      assertTrue(stateConsumer.hasActiveTransfers());
 
       stateConsumer.onTopologyUpdate(new CacheTopology(2, ch2, ch3), true);
-      assertTrue(stateConsumer.isStateTransferInProgress());
+      assertTrue(stateConsumer.hasActiveTransfers());
 
       stateConsumer.stop();
-      assertFalse(stateConsumer.isStateTransferInProgress());
+      assertFalse(stateConsumer.hasActiveTransfers());
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2507
https://issues.jboss.org/browse/ISPN-2401

I fixed ISPN-2401 as well, because it needed the same approach as notifying
the listeners of the start and end of rebalancing at the right time.

I added the consistent hash to the DataRehashedEvent, which should be
backwards compatible, because user code is not supposed to implement it.
