### PR TITLE
ISPN-3008 Make sure that the topology cache has unique names 

### DIFF
--- a/server/core/src/main/scala/org/infinispan/server/core/configuration/ProtocolServerConfiguration.java
+++ b/server/core/src/main/scala/org/infinispan/server/core/configuration/ProtocolServerConfiguration.java
@@ -25,6 +25,7 @@ package org.infinispan.server.core.configuration;
  * @since 5.3
  */
 public abstract class ProtocolServerConfiguration {
+   private final String name;
    private final String host;
    private final int port;
    private final int idleTimeout;
@@ -34,7 +35,8 @@ public abstract class ProtocolServerConfiguration {
    private final boolean tcpNoDelay;
    private final int workerThreads;
 
-   protected ProtocolServerConfiguration(String host, int port, int idleTimeout, int recvBufSize, int sendBufSize, SslConfiguration ssl, boolean tcpNoDelay, int workerThreads) {
+   protected ProtocolServerConfiguration(String name, String host, int port, int idleTimeout, int recvBufSize, int sendBufSize, SslConfiguration ssl, boolean tcpNoDelay, int workerThreads) {
+      this.name = name;
       this.host = host;
       this.port = port;
       this.idleTimeout = idleTimeout;
@@ -43,6 +45,10 @@ public abstract class ProtocolServerConfiguration {
       this.ssl = ssl;
       this.tcpNoDelay = tcpNoDelay;
       this.workerThreads = workerThreads;
+   }
+
+   public String name() {
+      return name;
    }
 
    public String host() {
@@ -79,8 +85,8 @@ public abstract class ProtocolServerConfiguration {
 
    @Override
    public String toString() {
-      return "ProtocolServerConfiguration [host=" + host + ", port=" + port + ", idleTimeout=" + idleTimeout + ", recvBufSize=" + recvBufSize + ", sendBufSize=" + sendBufSize
-            + ", ssl=" + ssl + ", tcpNoDelay=" + tcpNoDelay + ", workerThreads=" + workerThreads + "]";
+      return "ProtocolServerConfiguration [name=" + name + ", host=" + host + ", port=" + port + ", idleTimeout=" + idleTimeout + ", recvBufSize=" + recvBufSize + ", sendBufSize="
+            + sendBufSize + ", ssl=" + ssl + ", tcpNoDelay=" + tcpNoDelay + ", workerThreads=" + workerThreads + "]";
    }
 
 }

--- a/server/core/src/main/scala/org/infinispan/server/core/configuration/ProtocolServerConfigurationBuilder.java
+++ b/server/core/src/main/scala/org/infinispan/server/core/configuration/ProtocolServerConfigurationBuilder.java
@@ -29,6 +29,7 @@ import org.infinispan.util.logging.LogFactory;
 public abstract class ProtocolServerConfigurationBuilder<T extends ProtocolServerConfiguration, S extends ProtocolServerConfigurationChildBuilder<T, S>> implements
       ProtocolServerConfigurationChildBuilder<T, S>, Builder<T> {
    private static final JavaLog log = LogFactory.getLog(ProtocolServerConfigurationBuilder.class, JavaLog.class);
+   protected String name = "";
    protected String host = "127.0.0.1";
    protected int port = -1;
    protected int idleTimeout = -1;
@@ -41,6 +42,12 @@ public abstract class ProtocolServerConfigurationBuilder<T extends ProtocolServe
    protected ProtocolServerConfigurationBuilder(int port) {
       this.port = port;
       this.ssl = new SslConfigurationBuilder();
+   }
+
+   @Override
+   public S name(String name) {
+      this.name = name;
+      return this.self();
    }
 
    @Override
@@ -126,6 +133,7 @@ public abstract class ProtocolServerConfigurationBuilder<T extends ProtocolServe
 
    @Override
    public Builder<?> read(T template) {
+      this.name = template.name();
       this.host = template.host();
       this.port = template.port();
       this.idleTimeout = template.idleTimeout();

--- a/server/core/src/main/scala/org/infinispan/server/core/configuration/ProtocolServerConfigurationChildBuilder.java
+++ b/server/core/src/main/scala/org/infinispan/server/core/configuration/ProtocolServerConfigurationChildBuilder.java
@@ -24,6 +24,11 @@ import org.infinispan.configuration.Self;
 
 public interface ProtocolServerConfigurationChildBuilder<T extends ProtocolServerConfiguration, S extends ProtocolServerConfigurationChildBuilder<T,S>> extends Self<S> {
    /**
+    * Specifies a custom name for this server in order to easily distinguish it from other servers, e.g. via JMX. Defaults to the empty string.
+    */
+   S name(String name);
+
+   /**
     * Specifies the host or IP address on which this server will listen
     */
    S host(String host);

--- a/server/core/src/test/scala/org/infinispan/server/core/configuration/MockServerConfiguration.java
+++ b/server/core/src/test/scala/org/infinispan/server/core/configuration/MockServerConfiguration.java
@@ -20,7 +20,7 @@ package org.infinispan.server.core.configuration;
 
 public class MockServerConfiguration extends ProtocolServerConfiguration {
 
-   protected MockServerConfiguration(String host, int port, int idleTimeout, int recvBufSize, int sendBufSize, SslConfiguration ssl, boolean tcpNoDelay, int workerThreads) {
-      super(host, port, idleTimeout, recvBufSize, sendBufSize, ssl, tcpNoDelay, workerThreads);
+   protected MockServerConfiguration(String name, String host, int port, int idleTimeout, int recvBufSize, int sendBufSize, SslConfiguration ssl, boolean tcpNoDelay, int workerThreads) {
+      super(name, host, port, idleTimeout, recvBufSize, sendBufSize, ssl, tcpNoDelay, workerThreads);
    }
 }

--- a/server/core/src/test/scala/org/infinispan/server/core/configuration/MockServerConfigurationBuilder.java
+++ b/server/core/src/test/scala/org/infinispan/server/core/configuration/MockServerConfigurationBuilder.java
@@ -48,6 +48,6 @@ public class MockServerConfigurationBuilder extends ProtocolServerConfigurationB
 
    @Override
    public MockServerConfiguration create() {
-      return new MockServerConfiguration(host, port, idleTimeout, recvBufSize, sendBufSize, ssl.create(), tcpNoDelay, workerThreads);
+      return new MockServerConfiguration(name, host, port, idleTimeout, recvBufSize, sendBufSize, ssl.create(), tcpNoDelay, workerThreads);
    }
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
@@ -37,6 +37,7 @@ import org.jboss.netty.channel.Channel
 import java.lang.StringBuilder
 import org.infinispan.container.versioning.EntryVersion
 import org.infinispan.container.entries.CacheEntry
+import org.infinispan.server.hotrod.configuration.HotRodServerConfiguration
 
 /**
  * Top level Hot Rod decoder that after figuring out the version, delegates the rest of the reading to the
@@ -104,9 +105,9 @@ class HotRodDecoder(cacheManager: EmbeddedCacheManager, transport: NettyTranspor
       val cacheName = header.cacheName
       // Talking to the wrong cache are really request parsing errors
       // and hence should be treated as client errors
-      if (cacheName == HotRodServer.ADDRESS_CACHE_NAME)
+      if (cacheName.startsWith(HotRodServerConfiguration.TOPOLOGY_CACHE_NAME_PREFIX))
          throw new RequestParsingException(
-            "Remote requests are not allowed to topology cache. Do no send remote requests to cache '%s'".format(HotRodServer.ADDRESS_CACHE_NAME),
+            "Remote requests are not allowed to topology cache. Do no send remote requests to cache '%s'".format(cacheName),
             header.version, header.messageId)
 
       var seenForFirstTime = false

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
@@ -43,7 +43,7 @@ class HotRodEncoder(cacheManager: EmbeddedCacheManager, server: HotRodServer)
 
    private lazy val isClustered: Boolean = cacheManager.getGlobalConfiguration.getTransportClass != null
    private lazy val addressCache: Cache[Address, ServerAddress] =
-      if (isClustered) cacheManager.getCache(HotRodServer.ADDRESS_CACHE_NAME) else null
+      if (isClustered) cacheManager.getCache(server.getConfiguration.topologyCacheName) else null
    private val isTrace = isTraceEnabled
 
    override def encode(ctx: ChannelHandlerContext, ch: Channel, msg: AnyRef): AnyRef = {

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/configuration/HotRodServerConfiguration.java
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/configuration/HotRodServerConfiguration.java
@@ -24,22 +24,23 @@ import org.infinispan.server.core.configuration.SslConfiguration;
 
 @BuiltBy(HotRodServerConfigurationBuilder.class)
 public class HotRodServerConfiguration extends ProtocolServerConfiguration {
+   public static final String TOPOLOGY_CACHE_NAME_PREFIX = "___hotRodTopologyCache";
    private final String proxyHost;
    private final int proxyPort;
+   private final String topologyCacheName;
    private final long topologyLockTimeout;
    private final long topologyReplTimeout;
    private final boolean topologyStateTransfer;
-   private final long topologyUpdateTimeout;
 
-   HotRodServerConfiguration(String proxyHost, int proxyPort, long topologyLockTimeout, long topologyReplTimeout, boolean topologyStateTransfer, long topologyUpdateTimeout,
-         String host, int port, int idleTimeout, int recvBufSize, int sendBufSize, SslConfiguration ssl, boolean tcpNoDelay, int workerThreads) {
-      super(host, port, idleTimeout, recvBufSize, sendBufSize, ssl, tcpNoDelay, workerThreads);
+   HotRodServerConfiguration(String proxyHost, int proxyPort, long topologyLockTimeout, long topologyReplTimeout, boolean topologyStateTransfer,
+         String name, String host, int port, int idleTimeout, int recvBufSize, int sendBufSize, SslConfiguration ssl, boolean tcpNoDelay, int workerThreads) {
+      super(name, host, port, idleTimeout, recvBufSize, sendBufSize, ssl, tcpNoDelay, workerThreads);
       this.proxyHost = proxyHost;
       this.proxyPort = proxyPort;
+      this.topologyCacheName = TOPOLOGY_CACHE_NAME_PREFIX + (name.length() > 0 ? "_" + name : name);
       this.topologyLockTimeout = topologyLockTimeout;
       this.topologyReplTimeout = topologyReplTimeout;
       this.topologyStateTransfer = topologyStateTransfer;
-      this.topologyUpdateTimeout = topologyUpdateTimeout;
    }
 
    public String proxyHost() {
@@ -48,6 +49,10 @@ public class HotRodServerConfiguration extends ProtocolServerConfiguration {
 
    public int proxyPort() {
       return proxyPort;
+   }
+
+   public String topologyCacheName() {
+      return topologyCacheName;
    }
 
    public long topologyLockTimeout() {
@@ -62,13 +67,9 @@ public class HotRodServerConfiguration extends ProtocolServerConfiguration {
       return topologyStateTransfer;
    }
 
-   public long topologyUpdateTimeout() {
-      return topologyUpdateTimeout;
-   }
    @Override
    public String toString() {
-      return "HotRodServerConfiguration [proxyHost=" + proxyHost + ", proxyPort=" + proxyPort + ", topologyLockTimeout=" + topologyLockTimeout + ", topologyReplTimeout="
-            + topologyReplTimeout + ", topologyStateTransfer=" + topologyStateTransfer + ", topologyUpdateTimeout=" + topologyUpdateTimeout + ", " + super.toString()
-            + "]";
+      return "HotRodServerConfiguration [proxyHost=" + proxyHost + ", proxyPort=" + proxyPort + ", topologyLockTimeout="
+            + topologyLockTimeout + ", topologyReplTimeout=" + topologyReplTimeout + ", topologyStateTransfer=" + topologyStateTransfer + ", " + super.toString() + "]";
    }
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/logging/JavaLog.java
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/logging/JavaLog.java
@@ -22,6 +22,7 @@
 
 package org.infinispan.server.hotrod.logging;
 
+import org.infinispan.config.ConfigurationException;
 import org.jboss.logging.Cause;
 import org.jboss.logging.LogMessage;
 import org.jboss.logging.Message;
@@ -51,4 +52,10 @@ public interface JavaLog extends org.infinispan.util.logging.Log {
    @Message(value = "Error detecting crashed member", id = 6002)
    void errorDetectingCrashedMember(@Cause Throwable t);
 
+   @Message(value = "A topology cache named '%s' has already been defined", id = 6003)
+   ConfigurationException invalidTopologyCache(String topologyCacheName);
+
+   @LogMessage(level = WARN)
+   @Message(value = "The topology update timeout configuration is ignored", id = 6004)
+   void topologyUpdateTimeoutIgnored();
 }

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodConfigurationTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodConfigurationTest.scala
@@ -32,6 +32,7 @@ import org.infinispan.server.core.test.Stoppable
 import org.infinispan.configuration.cache.Configuration
 import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder
 import org.infinispan.configuration.cache.ClusterCacheLoaderConfiguration
+import org.infinispan.server.hotrod.configuration.HotRodServerConfiguration
 
 /**
  * Test to verify that configuration changes are reflected in backend caches.
@@ -41,8 +42,6 @@ import org.infinispan.configuration.cache.ClusterCacheLoaderConfiguration
  */
 @Test(groups = Array("functional"), testName = "server.hotrod.HotRodConfigurationTest")
 class HotRodConfigurationTest {
-
-   import HotRodServer.ADDRESS_CACHE_NAME
 
    def testUserDefinedTimeouts() {
       val builder = new HotRodServerConfigurationBuilder
@@ -71,7 +70,7 @@ class HotRodConfigurationTest {
    private def withClusteredServer(builder: HotRodServerConfigurationBuilder) (assert: (Configuration, Long) => Unit) {
       Stoppable.useCacheManager(TestCacheManagerFactory.createClusteredCacheManager(hotRodCacheConfiguration())) { cm =>
          Stoppable.useServer(startHotRodServer(cm, UniquePortThreadLocal.get.intValue, builder)) { server =>
-            val cfg = cm.getCache(ADDRESS_CACHE_NAME).getCacheConfiguration
+            val cfg = cm.getCache(HotRodServerConfiguration.TOPOLOGY_CACHE_NAME_PREFIX).getCacheConfiguration
             assert(cfg, cm.getCacheManagerConfiguration.transport().distributedSyncTimeout())
          }
       }

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodFunctionalTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodFunctionalTest.scala
@@ -33,6 +33,8 @@ import org.infinispan.test.TestingUtil.generateRandomString
 import org.infinispan.config.Configuration
 import java.util.concurrent.TimeUnit
 import org.infinispan.server.core.test.Stoppable
+import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder
+import org.infinispan.server.hotrod.configuration.HotRodServerConfiguration
 
 /**
  * Hot Rod server functional test.
@@ -42,8 +44,6 @@ import org.infinispan.server.core.test.Stoppable
  */
 @Test(groups = Array("functional"), testName = "server.hotrod.HotRodFunctionalTest")
 class HotRodFunctionalTest extends HotRodSingleNodeTest {
-
-   import HotRodServer.ADDRESS_CACHE_NAME
 
    def testUnknownCommand(m: Method) {
       val status = client.execute(0xA0, 0x77, cacheName, k(m) , 0, 0, v(m), 0, 1, 0).status
@@ -78,7 +78,7 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
    }
 
    def testPutOnTopologyCache(m: Method) {
-      val resp = client.execute(0xA0, 0x01, ADDRESS_CACHE_NAME, k(m), 0, 0, v(m), 0, 1, 0).asInstanceOf[TestErrorResponse]
+      val resp = client.execute(0xA0, 0x01, HotRodServerConfiguration.TOPOLOGY_CACHE_NAME_PREFIX, k(m), 0, 0, v(m), 0, 1, 0).asInstanceOf[TestErrorResponse]
       assertTrue(resp.msg.contains("Remote requests are not allowed to topology cache."))
       assertEquals(resp.status, ParseError, "Status should have been 'ParseError' but instead was: " + resp.status)
       client.assertPut(m)
@@ -447,7 +447,7 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
          }
       }
    }
-   
+
    def testBulkGetKeys(m: Method) {
       var size = 100
       for (i <- 0 until size) {
@@ -462,7 +462,7 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
          val filtered = bulkData.filter(java.util.Arrays.equals(_, k(m, i + "k-")))
          assertEquals(1, filtered.size)
       }
-      
+
       resp = client.bulkGetKeys(1)
       assertStatus(resp, Success)
       bulkData = resp.bulkData
@@ -471,7 +471,7 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
          val filtered = bulkData.filter(java.util.Arrays.equals(_, k(m, i + "k-")))
          assertEquals(1, filtered.size)
       }
-      
+
       resp = client.bulkGetKeys(2)
       assertStatus(resp, Success)
       bulkData = resp.bulkData

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodSharedContainerTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodSharedContainerTest.scala
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.infinispan.server.hotrod
+
+import test.HotRodClient
+import java.lang.reflect.Method
+import org.infinispan.server.hotrod.OperationStatus._
+import org.infinispan.test.MultipleCacheManagersTest
+import test.HotRodTestingUtil._
+import org.infinispan.test.AbstractCacheTest._
+import org.testng.annotations.{AfterClass, BeforeClass, AfterMethod, Test}
+import org.infinispan.server.core.test.ServerTestingUtil._
+import org.infinispan.test.fwk.TestCacheManagerFactory
+import org.infinispan.configuration.cache.CacheMode
+import org.infinispan.util.ByteArrayEquivalence
+import org.infinispan.config.ConfigurationException
+import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder
+import org.infinispan.configuration.global.GlobalConfigurationBuilder
+import org.infinispan.server.hotrod.test.UniquePortThreadLocal
+
+@Test(groups = Array("functional"), testName = "server.hotrod.HotRodSharedContainerTest")
+class HotRodSharedContainerTest extends MultipleCacheManagersTest {
+
+   private var hotRodServer1: HotRodServer = _
+   private var hotRodServer2: HotRodServer = _
+   private var hotRodClient1: HotRodClient = _
+   private var hotRodClient2: HotRodClient = _
+   private val cacheName = "HotRodCache"
+
+   @Test(enabled=false) // to avoid TestNG picking it up as a test
+   override def createCacheManagers() {
+      val globalCfg = GlobalConfigurationBuilder.defaultClusteredBuilder()
+      globalCfg.globalJmxStatistics().allowDuplicateDomains(true)
+      val cm = TestCacheManagerFactory.createClusteredCacheManager(globalCfg, hotRodCacheConfiguration())
+      cacheManagers.add(cm)
+      val builder = hotRodCacheConfiguration(
+         getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false))
+      cm.defineConfiguration(cacheName, builder.build())
+   }
+
+   @Test(expectedExceptions= Array(classOf[ConfigurationException]))
+   def testTopologyConflict() {
+      val basePort = UniquePortThreadLocal.get.intValue
+      hotRodServer1 = startHotRodServer(cacheManagers.get(0), basePort, new HotRodServerConfigurationBuilder())
+      hotRodServer2 = startHotRodServer(cacheManagers.get(0), basePort + 50, new HotRodServerConfigurationBuilder())
+   }
+
+   def testSharedContainer(m: Method) {
+      val basePort = UniquePortThreadLocal.get.intValue
+      hotRodServer1 = startHotRodServer(cacheManagers.get(0), basePort, new HotRodServerConfigurationBuilder().name("1"))
+      hotRodServer2 = startHotRodServer(cacheManagers.get(0), basePort + 50, new HotRodServerConfigurationBuilder().name("2"))
+
+      hotRodClient1 = new HotRodClient("127.0.0.1", hotRodServer1.getPort, cacheName, 60, 12)
+      hotRodClient2 = new HotRodClient("127.0.0.1", hotRodServer2.getPort, cacheName, 60, 12)
+
+      hotRodClient1.put(k(m) , 0, 0, v(m))
+      assertSuccess(hotRodClient2.get(k(m), 0), v(m))
+   }
+
+   @AfterMethod(alwaysRun = true)
+   def killClientsAndServers() {
+      killClient(hotRodClient1)
+      killClient(hotRodClient2)
+      killServer(hotRodServer1)
+      killServer(hotRodServer2)
+   }
+
+}

--- a/server/memcached/src/main/scala/org/infinispan/server/memcached/configuration/MemcachedServerConfiguration.java
+++ b/server/memcached/src/main/scala/org/infinispan/server/memcached/configuration/MemcachedServerConfiguration.java
@@ -31,7 +31,7 @@ import org.infinispan.server.core.configuration.SslConfiguration;
 @BuiltBy(MemcachedServerConfigurationBuilder.class)
 public class MemcachedServerConfiguration extends ProtocolServerConfiguration {
 
-   MemcachedServerConfiguration(String host, int port, int idleTimeout, int recvBufSize, int sendBufSize, SslConfiguration ssl, boolean tcpNoDelay, int workerThreads) {
-      super(host, port, idleTimeout, recvBufSize, sendBufSize, ssl, tcpNoDelay, workerThreads);
+   MemcachedServerConfiguration(String name, String host, int port, int idleTimeout, int recvBufSize, int sendBufSize, SslConfiguration ssl, boolean tcpNoDelay, int workerThreads) {
+      super(name, host, port, idleTimeout, recvBufSize, sendBufSize, ssl, tcpNoDelay, workerThreads);
    }
 }

--- a/server/memcached/src/main/scala/org/infinispan/server/memcached/configuration/MemcachedServerConfigurationBuilder.java
+++ b/server/memcached/src/main/scala/org/infinispan/server/memcached/configuration/MemcachedServerConfigurationBuilder.java
@@ -41,7 +41,7 @@ public class MemcachedServerConfigurationBuilder extends ProtocolServerConfigura
 
    @Override
    public MemcachedServerConfiguration create() {
-      return new MemcachedServerConfiguration(host, port, idleTimeout, recvBufSize, sendBufSize, ssl.create(), tcpNoDelay, workerThreads);
+      return new MemcachedServerConfiguration(name, host, port, idleTimeout, recvBufSize, sendBufSize, ssl.create(), tcpNoDelay, workerThreads);
    }
 
    public MemcachedServerConfiguration build(boolean validate) {

--- a/server/websocket/src/main/java/org/infinispan/server/websocket/configuration/WebSocketServerConfiguration.java
+++ b/server/websocket/src/main/java/org/infinispan/server/websocket/configuration/WebSocketServerConfiguration.java
@@ -31,7 +31,7 @@ import org.infinispan.server.core.configuration.SslConfiguration;
 @BuiltBy(WebSocketServerConfigurationBuilder.class)
 public class WebSocketServerConfiguration extends ProtocolServerConfiguration {
 
-   WebSocketServerConfiguration(String host, int port, int idleTimeout, int recvBufSize, int sendBufSize, SslConfiguration ssl, boolean tcpNoDelay, int workerThreads) {
-      super(host, port, idleTimeout, recvBufSize, sendBufSize, ssl, tcpNoDelay, workerThreads);
+   WebSocketServerConfiguration(String name, String host, int port, int idleTimeout, int recvBufSize, int sendBufSize, SslConfiguration ssl, boolean tcpNoDelay, int workerThreads) {
+      super(name, host, port, idleTimeout, recvBufSize, sendBufSize, ssl, tcpNoDelay, workerThreads);
    }
 }

--- a/server/websocket/src/main/java/org/infinispan/server/websocket/configuration/WebSocketServerConfigurationBuilder.java
+++ b/server/websocket/src/main/java/org/infinispan/server/websocket/configuration/WebSocketServerConfigurationBuilder.java
@@ -41,7 +41,7 @@ public class WebSocketServerConfigurationBuilder extends ProtocolServerConfigura
 
    @Override
    public WebSocketServerConfiguration create() {
-      return new WebSocketServerConfiguration(host, port, idleTimeout, recvBufSize, sendBufSize, ssl.create(), tcpNoDelay, workerThreads);
+      return new WebSocketServerConfiguration(name, host, port, idleTimeout, recvBufSize, sendBufSize, ssl.create(), tcpNoDelay, workerThreads);
    }
 
    public WebSocketServerConfiguration build(boolean validate) {


### PR DESCRIPTION
ISPN-3008 Make sure that the topology cache has unique names when a container is shared by multiple servers
ISPN-3107 Add Javadocs to the HotRodServerConfigurationBuilder
ISPN-3113 Deprecate updateTimeout attribute of the HotRod topology state transfer configuration

Also handle https://github.com/infinispan/infinispan-server/pull/103 at the same time
