### PR TITLE
ISPN-2914 - Some tests are not picked up by Surefire - part2

### DIFF
--- a/cachestore/hbase/src/test/java/org/infinispan/loaders/hbase/HBaseCacheStoreStandaloneTest.java
+++ b/cachestore/hbase/src/test/java/org/infinispan/loaders/hbase/HBaseCacheStoreStandaloneTest.java
@@ -36,7 +36,7 @@ import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
-@Test(groups = "manual", testName = "loaders.hbase.HBaseCacheStoreTestStandalone")
+@Test(groups = "manual", testName = "loaders.hbase.HBaseCacheStoreStandaloneTest")
 public class HBaseCacheStoreStandaloneTest extends SingleCacheManagerTest {
 
    private static final boolean USE_EMBEDDED = true;

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/NonStringKeyStateTransferTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/NonStringKeyStateTransferTest.java
@@ -36,7 +36,7 @@ import static junit.framework.Assert.assertEquals;
  * @author Mircea.Markus@jboss.com
  * @since 4.1
  */
-@Test(groups = "functional", testName = "jdbc.stringbased.NonStringKeyStateTransferTest")
+@Test(groups = "functional", testName = "loaders.jdbc.stringbased.NonStringKeyStateTransferTest")
 public class NonStringKeyStateTransferTest extends AbstractCacheTest {
 
    public void testReplicatedStateTransfer() {

--- a/cachestore/remote/src/test/java/org/infinispan/loaders/remote/RemoteCacheStoreWrapperTest.java
+++ b/cachestore/remote/src/test/java/org/infinispan/loaders/remote/RemoteCacheStoreWrapperTest.java
@@ -42,7 +42,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-@Test(testName = "loaders.remote.RemoteCacheStoreMixedAccessTest", groups="functional")
+@Test(testName = "loaders.remote.RemoteCacheStoreWrapperTest", groups="functional")
 public class RemoteCacheStoreWrapperTest extends AbstractInfinispanTest {
 
    private HotRodServer sourceServer;

--- a/cdi/extension/src/test/java/org/infinispan/cdi/test/distexec/DistributedExecutorCDITest.java
+++ b/cdi/extension/src/test/java/org/infinispan/cdi/test/distexec/DistributedExecutorCDITest.java
@@ -44,7 +44,7 @@ import org.testng.annotations.Test;
  * 
  * @author Vladimir Blagojevic 
  */
-@Test(enabled = true, groups = "functional", testName = "distexec.DistributedExecutorTest")
+@Test(enabled = true, groups = "functional", testName = "cdi.test.distexec.DistributedExecutorCDITest")
 public class DistributedExecutorCDITest extends MultipleCacheManagersArquillianTest {
    
    DistributedExecutorTest delegate;

--- a/cdi/extension/src/test/java/org/infinispan/cdi/test/distexec/WordCountMapReduceCDITest.java
+++ b/cdi/extension/src/test/java/org/infinispan/cdi/test/distexec/WordCountMapReduceCDITest.java
@@ -50,7 +50,7 @@ import org.testng.annotations.Test;
  * 
  * @author Vladimir Blagojevic
  */
-@Test(enabled = true, groups = "functional", testName = "distexec.WordCountMapReduceCDITest")
+@Test(enabled = true, groups = "functional", testName = "cdi.test.distexec.WordCountMapReduceCDITest")
 public class WordCountMapReduceCDITest extends MultipleCacheManagersArquillianTest {
 
    BaseWordCountMapReduceTest delegate;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ApacheAvroMarshallerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ApacheAvroMarshallerTest.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-@Test(groups = "functional", testName = "client.hotrod.ApacheAvroMarshallerTest")
+@Test(groups = "functional", testName = "client.hotrod.marshall.ApacheAvroMarshallerTest")
 public class ApacheAvroMarshallerTest {
 
    private final ApacheAvroMarshaller marshaller = new ApacheAvroMarshaller();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/DistributionRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/DistributionRetryTest.java
@@ -49,7 +49,7 @@ import static org.testng.Assert.assertEquals;
  * @author Mircea.Markus@jboss.com
  * @since 4.1
  */
-@Test(testName = "hotrod.retry.DistributionRetryTest", groups = "functional")
+@Test(testName = "client.hotrod.retry.DistributionRetryTest", groups = "functional")
 public class DistributionRetryTest extends AbstractRetryTest {
 
    @Override

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ReplicationRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ReplicationRetryTest.java
@@ -39,7 +39,7 @@ import org.testng.annotations.Test;
  * @author Mircea.Markus@jboss.com
  * @since 4.1
  */
-@Test (testName = "client.hotrod.ReplicationRetryTest", groups = "functional")
+@Test (testName = "client.hotrod.retry.ReplicationRetryTest", groups = "functional")
 public class ReplicationRetryTest extends AbstractRetryTest {
 
    public void testGet() {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/ClientConsistentHashPerfTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/ClientConsistentHashPerfTest.java
@@ -41,7 +41,7 @@ import org.testng.annotations.Test;
  * @author Dan Berindei
  * @since 5.3
  */
-@Test(groups = "profiling", testName = "client.hotrod.ClientConsistentHashPerfTest")
+@Test(groups = "profiling", testName = "client.hotrod.stress.ClientConsistentHashPerfTest")
 public class ClientConsistentHashPerfTest extends MultiHotRodServersTest {
 
    private static final int NUM_SERVERS = 64;

--- a/core/src/test/java/org/infinispan/config/ProgrammaticNameSetConfigTest.java
+++ b/core/src/test/java/org/infinispan/config/ProgrammaticNameSetConfigTest.java
@@ -36,8 +36,9 @@ import static org.testng.Assert.assertEquals;
  * @author Mircea Markus
  * @since 4.2
  */
-@Test (groups = "functional", testName = "config.ProgrammaticNameSetConfig")
-public class ProgrammaticNameSetConfig extends SingleCacheManagerTest {
+@Test (groups = "functional", testName = "config.ProgrammaticNameSetConfigTest", enabled = false,
+       description = "Disabled as this functionality is not working for Old API and for New API it is useless.")
+public class ProgrammaticNameSetConfigTest extends SingleCacheManagerTest {
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {

--- a/core/src/test/java/org/infinispan/container/versioning/SimpleConditionalOperationsWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/SimpleConditionalOperationsWriteSkewTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
-@Test(groups = "functional", testName = "api.SimpleConditionalOperationsWriteSkewTest")
+@Test(groups = "functional", testName = "container.versioning.SimpleConditionalOperationsWriteSkewTest")
 public class SimpleConditionalOperationsWriteSkewTest extends MultipleCacheManagersTest {
 
    protected ConfigurationBuilder getConfig() {

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/BookStoreAsBinarySearchTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/BookStoreAsBinarySearchTest.java
@@ -1,3 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.infinispan.distexec.mapreduce;
 
 import org.infinispan.configuration.cache.CacheMode;
@@ -10,7 +32,7 @@ import org.testng.annotations.Test;
  *
  * @author Anna Manukyan
  */
-@Test(groups = "functional", testName = "distexec.BookStoreAsBinarySearchTest")
+@Test(groups = "functional", testName = "distexec.mapreduce.BookStoreAsBinarySearchTest")
 public class BookStoreAsBinarySearchTest extends BookSearchTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/BookStoreAsBinaryWithCacheLoaderSearchTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/BookStoreAsBinaryWithCacheLoaderSearchTest.java
@@ -1,3 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.infinispan.distexec.mapreduce;
 
 import org.infinispan.configuration.cache.CacheMode;
@@ -14,7 +36,7 @@ import org.testng.annotations.Test;
  *
  * @author Anna Manukyan
  */
-@Test(groups = "functional", testName = "distexec.BookStoreAsBinaryWithCacheLoaderSearchTest")
+@Test(groups = "functional", testName = "distexec.mapreduce.BookStoreAsBinaryWithCacheLoaderSearchTest")
 public class BookStoreAsBinaryWithCacheLoaderSearchTest extends BookSearchTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/DistributedFourNodesMapReduceTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/DistributedFourNodesMapReduceTest.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * @author Vladimir Blagojevic
  * @since 5.2
  */
-@Test(groups = "functional", testName = "distexec.DistributedFourNodesMapReduceTest")
+@Test(groups = "functional", testName = "distexec.mapreduce.DistributedFourNodesMapReduceTest")
 public class DistributedFourNodesMapReduceTest extends BaseWordCountMapReduceTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/DistributedSharedCacheFourNodesMapReduceTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/DistributedSharedCacheFourNodesMapReduceTest.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * @author Vladimir Blagojevic
  * @since 5.2
  */
-@Test(groups = "functional", testName = "distexec.DistributedSharedCacheFourNodesMapReduceTest")
+@Test(groups = "functional", testName = "distexec.mapreduce.DistributedSharedCacheFourNodesMapReduceTest")
 public class DistributedSharedCacheFourNodesMapReduceTest extends BaseWordCountMapReduceTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/DistributedSharedCacheTwoNodesMapReduceTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/DistributedSharedCacheTwoNodesMapReduceTest.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * @author Vladimir Blagojevic
  * @since 5.2
  */
-@Test(groups = "functional", testName = "distexec.DistributedSharedCacheTwoNodesMapReduceTest")
+@Test(groups = "functional", testName = "distexec.mapreduce.DistributedSharedCacheTwoNodesMapReduceTest")
 public class DistributedSharedCacheTwoNodesMapReduceTest extends BaseWordCountMapReduceTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/DistributedTwoNodesMapReduceTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/DistributedTwoNodesMapReduceTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  * @author Vladimir Blagojevic
  * @since 5.2
  */
-@Test(groups = "functional", testName = "distexec.DistributedTwoNodesMapReduceTest")
+@Test(groups = "functional", testName = "distexec.mapreduce.DistributedTwoNodesMapReduceTest")
 public class DistributedTwoNodesMapReduceTest extends BaseWordCountMapReduceTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/SimpleBookSearchTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/SimpleBookSearchTest.java
@@ -1,3 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.infinispan.distexec.mapreduce;
 
 import org.infinispan.configuration.cache.CacheMode;
@@ -9,7 +31,7 @@ import org.testng.annotations.Test;
  *
  * @author Anna Manukyan
  */
-@Test(groups = "functional", testName = "distexec.SimpleBookSearchTest")
+@Test(groups = "functional", testName = "distexec.mapreduce.SimpleBookSearchTest")
 public class SimpleBookSearchTest extends BookSearchTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/SimpleFourNodesMapReduceTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/SimpleFourNodesMapReduceTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
  * @author Vladimir Blagojevic
  * @since 5.0
  */
-@Test(groups = "functional", testName = "distexec.SimpleFourNodesMapReduceTest")
+@Test(groups = "functional", testName = "distexec.mapreduce.SimpleFourNodesMapReduceTest")
 public class SimpleFourNodesMapReduceTest extends BaseWordCountMapReduceTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/SimpleTwoNodesMapReduceTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/SimpleTwoNodesMapReduceTest.java
@@ -54,7 +54,7 @@ import static org.infinispan.test.TestingUtil.withCacheManager;
  * @author Vladimir Blagojevic
  * @since 5.0
  */
-@Test(groups = "functional", testName = "distexec.SimpleTwoNodesMapReduceTest")
+@Test(groups = "functional", testName = "distexec.mapreduce.SimpleTwoNodesMapReduceTest")
 public class SimpleTwoNodesMapReduceTest extends BaseWordCountMapReduceTest {
    
    

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/TopologyAwareTwoNodesMapReduceTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/TopologyAwareTwoNodesMapReduceTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
  *
  * @author Anna Manukyan
  */
-@Test(groups = "functional", testName = "distexec.TopologyAwareTwoNodesMapReduceTest")
+@Test(groups = "functional", testName = "distexec.mapreduce.TopologyAwareTwoNodesMapReduceTest")
 public class TopologyAwareTwoNodesMapReduceTest extends SimpleTwoNodesMapReduceTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/TwoNodesWithCacheLoaderMapReduceTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/TwoNodesWithCacheLoaderMapReduceTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
  * @author Vladimir Blagojevic
  * @since 5.2
  */
-@Test(groups = "functional", testName = "distexec.TwoNodesWithCacheLoaderMapReduceTest")
+@Test(groups = "functional", testName = "distexec.mapreduce.TwoNodesWithCacheLoaderMapReduceTest")
 public class TwoNodesWithCacheLoaderMapReduceTest extends BaseWordCountMapReduceTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/TwoNodesWithCacheStoreMapReduceTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/TwoNodesWithCacheStoreMapReduceTest.java
@@ -41,7 +41,7 @@ import org.testng.annotations.Test;
  * @author Vladimir Blagojevic
  * @since 5.2
  */
-@Test(groups = "functional", testName = "distexec.TwoNodesWithCacheStoreMapReduceTest")
+@Test(groups = "functional", testName = "distexec.mapreduce.TwoNodesWithCacheStoreMapReduceTest")
 public class TwoNodesWithCacheStoreMapReduceTest extends BaseWordCountMapReduceTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distribution/DisabledL1WithRetValsNonConcurrentTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DisabledL1WithRetValsNonConcurrentTest.java
@@ -21,7 +21,7 @@ package org.infinispan.distribution;
 
 import org.testng.annotations.Test;
 
-@Test(groups = "functional", testName = "DisabledL1WithRetValsNonConcurrentTest")
+@Test(groups = "functional", testName = "distribution.DisabledL1WithRetValsNonConcurrentTest")
 public class DisabledL1WithRetValsNonConcurrentTest extends DisabledL1WithRetValsTest {
 
    public DisabledL1WithRetValsNonConcurrentTest() {

--- a/core/src/test/java/org/infinispan/distribution/PessimisticDistSyncTxCacheStoreSharedTest.java
+++ b/core/src/test/java/org/infinispan/distribution/PessimisticDistSyncTxCacheStoreSharedTest.java
@@ -42,7 +42,7 @@ import java.util.Set;
  * @author Thomas Fromm
  * @since 5.1
  */
-@Test(groups = "functional", testName = "loaders.PessimisticDistSyncTxCacheStoreSharedTest")
+@Test(groups = "functional", testName = "distribution.PessimisticDistSyncTxCacheStoreSharedTest")
 public class PessimisticDistSyncTxCacheStoreSharedTest extends MultipleCacheManagersTest {
 
    private ConfigurationBuilder getCB(){

--- a/core/src/test/java/org/infinispan/distribution/ch/DefaultConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/DefaultConsistentHashFactoryTest.java
@@ -44,7 +44,7 @@ import static org.testng.Assert.*;
  * @author Dan Berindei
  * @since 5.2
  */
-@Test(groups = "unit", testName = "ch.DefaultConsistentHashFactoryTest")
+@Test(groups = "unit", testName = "distribution.ch.DefaultConsistentHashFactoryTest")
 public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
 
    private int iterationCount = 0;

--- a/core/src/test/java/org/infinispan/distribution/ch/SyncConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/SyncConsistentHashFactoryTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
  * @author Dan Berindei
  * @since 5.2
  */
-@Test(groups = "unit", testName = "ch.SyncConsistentHashFactoryTest")
+@Test(groups = "unit", testName = "distribution.ch.SyncConsistentHashFactoryTest")
 public class SyncConsistentHashFactoryTest extends DefaultConsistentHashFactoryTest {
    @Override
    protected ConsistentHashFactory createConsistentHashFactory() {

--- a/core/src/test/java/org/infinispan/distribution/groups/GroupsChFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/groups/GroupsChFunctionalTest.java
@@ -36,7 +36,7 @@ import java.util.Collections;
  * @author Pete Muir
  * @since 5.0
  */
-@Test(groups = "functional", testName = "distribution.GroupsChFunctionalTest")
+@Test(groups = "functional", testName = "distribution.groups.GroupsChFunctionalTest")
 @CleanupAfterMethod
 public class GroupsChFunctionalTest extends DistSyncFuncTest {
 

--- a/core/src/test/java/org/infinispan/distribution/groups/GroupsDistAsyncFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/groups/GroupsDistAsyncFuncTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
  * @author Pete Muir
  * @since 5.0
  */
-@Test (groups = "functional", testName = "distribution.GroupsDistAsyncFuncTest")
+@Test (groups = "functional", testName = "distribution.groups.GroupsDistAsyncFuncTest")
 public class GroupsDistAsyncFuncTest extends DistAsyncFuncTest {
 
    public GroupsDistAsyncFuncTest() {

--- a/core/src/test/java/org/infinispan/distribution/groups/GroupsDistAsyncNonConcurrentFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/groups/GroupsDistAsyncNonConcurrentFuncTest.java
@@ -21,7 +21,7 @@ package org.infinispan.distribution.groups;
 
 import org.testng.annotations.Test;
 
-@Test(groups = "functional", testName = "distribution.GroupsDistAsyncNonConcurrentFuncTest")
+@Test(groups = "functional", testName = "distribution.groups.GroupsDistAsyncNonConcurrentFuncTest")
 public class GroupsDistAsyncNonConcurrentFuncTest extends GroupsDistAsyncFuncTest {
    public GroupsDistAsyncNonConcurrentFuncTest() {
       supportConcurrentWrites = false;

--- a/core/src/test/java/org/infinispan/distribution/groups/GroupsDistSyncUnsafeFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/groups/GroupsDistSyncUnsafeFuncTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
  * @author Pete Muir
  * @since 5.0
  */
-@Test(testName="distribution.GroupsDistSyncUnsafeFuncTest", groups = "functional")
+@Test(testName="distribution.groups.GroupsDistSyncUnsafeFuncTest", groups = "functional")
 public class GroupsDistSyncUnsafeFuncTest extends DistSyncUnsafeFuncTest {
    
    public GroupsDistSyncUnsafeFuncTest() {

--- a/core/src/test/java/org/infinispan/distribution/rehash/DataLossOnJoinOneOwner2Test.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/DataLossOnJoinOneOwner2Test.java
@@ -21,7 +21,7 @@ package org.infinispan.distribution.rehash;
 
 import org.testng.annotations.Test;
 
-@Test(groups="functional", testName = "DataLossOnJoinOneOwner2Test")
+@Test(groups="functional", testName = "distribution.rehash.DataLossOnJoinOneOwner2Test")
 public class DataLossOnJoinOneOwner2Test extends DataLossOnJoinOneOwnerTest {
    public DataLossOnJoinOneOwner2Test() {
       supportsConcurrentUpdates = false;

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashAfterJoinWithPreloadNotConcurrentTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashAfterJoinWithPreloadNotConcurrentTest.java
@@ -21,7 +21,7 @@ package org.infinispan.distribution.rehash;
 
 import org.testng.annotations.Test;
 
-@Test(groups = "functional", testName = "distribution.RehashAfterJoinWithPreloadNotConcurrentTest")
+@Test(groups = "functional", testName = "distribution.rehash.RehashAfterJoinWithPreloadNotConcurrentTest")
 public class RehashAfterJoinWithPreloadNotConcurrentTest extends RehashAfterJoinWithPreloadTest {
    public RehashAfterJoinWithPreloadNotConcurrentTest() {
       supportsConcurrentUpdates = false;

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashCompletedOnJoinNotConcurrentTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashCompletedOnJoinNotConcurrentTest.java
@@ -21,7 +21,7 @@ package org.infinispan.distribution.rehash;
 
 import org.testng.annotations.Test;
 
-@Test(groups = "functional", testName = "distribution.RehashCompletedOnJoinNotConcurrentTest")
+@Test(groups = "functional", testName = "distribution.rehash.RehashCompletedOnJoinNotConcurrentTest")
 public class RehashCompletedOnJoinNotConcurrentTest extends RehashCompletedOnJoinTest {
 
    public RehashCompletedOnJoinNotConcurrentTest() {

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashStressTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashStressTest.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * @author esalter
  */
-@Test(groups = "stress", testName = "org.infinispan.RehashStressTest")
+@Test(groups = "stress", testName = "distribution.rehash.RehashStressTest")
 public class RehashStressTest extends AbstractInfinispanTest {
 
     @AfterMethod(alwaysRun = true)

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashWithSharedCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashWithSharedCacheStoreTest.java
@@ -42,12 +42,12 @@ import static java.lang.String.format;
  * Should ensure that persistent state is not rehashed if the cache store is shared.  See ISPN-861
  *
  */
-@Test (testName = "distribution.rehash.RehashWithSharedCacheStore", groups = "functional")
-public class RehashWithSharedCacheStore extends BaseDistCacheStoreTest {
+@Test (testName = "distribution.rehash.RehashWithSharedCacheStoreTest", groups = "functional")
+public class RehashWithSharedCacheStoreTest extends BaseDistCacheStoreTest {
 
-   private static final Log log = LogFactory.getLog(RehashWithSharedCacheStore.class);
+   private static final Log log = LogFactory.getLog(RehashWithSharedCacheStoreTest.class);
 
-   public RehashWithSharedCacheStore() {
+   public RehashWithSharedCacheStoreTest() {
       INIT_CLUSTER_SIZE = 3;
       sync = true;
       tx = false;

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareChFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareChFunctionalTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
  * @author Mircea.Markus@jboss.com
  * @since 4.2
  */
-@Test (groups = "functional", testName = "distribution.TopologyAwareChFunctionalTest")
+@Test (groups = "functional", testName = "distribution.topologyaware.TopologyAwareChFunctionalTest")
 public class TopologyAwareChFunctionalTest extends DistSyncFuncTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareConsistentHashFactoryTest.java
@@ -48,7 +48,7 @@ import static org.testng.Assert.assertEquals;
  * @author Dan Berindei
  * @since 4.2
  */
-@Test(groups = "unit", testName = "topologyaware.TopologyAwareConsistentHashFactoryTest")
+@Test(groups = "unit", testName = "distribution.topologyaware.TopologyAwareConsistentHashFactoryTest")
 public class TopologyAwareConsistentHashFactoryTest extends AbstractInfinispanTest {
    
    private static final Log log = LogFactory.getLog(TopologyAwareConsistentHashFactoryTest.class);

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareDistAsyncFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareDistAsyncFuncTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  * @author Mircea.Markus@jboss.com
  * @since 4.2
  */
-@Test (groups = "functional", testName = "topologyaware.TopologyAwareDistAsyncFuncTest")
+@Test (groups = "functional", testName = "distribution.topologyaware.TopologyAwareDistAsyncFuncTest")
 public class TopologyAwareDistAsyncFuncTest extends DistAsyncFuncTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareDistSyncUnsafeFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareDistSyncUnsafeFuncTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  * @author Mircea.Markus@jboss.com
  * @since 4.2
  */
-@Test(testName="topologyaware.TopologyAwareDistSyncUnsafeFuncTest", groups = "functional")
+@Test(testName="distribution.topologyaware.TopologyAwareDistSyncUnsafeFuncTest", groups = "functional")
 public class TopologyAwareDistSyncUnsafeFuncTest extends DistSyncUnsafeFuncTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareStateTransferTest.java
@@ -41,7 +41,7 @@ import java.util.List;
  * @author Mircea.Markus@jboss.com
  * @since 4.2
  */
-@Test(groups = "functional", testName = "topologyaware.TopologyAwareStateTransferTest")
+@Test(groups = "functional", testName = "distribution.topologyaware.TopologyAwareStateTransferTest")
 @CleanupAfterTest
 public class TopologyAwareStateTransferTest extends MultipleCacheManagersTest {
 

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareSyncConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareSyncConsistentHashFactoryTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
  * @author Dan Berindei
  * @since 5.2
  */
-@Test(groups = "unit", testName = "topologyaware.TopologyAwareSyncConsistentHashFactoryTest")
+@Test(groups = "unit", testName = "distribution.topologyaware.TopologyAwareSyncConsistentHashFactoryTest")
 public class TopologyAwareSyncConsistentHashFactoryTest extends TopologyAwareConsistentHashFactoryTest {
 
    public TopologyAwareSyncConsistentHashFactoryTest() {

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyInfoBroadcastNoRehashTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyInfoBroadcastNoRehashTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
  * @author Mircea.Markus@jboss.com
  * @since 4.2
  */
-@Test(groups = "functional", testName = "topologyaware.TopologyInfoBroadcastNoRehashTest")
+@Test(groups = "functional", testName = "distribution.topologyaware.TopologyInfoBroadcastNoRehashTest")
 public class TopologyInfoBroadcastNoRehashTest extends TopologyInfoBroadcastTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyInfoBroadcastTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyInfoBroadcastTest.java
@@ -42,7 +42,7 @@ import static org.testng.Assert.assertEquals;
  * @author Mircea.Markus@jboss.com
  * @since 4.2
  */
-@Test(groups = "functional", testName = "topologyaware.TopologyInfoBroadcastTest")
+@Test(groups = "functional", testName = "distribution.topologyaware.TopologyInfoBroadcastTest")
 public class TopologyInfoBroadcastTest extends MultipleCacheManagersTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/eviction/ExpensiveEvictionTest.java
+++ b/core/src/test/java/org/infinispan/eviction/ExpensiveEvictionTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 /**
  * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
  */
-@Test(groups = "profiling", enabled = false, testName = "profiling.ExpensiveEvictionTest")
+@Test(groups = "profiling", enabled = false, testName = "eviction.ExpensiveEvictionTest")
 public class ExpensiveEvictionTest extends SingleCacheManagerTest {
 
    private final Integer MAX_CACHE_ELEMENTS = 10 * 1000 * 1000;

--- a/core/src/test/java/org/infinispan/loaders/decorators/AsyncStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/loaders/decorators/AsyncStoreFunctionalTest.java
@@ -61,7 +61,7 @@ import static org.testng.AssertJUnit.assertTrue;
  * @author Galder Zamarreño
  * @since 5.2
  */
-@Test(groups = "functional", testName = "loaders.AsyncStoreFunctionalTest")
+@Test(groups = "functional", testName = "loaders.decorators.AsyncStoreFunctionalTest")
 public class AsyncStoreFunctionalTest {
 
    private static final Log log = LogFactory.getLog(AsyncStoreFunctionalTest.class);

--- a/core/src/test/java/org/infinispan/loaders/decorators/BatchAsyncCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/decorators/BatchAsyncCacheStoreTest.java
@@ -47,7 +47,7 @@ import org.testng.annotations.Test;
  * @author Sanne Grinovero
  * @since 4.1
  */
-@Test(groups = "functional", testName = "loaders.BatchAsyncCacheStoreTest")
+@Test(groups = "functional", testName = "loaders.decorators.BatchAsyncCacheStoreTest")
 public class BatchAsyncCacheStoreTest extends SingleCacheManagerTest {
 
    private final HashMap<Object, Object> cacheCopy = new HashMap<Object, Object>();

--- a/core/src/test/java/org/infinispan/lock/singlelock/optimistic/BasicSingleLockOptimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/optimistic/BasicSingleLockOptimisticTest.java
@@ -37,7 +37,7 @@ import static org.testng.Assert.assertEquals;
  * @author Mircea Markus
  * @since 5.1
  */
-@Test (groups = "functional",testName = "lock.singlelock.BasicSingleLockOptimisticTest")
+@Test (groups = "functional",testName = "lock.singlelock.optimistic.BasicSingleLockOptimisticTest")
 public class BasicSingleLockOptimisticTest extends AbstractNoCrashTest {
 
    public BasicSingleLockOptimisticTest() {

--- a/core/src/test/java/org/infinispan/lock/singlelock/optimistic/InitiatorCrashOptimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/optimistic/InitiatorCrashOptimisticTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  * @author Mircea Markus
  * @since 5.1
  */
-@Test (groups = "functional", testName = "lock.singlelock.InitiatorCrashOptimisticTest")
+@Test (groups = "functional", testName = "lock.singlelock.optimistic.InitiatorCrashOptimisticTest")
 @CleanupAfterMethod
 public class InitiatorCrashOptimisticTest extends AbstractInitiatorCrashTest {
 

--- a/core/src/test/java/org/infinispan/lock/singlelock/optimistic/LockOwnerCrashOptimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/optimistic/LockOwnerCrashOptimisticTest.java
@@ -37,7 +37,7 @@ import static org.testng.Assert.fail;
  * @author Mircea Markus
  * @since 5.1
  */
-@Test (groups = "functional", testName = "lock.singlelock.LockOwnerCrashOptimisticTest")
+@Test (groups = "functional", testName = "lock.singlelock.optimistic.LockOwnerCrashOptimisticTest")
 @CleanupAfterMethod
 public class LockOwnerCrashOptimisticTest extends AbstractLockOwnerCrashTest {
 

--- a/core/src/test/java/org/infinispan/lock/singlelock/optimistic/SyncBasicSingleLockOptimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/optimistic/SyncBasicSingleLockOptimisticTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
  * @author Mircea Markus
  * @since 5.1
  */
-@Test (groups = "functional", testName = "lock.singlelock.SyncBasicSingleLockOptimisticTest")
+@Test (groups = "functional", testName = "lock.singlelock.optimistic.SyncBasicSingleLockOptimisticTest")
 public class SyncBasicSingleLockOptimisticTest extends BasicSingleLockOptimisticTest {
 
    public SyncBasicSingleLockOptimisticTest() {

--- a/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/BasicSingleLockPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/BasicSingleLockPessimisticTest.java
@@ -36,7 +36,7 @@ import static org.testng.Assert.assertEquals;
  * @author Mircea Markus
  * @since 5.1
  */
-@Test (groups = "functional", testName = "lock.singlelock.BasicSingleLockPessimisticTest")
+@Test (groups = "functional", testName = "lock.singlelock.pessimistic.BasicSingleLockPessimisticTest")
 public class BasicSingleLockPessimisticTest extends AbstractNoCrashTest {
 
    public BasicSingleLockPessimisticTest() {

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/optimistic/LockOwnerCrashOptimisticReplTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/optimistic/LockOwnerCrashOptimisticReplTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  * @author Mircea Markus
  * @since 5.1
  */
-@Test (groups = "functional", testName = "singlelock.replicated.optimistic.LockOwnerCrashOptimisticReplTest")
+@Test (groups = "functional", testName = "lock.singlelock.replicated.optimistic.LockOwnerCrashOptimisticReplTest")
 @CleanupAfterMethod
 public class LockOwnerCrashOptimisticReplTest extends AbstractLockOwnerCrashTest {
 

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/BasicSingleLockRepPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/BasicSingleLockRepPessimisticTest.java
@@ -34,7 +34,7 @@ import org.testng.annotations.Test;
  * @author Mircea Markus
  * @since 5.1
  */
-@Test (groups = "functional", testName = "singlelock.replicated.pessimistic.BasicSingleLockRepPessimisticTest")
+@Test (groups = "functional", testName = "lock.singlelock.replicated.pessimistic.BasicSingleLockRepPessimisticTest")
 public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
 
    public BasicSingleLockRepPessimisticTest() {

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/InitiatorCrashPessimisticReplTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/InitiatorCrashPessimisticReplTest.java
@@ -35,7 +35,7 @@ import java.util.concurrent.CountDownLatch;
  * @author Mircea Markus
  * @since 5.1
  */
-@Test(groups = "functional", testName = "singlelock.replicated.pessimistic.InitiatorCrashPessimisticReplTest", enabled = false, description = "See ISPN-2161")
+@Test(groups = "functional", testName = "lock.singlelock.replicated.pessimistic.InitiatorCrashPessimisticReplTest", enabled = false, description = "See ISPN-2161")
 @CleanupAfterMethod
 public class InitiatorCrashPessimisticReplTest extends InitiatorCrashOptimisticReplTest {
 

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/LockOwnerCrashPessimisticReplTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/LockOwnerCrashPessimisticReplTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  * @author Mircea Markus
  * @since 5.1
  */
-@Test(groups = "functional", testName = "singlelock.replicated.optimistic.LockOwnerCrashPessimisticReplTest")
+@Test(groups = "functional", testName = "lock.singlelock.replicated.pessimistic.LockOwnerCrashPessimisticReplTest")
 @CleanupAfterMethod
 public class LockOwnerCrashPessimisticReplTest extends AbstractLockOwnerCrashTest {
 

--- a/core/src/test/java/org/infinispan/manager/ConcurrentCacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/ConcurrentCacheManagerTest.java
@@ -44,7 +44,7 @@ import java.util.concurrent.Future;
  * @author Galder Zamarreño
  * @since 4.2
  */
-@Test(groups = "functional", testName = "ConcurrentCacheManagerTest")
+@Test(groups = "functional", testName = "manager.ConcurrentCacheManagerTest")
 public class ConcurrentCacheManagerTest extends AbstractCacheTest {
    static final int NUM_CACHES = 4;
    static final int NUM_THREADS = 25;

--- a/core/src/test/java/org/infinispan/marshall/MarshallExternalPojosTest.java
+++ b/core/src/test/java/org/infinispan/marshall/MarshallExternalPojosTest.java
@@ -37,7 +37,7 @@ import java.lang.reflect.Method;
 import static org.infinispan.test.TestingUtil.k;
 import static org.testng.AssertJUnit.assertEquals;
 
-@Test(groups = "functional", testName = "marshall.jboss.MarshallExternalPojosTest")
+@Test(groups = "functional", testName = "marshall.MarshallExternalPojosTest")
 public class MarshallExternalPojosTest extends MultipleCacheManagersTest {
 
    private static final String CACHE_NAME = MarshallExternalPojosTest.class.getName();

--- a/core/src/test/java/org/infinispan/marshall/MarshallerPickAfterCacheRestart.java
+++ b/core/src/test/java/org/infinispan/marshall/MarshallerPickAfterCacheRestart.java
@@ -37,7 +37,7 @@ import static org.testng.AssertJUnit.assertEquals;
  * @author Galder Zamarreño
  * @since 5.1
  */
-@Test(groups = "functional", testName = "marshall.CustomClassResolverCacheRestartTest")
+@Test(groups = "functional", testName = "marshall.MarshallerPickAfterCacheRestart")
 public class MarshallerPickAfterCacheRestart extends MultipleCacheManagersTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/marshall/multiversion/MultiPojoVersionMarshallTest.java
+++ b/core/src/test/java/org/infinispan/marshall/multiversion/MultiPojoVersionMarshallTest.java
@@ -61,7 +61,7 @@ import static org.testng.AssertJUnit.assertNull;
  * @author Galder Zamarreño
  * @since 5.0
  */
-@Test(groups = "functional", testName = "marshall.MultiPojoVersionMarshallTest")
+@Test(groups = "functional", testName = "marshall.multiversion.MultiPojoVersionMarshallTest")
 public class MultiPojoVersionMarshallTest extends AbstractInfinispanTest {
 
    private static final String BASE = "org.infinispan.marshall.multiversion.MultiPojoVersionMarshallTest$";

--- a/core/src/test/java/org/infinispan/notifications/DistListenerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/DistListenerTest.java
@@ -41,7 +41,7 @@ import org.testng.annotations.Test;
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
  * @since 5.0
  */
-@Test(groups = "functional", testName = "distribution.DistListenerTest")
+@Test(groups = "functional", testName = "notifications.DistListenerTest")
 public class DistListenerTest extends MultipleCacheManagersTest {
 
    private TestListener listener;

--- a/core/src/test/java/org/infinispan/notifications/MergeViewTest.java
+++ b/core/src/test/java/org/infinispan/notifications/MergeViewTest.java
@@ -38,7 +38,7 @@ import static org.testng.AssertJUnit.assertEquals;
 /**
  * @author Mircea.Markus@jboss.com
  */
-@Test(groups = "functional", testName = "notification.MergeViewTest")
+@Test(groups = "functional", testName = "notifications.MergeViewTest")
 public class MergeViewTest extends MultipleCacheManagersTest {
 
    private static final Log log = LogFactory.getLog(MergeViewTest.class);

--- a/core/src/test/java/org/infinispan/profiling/TestProfileSlave.java
+++ b/core/src/test/java/org/infinispan/profiling/TestProfileSlave.java
@@ -28,11 +28,11 @@ import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
 import org.infinispan.test.TestingUtil;
 import org.testng.annotations.Test;
 
-@Test(groups = "profiling", enabled = false, testName = "profiling.ProfileTestSlave")
-public class ProfileTestSlave extends AbstractProfileTest {
+@Test(groups = "profiling", enabled = false, testName = "profiling.TestProfileSlave")
+public class TestProfileSlave extends AbstractProfileTest {
 
    public static void main(String[] args) throws Exception {
-      ProfileTestSlave pst = new ProfileTestSlave();
+      TestProfileSlave pst = new TestProfileSlave();
       pst.startedInCmdLine = true;
 
       String mode = args[0];

--- a/core/src/test/java/org/infinispan/remoting/jgroups/MissingRpcDispatcherTest.java
+++ b/core/src/test/java/org/infinispan/remoting/jgroups/MissingRpcDispatcherTest.java
@@ -51,7 +51,7 @@ import java.util.Properties;
  * @since 5.1
  * @author Dan Berindei &lt;dan@infinispan.org&gt;
  */
-@Test(groups = "functional", testName = "remoting.MissingRpcDispatcherTest",
+@Test(groups = "functional", testName = "remoting.jgroups.MissingRpcDispatcherTest",
       enabled = false, description = "Temporarily disabled because I removed the cache members filter in 5.2")
 @CleanupAfterMethod
 public class MissingRpcDispatcherTest extends MultipleCacheManagersTest {

--- a/core/src/test/java/org/infinispan/statetransfer/StaleLocksWithCommitDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StaleLocksWithCommitDuringStateTransferTest.java
@@ -43,7 +43,7 @@ import org.infinispan.transaction.TransactionCoordinator;
 import org.infinispan.transaction.TransactionTable;
 import org.testng.annotations.Test;
 
-@Test(testName = "lock.StaleLocksWithCommitDuringStateTransferTest", groups = "functional",
+@Test(testName = "statetransfer.StaleLocksWithCommitDuringStateTransferTest", groups = "functional",
       enabled = false, description = "This test relies on implementation details of the old state algorithm")
 @CleanupAfterMethod
 public class StaleLocksWithCommitDuringStateTransferTest extends MultipleCacheManagersTest {

--- a/core/src/test/java/org/infinispan/stress/LargeClusterStressTest.java
+++ b/core/src/test/java/org/infinispan/stress/LargeClusterStressTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
  * @author Dan Berindei
  * @since 5.3
  */
-@Test(groups = "stress", testName = "statetransfer.LargeClusterStressTest")
+@Test(groups = "stress", testName = "stress.LargeClusterStressTest")
 public class LargeClusterStressTest extends MultipleCacheManagersTest {
 
    private static final int NUM_NODES = 64;

--- a/core/src/test/java/org/infinispan/test/fwk/SuiteResourcesAndLogTest.java
+++ b/core/src/test/java/org/infinispan/test/fwk/SuiteResourcesAndLogTest.java
@@ -34,7 +34,7 @@ import org.testng.annotations.Test;
  * @author Mircea.Markus@jboss.com
  * @author Galder Zamarreño
  */
-@Test(groups = "functional", testName = "test.testng.SuiteResourcesAndLogTest", alwaysRun=true)
+@Test(groups = "functional", testName = "test.fwk.SuiteResourcesAndLogTest", alwaysRun=true)
 public class SuiteResourcesAndLogTest {
 
    private static final Log log = LogFactory.getLog(SuiteResourcesAndLogTest.class);

--- a/core/src/test/java/org/infinispan/tx/RemoteLockCleanupStressTest.java
+++ b/core/src/test/java/org/infinispan/tx/RemoteLockCleanupStressTest.java
@@ -41,7 +41,7 @@ import javax.transaction.TransactionManager;
 
 import static org.infinispan.test.TestingUtil.sleepThread;
 
-@Test (groups = "functional", testName = "lock.RemoteLockCleanupStressTest", invocationCount = 20, enabled = false)
+@Test (groups = "functional", testName = "tx.RemoteLockCleanupStressTest", invocationCount = 20, enabled = false)
 @CleanupAfterMethod
 public class RemoteLockCleanupStressTest extends MultipleCacheManagersTest {
 

--- a/core/src/test/java/org/infinispan/tx/TransactionCleanupWithAsync2ndPhaseRecoveryTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionCleanupWithAsync2ndPhaseRecoveryTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
  * @author Mircea Markus
  * @since 5.1
  */
-@Test(groups = "functional", testName = "TransactionCleanupWithAsync2ndPhaseRecoveryTest")
+@Test(groups = "functional", testName = "tx.TransactionCleanupWithAsync2ndPhaseRecoveryTest")
 public class TransactionCleanupWithAsync2ndPhaseRecoveryTest extends TransactionCleanupWithAsync2ndPhaseTest {
 
    protected Configuration getConfiguration() {

--- a/core/src/test/java/org/infinispan/tx/TransactionCleanupWithRecoveryTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionCleanupWithRecoveryTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 
 import javax.transaction.Transaction;
 
-@Test(groups = "functional", testName = "TransactionCleanupWithRecoveryTest")
+@Test(groups = "functional", testName = "tx.TransactionCleanupWithRecoveryTest")
 public class TransactionCleanupWithRecoveryTest extends MultipleCacheManagersTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/tx/exception/CustomInterceptorException.java
+++ b/core/src/test/java/org/infinispan/tx/exception/CustomInterceptorException.java
@@ -40,7 +40,7 @@ import static org.testng.Assert.assertEquals;
  * @author Mircea.Markus@jboss.com
  * @since 4.2
  */
-@Test(groups = "functional", testName = "CustomInterceptorException")
+@Test(groups = "functional", testName = "tx.exception.CustomInterceptorException")
 public class CustomInterceptorException extends SingleCacheManagerTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/tx/exception/TxAndRemoteTimeoutExceptionTest.java
+++ b/core/src/test/java/org/infinispan/tx/exception/TxAndRemoteTimeoutExceptionTest.java
@@ -53,7 +53,7 @@ import static org.testng.Assert.assertEquals;
  * @author Mircea.Markus@jboss.com
  * @since 4.2
  */
-@Test(groups = "functional", testName = "tx.TxAndRemoteTimeoutExceptionTest")
+@Test(groups = "functional", testName = "tx.exception.TxAndRemoteTimeoutExceptionTest")
 public class TxAndRemoteTimeoutExceptionTest extends MultipleCacheManagersTest {
 
    private static final Log log = LogFactory.getLog(TxAndRemoteTimeoutExceptionTest.class);

--- a/core/src/test/java/org/infinispan/tx/exception/TxAndTimeoutExceptionTest.java
+++ b/core/src/test/java/org/infinispan/tx/exception/TxAndTimeoutExceptionTest.java
@@ -47,7 +47,7 @@ import static org.testng.Assert.assertEquals;
  * @author Mircea.Markus@jboss.com
  * @since 4.2
  */
-@Test(testName = "tx.TxAndTimeoutExceptionTest", groups = "functional")
+@Test(testName = "tx.exception.TxAndTimeoutExceptionTest", groups = "functional")
 public class TxAndTimeoutExceptionTest extends SingleCacheManagerTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/tx/recovery/RecoveryHandlerTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/RecoveryHandlerTest.java
@@ -34,7 +34,7 @@ import javax.transaction.xa.Xid;
  * @author Mircea Markus
  * @since 5.1
  */
-@Test (groups = "functional", testName = "tx.RecoveryHandlerTest")
+@Test (groups = "functional", testName = "tx.recovery.RecoveryHandlerTest")
 public class RecoveryHandlerTest extends MultipleCacheManagersTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/tx/synchronisation/APIDistWithSyncTest.java
+++ b/core/src/test/java/org/infinispan/tx/synchronisation/APIDistWithSyncTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
  * @author Mircea.Markus@jboss.com
  * @since 5.0
  */
-@Test(groups = "functional", testName = "tx.synchronization.APIDistWithSyncTest")
+@Test(groups = "functional", testName = "tx.synchronisation.APIDistWithSyncTest")
 public class APIDistWithSyncTest extends APIDistTest {
    @Override
    protected Configuration createConfig() {

--- a/core/src/test/java/org/infinispan/tx/synchronisation/DldEagerLockingDistributedWithSyncTest.java
+++ b/core/src/test/java/org/infinispan/tx/synchronisation/DldEagerLockingDistributedWithSyncTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
  * @author Mircea.Markus@jboss.com
  * @since 5.0
  */
-@Test (groups = "functional", testName = "tx.synchronization.DldEagerLockingDistributedWithSyncTest")
+@Test (groups = "functional", testName = "tx.synchronisation.DldEagerLockingDistributedWithSyncTest")
 public class DldEagerLockingDistributedWithSyncTest extends DldPessimisticLockingDistributedTest {
    @Override
    protected Configuration createConfiguration() {

--- a/core/src/test/java/org/infinispan/tx/synchronisation/DldEagerLockingReplicationWithSyncTest.java
+++ b/core/src/test/java/org/infinispan/tx/synchronisation/DldEagerLockingReplicationWithSyncTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
  * @author Mircea.Markus@jboss.com
  * @since 5.0
  */
-@Test (groups = "functional", testName = "tx.synchronization.DldEagerLockingReplicationWithSyncTest")
+@Test (groups = "functional", testName = "tx.synchronisation.DldEagerLockingReplicationWithSyncTest")
 public class DldEagerLockingReplicationWithSyncTest extends DldPessimisticLockingReplicationTest {
    @Override
    protected Configuration getConfiguration() throws Exception {

--- a/core/src/test/java/org/infinispan/tx/synchronisation/LocalDldWithSyncTest.java
+++ b/core/src/test/java/org/infinispan/tx/synchronisation/LocalDldWithSyncTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
  * @author Mircea.Markus@jboss.com
  * @since 5.0
  */
-@Test (groups = "functional", testName = "tx.synchronization.LocalDldWithSyncTest")
+@Test (groups = "functional", testName = "tx.synchronisation.LocalDldWithSyncTest")
 public class LocalDldWithSyncTest extends LocalDeadlockDetectionTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/tx/synchronisation/LocalModeWithSyncTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/synchronisation/LocalModeWithSyncTxTest.java
@@ -41,7 +41,7 @@ import static org.testng.Assert.assertEquals;
  * @author Mircea.Markus@jboss.com
  * @since 5.0
  */
-@Test(groups = "functional", testName = "tx.synchronization.LocalModeWithSyncTxTest")
+@Test(groups = "functional", testName = "tx.synchronisation.LocalModeWithSyncTxTest")
 public class LocalModeWithSyncTxTest extends LocalModeTxTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/tx/synchronisation/NoXaConfigTest.java
+++ b/core/src/test/java/org/infinispan/tx/synchronisation/NoXaConfigTest.java
@@ -34,7 +34,7 @@ import org.testng.annotations.Test;
  * @author Mircea.Markus@jboss.com
  * @since 5.0
  */
-@Test (groups = "functional", testName = "tx.synchronization.NoXaConfigTest")
+@Test (groups = "functional", testName = "tx.synchronisation.NoXaConfigTest")
 public class NoXaConfigTest extends SingleCacheManagerTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/tx/synchronisation/TransactionsSpanningCachesSyncTest.java
+++ b/core/src/test/java/org/infinispan/tx/synchronisation/TransactionsSpanningCachesSyncTest.java
@@ -34,7 +34,7 @@ import org.testng.annotations.Test;
  * @author Mircea.Markus@jboss.com
  * @since 5.0
  */
-@Test(groups = "functional", testName = "tx.synchronization.TransactionsSpanningCachesSyncTest")
+@Test(groups = "functional", testName = "tx.synchronisation.TransactionsSpanningCachesSyncTest")
 public class TransactionsSpanningCachesSyncTest extends TransactionsSpanningCaches {
 
    @Override

--- a/core/src/test/java/org/infinispan/xsite/BackupCacheStoppedTest.java
+++ b/core/src/test/java/org/infinispan/xsite/BackupCacheStoppedTest.java
@@ -32,7 +32,7 @@ import static org.testng.AssertJUnit.*;
  * @author Mircea Markus
  * @since 5.2
  */
-@Test (groups = "xsite", testName = "xsite.NonTxAsyncBackupTest")
+@Test (groups = "xsite", testName = "xsite.BackupCacheStoppedTest")
 public class BackupCacheStoppedTest extends AbstractTwoSitesTest {
 
    public void testCacheStopped() {

--- a/core/src/test/java/org/infinispan/xsite/BackupForNotSpecifiedTest.java
+++ b/core/src/test/java/org/infinispan/xsite/BackupForNotSpecifiedTest.java
@@ -33,8 +33,8 @@ import static org.testng.AssertJUnit.assertNull;
  * @author Mircea Markus
  * @since 5.2
  */
-@Test(groups = "xsite", testName = "xsite.TestBackupForNotSpecified")
-public class TestBackupForNotSpecified extends AbstractXSiteTest {
+@Test(groups = "xsite", testName = "xsite.BackupForNotSpecifiedTest")
+public class BackupForNotSpecifiedTest extends AbstractXSiteTest {
 
    @Override
    protected void createSites() {

--- a/core/src/test/java/org/infinispan/xsite/NoFailureAsyncReplWarnFailurePolicyTest.java
+++ b/core/src/test/java/org/infinispan/xsite/NoFailureAsyncReplWarnFailurePolicyTest.java
@@ -30,7 +30,7 @@ import java.util.Collections;
 import static org.testng.Assert.assertNull;
 import static org.testng.AssertJUnit.assertEquals;
 
-@Test (groups = "xsite", testName = "xsite.bridgemissing.NoFailureAsyncReplWarnFailurePolicyTest")
+@Test (groups = "xsite", testName = "xsite.NoFailureAsyncReplWarnFailurePolicyTest")
 public class NoFailureAsyncReplWarnFailurePolicyTest extends BaseSiteUnreachableTest {
 
    public NoFailureAsyncReplWarnFailurePolicyTest() {

--- a/core/src/test/java/org/infinispan/xsite/XSiteAdminOperationsTest.java
+++ b/core/src/test/java/org/infinispan/xsite/XSiteAdminOperationsTest.java
@@ -34,7 +34,7 @@ import static org.testng.AssertJUnit.assertEquals;
  * @author Mircea Markus
  * @since 5.2
  */
-@Test(groups = "xsite", testName = "xsite.admin.XSiteAdminOperationsTest")
+@Test(groups = "xsite", testName = "xsite.XSiteAdminOperationsTest")
 public class XSiteAdminOperationsTest extends AbstractTwoSitesTest {
 
    @Override

--- a/core/src/test/java/org/infinispan/xsite/backupfailure/tx/DistLocalClusterFailureTest.java
+++ b/core/src/test/java/org/infinispan/xsite/backupfailure/tx/DistLocalClusterFailureTest.java
@@ -27,8 +27,8 @@ import org.testng.annotations.Test;
  * @author Mircea Markus
  * @since 5.2
  */
-@Test (groups = "xsite")
-public class DistLocalClusterFailure extends BaseLocalClusterTxFailureTest {
+@Test (groups = "xsite", testName = "xsite.backupfailure.tx.DistLocalClusterFailureTest")
+public class DistLocalClusterFailureTest extends BaseLocalClusterTxFailureTest {
 
    @Override
    protected ConfigurationBuilder getNycActiveConfig() {

--- a/core/src/test/java/org/infinispan/xsite/backupfailure/tx/DistLocalClusterTxBackupFailureTest.java
+++ b/core/src/test/java/org/infinispan/xsite/backupfailure/tx/DistLocalClusterTxBackupFailureTest.java
@@ -27,10 +27,10 @@ import org.testng.annotations.Test;
  * @author Mircea Markus
  * @since 5.2
  */
-@Test (groups = "xsite", testName = "xsite.backupfailure.tx.DistLocalClusterTxBackupFailure")
-public class DistLocalClusterTxBackupFailure extends BaseLocalClusterTxFailureTest {
+@Test (groups = "xsite", testName = "xsite.backupfailure.tx.DistLocalClusterTxBackupFailureTest")
+public class DistLocalClusterTxBackupFailureTest extends BaseLocalClusterTxFailureTest {
 
-   public DistLocalClusterTxBackupFailure() {
+   public DistLocalClusterTxBackupFailureTest() {
       isLonBackupTransactional = true;
    }
 

--- a/core/src/test/java/org/infinispan/xsite/backupfailure/tx/ReplLocalClusterFailureTest.java
+++ b/core/src/test/java/org/infinispan/xsite/backupfailure/tx/ReplLocalClusterFailureTest.java
@@ -27,8 +27,8 @@ import org.testng.annotations.Test;
  * @author Mircea Markus
  * @since 5.2
  */
-@Test (groups = "xsite", testName = "xsite.backupfailure.tx.ReplLocalClusterFailure")
-public class ReplLocalClusterFailure extends BaseLocalClusterTxFailureTest {
+@Test (groups = "xsite", testName = "xsite.backupfailure.tx.ReplLocalClusterFailureTest")
+public class ReplLocalClusterFailureTest extends BaseLocalClusterTxFailureTest {
 
    @Override
    protected ConfigurationBuilder getNycActiveConfig() {

--- a/query/src/test/java/org/infinispan/query/analysis/SolrAnalyzerTest.java
+++ b/query/src/test/java/org/infinispan/query/analysis/SolrAnalyzerTest.java
@@ -43,7 +43,7 @@ import static junit.framework.Assert.assertEquals;
  * @author Emmanuel Bernard
  * @author Hardy Ferentschik
  */
-@Test(groups = "functional", testName = "query.analyzer.SolrAnalyzerTest")
+@Test(groups = "functional", testName = "query.analysis.SolrAnalyzerTest")
 public class SolrAnalyzerTest extends SingleCacheManagerTest {
 
    protected EmbeddedCacheManager createCacheManager() throws Exception {

--- a/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredCacheTest.java
@@ -36,7 +36,7 @@ import java.util.List;
  *
  * @author Anna Manukyan
  */
-@Test(groups = "functional", testName = "query.distributed.TopologyAwareClusteredCacheTest")
+@Test(groups = "functional", testName = "query.blackbox.TopologyAwareClusteredCacheTest")
 public class TopologyAwareClusteredCacheTest extends ClusteredCacheTest {
 
    @Override

--- a/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareClusteredQueryTest.java
@@ -36,7 +36,7 @@ import java.util.List;
  *
  * @author Anna Manukyan
  */
-@Test(groups = "functional", testName = "query.distributed.TopologyAwareClusteredQueryTest")
+@Test(groups = "functional", testName = "query.blackbox.TopologyAwareClusteredQueryTest")
 public class TopologyAwareClusteredQueryTest extends ClusteredQueryTest {
 
    @Override

--- a/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareDistributedCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareDistributedCacheTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
  *
  * @author Anna Manukyan
  */
-@Test(groups = "functional", testName = "query.distributed.TopologyAwareDistributedCacheTest")
+@Test(groups = "functional", testName = "query.blackbox.TopologyAwareDistributedCacheTest")
 public class TopologyAwareDistributedCacheTest extends TopologyAwareClusteredCacheTest {
 
    @Override

--- a/query/src/test/java/org/infinispan/query/config/DefaultCacheInheritancePreventedTest.java
+++ b/query/src/test/java/org/infinispan/query/config/DefaultCacheInheritancePreventedTest.java
@@ -40,7 +40,7 @@ import static org.infinispan.test.TestingUtil.withCacheManager;
  * @author Sanne Grinovero
  * @since 5.2
  */
-@Test(groups = "unit", testName = "query.config.QueryParsingTest")
+@Test(groups = "unit", testName = "query.config.DefaultCacheInheritancePreventedTest")
 public class DefaultCacheInheritancePreventedTest {
 
    @Test

--- a/query/src/test/java/org/infinispan/query/config/IndexingConfigurationIgnoredTest.java
+++ b/query/src/test/java/org/infinispan/query/config/IndexingConfigurationIgnoredTest.java
@@ -27,8 +27,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertFalse;
 
-@Test(groups = "functional", testName = "query.config.IndexingConfigurationIgnored")
-public class IndexingConfigurationIgnored {
+@Test(groups = "functional", testName = "query.config.IndexingConfigurationIgnoredTest")
+public class IndexingConfigurationIgnoredTest {
 
    private EmbeddedCacheManager manager;
 

--- a/query/src/test/java/org/infinispan/query/config/LegacyConfigurationAdaptorTest.java
+++ b/query/src/test/java/org/infinispan/query/config/LegacyConfigurationAdaptorTest.java
@@ -31,8 +31,8 @@ import org.testng.annotations.Test;
  *
  * @author Anna Manukyan
  */
-@Test(groups = "functional", testName = "query.config.LegacyConfigurationAdaptorTests")
-public class LegacyConfigurationAdaptorTests {
+@Test(groups = "functional", testName = "query.config.LegacyConfigurationAdaptorTest")
+public class LegacyConfigurationAdaptorTest {
 
    @Test
    public void testIndexingWithLegacyAdapt() {

--- a/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
@@ -45,7 +45,7 @@ import org.testng.annotations.Test;
 /**
  * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
  */
-@Test(groups = "unit", testName = "config.MultipleCachesTest")
+@Test(groups = "unit", testName = "query.config.MultipleCachesTest")
 public class MultipleCachesTest extends SingleCacheManagerTest {
 
    @Override

--- a/query/src/test/java/org/infinispan/query/config/QueryParsingTest.java
+++ b/query/src/test/java/org/infinispan/query/config/QueryParsingTest.java
@@ -32,7 +32,7 @@ import org.infinispan.configuration.parsing.ParserRegistry;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.testng.annotations.Test;
 
-@Test(groups = "unit", testName = "config.parsing.QueryParsingTest")
+@Test(groups = "unit", testName = "query.config.QueryParsingTest")
 public class QueryParsingTest extends AbstractInfinispanTest {
 
    public void testConfigurationFileParsing() throws IOException {

--- a/query/src/test/java/org/infinispan/query/distributed/DistProgrammaticMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/DistProgrammaticMassIndexTest.java
@@ -45,7 +45,7 @@ import static org.infinispan.query.helper.TestQueryHelperFactory.createQueryPars
  *
  * @author Anna Manukyan
  */
-@Test(groups = "functional", testName = "query.distributed.DistProgrammaticMassIndex")
+@Test(groups = "functional", testName = "query.distributed.DistProgrammaticMassIndexTest")
 public class DistProgrammaticMassIndexTest extends DistributedMassIndexingTest {
 
    @Override

--- a/query/src/test/java/org/infinispan/query/distributed/DistributedMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/DistributedMassIndexingTest.java
@@ -39,7 +39,7 @@ import org.testng.annotations.Test;
 /**
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
  */
-@Test(groups = "functional", testName = "query.distributed.DistributedMassIndexing")
+@Test(groups = "functional", testName = "query.distributed.DistributedMassIndexingTest")
 public class DistributedMassIndexingTest extends MultipleCacheManagersTest {
 
    protected static final int NUM_NODES = 4;

--- a/query/src/test/java/org/infinispan/query/distributed/TopologyAwareDistMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/TopologyAwareDistMassIndexingTest.java
@@ -34,7 +34,7 @@ import org.testng.annotations.Test;
 /**
  * Tests verifying that Mass Indexer works properly on Topology Aware nodes.
  */
-@Test(groups = "functional", testName = "query.distributed.ClusteredQueryMassIndexingTest")
+@Test(groups = "functional", testName = "query.distributed.TopologyAwareDistMassIndexingTest")
 public class TopologyAwareDistMassIndexingTest extends DistributedMassIndexingTest {
 
    @Override

--- a/query/src/test/java/org/infinispan/query/indexedembedded/BooksExampleTest.java
+++ b/query/src/test/java/org/infinispan/query/indexedembedded/BooksExampleTest.java
@@ -34,7 +34,7 @@ import org.testng.annotations.Test;
 /**
  * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
  */
-@Test(groups = "functional", testName = "query.BooksExampleTest")
+@Test(groups = "functional", testName = "query.indexedembedded.BooksExampleTest")
 public class BooksExampleTest extends SingleCacheManagerTest {
 
    protected EmbeddedCacheManager createCacheManager() throws Exception {

--- a/query/src/test/java/org/infinispan/query/indexedembedded/CollectionsIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/indexedembedded/CollectionsIndexingTest.java
@@ -45,7 +45,7 @@ import org.testng.annotations.Test;
 /**
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
  */
-@Test(groups = "functional", testName = "query.CollectionsIndexingTest")
+@Test(groups = "functional", testName = "query.indexedembedded.CollectionsIndexingTest")
 public class CollectionsIndexingTest extends SingleCacheManagerTest {
 
    private SearchManager qf;

--- a/query/src/test/java/org/infinispan/query/queries/faceting/SimpleFacetingTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/faceting/SimpleFacetingTest.java
@@ -46,7 +46,7 @@ import static junit.framework.Assert.assertEquals;
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
  * @author Hardy Ferentschik
  */
-@Test(groups = "functional", testName = "query.faceting.SimpleFacetingTest")
+@Test(groups = "functional", testName = "query.queries.faceting.SimpleFacetingTest")
 public class SimpleFacetingTest extends SingleCacheManagerTest {
    
    private static final String indexFieldName = "cubicCapacity";

--- a/query/src/test/java/org/infinispan/query/queries/phrases/QueryPhrasesTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/phrases/QueryPhrasesTest.java
@@ -47,7 +47,7 @@ import static org.infinispan.query.helper.TestQueryHelperFactory.createQueryPars
  *
  * @author Anna Manukyan
  */
-@Test(groups = "functional", testName = "query.ranges.QueryPhrasesTest")
+@Test(groups = "functional", testName = "query.queries.phrases.QueryPhrasesTest")
 public class QueryPhrasesTest extends SingleCacheManagerTest {
    private Person person1;
    private Person person2;

--- a/query/src/test/java/org/infinispan/query/queries/ranges/QueryRangesTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/ranges/QueryRangesTest.java
@@ -42,8 +42,8 @@ import java.util.List;
  *
  * @author Anna Manukyan
  */
-@Test(groups = "functional", testName = "query.ranges.QueryRangesTests")
-public class QueryRangesTests extends SingleCacheManagerTest {
+@Test(groups = "functional", testName = "query.queries.ranges.QueryRangesTest")
+public class QueryRangesTest extends SingleCacheManagerTest {
    private Person person1;
    private Person person2;
    private Person person3;
@@ -53,7 +53,7 @@ public class QueryRangesTests extends SingleCacheManagerTest {
    protected String key2 = "test2";
    protected String key3 = "test3";
 
-   public QueryRangesTests() {
+   public QueryRangesTest() {
       cleanup = CleanupPhase.AFTER_METHOD;
    }
 

--- a/query/src/test/java/org/infinispan/query/queries/spatial/QuerySpatialTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/spatial/QuerySpatialTest.java
@@ -48,7 +48,7 @@ import java.util.List;
  *
  * @author Anna Manukyan
  */
-@Test(groups = "functional", testName = "query.ranges.QuerySpatialTest")
+@Test(groups = "functional", testName = "query.queries.spatial.QuerySpatialTest")
 public class QuerySpatialTest extends SingleCacheManagerTest {
 
    public QuerySpatialTest() {

--- a/query/src/test/java/org/infinispan/query/searchmanager/ClusteredCacheQueryTimeoutTest.java
+++ b/query/src/test/java/org/infinispan/query/searchmanager/ClusteredCacheQueryTimeoutTest.java
@@ -46,7 +46,7 @@ import static org.infinispan.query.helper.TestQueryHelperFactory.createQueryPars
  *
  * @author Anna Manukyan
  */
-@Test(groups = "functional", testName = "query.ClusteredCacheQueryTimeoutTest")
+@Test(groups = "functional", testName = "query.searchmanager.ClusteredCacheQueryTimeoutTest")
 public class ClusteredCacheQueryTimeoutTest extends MultipleCacheManagersTest {
    private Cache cache1;
 

--- a/query/src/test/java/org/infinispan/query/searchmanager/TimeoutTest.java
+++ b/query/src/test/java/org/infinispan/query/searchmanager/TimeoutTest.java
@@ -1,3 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.infinispan.query.searchmanager;
 
 import org.apache.lucene.search.Query;
@@ -20,7 +42,7 @@ import static org.testng.Assert.fail;
 /**
  * @author <a href="mailto:mluksa@redhat.com">Marko Luksa</a>
  */
-@Test(groups = "functional", testName = "query.TimeoutTest")
+@Test(groups = "functional", testName = "query.searchmanager.TimeoutTest")
 public class TimeoutTest extends SingleCacheManagerTest {
 
    @Override

--- a/query/src/test/java/org/infinispan/query/statetransfer/StateTransferQueryDistributedIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/statetransfer/StateTransferQueryDistributedIndexTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
  * @author anistor@redhat.com
  * @since 5.2
  */
-@Test(groups = "functional", testName = "query.statetransfer.StateTransferQueryIndexTest")
+@Test(groups = "functional", testName = "query.statetransfer.StateTransferQueryDistributedIndexTest")
 public class StateTransferQueryDistributedIndexTest extends StateTransferQueryIndexTest {
 
    @Override

--- a/server/core/src/test/scala/org/infinispan/server/core/ConnectionStatsTest.scala
+++ b/server/core/src/test/scala/org/infinispan/server/core/ConnectionStatsTest.scala
@@ -34,7 +34,7 @@ import org.testng.Assert._
  * @author Galder Zamarreño
  * @since 5.2
  */
-object ConnectionStatsTests {
+object ConnectionStatsTest {
 
    def testSingleLocalConnection(jmxDomain: String, serverName: String) {
       val mbeanServer = PerThreadMBeanServerLookup.getThreadMBeanServer

--- a/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedClusteredStatsTest.scala
+++ b/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedClusteredStatsTest.scala
@@ -26,7 +26,7 @@ package org.infinispan.server.memcached
 import org.infinispan.manager.EmbeddedCacheManager
 import org.infinispan.test.fwk.TestCacheManagerFactory
 import org.infinispan.configuration.cache.{CacheMode, ConfigurationBuilder}
-import org.infinispan.server.core.ConnectionStatsTests._
+import org.infinispan.server.core.ConnectionStatsTest._
 import org.testng.annotations.Test
 import javax.management.{MBeanServer, MBeanServerFactory}
 import org.infinispan.jmx.MBeanServerLookup

--- a/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedStatsTest.scala
+++ b/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedStatsTest.scala
@@ -33,7 +33,7 @@ import test.MemcachedTestingUtil._
 import org.infinispan.manager.EmbeddedCacheManager
 import net.spy.memcached.MemcachedClient
 import annotation.tailrec
-import org.infinispan.server.core.ConnectionStatsTests._
+import org.infinispan.server.core.ConnectionStatsTest._
 
 /**
  * Tests stats command for Infinispan Memcached server.

--- a/upgrade-tools/src/test/java/org/infinispan/upgrade/hotrod/HotRodUpgradeSynchronizerTest.java
+++ b/upgrade-tools/src/test/java/org/infinispan/upgrade/hotrod/HotRodUpgradeSynchronizerTest.java
@@ -44,7 +44,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-@Test(testName = "loaders.remote.RemoteCacheStoreMixedAccessTest", groups = "functional")
+@Test(testName = "upgrade.hotrod.HotRodUpgradeSynchronizerTest", groups = "functional")
 public class HotRodUpgradeSynchronizerTest extends AbstractInfinispanTest {
 
    private HotRodServer sourceServer;


### PR DESCRIPTION
- Some tests are renamed according to Maven Conventions.
- The test names in @Test annotation are fixed according to TestNameVerifier class.
