### PR TITLE
ISPN-2832 upgrade to JGroups 3.3.0.Alpha2

### DIFF
--- a/core/src/main/resources/jgroups-ec2.xml
+++ b/core/src/main/resources/jgroups-ec2.xml
@@ -32,7 +32,6 @@
         send_buf_size="640000"
         max_bundle_size="64000"
         max_bundle_timeout="30"
-        enable_bundling="true"
         use_send_queues="true"
         sock_conn_timeout="300"
         enable_diagnostics="false"

--- a/core/src/main/resources/jgroups-tcp.xml
+++ b/core/src/main/resources/jgroups-tcp.xml
@@ -32,7 +32,6 @@
         send_buf_size="640k"
         max_bundle_size="64000"
         max_bundle_timeout="30"
-        enable_bundling="true"
         use_send_queues="true"
         enable_diagnostics="false"
         bundler_type="old"

--- a/core/src/main/resources/jgroups-udp.xml
+++ b/core/src/main/resources/jgroups-udp.xml
@@ -35,7 +35,6 @@
          max_bundle_size="64000"
          max_bundle_timeout="30"
          ip_ttl="${jgroups.udp.ip_ttl:2}"
-         enable_bundling="true"
          enable_diagnostics="false"
          bundler_type="old"
 

--- a/core/src/test/java/org/infinispan/jmx/ClusteredCacheManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/ClusteredCacheManagerMBeanTest.java
@@ -95,9 +95,9 @@ public class ClusteredCacheManagerMBeanTest extends MultipleCacheManagersTest {
    public void testJGroupsInformation() throws Exception {
       ObjectName jchannelName1 = getJGroupsChannelObjectName(JMX_DOMAIN, manager(0).getClusterName());
       ObjectName jchannelName2 = getJGroupsChannelObjectName(JMX_DOMAIN2, manager(1).getClusterName());
-      assertEquals(server.getAttribute(name1, "NodeAddress"), server.getAttribute(jchannelName1, "Address"));
-      assertEquals(server.getAttribute(name2, "NodeAddress"), server.getAttribute(jchannelName2, "Address"));
-      assert (Boolean) server.getAttribute(jchannelName1, "Connected");
-      assert (Boolean) server.getAttribute(jchannelName2, "Connected");
+      assertEquals(server.getAttribute(name1, "NodeAddress"), server.getAttribute(jchannelName1, "address"));
+      assertEquals(server.getAttribute(name2, "NodeAddress"), server.getAttribute(jchannelName2, "address"));
+      assert (Boolean) server.getAttribute(jchannelName1, "connected");
+      assert (Boolean) server.getAttribute(jchannelName2, "connected");
    }
 }

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -28,7 +28,6 @@
          send_buf_size="640000"
          max_bundle_size="64000"
          max_bundle_timeout="30"
-         enable_bundling="true"
          use_send_queues="true"
          sock_conn_timeout="300"
          enable_diagnostics="false"

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -30,7 +30,6 @@
         send_buf_size="640000"
         max_bundle_size="64000"
         max_bundle_timeout="30"
-        enable_bundling="true"
         use_send_queues="true"
         sock_conn_timeout="300"
         enable_diagnostics="false"

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -30,7 +30,6 @@
         send_buf_size="640000"
         max_bundle_size="64000"
         max_bundle_timeout="30"
-        enable_bundling="false"
         use_send_queues="false"
         sock_conn_timeout="300"
         bundler_type="old"

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -30,7 +30,6 @@
         send_buf_size="640000"
         max_bundle_size="64000"
         max_bundle_timeout="30"
-        enable_bundling="false"
         use_send_queues="false"
         sock_conn_timeout="300"
         bundler_type="old"

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -35,7 +35,6 @@
          max_bundle_size="64000"
          max_bundle_timeout="30"
          ip_ttl="${jgroups.udp.ip_ttl:0}"
-         enable_bundling="true"
          enable_diagnostics="false"
  
          thread_naming_pattern="pl"

--- a/demos/gui/src/main/release/etc/config-samples/jgroups-relay1.xml
+++ b/demos/gui/src/main/release/etc/config-samples/jgroups-relay1.xml
@@ -22,7 +22,6 @@
          max_bundle_size="64000"
          max_bundle_timeout="30"
          ip_ttl="${jgroups.udp.ip_ttl:0}"
-         enable_bundling="true"
          enable_unicast_bundling="true"
          enable_diagnostics="true"
          thread_naming_pattern="cl"

--- a/demos/gui/src/main/release/etc/config-samples/jgroups-relay2.xml
+++ b/demos/gui/src/main/release/etc/config-samples/jgroups-relay2.xml
@@ -22,7 +22,6 @@
          max_bundle_size="64000"
          max_bundle_timeout="30"
          ip_ttl="${jgroups.udp.ip_ttl:0}"
-         enable_bundling="true"
          enable_unicast_bundling="true"
          enable_diagnostics="true"
          thread_naming_pattern="cl"

--- a/demos/gui/src/main/release/etc/config-samples/jgroups-tcp.xml
+++ b/demos/gui/src/main/release/etc/config-samples/jgroups-tcp.xml
@@ -17,7 +17,6 @@
          loopback="false"
          max_bundle_size="64000"
          max_bundle_timeout="30"
-         enable_bundling="true"
          enable_unicast_bundling="true"
          enable_diagnostics="true"
          thread_naming_pattern="cl"

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -153,7 +153,7 @@
       <version.jclouds>1.4.1</version.jclouds>
       <version.jetty>6.1.25</version.jetty>
       <version.jgoodies.forms>1.0.5</version.jgoodies.forms>
-      <version.jgroups>3.2.7.Final</version.jgroups>
+      <version.jgroups>3.3.0.Alpha2</version.jgroups>
       <version.jsap>2.1</version.jsap>
       <version.json>20090211</version.json>
       <version.jstl>1.2</version.jstl>


### PR DESCRIPTION
ISPN-2832 is a requirement for the integration of TO protocols in ISPN
