### PR TITLE
ISPN-2581 StateTransferManagerImpl.waitForInitialStateTransferToComplete...

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -196,10 +196,12 @@ public class StateTransferManagerImpl implements StateTransferManager {
 
       cacheNotifier.notifyTopologyChanged(oldCH, newCH, newCacheTopology.getTopologyId(), false);
 
-      boolean isJoined = stateConsumer.getCacheTopology().getReadConsistentHash().getMembers().contains(rpcManager.getAddress());
-      if (initialStateTransferComplete.getCount() > 0 && isJoined) {
-         initialStateTransferComplete.countDown();
-         log.tracef("Initial state transfer complete for cache %s on node %s", cacheName, rpcManager.getAddress());
+      if (initialStateTransferComplete.getCount() > 0) {
+         boolean isJoined = stateConsumer.getCacheTopology().getReadConsistentHash().getMembers().contains(rpcManager.getAddress());
+         if (isJoined) {
+            initialStateTransferComplete.countDown();
+            log.tracef("Initial state transfer complete for cache %s on node %s", cacheName, rpcManager.getAddress());
+         }
       }
    }
 
@@ -288,11 +290,6 @@ public class StateTransferManagerImpl implements StateTransferManager {
 
    @Override
    public void notifyEndOfTopologyUpdate(int topologyId) {
-      if (initialStateTransferComplete.getCount() > 0
-            && stateConsumer.getCacheTopology().getWriteConsistentHash().getMembers().contains(rpcManager.getAddress())) {
-         initialStateTransferComplete.countDown();
-         log.tracef("Initial state transfer complete for cache %s on node %s", cacheName, rpcManager.getAddress());
-      }
       localTopologyManager.confirmRebalance(cacheName, topologyId, null);
    }
 }


### PR DESCRIPTION
...() returns too soon

https://issues.jboss.org/browse/ISPN-2581

Should also resolve https://issues.jboss.org/browse/ISPN-2541

Don't flag the initial state transfer as complete as soon as we send the
rebalance confirmation to the coordinator. It will be flagged while
processing the next topology update.
