### PR TITLE
ISPN-2787 NPE after ReplaceCommand

### DIFF
--- a/core/src/test/java/org/infinispan/statetransfer/MergeDuringReplaceTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/MergeDuringReplaceTest.java
@@ -1,0 +1,116 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.infinispan.statetransfer;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.write.ReplaceCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.jgroups.SuspectException;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.TransportFlags;
+import org.infinispan.tx.dld.ControlledRpcManager;
+import org.jgroups.protocols.DISCARD;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertTrue;
+
+@Test(groups = "functional", testName = "statetransfer.MergeDuringReplaceTest")
+@CleanupAfterMethod
+public class MergeDuringReplaceTest extends MultipleCacheManagersTest {
+
+   private DISCARD[] discard;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder defaultConfig = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      createClusteredCaches(3, defaultConfig, new TransportFlags().withFD(true).withMerge(true));
+
+      DISCARD d1 = TestingUtil.getDiscardForCache(cache(0));
+      d1.setExcludeItself(true);
+      DISCARD d2 = TestingUtil.getDiscardForCache(cache(1));
+      d2.setExcludeItself(true);
+      DISCARD d3 = TestingUtil.getDiscardForCache(cache(2));
+      d3.setExcludeItself(true);
+      discard = new DISCARD[]{d1, d2, d3};
+   }
+
+   public void testMergeDuringReplace() throws Exception {
+      final String key = "myKey";
+      final String value = "myValue";
+
+      cache(0).put(key, value);
+
+      ConsistentHash ch = cache(0).getAdvancedCache().getComponentRegistry()
+            .getStateTransferManager().getCacheTopology().getCurrentCH();
+      List<Address> members = new ArrayList<Address>(ch.getMembers());
+      List<Address> owners = ch.locateOwners(key);
+      members.removeAll(owners);
+      int nonOwner = ch.getMembers().indexOf(members.get(0));
+      final Cache<Object, Object> c = cache(nonOwner);
+
+      List<Cache<Object, Object>> partition1 = caches();
+      partition1.remove(c);
+
+      ControlledRpcManager controlledRpcManager = new ControlledRpcManager(c.getAdvancedCache().getRpcManager());
+      TestingUtil.replaceComponent(c, RpcManager.class, controlledRpcManager, true);
+
+      controlledRpcManager.blockBefore(ReplaceCommand.class);
+
+      Future<Boolean> future = fork(new Callable<Boolean>() {
+         @Override
+         public Boolean call() throws Exception {
+            return c.replace(key, value, "myNewValue");
+         }
+      });
+
+      discard[nonOwner].setDiscardAll(true);
+
+      // wait for the partitions to form
+      TestingUtil.blockUntilViewsReceived(30000, false, partition1.get(0), partition1.get(1));
+      TestingUtil.blockUntilViewsReceived(30000, false, c);
+      TestingUtil.waitForRehashToComplete(partition1.get(0), partition1.get(1));
+      TestingUtil.waitForRehashToComplete(c);
+
+      controlledRpcManager.stopBlocking();
+
+      try {
+         future.get();
+      } catch (ExecutionException e) {
+         Throwable cause = e.getCause();
+         assertTrue(cause instanceof SuspectException);
+         assertTrue(cause.getMessage().startsWith("One or more nodes have left the cluster while replicating command"));
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/tx/dld/ControlledRpcManager.java
+++ b/core/src/test/java/org/infinispan/tx/dld/ControlledRpcManager.java
@@ -65,8 +65,6 @@ public class ControlledRpcManager implements RpcManager {
       this.realOne = realOne;
    }
 
-
-
    public void failFor(Class... filter) {
       this.failFilter = new HashSet<Class>(Arrays.asList(filter));
    }
@@ -153,14 +151,13 @@ public class ControlledRpcManager implements RpcManager {
       return responseMap;
    }
 
-
    public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, boolean sync) throws RpcException {
       log.trace("invokeRemotely4");
       failIfNeeded(rpcCommand);
       waitBefore(rpcCommand);
-      realOne.invokeRemotely(recipients, rpcCommand, sync);
+      Map<Address, Response> responseMap = realOne.invokeRemotely(recipients, rpcCommand, sync);
       waitAfter(rpcCommand);
-      return null;
+      return responseMap;
    }
 
    public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, boolean sync, boolean usePriorityQueue) throws RpcException {
@@ -171,7 +168,6 @@ public class ControlledRpcManager implements RpcManager {
       waitAfter(rpcCommand);
       return responses;
    }
-
 
    public void broadcastRpcCommand(ReplicableCommand rpcCommand, boolean sync) throws RpcException {
       log.trace("ControlledRpcManager.broadcastRpcCommand1");
@@ -189,7 +185,6 @@ public class ControlledRpcManager implements RpcManager {
       waitAfter(rpcCommand);
    }
 
-
    public void broadcastRpcCommandInFuture(ReplicableCommand rpcCommand, NotifyingNotifiableFuture<Object> future) {
       log.trace("ControlledRpcManager.broadcastRpcCommandInFuture1");
       failIfNeeded(rpcCommand);
@@ -205,7 +200,6 @@ public class ControlledRpcManager implements RpcManager {
       realOne.broadcastRpcCommandInFuture(rpcCommand, usePriorityQueue, future);
       waitAfter(rpcCommand);
    }
-
 
    public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpcCommand, NotifyingNotifiableFuture<Object> future) {
       log.trace("ControlledRpcManager.invokeRemotelyInFuture1");
@@ -258,8 +252,6 @@ public class ControlledRpcManager implements RpcManager {
    public int getTopologyId() {
       return realOne.getTopologyId();
    }
-
-
 
    @Override
    public List<Address> getMembers() {


### PR DESCRIPTION
- Add MergeDuringReplaceTest to reproduce the issue.
- Fix one of the ControlledRpcManager.invokeRemotely methods that was ignoring the actual result and was always returning null.
- Minor logging improvements to be able to debug this issue.
- Remove harmfull optimization from RpcManagerImpl.invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, ResponseMode mode, long timeout, boolean usePriorityQueue, ResponseFilter responseFilter) that was not going remotely and neither threw any exception if the destinations were no longer in cluster and current node was the only member.

Please integrate in master and 5.2.x (anistor/t_2787_52).

JIRA:  https://issues.jboss.org/browse/ISPN-2787
