### PR TITLE
ISPN-2808 - Make Infinispan use its own thread pool for sending messages...

### DIFF
--- a/core/src/main/java/org/infinispan/commands/CancelCommand.java
+++ b/core/src/main/java/org/infinispan/commands/CancelCommand.java
@@ -128,4 +128,8 @@ public class CancelCommand extends BaseRpcCommand {
       return "CancelCommand [uuid=" + commandToCancel + "]";
    }
 
+   @Override
+   public boolean canBlock() {
+      return false;
+   }
 }

--- a/core/src/main/java/org/infinispan/commands/CreateCacheCommand.java
+++ b/core/src/main/java/org/infinispan/commands/CreateCacheCommand.java
@@ -202,4 +202,9 @@ public class CreateCacheCommand extends BaseRpcCommand {
    public boolean isReturnValueExpected() {
       return true;
    }
+
+   @Override
+   public boolean canBlock() {
+      return true;
+   }
 }

--- a/core/src/main/java/org/infinispan/commands/RemoveCacheCommand.java
+++ b/core/src/main/java/org/infinispan/commands/RemoveCacheCommand.java
@@ -92,4 +92,9 @@ public class RemoveCacheCommand extends BaseRpcCommand {
    public boolean isReturnValueExpected() {
       return false;
    }
+
+   @Override
+   public boolean canBlock() {
+      return true;
+   }
 }

--- a/core/src/main/java/org/infinispan/commands/ReplicableCommand.java
+++ b/core/src/main/java/org/infinispan/commands/ReplicableCommand.java
@@ -73,4 +73,16 @@ public interface ReplicableCommand {
     * @return true or false
     */
    boolean isReturnValueExpected();
+
+   /**
+    * If true, the command is processed asynchronously in a thread provided by an Infinispan thread pool. Otherwise,
+    * the command is processed directly in the JGroups thread.
+    * <p/>
+    * This feature allows to avoid keep a JGroups thread busy that can originate discard of messages and 
+    * retransmissions. So, the commands that can block (waiting for some state, acquiring locks, etc.) should return
+    * true.
+    * 
+    * @return  {@code true} if the command can block/wait, {@code false} otherwise  
+    */
+   boolean canBlock();
 }

--- a/core/src/main/java/org/infinispan/commands/read/AbstractDataCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/AbstractDataCommand.java
@@ -112,4 +112,9 @@ public abstract class AbstractDataCommand extends AbstractFlagAffectedCommand im
    public boolean isReturnValueExpected() {
       return true;
    }
+
+   @Override
+   public boolean canBlock() {
+      return false;
+   }
 }

--- a/core/src/main/java/org/infinispan/commands/read/AbstractLocalCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/AbstractLocalCommand.java
@@ -64,4 +64,8 @@ public class AbstractLocalCommand implements LocalCommand {
    public boolean isReturnValueExpected() {
       return false;
    }
+
+   public boolean canBlock() {
+      return false;
+   }
 }

--- a/core/src/main/java/org/infinispan/commands/read/DistributedExecuteCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/DistributedExecuteCommand.java
@@ -203,4 +203,9 @@ public class DistributedExecuteCommand<V> extends BaseRpcCommand implements Visi
       return true;
    }
 
+   @Override
+   public boolean canBlock() {
+      return true;
+   }
+
 }

--- a/core/src/main/java/org/infinispan/commands/read/MapCombineCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/MapCombineCommand.java
@@ -164,6 +164,11 @@ public class MapCombineCommand<KIn, VIn, KOut, VOut> extends BaseRpcCommand impl
    }
 
    @Override
+   public boolean canBlock() {
+      return true;
+   }
+
+   @Override
    public int hashCode() {
       final int prime = 31;
       int result = 1;

--- a/core/src/main/java/org/infinispan/commands/read/ReduceCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/ReduceCommand.java
@@ -141,6 +141,11 @@ public class ReduceCommand<KOut, VOut> extends BaseRpcCommand implements Cancell
       return true;
    }
 
+   @Override
+   public boolean canBlock() {
+      return true;
+   }
+
    @SuppressWarnings("rawtypes")
    @Override
    public boolean equals(Object obj) {

--- a/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
@@ -232,6 +232,11 @@ public class ClusteredGetCommand extends BaseRpcCommand implements FlagAffectedC
    }
 
    @Override
+   public boolean canBlock() {
+      return false;
+   }
+
+   @Override
    public int getTopologyId() {
       return topologyId;
    }

--- a/core/src/main/java/org/infinispan/commands/remote/MultipleRpcCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/MultipleRpcCommand.java
@@ -140,4 +140,14 @@ public class MultipleRpcCommand extends BaseRpcInvokingCommand {
    public boolean isReturnValueExpected() {
       return false;
    }
+
+   @Override
+   public boolean canBlock() {
+      for (ReplicableCommand command : commands) {
+         if (command.canBlock()) {
+            return true;
+         }
+      }
+      return false;            
+   }
 }

--- a/core/src/main/java/org/infinispan/commands/remote/SingleRpcCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/SingleRpcCommand.java
@@ -109,4 +109,9 @@ public class SingleRpcCommand extends BaseRpcInvokingCommand {
    public boolean isReturnValueExpected() {
       return command.isReturnValueExpected();
    }
+
+   @Override
+   public boolean canBlock() {
+      return command.canBlock();
+   }
 }

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/CompleteTransactionCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/CompleteTransactionCommand.java
@@ -86,6 +86,12 @@ public class CompleteTransactionCommand extends RecoveryCommand {
    }
 
    @Override
+   public boolean canBlock() {
+      //this command performs the 2PC commit.
+      return true;
+   }
+
+   @Override
    public String toString() {
       return getClass().getSimpleName() +
             "{ xid=" + xid +

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/RecoveryCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/RecoveryCommand.java
@@ -51,4 +51,9 @@ public abstract class RecoveryCommand extends BaseRpcCommand {
    public boolean isReturnValueExpected() {
       return true;
    }
+
+   @Override
+   public boolean canBlock() {
+      return false;
+   }
 }

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/TxCompletionNotificationCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/TxCompletionNotificationCommand.java
@@ -152,6 +152,12 @@ public class TxCompletionNotificationCommand  extends RecoveryCommand implements
    }
 
    @Override
+   public boolean canBlock() {
+      //this command can be forwarded (state transfer)
+      return true;
+   }
+
+   @Override
    public String toString() {
       return getClass().getSimpleName() +
             "{ xid=" + xid +

--- a/core/src/main/java/org/infinispan/commands/tx/AbstractTransactionBoundaryCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/AbstractTransactionBoundaryCommand.java
@@ -180,4 +180,10 @@ public abstract class AbstractTransactionBoundaryCommand implements TransactionB
    public boolean isReturnValueExpected() {
       return true;
    }
+
+   @Override
+   public final boolean canBlock() {
+      //all tx commands must wait for the correct topology
+      return true;
+   }
 }

--- a/core/src/main/java/org/infinispan/commands/write/AbstractDataWriteCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/AbstractDataWriteCommand.java
@@ -69,4 +69,9 @@ public abstract class AbstractDataWriteCommand extends AbstractDataCommand imple
    public final boolean wasPreviousRead() {
       return previousRead;
    }
+   
+   @Override
+   public boolean canBlock() {
+      return true;
+   }
 }

--- a/core/src/main/java/org/infinispan/commands/write/ClearCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/ClearCommand.java
@@ -132,6 +132,11 @@ public class ClearCommand extends AbstractFlagAffectedCommand implements WriteCo
    }
 
    @Override
+   public boolean canBlock() {
+      return true;
+   }
+
+   @Override
    public boolean ignoreCommandOnStatus(ComponentStatus status) {
       return false;
    }

