### PR TITLE
ISPN-2435 Cache#replace(key, old, new) method doesn't check old value on...

### DIFF
--- a/core/src/main/java/org/infinispan/commands/write/RemoveCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/RemoveCommand.java
@@ -46,6 +46,7 @@ public class RemoveCommand extends AbstractDataWriteCommand {
    protected CacheNotifier notifier;
    boolean successful = true;
    boolean nonExistent = false;
+   private boolean ignorePreviousValue;
 
    /**
     * When not null, value indicates that the entry should only be removed if the key is mapped to this value. By the
@@ -88,7 +89,7 @@ public class RemoveCommand extends AbstractDataWriteCommand {
 
       if (!(e instanceof MVCCEntry)) ctx.putLookedUpEntry(key, null);
 
-      if (value != null && e.getValue() != null && !e.getValue().equals(value)) {
+      if (!ignorePreviousValue && value != null && e.getValue() != null && !e.getValue().equals(value)) {
          successful = false;
          e.rollback();
          return false;
@@ -152,6 +153,7 @@ public class RemoveCommand extends AbstractDataWriteCommand {
          .append(key)
          .append(", value=").append(value)
          .append(", flags=").append(flags)
+         .append(", ignorePreviousValue=").append(ignorePreviousValue)
          .append("}")
          .toString();
    }
@@ -177,11 +179,16 @@ public class RemoveCommand extends AbstractDataWriteCommand {
       key = parameters[0];
       value = parameters[1];
       flags = (Set<Flag>) parameters[2];
+      ignorePreviousValue = (Boolean) parameters[3];
    }
 
    @Override
    public Object[] getParameters() {
-      return new Object[]{key, value, Flag.copyWithoutRemotableFlags(flags)};
+      return new Object[]{key, value, Flag.copyWithoutRemotableFlags(flags), ignorePreviousValue};
+   }
+
+   public void setIgnorePreviousValue(boolean ignorePreviousValue) {
+      this.ignorePreviousValue = ignorePreviousValue;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/write/ReplaceCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/ReplaceCommand.java
@@ -45,6 +45,8 @@ public class ReplaceCommand extends AbstractDataWriteCommand {
    CacheNotifier notifier;
    boolean successful = true;
 
+   private boolean ignorePreviousValue;
+
    public ReplaceCommand() {
    }
 
@@ -79,7 +81,8 @@ public class ReplaceCommand extends AbstractDataWriteCommand {
             }
          }
 
-         if (oldValue == null || oldValue.equals(e.getValue())) {
+         if (oldValue == null || oldValue.equals(e.getValue()) || ignorePreviousValue) {
+            e.setChanged(true);
             Object old = e.setValue(newValue);
             e.setLifespan(lifespanMillis);
             e.setMaxIdle(maxIdleTimeMillis);
@@ -115,7 +118,7 @@ public class ReplaceCommand extends AbstractDataWriteCommand {
 
    @Override
    public Object[] getParameters() {
-      return new Object[]{key, oldValue, newValue, lifespanMillis, maxIdleTimeMillis,
+      return new Object[]{key, oldValue, newValue, lifespanMillis, maxIdleTimeMillis, ignorePreviousValue,
                           Flag.copyWithoutRemotableFlags(flags)};
    }
 
@@ -128,7 +131,8 @@ public class ReplaceCommand extends AbstractDataWriteCommand {
       newValue = parameters[2];
       lifespanMillis = (Long) parameters[3];
       maxIdleTimeMillis = (Long) parameters[4];
-      flags = (Set<Flag>) parameters[5];
+      ignorePreviousValue = (Boolean) parameters[5];
+      flags = (Set<Flag>) parameters[6];
    }
 
    @Override
@@ -191,6 +195,14 @@ public class ReplaceCommand extends AbstractDataWriteCommand {
       this.newValue = newValue;
    }
 
+   public boolean isIgnorePreviousValue() {
+      return ignorePreviousValue;
+   }
+
+   public void setIgnorePreviousValue(boolean ignorePreviousValue) {
+      this.ignorePreviousValue = ignorePreviousValue;
+   }
+
    @Override
    public String toString() {
       return "ReplaceCommand{" +
@@ -199,6 +211,7 @@ public class ReplaceCommand extends AbstractDataWriteCommand {
             ", newValue=" + newValue +
             ", flags=" + flags +
             ", successful=" + successful +
+            ", ignorePreviousValue=" + ignorePreviousValue +
             '}';
    }
 }

--- a/core/src/main/java/org/infinispan/container/entries/MVCCEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/MVCCEntry.java
@@ -46,4 +46,6 @@ public interface MVCCEntry extends CacheEntry, StateChangingEntry {
     * @param placeholder if true, the entry is marked as a lock placeholder.  If false, the entry is un-marked as a placeholder.
     */
    void setLockPlaceholder(boolean placeholder);
+
+   void setChanged(boolean isChanged);
 }

