### PR TITLE
ISPN-2883 + ISPN-2885 Various JMX and RHQ plugin fixes

### DIFF
--- a/core/src/main/java/org/infinispan/factories/components/JmxOperationParameter.java
+++ b/core/src/main/java/org/infinispan/factories/components/JmxOperationParameter.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.factories.components;
+
+import java.io.Serializable;
+
+import javax.management.MBeanParameterInfo;
+
+/**
+ * JmxOperationParameter stores metadata information about MBean operation parameters which
+ * is then used at runtime to build the relevant {@link MBeanParameterInfo}
+ *
+ * @author Tristan Tarrant
+ * @since 5.2.3
+ */
+public class JmxOperationParameter implements Serializable {
+   final String name;
+   final String type;
+   final String description;
+
+   public JmxOperationParameter(String name, String type, String description) {
+      this.name = name;
+      this.type = type;
+      this.description = description;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public String getType() {
+      return type;
+   }
+
+   public String getDescription() {
+      return description;
+   }
+
+   @Override
+   public String toString() {
+      return "JmxOperationParameter [name=" + name + ", type=" + type + ", description=" + description + "]";
+   }
+
+}

--- a/core/src/main/java/org/infinispan/jmx/ResourceDMBean.java
+++ b/core/src/main/java/org/infinispan/jmx/ResourceDMBean.java
@@ -24,6 +24,7 @@ package org.infinispan.jmx;
 
 import org.infinispan.factories.components.JmxAttributeMetadata;
 import org.infinispan.factories.components.JmxOperationMetadata;
+import org.infinispan.factories.components.JmxOperationParameter;
 import org.infinispan.factories.components.ManageableComponentMetadata;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedOperation;
@@ -40,6 +41,7 @@ import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanException;
 import javax.management.MBeanInfo;
 import javax.management.MBeanOperationInfo;
+import javax.management.MBeanParameterInfo;
 import javax.management.ReflectionException;
 import javax.management.ServiceNotFoundException;
 import java.lang.reflect.Field;
@@ -180,10 +182,12 @@ public class ResourceDMBean implements DynamicMBean {
    }
 
    private MBeanOperationInfo toJmxInfo(JmxOperationMetadata operationMetadata) throws ClassNotFoundException {
-      return new MBeanOperationInfo(operationMetadata.getDescription(),
-                                    ReflectionUtil.findMethod(objectClass,
-                                                              operationMetadata.getMethodName(),
-                                                              getParameterArray(operationMetadata.getMethodParameters())));
+      JmxOperationParameter[] parameters = operationMetadata.getMethodParameters();
+      MBeanParameterInfo[] params = new MBeanParameterInfo[parameters.length];
+      for(int i=0; i< parameters.length; i++) {
+         params[i] = new MBeanParameterInfo(parameters[i].getName(), parameters[i].getType(), parameters[i].getDescription());
+      }
+      return new MBeanOperationInfo(operationMetadata.getMethodName(), operationMetadata.getDescription(), params, operationMetadata.getReturnType(), MBeanOperationInfo.UNKNOWN);
    }
 
    Object getObject() {

--- a/core/src/main/java/org/infinispan/jmx/annotations/Parameter.java
+++ b/core/src/main/java/org/infinispan/jmx/annotations/Parameter.java
@@ -24,7 +24,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 public @interface Parameter {
    String name() default "";
    String description() default "";

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -885,7 +885,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
       getCache();
    }
 
-   @ManagedOperation(description = "Starts a named cache from this cache manager", name = "startCacheWithCacheName", displayName = "Starts a cache with the given name")
+   @ManagedOperation(description = "Starts a named cache from this cache manager", name = "startCache|cacheName", displayName = "Starts a cache with the given name")
    public void startCache(@Parameter(name = "cacheName", description = "Name of cache to start") String cacheName) {
       getCache(cacheName);
    }

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAdminOperations.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAdminOperations.java
@@ -89,7 +89,7 @@ public class RecoveryAdminOperations {
       return completeBasedOnInternalId(internalId, true);
    }
 
-   @ManagedOperation(description = "Forces the commit of an in-doubt transaction", displayName="Force commit by Xid", name="forceCommitByXid")
+   @ManagedOperation(description = "Forces the commit of an in-doubt transaction", displayName="Force commit by Xid", name="forceCommit|ByXid")
    public String forceCommit(
          @Parameter(name = "formatId", description = "The formatId of the transaction") int formatId,
          @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId,
@@ -102,7 +102,7 @@ public class RecoveryAdminOperations {
       return completeBasedOnInternalId(internalId, false);
    }
 
-   @ManagedOperation(description = "Forces the rollback of an in-doubt transaction", displayName="Force rollback by Xid", name="forceRollbackByXid")
+   @ManagedOperation(description = "Forces the rollback of an in-doubt transaction", displayName="Force rollback by Xid", name="forceRollback|ByXid")
    public String forceRollback(
          @Parameter(name = "formatId", description = "The formatId of the transaction") int formatId,
          @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId,
@@ -110,7 +110,7 @@ public class RecoveryAdminOperations {
       return completeBasedOnXid(formatId, globalTxId, branchQualifier, false);
    }
 
-   @ManagedOperation(description = "Removes recovery info for the given transaction.", displayName="Remove recovery info by Xid", name="forgetByXid")
+   @ManagedOperation(description = "Removes recovery info for the given transaction.", displayName="Remove recovery info by Xid", name="forget|ByXid")
    public String forget(
          @Parameter(name = "formatId", description = "The formatId of the transaction") int formatId,
          @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId,

--- a/core/src/test/java/org/infinispan/jmx/CacheLoaderAndCacheStoreInterceptorMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheLoaderAndCacheStoreInterceptorMBeanTest.java
@@ -55,6 +55,7 @@ public class CacheLoaderAndCacheStoreInterceptorMBeanTest extends SingleCacheMan
    private CacheStore cacheStore;
    private static final String JMX_DOMAIN = CacheLoaderAndCacheStoreInterceptorMBeanTest.class.getName();
 
+   @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       GlobalConfiguration globalConfiguration = GlobalConfiguration.getNonClusteredDefault();
       globalConfiguration.setMBeanServerLookup(PerThreadMBeanServerLookup.class.getName());
@@ -85,6 +86,11 @@ public class CacheLoaderAndCacheStoreInterceptorMBeanTest extends SingleCacheMan
    public void resetStats() throws Exception {
       threadMBeanServer.invoke(loaderInterceptorObjName, "resetStatistics", new Object[0], new String[0]);
       threadMBeanServer.invoke(storeInterceptorObjName, "resetStatistics", new Object[0], new String[0]);
+   }
+
+   public void testJmxOperationMetadata() throws Exception {
+      checkMBeanOperationParameterNaming(loaderInterceptorObjName);
+      checkMBeanOperationParameterNaming(storeInterceptorObjName);
    }
 
    public void testPutKeyValue() throws Exception {

--- a/core/src/test/java/org/infinispan/jmx/CacheMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheMBeanTest.java
@@ -25,6 +25,9 @@ package org.infinispan.jmx;
 import java.lang.reflect.Method;
 
 import javax.management.InstanceNotFoundException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.MBeanParameterInfo;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
@@ -56,7 +59,12 @@ public class CacheMBeanTest extends SingleCacheManagerTest {
       server = PerThreadMBeanServerLookup.getThreadMBeanServer();
       return cacheManager;
    }
-   
+
+   public void testJmxOperationMetadata() throws Exception {
+      ObjectName name = getCacheObjectName(JMX_DOMAIN);
+      checkMBeanOperationParameterNaming(name);
+   }
+
    public void testStartStopManagedOperations() throws Exception {
       ObjectName defaultOn = getCacheObjectName(JMX_DOMAIN);
       ObjectName managerON = getCacheManagerObjectName(JMX_DOMAIN);
@@ -85,7 +93,7 @@ public class CacheMBeanTest extends SingleCacheManagerTest {
       assert server.getAttribute(managerON, "RunningCacheCount").equals("0");
       assert ComponentStatus.TERMINATED.toString().equals(server.getAttribute(defaultOn, "CacheStatus"));
    }
-   
+
    public void testManagerStopRemovesCacheMBean(Method m) throws Exception {
       final String otherJmxDomain = getMethodSpecificJmxDomain(m, JMX_DOMAIN);
       ObjectName defaultOn = getCacheObjectName(otherJmxDomain);

--- a/core/src/test/java/org/infinispan/jmx/MvccLockManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/MvccLockManagerMBeanTest.java
@@ -36,6 +36,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.transaction.TransactionManager;
 
+import static org.infinispan.test.TestingUtil.checkMBeanOperationParameterNaming;
 import static org.infinispan.test.TestingUtil.getCacheObjectName;
 
 /**
@@ -52,6 +53,7 @@ public class MvccLockManagerMBeanTest extends SingleCacheManagerTest {
    private MBeanServer threadMBeanServer;
    private static final String JMX_DOMAIN = "MvccLockManagerMBeanTest";
 
+   @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       GlobalConfiguration globalConfiguration = GlobalConfiguration.getNonClusteredDefault().fluent()
             .globalJmxStatistics()
@@ -76,6 +78,10 @@ public class MvccLockManagerMBeanTest extends SingleCacheManagerTest {
 
       threadMBeanServer = PerThreadMBeanServerLookup.getThreadMBeanServer();
       return cacheManager;
+   }
+
+   public void testJmxOperationMetadata() throws Exception {
+      checkMBeanOperationParameterNaming(lockManagerObjName);
    }
 
    public void testConcurrencyLevel() throws Exception {

--- a/core/src/test/java/org/infinispan/jmx/RpcManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/RpcManagerMBeanTest.java
@@ -52,6 +52,7 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.TransportFlags;
 import org.testng.annotations.Test;
 
+import static org.infinispan.test.TestingUtil.checkMBeanOperationParameterNaming;
 import static org.infinispan.test.TestingUtil.getCacheObjectName;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
@@ -100,6 +101,11 @@ public class RpcManagerMBeanTest extends MultipleCacheManagersTest {
       cb.clustering().cacheMode(CacheMode.REPL_SYNC).jmxStatistics().enable();
       defineConfigurationOnAllManagers(cachename, cb);
       waitForClusterToForm(cachename);
+   }
+
+   public void testJmxOperationMetadata() throws Exception {
+      ObjectName rpcManager = getCacheObjectName(JMX_DOMAIN, cachename + "(repl_sync)", "RpcManager");
+      checkMBeanOperationParameterNaming(rpcManager);
    }
 
    public void testEnableJmxStats() throws Exception {

--- a/core/src/test/java/org/infinispan/jmx/TxInterceptorMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/TxInterceptorMBeanTest.java
@@ -37,6 +37,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.transaction.TransactionManager;
 
+import static org.infinispan.test.TestingUtil.checkMBeanOperationParameterNaming;
 import static org.infinispan.test.TestingUtil.getCacheObjectName;
 
 @Test(groups = "functional", testName = "jmx.TxInterceptorMBeanTest")
@@ -50,6 +51,7 @@ public class TxInterceptorMBeanTest extends MultipleCacheManagersTest {
    private Cache cache1;
    private Cache cache2;
 
+   @Override
    protected void createCacheManagers() throws Throwable {
       GlobalConfiguration globalConfiguration = GlobalConfiguration.getClusteredDefault();
       globalConfiguration.setExposeGlobalJmxStatistics(true);
@@ -82,7 +84,11 @@ public class TxInterceptorMBeanTest extends MultipleCacheManagersTest {
       threadMBeanServer.invoke(txInterceptor2, "resetStatistics", new Object[0], new String[0]);
    }
 
-   public void testCommit() throws Exception {      
+   public void testJmxOperationMetadata() throws Exception {
+      checkMBeanOperationParameterNaming(txInterceptor);
+   }
+
+   public void testCommit() throws Exception {
       assertCommitRollback(0, 0, txInterceptor);
       tm.begin();
       //enlist another resource adapter to force TM to execute 2PC (otherwise 1PC)

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -24,6 +24,7 @@
 package org.infinispan.test;
 
 import static java.io.File.separator;
+import static org.testng.AssertJUnit.assertFalse;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -41,8 +42,14 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.MBeanParameterInfo;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
+import javax.management.ReflectionException;
 import javax.transaction.Status;
 import javax.transaction.TransactionManager;
 
@@ -1161,6 +1168,16 @@ public class TestingUtil {
          if (domainSet.contains(domain)) return true;
       }
       return false;
+   }
+
+   public static void checkMBeanOperationParameterNaming(ObjectName objectName) throws Exception {
+      MBeanServer mBeanServer = PerThreadMBeanServerLookup.getThreadMBeanServer();
+      MBeanInfo mBeanInfo = mBeanServer.getMBeanInfo(objectName);
+      for(MBeanOperationInfo op : mBeanInfo.getOperations()) {
+         for(MBeanParameterInfo param : op.getSignature()) {
+            assertFalse(param.getName().matches("p[0-9]+"));
+         }
+      }
    }
 
    public static String generateRandomString(int numberOfChars) {

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/SimpleCacheRecoveryAdminTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/SimpleCacheRecoveryAdminTest.java
@@ -42,6 +42,7 @@ import javax.management.ObjectName;
 import javax.transaction.xa.Xid;
 import java.util.List;
 
+import static org.infinispan.test.TestingUtil.checkMBeanOperationParameterNaming;
 import static org.infinispan.test.TestingUtil.getCacheObjectName;
 import static org.infinispan.tx.recovery.RecoveryTestUtil.beginAndSuspendTx;
 import static org.infinispan.tx.recovery.RecoveryTestUtil.prepareTransaction;
@@ -99,6 +100,10 @@ public class SimpleCacheRecoveryAdminTest extends AbstractRecoveryTest {
       TestingUtil.killCacheManagers(manager(2));
       TestingUtil.blockUntilViewsReceived(90000, false, cache(0, "test"), cache(1, "test"));
 
+   }
+
+   public void testJmxOperationMetadata() throws Exception {
+      checkMBeanOperationParameterNaming(getRecoveryAdminObjectName(0));
    }
 
    public void testForceCommitOnOtherNode() throws Exception {
@@ -169,6 +174,7 @@ public class SimpleCacheRecoveryAdminTest extends AbstractRecoveryTest {
    }
 
 
+   @Override
    protected void checkProperlyCleanup(final int managerIndex) {
       eventually(new Condition() {
          @Override

--- a/rhq-plugin/src/main/java/org/infinispan/rhq/CacheDiscovery.java
+++ b/rhq-plugin/src/main/java/org/infinispan/rhq/CacheDiscovery.java
@@ -64,7 +64,7 @@ public class CacheDiscovery extends MBeanResourceDiscoveryComponent<CacheManager
 
       for (EmsBean bean : beans) {
          // Filter out spurious beans
-         if (CacheComponent.isCacheComponent(bean)) {
+         if (CacheComponent.isCacheComponent(bean, "Cache")) {
             /* A discovered resource must have a unique key, that must
              * stay the same when the resource is discovered the next
              * time */


### PR DESCRIPTION
ISPN-2883 Use special naming to overcome JMX method overloading with RHQ
operation name uniqueness
ISPN-2885 Expose parameter names in MBean metadata

https://issues.jboss.org/browse/ISPN-2885
https://issues.jboss.org/browse/ISPN-2883

Applies to both 5.2.x and master
