### PR TITLE
ISPN-2796 ConcurrentCacheManagerTest.testConcurrentGetCacheCalls hangs t...

### DIFF
--- a/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
@@ -287,6 +287,7 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
       } else {
          // create this component and add it to the registry
          AbstractComponentFactory factory = getFactory(componentClass);
+         getLog().tracef("Creating component %s with factory %s", name, factory.getClass());
          component = factory instanceof NamedComponentFactory ?
                ((NamedComponentFactory) factory).construct(componentClass, name)
                : factory.construct(componentClass);
@@ -310,7 +311,8 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
     * @param componentClass type of component to construct
     * @return component factory capable of constructing such components
     */
-   protected AbstractComponentFactory getFactory(Class<?> componentClass) {
+   protected synchronized AbstractComponentFactory getFactory(Class<?> componentClass) {
+      getLog().tracef("Looking up factory for class %s", componentClass);
       String cfClass = getComponentMetadataRepo().findFactoryForComponent(componentClass);
       if (cfClass == null) {
          throwStackAwareConfigurationException("No registered default factory for component '" + componentClass + "' found!");
@@ -334,6 +336,7 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
       if (component != null) return component;
 
       //hasn't yet been created.  Create and put in registry
+      getLog().tracef("Creating factory %s for component %s", cfClass, componentClass);
       AbstractComponentFactory cf = instantiateFactory(cfClass);
       if (cf == null)
          throwStackAwareConfigurationException("Unable to locate component factory for component " + componentClass);
@@ -893,7 +896,7 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
 
    }
 
-   private void throwStackAwareConfigurationException(String message) {
+   protected void throwStackAwareConfigurationException(String message) {
       if (debugStack == null) {
          throw new ConfigurationException(message + ". To get more detail set the system property " + DEPENDENCIES_ENABLE_JVMOPTION + " to true");
       } else {

--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -163,6 +163,24 @@ public final class ComponentRegistry extends AbstractComponentRegistry {
    }
 
    @Override
+   protected AbstractComponentFactory getFactory(Class<?> componentClass) {
+      String cfClass = getComponentMetadataRepo().findFactoryForComponent(componentClass);
+      if (cfClass == null) {
+         throwStackAwareConfigurationException("No registered default factory for component '" + componentClass + "' found!");
+      }
+
+      AbstractComponentFactory cf;
+      if (isGlobal(cfClass)) {
+         log.tracef("Looking up global factory for component %s", componentClass);
+         cf = globalComponents.getFactory(componentClass);
+      } else {
+         log.tracef("Looking up local factory for component %s", componentClass);
+         cf = super.getFactory(componentClass);
+      }
+      return cf;
+   }
+
+   @Override
    protected final void registerComponentInternal(Object component, String name, boolean nameIsFQCN) {
       if (isGlobal(nameIsFQCN ? name : component.getClass().getName())) {
          globalComponents.registerComponentInternal(component, name, nameIsFQCN);

--- a/core/src/main/java/org/infinispan/factories/TestDelayFactory.java
+++ b/core/src/main/java/org/infinispan/factories/TestDelayFactory.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.infinispan.factories;
+
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+
+/**
+ * Internal class, only used for testing.
+ *
+ * It has to reside in the production source tree because the component metadata persister doesn't parse
+ * test classes.
+ *
+ * @author Dan Berindei
+ * @since 5.2
+ */
+@Scope(Scopes.GLOBAL)
+@DefaultFactoryFor(classes = TestDelayFactory.Component.class)
+public class TestDelayFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
+   private boolean injectionDone = false;
+
+   @Inject
+   public void inject(GlobalConfiguration gc) throws InterruptedException {
+      Thread.sleep(1000);
+      injectionDone = true;
+   }
+
+   public <T> T construct(Class<T> componentType) {
+      if (!injectionDone) {
+         throw new IllegalStateException("GlobalConfiguration reference is null");
+      }
+      return componentType.cast(new Component());
+   }
+
+   @Scope(Scopes.NAMED_CACHE)
+   public static class Component {
+   }
+}

--- a/core/src/test/java/org/infinispan/factories/ComponentRegistryTest.java
+++ b/core/src/test/java/org/infinispan/factories/ComponentRegistryTest.java
@@ -1,0 +1,109 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.infinispan.factories;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Test the concurrent lookup of components for ISPN-2796.
+ *
+ * @author Dan Berindei
+ * @since 5.2
+ */
+@Test(groups = "unit", testName = "factories.ComponentRegistryTest")
+public class ComponentRegistryTest extends AbstractInfinispanTest {
+
+   private GlobalComponentRegistry gcr;
+   private ComponentRegistry cr1;
+   private ComponentRegistry cr2;
+
+   @BeforeMethod
+   public void setUp() throws InterruptedException, ExecutionException {
+      GlobalConfiguration gc = new GlobalConfigurationBuilder().build();
+      Configuration c = new ConfigurationBuilder().build();
+      Set<String> cachesSet = new HashSet<String>();
+      EmbeddedCacheManager cm = mock(EmbeddedCacheManager.class);
+      AdvancedCache cache = mock(AdvancedCache.class);
+
+      gcr = new GlobalComponentRegistry(gc, cm, cachesSet);
+      cr1 = new ComponentRegistry("cache", c, cache, gcr, ComponentRegistryTest.class.getClassLoader());
+      cr2 = new ComponentRegistry("cache", c, cache, gcr, ComponentRegistryTest.class.getClassLoader());
+   }
+
+   public void testSingleThreadLookup() throws InterruptedException, ExecutionException {
+      TestDelayFactory.Component c1 = cr1.getOrCreateComponent(TestDelayFactory.Component.class);
+      assertNotNull(c1);
+
+      TestDelayFactory.Component c2 = cr1.getOrCreateComponent(TestDelayFactory.Component.class);
+      assertNotNull(c2);
+   }
+
+   public void testConcurrentLookupSameComponentRegistry() throws InterruptedException, ExecutionException {
+
+      Future<Object> future = fork(new Callable<Object>() {
+         @Override
+         public Object call() throws Exception {
+            return cr1.getOrCreateComponent(TestDelayFactory.Component.class);
+         }
+      });
+
+      Thread.sleep(500);
+
+      // getComponent doesn't wait for the getOrCreateComponent call on the forked thread to finish
+      // It returns null instead, but that's ok because getComponent doesn't guarantee anything
+      assertNull(cr1.getComponent(TestDelayFactory.Component.class));
+      assertNotNull(future.get());
+      // now that getOrCreateComponent has finished, getComponent works as well
+      assertNotNull(cr1.getComponent(TestDelayFactory.Component.class));
+   }
+
+   public void testConcurrentLookupDifferentComponentRegistries() throws InterruptedException, ExecutionException {
+
+      Future<Object> future = fork(new Callable<Object>() {
+         @Override
+         public Object call() throws Exception {
+            return cr1.getOrCreateComponent(TestDelayFactory.Component.class);
+         }
+      });
+
+      Thread.sleep(500);
+
+      assertNotNull(cr2.getOrCreateComponent(TestDelayFactory.Component.class));
+      assertNotNull(future.get());
+   }
+}

--- a/core/src/test/java/org/infinispan/manager/ConcurrentCacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/ConcurrentCacheManagerTest.java
@@ -22,6 +22,7 @@
  */
 package org.infinispan.manager;
 
+import org.infinispan.Cache;
 import org.infinispan.test.AbstractCacheTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -67,7 +68,7 @@ public class ConcurrentCacheManagerTest extends AbstractCacheTest {
    public void testConcurrentGetCacheCalls() throws Exception {
       final CyclicBarrier barrier = new CyclicBarrier(NUM_THREADS + 1);
       List<Future<Void>> futures = new ArrayList<Future<Void>>(NUM_THREADS);
-      ExecutorService executorService = Executors.newFixedThreadPool(NUM_THREADS);
+      ExecutorService executorService = Executors.newFixedThreadPool(NUM_THREADS, getTestThreadFactory("Worker"));
       for (int i = 0; i < NUM_THREADS; i++) {
          log.debug("Schedule execution");
          final String name = "cache" + (i % NUM_CACHES);
@@ -77,7 +78,9 @@ public class ConcurrentCacheManagerTest extends AbstractCacheTest {
             public Void call() throws Exception {
                try {
                   barrier.await();
-                  cacheManager.getCache(name).put("a", "b");
+                  log.tracef("Creating cache %s", name);
+                  Cache<Object,Object> cache = cacheManager.getCache(name);
+                  cache.put("a", "b");
                   return null;
                } catch (Throwable t) {
                   log.error("Got", t);


### PR DESCRIPTION
...he test suite (randomly)

https://issues.jboss.org/browse/ISPN-2796

Please also integrate `t_2796_52` in branch `5.2.x`.
- DefaultCacheManager.wireAndStartCache didn't open the cache latch if
  it failed to inject all dependencies, blocking all other threads.
- ComponentRegistry.getOrCreateComponent was not atomic if the component
  was cache-scoped and the factory was global-scoped.
