### PR TITLE
ISPN-3012 Defensive copying should recompact after returning values

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/DefensiveMarshalledValueInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/DefensiveMarshalledValueInterceptor.java
@@ -23,6 +23,7 @@
 
 package org.infinispan.interceptors;
 
+import org.infinispan.context.InvocationContext;
 import org.infinispan.marshall.MarshalledValue;
 
 /**
@@ -41,6 +42,18 @@ public class DefensiveMarshalledValueInterceptor extends MarshalledValueIntercep
       // Force marshalled version to be stored
       if (mv != null)
          mv.compact(true, true);
+   }
+
+   @Override
+   protected Object processRetVal(Object retVal, InvocationContext ctx) {
+      Object ret = retVal;
+      if (retVal instanceof MarshalledValue) {
+         // Calculate return
+         ret = super.processRetVal(ret, ctx);
+         // Re-compact in case deserialization happened
+         ((MarshalledValue) retVal).compact(true, true);
+      }
+      return ret;
    }
 
 }

--- a/core/src/main/java/org/infinispan/interceptors/MarshalledValueInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/MarshalledValueInterceptor.java
@@ -320,7 +320,7 @@ public class MarshalledValueInterceptor extends CommandInterceptor {
       mv.compact(false, false);
    }
 
-   private Object processRetVal(Object retVal, InvocationContext ctx) {
+   protected Object processRetVal(Object retVal, InvocationContext ctx) {
       if (retVal instanceof MarshalledValue) {
          if (ctx.isOriginLocal()) {
             if (trace) log.tracef("Return is a marshall value, so extract instance from: %s", retVal);

--- a/core/src/test/java/org/infinispan/marshall/DefensiveCopyTest.java
+++ b/core/src/test/java/org/infinispan/marshall/DefensiveCopyTest.java
@@ -48,16 +48,26 @@ public class DefensiveCopyTest extends SingleCacheManagerTest {
       return TestCacheManagerFactory.createCacheManager(builder);
    }
 
-   public void testStoreByValue() {
-      Integer k = 1;
+   public void testOriginalReferenceSafety() {
+      final Integer k = 1;
       Person person = new Person("Mr Infinispan");
-      cache.put(k, person);
+      cache().put(k, person);
       assertEquals(person, cache.get(k));
       // Change referenced object
       person.setName("Ms Hibernate");
       // If defensive copies are working as expected,
       // it should be same as before
       assertEquals(new Person("Mr Infinispan"), cache.get(k));
+   }
+
+   public void testSafetyAfterRetrieving() {
+      final Integer k = 2;
+      Person person = new Person("Mr Coe");
+      cache().put(k, person);
+      Person cachedPerson = this.<Integer, Person>cache().get(k);
+      assertEquals(person, cachedPerson);
+      cachedPerson.setName("Mr Digweed");
+      assertEquals(new Person("Mr Coe"), cache.get(k));
    }
 
 }

--- a/jcache/src/test/java/org/infinispan/jcache/InvokeProcessorTest.java
+++ b/jcache/src/test/java/org/infinispan/jcache/InvokeProcessorTest.java
@@ -1,0 +1,109 @@
+package org.infinispan.jcache;
+
+import org.testng.annotations.Test;
+
+import javax.cache.Cache;
+import javax.cache.CacheException;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.SimpleConfiguration;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.fail;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * Add {@link Cache#invokeEntryProcessor(Object, javax.cache.Cache.EntryProcessor)}
+ * tests covering edge cases missing in the TCK.
+ *
+ * @author Galder Zamarreño
+ * @since 5.3
+ */
+@Test(groups = "functional", testName = "jcache.InvokeProcessorTest")
+public class InvokeProcessorTest {
+
+   public void testInvokeProcesorStoreByValueException(Method m) {
+      invokeProcessorThrowsException(m,
+            new SimpleConfiguration<String, List<Integer>>(),
+            new ArrayList<Integer>(Arrays.asList(1, 2, 3)));
+   }
+
+   public void testInvokeProcesorStoreByReferenceException(Method m) {
+      // As per: https://github.com/jsr107/jsr107spec/issues/106
+      invokeProcessorThrowsException(m,
+            new SimpleConfiguration<String, List<Integer>>().setStoreByValue(false),
+            new ArrayList<Integer>(Arrays.asList(1, 2, 3, 4)));
+   }
+
+   public void testInvokeProcesorStoreByValue(Method m) {
+      invokeProcessor(m, new SimpleConfiguration<String, List<Integer>>());
+   }
+
+   private void invokeProcessorThrowsException(
+         Method m, SimpleConfiguration<String, List<Integer>> jcacheCfg,
+         List<Integer> expectedValue) {
+      String name = getName(m);
+      CacheManager cm = Caching.getCacheManager(name);
+      try {
+         Cache<String, List<Integer>> cache = cm.configureCache(name, jcacheCfg);
+         List<Integer> list = new ArrayList<Integer>(Arrays.asList(1, 2, 3));
+         final String query = "select * from x";
+         cache.put(query , list);
+         try {
+            cache.invokeEntryProcessor(query,
+                  new Cache.EntryProcessor<String, List<Integer>, Object>() {
+                     @Override
+                     public Object process(Cache.MutableEntry<String, List<Integer>> entry) {
+                        entry.getValue().add(4);
+                        throw new UnexpectedException();
+                     }
+                  });
+            fail("Expected an exception to be thrown");
+         } catch (CacheException e) {
+            assertTrue(e.getCause() instanceof UnexpectedException);
+         }
+
+         assertEquals(expectedValue, cache.get(query));
+      } finally {
+         cm.shutdown();
+      }
+   }
+
+   private void invokeProcessor(
+         Method m, SimpleConfiguration<String, List<Integer>> jcacheCfg) {
+      String name = getName(m);
+      CacheManager cm = Caching.getCacheManager(name);
+      try {
+         Cache<String, List<Integer>> cache = cm.configureCache(name, jcacheCfg);
+         List<Integer> list = new ArrayList<Integer>(Arrays.asList(1, 2, 3));
+         final String query = "select * from x";
+         cache.put(query, list);
+         cache.invokeEntryProcessor(query,
+               new Cache.EntryProcessor<String, List<Integer>, Object>() {
+                  @Override
+                  public Object process(Cache.MutableEntry<String, List<Integer>> entry) {
+                     List<Integer> ids = entry.getValue();
+                     ids.add(4);
+                     entry.setValue(ids);
+                     return null;
+                  }
+               });
+
+         assertEquals(new ArrayList<Integer>(Arrays.asList(1, 2, 3, 4)),
+               cache.get(query));
+      } finally {
+         cm.shutdown();
+      }
+   }
+
+   private String getName(Method m) {
+      return getClass().getName() + '.' + m.getName();
+   }
+
+   private static class UnexpectedException extends RuntimeException {}
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3012
- Recompact when returning a value to avoid returned values being modified via client side direct reference.
- When using storeByValue, make safe copies of entries in invokeProcessor so that cache can be updated using atomic operations.
