### PR TITLE
ISPN-2723 Skip locality check for preload tx implied operations

### DIFF
--- a/core/src/main/java/org/infinispan/loaders/CacheLoaderManagerImpl.java
+++ b/core/src/main/java/org/infinispan/loaders/CacheLoaderManagerImpl.java
@@ -240,7 +240,7 @@ public class CacheLoaderManagerImpl implements CacheLoaderManager {
                throw new CacheException("Unable to preload!", e);
             }
 
-            List<Flag> flags = new ArrayList(Arrays.asList(
+            List<Flag> flags = new ArrayList<Flag>(Arrays.asList(
                   CACHE_MODE_LOCAL, SKIP_OWNERSHIP_CHECK, IGNORE_RETURN_VALUES, SKIP_CACHE_STORE, SKIP_LOCKING));
 
             if (clmConfig.shared() || !(loader instanceof ChainingCacheStore)) {
@@ -252,7 +252,7 @@ public class CacheLoaderManagerImpl implements CacheLoaderManager {
             }
 
             AdvancedCache<Object, Object> flaggedCache = cache.getAdvancedCache()
-                  .withFlags(flags.toArray(new Flag[]{}));
+                  .withFlags(flags.toArray(new Flag[flags.size()]));
 
             for (InternalCacheEntry e : state)
                flaggedCache.put(e.getKey(), e.getValue(),

--- a/core/src/test/java/org/infinispan/distribution/DistCacheStoreTxPreloadTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistCacheStoreTxPreloadTest.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.distribution;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test preloading with transactional distributed caches.
+ *
+ * @author Galder Zamarreño
+ * @since 5.2
+ */
+@Test(groups = "functional", testName = "distribution.DistCacheStoreTxPreloadTest")
+public class DistCacheStoreTxPreloadTest extends DistCacheStorePreloadTest {
+
+   public DistCacheStoreTxPreloadTest() {
+      tx = true;
+   }
+
+}

--- a/core/src/test/java/org/infinispan/distribution/DistPreloadWithoutConcurrentWritesTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistPreloadWithoutConcurrentWritesTest.java
@@ -21,10 +21,14 @@ package org.infinispan.distribution;
 
 import org.testng.annotations.Test;
 
-@Test (groups = "functional", testName = "distribution.DistCacheStorePreload2Test")
-public class DistCacheStorePreload2Test extends DistCacheStorePreloadTest {
+/**
+ * Tests distributed caches with cache store from which data is preloaded
+ * works fine with support for concurrent writes is disabled.
+ */
+@Test (groups = "functional", testName = "distribution.DistPreloadWithoutConcurrentWritesTest")
+public class DistPreloadWithoutConcurrentWritesTest extends DistCacheStorePreloadTest {
 
-   public DistCacheStorePreload2Test() {
+   public DistPreloadWithoutConcurrentWritesTest() {
       supportConcurrentWrites = false;
    }
 


### PR DESCRIPTION
I couldn't think of an more suitable fix for this. My fix is certainly debatable. 

Order in which preloading and state transfer happen should not change (iow, change start priorities).
