### PR TITLE
ISPN-2867 Use System.exit() to quit the CLI 

### DIFF
--- a/cli/cli-client/src/main/java/org/infinispan/cli/Main.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/Main.java
@@ -39,6 +39,7 @@ public class Main {
       Shell shell = new ShellImpl();
       shell.init(args);
       shell.run();
+      System.exit(0);
    }
 
 }


### PR DESCRIPTION
ISPN-2867 Use System.exit() to quit the CLI to workaround the fact that JBoss Remoting leaves threads hanging

https://issues.jboss.org/browse/ISPN-2867

Both master and 5.2.x
