### PR TITLE
ISPN-3120 StateConsumerImpl can ignore state received during a rebalance

### DIFF
--- a/core/src/main/java/org/infinispan/notifications/cachelistener/event/EventImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/event/EventImpl.java
@@ -218,16 +218,26 @@ public class EventImpl<K, V> implements CacheEntryActivatedEvent, CacheEntryCrea
 
    @Override
    public String toString() {
+      if (type == Type.TOPOLOGY_CHANGED || type == Type.DATA_REHASHED)
+         return "EventImpl{" +
+               "type=" + type +
+               ", pre=" + pre +
+               ", cache=" + cache +
+               ", consistentHashAtStart=" + consistentHashAtStart +
+               ", consistentHashAtEnd=" + consistentHashAtEnd +
+               ", newTopologyId=" + newTopologyId +
+               '}';
       return "EventImpl{" +
-            "pre=" + pre +
+            "type=" + type +
+            ", pre=" + pre +
+            ", cache=" + cache +
             ", key=" + key +
-            ", cache=" + cache.getName() +
+            ", value=" + value +
+            ", oldValue=" + oldValue +
             ", transaction=" + transaction +
             ", originLocal=" + originLocal +
             ", transactionSuccessful=" + transactionSuccessful +
-            ", type=" + type +
-            ", value=" + value +
-            ", oldValue=" + oldValue +
+            ", entries=" + entries +
             ", created=" + created +
             '}';
    }

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -565,6 +565,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
       gcr.wireDependencies(command);
       Response localResponse;
       try {
+         if (log.isTraceEnabled()) log.tracef("Attempting to execute command on self: %s", command);
          localResponse = (Response) command.perform(null);
       } catch (Throwable throwable) {
          throw new Exception(throwable);
@@ -602,6 +603,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
             public void run() {
                gcr.wireDependencies(command);
                try {
+                  if (log.isTraceEnabled()) log.tracef("Attempting to execute command on self: %s", command);
                   command.perform(null);
                } catch (Throwable throwable) {
                   // The command already logs any exception in perform()

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -260,6 +260,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
       Response response;
       if (transport.isCoordinator()) {
          try {
+            if (log.isTraceEnabled()) log.tracef("Attempting to execute command on self: %s", command);
             gcr.wireDependencies(command);
             response = (Response) command.perform(null);
          } catch (Throwable t) {
@@ -286,6 +287,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
          asyncTransportExecutor.submit(new Callable<Object>() {
             @Override
             public Object call() throws Exception {
+               if (log.isTraceEnabled()) log.tracef("Attempting to execute command on self: %s", command);
                gcr.wireDependencies(command);
                try {
                   return command.perform(null);

--- a/core/src/test/java/org/infinispan/distribution/rehash/OldStateResponseTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/OldStateResponseTest.java
@@ -1,0 +1,125 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.infinispan.distribution.rehash;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.infinispan.commands.remote.CacheRpcCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.DataContainer;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.manager.CacheContainer;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.remoting.InboundInvocationHandler;
+import org.infinispan.remoting.InboundInvocationHandlerImpl;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.Transport;
+import org.infinispan.remoting.transport.jgroups.CommandAwareRpcDispatcher;
+import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
+import org.infinispan.statetransfer.StateChunk;
+import org.infinispan.statetransfer.StateRequestCommand;
+import org.infinispan.statetransfer.StateResponseCommand;
+import org.infinispan.statetransfer.StateTransferManager;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.tx.dld.ControlledRpcManager;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Start two rebalance operations by stopping two members of a cluster in sequence.
+ * Test that a delayed StateResponseCommand from an already stopped member doesn't break state transfer.
+ *
+ * @author Dan Berindei
+ */
+@Test(groups = "functional", testName = "distribution.rehash.OldStateResponseTest")
+public class OldStateResponseTest extends MultipleCacheManagersTest {
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+      builder.clustering().cacheMode(CacheMode.DIST_SYNC);
+      createCluster(builder, 3);
+      waitForClusterToForm();
+   }
+
+   public void testOldStateResponse() throws Throwable {
+      MagicKey k1 = new MagicKey("k1", cache(1));
+      MagicKey k2 = new MagicKey("k2", cache(2));
+      cache(1).put(k1, "v1");
+      cache(2).put(k2, "v2");
+
+      final StateTransferManager stm = cache(0).getAdvancedCache().getComponentRegistry().getStateTransferManager();
+      int initialTopologyId = stm.getCacheTopology().getTopologyId();
+
+      RpcManager rm = TestingUtil.extractComponent(cache(0), RpcManager.class);
+      ControlledRpcManager crm = new ControlledRpcManager(rm);
+      crm.blockBefore(StateRequestCommand.class);
+      TestingUtil.replaceComponent(cache(0), RpcManager.class, crm, true);
+
+      cache(2).stop();
+
+      eventually(new Condition() {
+         @Override
+         public boolean isSatisfied() throws Exception {
+            // Wait for the rebalance cache topology to be installed
+            return stm.getCacheTopology().getPendingCH() != null;
+         }
+      });
+
+      // Cache 0 didn't manage to send any StateRequestCommand yet.
+      // We'll pretend it got a StateResponseCommand with an older topology id.
+      InboundInvocationHandler iih = TestingUtil.extractGlobalComponent(manager(0), InboundInvocationHandler.class);
+      StateChunk stateChunk = new StateChunk(0, Collections.<InternalCacheEntry>emptyList(), true);
+      StateResponseCommand stateResponseCommand = new StateResponseCommand(CacheContainer.DEFAULT_CACHE_NAME,
+            address(2), initialTopologyId, Arrays.asList(stateChunk));
+      iih.handle(stateResponseCommand, address(2), null, false);
+
+      crm.stopBlocking();
+
+      TestingUtil.waitForRehashToComplete(cache(0), cache(1));
+
+      DataContainer dataContainer = TestingUtil.extractComponent(cache(0), DataContainer.class);
+      assertTrue(dataContainer.containsKey(k1));
+      assertTrue(dataContainer.containsKey(k2));
+   }
+
+   private void awaitStrict(CountDownLatch latch, long timeout, TimeUnit unit) throws InterruptedException, TimeoutException {
+      if (!latch.await(timeout, unit))
+         throw new TimeoutException();
+   }
+}

--- a/core/src/test/java/org/infinispan/distribution/rehash/OngoingTransactionsAndJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/OngoingTransactionsAndJoinTest.java
@@ -57,6 +57,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.infinispan.test.TestingUtil.extractComponent;
 import static org.infinispan.test.TestingUtil.replaceComponent;
+import static org.infinispan.test.TestingUtil.replaceField;
 
 /**
  * This tests the following scenario:
@@ -82,16 +83,7 @@ public class OngoingTransactionsAndJoinTest extends MultipleCacheManagersTest {
       replaceComponent(ecm, InboundInvocationHandler.class, lh, true);
       JGroupsTransport t = (JGroupsTransport) extractComponent(cache(0), Transport.class);
       CommandAwareRpcDispatcher card = t.getCommandAwareRpcDispatcher();
-      Field f = null;
-      try {
-         f = card.getClass().getDeclaredField("inboundInvocationHandler");
-         f.setAccessible(true);
-         f.set(card, lh);
-      } catch (NoSuchFieldException e) {
-         e.printStackTrace();
-      } catch (IllegalAccessException e) {
-         e.printStackTrace();
-      }
+      replaceField(lh, "inboundInvocationHandler", card, CommandAwareRpcDispatcher.class);
    }
 
    public void testRehashOnJoin() throws InterruptedException {

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashTestBase.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashTestBase.java
@@ -59,7 +59,7 @@ public abstract class RehashTestBase extends BaseDistFunctionalTest {
     * This is overridden by subclasses.  Could typically be a JOIN or LEAVE event.
     * @param offline
     */
-   abstract void performRehashEvent(boolean offline);
+   abstract void performRehashEvent(boolean offline) throws Throwable;
 
    /**
     * Blocks until a rehash completes.
@@ -92,7 +92,7 @@ public abstract class RehashTestBase extends BaseDistFunctionalTest {
     * Simple test.  Put some state, trigger event, test results
     */
    @Test
-   public void testNonTransactional() {
+   public void testNonTransactional() throws Throwable {
       List<MagicKey> keys = init();
 
       log.info("Invoking rehash event");
@@ -111,7 +111,7 @@ public abstract class RehashTestBase extends BaseDistFunctionalTest {
     * and test results.
     */
    @Test
-   public void testTransactional() throws Exception {
+   public void testTransactional() throws Throwable {
       final List<MagicKey> keys = init();
       final CountDownLatch l = new CountDownLatch(1);
       final AtomicBoolean rollback = new AtomicBoolean(false);
@@ -176,7 +176,7 @@ public abstract class RehashTestBase extends BaseDistFunctionalTest {
     * A stress test.  One node is constantly modified while a rehash occurs.
     */
    @Test(enabled = false, description = "Enable after releasing Beta1")
-   public void testNonTransactionalStress() throws Exception {
+   public void testNonTransactionalStress() throws Throwable {
       stressTest(false);
    }
 
@@ -184,11 +184,11 @@ public abstract class RehashTestBase extends BaseDistFunctionalTest {
     * A stress test.  One node is constantly modified using transactions while a rehash occurs.
     */
    @Test(enabled = false, description = "Enable after releasing Beta1")
-   public void testTransactionalStress() throws Exception {
+   public void testTransactionalStress() throws Throwable {
       stressTest(true);
    }
 
-   private void stressTest(boolean tx) throws Exception {
+   private void stressTest(boolean tx) throws Throwable {
       final List<MagicKey> keys = init();
       final CountDownLatch latch = new CountDownLatch(1);
       List<Updater> updaters = new ArrayList<Updater>(keys.size());

--- a/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
@@ -231,7 +231,7 @@ public class StateConsumerTest {
       assertFalse(stateConsumer.hasActiveTransfers());
 
       stateConsumer.onTopologyUpdate(new CacheTopology(1, ch2, null), false);
-      assertTrue(stateConsumer.hasActiveTransfers());
+      assertFalse(stateConsumer.hasActiveTransfers());
 
       stateConsumer.onTopologyUpdate(new CacheTopology(2, ch2, ch3), true);
       assertTrue(stateConsumer.hasActiveTransfers());


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3120
- Receiving state shouldn't finish the rebalance before all the added
  segments have a source.
- When all the owners of a segment leave and new owners are assigned, the
  new owners should not request state for those segments.
