### PR TITLE
ISPN-3061 Total Order Tweaks

### DIFF
--- a/core/src/main/java/org/infinispan/transaction/totalorder/TotalOrderManager.java
+++ b/core/src/main/java/org/infinispan/transaction/totalorder/TotalOrderManager.java
@@ -153,7 +153,6 @@ public class TotalOrderManager {
                     lockedKeys == null ? "[ClearCommand]" : lockedKeys);
       }
       state.reset();
-      totalOrderExecutor.checkForReadyTasks();
    }
 
    /**


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3061

change: checkForReadyTasks() is only performed after it sends back the Response to the originator, to avoid long response time.
