### PR TITLE
ISPN-3033 Lucene index stored in a StringBased CacheStore can get an una...

### DIFF
--- a/lucene/lucene-v3/src/main/java/org/infinispan/lucene/ChunkCacheKey.java
+++ b/lucene/lucene-v3/src/main/java/org/infinispan/lucene/ChunkCacheKey.java
@@ -126,6 +126,8 @@ public final class ChunkCacheKey implements Serializable, IndexScopedKey {
          return false;
       if (!fileName.equals(other.fileName))
          return false;
+      if (bufferSize != other.bufferSize)
+         return false;
       return indexName.equals(other.indexName);
    }
 

--- a/lucene/lucene-v3/src/main/java/org/infinispan/lucene/LuceneKey2StringMapper.java
+++ b/lucene/lucene-v3/src/main/java/org/infinispan/lucene/LuceneKey2StringMapper.java
@@ -100,7 +100,7 @@ public class LuceneKey2StringMapper implements TwoWayKey2StringMapper {
                if (split.length != 4) throw log.keyMappperUnexpectedStringFormat(key);
                try {
                   int chunkId = Integer.parseInt(split[1]);
-                  int bufferSize = Integer.parseInt(split[1]);
+                  int bufferSize = Integer.parseInt(split[2]);
                   return new ChunkCacheKey(split[3], split[0], chunkId, bufferSize);
                } catch (NumberFormatException nfe) {
                   throw log.keyMappperUnexpectedStringFormat(key);

--- a/lucene/lucene-v3/src/test/java/org/infinispan/lucene/readlocks/NoopSegmentReadLockerTest.java
+++ b/lucene/lucene-v3/src/test/java/org/infinispan/lucene/readlocks/NoopSegmentReadLockerTest.java
@@ -102,7 +102,7 @@ public class NoopSegmentReadLockerTest extends DistributedSegmentReadLockerTest 
       int chunkNumbers = (int)(totalFileSize / CHUNK_SIZE);
 
       for(int i = 0; i < chunkNumbers; i++) {
-         AssertJUnit.assertNotNull(cache.get(new ChunkCacheKey(INDEX_NAME, filename, CHUNK_SIZE, 0)));
+         AssertJUnit.assertNotNull(cache.get(new ChunkCacheKey(INDEX_NAME, filename, i, CHUNK_SIZE)));
       }
 
       boolean fileNameExistsInCache = false;

--- a/lucene/lucene-v4/src/test/java/org/infinispan/lucene/readlocks/NoopSegmentReadLockerTest.java
+++ b/lucene/lucene-v4/src/test/java/org/infinispan/lucene/readlocks/NoopSegmentReadLockerTest.java
@@ -103,7 +103,7 @@ public class NoopSegmentReadLockerTest extends DistributedSegmentReadLockerTest 
       int chunkNumbers = (int)(totalFileSize / CHUNK_SIZE);
 
       for(int i = 0; i < chunkNumbers; i++) {
-         AssertJUnit.assertNotNull(cache.get(new ChunkCacheKey(INDEX_NAME, filename, CHUNK_SIZE, 0)));
+         AssertJUnit.assertNotNull(cache.get(new ChunkCacheKey(INDEX_NAME, filename, i, CHUNK_SIZE)));
       }
 
       boolean fileNameExistsInCache = false;


### PR DESCRIPTION
...ligned bufferSize

https://issues.jboss.org/browse/ISPN-3033

There is no test as there was a test already; just that the existing test wouldn't
catch this case because the bufferSize wasn't part of the equals contract: the
assertion used the key.equals to verify correct interpretation.
Fixing the equals activated the unit test: org.infinispan.lucene.Key2StringMapperTest

NoopSegmentReadLockerTest had to be fixed too as there was a mistake which wasn't spotted
as it also took advantage of the same equals flaw.
