### PR TITLE
ISPN-2928 Fix the JDBC configuration parser not to set the connectionUrl with the driverClass value

### DIFF
--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcCacheStoreConfigurationParser52.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcCacheStoreConfigurationParser52.java
@@ -175,7 +175,7 @@ public class JdbcCacheStoreConfigurationParser52 implements ConfigurationParser<
          Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
          switch (attribute) {
          case CONNECTION_URL: {
-            builder.driverClass(value);
+            builder.connectionUrl(value);
             break;
          }
          case DRIVER_CLASS: {
@@ -206,7 +206,7 @@ public class JdbcCacheStoreConfigurationParser52 implements ConfigurationParser<
          Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
          switch (attribute) {
          case CONNECTION_URL: {
-            builder.driverClass(value);
+            builder.connectionUrl(value);
             break;
          }
          case DRIVER_CLASS: {

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcCacheStoreConfigurationParser53.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/JdbcCacheStoreConfigurationParser53.java
@@ -177,7 +177,7 @@ public class JdbcCacheStoreConfigurationParser53 implements ConfigurationParser<
          Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
          switch (attribute) {
          case CONNECTION_URL: {
-            builder.driverClass(value);
+            builder.connectionUrl(value);
             break;
          }
          case DRIVER_CLASS: {
@@ -208,7 +208,7 @@ public class JdbcCacheStoreConfigurationParser53 implements ConfigurationParser<
          Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
          switch (attribute) {
          case CONNECTION_URL: {
-            builder.driverClass(value);
+            builder.connectionUrl(value);
             break;
          }
          case DRIVER_CLASS: {

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/configuration/XmlFileParsingTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/configuration/XmlFileParsingTest.java
@@ -51,7 +51,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
             "   <default>\n" +
             "     <loaders>\n" +
             "       <stringKeyedJdbcStore xmlns=\"urn:infinispan:config:jdbc:5.3\" key2StringMapper=\"org.infinispan.loaders.jdbc.configuration.DummyKey2StringMapper\">\n" +
-            "         <connectionPool connectionUrl=\"jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=-1\" username=\"dbuser\" password=\"dbpass\" />\n" +
+            "         <connectionPool connectionUrl=\"jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=-1\" username=\"dbuser\" password=\"dbpass\" driverClass=\"org.h2.Driver\"/>\n" +
             "         <stringKeyedTable prefix=\"entry\" fetchSize=\"34\" batchSize=\"99\" >\n" +
             "           <idColumn name=\"id\" type=\"VARCHAR\" />\n" +
             "           <dataColumn name=\"datum\" type=\"BINARY\" />\n" +
@@ -70,7 +70,11 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       assertEquals("version", store.table().timestampColumnName());
       assertTrue(store.async().enabled());
       assertEquals("org.infinispan.loaders.jdbc.configuration.DummyKey2StringMapper", store.key2StringMapper());
-
+      PooledConnectionFactoryConfiguration connectionFactory = (PooledConnectionFactoryConfiguration) store.connectionFactory();
+      assertEquals("jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=-1", connectionFactory.connectionUrl());
+      assertEquals("org.h2.Driver", connectionFactory.driverClass());
+      assertEquals("dbuser", connectionFactory.username());
+      assertEquals("dbpass", connectionFactory.password());
    }
 
    public void testBinaryKeyedJdbcStore() throws Exception {
@@ -78,7 +82,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
             "   <default>\n" +
             "     <loaders>\n" +
             "       <binaryKeyedJdbcStore xmlns=\"urn:infinispan:config:jdbc:5.2\" ignoreModifications=\"true\">\n" +
-            "         <simpleConnection connectionUrl=\"jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=-1\" username=\"dbuser\" password=\"dbpass\" />\n" +
+            "         <simpleConnection connectionUrl=\"jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=-1\" username=\"dbuser\" password=\"dbpass\" driverClass=\"org.h2.Driver\"/>\n" +
             "         <binaryKeyedTable prefix=\"bucket\" fetchSize=\"34\" batchSize=\"99\">\n" +
             "           <idColumn name=\"id\" type=\"BINARY\" />\n" +
             "           <dataColumn name=\"datum\" type=\"BINARY\" />\n" +
@@ -98,6 +102,11 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       assertEquals("BINARY", store.table().dataColumnType());
       assertEquals("version", store.table().timestampColumnName());
       assertTrue(store.singletonStore().enabled());
+      SimpleConnectionFactoryConfiguration connectionFactory = (SimpleConnectionFactoryConfiguration) store.connectionFactory();
+      assertEquals("jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=-1", connectionFactory.connectionUrl());
+      assertEquals("org.h2.Driver", connectionFactory.driverClass());
+      assertEquals("dbuser", connectionFactory.username());
+      assertEquals("dbpass", connectionFactory.password());
    }
 
    public void testMixedKeyedJdbcStore() throws Exception {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2928

Also ISPN-2928/jdbc_connection_url_parser_52x for 5.2.x
