### PR TITLE
ISPN-2778 When a cache is restarted, the LEAVE and JOIN commands are not...

### DIFF
--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -118,12 +118,12 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
    @Override
    public void leave(String cacheName) {
       log.debugf("Node %s leaving cache %s", transport.getAddress(), cacheName);
-      runningCaches.remove(cacheName);
+      LocalCacheStatus cacheStatus = runningCaches.remove(cacheName);
 
       ReplicableCommand command = new CacheTopologyControlCommand(cacheName,
             CacheTopologyControlCommand.Type.LEAVE, transport.getAddress(), transport.getViewId());
       try {
-         executeOnCoordinatorAsync(command);
+         executeOnCoordinator(command, cacheStatus.getJoinInfo().getTimeout());
       } catch (Exception e) {
          log.debugf(e, "Error sending the leave request for cache %s to coordinator", cacheName);
       }


### PR DESCRIPTION
... ordered

https://issues.jboss.org/browse/ISPN-2778

Make the LEAVE command synchronous. Since the cache start/shutdown is
already synchronized, this will prevent the cache from restarting before
the coordinator has removed it from the members list.