--- a/core/src/main/java/org/infinispan/commands/write/InvalidateL1Command.java
+++ b/core/src/main/java/org/infinispan/commands/write/InvalidateL1Command.java
@@ -161,7 +161,7 @@ public class InvalidateL1Command extends InvalidateCommand {
    @Override
    public Object[] getParameters() {
       if (keys == null || keys.length == 0) {
-         return new Object[]{forRehash, writeOrigin};
+         return new Object[]{forRehash, writeOrigin, 0};
       } else if (keys.length == 1) {
          return new Object[]{forRehash, writeOrigin, 1,  keys[0]};
       } else {

--- a/core/src/main/java/org/infinispan/commands/write/PutMapCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/PutMapCommand.java
@@ -199,6 +199,11 @@ public class PutMapCommand extends AbstractFlagAffectedCommand implements WriteC
       return false;
    }
 
+   @Override
+   public boolean canBlock() {
+      return true;            
+   }
+
    public long getLifespanMillis() {
       return lifespanMillis;
    }

--- a/core/src/main/java/org/infinispan/configuration/global/AbstractGlobalConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/AbstractGlobalConfigurationBuilder.java
@@ -58,6 +58,11 @@ abstract class AbstractGlobalConfigurationBuilder<T> implements GlobalConfigurat
    }
 
    @Override
+   public ExecutorFactoryConfigurationBuilder remoteCommandsExecutor() {
+      return globalConfig.remoteCommandsExecutor();
+   }
+
+   @Override
    public ScheduledExecutorFactoryConfigurationBuilder evictionScheduledExecutor() {
       return globalConfig.evictionScheduledExecutor();
    }

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalConfiguration.java
@@ -60,6 +60,7 @@ public class GlobalConfiguration {
 
    private final ExecutorFactoryConfiguration asyncListenerExecutor;
    private final ExecutorFactoryConfiguration asyncTransportExecutor;
+   private final ExecutorFactoryConfiguration remoteCommandsExecutor;
    private final ScheduledExecutorFactoryConfiguration evictionScheduledExecutor;
    private final ScheduledExecutorFactoryConfiguration replicationQueueScheduledExecutor;
    private final GlobalJmxStatisticsConfiguration globalJmxStatistics;
@@ -71,12 +72,14 @@ public class GlobalConfiguration {
    private final WeakReference<ClassLoader> cl;
 
    GlobalConfiguration(ExecutorFactoryConfiguration asyncListenerExecutor,
-         ExecutorFactoryConfiguration asyncTransportExecutor, ScheduledExecutorFactoryConfiguration evictionScheduledExecutor,
+         ExecutorFactoryConfiguration asyncTransportExecutor, ExecutorFactoryConfiguration remoteCommandsExecutor,
+         ScheduledExecutorFactoryConfiguration evictionScheduledExecutor,
          ScheduledExecutorFactoryConfiguration replicationQueueScheduledExecutor, GlobalJmxStatisticsConfiguration globalJmxStatistics,
          TransportConfiguration transport, SerializationConfiguration serialization, ShutdownConfiguration shutdown,
          List<?> modules, SiteConfiguration site,ClassLoader cl) {
       this.asyncListenerExecutor = asyncListenerExecutor;
       this.asyncTransportExecutor = asyncTransportExecutor;
+      this.remoteCommandsExecutor = remoteCommandsExecutor;
       this.evictionScheduledExecutor = evictionScheduledExecutor;
       this.replicationQueueScheduledExecutor = replicationQueueScheduledExecutor;
       this.globalJmxStatistics = globalJmxStatistics;
@@ -98,6 +101,10 @@ public class GlobalConfiguration {
 
    public ExecutorFactoryConfiguration asyncTransportExecutor() {
       return asyncTransportExecutor;
+   }
+
+   public ExecutorFactoryConfiguration remoteCommandsExecutor() {
+      return remoteCommandsExecutor;
    }
 
    public ScheduledExecutorFactoryConfiguration evictionScheduledExecutor() {
@@ -149,6 +156,7 @@ public class GlobalConfiguration {
       return "GlobalConfiguration{" +
             "asyncListenerExecutor=" + asyncListenerExecutor +
             ", asyncTransportExecutor=" + asyncTransportExecutor +
+            ", remoteCommandsExecutor=" + remoteCommandsExecutor +
             ", evictionScheduledExecutor=" + evictionScheduledExecutor +
             ", replicationQueueScheduledExecutor=" + replicationQueueScheduledExecutor +
             ", globalJmxStatistics=" + globalJmxStatistics +

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalConfigurationBuilder.java
@@ -42,6 +42,7 @@ public class GlobalConfigurationBuilder implements GlobalConfigurationChildBuild
    private final SerializationConfigurationBuilder serialization;
    private final ExecutorFactoryConfigurationBuilder asyncTransportExecutor;
    private final ExecutorFactoryConfigurationBuilder asyncListenerExecutor;
+   private final ExecutorFactoryConfigurationBuilder remoteCommandsExecutor;
    private final ScheduledExecutorFactoryConfigurationBuilder evictionScheduledExecutor;
    private final ScheduledExecutorFactoryConfigurationBuilder replicationQueueScheduledExecutor;
    private final ShutdownConfigurationBuilder shutdown;
@@ -55,6 +56,7 @@ public class GlobalConfigurationBuilder implements GlobalConfigurationChildBuild
       this.serialization = new SerializationConfigurationBuilder(this);
       this.asyncListenerExecutor = new ExecutorFactoryConfigurationBuilder(this);
       this.asyncTransportExecutor = new ExecutorFactoryConfigurationBuilder(this);
+      this.remoteCommandsExecutor = new ExecutorFactoryConfigurationBuilder(this);
       this.evictionScheduledExecutor = new ScheduledExecutorFactoryConfigurationBuilder(this);
       this.replicationQueueScheduledExecutor = new ScheduledExecutorFactoryConfigurationBuilder(this);
       this.shutdown = new ShutdownConfigurationBuilder(this);
@@ -127,6 +129,11 @@ public class GlobalConfigurationBuilder implements GlobalConfigurationChildBuild
    }
 
    @Override
+   public ExecutorFactoryConfigurationBuilder remoteCommandsExecutor() {
+      return remoteCommandsExecutor;
+   }
+
+   @Override
    public ScheduledExecutorFactoryConfigurationBuilder evictionScheduledExecutor() {
       return evictionScheduledExecutor;
    }
@@ -169,7 +176,7 @@ public class GlobalConfigurationBuilder implements GlobalConfigurationChildBuild
    @SuppressWarnings("unchecked")
    public void validate() {
       for (AbstractGlobalConfigurationBuilder<?> validatable : asList(asyncListenerExecutor, asyncTransportExecutor,
-            evictionScheduledExecutor, replicationQueueScheduledExecutor, globalJmxStatistics, transport,
+            remoteCommandsExecutor, evictionScheduledExecutor, replicationQueueScheduledExecutor, globalJmxStatistics, transport,
             serialization, shutdown, site)) {
          validatable.validate();
       }
@@ -187,6 +194,7 @@ public class GlobalConfigurationBuilder implements GlobalConfigurationChildBuild
       return new GlobalConfiguration(
             asyncListenerExecutor.create(),
             asyncTransportExecutor.create(),
+            remoteCommandsExecutor.create(),
             evictionScheduledExecutor.create(),
             replicationQueueScheduledExecutor.create(),
             globalJmxStatistics.create(),
@@ -210,6 +218,7 @@ public class GlobalConfigurationBuilder implements GlobalConfigurationChildBuild
 
       asyncListenerExecutor.read(template.asyncListenerExecutor());
       asyncTransportExecutor.read(template.asyncTransportExecutor());
+      remoteCommandsExecutor.read(template.remoteCommandsExecutor());
       evictionScheduledExecutor.read(template.evictionScheduledExecutor());
       globalJmxStatistics.read(template.globalJmxStatistics());
       replicationQueueScheduledExecutor.read(template.replicationQueueScheduledExecutor());
@@ -240,6 +249,7 @@ public class GlobalConfigurationBuilder implements GlobalConfigurationChildBuild
             ", globalJmxStatistics=" + globalJmxStatistics +
             ", serialization=" + serialization +
             ", asyncTransportExecutor=" + asyncTransportExecutor +
+            ", remoteCommandsExecutor=" + remoteCommandsExecutor +
             ", evictionScheduledExecutor=" + evictionScheduledExecutor +
             ", replicationQueueScheduledExecutor=" + replicationQueueScheduledExecutor +
             ", shutdown=" + shutdown +
@@ -257,6 +267,8 @@ public class GlobalConfigurationBuilder implements GlobalConfigurationChildBuild
       if (asyncListenerExecutor != null ? !asyncListenerExecutor.equals(that.asyncListenerExecutor) : that.asyncListenerExecutor != null)
          return false;
       if (asyncTransportExecutor != null ? !asyncTransportExecutor.equals(that.asyncTransportExecutor) : that.asyncTransportExecutor != null)
+         return false;
+      if (remoteCommandsExecutor != null ? !remoteCommandsExecutor.equals(that.remoteCommandsExecutor) : that.remoteCommandsExecutor != null)
          return false;
       if (cl != null ? !cl.equals(that.cl) : that.cl != null) return false;
       if (evictionScheduledExecutor != null ? !evictionScheduledExecutor.equals(that.evictionScheduledExecutor) : that.evictionScheduledExecutor != null)
@@ -285,6 +297,7 @@ public class GlobalConfigurationBuilder implements GlobalConfigurationChildBuild
       result = 31 * result + (serialization != null ? serialization.hashCode() : 0);
       result = 31 * result + (asyncTransportExecutor != null ? asyncTransportExecutor.hashCode() : 0);
       result = 31 * result + (asyncListenerExecutor != null ? asyncListenerExecutor.hashCode() : 0);
+      result = 31 * result + (remoteCommandsExecutor != null ? remoteCommandsExecutor.hashCode() : 0);
       result = 31 * result + (evictionScheduledExecutor != null ? evictionScheduledExecutor.hashCode() : 0);
       result = 31 * result + (replicationQueueScheduledExecutor != null ? replicationQueueScheduledExecutor.hashCode() : 0);
       result = 31 * result + (shutdown != null ? shutdown.hashCode() : 0);

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalConfigurationChildBuilder.java
@@ -29,6 +29,8 @@ public interface GlobalConfigurationChildBuilder {
 
    ExecutorFactoryConfigurationBuilder asyncTransportExecutor();
    
+   ExecutorFactoryConfigurationBuilder remoteCommandsExecutor();
+   
    ScheduledExecutorFactoryConfigurationBuilder evictionScheduledExecutor();
 
    ScheduledExecutorFactoryConfigurationBuilder replicationQueueScheduledExecutor();

--- a/core/src/main/java/org/infinispan/configuration/parsing/Element.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Element.java
@@ -40,6 +40,7 @@ public enum Element {
     ASYNC("async"),
     ASYNC_LISTENER_EXECUTOR("asyncListenerExecutor"),
     ASYNC_TRANSPORT_EXECUTOR("asyncTransportExecutor"),
+    REMOTE_COMMNAND_EXECUTOR("remoteCommandsExecutor"),
     CLUSTERING("clustering"),
     CLUSTER_LOADER("clusterLoader"),
     CUSTOM_INTERCEPTORS("customInterceptors"),

--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser53.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser53.java
@@ -1486,6 +1486,10 @@ public class Parser53 implements ConfigurationParser<ConfigurationBuilderHolder>
                parseAsyncTransportExecutor(reader, holder);
                break;
             }
+            case REMOTE_COMMNAND_EXECUTOR: {
+               parseRemoteCommandsExecutor(reader, holder);
+               break;
+            }
             case EVICTION_SCHEDULED_EXECUTOR: {
                parseEvictionScheduledExecutor(reader, holder);
                break;
@@ -1531,6 +1535,38 @@ public class Parser53 implements ConfigurationParser<ConfigurationBuilderHolder>
          // The transport *has* been parsed.  If we don't have a transport set, make sure we set the default.
          if (builder.transport().getTransport() == null) {
             builder.transport().defaultTransport();
+         }
+      }
+   }
+
+   private void parseRemoteCommandsExecutor(final XMLExtendedStreamReader reader, final ConfigurationBuilderHolder holder)
+         throws XMLStreamException {
+      GlobalConfigurationBuilder builder = holder.getGlobalConfigurationBuilder();
+      for (int i = 0; i < reader.getAttributeCount(); i++) {
+         ParseUtils.requireNoNamespaceAttribute(reader, i);
+         String value = replaceProperties(reader.getAttributeValue(i));
+         Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+         switch (attribute) {
+            case FACTORY: {
+               builder.remoteCommandsExecutor().factory(Util.<ExecutorFactory> getInstance(value, holder.getClassLoader()));
+               break;
+            }
+            default: {
+               throw ParseUtils.unexpectedAttribute(reader, i);
+            }
+         }
+      }
+
+      while (reader.hasNext() && (reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {
+         Element element = Element.forName(reader.getLocalName());
+         switch (element) {
+            case PROPERTIES: {
+               builder.remoteCommandsExecutor().withProperties(parseProperties(reader));
+               break;
+            }
+            default: {
+               throw ParseUtils.unexpectedElement(reader);
+            }
          }
       }
    }

--- a/core/src/main/java/org/infinispan/executors/DefaultExecutorFactory.java
+++ b/core/src/main/java/org/infinispan/executors/DefaultExecutorFactory.java
@@ -27,8 +27,10 @@ import org.infinispan.factories.annotations.Inject;
 import org.infinispan.util.TypedProperties;
 
 import java.util.Properties;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -48,9 +50,13 @@ public class DefaultExecutorFactory implements ExecutorFactory {
       TypedProperties tp = TypedProperties.toTypedProperties(p);
       int maxThreads = tp.getIntProperty("maxThreads", 1);
       int queueSize = tp.getIntProperty("queueSize", 100000);
+      int coreThreads = queueSize == 0 ? 1 : tp.getIntProperty("coreThreads", maxThreads);
+      long keepAliveTime = tp.getLongProperty("keepAliveTime", 60000);
       final int threadPrio = tp.getIntProperty("threadPriority", Thread.MIN_PRIORITY);
       final String threadNamePrefix = tp.getProperty("threadNamePrefix", tp.getProperty("componentName", "Thread"));
       final String threadNameSuffix = tp.getProperty("threadNameSuffix", "");
+      BlockingQueue<Runnable> queue = queueSize == 0 ? new SynchronousQueue<Runnable>() : 
+            new LinkedBlockingQueue<Runnable>(queueSize);
       ThreadFactory tf = new ThreadFactory() {
          @Override
          public Thread newThread(Runnable r) {
@@ -62,9 +68,7 @@ public class DefaultExecutorFactory implements ExecutorFactory {
          }
       };
 
-      return new ThreadPoolExecutor(maxThreads, maxThreads,
-                                    0L, TimeUnit.MILLISECONDS,
-                                    new LinkedBlockingQueue<Runnable>(queueSize),
-                                    tf);
+      return new ThreadPoolExecutor(coreThreads, maxThreads, keepAliveTime, TimeUnit.MILLISECONDS, queue, tf,
+                                    new ThreadPoolExecutor.CallerRunsPolicy());
    }
 }

--- a/core/src/main/java/org/infinispan/executors/WithinThreadExecutorFactory.java
+++ b/core/src/main/java/org/infinispan/executors/WithinThreadExecutorFactory.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source                           
+ *  Copyright 2013 Red Hat Inc. and/or its affiliates and other       
+ *  contributors as indicated by the @author tags. All rights reserved
+ *  See the copyright.txt in the distribution for a full listing of   
+ *  individual contributors.                                          
+ *                                                                    
+ *  This is free software; you can redistribute it and/or modify it   
+ *  under the terms of the GNU Lesser General Public License as       
+ *  published by the Free Software Foundation; either version 2.1 of  
+ *  the License, or (at your option) any later version.               
+ *                                                                    
+ *  This software is distributed in the hope that it will be useful,  
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of    
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU  
+ *  Lesser General Public License for more details.                   
+ *                                                                    
+ *  You should have received a copy of the GNU Lesser General Public  
+ *  License along with this software; if not, write to the Free       
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.executors;
+
+import org.infinispan.util.concurrent.WithinThreadExecutor;
+
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Executor factory that creates WithinThreadExecutor. This executor executes the tasks in the caller thread.
+ *
+ * @author Pedro Ruivo
+ * @since 5.3
+ */
+public class WithinThreadExecutorFactory implements ExecutorFactory {
+   
+   @Override
+   public ExecutorService getExecutor(Properties p) {
+      return new WithinThreadExecutor();
+   }
+}

--- a/core/src/main/java/org/infinispan/factories/KnownComponentNames.java
+++ b/core/src/main/java/org/infinispan/factories/KnownComponentNames.java
@@ -36,6 +36,7 @@ import java.util.Map;
  */
 public class KnownComponentNames {
    public static final String ASYNC_TRANSPORT_EXECUTOR = "org.infinispan.executors.transport";
+   public static final String REMOTE_REQUEST_EXECUTOR = "org.infinispan.executors.request";
    public static final String ASYNC_NOTIFICATION_EXECUTOR = "org.infinispan.executors.notification";
    public static final String EVICTION_SCHEDULED_EXECUTOR = "org.infinispan.executors.eviction";
    public static final String ASYNC_REPLICATION_QUEUE_EXECUTOR = "org.infinispan.executors.replicationQueue";
@@ -48,18 +49,26 @@ public class KnownComponentNames {
    // Please make sure this is kept up to date
    public static final Collection<String> ALL_KNOWN_COMPONENT_NAMES = Arrays.asList(
       ASYNC_TRANSPORT_EXECUTOR, ASYNC_NOTIFICATION_EXECUTOR, EVICTION_SCHEDULED_EXECUTOR, ASYNC_REPLICATION_QUEUE_EXECUTOR,
-      MODULE_COMMAND_INITIALIZERS, MODULE_COMMAND_FACTORIES, GLOBAL_MARSHALLER, CACHE_MARSHALLER, CLASS_LOADER
+      MODULE_COMMAND_INITIALIZERS, MODULE_COMMAND_FACTORIES, GLOBAL_MARSHALLER, CACHE_MARSHALLER, CLASS_LOADER,
+      REMOTE_REQUEST_EXECUTOR
    );
 
-   private static final Map<String, Integer> DEFAULT_THREADCOUNTS = new HashMap<String, Integer>(2);
-   private static final Map<String, Integer> DEFAULT_THREADPRIO = new HashMap<String, Integer>(4);
+   private static final Map<String, Integer> DEFAULT_THREADCOUNTS = new HashMap<String, Integer>(3);
+   private static final Map<String, Integer> DEFAULT_QUEUE_SIZE = new HashMap<String, Integer>(3);
+   private static final Map<String, Integer> DEFAULT_THREADPRIO = new HashMap<String, Integer>(5);
 
    static {
       DEFAULT_THREADCOUNTS.put(ASYNC_NOTIFICATION_EXECUTOR, 1);
       DEFAULT_THREADCOUNTS.put(ASYNC_TRANSPORT_EXECUTOR, 25);
+      DEFAULT_THREADCOUNTS.put(REMOTE_REQUEST_EXECUTOR, 32);
+
+      DEFAULT_QUEUE_SIZE.put(ASYNC_NOTIFICATION_EXECUTOR, 100000);
+      DEFAULT_QUEUE_SIZE.put(ASYNC_TRANSPORT_EXECUTOR, 100000);
+      DEFAULT_QUEUE_SIZE.put(REMOTE_REQUEST_EXECUTOR, 0);
 
       DEFAULT_THREADPRIO.put(ASYNC_NOTIFICATION_EXECUTOR, Thread.MIN_PRIORITY);
       DEFAULT_THREADPRIO.put(ASYNC_TRANSPORT_EXECUTOR, Thread.NORM_PRIORITY);
+      DEFAULT_THREADPRIO.put(REMOTE_REQUEST_EXECUTOR, Thread.NORM_PRIORITY);
       DEFAULT_THREADPRIO.put(EVICTION_SCHEDULED_EXECUTOR, Thread.MIN_PRIORITY);
       DEFAULT_THREADPRIO.put(ASYNC_REPLICATION_QUEUE_EXECUTOR, Thread.NORM_PRIORITY);
    }
@@ -70,5 +79,9 @@ public class KnownComponentNames {
 
    public static int getDefaultThreadPrio(String componentName) {
       return DEFAULT_THREADPRIO.get(componentName);
+   }
+   
+   public static int getDefaultQueueSize(String componentName) {
+      return DEFAULT_QUEUE_SIZE.get(componentName);
    }
 }

--- a/core/src/main/java/org/infinispan/remoting/InboundInvocationHandler.java
+++ b/core/src/main/java/org/infinispan/remoting/InboundInvocationHandler.java
@@ -25,8 +25,8 @@ package org.infinispan.remoting;
 import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
-import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.transport.Address;
+import org.jgroups.blocks.Response;
 
 /**
  * A globally scoped component, that is able to locate named caches and invoke remotely originating calls on the
@@ -42,9 +42,12 @@ public interface InboundInvocationHandler {
    /**
     * Invokes a command on the cache, from a remote source.
     *
+    *
     * @param command command to invoke
-    * @return results, if any, from the invocation
+    * @param response the asynchronous request reference from {@code org.infinispan.remoting.transport.Transport}.
+    *                A {@code null} value means that the request does not expect a return value.
+    * @param cannotBeReordered
     * @throws Throwable in the event of problems executing the command
     */
-   Response handle(CacheRpcCommand command, Address origin) throws Throwable;
+   void handle(CacheRpcCommand command, Address origin, Response response, boolean cannotBeReordered) throws Throwable;
 }

--- a/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
@@ -22,6 +22,7 @@
  */
 package org.infinispan.remoting;
 
+import org.infinispan.CacheException;
 import org.infinispan.commands.CancellableCommand;
 import org.infinispan.commands.CancellationService;
 import org.infinispan.commands.CommandsFactory;
@@ -29,6 +30,8 @@ import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.factories.KnownComponentNames;
+import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
@@ -41,6 +44,8 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.Transport;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+
+import java.util.concurrent.ExecutorService;
 
 /**
  * Sets the cache interceptor chain on an RPCCommand before calling it to perform
@@ -56,18 +61,21 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
    private GlobalConfiguration globalConfiguration;
    private Transport transport;
    private CancellationService cancelService;
+   private ExecutorService remoteCommandsExecutor;
 
    @Inject
    public void inject(GlobalComponentRegistry gcr, Transport transport,
+                      @ComponentName(KnownComponentNames.REMOTE_REQUEST_EXECUTOR) ExecutorService remoteCommandsExecutor,
                       GlobalConfiguration globalConfiguration, CancellationService cancelService) {
       this.gcr = gcr;
       this.transport = transport;
       this.globalConfiguration = globalConfiguration;
       this.cancelService = cancelService;
+      this.remoteCommandsExecutor = remoteCommandsExecutor;
    }
 
    @Override
-   public Response handle(final CacheRpcCommand cmd, Address origin) throws Throwable {
+   public void handle(final CacheRpcCommand cmd, Address origin, org.jgroups.blocks.Response response, boolean cannotBeReordered) throws Throwable {
       cmd.setOrigin(origin);
 
       String cacheName = cmd.getCacheName();
@@ -76,22 +84,21 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
       if (cr == null) {
          if (!globalConfiguration.transport().strictPeerToPeer()) {
             if (trace) log.tracef("Strict peer to peer off, so silently ignoring that %s cache is not defined", cacheName);
-            return null;
+            reply(response, null);
+            return;
          }
 
          log.namedCacheDoesNotExist(cacheName);
-         return new ExceptionResponse(new NamedCacheNotFoundException(cacheName, "Cache has not been started on node " + transport.getAddress()));
+         Response retVal = new ExceptionResponse(new NamedCacheNotFoundException(cacheName, "Cache has not been started on node " + transport.getAddress()));
+         reply(response, retVal); 
+         return;
       }
 
-      return handleWithWaitForBlocks(cmd, cr);
+      handleWithWaitForBlocks(cmd, cr, response, cannotBeReordered);
    }
 
 
    private Response handleInternal(final CacheRpcCommand cmd, final ComponentRegistry cr) throws Throwable {
-      CommandsFactory commandsFactory = cr.getCommandsFactory();
-
-      // initialize this command with components specific to the intended cache instance
-      commandsFactory.initializeReplicableCommand(cmd, true);
       try {
          if (trace) log.tracef("Calling perform() on %s", cmd);
          ResponseGenerator respGen = cr.getResponseGenerator();
@@ -112,13 +119,37 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
       }
    }
 
-   private Response handleWithWaitForBlocks(final CacheRpcCommand cmd, final ComponentRegistry cr) throws Throwable {
+   private void handleWithWaitForBlocks(final CacheRpcCommand cmd, final ComponentRegistry cr, final org.jgroups.blocks.Response response, boolean cannotBeReordered) throws Throwable {
       StateTransferManager stm = cr.getStateTransferManager();
       // We must have completed the join before handling commands
       // (even if we didn't complete the initial state transfer)
-      if (!stm.isJoinComplete())
-         return null;
+      if (!stm.isJoinComplete()) {
+         reply(response, null);
+         return;
+      }
 
+      CommandsFactory commandsFactory = cr.getCommandsFactory();
+
+      // initialize this command with components specific to the intended cache instance
+      commandsFactory.initializeReplicableCommand(cmd, true);
+
+      if (!cannotBeReordered && cmd.canBlock()) {
+         remoteCommandsExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+               Response resp;
+               try {
+                  resp = handleInternal(cmd, cr);
+               } catch (Throwable throwable) {
+                  log.warnf(throwable, "Problems invoking command %s", cmd);
+                  resp = new ExceptionResponse(new CacheException("Problems invoking command.", throwable));
+               }
+               //the ResponseGenerated is null in this case because the return value is a Response
+               reply(response, resp);
+            }
+         });
+         return;
+      }
       Response resp = handleInternal(cmd, cr);
 
       // A null response is valid and OK ...
@@ -126,8 +157,13 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
          // invalid response
          log.tracef("Unable to execute command, got invalid response %s", resp);
       }
-
-      return resp;
+      reply(response, resp);
+   }
+   
+   private void reply(org.jgroups.blocks.Response response, Object retVal) {
+      if (response != null) {
+         response.send(retVal, false);
+      }
    }
 
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -82,6 +82,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import static org.infinispan.factories.KnownComponentNames.REMOTE_REQUEST_EXECUTOR;
 import static org.infinispan.factories.KnownComponentNames.ASYNC_TRANSPORT_EXECUTOR;
 import static org.infinispan.factories.KnownComponentNames.GLOBAL_MARSHALLER;
 
@@ -119,6 +120,7 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
    protected InboundInvocationHandler inboundInvocationHandler;
    protected StreamingMarshaller marshaller;
    protected ExecutorService asyncExecutor;
+   protected ExecutorService remoteCommandsExecutor;
    protected CacheManagerNotifier notifier;
    private GlobalComponentRegistry gcr;
    private BackupReceiverRepository backupReceiverRepository;
@@ -177,10 +179,12 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
    @Inject
    public void initialize(@ComponentName(GLOBAL_MARSHALLER) StreamingMarshaller marshaller,
                           @ComponentName(ASYNC_TRANSPORT_EXECUTOR) ExecutorService asyncExecutor,
+                          @ComponentName(REMOTE_REQUEST_EXECUTOR) ExecutorService remoteCommandsExecutor,
                           InboundInvocationHandler inboundInvocationHandler, CacheManagerNotifier notifier,
                           GlobalComponentRegistry gcr, BackupReceiverRepository backupReceiverRepository) {
       this.marshaller = marshaller;
       this.asyncExecutor = asyncExecutor;
+      this.remoteCommandsExecutor = remoteCommandsExecutor;
       this.inboundInvocationHandler = inboundInvocationHandler;
       this.notifier = notifier;
       this.gcr = gcr;
@@ -320,7 +324,7 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
 
    private void initChannelAndRPCDispatcher() throws CacheException {
       initChannel();
-      dispatcher = new CommandAwareRpcDispatcher(channel, this, asyncExecutor, inboundInvocationHandler, gcr, backupReceiverRepository);
+      dispatcher = new CommandAwareRpcDispatcher(channel, this, asyncExecutor, remoteCommandsExecutor, inboundInvocationHandler, gcr, backupReceiverRepository);
       MarshallerAdapter adapter = new MarshallerAdapter(marshaller);
       dispatcher.setRequestMarshaller(adapter);
       dispatcher.setResponseMarshaller(adapter);

--- a/core/src/main/java/org/infinispan/statetransfer/StateRequestCommand.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateRequestCommand.java
@@ -50,7 +50,7 @@ public class StateRequestCommand extends BaseRpcCommand {
 
    public static final byte COMMAND_ID = 15;
 
-   private Type type;
+   private Type type = Type.CANCEL_STATE_TRANSFER; //default value for org.infinispan.remoting.AsynchronousInvocationTest
 
    private int topologyId;
 
@@ -108,6 +108,11 @@ public class StateRequestCommand extends BaseRpcCommand {
    @Override
    public boolean isReturnValueExpected() {
       return type != Type.CANCEL_STATE_TRANSFER;
+   }
+
+   @Override
+   public boolean canBlock() {
+      return type == Type.GET_TRANSACTIONS || type == Type.START_STATE_TRANSFER;
    }
 
    public Type getType() {

--- a/core/src/main/java/org/infinispan/statetransfer/StateResponseCommand.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateResponseCommand.java
@@ -96,6 +96,11 @@ public class StateResponseCommand extends BaseRpcCommand {
    }
 
    @Override
+   public boolean canBlock() {
+      return true;            
+   }
+
+   @Override
    public byte getCommandId() {
       return COMMAND_ID;
    }

--- a/core/src/main/java/org/infinispan/topology/CacheTopologyControlCommand.java
+++ b/core/src/main/java/org/infinispan/topology/CacheTopologyControlCommand.java
@@ -247,4 +247,9 @@ public class CacheTopologyControlCommand implements ReplicableCommand {
    public boolean isReturnValueExpected() {
       return true;
    }
+
+   @Override
+   public boolean canBlock() {
+      return true;
+   }
 }

--- a/core/src/main/java/org/infinispan/xsite/XSiteAdminCommand.java
+++ b/core/src/main/java/org/infinispan/xsite/XSiteAdminCommand.java
@@ -128,6 +128,11 @@ public class XSiteAdminCommand extends BaseRpcCommand {
    }
 
    @Override
+   public boolean canBlock() {
+      return false;
+   }
+
+   @Override
    public String toString() {
       return "XSiteAdminCommand{" +
             "siteName='" + siteName + '\'' +

--- a/core/src/main/resources/schema/infinispan-config-5.3.xsd
+++ b/core/src/main/resources/schema/infinispan-config-5.3.xsd
@@ -50,6 +50,13 @@
                   </xs:documentation>
                 </xs:annotation>
               </xs:element>
+              <xs:element name="remoteCommandsExecutor" type="tns:executorFactory" minOccurs="0">
+                <xs:annotation>
+                  <xs:documentation>
+                    Configuration for the executor service used to execute remote work.
+                  </xs:documentation>
+                </xs:annotation>
+              </xs:element>
               <xs:element name="evictionScheduledExecutor" type="tns:scheduledExecutorFactory" minOccurs="0">
                 <xs:annotation>
                   <xs:documentation>

--- a/core/src/test/java/org/infinispan/configuration/XmlFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/XmlFileParsingTest.java
@@ -28,6 +28,7 @@ import static org.infinispan.test.TestingUtil.INFINISPAN_START_TAG_40;
 import static org.infinispan.test.TestingUtil.INFINISPAN_START_TAG_NO_SCHEMA;
 import static org.infinispan.test.TestingUtil.withCacheManager;
 import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
@@ -290,12 +291,27 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
 
       assert gc.asyncListenerExecutor().factory() instanceof DefaultExecutorFactory;
       assert gc.asyncListenerExecutor().properties().getProperty("maxThreads").equals("5");
+      if (!deprecated) {
+         assertEquals("10000", gc.asyncListenerExecutor().properties().getProperty("queueSize"));
+      }
       assert gc.asyncListenerExecutor().properties().getProperty("threadNamePrefix").equals("AsyncListenerThread");
 
       assert gc.asyncTransportExecutor().factory() instanceof DefaultExecutorFactory;
       // Should be 25, but it's overriden by the test cache manager factory
-      assertEquals("6", gc.asyncTransportExecutor().properties().getProperty("maxThreads"));
+      assertEquals(String.valueOf(TestCacheManagerFactory.MAX_ASYNC_EXEC_THREADS), gc.asyncTransportExecutor().properties().getProperty("maxThreads"));
+      if (!deprecated) {
+         assertEquals(String.valueOf(TestCacheManagerFactory.ASYNC_EXEC_QUEUE_SIZE), gc.asyncTransportExecutor().properties().getProperty("queueSize"));
+      }
       assert gc.asyncTransportExecutor().properties().getProperty("threadNamePrefix").equals("AsyncSerializationThread");
+      
+      if (!deprecated) {
+         assertTrue(gc.remoteCommandsExecutor().factory() instanceof DefaultExecutorFactory);
+         assertEquals(String.valueOf(TestCacheManagerFactory.MAX_REQ_EXEC_THREADS), 
+                      gc.remoteCommandsExecutor().properties().getProperty("maxThreads"));
+         assertEquals("RemoteCommandThread", gc.remoteCommandsExecutor().properties().getProperty("threadNamePrefix"));
+         assertEquals("2", gc.remoteCommandsExecutor().properties().getProperty("coreThreads"));
+         assertEquals(String.valueOf(TestCacheManagerFactory.KEEP_ALIVE), gc.remoteCommandsExecutor().properties().getProperty("keepAliveTime"));
+      }
 
       assert gc.evictionScheduledExecutor().factory() instanceof DefaultScheduledExecutorFactory;
       assert gc.evictionScheduledExecutor().properties().getProperty("threadNamePrefix").equals("EvictionThread");

--- a/core/src/test/java/org/infinispan/distribution/rehash/OngoingTransactionsAndJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/OngoingTransactionsAndJoinTest.java
@@ -308,7 +308,7 @@ public class OngoingTransactionsAndJoinTest extends MultipleCacheManagersTest {
       }
 
       @Override
-      public Response handle(CacheRpcCommand cmd, Address origin) throws Throwable {
+      public void handle(CacheRpcCommand cmd, Address origin, org.jgroups.blocks.Response response, boolean cannotBeReordered) throws Throwable {
          boolean notifyRehashStarted = false;
          if (cmd instanceof CacheTopologyControlCommand) {
             CacheTopologyControlCommand rcc = (CacheTopologyControlCommand) cmd;
@@ -325,9 +325,8 @@ public class OngoingTransactionsAndJoinTest extends MultipleCacheManagersTest {
             }
          }
 
-         Response r = delegate.handle(cmd, origin);
+         delegate.handle(cmd, origin, response, cannotBeReordered);
          if (notifyRehashStarted) rehashStarted.countDown();
-         return r;
       }
    }
 

--- a/core/src/test/java/org/infinispan/remoting/AsynchronousInvocationTest.java
+++ b/core/src/test/java/org/infinispan/remoting/AsynchronousInvocationTest.java
@@ -1,0 +1,462 @@
+/*
+ * JBoss, Home of Professional Open Source                           
+ *  Copyright 2013 Red Hat Inc. and/or its affiliates and other       
+ *  contributors as indicated by the @author tags. All rights reserved
+ *  See the copyright.txt in the distribution for a full listing of   
+ *  individual contributors.                                          
+ *                                                                    
+ *  This is free software; you can redistribute it and/or modify it   
+ *  under the terms of the GNU Lesser General Public License as       
+ *  published by the Free Software Foundation; either version 2.1 of  
+ *  the License, or (at your option) any later version.               
+ *                                                                    
+ *  This software is distributed in the hope that it will be useful,  
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of    
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU  
+ *  Lesser General Public License for more details.                   
+ *                                                                    
+ *  You should have received a copy of the GNU Lesser General Public  
+ *  License along with this software; if not, write to the Free       
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.remoting;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.CommandsFactory;
+import org.infinispan.commands.DataCommand;
+import org.infinispan.commands.LocalCommand;
+import org.infinispan.commands.RemoveCacheCommand;
+import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.commands.control.LockControlCommand;
+import org.infinispan.commands.remote.CacheRpcCommand;
+import org.infinispan.commands.remote.MultipleRpcCommand;
+import org.infinispan.commands.remote.SingleRpcCommand;
+import org.infinispan.commands.tx.AbstractTransactionBoundaryCommand;
+import org.infinispan.commands.tx.CommitCommand;
+import org.infinispan.commands.tx.PrepareCommand;
+import org.infinispan.commands.tx.RollbackCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.executors.ExecutorFactory;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.remoting.transport.Transport;
+import org.infinispan.remoting.transport.jgroups.CommandAwareRpcDispatcher;
+import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.transaction.xa.TransactionFactory;
+import org.infinispan.util.ClassFinder;
+import org.infinispan.util.InfinispanCollections;
+import org.jgroups.Address;
+import org.jgroups.Message;
+import org.jgroups.blocks.RpcDispatcher;
+import org.jgroups.util.Buffer;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.infinispan.test.TestingUtil.*;
+import static org.infinispan.test.fwk.TestCacheManagerFactory.createClusteredCacheManager;
+
+/**
+ * Tests the Asynchronous Invocation API and checks if the commands are correctly processed (or JGroups or Infinispan
+ * thread pool)
+ *
+ * @author Pedro Ruivo
+ * @since 5.3
+ */
+@Test(groups = "functional", testName = "remoting.AsynchronousInvocationTest")
+public class AsynchronousInvocationTest extends AbstractInfinispanTest {
+
+   private EmbeddedCacheManager cacheManager;
+   private String cacheName;
+   private DummyTaskCountExecutorService executorService;
+   private CommandAwareRpcDispatcher commandAwareRpcDispatcher;
+   private Address address;
+   private RpcDispatcher.Marshaller marshaller;
+   private TransactionFactory transactionFactory;
+   private CommandsFactory commandsFactory;
+   @BeforeMethod(alwaysRun = true)
+   public void setUp() {
+      GlobalConfigurationBuilder globalConfigurationBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+      DummyExecutorFactory factory = new DummyExecutorFactory();
+
+      globalConfigurationBuilder.remoteCommandsExecutor().factory(factory);
+      configurationBuilder.clustering().cacheMode(CacheMode.DIST_SYNC);
+
+      cacheManager = createClusteredCacheManager(globalConfigurationBuilder, configurationBuilder);
+      Cache<Object, Object> cache = cacheManager.getCache();
+      cacheName = cache.getName();
+      Transport transport = extractGlobalComponent(cacheManager, Transport.class);
+      if (transport instanceof JGroupsTransport) {
+         commandAwareRpcDispatcher = ((JGroupsTransport) transport).getCommandAwareRpcDispatcher();
+         address = ((JGroupsTransport) transport).getChannel().getAddress();
+         marshaller = commandAwareRpcDispatcher.getMarshaller();
+      } else {
+         Assert.fail("Expected a JGroups Transport");
+      }
+      transactionFactory = extractComponent(cache, TransactionFactory.class);
+      commandsFactory = extractCommandsFactory(cache);
+      executorService = factory.getExecutorService();
+   }
+
+   @AfterMethod
+   public void tearDown() {
+      if (cacheManager != null) {
+         cacheManager.stop();
+      }
+   }
+
+   public void testCacheRpcCommands() throws Exception {
+      List<Class<?>> cacheRpcCommandList = ClassFinder.isAssignableFrom(CacheRpcCommand.class);
+
+      for (Class<?> clazz : cacheRpcCommandList) {
+         if (clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers()) || LocalCommand.class.isAssignableFrom(clazz)) {
+            continue;
+         }
+
+         if (RemoveCacheCommand.class.isAssignableFrom(clazz) || SingleRpcCommand.class.isAssignableFrom(clazz) ||
+               MultipleRpcCommand.class.isAssignableFrom(clazz) || AbstractTransactionBoundaryCommand.class.isAssignableFrom(clazz)) {
+            //special cases
+            continue;
+         }
+
+         CacheRpcCommand command = (CacheRpcCommand) clazz.getConstructor(String.class).newInstance(cacheName);
+         assertDispatchForCommand(command);
+      }
+   }
+   
+   public void testCommitCommand() throws Exception {
+      List<Class<?>> cacheRpcCommandList = ClassFinder.isAssignableFrom(CommitCommand.class);
+
+      for (Class<?> clazz : cacheRpcCommandList) {
+         if (clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers())) {
+            continue;
+         } 
+
+         CacheRpcCommand command = (CacheRpcCommand) clazz.getConstructor(String.class, GlobalTransaction.class)
+               .newInstance(cacheName, transactionFactory.newGlobalTransaction());
+         assertDispatchForCommand(command);
+      }
+   }
+
+   public void testRollbackCommand() throws Exception {
+      List<Class<?>> cacheRpcCommandList = ClassFinder.isAssignableFrom(RollbackCommand.class);
+
+      for (Class<?> clazz : cacheRpcCommandList) {
+         if (clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers())) {
+            continue;
+         }
+
+         CacheRpcCommand command = (CacheRpcCommand) clazz.getConstructor(String.class, GlobalTransaction.class)
+               .newInstance(cacheName, transactionFactory.newGlobalTransaction());
+         assertDispatchForCommand(command);
+      }
+   }
+
+   public void testPrepareCommand() throws Exception {
+      List<Class<?>> cacheRpcCommandList = ClassFinder.isAssignableFrom(PrepareCommand.class);
+
+      for (Class<?> clazz : cacheRpcCommandList) {
+         if (clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers())) {
+            continue;
+         }
+
+         CacheRpcCommand command = (CacheRpcCommand) clazz.getConstructor(String.class, GlobalTransaction.class, List.class, boolean.class)
+               .newInstance(cacheName, transactionFactory.newGlobalTransaction(), InfinispanCollections.emptyList(), true);
+         assertDispatchForCommand(command);
+      }
+   }
+   
+   public void testLockControlCommand() throws Exception {
+      List<Class<?>> cacheRpcCommandList = ClassFinder.isAssignableFrom(LockControlCommand.class);
+
+      for (Class<?> clazz : cacheRpcCommandList) {
+         if (clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers())) {
+            continue;
+         }
+
+         CacheRpcCommand command = (CacheRpcCommand) clazz.getConstructor(Collection.class, String.class, Set.class, GlobalTransaction.class)
+               .newInstance(InfinispanCollections.emptyList(), cacheName, InfinispanCollections.emptySet(), transactionFactory.newGlobalTransaction());
+         assertDispatchForCommand(command);
+      }      
+   }
+
+   public void testRemoveCacheCommandInOOB() throws Exception {
+      CacheRpcCommand command = new RemoveCacheCommand(cacheName, null, null, null);
+
+      log.debugf("Testing " + command.getClass().getCanonicalName());
+      Message oobRequest = serialize(command, true);
+      if (oobRequest == null) {
+         log.debugf("Don't test " + command.getClass() + ". it is not Serializable");
+         return;
+      }
+      executorService.reset();
+      commandAwareRpcDispatcher.handle(oobRequest, null);
+      Assert.assertEquals(executorService.hasExecutedCommand, command.canBlock(),
+                          "Command " + command.getClass() + " dispatched wrongly.");
+   }
+
+   public void testRemoveCacheCommandInNonOOB() throws Exception {
+      CacheRpcCommand command = new RemoveCacheCommand(cacheName, null, null, null);
+
+      log.debugf("Testing " + command.getClass().getCanonicalName());
+      Message nonOobRequest = serialize(command, false);
+      if (nonOobRequest == null) {
+         log.debugf("Don't test " + command.getClass() + ". it is not Serializable");
+         return;
+      }
+      executorService.reset();
+      commandAwareRpcDispatcher.handle(nonOobRequest, null);
+      Assert.assertFalse(executorService.hasExecutedCommand, "Command " + command.getClass() + " dispatched wrongly.");
+   }
+
+   public void testSingleRpcCommandWithBlockingCommand() throws Exception {
+      ReplicableCommand other = getReplicableCommand(true);
+      CacheRpcCommand command = new SingleRpcCommand(cacheName, other);
+      //single rpc command has a blocking command, so it should be dispatched to the thread pool
+      assertDispatchForCommand(command, true);
+   }
+
+   public void testSingleRpcCommandWithNonBlockingCommand() throws Exception {
+      ReplicableCommand other = getReplicableCommand(false);
+      CacheRpcCommand command = new SingleRpcCommand(cacheName, other);
+      //single rpc command does *not* have a blocking command, so it should *not* be dispatched to the thread pool
+      assertDispatchForCommand(command, false);
+   }
+
+   public void testMultipleRpcCommandWithNonBlockingCommands() throws Exception {
+      ReplicableCommand other1 = getReplicableCommand(false);
+      ReplicableCommand other2 = getReplicableCommand(false);
+      CacheRpcCommand command = new MultipleRpcCommand(Arrays.asList(other1, other2), cacheName);
+      //multiple rpc command does *not* have a blocking command, so it should *not* be dispatched to the thread pool
+      assertDispatchForCommand(command, false);
+   }
+
+   public void testMultipleRpcCommandWithBlockingCommands() throws Exception {
+      ReplicableCommand other1 = getReplicableCommand(true);
+      ReplicableCommand other2 = getReplicableCommand(true);
+      CacheRpcCommand command = new MultipleRpcCommand(Arrays.asList(other1, other2), cacheName);
+      //multiple rpc command has a blocking command, so it should be dispatched to the thread pool
+      assertDispatchForCommand(command, true);
+   }
+
+   public void testMultipleRpcCommandWithBlockingAndNonBlockingCommand() throws Exception {
+      ReplicableCommand other1 = getReplicableCommand(true);
+      ReplicableCommand other2 = getReplicableCommand(false);
+      CacheRpcCommand command = new MultipleRpcCommand(Arrays.asList(other1, other2), cacheName);
+      //multiple rpc command has at least one blocking command, so it should be dispatched to the thread pool
+      assertDispatchForCommand(command, true);
+   }
+
+   public void testNonCacheRpcCommands() throws Exception {
+      List<Class<?>> cacheRpcCommandList = ClassFinder.isAssignableFrom(ReplicableCommand.class);
+
+      for (Class<?> clazz : cacheRpcCommandList) {
+         if (clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers()) || LocalCommand.class.isAssignableFrom(clazz) ||
+               CacheRpcCommand.class.isAssignableFrom(clazz)) {
+            continue;
+         }
+
+         Constructor constructor = clazz.getDeclaredConstructor();
+         constructor.setAccessible(true);
+         ReplicableCommand command = (ReplicableCommand) constructor.newInstance();
+
+         assertDispatchForCommand(command);
+      }
+   }
+   
+   private void assertDispatchForCommand(ReplicableCommand command) throws Exception {
+      log.debugf("Testing " + command.getClass().getCanonicalName());
+      commandsFactory.initializeReplicableCommand(command, true);
+      Message oobRequest = serialize(command, true);
+      if (oobRequest == null) {
+         log.debugf("Don't test " + command.getClass() + ". it is not Serializable");
+         return;
+      }
+      executorService.reset();
+      commandAwareRpcDispatcher.handle(oobRequest, null);
+      Assert.assertEquals(executorService.hasExecutedCommand, command.canBlock(),
+                          "Command " + command.getClass() + " dispatched wrongly.");
+
+      Message nonOobRequest = serialize(command, false);
+      if (nonOobRequest == null) {
+         log.debugf("Don't test " + command.getClass() + ". it is not Serializable");
+         return;
+      }
+      executorService.reset();
+      commandAwareRpcDispatcher.handle(nonOobRequest, null);
+      Assert.assertFalse(executorService.hasExecutedCommand, "Command " + command.getClass() + " dispatched wrongly.");
+   }
+
+   private void assertDispatchForCommand(ReplicableCommand command, boolean expected) throws Exception {
+      log.debugf("Testing " + command.getClass().getCanonicalName());
+      commandsFactory.initializeReplicableCommand(command, true);
+      Message oobRequest = serialize(command, true);
+      if (oobRequest == null) {
+         log.debugf("Don't test " + command.getClass() + ". it is not Serializable");
+         return;
+      }
+      executorService.reset();
+      commandAwareRpcDispatcher.handle(oobRequest, null);
+      Assert.assertEquals(executorService.hasExecutedCommand, expected,
+                          "Command " + command.getClass() + " dispatched wrongly.");
+
+      Message nonOobRequest = serialize(command, false);
+      if (nonOobRequest == null) {
+         log.debugf("Don't test " + command.getClass() + ". it is not Serializable");
+         return;
+      }
+      executorService.reset();
+      commandAwareRpcDispatcher.handle(nonOobRequest, null);
+      Assert.assertFalse(executorService.hasExecutedCommand, "Command " + command.getClass() + " dispatched wrongly.");
+   }
+
+   private Message serialize(ReplicableCommand command, boolean oob) {
+      Buffer buffer;
+      try {
+         buffer = marshaller.objectToBuffer(command);
+      } catch (Exception e) {
+         //ignore, it will not be replicated
+         return null;
+      }
+      Message message = new Message(null, address, buffer.getBuf(), buffer.getOffset(), buffer.getLength());
+      if (oob) {
+         message.setFlag(Message.Flag.OOB);
+      }
+      return message;
+   }
+
+   private ReplicableCommand getReplicableCommand(boolean blocking) throws Exception {
+      List<Class<?>> cacheRpcCommandList = ClassFinder.isAssignableFrom(ReplicableCommand.class);
+
+      for (Class<?> clazz : cacheRpcCommandList) {
+         if (clazz.isInterface() || Modifier.isAbstract(clazz.getModifiers()) || !DataCommand.class.isAssignableFrom(clazz)) {
+            continue;
+         }
+
+         try {
+            ReplicableCommand command = (ReplicableCommand) (CacheRpcCommand.class.isAssignableFrom(clazz) ?
+                                                                   clazz.getConstructor(String.class).newInstance(cacheName) :
+                                                                   clazz.newInstance());
+            if ((blocking && command.canBlock()) || (!blocking && !command.canBlock())) {
+               return command;
+            }
+         } catch (Exception e) {
+            //no-op, try next one
+         }
+      }
+      Assert.fail("Cannot find a " + (blocking ? "blocking" : "non-blocking") + " replicable command");
+      return null;
+   }
+
+   private class DummyExecutorFactory implements ExecutorFactory {
+
+      private final DummyTaskCountExecutorService executorService;
+
+      private DummyExecutorFactory() {
+         executorService = new DummyTaskCountExecutorService();
+      }
+
+      @Override
+      public ExecutorService getExecutor(Properties p) {
+         return executorService;
+      }
+
+      public DummyTaskCountExecutorService getExecutorService() {
+         return executorService;
+      }
+   }
+
+   private class DummyTaskCountExecutorService implements ExecutorService {
+
+      private volatile boolean hasExecutedCommand;
+
+      @Override
+      public void shutdown() {/*no-op*/}
+
+      @Override
+      public List<Runnable> shutdownNow() {
+         return Collections.emptyList();
+      }
+
+      @Override
+      public boolean isShutdown() {
+         return false;
+      }
+
+      @Override
+      public boolean isTerminated() {
+         return false;
+      }
+
+      @Override
+      public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+         return true;
+      }
+
+      @Override
+      public <T> Future<T> submit(Callable<T> task) {
+         return null; //no-op
+      }
+
+      @Override
+      public <T> Future<T> submit(Runnable task, T result) {
+         return null; //no-op
+      }
+
+      @Override
+      public Future<?> submit(Runnable task) {
+         return null; //no-op
+      }
+
+      @Override
+      public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+         return null; //no-op
+      }
+
+      @Override
+      public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+         return null; //no-op
+      }
+
+      @Override
+      public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+         return null; //no-op
+      }
+
+      @Override
+      public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+         return null; //no-op
+      }
+
+      @Override
+      public void execute(Runnable command) {
+         hasExecutedCommand = true;
+      }
+
+      public void reset() {
+         hasExecutedCommand = false;
+      }
+   }
+}

