### PR TITLE
ISPN-2768 - Write new tests for Query module

### DIFF
--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
@@ -22,15 +22,6 @@
  */
 package org.infinispan.query.blackbox;
 
-import static org.infinispan.query.helper.TestQueryHelperFactory.createCacheQuery;
-import static org.infinispan.query.helper.TestQueryHelperFactory.createQueryParser;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.transaction.TransactionManager;
-
 import org.apache.lucene.queryParser.QueryParser;
 import org.apache.lucene.search.Query;
 import org.hibernate.search.FullTextFilter;
@@ -52,6 +43,14 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
+
+import javax.transaction.TransactionManager;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.infinispan.query.helper.TestQueryHelperFactory.createCacheQuery;
+import static org.infinispan.query.helper.TestQueryHelperFactory.createQueryParser;
 
 /**
  * @author Navin Surtani
@@ -189,7 +188,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       cacheQuery = Search.getSearchManager(cache2).getQuery(luceneQuery);
       List<Object> found = cacheQuery.list();
 
-      assert found.size() == 2 : "Size of list should be 2";
+      AssertJUnit.assertEquals(2, found.size());
       assert found.contains(person2);
       assert found.contains(person3);
       assert !found.contains(person4) : "This should not contain object person4";
@@ -204,7 +203,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       cacheQuery = Search.getSearchManager(cache2).getQuery(luceneQuery);
       found = cacheQuery.list();
 
-      assert found.size() == 3 : "Size of list should be 3";
+      AssertJUnit.assertEquals(3, found.size());
       assert found.contains(person2);
       assert found.contains(person3);
       assert found.contains(person4) : "This should now contain object person4";
@@ -236,7 +235,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       cacheQuery = Search.getSearchManager(cache2).getQuery(luceneQuery);
       List<Object> found = cacheQuery.list();
 
-      assert found.size() == 1;
+      AssertJUnit.assertEquals(1, found.size());
    }
 
    public void testPutMap() throws Exception {
@@ -254,10 +253,12 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       allWrites.put(key3, person3);
 
       cache2.putAll(allWrites);
-      assert searchManager.getQuery(allQuery, Person.class).list().size() == 3;
+      List found = searchManager.getQuery(allQuery, Person.class).list();
+      AssertJUnit.assertEquals(3, found.size());
 
       cache2.putAll(allWrites);
-      assert searchManager.getQuery(allQuery, Person.class).list().size() == 3;
+      found = searchManager.getQuery(allQuery, Person.class).list();
+      AssertJUnit.assertEquals(3, found.size());
    }
 
    public void testClear() throws Exception {
@@ -274,14 +275,14 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
 
       Query luceneQuery = queries[0].combine(queries);
       CacheQuery cacheQuery = Search.getSearchManager(cache1).getQuery(luceneQuery);
-      assert cacheQuery.getResultSize() == 3;
+      AssertJUnit.assertEquals(3, cacheQuery.getResultSize());
 
       cache2.clear();
 
-      assert cacheQuery.getResultSize() == 3;
+      AssertJUnit.assertEquals(3, cacheQuery.getResultSize());
       cacheQuery = Search.getSearchManager(cache1).getQuery(luceneQuery);
 
-      assert cacheQuery.getResultSize() == 0;
+      AssertJUnit.assertEquals(0, cacheQuery.getResultSize());
    }
 
    public void testFullTextFilterOnOff() throws Exception {

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithInfinispanDirectoryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithInfinispanDirectoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.query.blackbox;
+
+import org.hibernate.search.infinispan.InfinispanIntegration;
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.query.test.Person;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * Tests verifying Querying on REPL cache configured with InfinispanIndexManager and infinispan directory provider.
+ *
+ * @author Anna Manukyan
+ */
+@Test(groups = "functional", testName = "query.blackbox.ClusteredCacheWithInfinispanDirectoryTest")
+public class ClusteredCacheWithInfinispanDirectoryTest extends ClusteredCacheTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder cacheCfg = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, transactionsEnabled());
+      cacheCfg.indexing()
+            .enable()
+            .indexLocalOnly(true)
+            .addProperty("default.directory_provider", getDirectoryProvider())
+            .addProperty("default.indexmanager", "org.infinispan.query.indexmanager.InfinispanIndexManager")
+            .addProperty("lucene_version", "LUCENE_36")
+            .addProperty("default.exclusive_index_use", "false");
+      enhanceConfig(cacheCfg);
+      List<Cache<String, Person>> caches = createClusteredCaches(2, cacheCfg);
+      cache1 = caches.get(0);
+      cache2 = caches.get(1);
+
+      ConfigurationBuilder cacheCfg1 = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
+      cacheManagers.get(0).defineConfiguration(InfinispanIntegration.DEFAULT_INDEXESDATA_CACHENAME, cacheCfg1.build());
+      cacheManagers.get(0).defineConfiguration( InfinispanIntegration.DEFAULT_LOCKING_CACHENAME, cacheCfg1.build());
+
+      cacheManagers.get(1).defineConfiguration(InfinispanIntegration.DEFAULT_INDEXESDATA_CACHENAME, cacheCfg1.build());
+      cacheManagers.get(1).defineConfiguration( InfinispanIntegration.DEFAULT_LOCKING_CACHENAME, cacheCfg1.build());
+   }
+
+   public String getDirectoryProvider() {
+      return "infinispan";
+   }
+}

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithRamDirIndexManagerTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithRamDirIndexManagerTest.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.query.blackbox;
+
+import org.testng.annotations.Test;
+
+/**
+ * Tests the queries on clustered cache which is configured with enabled indexing. The InfinispanIndexManager is enabled,
+ * but the directory provider is RAM.
+ *
+ * @author Anna Manukyan
+ */
+@Test(groups = "functional", testName = "query.blackbox.ClusteredCacheWithRamDirIndexManagerTest")
+public class ClusteredCacheWithRamDirIndexManagerTest extends ClusteredCacheWithInfinispanDirectoryTest {
+
+   public String getDirectoryProvider() {
+      return "ram";
+   }
+}

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
@@ -73,7 +73,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      ConfigurationBuilder cacheCfg = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
+      ConfigurationBuilder cacheCfg = getDefaultClusteredCacheConfig(getCacheMode(), false);
       cacheCfg
          .indexing()
             .enable()
