### PR TITLE
ISPN-2794 Stop the CacheManager when the servlet context is destroyed

### DIFF
--- a/server/rest/src/main/scala/org/infinispan/rest/StartupListener.scala
+++ b/server/rest/src/main/scala/org/infinispan/rest/StartupListener.scala
@@ -69,6 +69,14 @@ class StartupListener extends HttpServlet with Log {
       cm.getCache[String, Any]()
    }
 
+   override def destroy() {
+      super.destroy()
+      if (ManagerInstance.instance != null) {
+         ManagerInstance.instance.stop()
+      }
+      ManagerInstance.instance = null
+   }
+
    /**
     * To avoid any hard dependencies, checking whether the cache manager is injected
     * via the JBoss MicroContainer is done using reflection.

--- a/server/rest/src/test/scala/org/infinispan/rest/IntegrationTest.scala
+++ b/server/rest/src/test/scala/org/infinispan/rest/IntegrationTest.scala
@@ -76,6 +76,7 @@ class IntegrationTest {
    @AfterClass(alwaysRun = true)
    def tearDown() {
       ServerInstance.stop()
+      assertNull(ManagerInstance.instance)
    }
 
    def testBasicOperation(m: Method) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2794
