### PR TITLE
ISPN-2658 Fix expected value MarshalledValueTest.testModificationsOnSame...

### DIFF
--- a/core/src/test/java/org/infinispan/marshall/MarshalledValueTest.java
+++ b/core/src/test/java/org/infinispan/marshall/MarshalledValueTest.java
@@ -449,13 +449,10 @@ public class MarshalledValueTest extends MultipleCacheManagersTest {
       cache2.put(key, "2");
 
       // Deserialization only occurs when the cache2.put occurs, not during transport thread execution.
-      // Serialized 5 times:
-      //    twice when cache1 is stored, one to check if the type can be serialized, 2nd to replicate.
-      //    twice when cache1 is stored, one to check if the type can be serialized, 2nd to replicate.
-      //    the final time is when in the 1st node it compares the received
-      //    value and the one in the cache, whose comparison happens in
-      //    serialized mode since serializing is cheaper than deserializing.
-      assertSerializationCounts(5, 1);
+      // Serialized 4 times:
+      //    twice when put is invoked on cache1, one to check if the type can be serialized, 2nd to replicate.
+      //    twice when put is invoked on cache2, one to check if the type can be serialized, 2nd to replicate.
+      assertSerializationCounts(4, 1);
    }
 
    public void testReturnValueDeserialization() { 


### PR DESCRIPTION
...CustomKey

After fixing ISPN-2803 the key is not added in StateConsumerImpl.updatedKeys so no extra comparison (and serialization) is done. Decrease expected value by 1.

Please integrate in master and 5.2.x (anistor/t_2658_52).

JIRA: https://issues.jboss.org/browse/ISPN-2658
