### PR TITLE
ISPN-2699 Transport object factory propagates Ping exceptions

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/exceptions/RemoteNodeSuspectException.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/exceptions/RemoteNodeSuspectException.java
@@ -30,9 +30,9 @@ package org.infinispan.client.hotrod.exceptions;
  * @author Galder Zamarreño
  * @since 4.2
  */
-public class RemoteNodeSuspecException extends HotRodClientException {
+public class RemoteNodeSuspectException extends HotRodClientException {
 
-   public RemoteNodeSuspecException(String msgFromServer, long messageId, short status) {
+   public RemoteNodeSuspectException(String msgFromServer, long messageId, short status) {
       super(msgFromServer, messageId, status);
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/exceptions/TransportException.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/exceptions/TransportException.java
@@ -22,6 +22,8 @@
  */
 package org.infinispan.client.hotrod.exceptions;
 
+import java.net.SocketAddress;
+
 /**
  * Indicates a communication exception with the Hot Rod server: e.g. TCP connection is broken while reading a response
  * from the server.
@@ -30,18 +32,26 @@ package org.infinispan.client.hotrod.exceptions;
  * @since 4.1
  */
 public class TransportException extends HotRodClientException {
-   public TransportException() {
-   }
 
-   public TransportException(String message) {
+   private final SocketAddress serverAddress;
+
+   public TransportException(String message, SocketAddress serverAddress) {
       super(message);
+      this.serverAddress = serverAddress;
    }
 
-   public TransportException(String message, Throwable cause) {
+   public TransportException(String message, Throwable cause, SocketAddress serverAddress) {
       super(message, cause);
+      this.serverAddress = serverAddress;
    }
 
-   public TransportException(Throwable cause) {
+   public TransportException(Throwable cause, SocketAddress serverAddress) {
       super(cause);
+      this.serverAddress = serverAddress;
    }
+
+   public SocketAddress getServerAddress() {
+      return serverAddress;
+   }
+
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -42,8 +42,8 @@ import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.ServerStatistics;
 import org.infinispan.client.hotrod.Version;
 import org.infinispan.client.hotrod.VersionedValue;
+import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.client.hotrod.exceptions.RemoteCacheManagerNotStartedException;
-import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.client.hotrod.impl.async.NotifyingFutureImpl;
 import org.infinispan.client.hotrod.impl.operations.BulkGetKeysOperation;
 import org.infinispan.client.hotrod.impl.operations.BulkGetOperation;
@@ -450,7 +450,8 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
       try {
          return marshaller.objectToByteBuffer(o, isKey ? estimateKeySize : estimateValueSize);
       } catch (IOException ioe) {
-         throw new TransportException("Unable to marshall object of type [" + o.getClass().getName() + "]", ioe);
+         throw new HotRodClientException(
+               "Unable to marshall object of type [" + o.getClass().getName() + "]", ioe);
       } catch (InterruptedException ie) {
          Thread.currentThread().interrupt();
          return null;
@@ -462,7 +463,8 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
       try {
          return marshaller.objectFromByteBuffer(bytes);
       } catch (Exception e) {
-         throw new TransportException("Unable to unmarshall byte stream", e);
+         throw new HotRodClientException(
+               "Unable to unmarshall byte stream", e);
       }
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
@@ -25,7 +25,7 @@ package org.infinispan.client.hotrod.impl.operations;
 import net.jcip.annotations.Immutable;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
-import org.infinispan.client.hotrod.exceptions.RemoteNodeSuspecException;
+import org.infinispan.client.hotrod.exceptions.RemoteNodeSuspectException;
 import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.impl.transport.Transport;
@@ -67,8 +67,16 @@ public abstract class RetryOnFailureOperation<T> extends HotRodOperation {
             transport = getTransport(retryCount);
             return executeOperation(transport);
          } catch (TransportException te) {
+            // Invalidate transport since this exception means that this
+            // instance is no longer usable and should be destroyed.
+            transportFactory.invalidateTransport(
+                  te.getServerAddress(), transport);
             logErrorAndThrowExceptionIfNeeded(retryCount, te);
-         } catch (RemoteNodeSuspecException e) {
+         } catch (RemoteNodeSuspectException e) {
+            // Do not invalidate transport because this exception is caused
+            // as a result of a server finding out that another node has
+            // been suspected, so there's nothing really wrong with the server
+            // from which this node was received.
             logErrorAndThrowExceptionIfNeeded(retryCount, e);
          } finally {
             releaseTransport(transport);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec11.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec11.java
@@ -109,7 +109,7 @@ public class Codec11 extends Codec10 {
 
    private void cacheHashCode(Map<SocketAddress, Set<Integer>> servers2Hash,
             String host, int port, int hashCode) {
-      InetSocketAddress address = new InetSocketAddress(host, port);
+      SocketAddress address = new InetSocketAddress(host, port);
       Set<Integer> hashes = servers2Hash.get(address);
       if (hashes == null) {
          hashes = new HashSet<Integer>();

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/Transport.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/Transport.java
@@ -83,4 +83,9 @@ public interface Transport {
     */
    SocketAddress getRemoteSocketAddress();
 
+   /**
+    * Invalidates transport instance.
+    */
+   void invalidate();
+
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
@@ -26,6 +26,7 @@ import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashFactory;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.Map;
@@ -63,5 +64,7 @@ public interface TransportFactory {
    int getSoTimeout();
 
    int getConnectTimeout();
+
+   void invalidateTransport(SocketAddress serverAddress, Transport transport);
 
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/PropsKeyedObjectPoolFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/PropsKeyedObjectPoolFactory.java
@@ -34,12 +34,11 @@ import org.infinispan.client.hotrod.logging.LogFactory;
  * @author Mircea.Markus@jboss.com
  * @since 4.1
  */
-public class PropsKeyedObjectPoolFactory extends GenericKeyedObjectPoolFactory {
-
+public class PropsKeyedObjectPoolFactory<K, V> extends GenericKeyedObjectPoolFactory<K, V> {
 
    private static final Log log = LogFactory.getLog(PropsKeyedObjectPoolFactory.class);
 
-   public PropsKeyedObjectPoolFactory(KeyedPoolableObjectFactory factory, Properties props) {
+   public PropsKeyedObjectPoolFactory(KeyedPoolableObjectFactory<K, V> factory, Properties props) {
       super(factory);
       _maxActive = intProp(props, "maxActive", -1);
       _maxTotal = intProp(props, "maxTotal", -1);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
@@ -129,4 +129,8 @@ public interface Log extends BasicLogger {
    @Message(value = "Infinispan version: %s", id = 4021)
    void version(String version);
 
+   @LogMessage(level = WARN)
+   @Message(value = "Unable to invalidate transport for server: %s", id = 4022)
+   void unableToInvalidateTransport(SocketAddress serverAddress);
+
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ApacheCommonsPoolTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ApacheCommonsPoolTest.java
@@ -1,0 +1,103 @@
+package org.infinispan.client.hotrod;
+
+import org.apache.commons.pool.BaseKeyedPoolableObjectFactory;
+import org.apache.commons.pool.KeyedObjectPool;
+import org.apache.commons.pool.KeyedObjectPoolFactory;
+import org.apache.commons.pool.impl.GenericKeyedObjectPoolFactory;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.fail;
+
+/**
+ * // TODO: Document this
+ *
+ * @author Galder Zamarreño
+ * @since // TODO
+ */
+@Test(groups = "functional", testName = "client.hotrod.ApacheCommonsPoolTest")
+public class ApacheCommonsPoolTest {
+
+   public void testBorrowValidObjectFromPool() throws Exception {
+      KeyedObjectPool<Integer, String> pool =
+            BasicPoolFactory.createPoolFactory().createPool();
+      String obj = pool.borrowObject(1);
+      assertEquals("1", obj);
+   }
+
+   @Test(expectedExceptions = TooHighException.class)
+   public void testBorrowFromPoolException() throws Exception {
+      GenericKeyedObjectPoolFactory<Integer, String> poolFactory =
+            BasicPoolFactory.createPoolFactory();
+      try {
+         poolFactory.createPool().borrowObject(Integer.MAX_VALUE);
+      } finally {
+         BasicPoolFactory basicPoolFactory =
+               (BasicPoolFactory) poolFactory.getFactory();
+         assertEquals("invalid", basicPoolFactory.getState(Integer.MAX_VALUE));
+      }
+   }
+
+   public void testInvalidateBorrowFromPool() throws Exception {
+      GenericKeyedObjectPoolFactory<Integer, String> poolFactory =
+            BasicPoolFactory.createPoolFactory();
+      KeyedObjectPool<Integer, String> pool = poolFactory.createPool();
+      try {
+         pool.borrowObject(Integer.MAX_VALUE);
+         fail("Should have thrown a TooHighException");
+      } catch (TooHighException e) {
+         // Expected, now invalidate object
+         pool.invalidateObject(Integer.MAX_VALUE, null);
+         BasicPoolFactory basicPoolFactory =
+               (BasicPoolFactory) poolFactory.getFactory();
+         assertEquals("destroyed", basicPoolFactory.getState(Integer.MAX_VALUE));
+      }
+   }
+
+   private static class BasicPoolFactory
+         extends BaseKeyedPoolableObjectFactory<Integer, String> {
+
+      private Map<Integer, String> state = new HashMap<Integer, String>();
+
+      private BasicPoolFactory() {
+         // Singleton
+      }
+
+      @Override
+      public String makeObject(Integer key) throws Exception {
+         if (Integer.MAX_VALUE == key.intValue()) {
+            state.put(key, "invalid");
+            throw new TooHighException("Too high");
+         }
+
+         return key.toString();
+      }
+
+      @Override
+      public void destroyObject(Integer key, String obj) throws Exception {
+         state.put(key, "destroyed");
+      }
+
+      public String getState(Integer key) {
+         return state.get(key);
+      }
+
+      public static GenericKeyedObjectPoolFactory<Integer, String> createPoolFactory() {
+         return new GenericKeyedObjectPoolFactory<Integer, String>(
+               new BasicPoolFactory());
+      }
+
+   }
+
+   private static class TooHighException extends RuntimeException {
+
+      public TooHighException(String message) {
+         super(message);    // TODO: Customise this generated block
+      }
+
+   }
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
@@ -46,6 +46,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -167,7 +168,7 @@ public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
       for (int i = 0; i < 1000; i++) {
          byte[] key = generateKey(i);
          TcpTransport transport = (TcpTransport) tcpConnectionFactory.getTransport(key);
-         InetSocketAddress serverAddress = transport.getServerAddress();
+         SocketAddress serverAddress = transport.getServerAddress();
          CacheContainer cacheContainer = hrServ2CacheManager.get(serverAddress);
          assertNotNull("For server address " + serverAddress + " found " + cacheContainer + ". Map is: " + hrServ2CacheManager, cacheContainer);
          DistributionManager distributionManager = cacheContainer.getCache().getAdvancedCache().getDistributionManager();
@@ -211,7 +212,7 @@ public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
       }
    }
 
-   private void assertCacheContainsKey(InetSocketAddress serverAddress, byte[] keyBytes) {
+   private void assertCacheContainsKey(SocketAddress serverAddress, byte[] keyBytes) {
       CacheContainer cacheContainer = hrServ2CacheManager.get(serverAddress);
       Cache<Object, Object> cache = cacheContainer.getCache();
       DataContainer dataContainer = cache.getAdvancedCache().getDataContainer();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientAsymmetricClusterTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientAsymmetricClusterTest.java
@@ -55,7 +55,7 @@ public class ClientAsymmetricClusterTest extends MultiHotRodServersTest {
 
    @Test(expectedExceptions = HotRodClientException.class,
          expectedExceptionsMessageRegExp = ".*CacheNotFoundException.*")
-   public void test000() {
+   public void testAsymmetricCluster() {
       RemoteCacheManager client0 = client(0);
       RemoteCache<Object, Object> cache0 = client0.getCache(CACHE_NAME);
       cache0.put(1, "v1");

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientSocketReadTimeoutTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientSocketReadTimeoutTest.java
@@ -81,6 +81,9 @@ public class ClientSocketReadTimeoutTest extends SingleCacheManagerTest {
       config.put("infinispan.client.hotrod.socket_timeout", "5000");
       config.put("infinispan.client.hotrod.connect_timeout", "5000");
       config.put("maxActive", 2);
+      // Set ping on startup false, so that the hang can happen
+      // when the put comes, and not when the remote cache manager is built.
+      config.put("infinispan.client.hotrod.ping_on_startup", "false");
       return new RemoteCacheManager(config);
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
@@ -44,8 +44,8 @@ import java.util.Map;
  */
 public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTest {
 
-   protected Map<InetSocketAddress, CacheContainer> hrServ2CacheManager = new HashMap<InetSocketAddress, CacheContainer>();
-   protected Map<InetSocketAddress, HotRodServer> addr2hrServer = new HashMap<InetSocketAddress, HotRodServer>();
+   protected Map<SocketAddress, CacheContainer> hrServ2CacheManager = new HashMap<SocketAddress, CacheContainer>();
+   protected Map<SocketAddress, HotRodServer> addr2hrServer = new HashMap<SocketAddress, HotRodServer>();
 
    @Override
    @BeforeMethod(alwaysRun=true)
@@ -115,9 +115,9 @@ public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTe
       cache.getAdvancedCache().addInterceptor(interceptor, 1);
    }
 
-   private InetSocketAddress getHotRodServerAddress(Cache<Object, Object> cache) {
-      InetSocketAddress addr = null;
-      for (Map.Entry<InetSocketAddress, CacheContainer> entry : hrServ2CacheManager.entrySet()) {
+   private SocketAddress getHotRodServerAddress(Cache<Object, Object> cache) {
+      SocketAddress addr = null;
+      for (Map.Entry<SocketAddress, CacheContainer> entry : hrServ2CacheManager.entrySet()) {
          if (entry.getValue().equals(cache.getCacheManager())) {
             addr = entry.getKey();
          }


### PR DESCRIPTION
5.2.x branch: `t_2699_5`
- Changed the way response header is changed so that all values are read as soon as possible, hence reducing the chances of sockets being left with unread data in case of any exception.
- Use generics properly in Apache pool object factory implementation for Transport objects.
- RetryOnFailureOperation now invalidates a Transport object in the pool if a TransportException is received. This is necessary so that those Transport objects that are invalid can be destroyed and hence any sockets left open can be closed properly.
- Cleaned up references to InetSocketAddress and replaced them with references to SocketAddress.
- Parsing related errors should invalidate transport instance since often these are the consequence of previous errors. This way, next time a client sends an operation to the server, a brand new connection will be used.