@@ -84,6 +84,10 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       List<Cache<String, Person>> caches = createClusteredCaches(2, cacheCfg);
       cache1 = caches.get(0);
       cache2 = caches.get(1);
+   }
+
+   protected CacheMode getCacheMode() {
+      return CacheMode.REPL_SYNC;
    }
 
    private void prepareTestData() {

--- a/query/src/test/java/org/infinispan/query/blackbox/DistributedCacheClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/DistributedCacheClusteredQueryTest.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.query.blackbox;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.testng.annotations.Test;
+
+/**
+ * Testing Clustered distributed queries on Distributed  cache.
+ *
+ * @author Anna Manukyan
+ */
+@Test(groups = "functional", testName = "query.blackbox.DistributedCacheClusteredQueryTest")
+public class DistributedCacheClusteredQueryTest extends ClusteredQueryTest {
+
+   public CacheMode getCacheMode() {
+      return CacheMode.DIST_SYNC;
+   }
+}

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCacheTest.java
@@ -98,6 +98,15 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       assert val.equals(person1) : "Expected " + person1 + " but was " + val;
    }
 
+   public void testSimpleForNonField() throws ParseException {
+      loadTestingData();
+      CacheQuery cacheQuery = createCacheQuery(cache, "nonSearchableField", "test1" );
+      List<Object> found = cacheQuery.list();
+
+      int elems = found.size();
+      assert elems == 0 : "Expected 0 but was " + elems;
+   }
+
    public void testEagerIterator() throws ParseException {
       loadTestingData();
       CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing" );
@@ -603,14 +612,17 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       person1 = new Person();
       person1.setName("Navin Surtani");
       person1.setBlurb("Likes playing WoW");
+      person1.setNonSearchableField("test1");
 
       person2 = new Person();
       person2.setName("Big Goat");
       person2.setBlurb("Eats grass");
+      person1.setNonSearchableField("test2");
 
       person3 = new Person();
       person3.setName("Mini Goat");
       person3.setBlurb("Eats cheese");
+      person1.setNonSearchableField("test3");
 
       anotherGrassEater = new AnotherGrassEater("Another grass-eater", "Eats grass");
    }

