### PR TITLE
ISPN-2878 Default iteration on QueryCache is changed to EAGER iteration

### DIFF
--- a/query/src/main/java/org/infinispan/query/CacheQuery.java
+++ b/query/src/main/java/org/infinispan/query/CacheQuery.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.Sort;
 import org.hibernate.search.FullTextFilter;
 import org.hibernate.search.query.engine.spi.FacetManager;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -54,6 +55,9 @@ public interface CacheQuery extends Iterable<Object> {
    /**
     * Returns the results of a search as a {@link ResultIterator}.
     *
+    * Warning: the return type is an extension of {@link Iterator} which introduces a {@link ResultIterator#close()}
+    * method. This close method needs to be invoked when the iteration is complete to avoid resource leakage.
+    *
     * @param fetchOptions how to fetch results (see @link FetchOptions)
     * @return a QueryResultIterator which can be used to iterate through the results that were found.
     */
@@ -61,7 +65,7 @@ public interface CacheQuery extends Iterable<Object> {
 
    /**
     * Returns the results of a search as a {@link ResultIterator}. This calls {@link CacheQuery#iterator(FetchOptions fetchOptions)}
-    * with default FetchOptions
+    * with default FetchOptions; this implies eager loading of all results.
     *
     * @return a ResultIterator which can be used to iterate through the results that were found.
     */

--- a/query/src/main/java/org/infinispan/query/impl/CacheQueryImpl.java
+++ b/query/src/main/java/org/infinispan/query/impl/CacheQueryImpl.java
@@ -42,6 +42,7 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.query.CacheQuery;
 import org.infinispan.query.FetchOptions;
 import org.infinispan.query.ResultIterator;
+import org.infinispan.query.FetchOptions.FetchMode;
 import org.infinispan.query.backend.KeyTransformationHandler;
 
 /**
@@ -54,7 +55,14 @@ import org.infinispan.query.backend.KeyTransformationHandler;
  */
 public class CacheQueryImpl implements CacheQuery {
 
-   private static final FetchOptions DEFAULT_FETCH_OPTIONS = new FetchOptions();
+   /**
+    * Since CacheQuery extends {@link Iterable} it is possible to implicitly invoke
+    * {@link #iterator()} in an "enhanced for loop".
+    * When using the {@link FetchMode#LAZY} it is mandatory to close the {@link ResultIterator},
+    * but users of the enhanced loop have no chance to invoke the method.
+    * Therefore, it's important that the default fetch options use EAGER iteration.
+    */
+   private static final FetchOptions DEFAULT_FETCH_OPTIONS = new FetchOptions().fetchMode(FetchMode.EAGER);
 
    protected final AdvancedCache<?, ?> cache;
    protected final KeyTransformationHandler keyTransformationHandler;


### PR DESCRIPTION
This is 
- https://issues.jboss.org/browse/ISPN-2878

Which is an inherent solution for
- https://issues.jboss.org/browse/ISPN-2874
