### PR TITLE
ISPN-3055 Unreleased lock after node restart

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/ReplicationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/ReplicationInterceptor.java
@@ -47,6 +47,7 @@ import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.rpc.RpcOptions;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.jgroups.SuspectException;
+import org.infinispan.transaction.LocalTransaction;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.logging.Log;
@@ -108,13 +109,21 @@ public class ReplicationInterceptor extends ClusteringInterceptor {
    }
 
    protected void broadcastPrepare(TxInvocationContext context, PrepareCommand command) {
-      boolean async = cacheConfiguration.clustering().cacheMode() == CacheMode.REPL_ASYNC;
-      rpcManager.invokeRemotely(null, command, rpcManager.getDefaultRpcOptions(!async));
+      try {
+         boolean sync = cacheConfiguration.clustering().cacheMode().isSynchronous();
+         rpcManager.invokeRemotely(null, command, rpcManager.getDefaultRpcOptions(sync));
+      } finally {
+         transactionRemotelyPrepared(context);
+      }
    }
 
    @Override
    public Object visitRollbackCommand(TxInvocationContext ctx, RollbackCommand command) throws Throwable {
-      if (shouldInvokeRemoteTxCommand(ctx) && !Configurations.isOnePhaseCommit(cacheConfiguration)) {
+      boolean prepareSent = ctx.isOriginLocal() && ((LocalTransaction) ctx.getCacheTransaction()).isPrepareSent();
+      //If we are using onePhaseCommit, the PrepareCommand cleanups everything related to the transaction (release
+      //locks, remove the transaction from transaction table, etc...). So we don't need to waste resource to send the
+      //command that is ignored in the other nodes.
+      if (shouldInvokeRemoteTxCommand(ctx) && !(prepareSent && Configurations.isOnePhaseCommit(cacheConfiguration))) {
          rpcManager.invokeRemotely(null, command, rpcManager.getDefaultRpcOptions(
                cacheConfiguration.transaction().syncRollbackPhase(), false));
       }

--- a/core/src/main/java/org/infinispan/interceptors/VersionedReplicationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/VersionedReplicationInterceptor.java
@@ -57,9 +57,13 @@ public class VersionedReplicationInterceptor extends ReplicationInterceptor {
       Address primaryOwner = getPrimaryOwner();
       if (!primaryOwner.equals(rpcManager.getAddress())) {
          setVersionsSeenOnPrepareCommand((VersionedPrepareCommand) command, context);
-         Map<Address, Response> resps = rpcManager.invokeRemotely(null, command, rpcManager.getDefaultRpcOptions(true, false));
-         Response r = resps.get(primaryOwner);  // We only really care about the coordinator's response.
-         readVersionsFromResponse(r, context.getCacheTransaction());
+         try {
+            Map<Address, Response> resps = rpcManager.invokeRemotely(null, command, rpcManager.getDefaultRpcOptions(true, false));
+            Response r = resps.get(primaryOwner);  // We only really care about the coordinator's response.
+            readVersionsFromResponse(r, context.getCacheTransaction());
+         } finally {
+            transactionRemotelyPrepared(context);
+         }
       } else {
          super.broadcastPrepare(context, command);
       }

--- a/core/src/main/java/org/infinispan/interceptors/base/BaseRpcInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/base/BaseRpcInterceptor.java
@@ -106,7 +106,7 @@ public abstract class BaseRpcInterceptor extends CommandInterceptor {
       return shouldInvokeRemotely;
    }
 
-   protected static void totalOrderTxPrepare(TxInvocationContext ctx) {
+   protected static void transactionRemotelyPrepared(TxInvocationContext ctx) {
       if (ctx.isOriginLocal()) {
          ((LocalTransaction)ctx.getCacheTransaction()).markPrepareSent();
       }

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -21,7 +21,6 @@ package org.infinispan.interceptors.distribution;
 
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.control.LockControlCommand;
-import org.infinispan.commands.read.GetCacheEntryCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
@@ -255,8 +254,12 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
    }
 
    protected void prepareOnAffectedNodes(TxInvocationContext ctx, PrepareCommand command, Collection<Address> recipients, boolean sync) {
-      // this method will return immediately if we're the only member (because exclude_self=true)
-      rpcManager.invokeRemotely(recipients, command, rpcManager.getDefaultRpcOptions(sync));
+      try {
+         // this method will return immediately if we're the only member (because exclude_self=true)
+         rpcManager.invokeRemotely(recipients, command, rpcManager.getDefaultRpcOptions(sync));
+      } finally {
+         transactionRemotelyPrepared(ctx);
+      }
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/distribution/VersionedDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/VersionedDistributionInterceptor.java
@@ -54,10 +54,14 @@ public class VersionedDistributionInterceptor extends TxDistributionInterceptor 
       setVersionsSeenOnPrepareCommand((VersionedPrepareCommand) command, ctx);
 
       // Perform the RPC
-      Map<Address, Response> resps = rpcManager.invokeRemotely(recipients, command, rpcManager.getDefaultRpcOptions(true, false));
+      try {
+         Map<Address, Response> resps = rpcManager.invokeRemotely(recipients, command, rpcManager.getDefaultRpcOptions(true, false));
 
-      // Now store newly generated versions from lock owners for use during the commit phase.
-      CacheTransaction ct = ctx.getCacheTransaction();
-      for (Response r : resps.values()) readVersionsFromResponse(r, ct);
+         // Now store newly generated versions from lock owners for use during the commit phase.
+         CacheTransaction ct = ctx.getCacheTransaction();
+         for (Response r : resps.values()) readVersionsFromResponse(r, ct);
+      } finally {
+         transactionRemotelyPrepared(ctx);
+      }
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderDistributionInterceptor.java
@@ -89,7 +89,7 @@ public class TotalOrderDistributionInterceptor extends TxDistributionInterceptor
       try {
          totalOrderAnycastPrepare(recipients, command, isSyncCommitPhase() ? null : getSelfDeliverFilter());
       } finally {
-         totalOrderTxPrepare(ctx);
+         transactionRemotelyPrepared(ctx);
       }
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderReplicationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderReplicationInterceptor.java
@@ -62,7 +62,7 @@ public class TotalOrderReplicationInterceptor extends ReplicationInterceptor {
       try {
          totalOrderBroadcastPrepare(command, isSyncCommitPhase() ? null : getSelfDeliverFilter());
       } finally {
-         totalOrderTxPrepare(context);
+         transactionRemotelyPrepared(context);
       }
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedDistributionInterceptor.java
@@ -107,7 +107,7 @@ public class TotalOrderVersionedDistributionInterceptor extends VersionedDistrib
             throw new CacheException("Not all keys were validated. Possible member has left the cluster");
          }
       } finally {
-         totalOrderTxPrepare(ctx);
+         transactionRemotelyPrepared(ctx);
       }
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedReplicationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedReplicationInterceptor.java
@@ -74,7 +74,7 @@ public class TotalOrderVersionedReplicationInterceptor extends VersionedReplicat
       try {
          totalOrderBroadcastPrepare(command, isSyncCommitPhase() ? null : getSelfDeliverFilter());
       } finally {
-         totalOrderTxPrepare(context);
+         transactionRemotelyPrepared(context);
       }
    }
 }

--- a/core/src/test/java/org/infinispan/tx/locking/AbstractLocalTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/AbstractLocalTest.java
@@ -33,6 +33,8 @@ import javax.transaction.xa.Xid;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.testng.Assert.assertNull;
+
 /**
  * @author Mircea Markus
  * @since 5.1
@@ -73,6 +75,15 @@ public abstract class AbstractLocalTest extends SingleCacheManagerTest {
       assertLocking();
    }
 
+   public void testRollback() throws Exception {
+      tm().begin();
+      cache().put("k", "v");
+      assertLockingOnRollback();
+      assertNull(cache().get("k"));
+   }
+
+   protected abstract void assertLockingOnRollback();
+
    protected abstract void assertLocking();
 
    protected void commit() {
@@ -89,6 +100,15 @@ public abstract class AbstractLocalTest extends SingleCacheManagerTest {
       try {
          dtm.firstEnlistedResource().prepare(getXid());
       } catch (Throwable e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   protected void rollback() {
+      DummyTransactionManager dtm = (DummyTransactionManager) tm();
+      try {
+         dtm.getTransaction().rollback();
+      } catch (SystemException e) {
          throw new RuntimeException(e);
       }
    }

--- a/core/src/test/java/org/infinispan/tx/locking/LocalOptimisticTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/LocalOptimisticTxTest.java
@@ -48,6 +48,13 @@ public class LocalOptimisticTxTest extends AbstractLocalTest {
       return TestCacheManagerFactory.createCacheManager(config);
    }
 
+   @Override
+   protected void assertLockingOnRollback() {
+      assertFalse(lockManager().isLocked("k"));
+      rollback();
+      assertFalse(lockManager().isLocked("k"));
+   }
+
    protected void assertLocking() {
       assertFalse(lockManager().isLocked("k"));
       prepare();

--- a/core/src/test/java/org/infinispan/tx/locking/LocalPessimisticTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/LocalPessimisticTxTest.java
@@ -30,8 +30,7 @@ import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 /**
  * @author Mircea Markus
@@ -40,12 +39,32 @@ import static org.testng.Assert.assertTrue;
 @Test (groups = "functional", testName = "tx.locking.LocalPessimisticTxTest")
 public class LocalPessimisticTxTest extends AbstractLocalTest {
 
+   public void testLockingWithRollback() throws Exception {
+      tm().begin();
+      cache().getAdvancedCache().lock("k");
+      assertLockingOnRollback();
+      assertNull(cache().get("k"));
+
+      tm().begin();
+      cache().getAdvancedCache().lock("k");
+      cache().put("k", "v");
+      assertLockingOnRollback();
+      assertNull(cache().get("k"));
+   }
+
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       final Configuration config = getDefaultStandaloneConfig(true);
       config.fluent().transaction().lockingMode(LockingMode.PESSIMISTIC)
             .transactionManagerLookup(new DummyTransactionManagerLookup());
       return TestCacheManagerFactory.createCacheManager(config);
+   }
+
+   @Override
+   protected void assertLockingOnRollback() {
+      assertTrue(lockManager().isLocked("k"));
+      rollback();
+      assertFalse(lockManager().isLocked("k"));
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/tx/locking/OptimisticReplTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/OptimisticReplTxTest.java
@@ -101,4 +101,13 @@ public class OptimisticReplTxTest extends AbstractClusteredTxTest {
       assertFalse(lockManager(0).isLocked(k));
       assertFalse(lockManager(1).isLocked(k));
    }
+
+   @Override
+   protected void assertLockingOnRollback() {
+      assertFalse(lockManager(0).isLocked(k));
+      assertFalse(lockManager(1).isLocked(k));
+      rollback();
+      assertFalse(lockManager(0).isLocked(k));
+      assertFalse(lockManager(1).isLocked(k));
+   }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3055

(maybe it is needed to change the JIRA title because the bug has nothing to do with the node restart)

notes:
- the bug was caused because the `RollbackCommand` was not sent in pessimistic mode.
- I'm keep tracking when the `PrepareCommand` is sent or not to know when we must send the ``RollbackCommand`
- The code already exist for Total Order based implementation. 