--- a/core/src/main/java/org/infinispan/interceptors/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/EntryWrappingInterceptor.java
@@ -345,7 +345,13 @@ public class EntryWrappingInterceptor extends CommandInterceptor {
       @Override
       public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) throws Throwable {
          if (cdl.localNodeIsOwner(command.getKey())) {
-            entryFactory.wrapEntryForReplace(ctx, command.getKey());
+            if (command.isIgnorePreviousValue()) {
+               //wrap it for put, as the previous value might not be present by now (e.g. might have been deleted)
+               // but we still need to apply the new value.
+               entryFactory.wrapEntryForPut(ctx, command.getKey(), null, false, command);
+            } else  {
+               entryFactory.wrapEntryForReplace(ctx, command.getKey());
+            }
             invokeNextInterceptor(ctx, command);
          }
          return null;

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentOptimisticTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentOptimisticTest.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.infinispan.api;
+
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * @author Mircea Markus
+ * @since 5.2
+ */
+@Test (groups = "functional", testName = "api.ConditionalOperationsConcurrentOptimisticTest")
+public class ConditionalOperationsConcurrentOptimisticTest extends ConditionalOperationsConcurrentTest {
+
+   public ConditionalOperationsConcurrentOptimisticTest() {
+      transactional = true;
+   }
+
+   @Override
+   public void testReplace() throws Exception {
+      List caches = caches(null);
+      testOnCaches(caches, new ReplaceOperation(false));
+   }
+
+   @Override
+   public void testConditionalRemove() throws Exception {
+      List caches = caches(null);
+      testOnCaches(caches, new ConditionalRemoveOperation(false));
+   }
+
+   public void testPutIfAbsent() throws Exception {
+      List caches = caches(null);
+      testOnCaches(caches, new PutIfAbsentOperation(false));
+   }
+}

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentPessimisticTest.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.infinispan.api;
+
+import org.infinispan.transaction.LockingMode;
+import org.testng.annotations.Test;
+
+@Test (groups = "functional", testName = "api.ConditionalOperationsConcurrentPessimisticTest")
+public class ConditionalOperationsConcurrentPessimisticTest extends ConditionalOperationsConcurrentTest {
+
+   public ConditionalOperationsConcurrentPessimisticTest() {
+      transactional = true;
+      lockingMode = LockingMode.PESSIMISTIC;
+   }
+}

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentTest.java
@@ -24,9 +24,13 @@ package org.infinispan.api;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
+import org.infinispan.CacheException;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.VersioningScheme;
 import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -41,6 +45,7 @@ import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -65,6 +70,7 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
    private static final int MOVES = 1000;
    private static final int THREAD_COUNT = 4;
    private static final String SHARED_KEY = "thisIsTheKeyForConcurrentAccess";
+   private final AtomicInteger threadIndex = new AtomicInteger();
 
    private static final String[] validMoves = generateValidMoves();
 
@@ -73,8 +79,10 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
    private static final AtomicInteger liveWorkers = new AtomicInteger();
    private static volatile String failureMessage = "";
 
-   private boolean transactional = false;
+   protected boolean transactional = false;
    private CacheMode mode = CacheMode.DIST_SYNC;
+   protected LockingMode lockingMode = LockingMode.OPTIMISTIC;
+   protected boolean writeSkewCheck;
 
    @BeforeMethod
    public void init() {
@@ -87,33 +95,45 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(mode, transactional);
+      dcc.transaction().lockingMode(lockingMode);
+      if (writeSkewCheck) {
+         dcc.transaction().locking().writeSkewCheck(true);
+         dcc.transaction().locking().isolationLevel(IsolationLevel.REPEATABLE_READ);
+         dcc.transaction().versioning().enable().scheme(VersioningScheme.SIMPLE);
+      }
       createCluster(dcc, NODES_NUM);
       waitForClusterToForm();
    }
 
    public void testReplace() throws Exception {
       List caches = caches(null);
-      testOnCaches(caches, new ReplaceOperation());
+      testOnCaches(caches, new ReplaceOperation(true));
    }
 
    public void testConditionalRemove() throws Exception {
       List caches = caches(null);
-      testOnCaches(caches, new ConditionalRemoveOperation());
+      testOnCaches(caches, new ConditionalRemoveOperation(true));
    }
 
    public void testPutIfAbsent() throws Exception {
       List caches = caches(null);
-      testOnCaches(caches, new PutIfAbsentOperation());
+      testOnCaches(caches, new PutIfAbsentOperation(true));
    }
 
-   private void testOnCaches(List<Cache> caches, CacheOperation operation) {
+   protected void testOnCaches(List<Cache> caches, CacheOperation operation) {
       failed.set(false);
       quit.set(false);
       caches.get(0).put(SHARED_KEY, "initialValue");
       final SharedState state = new SharedState(THREAD_COUNT);
       final PostOperationStateCheck stateCheck = new PostOperationStateCheck(caches, state, operation);
       final CyclicBarrier barrier = new CyclicBarrier(THREAD_COUNT, stateCheck);
-      ExecutorService exec = Executors.newFixedThreadPool(THREAD_COUNT);
+      final String className = getClass().getSimpleName();//in order to be able filter this test's log file correctly
+      ExecutorService exec = Executors.newFixedThreadPool(THREAD_COUNT, new ThreadFactory() {
+         @Override
+         public Thread newThread(Runnable r) {
+            return new Thread(r, className + "-" + threadIndex.getAndIncrement());
+         }
+      });
       for (int threadIndex = 0; threadIndex < THREAD_COUNT; threadIndex++) {
          Runnable validMover = new ValidMover(caches, barrier, threadIndex, state, operation);
          exec.execute(validMover);
@@ -192,14 +212,14 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
             quit.set(true);
             barrier.reset();
          } catch (InterruptedException e) {
-            log.error("Caught exception %s", e);
+            log.error("Caught exception", e);
             fail(e);
          } catch (BrokenBarrierException e) {
-            log.error("Caught exception %s", e);
+            log.error("Caught exception", e);
             //just quit
             print("Broken barrier!");
          } catch (RuntimeException e) {
-            log.error("Caught exception %s", e);
+            log.error("Caught exception", e);
             fail(e);
          } finally {
             int andGet = liveWorkers.decrementAndGet();
@@ -243,7 +263,6 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
       public boolean isAfter() {
          return after;
       }
-
    }
 
    static final class SharedThreadState {
@@ -344,7 +363,20 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
       private void checkNoLocks() {
          for (Cache c : caches) {
             LockManager lockManager = c.getAdvancedCache().getComponentRegistry().getComponent(LockManager.class);
-            if (lockManager.isLocked(SHARED_KEY)) {
+            //locks might be released async, so give it some time
+            boolean isLocked = true;
+            for (int i = 0; i < 30; i++) {
+               if (!lockManager.isLocked(SHARED_KEY)) {
+                  isLocked = false;
+                  break;
+               }
+               try {
+                  Thread.currentThread().sleep(500);
+               } catch (InterruptedException e) {
+                  throw new RuntimeException(e);
+               }
+            }
+            if (isLocked) {
                fail("lock on the entry wasn't cleaned up");
             }
          }
@@ -379,7 +411,15 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
    }
 
    public static abstract class CacheOperation {
-      abstract boolean isCas();
+      private final boolean isCas;
+
+      protected CacheOperation(boolean cas) {
+         isCas = cas;
+      }
+
+      public final boolean isCas() {
+         return isCas;
+      }
 
       abstract boolean execute(Cache cache, String sharedKey, Object existing, String targetValue);
 
@@ -391,14 +431,18 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
    }
 
    static class ReplaceOperation extends CacheOperation {
-      @Override
-      public boolean isCas() {
-         return true;
+
+      ReplaceOperation(boolean cas) {
+         super(cas);
       }
 
       @Override
       public boolean execute(Cache cache, String sharedKey, Object existing, String targetValue) {
-         return cache.replace(SHARED_KEY, existing, targetValue);
+         try {
+            return cache.replace(SHARED_KEY, existing, targetValue);
+         } catch (CacheException e) {
+            return false;
+         }
       }
 
       @Override
@@ -408,14 +452,18 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
 
    static class PutIfAbsentOperation extends CacheOperation {
 
-      @Override
-      public boolean isCas() {
-         return true;
+      PutIfAbsentOperation(boolean cas) {
+         super(cas);
       }
 
       @Override
       public boolean execute(Cache cache, String sharedKey, Object existing, String targetValue) {
-         return cache.putIfAbsent(SHARED_KEY, targetValue) == null;
+         try {
+            Object o = cache.putIfAbsent(SHARED_KEY, targetValue);
+            return o == null;
+         } catch (CacheException e) {
+            return false;
+         }
       }
 
       @Override
@@ -426,14 +474,17 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
 
    static class ConditionalRemoveOperation extends CacheOperation {
 
-      @Override
-      public boolean isCas() {
-         return true;
+      ConditionalRemoveOperation(boolean cas) {
+         super(cas);
       }
 
       @Override
       public boolean execute(Cache cache, String sharedKey, Object existing, String targetValue) {
-         return cache.remove(SHARED_KEY, existing);
+         try {
+            return cache.remove(SHARED_KEY, existing);
+         } catch (CacheException e) {
+            return false;
+         }
       }
 
       @Override

--- a/core/src/test/java/org/infinispan/api/ReplaceWithValueChangedTest.java
+++ b/core/src/test/java/org/infinispan/api/ReplaceWithValueChangedTest.java
@@ -1,0 +1,115 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.infinispan.api;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.annotations.Test;
+
+import javax.transaction.Transaction;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test the condition described here: {@link org.infinispan.interceptors.distribution.TxDistributionInterceptor#ignorePreviousValueOnBackup}.
+ *
+ * @author Mircea Markus
+ * @since 5.2
+ */
+@Test (groups = "functional", testName = "api.ReplaceWithValueChangedTest")
+public class ReplaceWithValueChangedTest extends MultipleCacheManagersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createClusteredCaches(2, getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true));
+   }
+
+   public void testReplace1() throws Throwable {
+      Object k1 = getKeyForCache(0);
+      cache(0).put(k1, "v1");
+      tm(0).begin();
+      assertEquals("v1", cache(0).replace(k1, "v2"));
+      Transaction suspendedTx = tm(0).suspend();
+
+      cache(0).remove(k1);
+      assertNull(cache(0).get(k1));
+      assertNull(cache(1).get(k1));
+
+      log.trace("Here it begins");
+      suspendedTx.commit();
+
+      assertEquals("v2", cache(0).get(k1));
+      assertEquals("v2", cache(1).get(k1));
+   }
+
+   public void testReplace2() throws Throwable {
+      Object k1 = getKeyForCache(0);
+      cache(0).put(k1, "v1");
+      tm(0).begin();
+      assertEquals("v1", cache(0).replace(k1, "v2"));
+      Transaction suspendedTx = tm(0).suspend();
+
+      cache(0).put(k1, "v3");
+      assertEquals(cache(0).get(k1), "v3");
+      assertEquals(cache(1).get(k1), "v3");
+
+      suspendedTx.commit();
+
+      assertEquals("v2", cache(0).get(k1));
+      assertEquals("v2", cache(1).get(k1));
+   }
+
+   public void testPutIfAbsent() throws Throwable {
+      Object k1 = getKeyForCache(0);
+
+      tm(0).begin();
+      assertNull(cache(0).putIfAbsent(k1, "v1"));
+      Transaction suspendedTx = tm(0).suspend();
+
+      cache(0).put(k1, "v2");
+      assertEquals(cache(0).get(k1), "v2");
+      assertEquals(cache(1).get(k1), "v2");
+
+      suspendedTx.commit();
+
+      assertEquals("v1", cache(0).get(k1));
+      assertEquals("v1", cache(1).get(k1));
+   }
+
+   public void testConditionalRemove() throws Throwable {
+      Object k1 = getKeyForCache(0);
+      cache(0).put(k1, "v1");
+      tm(0).begin();
+      assertTrue(cache(0).remove(k1, "v1"));
+      Transaction suspendedTx = tm(0).suspend();
+
+      cache(0).put(k1, "v2");
+      assertEquals(cache(0).get(k1), "v2");
+      assertEquals(cache(1).get(k1), "v2");
+
+      log.trace("here it is");
+      suspendedTx.commit();
+
+      assertNull(cache(0).get(k1));
+      assertNull(cache(1).get(k1));
+   }
+}

--- a/core/src/test/java/org/infinispan/api/SimpleConditionalOperationTest.java
+++ b/core/src/test/java/org/infinispan/api/SimpleConditionalOperationTest.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.infinispan.api;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+@Test(groups = "functional", testName = "api.SimpleConditionalOperationTest")
+public class SimpleConditionalOperationTest extends MultipleCacheManagersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder dcc = getConfig();
+      createCluster(dcc, 2);
+      waitForClusterToForm();
+   }
+
+   protected ConfigurationBuilder getConfig() {
+      return getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
+   }
+
+   public void testReplaceFromMainOwner() throws Throwable {
+      Object k = getKeyForCache(0);
+      cache(0).put(k, "0");
+      tm(0).begin();
+      cache(0).put("kkk", "vvv");
+      cache(0).replace(k, "v1", "v2");
+      tm(0).commit();
+
+      assertEquals(advancedCache(0).getDataContainer().get(k).getValue(), "0");
+      assertEquals(advancedCache(1).getDataContainer().get(k).getValue(), "0");
+
+      log.trace("here is the interesting replace.");
+      cache(0).replace(k, "0", "1");
+      assertEquals(advancedCache(0).getDataContainer().get(k).getValue(), "1");
+      assertEquals(advancedCache(1).getDataContainer().get(k).getValue(), "1");
+   }
+
+   public void testRemoveFromMainOwner() {
+      Object k = getKeyForCache(0);
+      cache(0).put(k, "0");
+      cache(0).remove(k, "1");
+
+      assertEquals(advancedCache(0).getDataContainer().get(k).getValue(), "0");
+      assertEquals(advancedCache(1).getDataContainer().get(k).getValue(), "0");
+
+      cache(0).remove(k, "0");
+      assertNull(advancedCache(0).getDataContainer().get(k));
+      assertNull(advancedCache(1).getDataContainer().get(k));
+   }
+
+   public void testPutIfAbsentFromMainOwner() {
+      Object k = getKeyForCache(0);
+      cache(0).put(k, "0");
+      cache(0).putIfAbsent(k, "1");
+
+      assertEquals(advancedCache(0).getDataContainer().get(k).getValue(), "0");
+      assertEquals(advancedCache(1).getDataContainer().get(k).getValue(), "0");
+
+      cache(0).remove(k);
+
+      cache(0).putIfAbsent(k, "1");
+      assertEquals(advancedCache(0).getDataContainer().get(k).getValue(), "1");
+      assertEquals(advancedCache(1).getDataContainer().get(k).getValue(), "1");
+   }
+}

--- a/core/src/test/java/org/infinispan/distribution/DistSkipRemoteLookupTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSkipRemoteLookupTest.java
@@ -23,6 +23,8 @@
 package org.infinispan.distribution;
 
 import static org.infinispan.context.Flag.SKIP_REMOTE_LOOKUP;
+import static org.testng.Assert.assertEquals;
+
 import java.util.concurrent.ExecutionException;
 import org.infinispan.context.Flag;
 import org.testng.annotations.Test;
@@ -117,7 +119,8 @@ public class DistSkipRemoteLookupTest extends BaseDistFunctionalTest {
       assert null == c1.put(k1, value);
 
       assertIsNotInL1(c3, k1);
-      assert value.equals(c3.remove(k1));
+      log.trace("here it is");
+      assertEquals(value, c3.remove(k1));
       assert null == c1.put(k1, value);
 
       assert null == c4.getAdvancedCache().withFlags(Flag.SKIP_REMOTE_LOOKUP).removeAsync(k1).get();


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2435
please cherry-pick on 5.2.x as well.