--- a/query/src/test/java/org/infinispan/query/blackbox/MarshalledValueClusteredQueryCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/MarshalledValueClusteredQueryCacheTest.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.query.blackbox;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for Clustered distributed queries using marshalled values in cache.
+ *
+ * @author Anna Manukyan
+ */
+@Test(groups = "functional", testName = "query.blackbox.MarshalledValueClusteredQueryCacheTest")
+public class MarshalledValueClusteredQueryCacheTest extends ClusteredQueryTest {
+
+   protected void enhanceConfig(ConfigurationBuilder cacheCfg) {
+      cacheCfg.storeAsBinary().enabled(true);
+   }
+}

--- a/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredCacheTest.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.query.blackbox;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.query.helper.TestQueryHelperFactory;
+import org.infinispan.query.test.Person;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * Testing the query functionality on clustered caches started on TopologyAware nodes.
+ *
+ * @author Anna Manukyan
+ */
+@Test(groups = "functional", testName = "query.distributed.TopologyAwareClusteredCacheTest")
+public class TopologyAwareClusteredCacheTest extends ClusteredCacheTest {
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      List caches = TestQueryHelperFactory.createTopologyAwareCacheNodes(2, getCacheMode(), transactionEnabled(),
+                                                                         isIndexLocalOnly(), isRamDirectory());
+
+      for(Object cache : caches) {
+         cacheManagers.add(((Cache) cache).getCacheManager());
+      }
+
+      cache1 = (Cache<String, Person>) caches.get(0);
+      cache2 = (Cache<String, Person>) caches.get(1);
+
+      waitForClusterToForm();
+   }
+
+   public CacheMode getCacheMode() {
+      return CacheMode.REPL_SYNC;
+   }
+
+   public boolean isIndexLocalOnly() {
+      return false;
+   }
+
+   public boolean isRamDirectory() {
+      return true;
+   }
+
+   public boolean transactionEnabled() {
+      return false;
+   }
+}

--- a/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredQueryTest.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.query.blackbox;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.query.helper.TestQueryHelperFactory;
+import org.infinispan.query.test.Person;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * Tests for testing clustered queries functionality on topology aware nodes.
+ *
+ * @author Anna Manukyan
+ */
+@Test(groups = "functional", testName = "query.distributed.TopologyAwareClusteredQueryTest")
+public class TopologyAwareClusteredQueryTest extends ClusteredQueryTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      List caches = TestQueryHelperFactory.createTopologyAwareCacheNodes(2, getCacheMode(), transactionEnabled(),
+                                                                         isIndexLocalOnly(), isRamDirectory());
+
+      for(Object cache : caches) {
+         cacheManagers.add(((Cache) cache).getCacheManager());
+      }
+
+      cache1 = (Cache<String, Person>) caches.get(0);
+      cache2 = (Cache<String, Person>) caches.get(1);
+
+      waitForClusterToForm();
+   }
+
+   public CacheMode getCacheMode() {
+      return CacheMode.REPL_SYNC;
+   }
+
+   public boolean isIndexLocalOnly() {
+      return true;
+   }
+
+   public boolean isRamDirectory() {
+      return true;
+   }
+
+   public boolean transactionEnabled() {
+      return false;
+   }
+}

--- a/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareDistributedCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareDistributedCacheTest.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.query.blackbox;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.testng.annotations.Test;
+
+/**
+ * Testing query functionality on InfinispanIndexManager enabled Topology aware nodes.
+ *
+ * @author Anna Manukyan
+ */
+@Test(groups = "functional", testName = "query.distributed.TopologyAwareDistributedCacheTest")
+public class TopologyAwareDistributedCacheTest extends TopologyAwareClusteredCacheTest {
+
+   @Override
+   public CacheMode getCacheMode() {
+      return CacheMode.DIST_SYNC;
+   }
+
+   @Override
+   public boolean isIndexLocalOnly() {
+      return true;
+   }
+
+   @Override
+   public boolean isRamDirectory() {
+      return false;
+   }
+
+}

