### PR TITLE
ISPN-2715 - org.infinispan.distexec.mapreduce.TopologyAwareTwoNodesMapReduceTest.testCombinerDoesNotChangeResult test fails randomly

### DIFF
--- a/core/src/test/java/org/infinispan/distexec/mapreduce/BaseWordCountMapReduceTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/BaseWordCountMapReduceTest.java
@@ -38,6 +38,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 
 /**
@@ -214,8 +215,9 @@ public abstract class BaseWordCountMapReduceTest extends MultipleCacheManagersTe
  
       MapReduceTask<String,String,String,Integer> task2 = invokeMapReduce(null, false);
       Map<String, Integer> mapReduce2 = task2.execute();
-      assert mapReduce2.get("Infinispan") == mapReduce.get("Infinispan");
-      assert mapReduce2.get("RedHat") == mapReduce.get("RedHat");      
+
+      AssertJUnit.assertEquals(mapReduce2.get("Infinispan"), mapReduce.get("Infinispan"));
+      AssertJUnit.assertEquals(mapReduce2.get("RedHat"), mapReduce.get("RedHat"));
    }
    
    /**

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/TopologyAwareTwoNodesMapReduceTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/TopologyAwareTwoNodesMapReduceTest.java
@@ -53,7 +53,7 @@ public class TopologyAwareTwoNodesMapReduceTest extends SimpleTwoNodesMapReduceT
       cm2.defineConfiguration(cacheName(), builder.build());
       cacheManagers.add(cm2);
 
-      waitForClusterToForm();
+      waitForClusterToForm(cacheName());
    }
 
    //Overriding these tests with empty body due to additional cache that is created during these tests.


### PR DESCRIPTION
I've changed the test so that, the cache setup part waits till the cluster consisting of topology aware nodes is formed for the particular cache which is used, and then the tests are running.
