### PR TITLE
ISPN-2503 Re-enable FD_SOCK in the test suite

### DIFF
--- a/core/src/test/java/org/infinispan/test/fwk/JGroupsConfigBuilder.java
+++ b/core/src/test/java/org/infinispan/test/fwk/JGroupsConfigBuilder.java
@@ -159,7 +159,6 @@ public class JGroupsConfigBuilder {
     */
    private static void removeFailureDetectionTcp(JGroupsProtocolCfg jgroupsCfg) {
       jgroupsCfg.removeProtocol(FD)
-            .removeProtocol(FD_SOCK)
             .removeProtocol(VERIFY_SUSPECT);
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2503

Please cherry-pick on `5.2.x` as well.

Fixes the core test suite hanging on Sanne's machine.

It does create 2 extra threads per cache manager (1 pinger + 1 acceptor), but none of them will actually do any work.