--- a/core/src/test/resources/configs/all.xml
+++ b/core/src/test/resources/configs/all.xml
@@ -37,6 +37,11 @@
             <property name="foo" value="bar"/>
           </properties>
         </asyncTransportExecutor>
+        <remoteCommandsExecutor factory="com.acme.Factory">
+          <properties>
+            <property name="foo" value="bar"/>
+          </properties>
+        </remoteCommandsExecutor>
         <evictionScheduledExecutor factory="com.acme.Factory">
           <properties>
             <property name="foo" value="bar"/>

--- a/core/src/test/resources/configs/named-cache-test.xml
+++ b/core/src/test/resources/configs/named-cache-test.xml
@@ -31,6 +31,7 @@
       <asyncListenerExecutor factory="org.infinispan.executors.DefaultExecutorFactory">
       	 <properties>
          	<property name="maxThreads" value="5"/>
+            <property name="queueSize" value="10000"/>
          	<property name="threadNamePrefix" value="AsyncListenerThread"/>
          </properties>         
       </asyncListenerExecutor>
@@ -38,9 +39,19 @@
       <asyncTransportExecutor factory="org.infinispan.executors.DefaultExecutorFactory">
       	<properties>	
          <property name="maxThreads" value="25"/>
+         <property name="queueSize" value="10000"/>
          <property name="threadNamePrefix" value="AsyncSerializationThread"/>
          </properties>
       </asyncTransportExecutor>
