### PR TITLE
ISPN-2852 CacheQuery.maxResults not honored everywhere

### DIFF
--- a/query/src/main/java/org/infinispan/query/CacheQuery.java
+++ b/query/src/main/java/org/infinispan/query/CacheQuery.java
@@ -93,9 +93,9 @@ public interface CacheQuery extends Iterable<Object> {
    FacetManager getFacetManager();
 
    /**
-    * Gets the integer number of results.
+    * Gets the total number of results matching the query, ignoring pagination (firstResult, maxResult).
     *
-    * @return integer number of results.
+    * @return total number of results.
     */
    int getResultSize();
 

--- a/query/src/main/java/org/infinispan/query/impl/LazyIterator.java
+++ b/query/src/main/java/org/infinispan/query/impl/LazyIterator.java
@@ -48,7 +48,7 @@ public class LazyIterator extends AbstractIterator {
       super(resultLoader, fetchSize);
       this.extractor = hSearchQuery.queryDocumentExtractor(); //triggers actual Lucene search
       this.index = extractor.getFirstIndex();
-      this.max = hSearchQuery.queryResultSize() - 1;
+      this.max = extractor.getMaxIndex();
    }
 
    @Override

--- a/query/src/test/java/org/infinispan/query/impl/LazyIteratorTest.java
+++ b/query/src/test/java/org/infinispan/query/impl/LazyIteratorTest.java
@@ -51,6 +51,7 @@ public class LazyIteratorTest extends EagerIteratorTest {
       super.setUp();
 
       extractor = mock(DocumentExtractor.class);
+      when(extractor.getMaxIndex()).thenReturn(entityInfos.size() - 1);
       when(extractor.extract(anyInt())).thenAnswer(new Answer<EntityInfo>() {
          @Override
          public EntityInfo answer(InvocationOnMock invocation) throws Throwable {
@@ -61,7 +62,6 @@ public class LazyIteratorTest extends EagerIteratorTest {
 
       HSQuery hsQuery = mock(HSQuery.class);
       when(hsQuery.queryDocumentExtractor()).thenReturn(extractor);
-      when(hsQuery.queryResultSize()).thenReturn(entityInfos.size());
 
       iterator = new LazyIterator(hsQuery, new EntityLoader(cache, new KeyTransformationHandler()), getFetchSize());
    }


### PR DESCRIPTION
If 5.3.0 isn't going to be released really soon, we'd appreciate this patch going into 5.2.x as soon as possible.