--- a/query/src/test/java/org/infinispan/query/distributed/ClusteredQueryMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/ClusteredQueryMassIndexingTest.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.query.distributed;
+
+import org.apache.lucene.queryParser.ParseException;
+import org.apache.lucene.queryParser.QueryParser;
+import org.apache.lucene.search.Query;
+import org.infinispan.Cache;
+import org.infinispan.query.CacheQuery;
+import org.infinispan.query.Search;
+import org.infinispan.query.queries.faceting.Car;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.infinispan.query.helper.TestQueryHelperFactory.createQueryParser;
+
+/**
+ * Tests verifying that the Mass Indexing works for Clustered queries as well.
+ *
+ * @TODO enable the test when ISPN-2661 is fixed.
+ */
+@Test(groups = "functional", testName = "query.distributed.ClusteredQueryMassIndexingTest", enabled = false)
+public class ClusteredQueryMassIndexingTest extends DistributedMassIndexingTest {
+
+   protected void verifyFindsCar(Cache cache, int expectedCount, String carMake) {
+      QueryParser queryParser = createQueryParser("make");
+
+      try {
+         Query luceneQuery = queryParser.parse(carMake);
+         CacheQuery cacheQuery = Search.getSearchManager(cache).getClusteredQuery(luceneQuery, Car.class);
+
+         Assert.assertEquals(expectedCount, cacheQuery.getResultSize());
+      } catch(ParseException ex) {
+         ex.printStackTrace();
+         Assert.fail("Failed due to: " + ex.getMessage());
+      }
+   }
+
+   //@TODO remove when ISPN-2661 is fixed.
+   @Test(enabled = false)
+   public void testReindexing() throws Exception {}
+}

--- a/query/src/test/java/org/infinispan/query/distributed/DistProgrammaticMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/DistProgrammaticMassIndexTest.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.query.distributed;
+
+import junit.framework.Assert;
+import org.apache.lucene.queryParser.ParseException;
+import org.apache.lucene.queryParser.QueryParser;
+import org.apache.lucene.search.Query;
+import org.hibernate.search.infinispan.InfinispanIntegration;
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.query.CacheQuery;
+import org.infinispan.query.Search;
+import org.infinispan.query.queries.faceting.Car;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.infinispan.query.helper.TestQueryHelperFactory.createQueryParser;
+
+/**
+ * Tests verifying that the Mass Indexing for programmatic cache configuration works as well.
+ *
+ * @author Anna Manukyan
+ */
+@Test(groups = "functional", testName = "query.distributed.DistProgrammaticMassIndex")
+public class DistProgrammaticMassIndexTest extends DistributedMassIndexingTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder cacheCfg = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      cacheCfg.indexing()
+            .enable()
+            .indexLocalOnly(true)
+            .addProperty("hibernate.search.default.indexmanager", "org.infinispan.query.indexmanager.InfinispanIndexManager")
+            .addProperty("hibernate.search.default.directory_provider", "infinispan")
+            .addProperty("hibernate.search.default.exclusive_index_use", "false")
+            .addProperty("lucene_version", "LUCENE_36");
+      List<Cache<String, Car>> cacheList = createClusteredCaches(NUM_NODES, cacheCfg);
+
+      for(int i = 0; i < NUM_NODES; i++) {
+         ConfigurationBuilder cacheCfg1 = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
+         cacheManagers.get(i).defineConfiguration(InfinispanIntegration.DEFAULT_INDEXESDATA_CACHENAME, cacheCfg1.build());
+         cacheManagers.get(i).defineConfiguration( InfinispanIntegration.DEFAULT_LOCKING_CACHENAME, cacheCfg1.build());
+      }
+
+      waitForClusterToForm(neededCacheNames);
+
+      for(Cache cache : cacheList) {
+         caches.add(cache);
+      }
+   }
+
+   protected void verifyFindsCar(Cache cache, int count, String carMake) {
+      QueryParser queryParser = createQueryParser("make");
+
+      try {
+         Query luceneQuery = queryParser.parse(carMake);
+         CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery, Car.class);
+
+         Assert.assertEquals(count, cacheQuery.getResultSize());
+
+      } catch(ParseException ex) {
+         ex.printStackTrace();
+         Assert.fail("Failed due to: " + ex.getMessage());
+      }
+   }
+
+}