+
+      <remoteCommandsExecutor factory="org.infinispan.executors.DefaultExecutorFactory">
+        <properties>
+            <property name="maxThreads" value="30"/>
+            <property name="coreThreads" value="2"/>
+            <property name="keepAliveTime" value="10000"/>
+            <property name="threadNamePrefix" value="RemoteCommandThread"/>
+        </properties>
+      </remoteCommandsExecutor>
 
       <evictionScheduledExecutor factory="org.infinispan.executors.DefaultScheduledExecutorFactory">
       <properties>

--- a/query/src/main/java/org/infinispan/query/clustered/ClusteredQueryCommand.java
+++ b/query/src/main/java/org/infinispan/query/clustered/ClusteredQueryCommand.java
@@ -191,4 +191,9 @@ public class ClusteredQueryCommand extends BaseRpcCommand implements ReplicableC
    public boolean isReturnValueExpected() {
       return true;
    }
+
+   @Override
+   public boolean canBlock() {
+      return true;
+   }
 }

--- a/query/src/main/java/org/infinispan/query/indexmanager/IndexUpdateCommand.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/IndexUpdateCommand.java
@@ -111,6 +111,11 @@ public class IndexUpdateCommand extends BaseRpcCommand implements ReplicableComm
       return false;
    }
 
