### PR TITLE
ISPN-2756 Enabling/disabling RpcManager statistics via JMX doesn't work

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/InvalidationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/InvalidationInterceptor.java
@@ -79,7 +79,6 @@ import org.infinispan.util.logging.LogFactory;
 public class InvalidationInterceptor extends BaseRpcInterceptor {
    private final AtomicLong invalidations = new AtomicLong(0);
    private CommandsFactory commandsFactory;
-   @ManagedAttribute(description = "Enables or disables the gathering of statistics by this component", writable = true)
    private boolean statisticsEnabled;
 
    private static final Log log = LogFactory.getLog(InvalidationInterceptor.class);
@@ -267,15 +266,13 @@ public class InvalidationInterceptor extends BaseRpcInterceptor {
 
    @ManagedAttribute(
          displayName = "Statistics enabled",
-         dataType = DataType.TRAIT
+         dataType = DataType.TRAIT,
+         writable = true
    )
    public boolean getStatisticsEnabled() {
       return this.statisticsEnabled;
    }
 
-   @ManagedAttribute(
-         displayName = "Enable/disable statistics"
-   )
    public void setStatisticsEnabled(@Parameter(name = "enabled", description = "Whether statistics should be enabled or disabled (true/false)") boolean enabled) {
       this.statisticsEnabled = enabled;
    }

--- a/core/src/main/java/org/infinispan/interceptors/TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/TxInterceptor.java
@@ -86,7 +86,6 @@ public class TxInterceptor extends CommandInterceptor {
    private final AtomicLong prepares = new AtomicLong(0);
    private final AtomicLong commits = new AtomicLong(0);
    private final AtomicLong rollbacks = new AtomicLong(0);
-   @ManagedAttribute(description = "Enables or disables the gathering of statistics by this component", writable = true)
    private boolean statisticsEnabled;
    protected TransactionCoordinator txCoordinator;
    protected RpcManager rpcManager;
@@ -304,8 +303,11 @@ public class TxInterceptor extends CommandInterceptor {
       rollbacks.set(0);
    }
 
+   /**
+    * @deprecated Use the statisticsEnabled attribute instead.
+    */
    @ManagedOperation(
-         displayName = "Enable/disable statistics"
+         displayName = "Enable/disable statistics. Deprecated, use the statisticsEnabled attribute instead."
    )
    public void setStatisticsEnabled(@Parameter(name = "enabled", description = "Whether statistics should be enabled or disabled (true/false)") boolean enabled) {
       this.statisticsEnabled = enabled;
@@ -313,7 +315,8 @@ public class TxInterceptor extends CommandInterceptor {
 
    @ManagedAttribute(
          displayName = "Statistics enabled",
-         dataType = DataType.TRAIT
+         dataType = DataType.TRAIT,
+         writable = true
    )
    public boolean isStatisticsEnabled() {
       return this.statisticsEnabled;

--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
@@ -87,8 +87,7 @@ public class RpcManagerImpl implements RpcManager {
    private final AtomicLong replicationFailures = new AtomicLong(0);
    private final AtomicLong totalReplicationTime = new AtomicLong(0);
 
-   @ManagedAttribute(description = "Enables or disables the gathering of statistics by this component", writable = true)
-   boolean statisticsEnabled = false; // by default, don't gather statistics.
+   private boolean statisticsEnabled = false; // by default, don't gather statistics.
    private Configuration configuration;
    private GlobalConfiguration globalCfg;
    private ReplicationQueue replicationQueue;
@@ -354,12 +353,15 @@ public class RpcManagerImpl implements RpcManager {
       return replicationFailures.get();
    }
 
-   @ManagedAttribute(displayName = "Statistics enabled", dataType = DataType.TRAIT)
+   @ManagedAttribute(description = "Statistics enabled", dataType = DataType.TRAIT, writable = true)
    public boolean isStatisticsEnabled() {
       return statisticsEnabled;
    }
 
-   @ManagedOperation(displayName = "Enable/disable statistics")
+   /**
+    * @deprecated We already have an attribute, we shouldn't have an operation for the same thing.
+    */
+   @ManagedOperation(displayName = "Enable/disable statistics. Deprecated, use the statisticsEnabled attribute instead.")
    public void setStatisticsEnabled(@Parameter(name = "enabled", description = "Whether statistics should be enabled or disabled (true/false)") boolean statisticsEnabled) {
       this.statisticsEnabled = statisticsEnabled;
    }

--- a/core/src/test/java/org/infinispan/jmx/RpcManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/RpcManagerMBeanTest.java
@@ -136,7 +136,7 @@ public class RpcManagerMBeanTest extends MultipleCacheManagersTest {
       cache1.put("key", "value");
       assertEquals(cache2.get("key"), "value");
       assertEquals(mBeanServer.getAttribute(rpcManager1, "ReplicationCount"), (long) -1);
-      assertEquals(mBeanServer.getAttribute(rpcManager1, "ReplicationCount"), (long) -1);
+      assertEquals(mBeanServer.getAttribute(rpcManager1, "ReplicationFailures"), (long) -1);
 
       // reset stats enabled parameter
       mBeanServer.setAttribute(rpcManager1, new Attribute("StatisticsEnabled", Boolean.TRUE));


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2756

Remove some duplicate @ManagedAttribute annotations for the same JMX
attribute and change ResourceDMBean to fail when it finds such duplicates.