--- a/query/src/test/java/org/infinispan/query/distributed/DistributedMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/DistributedMassIndexingTest.java
@@ -99,7 +99,7 @@ public class DistributedMassIndexingTest extends MultipleCacheManagersTest {
       }
    }
 
-   private void verifyFindsCar(Cache cache, int expectedCount, String carMake) {
+   protected void verifyFindsCar(Cache cache, int expectedCount, String carMake) {
       SearchManager searchManager = Search.getSearchManager(cache);
       QueryBuilder carQueryBuilder = searchManager.buildQueryBuilderForClass(Car.class).get();
       Query fullTextQuery = carQueryBuilder.keyword().onField("make").matching(carMake).createQuery();

--- a/query/src/test/java/org/infinispan/query/distributed/MultiNodeDistributedTxTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/MultiNodeDistributedTxTest.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.query.distributed;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.test.Person;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.TransactionMode;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+/**
+ * The same as the MultiNodeDistributedTest, only the cache configuration is transactional.
+ *
+ * @author Anna Manukyan
+ */
+@Test(groups = "functional", testName = "query.distributed.MultiNodeDistributedTxTest")
+public class MultiNodeDistributedTxTest extends MultiNodeDistributedTest {
+
+   protected boolean transactionsEnabled() {
+      return true;
+   }
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws IOException {
+      ConfigurationBuilderHolder holder = readFromXml();
+      holder.getDefaultConfigurationBuilder().transaction().transactionMode(TransactionMode.TRANSACTIONAL);
+
+      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createClusteredCacheManager(holder, false);
+      cacheManagers.add(cacheManager);
+      Cache<String, Person> cache = cacheManager.getCache();
+      caches.add(cache);
+      TestingUtil.waitForRehashToComplete(caches);
+
+      return cacheManager;
+   }
+}

--- a/query/src/test/java/org/infinispan/query/distributed/MultiNodeLocalTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/MultiNodeLocalTest.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.query.distributed;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.test.Person;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.TransactionMode;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+/**
+ * Similar to MultiNodeDistributedTest, but using a local cache configuration both for
+ * the indexed cache and for the storage of the index data.
+ *
+ * @author Anna Manukyan
+ */
+@Test(groups = "functional", testName = "query.distributed.MultiNodeLocalTest")
+public class MultiNodeLocalTest extends MultiNodeDistributedTest {
+
+   protected EmbeddedCacheManager createCacheManager() throws IOException {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder
+            .clustering()
+            .cacheMode(CacheMode.LOCAL)
+            .indexing()
+            .enabled(true)
+            .addProperty("hibernate.search.lucene_version", "LUCENE_CURRENT")
+            .addProperty("default.exclusive_index_use", "false")
+            .addProperty("default.indexmanager", "org.infinispan.query.indexmanager.InfinispanIndexManager");
+
+      if(transactionsEnabled()) {
+         builder.transaction().transactionMode(TransactionMode.TRANSACTIONAL);
+      }
+      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createCacheManager(builder);
+      cacheManagers.add(cacheManager);
+      Cache<String, Person> cache = cacheManager.getCache();
+      caches.add(cache);
+
+      return cacheManager;
+   }
+
+   public void testIndexingWorkDistribution() throws Exception {
+      try {
+         createCacheManager();
+         assertIndexSize(0);
+         storeOn(caches.get(0), "k1", new Person("K. Firt", "Is not a character from the matrix", 1));
+         assertIndexSize(1);
+
+         createCacheManager();
+         storeOn(caches.get(1), "k2", new Person("K. Seycond", "Is a pilot", 1));
+         assertIndexSize(1);
+
+         killMasterNode();
+         assertIndexSize(1);
+      }
+      finally {
+         TestingUtil.killCacheManagers(cacheManagers);
+      }
+   }
+
+}

--- a/query/src/test/java/org/infinispan/query/distributed/MultiNodeLocalTxTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/MultiNodeLocalTxTest.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.query.distributed;
+
+import org.testng.annotations.Test;
+
+/**
+ * Similiar to MultiNodeLocalTest, only uses transactional infinispan configuration.
+ *
+ * @TODO enable the test when ISPN-2727 is fixed.
+ *
+ * @author Anna Manukyan
+ */
+@Test(groups = "functional", testName = "query.distributed.MultiNodeLocalTxTest", enabled = false)
+public class MultiNodeLocalTxTest extends MultiNodeLocalTest {
+
+   public boolean transactionsEnabled() {
+      return true;
+   }
+
+   //@TODO enable the test when ISPN-2727 is fixed.
+   @Test(enabled = false)
+   public void testIndexingWorkDistribution() throws Exception {
+
+   }
+}

--- a/query/src/test/java/org/infinispan/query/distributed/MultiNodeReplicatedTxTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/MultiNodeReplicatedTxTest.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.query.distributed;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.test.Person;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.TransactionMode;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+/**
+ * Similiar as MultiNodeReplicatedTest, but uses transactional configuration for the Infinispan.
+ *
+ * @TODO enable the test when ISPN-2727 is fixed.
+ *
+ * @author Anna Manukyan
+ */
+@Test(groups = "functional", testName = "query.distributed.MultiNodeReplicatedTxTest", enabled = false)
+public class MultiNodeReplicatedTxTest extends MultiNodeReplicatedTest {
+
+   protected boolean transactionsEnabled() {
+      return true;
+   }
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws IOException {
+      ConfigurationBuilderHolder holder = readFromXml();
+
+      holder.getDefaultConfigurationBuilder().transaction().transactionMode(TransactionMode.TRANSACTIONAL);
+
+      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createClusteredCacheManager(holder, false);
+      cacheManagers.add(cacheManager);
+      Cache<String, Person> cache = cacheManager.getCache();
+      caches.add(cache);
+      TestingUtil.waitForRehashToComplete(caches);
+
+      return cacheManager;
+   }
+
+   //@TODO enable the test when ISPN-2727 is fixed.
+   @Test(enabled = false)
+   public void testIndexingWorkDistribution() throws Exception {
+
+   }
+}

--- a/query/src/test/java/org/infinispan/query/distributed/TopologyAwareDistMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/TopologyAwareDistMassIndexingTest.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.query.distributed;
+
+import org.hibernate.search.infinispan.InfinispanIntegration;
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.helper.TestQueryHelperFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Tests verifying that Mass Indexer works properly on Topology Aware nodes.
+ */
+@Test(groups = "functional", testName = "query.distributed.ClusteredQueryMassIndexingTest")
+public class TopologyAwareDistMassIndexingTest extends DistributedMassIndexingTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      caches = TestQueryHelperFactory.createTopologyAwareCacheNodes(NUM_NODES, CacheMode.DIST_SYNC, false, true, false);
+
+      for(Object cache : caches) {
+         Cache cacheObj = (Cache) cache;
+         EmbeddedCacheManager cm1 = cacheObj.getCacheManager();
+         ConfigurationBuilder cacheCfg1 = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
+         cm1.defineConfiguration(InfinispanIntegration.DEFAULT_INDEXESDATA_CACHENAME, cacheCfg1.build());
+         cm1.defineConfiguration(InfinispanIntegration.DEFAULT_LOCKING_CACHENAME, cacheCfg1.build());
+
+         cacheManagers.add(cm1);
+      }
+
+      waitForClusterToForm(neededCacheNames);
+   }
+}

--- a/query/src/test/java/org/infinispan/query/test/Person.java
+++ b/query/src/test/java/org/infinispan/query/test/Person.java
@@ -47,6 +47,8 @@ public class Person implements Serializable {
    private String blurb;
    @Field(store = Store.YES, analyze=Analyze.NO)
    private int age;
+
+   private String nonSearchableField;
    private static final long serialVersionUID = 8251606115293644545L;
 
    public Person() {
@@ -80,6 +82,14 @@ public class Person implements Serializable {
 
    public void setAge(int age) {
       this.age = age;
+   }
+
+   public String getNonSearchableField() {
+      return nonSearchableField;
+   }
+
+   public void setNonSearchableField(String nonSearchableField) {
+      this.nonSearchableField = nonSearchableField;
    }
 
    public boolean equals(Object o) {


### PR DESCRIPTION
- New tests are added to Infinispan Query module testing Clustered Queries;
- New tests are added for testing Queries on Topology Aware nodes;
- New tests are added testing programmatic configuration for mass indexers;