+   @Override
+   public boolean canBlock() {
+      return true;
+   }
+
    /**
     * This is invoked only on the receiving node, before {@link #perform(InvocationContext)}
     */

--- a/spring/src/main/java/org/infinispan/spring/AbstractEmbeddedCacheManagerFactory.java
+++ b/spring/src/main/java/org/infinispan/spring/AbstractEmbeddedCacheManagerFactory.java
@@ -212,6 +212,14 @@ public class AbstractEmbeddedCacheManagerFactory {
    }
 
    /**
+    * @param remoteCommandsExecutorFactoryClass
+    * @see org.infinispan.config.GlobalConfiguration#setRemoteCommandsExecutorFactoryClass(java.lang.String)
+    */
+   public void setRemoteCommandsExecutorFactoryClass(final String remoteCommandsExecutorFactoryClass) {
+      this.globalConfigurationOverrides.remoteCommandsExecutorFactoryClass = remoteCommandsExecutorFactoryClass;
+   }
+
+   /**
     * @param evictionScheduledExecutorFactoryClass
     * @see org.infinispan.config.GlobalConfiguration#setEvictionScheduledExecutorFactoryClass(java.lang.String)
     */
@@ -315,6 +323,14 @@ public class AbstractEmbeddedCacheManagerFactory {
     */
    public void setAsyncTransportExecutorProperties(final Properties asyncTransportExecutorProperties) {
       this.globalConfigurationOverrides.asyncTransportExecutorProperties = asyncTransportExecutorProperties;
+   }
+
+   /**
+    * @param remoteCommandsExecutorProperties
+    * @see org.infinispan.config.GlobalConfiguration#setRemoteCommandsExecutorProperties(java.util.Properties)
+    */
+   public void setRemoteCommandsExecutorProperties(final Properties remoteCommandsExecutorProperties) {
+      this.globalConfigurationOverrides.remoteCommandsExecutorProperties = remoteCommandsExecutorProperties;
    }
 
    /**
@@ -810,6 +826,8 @@ public class AbstractEmbeddedCacheManagerFactory {
 
       private String asyncTransportExecutorFactoryClass;
 
+      private String remoteCommandsExecutorFactoryClass;
+
       private String evictionScheduledExecutorFactoryClass;
 
       private String replicationQueueScheduledExecutorFactoryClass;
@@ -823,6 +841,8 @@ public class AbstractEmbeddedCacheManagerFactory {
       private Properties asyncListenerExecutorProperties;
 
       private Properties asyncTransportExecutorProperties;
+
+      private Properties remoteCommandsExecutorProperties;
 
       private Properties evictionScheduledExecutorProperties;
 
@@ -927,6 +947,14 @@ public class AbstractEmbeddedCacheManagerFactory {
                   Util.<ExecutorFactory>getInstance(this.asyncTransportExecutorFactoryClass,
                         Thread.currentThread().getContextClassLoader()));
          }
+         if (this.remoteCommandsExecutorFactoryClass != null) {
+            this.logger
+                  .debug("Overriding property [remoteCommandsExecutorFactoryClass] with new value ["
+                               + this.remoteCommandsExecutorFactoryClass + "]");
+            globalConfigurationToOverride.remoteCommandsExecutor().factory(
+                  Util.<ExecutorFactory>getInstance(this.remoteCommandsExecutorFactoryClass,
+                                                    Thread.currentThread().getContextClassLoader()));
+         }
          if (this.evictionScheduledExecutorFactoryClass != null) {
             this.logger
                      .debug("Overriding property [evictionScheduledExecutorFactoryClass] with new value ["
@@ -974,6 +1002,13 @@ public class AbstractEmbeddedCacheManagerFactory {
                               + this.asyncTransportExecutorProperties + "]");
             globalConfigurationToOverride.asyncTransportExecutor().withProperties(
                   this.asyncTransportExecutorProperties);
+         }
+         if (this.remoteCommandsExecutorProperties != null) {
+            this.logger
+                  .debug("Overriding property [remoteCommandsExecutorProperties] with new value ["
+                               + this.remoteCommandsExecutorProperties + "]");
+            globalConfigurationToOverride.remoteCommandsExecutor().withProperties(
+                  this.remoteCommandsExecutorProperties);
          }
          if (this.evictionScheduledExecutorProperties != null) {
             this.logger


### PR DESCRIPTION
... in order to avoid thread deadlocks

https://issues.jboss.org/browse/ISPN-2808

My Idea:
- created a new thread pool to async request
- added a new method in ReplicableCommand (isProcessedAsynchronously) that returns true if the command should be processed in the ISPN thread pool
  *\* the commands that returns true are the possible blocking commands (i.e. the can make sync remote invocation, aquire locks, etc.)
- then a command is processed normally in the thread pool
