### PR TITLE
ISPN-2845 CLONE - ISPN000136: Execution error: java.lang.NullPointerExce...

### DIFF
--- a/core/src/test/java/org/infinispan/eviction/EvictionDuringBatchTest.java
+++ b/core/src/test/java/org/infinispan/eviction/EvictionDuringBatchTest.java
@@ -24,29 +24,34 @@
 package org.infinispan.eviction;
 
 import org.infinispan.AdvancedCache;
-import org.infinispan.config.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 /**
  * @author Mircea Markus
+ * @author anistor@redhat.com
  * @since 5.1
  */
 @Test (groups = "functional", testName = "eviction.EvictionDuringBatchTest")
+@CleanupAfterMethod
 public class EvictionDuringBatchTest extends SingleCacheManagerTest {
 
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      Configuration cfg = new Configuration().fluent()
-         .eviction().strategy(EvictionStrategy.LRU).maxEntries(128) // 128 max entries
-         .expiration().wakeUpInterval(100L)
-         .locking().useLockStriping(false) // to minimize chances of deadlock in the unit test
-         .invocationBatching()
-         .build();
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(cfg);
+      ConfigurationBuilder cfgBuilder = new ConfigurationBuilder();
+      cfgBuilder.eviction().strategy(EvictionStrategy.LRU).maxEntries(128) // 128 max entries
+            .expiration().wakeUpInterval(100L)
+            .locking().useLockStriping(false) // to minimize chances of deadlock in the unit test
+            .invocationBatching().enable(true);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(cfgBuilder);
       cache = cm.getCache();
       cache.addListener(new BaseEvictionFunctionalTest.EvictionListener());
       return cm;
@@ -60,7 +65,20 @@ public class EvictionDuringBatchTest extends SingleCacheManagerTest {
          advancedCache.endBatch(true);
       }
       Thread.sleep(1000); // sleep long enough to allow the thread to wake-up
-      assert 0 < cache.size() : "no data in cache! all state lost? ";
-      assert 512 >= cache.size() : "cache size too big: " + cache.size();
+
+      int cacheSize = cache.size();
+      assertTrue("no data in cache! all state lost?", cacheSize != 0);
+      assertTrue("cache size too big: " + cacheSize, cacheSize < 512);
+   }
+
+   public void testEvictInBatch() throws Exception {
+      cache().put("myKey", "myValue");
+
+      cache().getAdvancedCache().startBatch();
+      //this should execute non-transactionally despite the batch transaction and should not fail as in https://issues.jboss.org/browse/ISPN-2845
+      cache().evict("myKey");
+      cache().getAdvancedCache().endBatch(true);
+
+      assertFalse(cache().containsKey("myKey"));
    }
 }


### PR DESCRIPTION
...ption -> JBAS018079: Failed to passivate session

CacheImpl.evict() during a batch leads to NPE in AbstractTxInvocationContext.clearLockedKeys because no transaction is actually started. This is caused by BatchingInterceptor replacing the non-transactional context of the evict command with a new transactional context for no reason - evict() is never transactional.

JIRA: https://issues.jboss.org/browse/ISPN-2845

Please integrate in master and 5.2.x (t_2845_52)
