### PR TITLE
ISPN-3022 Make CHMv8 the default CHM implementation when not running in Java8

### DIFF
--- a/core/src/main/java/org/infinispan/util/concurrent/ConcurrentMapFactory.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/ConcurrentMapFactory.java
@@ -90,7 +90,7 @@ public class ConcurrentMapFactory {
    static {
       boolean sunIncompatibleJvm;
       boolean jdk8;
-      boolean allowExperimentalMap = Boolean.getBoolean("infinispan.unsafe.allow_jdk8_chm");
+      boolean allowExperimentalMap = Boolean.parseBoolean(System.getProperty("infinispan.unsafe.allow_jdk8_chm", "true"));
 
       try {
          Class.forName("sun.misc.Unsafe");


### PR DESCRIPTION
See https://issues.jboss.org/browse/ISPN-3022
