### PR TITLE
ISPN-3011 If predefined in cache configuration, use that exclusively

### DIFF
--- a/jcache/src/test/java/org/infinispan/jcache/JCacheConfigurationTest.java
+++ b/jcache/src/test/java/org/infinispan/jcache/JCacheConfigurationTest.java
@@ -1,0 +1,32 @@
+package org.infinispan.jcache;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.CacheManagerCallable;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+import static org.infinispan.test.TestingUtil.withCacheManager;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * Tests JCache and JCacheManager configuration.
+ *
+ * @author Galder Zamarreño
+ * @since 5.3
+ */
+@Test(groups = "functional", testName = "jcache.JCacheConfigurationTest")
+public class JCacheConfigurationTest {
+
+   public void testNamedCacheConfiguration() {
+      withCacheManager(new CacheManagerCallable(
+            TestCacheManagerFactory.createLocalCacheManager(false)) {
+         @Override
+         public void call() {
+            cm.defineConfiguration("oneCache", new ConfigurationBuilder().build());
+            JCacheManager jCacheManager = new JCacheManager("oneCacheManager", cm);
+            assertTrue(null != jCacheManager.getCache("oneCache"));
+         }
+      });
+   }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3011
- Something to be noted in the documentation, but simplifies a lot the way configuration is managed internally in JSR-107, without having to start merging/mapping Infinispan configuration to JCache configuration, particularly taking in account how several aspects are very differently configured (i.e. expiration).
