### PR TITLE
ISPN-2860 RHQ plugin should ignore spurious MBeans returned by the AS7 MBeanServer

### DIFF
--- a/core/src/main/java/org/infinispan/eviction/ActivationManagerImpl.java
+++ b/core/src/main/java/org/infinispan/eviction/ActivationManagerImpl.java
@@ -57,7 +57,7 @@ public class ActivationManagerImpl implements ActivationManager {
    private Configuration cfg;
    private boolean enabled;
 
-   @ManagedAttribute(description = "Enables or disables the gathering of statistics by this component", writable = true)
+   @ManagedAttribute(description = "Enables or disables the gathering of statistics by this component", displayName = "Statistics enabled", writable = true)
    private boolean statisticsEnabled = false;
 
    @Inject

--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
@@ -353,7 +353,7 @@ public class RpcManagerImpl implements RpcManager {
       return replicationFailures.get();
    }
 
-   @ManagedAttribute(description = "Statistics enabled", dataType = DataType.TRAIT, writable = true)
+   @ManagedAttribute(description = "Statistics enabled", displayName = "Statistics enabled", dataType = DataType.TRAIT, writable = true)
    public boolean isStatisticsEnabled() {
       return statisticsEnabled;
    }
@@ -361,12 +361,13 @@ public class RpcManagerImpl implements RpcManager {
    /**
     * @deprecated We already have an attribute, we shouldn't have an operation for the same thing.
     */
+   @Deprecated
    @ManagedOperation(displayName = "Enable/disable statistics. Deprecated, use the statisticsEnabled attribute instead.")
    public void setStatisticsEnabled(@Parameter(name = "enabled", description = "Whether statistics should be enabled or disabled (true/false)") boolean statisticsEnabled) {
       this.statisticsEnabled = statisticsEnabled;
    }
 
-   @ManagedAttribute(description = "Successful replications as a ratio of total replications")
+   @ManagedAttribute(description = "Successful replications as a ratio of total replications", displayName = "Successful replications ratio")
    public String getSuccessRatio() {
       if (replicationCount.get() == 0 || !statisticsEnabled) {
          return "N/A";

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAdminOperations.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAdminOperations.java
@@ -56,7 +56,7 @@ public class RecoveryAdminOperations {
       this.recoveryManager = recoveryManager;
    }
 
-   @ManagedOperation(description = "Shows all the prepared transactions for which the originating node crashed")
+   @ManagedOperation(description = "Shows all the prepared transactions for which the originating node crashed", displayName="Show in doubt transactions")
    public String showInDoubtTransactions() {
       Set<RecoveryManager.InDoubtTxInfo> info = getRecoveryInfoFromCluster();
       if (log.isTraceEnabled()) {
@@ -82,14 +82,14 @@ public class RecoveryAdminOperations {
       return result.toString();
    }
 
-   @ManagedOperation(description = "Forces the commit of an in-doubt transaction")
+   @ManagedOperation(description = "Forces the commit of an in-doubt transaction", displayName="Force commit by internal id")
    public String forceCommit(@Parameter(name = "internalId", description = "The internal identifier of the transaction") long internalId) {
       if (log.isTraceEnabled())
          log.tracef("Forces the commit of an in-doubt transaction: %s", internalId);
       return completeBasedOnInternalId(internalId, true);
    }
 
-   @ManagedOperation(description = "Forces the commit of an in-doubt transaction", name="forceCommitByXid")
+   @ManagedOperation(description = "Forces the commit of an in-doubt transaction", displayName="Force commit by Xid", name="forceCommitByXid")
    public String forceCommit(
          @Parameter(name = "formatId", description = "The formatId of the transaction") int formatId,
          @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId,
@@ -97,12 +97,12 @@ public class RecoveryAdminOperations {
       return completeBasedOnXid(formatId, globalTxId, branchQualifier, true);
    }
 
-   @ManagedOperation(description = "Forces the rollback of an in-doubt transaction")
+   @ManagedOperation(description = "Forces the rollback of an in-doubt transaction", displayName="Force rollback by internal id")
    public String forceRollback(@Parameter(name = "internalId", description = "The internal identifier of the transaction") long internalId) {
       return completeBasedOnInternalId(internalId, false);
    }
 
-   @ManagedOperation(description = "Forces the rollback of an in-doubt transaction", name="forceRollbackByXid")
+   @ManagedOperation(description = "Forces the rollback of an in-doubt transaction", displayName="Force rollback by Xid", name="forceRollbackByXid")
    public String forceRollback(
          @Parameter(name = "formatId", description = "The formatId of the transaction") int formatId,
          @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId,
@@ -110,7 +110,7 @@ public class RecoveryAdminOperations {
       return completeBasedOnXid(formatId, globalTxId, branchQualifier, false);
    }
 
-   @ManagedOperation(description = "Removes recovery info for the given transaction.", name="forgetByXid")
+   @ManagedOperation(description = "Removes recovery info for the given transaction.", displayName="Remove recovery info by Xid", name="forgetByXid")
    public String forget(
          @Parameter(name = "formatId", description = "The formatId of the transaction") int formatId,
          @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId,
@@ -119,7 +119,7 @@ public class RecoveryAdminOperations {
       return "Recovery info removed.";
    }
 
-   @ManagedOperation(description = "Removes recovery info for the given transaction.")
+   @ManagedOperation(description = "Removes recovery info for the given transaction.", displayName="Remove recovery info by internal id")
    public String forget(@Parameter(name = "internalId", description = "The internal identifier of the transaction") long internalId) {
       recoveryManager.removeRecoveryInformationFromCluster(null, internalId, true);
       return "Recovery info removed.";

--- a/rhq-plugin/src/main/java/org/infinispan/rhq/CacheDiscovery.java
+++ b/rhq-plugin/src/main/java/org/infinispan/rhq/CacheDiscovery.java
@@ -63,25 +63,30 @@ public class CacheDiscovery extends MBeanResourceDiscoveryComponent<CacheManager
       if (trace) log.trace("Querying "+queryUtility.getTranslatedQuery()+" returned beans: " + beans);
 
       for (EmsBean bean : beans) {
-         /* A discovered resource must have a unique key, that must
-          * stay the same when the resource is discovered the next
-          * time */
-         String name = bean.getAttribute("CacheName").getValue().toString();
-         String mbeanCacheName = bean.getBeanName().getKeyProperty("name");
-         if (trace) log.trace("Resource name is "+name+" and resource key "+ mbeanCacheName);
-         DiscoveredResourceDetails detail = new DiscoveredResourceDetails(
-               ctx.getResourceType(), // Resource Type
-               mbeanCacheName, // Resource Key
-               name, // Resource name
-               null, // Version
-               "One cache within Infinispan", // ResourceDescription
-               ctx.getDefaultPluginConfiguration(), // Plugin Config
-               null // ProcessInfo
-         );
+         // Filter out spurious beans
+         if (CacheComponent.isCacheComponent(bean)) {
+            /* A discovered resource must have a unique key, that must
+             * stay the same when the resource is discovered the next
+             * time */
+            String name = bean.getAttribute("CacheName").getValue().toString();
+            String mbeanCacheName = bean.getBeanName().getKeyProperty("name");
+            if (trace) log.trace("Resource name is "+name+" and resource key "+ mbeanCacheName);
+            DiscoveredResourceDetails detail = new DiscoveredResourceDetails(
+                  ctx.getResourceType(), // Resource Type
+                  mbeanCacheName, // Resource Key
+                  name, // Resource name
+                  null, // Version
+                  "One cache within Infinispan", // ResourceDescription
+                  ctx.getDefaultPluginConfiguration(), // Plugin Config
+                  null // ProcessInfo
+            );
 
-         // Add to return values
-         discoveredResources.add(detail);
-         log.info("Discovered new ...  " + bean.getBeanName().getCanonicalName());
+            // Add to return values
+            discoveredResources.add(detail);
+            log.info("Discovered new ...  " + bean.getBeanName().getCanonicalName());
+         } else {
+            log.warn(String.format("MBeanServer returned spurious object %s", bean.getBeanName().getCanonicalName()));
+         }
       }
       return discoveredResources;
    }

--- a/rhq-plugin/src/main/java/org/infinispan/rhq/CacheManagerDiscovery.java
+++ b/rhq-plugin/src/main/java/org/infinispan/rhq/CacheManagerDiscovery.java
@@ -79,24 +79,29 @@ public class CacheManagerDiscovery extends MBeanResourceDiscoveryComponent<JMXCo
 
          Set<DiscoveredResourceDetails> discoveredResources = new HashSet<DiscoveredResourceDetails>();
          for (EmsBean bean : beans) {
-            String managerName = bean.getBeanName().getCanonicalName();
-            String resourceName = bean.getAttribute("Name").getValue().toString();
-            String version = bean.getAttribute("Version").getValue().toString();
-            /* A discovered resource must have a unique key, that must stay the same when the resource is discovered the next time */
-            if (trace) log.trace("Add resource with version '"+version+"' and type " + ctx.getResourceType());
-            DiscoveredResourceDetails detail = new DiscoveredResourceDetails(
-                  ctx.getResourceType(), // Resource type
-                  resourceName, // Resource key
-                  resourceName, // Resource name
-                  version, // Resource version
-                  "A cache manager within Infinispan", // Description
-                  pluginConfiguration, // Plugin config
-                  null // Process info from a process scan
-            );
-            if(log.isInfoEnabled()) {
-               log.info(String.format("Discovered Infinispan instance with key %s and name %s", resourceName, managerName));
+            // Filter out spurious beans
+            if (CacheManagerComponent.isCacheManagerComponent(bean)) {
+               String managerName = bean.getBeanName().getCanonicalName();
+               String resourceName = bean.getAttribute("Name").getValue().toString();
+               String version = bean.getAttribute("Version").getValue().toString();
+               /* A discovered resource must have a unique key, that must stay the same when the resource is discovered the next time */
+               if (trace) log.trace("Add resource with version '"+version+"' and type " + ctx.getResourceType());
+               DiscoveredResourceDetails detail = new DiscoveredResourceDetails(
+                     ctx.getResourceType(), // Resource type
+                     resourceName, // Resource key
+                     resourceName, // Resource name
+                     version, // Resource version
+                     "A cache manager within Infinispan", // Description
+                     pluginConfiguration, // Plugin config
+                     null // Process info from a process scan
+               );
+               if(log.isInfoEnabled()) {
+                  log.info(String.format("Discovered Infinispan instance with key %s and name %s", resourceName, managerName));
+               }
+               discoveredResources.add(detail);
+            } else {
+               log.warn(String.format("MBeanServer returned spurious object %s", bean.getBeanName().getCanonicalName()));
             }
-            discoveredResources.add(detail);
          }
          return discoveredResources;
       } else {

--- a/tools/src/main/java/org/infinispan/tools/rhq/RhqPluginXmlGenerator.java
+++ b/tools/src/main/java/org/infinispan/tools/rhq/RhqPluginXmlGenerator.java
@@ -149,7 +149,11 @@ public class RhqPluginXmlGenerator {
             if (managedAttr != null) {
                String property = prefix + getPropertyFromBeanConvention(ctMethod);
 
-               String displayName = withNamePrefix ? "[" + mbean.objectName() + "] " + managedAttr.displayName() : managedAttr.displayName();
+               String attrDisplayName = managedAttr.displayName();
+               if (attrDisplayName.length() == 0) {
+                  throw new RuntimeException("Missing displayName on: " + property);
+               }
+               String displayName = withNamePrefix ? "[" + mbean.objectName() + "] " + attrDisplayName : attrDisplayName;
                validateDisplayName(displayName);
 
                Element metric = doc.createElement("metric");
@@ -175,7 +179,11 @@ public class RhqPluginXmlGenerator {
                }
                uniqueOperations.add(name);
 
-               String displayName = withNamePrefix ? "[" + mbean.objectName() + "] " + managedOp.displayName() : managedOp.displayName();
+               String opDisplayName = managedOp.displayName();
+               if (opDisplayName.length() == 0) {
+                  throw new RuntimeException("Missing displayName on: " + name);
+               }
+               String displayName = withNamePrefix ? "[" + mbean.objectName() + "] " + opDisplayName : opDisplayName;
                validateDisplayName(displayName);
 
                Element operation = doc.createElement("operation");


### PR DESCRIPTION
RHQ plugin should ignore spurious MBeans returned by the AS7 MBeanServer
Add missing displayNames to attributes and operations
Make the RHQ plugin descriptor generator throw an exception if an attribute or operation is missing the displayName

https://issues.jboss.org/browse/ISPN-2860

Both for master and 5.2..x
