### PR TITLE
ISPN-3038 jcache module pom should honor skipTests property

### DIFF
--- a/jcache/pom.xml
+++ b/jcache/pom.xml
@@ -124,6 +124,7 @@
                <properties>
                   <!-- Skip tests parent's tests are skipped -->
                   <maven.test.skip.exec>${maven.test.skip.exec}</maven.test.skip.exec>
+                  <skipTests>${skipTests}</skipTests>
                   <!-- If logging enabled by client, pass it on -->
                   <log4j.configuration>${log4j.configuration}</log4j.configuration>
                </properties>


### PR DESCRIPTION
Add the skipTests property to the list of command line properties passed to the child build.

JIRA: https://issues.jboss.org/browse/ISPN-3038
