### PR TITLE
ISPN-2754 Fix the infinispan-config-5.2.xsd schema

### DIFF
--- a/core/src/main/resources/schema/infinispan-config-5.2.xsd
+++ b/core/src/main/resources/schema/infinispan-config-5.2.xsd
@@ -394,7 +394,7 @@
                 </xs:documentation>
               </xs:annotation>
             </xs:element>
-            <xs:any namespace="##other" minOccurs="0" />
+            <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded" />
           </xs:sequence>
           <xs:attribute name="passivation" type="xs:boolean">
             <xs:annotation>


### PR DESCRIPTION
ISPN-2754 Fix the infinispan-config-5.2.xsd schema to allow multiple "external" stores (i.e. declared in other schemas)
https://issues.jboss.org/browse/ISPN-2754
