### PR TITLE
ISPN-2983 Configuration builder for RemoteCacheManager

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/AbstractConfigurationChildBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/AbstractConfigurationChildBuilder.java
@@ -1,0 +1,161 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.client.hotrod.configuration;
+
+import java.util.Properties;
+
+import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHash;
+import org.infinispan.client.hotrod.impl.transport.TransportFactory;
+import org.infinispan.client.hotrod.impl.transport.tcp.RequestBalancingStrategy;
+import org.infinispan.marshall.Marshaller;
+
+/**
+ * AbstractConfigurationChildBuilder.
+ *
+ * @author Tristan Tarrant
+ * @since 5.3
+ */
+public abstract class AbstractConfigurationChildBuilder implements ConfigurationChildBuilder {
+   private final ConfigurationBuilder builder;
+
+   protected AbstractConfigurationChildBuilder(ConfigurationBuilder builder) {
+      this.builder = builder;
+   }
+
+   @Override
+   public ServerConfigurationBuilder addServer() {
+      return builder.addServer();
+   }
+
+   @Override
+   public ConfigurationBuilder addServers(String servers) {
+      return builder.addServers(servers);
+   }
+
+   @Override
+   public ExecutorFactoryConfigurationBuilder asyncExecutorFactory() {
+      return builder.asyncExecutorFactory();
+   }
+
+   @Override
+   public ConfigurationBuilder balancingStrategy(String balancingStrategy) {
+      return builder.balancingStrategy(balancingStrategy);
+   }
+
+   @Override
+   public ConfigurationBuilder balancingStrategy(Class<? extends RequestBalancingStrategy> balancingStrategy) {
+      return builder.balancingStrategy(balancingStrategy);
+   }
+
+   @Override
+   public ConfigurationBuilder classLoader(ClassLoader classLoader) {
+      return builder.classLoader(classLoader);
+   }
+
+   @Override
+   public ConnectionPoolConfigurationBuilder connectionPool() {
+      return builder.connectionPool();
+   }
+
+   @Override
+   public ConfigurationBuilder connectionTimeout(int connectionTimeout) {
+      return builder.connectionTimeout(connectionTimeout);
+   }
+
+   @Override
+   public ConfigurationBuilder consistentHashImpl(int version, Class<? extends ConsistentHash> consistentHashClass) {
+      return builder.consistentHashImpl(version, consistentHashClass);
+   }
+
+   @Override
+   public ConfigurationBuilder consistentHashImpl(int version, String consistentHashClass) {
+      return builder.consistentHashImpl(version, consistentHashClass);
+   }
+
+   @Override
+   public ConfigurationBuilder forceReturnValues(boolean forceReturnValues) {
+      return builder.forceReturnValues(forceReturnValues);
+   }
+
+   @Override
+   public ConfigurationBuilder keySizeEstimate(int keySizeEstimate) {
+      return builder.keySizeEstimate(keySizeEstimate);
+   }
+
+   @Override
+   public ConfigurationBuilder marshaller(String marshaller) {
+      return builder.marshaller(marshaller);
+   }
+
+   @Override
+   public ConfigurationBuilder marshaller(Class<? extends Marshaller> marshaller) {
+      return builder.marshaller(marshaller);
+   }
+
+   @Override
+   public ConfigurationBuilder marshaller(Marshaller marshaller) {
+      return builder.marshaller(marshaller);
+   }
+
+   @Override
+   public ConfigurationBuilder pingOnStartup(boolean pingOnStartup) {
+      return builder.pingOnStartup(pingOnStartup);
+   }
+
+   @Override
+   public ConfigurationBuilder protocolVersion(String protocolVersion) {
+      return builder.protocolVersion(protocolVersion);
+   }
+
+   @Override
+   public ConfigurationBuilder socketTimeout(int socketTimeout) {
+      return builder.socketTimeout(socketTimeout);
+   }
+
+   @Override
+   public ConfigurationBuilder tcpNoDelay(boolean tcpNoDelay) {
+      return builder.tcpNoDelay(tcpNoDelay);
+   }
+
+   @Override
+   public ConfigurationBuilder transportFactory(String transportFactory) {
+      return builder.transportFactory(transportFactory);
+   }
+
+   @Override
+   public ConfigurationBuilder transportFactory(Class<? extends TransportFactory> transportFactory) {
+      return builder.transportFactory(transportFactory);
+   }
+
+   @Override
+   public ConfigurationBuilder valueSizeEstimate(int valueSizeEstimate) {
+      return builder.valueSizeEstimate(valueSizeEstimate);
+   }
+
+   @Override
+   public ConfigurationBuilder withProperties(Properties properties) {
+      return builder.withProperties(properties);
+   }
+
+   @Override
+   public Configuration build() {
+      return builder.build();
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
@@ -1,0 +1,185 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.client.hotrod.configuration;
+
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHash;
+import org.infinispan.client.hotrod.impl.transport.TransportFactory;
+import org.infinispan.client.hotrod.impl.transport.tcp.RequestBalancingStrategy;
+import org.infinispan.configuration.BuiltBy;
+import org.infinispan.marshall.Marshaller;
+
+/**
+ * Configuration.
+ *
+ * @author Tristan Tarrant
+ * @since 5.3
+ */
+@BuiltBy(ConfigurationBuilder.class)
+public class Configuration {
+
+   private final ExecutorFactoryConfiguration asyncExecutorFactory;
+   private final Class<? extends RequestBalancingStrategy> balancingStrategy;
+   private final WeakReference<ClassLoader> classLoader;
+   private final ConnectionPoolConfiguration connectionPool;
+   private final int connectionTimeout;
+   private final Class<? extends ConsistentHash>[] consistentHashImpl;
+   private final boolean forceReturnValues;
+   private final int keySizeEstimate;
+   private final Class<? extends Marshaller> marshallerClass;
+   private final Marshaller marshaller;
+   private final boolean pingOnStartup;
+   private final String protocolVersion;
+   private final List<ServerConfiguration> servers;
+   private final int socketTimeout;
+   private final boolean tcpNoDelay;
+   private final Class<? extends TransportFactory> transportFactory;
+   private final int valueSizeEstimate;
+
+   Configuration(ExecutorFactoryConfiguration asyncExecutorFactory, Class<? extends RequestBalancingStrategy> balancingStrategy, ClassLoader classLoader,
+         ConnectionPoolConfiguration connectionPool, int connectionTimeout, Class<? extends ConsistentHash>[] consistentHashImpl, boolean forceReturnValues, int keySizeEstimate, Class<? extends Marshaller> marshallerClass,
+         boolean pingOnStartup, String protocolVersion, List<ServerConfiguration> servers, int socketTimeout, boolean tcpNoDelay,
+         Class<? extends TransportFactory> transportFactory, int valueSizeEstimate) {
+      this.asyncExecutorFactory = asyncExecutorFactory;
+      this.balancingStrategy = balancingStrategy;
+      this.classLoader = new WeakReference<ClassLoader>(classLoader);
+      this.connectionPool = connectionPool;
+      this.connectionTimeout = connectionTimeout;
+      this.consistentHashImpl = consistentHashImpl;
+      this.forceReturnValues = forceReturnValues;
+      this.keySizeEstimate = keySizeEstimate;
+      this.marshallerClass = marshallerClass;
+      this.marshaller = null;
+      this.pingOnStartup = pingOnStartup;
+      this.protocolVersion = protocolVersion;
+      this.servers = Collections.unmodifiableList(servers);
+      this.socketTimeout = socketTimeout;
+      this.tcpNoDelay = tcpNoDelay;
+      this.transportFactory = transportFactory;
+      this.valueSizeEstimate = valueSizeEstimate;
+   }
+
+   Configuration(ExecutorFactoryConfiguration asyncExecutorFactory, Class<? extends RequestBalancingStrategy> balancingStrategy, ClassLoader classLoader,
+         ConnectionPoolConfiguration connectionPool, int connectionTimeout, Class<? extends ConsistentHash>[] consistentHashImpl, boolean forceReturnValues, int keySizeEstimate, Marshaller marshaller,
+         boolean pingOnStartup, String protocolVersion, List<ServerConfiguration> servers, int socketTimeout, boolean tcpNoDelay,
+         Class<? extends TransportFactory> transportFactory, int valueSizeEstimate) {
+      this.asyncExecutorFactory = asyncExecutorFactory;
+      this.balancingStrategy = balancingStrategy;
+      this.classLoader = new WeakReference<ClassLoader>(classLoader);
+      this.connectionPool = connectionPool;
+      this.connectionTimeout = connectionTimeout;
+      this.consistentHashImpl = consistentHashImpl;
+      this.forceReturnValues = forceReturnValues;
+      this.keySizeEstimate = keySizeEstimate;
+      this.marshallerClass = null;
+      this.marshaller = marshaller;
+      this.pingOnStartup = pingOnStartup;
+      this.protocolVersion = protocolVersion;
+      this.servers = Collections.unmodifiableList(servers);
+      this.socketTimeout = socketTimeout;
+      this.tcpNoDelay = tcpNoDelay;
+      this.transportFactory = transportFactory;
+      this.valueSizeEstimate = valueSizeEstimate;
+   }
+
+   public ExecutorFactoryConfiguration asyncExecutorFactory() {
+      return asyncExecutorFactory;
+   }
+
+   public Class<? extends RequestBalancingStrategy> balancingStrategy() {
+      return balancingStrategy;
+   }
+
+   public ClassLoader classLoader() {
+      return classLoader.get();
+   }
+
+   public ConnectionPoolConfiguration connectionPool() {
+      return connectionPool;
+   }
+
+   public int connectionTimeout() {
+      return connectionTimeout;
+   }
+
+   public Class<? extends ConsistentHash>[] consistentHashImpl() {
+      return consistentHashImpl;
+   }
+
+   public Class<? extends ConsistentHash> consistentHashImpl(int version) {
+      return consistentHashImpl[version-1];
+   }
+
+   public boolean forceReturnValues() {
+      return forceReturnValues;
+   }
+
+   public int keySizeEstimate() {
+      return keySizeEstimate;
+   }
+
+   public Marshaller marshaller() {
+      return marshaller;
+   }
+
+   public Class<? extends Marshaller> marshallerClass() {
+      return marshallerClass;
+   }
+
+   public boolean pingOnStartup() {
+      return pingOnStartup;
+   }
+
+   public String protocolVersion() {
+      return protocolVersion;
+   }
+
+   public List<ServerConfiguration> servers() {
+      return servers;
+   }
+
+   public int socketTimeout() {
+      return socketTimeout;
+   }
+
+   public boolean tcpNoDelay() {
+      return tcpNoDelay;
+   }
+
+   public Class<? extends TransportFactory> transportFactory() {
+      return transportFactory;
+   }
+
+   public int valueSizeEstimate() {
+      return valueSizeEstimate;
+   }
+
+   @Override
+   public String toString() {
+      return "Configuration [asyncExecutorFactory=" + asyncExecutorFactory + ", balancingStrategy=" + balancingStrategy + ", classLoader=" + classLoader + ", connectionPool="
+            + connectionPool + ", connectionTimeout=" + connectionTimeout + ", consistentHashImpl=" + Arrays.toString(consistentHashImpl) + ", forceReturnValues="
+            + forceReturnValues + ", keySizeEstimate=" + keySizeEstimate + ", marshallerClass=" + marshallerClass + ", marshaller=" + marshaller + ", pingOnStartup="
+            + pingOnStartup + ", protocolVersion=" + protocolVersion + ", servers=" + servers + ", socketTimeout=" + socketTimeout + ", tcpNoDelay=" + tcpNoDelay
+            + ", transportFactory=" + transportFactory + ", valueSizeEstimate=" + valueSizeEstimate + "]";
+   }
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
@@ -1,0 +1,314 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.client.hotrod.configuration;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.impl.ConfigurationProperties;
+import org.infinispan.client.hotrod.impl.TypedProperties;
+import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHash;
+import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashV1;
+import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashV2;
+import org.infinispan.client.hotrod.impl.transport.TransportFactory;
+import org.infinispan.client.hotrod.impl.transport.tcp.RequestBalancingStrategy;
+import org.infinispan.client.hotrod.impl.transport.tcp.RoundRobinBalancingStrategy;
+import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory;
+import org.infinispan.configuration.Builder;
+import org.infinispan.marshall.Marshaller;
+import org.infinispan.marshall.jboss.GenericJBossMarshaller;
+import org.infinispan.util.Util;
+
+/**
+ * ConfigurationBuilder used to generate immutable {@link Configuration} objects to pass to the
+ * {@link RemoteCacheManager#RemoteCacheManager(Configuration)} constructor.
+ *
+ * @author Tristan Tarrant
+ * @since 5.3
+ */
+public class ConfigurationBuilder implements ConfigurationChildBuilder, Builder<Configuration> {
+   private WeakReference<ClassLoader> classLoader;
+   private final ExecutorFactoryConfigurationBuilder asyncExecutorFactory;
+   private Class<? extends RequestBalancingStrategy> balancingStrategy = RoundRobinBalancingStrategy.class;
+   private final ConnectionPoolConfigurationBuilder connectionPool;
+   private int connectionTimeout = ConfigurationProperties.DEFAULT_CONNECT_TIMEOUT;
+   @SuppressWarnings("unchecked")
+   private Class<? extends ConsistentHash> consistentHashImpl[] = new Class[] { ConsistentHashV1.class, ConsistentHashV2.class };
+   private boolean forceReturnValues;
+   private int keySizeEstimate = ConfigurationProperties.DEFAULT_KEY_SIZE;
+   private Class<? extends Marshaller> marshallerClass = GenericJBossMarshaller.class;
+   private Marshaller marshaller;
+   private boolean pingOnStartup = true;
+   private String protocolVersion = ConfigurationProperties.DEFAULT_PROTOCOL_VERSION;
+   private List<ServerConfigurationBuilder> servers = new ArrayList<ServerConfigurationBuilder>();
+   private int socketTimeout = ConfigurationProperties.DEFAULT_SO_TIMEOUT;
+   private boolean tcpNoDelay = true;
+   private Class<? extends TransportFactory> transportFactory = TcpTransportFactory.class;
+   private int valueSizeEstimate = ConfigurationProperties.DEFAULT_VALUE_SIZE;
+
+   public ConfigurationBuilder() {
+      this.classLoader = new WeakReference<ClassLoader>(Thread.currentThread().getContextClassLoader());
+      this.connectionPool = new ConnectionPoolConfigurationBuilder(this);
+      this.asyncExecutorFactory = new ExecutorFactoryConfigurationBuilder(this);
+   }
+
+   @Override
+   public ServerConfigurationBuilder addServer() {
+      ServerConfigurationBuilder builder = new ServerConfigurationBuilder(this);
+      this.servers.add(builder);
+      return builder;
+   }
+
+   @Override
+   public ConfigurationBuilder addServers(String servers) {
+      for (String server : servers.split(";")) {
+         String[] components = server.trim().split(":");
+         String host = components[0];
+         int port = ConfigurationProperties.DEFAULT_HOTROD_PORT;
+         if (components.length > 1)
+            port = Integer.parseInt(components[1]);
+         this.addServer().host(host).port(port);
+      }
+      return this;
+   }
+
+   @Override
+   public ExecutorFactoryConfigurationBuilder asyncExecutorFactory() {
+      return this.asyncExecutorFactory;
+   }
+
+   @Override
+   public ConfigurationBuilder balancingStrategy(String balancingStrategy) {
+      this.balancingStrategy = Util.loadClass(balancingStrategy, this.classLoader());
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder balancingStrategy(Class<? extends RequestBalancingStrategy> balancingStrategy) {
+      this.balancingStrategy = balancingStrategy;
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder classLoader(ClassLoader cl) {
+      this.classLoader = new WeakReference<ClassLoader>(cl);
+      return this;
+   }
+
+   ClassLoader classLoader() {
+      return classLoader != null ? classLoader.get() : null;
+   }
+
+   @Override
+   public ConnectionPoolConfigurationBuilder connectionPool() {
+      return connectionPool;
+   }
+
+   @Override
+   public ConfigurationBuilder connectionTimeout(int connectionTimeout) {
+      this.connectionTimeout = connectionTimeout;
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder consistentHashImpl(int version, Class<? extends ConsistentHash> consistentHashClass) {
+      this.consistentHashImpl[version - 1] = consistentHashClass;
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder consistentHashImpl(int version, String consistentHashClass) {
+      this.consistentHashImpl[version - 1] = Util.loadClass(consistentHashClass, classLoader());
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder forceReturnValues(boolean forceReturnValues) {
+      this.forceReturnValues = forceReturnValues;
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder keySizeEstimate(int keySizeEstimate) {
+      this.keySizeEstimate = keySizeEstimate;
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder marshaller(String marshaller) {
+      this.marshallerClass = Util.loadClass(marshaller, this.classLoader());
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder marshaller(Class<? extends Marshaller> marshaller) {
+      this.marshallerClass = marshaller;
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder marshaller(Marshaller marshaller) {
+      this.marshaller = marshaller;
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder pingOnStartup(boolean pingOnStartup) {
+      this.pingOnStartup = pingOnStartup;
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder protocolVersion(String protocolVersion) {
+      this.protocolVersion = protocolVersion;
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder socketTimeout(int socketTimeout) {
+      this.socketTimeout = socketTimeout;
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder tcpNoDelay(boolean tcpNoDelay) {
+      this.tcpNoDelay = tcpNoDelay;
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder transportFactory(String transportFactory) {
+      this.transportFactory = Util.loadClass(transportFactory, this.classLoader());
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder transportFactory(Class<? extends TransportFactory> transportFactory) {
+      this.transportFactory = transportFactory;
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder valueSizeEstimate(int valueSizeEstimate) {
+      this.valueSizeEstimate = valueSizeEstimate;
+      return this;
+   }
+
+   @Override
+   public ConfigurationBuilder withProperties(Properties properties) {
+      TypedProperties typed = TypedProperties.toTypedProperties(properties);
+
+      if (typed.containsKey(ConfigurationProperties.ASYNC_EXECUTOR_FACTORY)) {
+         this.asyncExecutorFactory().factoryClass(typed.getProperty(ConfigurationProperties.ASYNC_EXECUTOR_FACTORY));
+      }
+      this.asyncExecutorFactory().withExecutorProperties(typed);
+      this.balancingStrategy(typed.getProperty(ConfigurationProperties.REQUEST_BALANCING_STRATEGY, balancingStrategy.getName()));
+      this.connectionPool.withPoolProperties(typed);
+      this.connectionTimeout(typed.getIntProperty(ConfigurationProperties.CONNECT_TIMEOUT, connectionTimeout));
+      for (int i = 1; i <= consistentHashImpl.length; i++) {
+         this.consistentHashImpl(i, typed.getProperty(ConfigurationProperties.HASH_FUNCTION_PREFIX + "." + i, consistentHashImpl[i - 1].getName()));
+      }
+      this.forceReturnValues(typed.getBooleanProperty(ConfigurationProperties.FORCE_RETURN_VALUES, forceReturnValues));
+      this.keySizeEstimate(typed.getIntProperty(ConfigurationProperties.KEY_SIZE_ESTIMATE, keySizeEstimate));
+      if (typed.containsKey(ConfigurationProperties.MARSHALLER)) {
+         this.marshaller(typed.getProperty(ConfigurationProperties.MARSHALLER));
+      }
+      this.pingOnStartup(typed.getBooleanProperty(ConfigurationProperties.PING_ON_STARTUP, pingOnStartup));
+      this.protocolVersion(typed.getProperty(ConfigurationProperties.PROTOCOL_VERSION, protocolVersion));
+      this.servers.clear();
+      this.addServers(typed.getProperty(ConfigurationProperties.SERVER_LIST, ""));
+      this.socketTimeout(typed.getIntProperty(ConfigurationProperties.SO_TIMEOUT, socketTimeout));
+      this.tcpNoDelay(typed.getBooleanProperty(ConfigurationProperties.TCP_NO_DELAY, tcpNoDelay));
+      if (typed.containsKey(ConfigurationProperties.TRANSPORT_FACTORY)) {
+         this.transportFactory(typed.getProperty(ConfigurationProperties.TRANSPORT_FACTORY));
+      }
+      this.valueSizeEstimate(typed.getIntProperty(ConfigurationProperties.VALUE_SIZE_ESTIMATE, valueSizeEstimate));
+      return this;
+   }
+
+   @Override
+   public void validate() {
+      connectionPool.validate();
+      asyncExecutorFactory.validate();
+
+   }
+
+   @Override
+   public Configuration create() {
+      List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>();
+      if (this.servers.size() > 0)
+         for (ServerConfigurationBuilder server : this.servers) {
+            servers.add(server.create());
+         }
+      else {
+         servers.add(new ServerConfiguration("127.0.0.1", ConfigurationProperties.DEFAULT_HOTROD_PORT));
+      }
+      if (marshaller == null) {
+         return new Configuration(asyncExecutorFactory.create(), balancingStrategy, classLoader == null ? null : classLoader.get(), connectionPool.create(), connectionTimeout,
+               consistentHashImpl, forceReturnValues, keySizeEstimate, marshallerClass, pingOnStartup, protocolVersion, servers, socketTimeout, tcpNoDelay, transportFactory,
+               valueSizeEstimate);
+      } else {
+         return new Configuration(asyncExecutorFactory.create(), balancingStrategy, classLoader == null ? null : classLoader.get(), connectionPool.create(), connectionTimeout,
+               consistentHashImpl, forceReturnValues, keySizeEstimate, marshaller, pingOnStartup, protocolVersion, servers, socketTimeout, tcpNoDelay, transportFactory,
+               valueSizeEstimate);
+      }
+   }
+
+   @Override
+   public Configuration build() {
+      return build(true);
+   }
+
+   public Configuration build(boolean validate) {
+      if (validate) {
+         validate();
+      }
+      return create();
+   }
+
+   @Override
+   public ConfigurationBuilder read(Configuration template) {
+      this.classLoader = new WeakReference<ClassLoader>(template.classLoader());
+      this.asyncExecutorFactory.read(template.asyncExecutorFactory());
+      this.balancingStrategy = template.balancingStrategy();
+      this.connectionPool.read(template.connectionPool());
+      this.connectionTimeout = template.connectionTimeout();
+      for (int i = 0; i < consistentHashImpl.length; i++) {
+         this.consistentHashImpl[i] = template.consistentHashImpl()[i];
+      }
+      this.forceReturnValues = template.forceReturnValues();
+      this.keySizeEstimate = template.keySizeEstimate();
+      this.marshaller = template.marshaller();
+      this.marshallerClass = template.marshallerClass();
+      this.pingOnStartup = template.pingOnStartup();
+      this.protocolVersion = template.protocolVersion();
+      this.servers.clear();
+      for (ServerConfiguration server : template.servers()) {
+         this.addServer().host(server.host()).port(server.port());
+      }
+      this.socketTimeout = template.socketTimeout();
+      this.tcpNoDelay = template.tcpNoDelay();
+      this.transportFactory = template.transportFactory();
+      this.valueSizeEstimate = template.valueSizeEstimate();
+      return this;
+   }
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationChildBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationChildBuilder.java
@@ -1,0 +1,171 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.client.hotrod.configuration;
+
+import java.util.Properties;
+
+import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHash;
+import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashV1;
+import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashV2;
+import org.infinispan.client.hotrod.impl.transport.TransportFactory;
+import org.infinispan.client.hotrod.impl.transport.tcp.RequestBalancingStrategy;
+import org.infinispan.marshall.Marshaller;
+
+/**
+ * ConfigurationChildBuilder.
+ *
+ * @author Tristan Tarrant
+ * @since 5.3
+ */
+public interface ConfigurationChildBuilder {
+
+   /**
+    * Adds a new remote server
+    */
+   ServerConfigurationBuilder addServer();
+
+   /**
+    * Adds a list of remote servers in the form: host1[:port][;host2[:port]]...
+    */
+   ConfigurationBuilder addServers(String servers);
+
+   /**
+    * Configuration for the executor service used for asynchronous work on the Transport, including
+    * asynchronous marshalling and Cache 'async operations' such as Cache.putAsync().
+    */
+   ExecutorFactoryConfigurationBuilder asyncExecutorFactory();
+
+   /**
+    * For replicated (vs distributed) Hot Rod server clusters, the client balances requests to the
+    * servers according to this strategy.
+    */
+   ConfigurationBuilder balancingStrategy(String balancingStrategy);
+
+   /**
+    * For replicated (vs distributed) Hot Rod server clusters, the client balances requests to the
+    * servers according to this strategy.
+    */
+   ConfigurationBuilder balancingStrategy(Class<? extends RequestBalancingStrategy> balancingStrategy);
+
+   /**
+    * @param classLoader
+    * @return
+    */
+   ConfigurationBuilder classLoader(ClassLoader classLoader);
+
+   /**
+    * Configures the connection pool
+    */
+   ConnectionPoolConfigurationBuilder connectionPool();
+
+   /**
+    * This property defines the maximum socket connect timeout before giving up connecting to the
+    * server.
+    */
+   ConfigurationBuilder connectionTimeout(int connectionTimeout);
+
+   /**
+    * Defines the {@link ConsistentHash} implementation to use for the specified version. By default,
+    * {@link ConsistentHashV1} is used for version 1 and {@link ConsistentHashV2} is used for version 2.
+    */
+   ConfigurationBuilder consistentHashImpl(int version, Class<? extends ConsistentHash> consistentHashClass);
+
+   /**
+    * Defines the {@link ConsistentHash} implementation to use for the specified version. By default,
+    * {@link ConsistentHashV1} is used for version 1 and {@link ConsistentHashV2} is used for version 2.
+    */
+   ConfigurationBuilder consistentHashImpl(int version, String consistentHashClass);
+
+   /**
+    * Whether or not to implicitly FORCE_RETURN_VALUE for all calls.
+    */
+   ConfigurationBuilder forceReturnValues(boolean forceReturnValues);
+
+   /**
+    * This hint allows sizing of byte buffers when serializing and deserializing keys, to minimize array resizing. It defaults to 64.
+    */
+   ConfigurationBuilder keySizeEstimate(int keySizeEstimate);
+
+   /**
+    * Allows you to specify a custom {@link org.infinispan.marshall.Marshaller} implementation to
+    * serialize and deserialize user objects. This method is mutually exclusive with {@link #marshaller(Marshaller)}.
+    */
+   ConfigurationBuilder marshaller(String marshaller);
+
+   /**
+    * Allows you to specify a custom {@link org.infinispan.marshall.Marshaller} implementation to
+    * serialize and deserialize user objects. This method is mutually exclusive with {@link #marshaller(Marshaller)}.
+    */
+   ConfigurationBuilder marshaller(Class<? extends Marshaller> marshaller);
+
+   /**
+    * Allows you to specify an instance of {@link org.infinispan.marshall.Marshaller} to serialize
+    * and deserialize user objects. This method is mutually exclusive with {@link #marshaller(Class)}.
+    */
+   ConfigurationBuilder marshaller(Marshaller marshaller);
+
+   /**
+    * If true, a ping request is sent to a back end server in order to fetch cluster's topology.
+    */
+   ConfigurationBuilder pingOnStartup(boolean pingOnStartup);
+
+   /**
+    * This property defines the protocol version that this client should use. Defaults to 1.1. Other
+    * valid values include 1.0.
+    */
+   ConfigurationBuilder protocolVersion(String protocolVersion);
+
+   /**
+    * This property defines the maximum socket read timeout in milliseconds before giving up waiting
+    * for bytes from the server. Defaults to 60000 (1 minute)
+    */
+   ConfigurationBuilder socketTimeout(int socketTimeout);
+
+   /**
+    * Affects TCP NODELAY on the TCP stack. Defaults to enabled
+    */
+   ConfigurationBuilder tcpNoDelay(boolean tcpNoDelay);
+
+   /**
+    * Controls which transport to use. Currently only the TcpTransport is supported.
+    */
+   ConfigurationBuilder transportFactory(String transportFactory);
+
+   /**
+    * Controls which transport to use. Currently only the TcpTransport is supported.
+    */
+   ConfigurationBuilder transportFactory(Class<? extends TransportFactory> transportFactory);
+
+   /**
+    * This hint allows sizing of byte buffers when serializing and deserializing values, to minimize
+    * array resizing. It defaults to 512
+    */
+   ConfigurationBuilder valueSizeEstimate(int valueSizeEstimate);
+
+   /**
+    * Configures this builder using the specified properties
+    */
+   ConfigurationBuilder withProperties(Properties properties);
+
+   /**
+    * Builds a configuration object
+    */
+   Configuration build();
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConnectionPoolConfiguration.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConnectionPoolConfiguration.java
@@ -1,0 +1,118 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.client.hotrod.configuration;
+
+/**
+ * ConnectionPoolConfiguration.
+ *
+ * @author Tristan Tarrant
+ * @since 5.3
+ */
+public class ConnectionPoolConfiguration {
+   private final ExhaustedAction exhaustedAction;
+   private final boolean lifo;
+   private final int maxActive;
+   private final int maxTotal;
+   private final long maxWait;
+   private final int maxIdle;
+   private final int minIdle;
+   private final int numTestsPerEvictionRun;
+   private final long timeBetweenEvictionRuns;
+   private final long minEvictableIdleTime;
+   private final boolean testOnBorrow;
+   private final boolean testOnReturn;
+   private final boolean testWhileIdle;
+
+   ConnectionPoolConfiguration(ExhaustedAction exhaustedAction, boolean lifo, int maxActive, int maxTotal, long maxWait, int maxIdle, int minIdle, int numTestsPerEvictionRun,
+         long timeBetweenEvictionRuns, long minEvictableIdleTime, boolean testOnBorrow, boolean testOnReturn, boolean testWhileIdle) {
+      this.exhaustedAction = exhaustedAction;
+      this.lifo = lifo;
+      this.maxActive = maxActive;
+      this.maxTotal = maxTotal;
+      this.maxWait = maxWait;
+      this.maxIdle = maxIdle;
+      this.minIdle = minIdle;
+      this.numTestsPerEvictionRun = numTestsPerEvictionRun;
+      this.timeBetweenEvictionRuns = timeBetweenEvictionRuns;
+      this.minEvictableIdleTime = minEvictableIdleTime;
+      this.testOnBorrow = testOnBorrow;
+      this.testOnReturn = testOnReturn;
+      this.testWhileIdle = testWhileIdle;
+   }
+
+   public ExhaustedAction exhaustedAction() {
+      return exhaustedAction;
+   }
+
+   public boolean lifo() {
+      return lifo;
+   }
+
+   public int maxActive() {
+      return maxActive;
+   }
+
+   public int maxTotal() {
+      return maxTotal;
+   }
+
+   public long maxWait() {
+      return maxWait;
+   }
+
+   public int maxIdle() {
+      return maxIdle;
+   }
+
+   public int minIdle() {
+      return minIdle;
+   }
+
+   public int numTestsPerEvictionRun() {
+      return numTestsPerEvictionRun;
+   }
+
+   public long timeBetweenEvictionRuns() {
+      return timeBetweenEvictionRuns;
+   }
+
+   public long minEvictableIdleTime() {
+      return minEvictableIdleTime;
+   }
+
+   public boolean testOnBorrow() {
+      return testOnBorrow;
+   }
+
+   public boolean testOnReturn() {
+      return testOnReturn;
+   }
+
+   public boolean testWhileIdle() {
+      return testWhileIdle;
+   }
+
+   @Override
+   public String toString() {
+      return "ConnectionPoolConfiguration [exhaustedAction=" + exhaustedAction + ", lifo=" + lifo + ", maxActive=" + maxActive + ", maxTotal=" + maxTotal + ", maxWait=" + maxWait
+            + ", maxIdle=" + maxIdle + ", minIdle=" + minIdle + ", numTestsPerEvictionRun=" + numTestsPerEvictionRun + ", timeBetweenEvictionRuns=" + timeBetweenEvictionRuns
+            + ", minEvictableIdleTime=" + minEvictableIdleTime + ", testOnBorrow=" + testOnBorrow + ", testOnReturn=" + testOnReturn + ", testWhileIdle=" + testWhileIdle + "]";
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConnectionPoolConfigurationBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConnectionPoolConfigurationBuilder.java
@@ -1,0 +1,239 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.client.hotrod.configuration;
+
+import java.util.NoSuchElementException;
+import java.util.Properties;
+
+import org.infinispan.client.hotrod.impl.TypedProperties;
+import org.infinispan.configuration.Builder;
+
+/**
+ *
+ * ConnectionPoolConfigurationBuilder. Specified connection pooling properties for the HotRod client
+ *
+ * @author Tristan Tarrant
+ * @since 5.3
+ */
+public class ConnectionPoolConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<ConnectionPoolConfiguration> {
+   private ExhaustedAction exhaustedAction = ExhaustedAction.WAIT;
+   private boolean lifo = true;
+   private int maxActive = -1;
+   private int maxTotal = -1;
+   private long maxWait = -1;
+   private int maxIdle = -1;
+   private int minIdle = 1;
+   private long timeBetweenEvictionRuns = 120000;
+   private long minEvictableIdleTime = 1800000;
+   private int numTestsPerEvictionRun = 3;
+   private boolean testOnBorrow = false;
+   private boolean testOnReturn = false;
+   private boolean testWhileIdle = true;
+
+   ConnectionPoolConfigurationBuilder(ConfigurationBuilder builder) {
+      super(builder);
+   }
+
+   /**
+    * Specifies what happens when asking for a connection from a server's pool, and that pool is
+    * exhausted.
+    */
+   public ConnectionPoolConfigurationBuilder exhaustedAction(ExhaustedAction exhaustedAction) {
+      this.exhaustedAction = exhaustedAction;
+      return this;
+   }
+
+   /**
+    * Sets the LIFO status. True means that borrowObject returns the most recently used ("last in")
+    * idle object in a pool (if there are idle instances available). False means that pools behave
+    * as FIFO queues - objects are taken from idle object pools in the order that they are returned.
+    * The default setting is true
+    */
+   public ConnectionPoolConfigurationBuilder lifo(boolean enabled) {
+      this.lifo = enabled;
+      return this;
+   }
+
+   /**
+    * Controls the maximum number of connections per server that are allocated (checked out to
+    * client threads, or idle in the pool) at one time. When non-positive, there is no limit to the
+    * number of connections per server. When maxActive is reached, the connection pool for that
+    * server is said to be exhausted. The default setting for this parameter is -1, i.e. there is no
+    * limit.
+    */
+   public ConnectionPoolConfigurationBuilder maxActive(int maxActive) {
+      this.maxActive = maxActive;
+      return this;
+   }
+
+   /**
+    * Sets a global limit on the number persistent connections that can be in circulation within the
+    * combined set of servers. When non-positive, there is no limit to the total number of
+    * persistent connections in circulation. When maxTotal is exceeded, all connections pools are
+    * exhausted. The default setting for this parameter is -1 (no limit).
+    */
+   public ConnectionPoolConfigurationBuilder maxTotal(int maxTotal) {
+      this.maxTotal = maxTotal;
+      return this;
+   }
+
+   /**
+    * The amount of time in milliseconds to wait for a connection to become available when the
+    * exhausted action is {@link ExhaustedAction#WAIT}, after which a {@link NoSuchElementException}
+    * will be thrown. If a negative value is supplied, the pool will block indefinitely.
+    */
+   public ConnectionPoolConfigurationBuilder maxWait(long maxWait) {
+      this.maxWait = maxWait;
+      return this;
+   }
+
+   /**
+    * Controls the maximum number of idle persistent connections, per server, at any time. When
+    * negative, there is no limit to the number of connections that may be idle per server. The
+    * default setting for this parameter is -1.
+    */
+   public ConnectionPoolConfigurationBuilder maxIdle(int maxIdle) {
+      this.maxIdle = maxIdle;
+      return this;
+   }
+
+   /**
+    * Sets a target value for the minimum number of idle connections (per server) that should always
+    * be available. If this parameter is set to a positive number and timeBetweenEvictionRunsMillis
+    * > 0, each time the idle connection eviction thread runs, it will try to create enough idle
+    * instances so that there will be minIdle idle instances available for each server. The default
+    * setting for this parameter is 1.
+    */
+   public ConnectionPoolConfigurationBuilder minIdle(int minIdle) {
+      this.minIdle = minIdle;
+      return this;
+   }
+
+   /**
+    * Indicates the maximum number of connections to test during idle eviction runs. The default
+    * setting is 3.
+    */
+   public ConnectionPoolConfigurationBuilder numTestsPerEvictionRun(int numTestsPerEvictionRun) {
+      this.numTestsPerEvictionRun = numTestsPerEvictionRun;
+      return this;
+   }
+
+   /**
+    * Indicates how long the eviction thread should sleep before "runs" of examining idle
+    * connections. When non-positive, no eviction thread will be launched. The default setting for
+    * this parameter is 2 minutes.
+    */
+   public ConnectionPoolConfigurationBuilder timeBetweenEvictionRuns(long timeBetweenEvictionRuns) {
+      this.timeBetweenEvictionRuns = timeBetweenEvictionRuns;
+      return this;
+   }
+
+   /**
+    * Specifies the minimum amount of time that an connection may sit idle in the pool before it is
+    * eligible for eviction due to idle time. When non-positive, no connection will be dropped from
+    * the pool due to idle time alone. This setting has no effect unless
+    * timeBetweenEvictionRunsMillis > 0. The default setting for this parameter is 1800000(30
+    * minutes).
+    */
+   public ConnectionPoolConfigurationBuilder minEvictableIdleTime(long minEvictableIdleTime) {
+      this.minEvictableIdleTime = minEvictableIdleTime;
+      return this;
+   }
+
+   /**
+    * Indicates whether connections should be validated before being taken from the pool by sending
+    * an TCP packet to the server. Connections that fail to validate will be dropped from the pool.
+    * The default setting for this parameter is false.
+    */
+   public ConnectionPoolConfigurationBuilder testOnBorrow(boolean testOnBorrow) {
+      this.testOnBorrow = testOnBorrow;
+      return this;
+   }
+
+   /**
+    * Indicates whether connections should be validated when being returned to the pool sending an
+    * TCP packet to the server. Connections that fail to validate will be dropped from the pool. The
+    * default setting for this parameter is false.
+    */
+   public ConnectionPoolConfigurationBuilder testOnReturn(boolean testOnReturn) {
+      this.testOnReturn = testOnReturn;
+      return this;
+   }
+
+   /**
+    * Indicates whether or not idle connections should be validated by sending an TCP packet to the
+    * server, during idle connection eviction runs. Connections that fail to validate will be
+    * dropped from the pool. This setting has no effect unless timeBetweenEvictionRunsMillis > 0.
+    * The default setting for this parameter is true.
+    */
+   public ConnectionPoolConfigurationBuilder testWhileIdle(boolean testWhileIdle) {
+      this.testWhileIdle = testWhileIdle;
+      return this;
+   }
+
+   /**
+    * Configures the connection pool parameter according to properties
+    */
+   public ConnectionPoolConfigurationBuilder withPoolProperties(Properties properties) {
+      TypedProperties typed = TypedProperties.toTypedProperties(properties);
+      exhaustedAction(ExhaustedAction.values()[typed.getIntProperty("whenExhaustedAction", exhaustedAction.ordinal())]);
+      lifo(typed.getBooleanProperty("lifo", lifo));
+      maxActive(typed.getIntProperty("maxActive", maxActive));
+      maxTotal(typed.getIntProperty("maxTotal", maxTotal));
+      maxWait(typed.getLongProperty("maxWait", maxWait));
+      maxIdle(typed.getIntProperty("maxIdle", maxIdle));
+      minIdle(typed.getIntProperty("minIdle", minIdle));
+      numTestsPerEvictionRun(typed.getIntProperty("numTestsPerEvictionRun", numTestsPerEvictionRun));
+      timeBetweenEvictionRuns(typed.getLongProperty("timeBetweenEvictionRunsMillis", timeBetweenEvictionRuns));
+      minEvictableIdleTime(typed.getLongProperty("minEvictableIdleTimeMillis", minEvictableIdleTime));
+      testOnBorrow(typed.getBooleanProperty("testOnBorrow", testOnBorrow));
+      testOnReturn(typed.getBooleanProperty("testOnReturn", testOnReturn));
+      testWhileIdle(typed.getBooleanProperty("testWhileIdle", testWhileIdle));
+      return this;
+   }
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public ConnectionPoolConfiguration create() {
+      return new ConnectionPoolConfiguration(exhaustedAction, lifo, maxActive, maxTotal, maxWait, maxIdle, minIdle, numTestsPerEvictionRun, timeBetweenEvictionRuns,
+            minEvictableIdleTime, testOnBorrow, testOnReturn, testWhileIdle);
+   }
+
+   @Override
+   public ConnectionPoolConfigurationBuilder read(ConnectionPoolConfiguration template) {
+      exhaustedAction = template.exhaustedAction();
+      lifo = template.lifo();
+      maxActive = template.maxActive();
+      maxTotal = template.maxTotal();
+      maxWait = template.maxWait();
+      maxIdle = template.maxIdle();
+      minIdle = template.minIdle();
+      numTestsPerEvictionRun = template.numTestsPerEvictionRun();
+      timeBetweenEvictionRuns = template.timeBetweenEvictionRuns();
+      minEvictableIdleTime = template.minEvictableIdleTime();
+      testOnBorrow = template.testOnBorrow();
+      testOnReturn = template.testOnReturn();
+      testWhileIdle = template.testWhileIdle();
+      return this;
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ExecutorFactoryConfiguration.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ExecutorFactoryConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+package org.infinispan.client.hotrod.configuration;
+
+import org.infinispan.configuration.AbstractTypedPropertiesConfiguration;
+import org.infinispan.executors.ExecutorFactory;
+import org.infinispan.util.TypedProperties;
+
+/**
+ * ExecutorFactoryConfiguration.
+ *
+ * @author Tristan Tarrant
+ * @since 5.3
+ */
+public class ExecutorFactoryConfiguration extends AbstractTypedPropertiesConfiguration {
+
+   private final Class<? extends ExecutorFactory> factoryClass;
+   private final ExecutorFactory factory;
+
+   ExecutorFactoryConfiguration(Class<? extends ExecutorFactory> factoryClass, TypedProperties properties) {
+      super(properties);
+      this.factoryClass = factoryClass;
+      this.factory = null;
+   }
+
+   ExecutorFactoryConfiguration(ExecutorFactory factory, TypedProperties properties) {
+      super(properties);
+      this.factory = factory;
+      this.factoryClass = null;
+   }
+
+   public Class<? extends ExecutorFactory> factoryClass() {
+      return factoryClass;
+   }
+
+   public ExecutorFactory factory() {
+      return factory;
+   }
+
+   @Override
+   public String toString() {
+      return "ExecutorFactoryConfiguration [factoryClass=" + factoryClass + ", factory=" + factory + ", properties()=" + properties() + "]";
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ExecutorFactoryConfigurationBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ExecutorFactoryConfigurationBuilder.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2011 Red Hat, Inc. and/or its affiliates.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+package org.infinispan.client.hotrod.configuration;
+
+import java.util.Properties;
+
+import org.infinispan.client.hotrod.impl.async.DefaultAsyncExecutorFactory;
+import org.infinispan.configuration.Builder;
+import org.infinispan.executors.ExecutorFactory;
+import org.infinispan.util.TypedProperties;
+import org.infinispan.util.Util;
+
+/**
+ * Configures executor factory.
+ *
+ * @author Tristan Tarrant
+ * @since 5.3
+ */
+public class ExecutorFactoryConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<ExecutorFactoryConfiguration> {
+
+   private Class<? extends ExecutorFactory> factoryClass = DefaultAsyncExecutorFactory.class;
+   private ExecutorFactory factory;
+   private Properties properties;
+   private final ConfigurationBuilder builder;
+
+   ExecutorFactoryConfigurationBuilder(ConfigurationBuilder builder) {
+      super(builder);
+      this.builder = builder;
+      this.properties = new Properties();
+   }
+
+   /**
+    * Specify factory class for executor
+    *
+    * @param factory
+    *           clazz
+    * @return this ExecutorFactoryConfig
+    */
+   public ExecutorFactoryConfigurationBuilder factoryClass(Class<? extends ExecutorFactory> factoryClass) {
+      this.factoryClass = factoryClass;
+      return this;
+   }
+
+   public ExecutorFactoryConfigurationBuilder factoryClass(String factoryClass) {
+      this.factoryClass = Util.loadClass(factoryClass, builder.classLoader());
+      return this;
+   }
+
+   /**
+    * Specify factory class for executor
+    *
+    * @param factory
+    *           clazz
+    * @return this ExecutorFactoryConfig
+    */
+   public ExecutorFactoryConfigurationBuilder factory(ExecutorFactory factory) {
+      this.factory = factory;
+      return this;
+   }
+
+   /**
+    * Add key/value property pair to this executor factory configuration
+    *
+    * @param key
+    *           property key
+    * @param value
+    *           property value
+    * @return previous value if exists, null otherwise
+    */
+   public ExecutorFactoryConfigurationBuilder addExecutorProperty(String key, String value) {
+      this.properties.put(key, value);
+      return this;
+   }
+
+   /**
+    * Set key/value properties to this executor factory configuration
+    *
+    * @param props
+    *           Properties
+    * @return this ExecutorFactoryConfig
+    */
+   public ExecutorFactoryConfigurationBuilder withExecutorProperties(Properties props) {
+      this.properties = props;
+      return this;
+   }
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public ExecutorFactoryConfiguration create() {
+      if (factory != null)
+         return new ExecutorFactoryConfiguration(factory, TypedProperties.toTypedProperties(properties));
+      else
+         return new ExecutorFactoryConfiguration(factoryClass, TypedProperties.toTypedProperties(properties));
+   }
+
+   @Override
+   public ExecutorFactoryConfigurationBuilder read(ExecutorFactoryConfiguration template) {
+      this.factory = template.factory();
+      this.factoryClass = template.factoryClass();
+      this.properties = template.properties();
+
+      return this;
+   }
+
+   @Override
+   public String toString() {
+      return "ExecutorFactoryConfigurationBuilder [factoryClass=" + factoryClass + ", factory=" + factory + ", properties=" + properties + "]";
+   }
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ExhaustedAction.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ExhaustedAction.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.client.hotrod.configuration;
+
+/**
+ * Enumeration for whenExhaustedAction. Order is important, as the underlying commons-pool uses a byte to represent values
+ * ExhaustedAction.
+ *
+ * @author Tristan Tarrant
+ * @since 5.3
+ */
+public enum ExhaustedAction {
+   EXCEPTION, // GenericKeyedObjectPool.WHEN_EXHAUSTED_FAIL
+   WAIT, // GenericKeyedObjectPool.WHEN_EXHAUSTED_BLOCK
+   CREATE_NEW // GenericKeyedObjectPool.WHEN_EXHAUSTED_GROW
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ServerConfiguration.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ServerConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.client.hotrod.configuration;
+
+/**
+ * ServerConfiguration.
+ *
+ * @author Tristan Tarrant
+ * @since 5.3
+ */
+public class ServerConfiguration {
+   private final String host;
+   private final int port;
+
+   ServerConfiguration(String host, int port) {
+      this.host = host;
+      this.port = port;
+   }
+
+   public String host() {
+      return host;
+   }
+
+   public int port() {
+      return port;
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ServerConfigurationBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ServerConfigurationBuilder.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.client.hotrod.configuration;
+
+import org.infinispan.configuration.Builder;
+
+/**
+ * ServerConfigurationBuilder.
+ *
+ * @author Tristan Tarrant
+ * @since 5.3
+ */
+public class ServerConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<ServerConfiguration> {
+   private String host;
+   private int port = 11222;
+
+   ServerConfigurationBuilder(ConfigurationBuilder builder) {
+      super(builder);
+   }
+
+   public ServerConfigurationBuilder host(String host) {
+      this.host = host;
+      return this;
+   }
+
+   public ServerConfigurationBuilder port(int port) {
+      this.port = port;
+      return this;
+   }
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public ServerConfiguration create() {
+      return new ServerConfiguration(host, port);
+   }
+
+   @Override
+   public ServerConfigurationBuilder read(ServerConfiguration template) {
+      this.host = template.host();
+      this.port = template.port();
+
+      return this;
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHashFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHashFactory.java
@@ -23,23 +23,17 @@
 package org.infinispan.client.hotrod.impl.consistenthash;
 
 
-import static org.infinispan.client.hotrod.impl.ConfigurationProperties.HASH_FUNCTION_PREFIX;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.infinispan.client.hotrod.impl.ConfigurationProperties;
+import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.util.Util;
-import org.infinispan.util.logging.BasicLogFactory;
-import org.jboss.logging.BasicLogger;
 
 /**
  * Factory for {@link org.infinispan.client.hotrod.impl.consistenthash.ConsistentHash} function. It will try to look
  * into the configuration for consistent hash definitions as follows:
  * consistent-hash.[version]=[fully qualified class implementing ConsistentHash]
  * e.g.
- * infinispan.client.hotrod.hash_function_impl.1=org.infinispan.client.hotrod.impl.consistenthash.ConsitentHashV1
+ * <code>infinispan.client.hotrod.hash_function_impl.1=org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashV1</code>
+ * or if using the {@link Configuration} API,
+ * <code>configuration.consistentHashImpl(1, org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashV1.class);</code>
  * <p/>
  * If no CH function is defined for a certain version, then it will be defaulted to "org.infinispan.client.hotrod.impl.ConsistentHashV[version]".
  * E.g. if the server indicates that in use CH is version 1, and it is not defined within the configuration, it will be defaulted to
@@ -49,42 +43,15 @@ import org.jboss.logging.BasicLogger;
  * @since 4.1
  */
 public class ConsistentHashFactory {
+   private Class<? extends ConsistentHash>[] version2ConsistentHash;
 
-   private static final BasicLogger log = BasicLogFactory.getLog(ConsistentHashFactory.class);
-
-   private final Map<Integer, String> version2ConsistentHash = new HashMap<Integer, String>();
-
-   private ClassLoader classLoader;
-   
-   public void init(ConfigurationProperties config, ClassLoader classLoader) {
-	  this.classLoader = classLoader;
-      for (String propName : config.getProperties().stringPropertyNames()) {
-         if (propName.startsWith(HASH_FUNCTION_PREFIX)) {
-            if (log.isTraceEnabled()) log.tracef("Processing consistent hash: %s", propName);
-            String versionString = propName.substring((HASH_FUNCTION_PREFIX + ".").length());
-            int version = Integer.parseInt(versionString);
-            String hashFunction = config.getProperties().getProperty(propName);
-            version2ConsistentHash.put(version, hashFunction);
-            if (log.isTraceEnabled()) {
-               log.tracef("Added consistent hash version %d: %s", version, hashFunction);
-            }
-         }
-      }
+   public void init(Configuration configuration) {
+      this.version2ConsistentHash = configuration.consistentHashImpl();
    }
 
    public ConsistentHash newConsistentHash(int version) {
-      String hashFunctionClass = version2ConsistentHash.get(version);
-      if (hashFunctionClass == null) {
-         if (log.isTraceEnabled()) log.tracef("No hash function configured for version %d", version);
-         hashFunctionClass = ConsistentHashFactory.class.getPackage().getName() + ".ConsistentHashV" + version;
-         if (log.isTraceEnabled()) log.tracef("Trying to use default value: %s", hashFunctionClass);
-         version2ConsistentHash.put(version, hashFunctionClass);
-      }
+      Class<? extends ConsistentHash> hashFunctionClass = version2ConsistentHash[version-1];
       // TODO: Why create a brand new instance via reflection everytime a new hash topology is received? Caching???
-      return (ConsistentHash) Util.getInstance(hashFunctionClass, classLoader);
-   }
-
-   public Map<Integer, String> getVersion2ConsistentHash() {
-      return Collections.unmodifiableMap(version2ConsistentHash);
+      return Util.getInstance(hashFunctionClass);
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
@@ -22,11 +22,10 @@
  */
 package org.infinispan.client.hotrod.impl.transport;
 
-import org.infinispan.client.hotrod.impl.ConfigurationProperties;
+import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashFactory;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.Map;
@@ -45,7 +44,7 @@ public interface TransportFactory {
 
    void releaseTransport(Transport transport);
 
-   void start(Codec codec, ConfigurationProperties props, Collection<SocketAddress> staticConfiguredServers, AtomicInteger topologyId, ClassLoader classLoader);
+   void start(Codec codec, Configuration configuration, AtomicInteger topologyId);
 
    void updateServers(Collection<SocketAddress> newServers);
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheManagerNotStartedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheManagerNotStartedTest.java
@@ -62,7 +62,7 @@ public class CacheManagerNotStartedTest extends SingleCacheManagerTest {
       super.setup();
       hotrodServer = TestHelper.startHotRodServer(cacheManager);
       remoteCacheManager = new RemoteCacheManager(
-            "localhost:" + hotrodServer.getHost(), false);
+            "127.0.0.1:" + hotrodServer.getPort(), false);
    }
 
    @AfterClass(alwaysRun = true)

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConfigurationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConfigurationTest.java
@@ -1,0 +1,101 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.client.hotrod;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+import org.infinispan.client.hotrod.configuration.Configuration;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.configuration.ExhaustedAction;
+import org.testng.annotations.Test;
+
+@Test(testName = "client.hotrod.ConfigurationTest", groups = "functional" )
+public class ConfigurationTest {
+
+   public void testConfiguration() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder
+         .addServer()
+            .host("host1")
+            .port(11222)
+         .addServer()
+            .host("host2")
+            .port(11222)
+         .asyncExecutorFactory()
+            .factoryClass(SomeAsyncExecutorFactory.class)
+         .balancingStrategy(SomeRequestBalancingStrategy.class)
+         .connectionPool()
+            .maxActive(100)
+            .maxTotal(150)
+            .maxWait(1000)
+            .maxIdle(20)
+            .minIdle(10)
+            .exhaustedAction(ExhaustedAction.WAIT)
+            .numTestsPerEvictionRun(5)
+            .testOnBorrow(true)
+            .testOnReturn(true)
+            .testWhileIdle(false)
+            .minEvictableIdleTime(12000)
+            .timeBetweenEvictionRuns(15000)
+         .connectionTimeout(100)
+         .consistentHashImpl(1, SomeCustomConsistentHashV1.class)
+         .socketTimeout(100)
+         .tcpNoDelay(false)
+         .pingOnStartup(false)
+         .keySizeEstimate(128)
+         .valueSizeEstimate(1024)
+         .transportFactory(SomeTransportfactory.class);
+
+      Configuration configuration = builder.build();
+      validateConfiguration(configuration);
+
+      ConfigurationBuilder newBuilder = new ConfigurationBuilder();
+      newBuilder.read(configuration);
+      Configuration newConfiguration = newBuilder.build();
+      validateConfiguration(newConfiguration);
+   }
+
+   private void validateConfiguration(Configuration configuration) {
+      assertEquals(2, configuration.servers().size());
+      assertEquals(SomeAsyncExecutorFactory.class, configuration.asyncExecutorFactory().factoryClass());
+      assertEquals(SomeRequestBalancingStrategy.class, configuration.balancingStrategy());
+      assertEquals(SomeTransportfactory.class, configuration.transportFactory());
+      assertEquals(SomeCustomConsistentHashV1.class, configuration.consistentHashImpl(1));
+      assertEquals(100, configuration.connectionPool().maxActive());
+      assertEquals(150, configuration.connectionPool().maxTotal());
+      assertEquals(1000, configuration.connectionPool().maxWait());
+      assertEquals(20, configuration.connectionPool().maxIdle());
+      assertEquals(10, configuration.connectionPool().minIdle());
+      assertEquals(ExhaustedAction.WAIT, configuration.connectionPool().exhaustedAction());
+      assertEquals(5, configuration.connectionPool().numTestsPerEvictionRun());
+      assertEquals(15000, configuration.connectionPool().timeBetweenEvictionRuns());
+      assertEquals(12000, configuration.connectionPool().minEvictableIdleTime());
+      assertTrue(configuration.connectionPool().testOnBorrow());
+      assertTrue(configuration.connectionPool().testOnReturn());
+      assertFalse(configuration.connectionPool().testWhileIdle());
+      assertEquals(100, configuration.connectionTimeout());
+      assertEquals(100, configuration.socketTimeout());
+      assertFalse(configuration.tcpNoDelay());
+      assertFalse(configuration.pingOnStartup());
+      assertEquals(128, configuration.keySizeEstimate());
+      assertEquals(1024, configuration.valueSizeEstimate());
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashFactoryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashFactoryTest.java
@@ -22,13 +22,12 @@
  */
 package org.infinispan.client.hotrod;
 
-import org.infinispan.client.hotrod.impl.ConfigurationProperties;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHash;
 import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashFactory;
 import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashV1;
 import org.testng.annotations.Test;
-
-import java.util.Properties;
+import static org.testng.AssertJUnit.*;
 
 /**
  * Tester for ConsistentHashFactory.
@@ -40,20 +39,21 @@ import java.util.Properties;
 public class ConsistentHashFactoryTest {
 
    public void testPropertyCorrectlyRead() {
-      Properties propos = new Properties();
-      String value = "org.infinispan.client.hotrod.impl.consistenthash.SomeCustomConsitentHashV1";
-      propos.put(ConfigurationProperties.HASH_FUNCTION_PREFIX + ".1", value);
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.consistentHashImpl(1, SomeCustomConsistentHashV1.class);
       ConsistentHashFactory chf = new ConsistentHashFactory();
-      chf.init(new ConfigurationProperties(propos), Thread.currentThread().getContextClassLoader());
-      String s = chf.getVersion2ConsistentHash().get(1);
-      assert s != null;
-      assert value.equals(s);
+      chf.init(builder.build());
+      ConsistentHash hash = chf.newConsistentHash(1);
+      assertNotNull(hash);
+      assertEquals(hash.getClass(), SomeCustomConsistentHashV1.class);
    }
 
    public void testNoChDefined() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
       ConsistentHashFactory chf = new ConsistentHashFactory();
+      chf.init(builder.build());
       ConsistentHash hash = chf.newConsistentHash(1);
-      assert hash != null;
-      assert hash.getClass().equals(ConsistentHashV1.class);
+      assertNotNull(hash);
+      assertEquals(hash.getClass(), ConsistentHashV1.class);
    }
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HeavyLoadConnectionPoolingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HeavyLoadConnectionPoolingTest.java
@@ -43,7 +43,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
-import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author Mircea.Markus@jboss.com
@@ -54,7 +53,7 @@ public class HeavyLoadConnectionPoolingTest extends SingleCacheManagerTest {
    private HotRodServer hotRodServer;
    private RemoteCacheManager remoteCacheManager;
    private RemoteCache<Object, Object> remoteCache;
-   private GenericKeyedObjectPool connectionPool;
+   private GenericKeyedObjectPool<?,?> connectionPool;
 
    @AfterMethod(alwaysRun=true)
    @Override
@@ -72,16 +71,16 @@ public class HeavyLoadConnectionPoolingTest extends SingleCacheManagerTest {
       hotRodServer = TestHelper.startHotRodServer(cacheManager);
 
       Properties hotrodClientConf = new Properties();
-      hotrodClientConf.put("infinispan.client.hotrod.server_list", "localhost:"+hotRodServer.getPort());
-      hotrodClientConf.put("timeBetweenEvictionRunsMillis", "500");
-      hotrodClientConf.put("minEvictableIdleTimeMillis", "100");
-      hotrodClientConf.put("numTestsPerEvictionRun", "10");
-      hotrodClientConf.put("infinispan.client.hotrod.ping_on_startup", "true");
+      hotrodClientConf.setProperty("infinispan.client.hotrod.server_list", "localhost:"+hotRodServer.getPort());
+      hotrodClientConf.setProperty("timeBetweenEvictionRunsMillis", "500");
+      hotrodClientConf.setProperty("minEvictableIdleTimeMillis", "100");
+      hotrodClientConf.setProperty("numTestsPerEvictionRun", "10");
+      hotrodClientConf.setProperty("infinispan.client.hotrod.ping_on_startup", "true");
       remoteCacheManager = new RemoteCacheManager(hotrodClientConf);
       remoteCache = remoteCacheManager.getCache();
 
       TcpTransportFactory tcpConnectionFactory = (TcpTransportFactory) TestingUtil.extractField(remoteCacheManager, "transportFactory");
-      connectionPool = (GenericKeyedObjectPool) TestingUtil.extractField(tcpConnectionFactory, "connectionPool");
+      connectionPool = (GenericKeyedObjectPool<?, ?>) TestingUtil.extractField(tcpConnectionFactory, "connectionPool");
 
       return cacheManager;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SomeAsyncExecutorFactory.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SomeAsyncExecutorFactory.java
@@ -1,0 +1,25 @@
+/* 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.client.hotrod;
+
+import org.infinispan.client.hotrod.impl.async.DefaultAsyncExecutorFactory;
+
+public class SomeAsyncExecutorFactory extends DefaultAsyncExecutorFactory {
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SomeCustomConsistentHashV1.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SomeCustomConsistentHashV1.java
@@ -1,0 +1,25 @@
+/* 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.client.hotrod;
+
+import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashV1;
+
+public class SomeCustomConsistentHashV1 extends ConsistentHashV1 {
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SomeRequestBalancingStrategy.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SomeRequestBalancingStrategy.java
@@ -1,0 +1,25 @@
+/* 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.client.hotrod;
+
+import org.infinispan.client.hotrod.impl.transport.tcp.RoundRobinBalancingStrategy;
+
+public class SomeRequestBalancingStrategy extends RoundRobinBalancingStrategy {
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SomeTransportfactory.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SomeTransportfactory.java
@@ -1,0 +1,25 @@
+/* 
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.infinispan.client.hotrod;
+
+import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory;
+
+public class SomeTransportfactory extends TcpTransportFactory {
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-2983

This commit introduce a ConfigurationBuilder/Configuration pair comparable to what we have in core. 
It deprecates most of the existing RemoteCacheManager constructors.
