### PR TITLE
Slight cleanup

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHash.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHash.java
@@ -38,6 +38,11 @@ public interface ConsistentHash {
 
    SocketAddress getServer(byte[] key);
 
-   int getNormalizedHash(Object key);
-
+   /**
+    * Computes hash code of a given object, and then normalizes it to ensure a positive
+    * value is always returned.
+    * @param object to hash
+    * @return a non-null, non-negative normalized hash code for a given object
+    */
+   int getNormalizedHash(Object object);
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHashV1.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHashV1.java
@@ -96,11 +96,7 @@ public class ConsistentHashV1 implements ConsistentHash {
 
    @Override
    public SocketAddress getServer(byte[] key) {
-      int keyHashCode = getNormalizedHash(key);
-      if (keyHashCode == Integer.MIN_VALUE) keyHashCode += 1;
-      int hash = Math.abs(keyHashCode);
-
-      int normalisedHashForKey = hash % hashSpace;
+      int normalisedHashForKey = getNormalizedHash(key) % hashSpace;
 
       int mainOwner = getHashIndex(normalisedHashForKey);
 
@@ -132,7 +128,7 @@ public class ConsistentHashV1 implements ConsistentHash {
    }
 
    @Override
-   public int getNormalizedHash(Object key) {
-      return Util.getNormalizedHash(key, hash);
+   public final int getNormalizedHash(Object object) {
+      return Util.getNormalizedHash(object, hash);
    }
 }

--- a/core/src/main/java/org/infinispan/util/Util.java
+++ b/core/src/main/java/org/infinispan/util/Util.java
@@ -596,9 +596,16 @@ public final class Util {
       throw new IllegalStateException(String.format("Expected a value that can be converted into a double: type=%s, value=%s", type, o));
    }
 
-   public static int getNormalizedHash(Object key, Hash hashFct) {
-      // more efficient impl
-      return hashFct.hash(key) & Integer.MAX_VALUE; // make sure no negative numbers are involved.
+   /**
+    * Applies the given hash function to the hash code of a given object, and then normalizes it to ensure a positive
+    * value is always returned.
+    * @param object to hash
+    * @param hashFct hash function to apply
+    * @return a non-null, non-negative normalized hash code for a given object
+    */
+   public static int getNormalizedHash(Object object, Hash hashFct) {
+      // make sure no negative numbers are involved.
+      return hashFct.hash(object) & Integer.MAX_VALUE;
    }
 
    public static boolean isIBMJavaVendor() {


### PR DESCRIPTION
- Javadoc for getNormalizedHash() in Util and ConsistentHash
- Remove redundant "normalization" checks in ConsistentHashV1.getServer()
