### PR TITLE
ISPN-2759 Don't throw an NPE when invoking operations via the RHQ plugin

### DIFF
--- a/rhq-plugin/src/main/java/org/infinispan/rhq/CacheComponent.java
+++ b/rhq-plugin/src/main/java/org/infinispan/rhq/CacheComponent.java
@@ -186,8 +186,9 @@ public class CacheComponent extends MBeanResourceComponent<CacheManagerComponent
          throw new Exception("Operation " + fullOpName + " can't be found");
 
       Object result = ops.invoke(realParams);
-      if (trace) log.trace("Returning operation result containing " + result.toString());
-      return new OperationResult(result.toString());
+      if (trace)
+         log.trace("Returning operation result containing " + result != null ? result.toString() : "");
+      return new OperationResult(result != null ? result.toString() : "");
    }
 
    private EmsConnection getConnection() {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2759
