### PR TITLE
ISPN-2828 CLI locate command with encoding

### DIFF
--- a/cli/cli-client/src/main/java/org/infinispan/cli/commands/server/Locate.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/commands/server/Locate.java
@@ -18,11 +18,20 @@
  */
 package org.infinispan.cli.commands.server;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class Locate extends AbstractServerCommand {
+   private final static List<String> OPTIONS = Arrays.asList("--codec=");
 
    @Override
    public String getName() {
       return "locate";
+   }
+
+   @Override
+   public List<String> getOptions() {
+      return OPTIONS;
    }
 
    @Override

--- a/cli/cli-client/src/main/resources/help/locate.txt
+++ b/cli/cli-client/src/main/resources/help/locate.txt
@@ -1,5 +1,5 @@
 .SH SYNOPSIS
-.B locate [
+.B locate [--encoding=codec] [
 .I cache.
 .B ]
 .I key
@@ -13,4 +13,7 @@ works for distributed caches
 command
 .IP key
 the key of the entry for which to show the address
-.SH OUTPUT
+.I --codec=codec
+option has been specified then the key will be encoded using the specified codec, otherwise the default session codec will be used. See the
+.B encoding
+command for more information

--- a/cli/cli-server/src/main/antlr3/org/infinispan/cli/interpreter/IspnQL.g
+++ b/cli/cli-server/src/main/antlr3/org/infinispan/cli/interpreter/IspnQL.g
@@ -178,7 +178,7 @@ infoStatement returns [InfoStatement stmt]
    ;
 
 locateStatement returns [LocateStatement stmt]
-   : LOCATE key = keyIdentifier (EOL | ';')! { $stmt = new LocateStatement($key.key); }
+   : LOCATE opts = statementOptions key = keyIdentifier (EOL | ';')! { $stmt = new LocateStatement($opts.options, $key.key); }
    ;
 
 pingStatement returns [PingStatement stmt]

--- a/cli/cli-server/src/main/java/org/infinispan/cli/interpreter/statement/LocateStatement.java
+++ b/cli/cli-server/src/main/java/org/infinispan/cli/interpreter/statement/LocateStatement.java
@@ -21,6 +21,7 @@ package org.infinispan.cli.interpreter.statement;
 import java.util.List;
 
 import org.infinispan.Cache;
+import org.infinispan.cli.interpreter.codec.Codec;
 import org.infinispan.cli.interpreter.logging.Log;
 import org.infinispan.cli.interpreter.result.Result;
 import org.infinispan.cli.interpreter.result.StatementException;
@@ -39,18 +40,39 @@ import org.infinispan.util.logging.LogFactory;
 public class LocateStatement implements Statement {
    private static final Log log = LogFactory.getLog(LocateStatement.class, Log.class);
 
-   final KeyData keyData;
+   private enum Options {
+      CODEC
+   };
 
-   public LocateStatement(final KeyData key) {
+   final KeyData keyData;
+   final private List<Option> options;
+
+   public LocateStatement(List<Option> options, KeyData key) {
+      this.options = options;
       this.keyData = key;
    }
 
    @Override
    public Result execute(Session session) throws StatementException {
       Cache<Object, Object> cache = session.getCache(keyData.getCacheName());
+      Codec codec = session.getCodec();
+      if (options.size() > 0) {
+         for (Option option : options) {
+            switch (option.toEnum(Options.class)) {
+            case CODEC: {
+               if (option.getParameter() == null) {
+                  throw log.missingOptionParameter(option.getName());
+               } else {
+                  codec = session.getCodec(option.getParameter());
+               }
+            }
+            }
+         }
+      }
       DistributionManager distributionManager = cache.getAdvancedCache().getDistributionManager();
       if(distributionManager!=null) {
-         List<Address> addresses = distributionManager.locate(keyData.getKey());
+         Object key = keyData.getKey();
+         List<Address> addresses = distributionManager.locate(codec.encodeKey(key));
          return new StringResult(addresses.toString());
       } else {
          throw log.cacheNotDistributed();


### PR DESCRIPTION
ISPN-2828 The locate command in the CLI supports session and per-statement encoding of the key to calculate its location in the cluster

This applies to both master and 5.2.x

https://issues.jboss.org/browse/ISPN-2828
