### PR TITLE
ISPN-3108 Server compatibility minor adjustments

### DIFF
--- a/core/src/main/java/org/infinispan/DecoratedCache.java
+++ b/core/src/main/java/org/infinispan/DecoratedCache.java
@@ -156,7 +156,7 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
    public V put(K key, V value, long lifespan, TimeUnit unit) {
       Metadata metadata = new EmbeddedMetadata.Builder()
             .lifespan(lifespan, unit)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
+            .maxIdle(cacheImplementation.defaultMetadata.maxIdle(), MILLISECONDS)
             .build();
 
       return cacheImplementation.put(key, value, metadata, flags, classLoader.get());
@@ -166,7 +166,7 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
    public V putIfAbsent(K key, V value, long lifespan, TimeUnit unit) {
       Metadata metadata = new EmbeddedMetadata.Builder()
             .lifespan(lifespan, unit)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
+            .maxIdle(cacheImplementation.defaultMetadata.maxIdle(), MILLISECONDS)
             .build();
 
       return cacheImplementation.putIfAbsent(key, value, metadata, flags, classLoader.get());
@@ -176,7 +176,7 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
    public void putAll(Map<? extends K, ? extends V> map, long lifespan, TimeUnit unit) {
       Metadata metadata = new EmbeddedMetadata.Builder()
             .lifespan(lifespan, unit)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
+            .maxIdle(cacheImplementation.defaultMetadata.maxIdle(), MILLISECONDS)
             .build();
       cacheImplementation.putAll(map, metadata, flags, classLoader.get());
    }
@@ -185,7 +185,7 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
    public V replace(K key, V value, long lifespan, TimeUnit unit) {
       Metadata metadata = new EmbeddedMetadata.Builder()
             .lifespan(lifespan, unit)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
+            .maxIdle(cacheImplementation.defaultMetadata.maxIdle(), MILLISECONDS)
             .build();
 
       return cacheImplementation.replace(key, value, metadata, flags, classLoader.get());
@@ -195,7 +195,7 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
    public boolean replace(K key, V oldValue, V value, long lifespan, TimeUnit unit) {
       Metadata metadata = new EmbeddedMetadata.Builder()
             .lifespan(lifespan, unit)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
+            .maxIdle(cacheImplementation.defaultMetadata.maxIdle(), MILLISECONDS)
             .build();
 
       return cacheImplementation.replace(key, oldValue, value, metadata, flags, classLoader.get());
@@ -252,19 +252,14 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
 
    @Override
    public NotifyingFuture<V> putAsync(K key, V value) {
-      Metadata metadata = new EmbeddedMetadata.Builder()
-            .lifespan(cacheImplementation.defaultLifespan, MILLISECONDS)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
-            .build();
-
-      return cacheImplementation.putAsync(key, value, metadata, flags, classLoader.get());
+      return cacheImplementation.putAsync(key, value, cacheImplementation.defaultMetadata, flags, classLoader.get());
    }
 
    @Override
    public NotifyingFuture<V> putAsync(K key, V value, long lifespan, TimeUnit unit) {
       Metadata metadata = new EmbeddedMetadata.Builder()
             .lifespan(lifespan, unit)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
+            .maxIdle(cacheImplementation.defaultMetadata.maxIdle(), MILLISECONDS)
             .build();
 
       return cacheImplementation.putAsync(key, value, metadata, flags, classLoader.get());
@@ -282,18 +277,14 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
 
    @Override
    public NotifyingFuture<Void> putAllAsync(Map<? extends K, ? extends V> data) {
-      Metadata metadata = new EmbeddedMetadata.Builder()
-            .lifespan(cacheImplementation.defaultLifespan, MILLISECONDS)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
-            .build();
-      return cacheImplementation.putAllAsync(data, metadata, flags, classLoader.get());
+      return cacheImplementation.putAllAsync(data, cacheImplementation.defaultMetadata, flags, classLoader.get());
    }
 
    @Override
    public NotifyingFuture<Void> putAllAsync(Map<? extends K, ? extends V> data, long lifespan, TimeUnit unit) {
       Metadata metadata = new EmbeddedMetadata.Builder()
             .lifespan(lifespan, unit)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
+            .maxIdle(cacheImplementation.defaultMetadata.maxIdle(), MILLISECONDS)
             .build();
       return cacheImplementation.putAllAsync(data, metadata, flags, classLoader.get());
    }
@@ -314,19 +305,14 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
 
    @Override
    public NotifyingFuture<V> putIfAbsentAsync(K key, V value) {
-      Metadata metadata = new EmbeddedMetadata.Builder()
-            .lifespan(cacheImplementation.defaultLifespan, MILLISECONDS)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
-            .build();
-
-      return cacheImplementation.putIfAbsentAsync(key, value, metadata, flags, classLoader.get());
+      return cacheImplementation.putIfAbsentAsync(key, value, cacheImplementation.defaultMetadata, flags, classLoader.get());
    }
 
    @Override
    public NotifyingFuture<V> putIfAbsentAsync(K key, V value, long lifespan, TimeUnit unit) {
       Metadata metadata = new EmbeddedMetadata.Builder()
             .lifespan(lifespan, unit)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
+            .maxIdle(cacheImplementation.defaultMetadata.maxIdle(), MILLISECONDS)
             .build();
 
       return cacheImplementation.putIfAbsentAsync(key, value, metadata, flags, classLoader.get());
@@ -354,19 +340,14 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
 
    @Override
    public NotifyingFuture<V> replaceAsync(K key, V value) {
-      Metadata metadata = new EmbeddedMetadata.Builder()
-            .lifespan(cacheImplementation.defaultLifespan, MILLISECONDS)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
-            .build();
-
-      return cacheImplementation.replaceAsync(key, value, metadata, flags, classLoader.get());
+      return cacheImplementation.replaceAsync(key, value, cacheImplementation.defaultMetadata, flags, classLoader.get());
    }
 
    @Override
    public NotifyingFuture<V> replaceAsync(K key, V value, long lifespan, TimeUnit unit) {
       Metadata metadata = new EmbeddedMetadata.Builder()
             .lifespan(lifespan, unit)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
+            .maxIdle(cacheImplementation.defaultMetadata.maxIdle(), MILLISECONDS)
             .build();
 
       return cacheImplementation.replaceAsync(key, value, metadata, flags, classLoader.get());
@@ -384,19 +365,14 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
 
    @Override
    public NotifyingFuture<Boolean> replaceAsync(K key, V oldValue, V newValue) {
-      Metadata metadata = new EmbeddedMetadata.Builder()
-            .lifespan(cacheImplementation.defaultLifespan, MILLISECONDS)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
-            .build();
-
-      return cacheImplementation.replaceAsync(key, oldValue, newValue, metadata, flags, classLoader.get());
+      return cacheImplementation.replaceAsync(key, oldValue, newValue, cacheImplementation.defaultMetadata, flags, classLoader.get());
    }
 
    @Override
    public NotifyingFuture<Boolean> replaceAsync(K key, V oldValue, V newValue, long lifespan, TimeUnit unit) {
       Metadata metadata = new EmbeddedMetadata.Builder()
             .lifespan(lifespan, unit)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
+            .maxIdle(cacheImplementation.defaultMetadata.maxIdle(), MILLISECONDS)
             .build();
 
       return cacheImplementation.replaceAsync(key, oldValue, newValue, metadata, flags, classLoader.get());
@@ -439,12 +415,7 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
 
    @Override
    public V put(K key, V value) {
-      Metadata metadata = new EmbeddedMetadata.Builder()
-            .lifespan(cacheImplementation.defaultLifespan, MILLISECONDS)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
-            .build();
-
-      return cacheImplementation.put(key, value, metadata, flags, classLoader.get());
+      return cacheImplementation.put(key, value, cacheImplementation.defaultMetadata, flags, classLoader.get());
    }
 
    @Override
@@ -454,12 +425,7 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
 
    @Override
    public void putAll(Map<? extends K, ? extends V> m) {
-      Metadata metadata = new EmbeddedMetadata.Builder()
-            .lifespan(cacheImplementation.defaultLifespan, MILLISECONDS)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
-            .build();
-
-      cacheImplementation.putAll(m, metadata, flags, classLoader.get());
+      cacheImplementation.putAll(m, cacheImplementation.defaultMetadata, flags, classLoader.get());
    }
 
    @Override
@@ -484,12 +450,7 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
 
    @Override
    public V putIfAbsent(K key, V value) {
-      Metadata metadata = new EmbeddedMetadata.Builder()
-            .lifespan(cacheImplementation.defaultLifespan, MILLISECONDS)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
-            .build();
-
-      return cacheImplementation.putIfAbsent(key, value, metadata, flags, classLoader.get());
+      return cacheImplementation.putIfAbsent(key, value, cacheImplementation.defaultMetadata, flags, classLoader.get());
    }
 
    @Override
@@ -499,22 +460,12 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
 
    @Override
    public boolean replace(K key, V oldValue, V newValue) {
-      Metadata metadata = new EmbeddedMetadata.Builder()
-            .lifespan(cacheImplementation.defaultLifespan, MILLISECONDS)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
-            .build();
-
-      return cacheImplementation.replace(key, oldValue, newValue, metadata, flags, classLoader.get());
+      return cacheImplementation.replace(key, oldValue, newValue, cacheImplementation.defaultMetadata, flags, classLoader.get());
    }
 
    @Override
    public V replace(K key, V value) {
-      Metadata metadata = new EmbeddedMetadata.Builder()
-            .lifespan(cacheImplementation.defaultLifespan, MILLISECONDS)
-            .maxIdle(cacheImplementation.defaultMaxIdleTime, MILLISECONDS)
-            .build();
-
-      return cacheImplementation.replace(key, value, metadata, flags, classLoader.get());
+      return cacheImplementation.replace(key, value, cacheImplementation.defaultMetadata, flags, classLoader.get());
    }
 
    //Not exposed on interface

--- a/core/src/main/java/org/infinispan/EmbeddedMetadata.java
+++ b/core/src/main/java/org/infinispan/EmbeddedMetadata.java
@@ -72,10 +72,7 @@ public final class EmbeddedMetadata implements Metadata {
    @Override
    public Metadata.Builder builder() {
       // This method will be called rarely, so don't keep a reference!
-      return new Builder()
-            .lifespan(lifespan, TimeUnit.MILLISECONDS)
-            .maxIdle(lifespan, TimeUnit.MILLISECONDS)
-            .version(version);
+      return new Builder().lifespan(lifespan).maxIdle(lifespan).version(version);
    }
 
    @Override
@@ -125,10 +122,20 @@ public final class EmbeddedMetadata implements Metadata {
       }
 
       @Override
+      public Metadata.Builder lifespan(long time) {
+         return lifespan(time, TimeUnit.MILLISECONDS);
+      }
+
+      @Override
       public Metadata.Builder maxIdle(long time, TimeUnit unit) {
          maxIdle = time;
          maxIdleUnit = unit;
          return this;
+      }
+
+      @Override
+      public Metadata.Builder maxIdle(long time) {
+         return maxIdle(time, TimeUnit.MILLISECONDS);
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/Metadata.java
+++ b/core/src/main/java/org/infinispan/Metadata.java
@@ -77,28 +77,44 @@ public interface Metadata {
    public interface Builder {
 
       /**
-       * Set lifespan.
+       * Set lifespan time with a given time unit.
        *
        * @param time of lifespan
-       * @param unit of lifespan time
-       * @return a builder instance
+       * @param unit unit of time for lifespan time
+       * @return a builder instance with the lifespan time applied
        */
       Builder lifespan(long time, TimeUnit unit);
 
       /**
-       * Set max idle time.
+       * Set lifespan time assuming that the time unit is milliseconds.
+       *
+       * @param time of lifespan, in milliseconds
+       * @return a builder instance with the lifespan time applied
+       */
+      Builder lifespan(long time);
+
+      /**
+       * Set max idle time with a given time unit.
        *
        * @param time of max idle
        * @param unit of max idle time
-       * @return a builder instance
+       * @return a builder instance with the max idle time applied
        */
       Builder maxIdle(long time, TimeUnit unit);
+
+      /**
+       * Set max idle time assuming that the time unit is milliseconds.
+       *
+       * @param time of max idle, in milliseconds
+       * @return a builder instance with the max idle time applied
+       */
+      Builder maxIdle(long time);
 
       /**
        * Set version.
        *
        * @param version of the metadata
-       * @return a builder instance
+       * @return a builder instance with the version applied
        */
       Builder version(EntryVersion version);
 

--- a/core/src/main/java/org/infinispan/commands/AbstractFlagAffectedCommand.java
+++ b/core/src/main/java/org/infinispan/commands/AbstractFlagAffectedCommand.java
@@ -19,6 +19,7 @@
 
 package org.infinispan.commands;
 
+import org.infinispan.Metadata;
 import org.infinispan.context.Flag;
 
 import java.util.Arrays;
@@ -70,4 +71,10 @@ public abstract class AbstractFlagAffectedCommand implements FlagAffectedCommand
    public void setTopologyId(int topologyId) {
       this.topologyId = topologyId;
    }
+
+   @Override
+   public Metadata getMetadata() {
+      return null;
+   }
+
 }

--- a/core/src/main/java/org/infinispan/commands/FlagAffectedCommand.java
+++ b/core/src/main/java/org/infinispan/commands/FlagAffectedCommand.java
@@ -36,7 +36,7 @@ import org.infinispan.context.Flag;
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
  * @since 5.0
  */
-public interface FlagAffectedCommand extends VisitableCommand, TopologyAffectedCommand {
+public interface FlagAffectedCommand extends VisitableCommand, TopologyAffectedCommand, MetadataAwareCommand {
    
    /**
     * @return the Flags which where set in the context - only valid to invoke after {@link #setFlags(Set)}

--- a/core/src/main/java/org/infinispan/commands/control/LockControlCommand.java
+++ b/core/src/main/java/org/infinispan/commands/control/LockControlCommand.java
@@ -22,6 +22,7 @@
  */
 package org.infinispan.commands.control;
 
+import org.infinispan.Metadata;
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.Visitor;
 import org.infinispan.commands.tx.AbstractTransactionBoundaryCommand;
@@ -242,6 +243,11 @@ public class LockControlCommand extends AbstractTransactionBoundaryCommand imple
          this.flags = EnumSet.copyOf(Arrays.asList(flags));
       else
          this.flags.addAll(Arrays.asList(flags));
+   }
+
+   @Override
+   public Metadata getMetadata() {
+      return null;
    }
 
 }

--- a/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
@@ -22,6 +22,7 @@
  */
 package org.infinispan.commands.remote;
 
+import org.infinispan.Metadata;
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.Visitor;
@@ -256,4 +257,10 @@ public class ClusteredGetCommand extends BaseRpcCommand implements FlagAffectedC
    public boolean ignoreCommandOnStatus(ComponentStatus status) {
       return false;
    }
+
+   @Override
+   public Metadata getMetadata() {
+      return null;
+   }
+
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/DataContainerConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/DataContainerConfiguration.java
@@ -52,11 +52,13 @@ public class DataContainerConfiguration extends AbstractTypedPropertiesConfigura
       return dataContainer;
    }
 
-   public Equivalence keyEquivalence() {
+   @SuppressWarnings("unchecked")
+   public <K> Equivalence<K> keyEquivalence() {
       return keyEquivalence;
    }
 
-   public Equivalence valueEquivalence() {
+   @SuppressWarnings("unchecked")
+   public <V> Equivalence<V> valueEquivalence() {
       return valueEquivalence;
    }
 

--- a/core/src/main/java/org/infinispan/configuration/cache/DataContainerConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/DataContainerConfigurationBuilder.java
@@ -36,8 +36,8 @@ public class DataContainerConfigurationBuilder extends AbstractConfigurationChil
 
    // No default here. DataContainerFactory figures out default.
    private DataContainer dataContainer;
-   private Equivalence keyEquivalence = AnyEquivalence.OBJECT;
-   private Equivalence valueEquivalence = AnyEquivalence.OBJECT;
+   private Equivalence keyEquivalence = AnyEquivalence.getInstance();
+   private Equivalence valueEquivalence = AnyEquivalence.getInstance();
    // TODO: What are properties used for? Is it just legacy?
    private Properties properties = new Properties();
 
@@ -88,7 +88,7 @@ public class DataContainerConfigurationBuilder extends AbstractConfigurationChil
     *                     key types.
     * @return this configuration builder
     */
-   public DataContainerConfigurationBuilder keyEquivalence(Equivalence keyEquivalence) {
+   public <K> DataContainerConfigurationBuilder keyEquivalence(Equivalence<K> keyEquivalence) {
       this.keyEquivalence = keyEquivalence;
       return this;
    }
@@ -103,7 +103,7 @@ public class DataContainerConfigurationBuilder extends AbstractConfigurationChil
     *                       value types.
     * @return this configuration builder
     */
-   public DataContainerConfigurationBuilder valueEquivalence(Equivalence valueEquivalence) {
+   public <V> DataContainerConfigurationBuilder valueEquivalence(Equivalence<V> valueEquivalence) {
       this.valueEquivalence = valueEquivalence;
       return this;
    }

--- a/core/src/main/java/org/infinispan/container/EntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/EntryFactoryImpl.java
@@ -27,7 +27,6 @@ import org.infinispan.Metadata;
 import org.infinispan.atomic.Delta;
 import org.infinispan.atomic.DeltaAware;
 import org.infinispan.commands.FlagAffectedCommand;
-import org.infinispan.commands.MetadataAwareCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.entries.CacheEntry;
@@ -114,7 +113,7 @@ public class EntryFactoryImpl implements EntryFactory {
    @Override
    public final  MVCCEntry wrapEntryForReplace(InvocationContext ctx, ReplaceCommand cmd) throws InterruptedException {
       Object key = cmd.getKey();
-      MVCCEntry mvccEntry = wrapEntry(ctx, key, extractMetadata(cmd));
+      MVCCEntry mvccEntry = wrapEntry(ctx, key, cmd.getMetadata());
       if (mvccEntry == null) {
          // make sure we record this! Null value since this is a forced lock on the key
          ctx.putLookedUpEntry(key, null);
@@ -154,7 +153,7 @@ public class EntryFactoryImpl implements EntryFactory {
       CacheEntry cacheEntry = getFromContext(ctx, key);
       MVCCEntry mvccEntry;
       if (cacheEntry != null && cacheEntry.isNull()) cacheEntry = null;
-      Metadata providedMetadata = extractMetadata(cmd);
+      Metadata providedMetadata = cmd.getMetadata();
       if (cacheEntry != null) {
          mvccEntry = wrapMvccEntryForPut(ctx, key, cacheEntry, providedMetadata);
          mvccEntry.undelete(undeleteIfNeeded);
@@ -298,11 +297,6 @@ public class EntryFactoryImpl implements EntryFactory {
    
    private DeltaAwareCacheEntry createWrappedDeltaEntry(Object key, DeltaAware deltaAware, CacheEntry entry) {
       return new DeltaAwareCacheEntry(key,deltaAware, entry);
-   }
-
-   private Metadata extractMetadata(FlagAffectedCommand cmd) {
-      return cmd instanceof MetadataAwareCommand
-            ? ((MetadataAwareCommand) cmd).getMetadata() : null;
    }
 
 }

--- a/core/src/main/java/org/infinispan/container/InternalEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/InternalEntryFactoryImpl.java
@@ -91,9 +91,7 @@ public class InternalEntryFactoryImpl implements InternalEntryFactory {
       } else {
          // If no metadata passed, assumed embedded metadata
          Metadata metadata = new EmbeddedMetadata.Builder()
-               .lifespan(lifespan, TimeUnit.MILLISECONDS)
-               .maxIdle(maxIdle, TimeUnit.MILLISECONDS)
-               .version(version).build();
+               .lifespan(lifespan).maxIdle(maxIdle).version(version).build();
          if (lifespan < 0 && maxIdle < 0) return new MetadataImmortalCacheEntry(key, value, metadata);
          if (lifespan > -1 && maxIdle < 0) return new MetadataMortalCacheEntry(key, value, metadata, created);
          if (lifespan < 0 && maxIdle > -1) return new MetadataTransientCacheEntry(key, value, metadata, lastUsed);

--- a/core/src/main/java/org/infinispan/container/entries/MortalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/MortalCacheEntry.java
@@ -134,8 +134,7 @@ public class MortalCacheEntry extends AbstractInternalCacheEntry {
 
    @Override
    public Metadata getMetadata() {
-      return new EmbeddedMetadata.Builder()
-            .lifespan(cacheValue.getLifespan(), TimeUnit.MILLISECONDS).build();
+      return new EmbeddedMetadata.Builder().lifespan(cacheValue.getLifespan()).build();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/container/entries/TransientMortalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/TransientMortalCacheEntry.java
@@ -156,8 +156,8 @@ public class TransientMortalCacheEntry extends AbstractInternalCacheEntry {
    @Override
    public Metadata getMetadata() {
       return new EmbeddedMetadata.Builder()
-            .lifespan(cacheValue.getLifespan(), TimeUnit.MILLISECONDS)
-            .maxIdle(cacheValue.getMaxIdle(), TimeUnit.MILLISECONDS).build();
+            .lifespan(cacheValue.getLifespan())
+            .maxIdle(cacheValue.getMaxIdle()).build();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/context/impl/LocalTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/LocalTxInvocationContext.java
@@ -50,12 +50,12 @@ import java.util.Set;
  */
 public class LocalTxInvocationContext extends AbstractTxInvocationContext {
 
-   public final Map<Object,CacheEntry> emptyEntryMap;
+   public final Map<Object, CacheEntry> emptyEntryMap;
 
    private LocalTransaction localTransaction;
 
-   public LocalTxInvocationContext(Equivalence keyEq) {
-      emptyEntryMap = CollectionFactory.makeMap(0, keyEq, AnyEquivalence.OBJECT);
+   public LocalTxInvocationContext(Equivalence<Object> keyEq) {
+      emptyEntryMap = CollectionFactory.makeMap(0, keyEq, AnyEquivalence.<CacheEntry>getInstance());
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/context/impl/NonTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/NonTxInvocationContext.java
@@ -45,16 +45,16 @@ public class NonTxInvocationContext extends AbstractInvocationContext {
 
    protected Set<Object> lockedKeys;
 
-   private final Equivalence keyEq;
+   private final Equivalence<Object> keyEq;
 
-   public NonTxInvocationContext(int numEntries, boolean local, Equivalence keyEq) {
-      lookedUpEntries = CollectionFactory.makeMap(numEntries, keyEq, AnyEquivalence.OBJECT);
+   public NonTxInvocationContext(int numEntries, boolean local, Equivalence<Object> keyEq) {
+      lookedUpEntries = CollectionFactory.makeMap(numEntries, keyEq, AnyEquivalence.<CacheEntry>getInstance());
       setOriginLocal(local);
       this.keyEq = keyEq;
    }
 
-   public NonTxInvocationContext(Equivalence keyEq) {
-      lookedUpEntries = CollectionFactory.makeMap(INITIAL_CAPACITY, keyEq, AnyEquivalence.OBJECT);
+   public NonTxInvocationContext(Equivalence<Object> keyEq) {
+      lookedUpEntries = CollectionFactory.makeMap(INITIAL_CAPACITY, keyEq, AnyEquivalence.<CacheEntry>getInstance());
       this.keyEq = keyEq;
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/CacheLoaderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheLoaderInterceptor.java
@@ -24,7 +24,6 @@ package org.infinispan.interceptors;
 
 import org.infinispan.Metadata;
 import org.infinispan.commands.FlagAffectedCommand;
-import org.infinispan.commands.MetadataAwareCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.write.*;
 import org.infinispan.configuration.cache.CacheStoreConfiguration;
@@ -86,6 +85,7 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
    }
 
    @Start(priority = 15)
+   @SuppressWarnings("unused")
    protected void startInterceptor() {
       loader = clm.getCacheLoader();
    }
@@ -237,7 +237,7 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
          sendNotification(key, value, true, ctx, cmd);
          entry.setValue(value);
 
-         Metadata metadata = extractMetadata(cmd);
+         Metadata metadata = cmd.getMetadata();
          Metadata loadedMetadata = loadedEntry.getMetadata();
          if (metadata != null && loadedMetadata != null)
             metadata = metadata.builder().read(loadedMetadata).build();
@@ -270,6 +270,7 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
          displayName = "Number of cache store loads",
          measurementType = MeasurementType.TRENDSUP
    )
+   @SuppressWarnings("unused")
    public long getCacheLoaderLoads() {
       return cacheLoads.get();
    }
@@ -279,6 +280,7 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
          displayName = "Number of cache store load misses",
          measurementType = MeasurementType.TRENDSUP
    )
+   @SuppressWarnings("unused")
    public long getCacheLoaderMisses() {
       return cacheMisses.get();
    }
@@ -315,10 +317,12 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
          return InfinispanCollections.emptySet();
       }
    }
+
    @ManagedOperation(
          description = "Disable all cache loaders of a given type, where type is a fully qualified class name of the cache loader to disable",
          displayName = "Disable all cache loaders of a given type"
    )
+   @SuppressWarnings("unused")
    /**
     * Disables a cache loader of a given type, where type is the fully qualified class name of a {@link CacheLoader} implementation.
     *
@@ -333,11 +337,6 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
 
    public void disableInterceptor() {
       enabled = false;
-   }
-
-   private Metadata extractMetadata(FlagAffectedCommand cmd) {
-      return cmd instanceof MetadataAwareCommand
-            ? ((MetadataAwareCommand) cmd).getMetadata() : null;
    }
 
 }

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
@@ -86,8 +86,7 @@ public class L1NonTxInterceptor extends BaseRpcInterceptor {
             // Make a copy of the metadata stored internally, adjust
             // lifespan/maxIdle settings and send them a modification
             Metadata newMetadata = ice.getMetadata().builder()
-                  .lifespan(lifespan, TimeUnit.MILLISECONDS)
-                  .maxIdle(-1, TimeUnit.MILLISECONDS).build();
+                  .lifespan(lifespan).maxIdle(-1).build();
             PutKeyValueCommand put = cf.buildPutKeyValueCommand(ice.getKey(), ice.getValue(),
                   newMetadata, Collections.singleton(Flag.CACHE_MODE_LOCAL));
             lockAndWrap(ctx, command.getKey(), ice, command);

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -389,8 +389,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
                   // Make a copy of the metadata stored internally, adjust
                   // lifespan/maxIdle settings and send them a modification
                   Metadata newMetadata = ice.getMetadata().builder()
-                        .lifespan(lifespan, TimeUnit.MILLISECONDS)
-                        .maxIdle(-1, TimeUnit.MILLISECONDS).build();
+                        .lifespan(lifespan).maxIdle(-1).build();
                   PutKeyValueCommand put = cf.buildPutKeyValueCommand(
                         ice.getKey(), ice.getValue(), newMetadata, command.getFlags());
                   lockAndWrap(ctx, key, ice, command);

--- a/core/src/main/java/org/infinispan/interceptors/locking/ClusteringDependentLogic.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/ClusteringDependentLogic.java
@@ -380,8 +380,7 @@ public interface ClusteringDependentLogic {
                   // transform for L1
                   if (entry.getLifespan() < 0 || entry.getLifespan() > configuration.clustering().l1().lifespan()) {
                      Metadata newMetadata = entry.getMetadata().builder()
-                           .lifespan(configuration.clustering().l1().lifespan(),
-                                 TimeUnit.MILLISECONDS)
+                           .lifespan(configuration.clustering().l1().lifespan())
                            .build();
                      entry.setMetadata(newMetadata);
                   }

--- a/core/src/main/java/org/infinispan/transaction/synchronization/SyncLocalTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/synchronization/SyncLocalTransaction.java
@@ -24,6 +24,7 @@ package org.infinispan.transaction.synchronization;
 
 import org.infinispan.transaction.LocalTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.Equivalence;
 
 import javax.transaction.Transaction;
 
@@ -35,8 +36,9 @@ import javax.transaction.Transaction;
  */
 public class SyncLocalTransaction extends LocalTransaction {
 
-   public SyncLocalTransaction(Transaction transaction, GlobalTransaction tx, boolean implicitTransaction, int topologyId) {
-      super(transaction, tx, implicitTransaction, topologyId);
+   public SyncLocalTransaction(Transaction transaction, GlobalTransaction tx,
+         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence) {
+      super(transaction, tx, implicitTransaction, topologyId, keyEquivalence);
    }
 
    private boolean enlisted;

--- a/core/src/main/java/org/infinispan/transaction/xa/LocalXaTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/LocalXaTransaction.java
@@ -24,6 +24,7 @@ package org.infinispan.transaction.xa;
 
 import org.infinispan.transaction.LocalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoverableTransactionIdentifier;
+import org.infinispan.util.Equivalence;
 
 import javax.transaction.Transaction;
 import javax.transaction.xa.Xid;
@@ -38,8 +39,9 @@ public class LocalXaTransaction extends LocalTransaction {
 
    private Xid xid;
 
-   public LocalXaTransaction(Transaction transaction, GlobalTransaction tx, boolean implicitTransaction, int topologyId) {
-      super(transaction, tx, implicitTransaction, topologyId);
+   public LocalXaTransaction(Transaction transaction, GlobalTransaction tx,
+         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence) {
+      super(transaction, tx, implicitTransaction, topologyId, keyEquivalence);
    }
 
    public void setXid(Xid xid) {

--- a/core/src/main/java/org/infinispan/transaction/xa/TransactionFactory.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/TransactionFactory.java
@@ -39,6 +39,7 @@ import org.infinispan.transaction.xa.recovery.RecoveryAwareGlobalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryAwareLocalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryAwareRemoteTransaction;
 import org.infinispan.util.ClusterIdGenerator;
+import org.infinispan.util.Equivalence;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -61,13 +62,15 @@ public class TransactionFactory {
    private ClusterIdGenerator clusterIdGenerator;
    private boolean isClustered;
    private RpcManager rpcManager;
+   private Equivalence<Object> keyEquivalence;
 
    public enum TxFactoryEnum {
 
       DLD_RECOVERY_XA {
          @Override
-         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId) {
-            return new RecoveryAwareLocalTransaction(tx, gtx, implicitTransaction, topologyId);
+         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId,
+               Equivalence<Object> keyEquivalence) {
+            return new RecoveryAwareLocalTransaction(tx, gtx, implicitTransaction, topologyId, keyEquivalence);
          }
 
          @Override
@@ -83,20 +86,21 @@ public class TransactionFactory {
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId) {
-            return new RecoveryAwareRemoteTransaction(modifications, tx, topologyId);
+         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+            return new RecoveryAwareRemoteTransaction(modifications, tx, topologyId, keyEquivalence);
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId) {
-            return new RecoveryAwareRemoteTransaction(tx, topologyId);
+         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+            return new RecoveryAwareRemoteTransaction(tx, topologyId, keyEquivalence);
          }
       },
 
       DLD_NORECOVERY_XA {
          @Override
-         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId) {
-            return new LocalXaTransaction(tx, gtx, implicitTransaction, topologyId);
+         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId,
+               Equivalence<Object> keyEquivalence) {
+            return new LocalXaTransaction(tx, gtx, implicitTransaction, topologyId, keyEquivalence);
          }
 
          @Override
@@ -110,20 +114,21 @@ public class TransactionFactory {
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId) {
-            return new RemoteTransaction(modifications, tx, topologyId);
+         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+            return new RemoteTransaction(modifications, tx, topologyId, keyEquivalence);
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId) {
-            return new RemoteTransaction(tx, topologyId);
+         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+            return new RemoteTransaction(tx, topologyId, keyEquivalence);
          }
       },
 
       DLD_NORECOVERY_NOXA {
          @Override
-         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId) {
-            return new SyncLocalTransaction(tx, gtx, implicitTransaction, topologyId);
+         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId,
+               Equivalence<Object> keyEquivalence) {
+            return new SyncLocalTransaction(tx, gtx, implicitTransaction, topologyId, keyEquivalence);
          }
 
          @Override
@@ -137,19 +142,19 @@ public class TransactionFactory {
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId) {
-            return new RemoteTransaction(modifications, tx, topologyId);
+         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+            return new RemoteTransaction(modifications, tx, topologyId, keyEquivalence);
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId) {
-            return new RemoteTransaction(tx, topologyId);
+         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+            return new RemoteTransaction(tx, topologyId, keyEquivalence);
          }
       },
       NODLD_RECOVERY_XA {
          @Override
-         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId) {
-            return new RecoveryAwareLocalTransaction(tx, gtx, implicitTransaction, topologyId);
+         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence) {
+            return new RecoveryAwareLocalTransaction(tx, gtx, implicitTransaction, topologyId, keyEquivalence);
          }
 
          @Override
@@ -165,19 +170,20 @@ public class TransactionFactory {
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId) {
-            return new RecoveryAwareRemoteTransaction(modifications, tx, topologyId);
+         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+            return new RecoveryAwareRemoteTransaction(modifications, tx, topologyId, keyEquivalence);
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId) {
-            return new RecoveryAwareRemoteTransaction(tx, topologyId);
+         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+            return new RecoveryAwareRemoteTransaction(tx, topologyId, keyEquivalence);
          }
       },
       NODLD_NORECOVERY_XA {
          @Override
-         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId) {
-            return new LocalXaTransaction(tx, gtx, implicitTransaction, topologyId);
+         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId,
+               Equivalence<Object> keyEquivalence) {
+            return new LocalXaTransaction(tx, gtx, implicitTransaction, topologyId, keyEquivalence);
          }
 
          @Override
@@ -191,19 +197,20 @@ public class TransactionFactory {
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId) {
-            return new RemoteTransaction(modifications, tx, topologyId);
+         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+            return new RemoteTransaction(modifications, tx, topologyId, keyEquivalence);
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId) {
-            return new RemoteTransaction(tx, topologyId);
+         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+            return new RemoteTransaction(tx, topologyId, keyEquivalence);
          }
       },
       NODLD_NORECOVERY_NOXA {
          @Override
-         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId) {
-            return new SyncLocalTransaction(tx, gtx, implicitTransaction, topologyId);
+         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId,
+               Equivalence<Object> keyEquivalence) {
+            return new SyncLocalTransaction(tx, gtx, implicitTransaction, topologyId, keyEquivalence);
          }
 
          @Override
@@ -217,18 +224,19 @@ public class TransactionFactory {
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId) {
-            return new RemoteTransaction(modifications, tx, topologyId);
+         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+            return new RemoteTransaction(modifications, tx, topologyId, keyEquivalence);
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId) {
-            return new RemoteTransaction(tx, topologyId);
+         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+            return new RemoteTransaction(tx, topologyId, keyEquivalence);
          }
       };
 
 
-      public abstract LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId);
+      public abstract LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId,
+            Equivalence<Object> keyEquivalence);
       public abstract GlobalTransaction newGlobalTransaction(Address addr, boolean remote, ClusterIdGenerator clusterIdGenerator, boolean clustered);
       public abstract GlobalTransaction newGlobalTransaction();
 
@@ -246,9 +254,9 @@ public class TransactionFactory {
        */
       private final Random rnd = new Random();
 
-      public abstract RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId);
+      public abstract RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence);
 
-      public abstract RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId);
+      public abstract RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence);
    }
 
 
@@ -261,15 +269,15 @@ public class TransactionFactory {
    }
 
    public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId) {
-      return txFactoryEnum.newLocalTransaction(tx, gtx, implicitTransaction, topologyId);
+      return txFactoryEnum.newLocalTransaction(tx, gtx, implicitTransaction, topologyId, keyEquivalence);
    }
 
    public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId) {
-      return txFactoryEnum.newRemoteTransaction(modifications, tx, topologyId);
+      return txFactoryEnum.newRemoteTransaction(modifications, tx, topologyId, keyEquivalence);
    }
 
    public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId) {
-      return txFactoryEnum.newRemoteTransaction(tx, topologyId);
+      return txFactoryEnum.newRemoteTransaction(tx, topologyId, keyEquivalence);
    }
 
    @Inject
@@ -291,6 +299,7 @@ public class TransactionFactory {
          Transport transport = rpcManager != null ? rpcManager.getTransport() : null;
          clusterIdGenerator = new ClusterIdGenerator(cm, transport);
       }
+      keyEquivalence = configuration.dataContainer().keyEquivalence();
    }
 
    public void init(boolean dldEnabled, boolean recoveryEnabled, boolean xa, boolean batchingEnabled) {

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareLocalTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareLocalTransaction.java
@@ -24,6 +24,7 @@ package org.infinispan.transaction.xa.recovery;
 
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.LocalXaTransaction;
+import org.infinispan.util.Equivalence;
 
 import javax.transaction.Transaction;
 
@@ -39,8 +40,9 @@ public class RecoveryAwareLocalTransaction extends LocalXaTransaction implements
 
    private boolean completionFailed;
 
-   public RecoveryAwareLocalTransaction(Transaction transaction, GlobalTransaction tx, boolean implicitTransaction, int topologyId) {
-      super(transaction, tx, implicitTransaction, topologyId);
+   public RecoveryAwareLocalTransaction(Transaction transaction, GlobalTransaction tx,
+         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence) {
+      super(transaction, tx, implicitTransaction, topologyId, keyEquivalence);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareRemoteTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareRemoteTransaction.java
@@ -26,6 +26,7 @@ import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.RemoteTransaction;
+import org.infinispan.util.Equivalence;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -48,12 +49,12 @@ public class RecoveryAwareRemoteTransaction extends RemoteTransaction implements
 
    private Integer status;
 
-   public RecoveryAwareRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId) {
-      super(modifications, tx, topologyId);
+   public RecoveryAwareRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+      super(modifications, tx, topologyId, keyEquivalence);
    }
 
-   public RecoveryAwareRemoteTransaction(GlobalTransaction tx, int topologyId) {
-      super(tx, topologyId);
+   public RecoveryAwareRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+      super(tx, topologyId, keyEquivalence);
    }
 
    /**

--- a/core/src/main/java/org/infinispan/util/AnyEquivalence.java
+++ b/core/src/main/java/org/infinispan/util/AnyEquivalence.java
@@ -31,7 +31,7 @@ package org.infinispan.util;
  */
 public final class AnyEquivalence<T> implements Equivalence<T> {
 
-   public static AnyEquivalence<Object> OBJECT = new AnyEquivalence<Object>();
+   private static AnyEquivalence<Object> OBJECT = new AnyEquivalence<Object>();
 
    public static AnyEquivalence<String> STRING = new AnyEquivalence<String>();
 
@@ -48,6 +48,10 @@ public final class AnyEquivalence<T> implements Equivalence<T> {
    public static AnyEquivalence<Float> FLOAT = new AnyEquivalence<Float>();
 
    public static AnyEquivalence<Boolean> BOOLEAN = new AnyEquivalence<Boolean>();
+
+   // To avoid instantiation
+   private AnyEquivalence() {
+   }
 
    @Override
    public int hashCode(Object obj) {
@@ -71,8 +75,13 @@ public final class AnyEquivalence<T> implements Equivalence<T> {
 
    @Override
    @SuppressWarnings("unchecked")
-   public int compare(Object obj, Object otherObj) {
-      return ((Comparable<Object>) obj).compareTo(otherObj);
+   public int compare(T obj, T otherObj) {
+      return ((Comparable<T>) obj).compareTo(otherObj);
+   }
+
+   @SuppressWarnings("unchecked")
+   public static <T> AnyEquivalence<T> getInstance() {
+      return (AnyEquivalence<T>) OBJECT;
    }
 
 }

--- a/core/src/main/java/org/infinispan/util/ByteArrayEquivalence.java
+++ b/core/src/main/java/org/infinispan/util/ByteArrayEquivalence.java
@@ -26,7 +26,7 @@ package org.infinispan.util;
 import java.util.Arrays;
 
 /**
- * A compare function for byte arrays.
+ * A compare function for unsigned byte arrays.
  *
  * @author Galder Zamarreño
  * @since 5.3
@@ -56,12 +56,19 @@ public class ByteArrayEquivalence implements Equivalence<byte[]> {
 
    @Override
    public boolean isComparable(Object obj) {
-      return false;
+      return true;
    }
 
    @Override
-   public int compare(Object obj, Object otherObj) {
-      return 0; // irrelevant
+   public int compare(byte[] obj, byte[] otherObj) {
+      // Assumes unsigned byte arrays
+      int minLength = Math.min(obj.length, otherObj.length);
+      for (int i = 0; i < minLength; i++) {
+         int compareResult = obj[i] - otherObj[i];
+         if (compareResult != 0)
+            return compareResult;
+      }
+      return obj.length - otherObj.length;
    }
 
 }

--- a/core/src/main/java/org/infinispan/util/CollectionFactory.java
+++ b/core/src/main/java/org/infinispan/util/CollectionFactory.java
@@ -74,25 +74,25 @@ public class CollectionFactory {
       @Override
       public <K, V> ConcurrentMap<K, V> createConcurrentMap() {
          return new EquivalentConcurrentHashMapV8<K, V>(
-               new AnyEquivalence<K>(), new AnyEquivalence<V>());
+               AnyEquivalence.<K>getInstance(), AnyEquivalence.<V>getInstance());
       }
 
       @Override
       public <K, V> ConcurrentMap<K, V> createConcurrentMap(int initialCapacity) {
          return new EquivalentConcurrentHashMapV8<K, V>(initialCapacity,
-               new AnyEquivalence<K>(), new AnyEquivalence<V>());
+               AnyEquivalence.<K>getInstance(), AnyEquivalence.<V>getInstance());
       }
 
       @Override
       public <K, V> ConcurrentMap<K, V> createConcurrentMap(int initialCapacity, int concurrencyLevel) {
          return new EquivalentConcurrentHashMapV8<K, V>(initialCapacity, 0.75f,
-               concurrencyLevel, new AnyEquivalence<K>(), new AnyEquivalence<V>());
+               concurrencyLevel, AnyEquivalence.<K>getInstance(), AnyEquivalence.<V>getInstance());
       }
 
       @Override
       public <K, V> ConcurrentMap<K, V> createConcurrentMap(int initialCapacity, float loadFactor, int concurrencyLevel) {
          return new EquivalentConcurrentHashMapV8<K, V>(initialCapacity, loadFactor,
-               concurrencyLevel, new AnyEquivalence<K>(), new AnyEquivalence<V>());
+               concurrencyLevel, AnyEquivalence.<K>getInstance(), AnyEquivalence.<V>getInstance());
       }
    }
    
@@ -188,6 +188,14 @@ public class CollectionFactory {
          return new HashMap<K, V>(initialCapacity);
    }
 
+   public static <K, V> Map<K, V> makeMap(
+         Map<? extends K, ? extends V> entries, Equivalence<K> keyEq, Equivalence<V> valueEq) {
+      if (requiresEquivalent(keyEq, valueEq))
+         return new EquivalentHashMap<K, V>(entries, keyEq, valueEq);
+      else
+         return new HashMap<K, V>(entries);
+   }
+
    public static <T> Set<T> makeSet(Equivalence<T> entryEq) {
       if (requiresEquivalent(entryEq))
          return new EquivalentHashSet<T>(entryEq);
@@ -204,11 +212,12 @@ public class CollectionFactory {
 
    private static <K, V> boolean requiresEquivalent(
          Equivalence<K> keyEq, Equivalence<V> valueEq) {
-      return keyEq != AnyEquivalence.OBJECT || valueEq != AnyEquivalence.OBJECT;
+      AnyEquivalence<Object> instance = AnyEquivalence.getInstance();
+      return keyEq != instance || valueEq != instance;
    }
 
    private static <T> boolean requiresEquivalent(Equivalence<T> typeEq) {
-      return typeEq != AnyEquivalence.OBJECT;
+      return typeEq != AnyEquivalence.getInstance();
    }
 
 }

--- a/core/src/main/java/org/infinispan/util/Equivalence.java
+++ b/core/src/main/java/org/infinispan/util/Equivalence.java
@@ -97,6 +97,6 @@ public interface Equivalence<T> extends Serializable {
     *         first object is less than, equal to, or greater than the
     *         second object
     */
-   int compare(Object obj, Object otherObj); // For future support for objects that are not comparable, i.e. arrays
+   int compare(T obj, T otherObj); // For future support for objects that are not comparable, i.e. arrays
 
 }

--- a/core/src/main/java/org/infinispan/util/EquivalentHashMap.java
+++ b/core/src/main/java/org/infinispan/util/EquivalentHashMap.java
@@ -91,6 +91,35 @@ public class EquivalentHashMap<K, V> extends AbstractMap<K, V> {
       this.valueEq = valueEq;
    }
 
+   @SuppressWarnings("unchecked")
+   public EquivalentHashMap(
+         Map<? extends K, ? extends V> map, Equivalence<K> keyEq, Equivalence<V> valueEq) {
+      if (map instanceof EquivalentHashMap) {
+         EquivalentHashMap<? extends K, ? extends V> equivalentMap =
+               (EquivalentHashMap<? extends K, ? extends V>) map;
+         this.table = (Node<K, V>[]) equivalentMap.table.clone();
+         this.loadFactor = equivalentMap.loadFactor;
+         this.size = equivalentMap.size;
+         this.threshold = equivalentMap.threshold;
+      } else {
+         this.loadFactor = DEFAULT_LOAD_FACTOR;
+         init(map.size(), this.loadFactor);
+         putAll(map);
+      }
+      this.keyEq = keyEq;
+      this.valueEq = valueEq;
+   }
+
+   @SuppressWarnings("unchecked")
+   private void init(int initialCapacity, float loadFactor) {
+      int c = 1;
+      for (; c < initialCapacity; c <<= 1) ;
+
+      this.table = new Node[c];
+
+      threshold = (int) (c * loadFactor);
+   }
+
    @Override
    public int size() {
       return size;

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/containers/AbstractPerEntryLockContainer.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/containers/AbstractPerEntryLockContainer.java
@@ -46,7 +46,7 @@ public abstract class AbstractPerEntryLockContainer<L extends RefCountingLock> e
 
    protected AbstractPerEntryLockContainer(int concurrencyLevel) {
       locks = new EquivalentConcurrentHashMapV8<Object, L>(
-            16, concurrencyLevel, AnyEquivalence.OBJECT, new AnyEquivalence<L>());
+            16, concurrencyLevel, AnyEquivalence.getInstance(), AnyEquivalence.<L>getInstance());
    }
 
    protected abstract L newLock();

--- a/core/src/test/java/org/infinispan/api/MetadataAPITest.java
+++ b/core/src/test/java/org/infinispan/api/MetadataAPITest.java
@@ -220,8 +220,18 @@ public class MetadataAPITest extends SingleCacheManagerTest {
       }
 
       @Override
+      public Builder lifespan(long time) {
+         return lifespan(time, TimeUnit.MILLISECONDS);
+      }
+
+      @Override
       public Builder maxIdle(long time, TimeUnit unit) {
          return new CustomMetadata(lifespan, unit.toMillis(time));
+      }
+
+      @Override
+      public Builder maxIdle(long time) {
+         return maxIdle(time, TimeUnit.MILLISECONDS);
       }
 
       @Override

--- a/core/src/test/java/org/infinispan/configuration/XmlFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/XmlFileParsingTest.java
@@ -354,7 +354,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
          @Override
          public void call() {
             Configuration cfg = cm.getDefaultCacheConfiguration();
-            assert cfg.dataContainer().keyEquivalence() instanceof ByteArrayEquivalence;
+            assert cfg.dataContainer().<byte[]>keyEquivalence() instanceof ByteArrayEquivalence;
             assert cfg.dataContainer().valueEquivalence() instanceof AnyEquivalence;
          }
       });
@@ -370,8 +370,8 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
          @Override
          public void call() {
             Configuration cfg = cm.getDefaultCacheConfiguration();
-            assert cfg.dataContainer().keyEquivalence() instanceof ByteArrayEquivalence;
-            assert cfg.dataContainer().valueEquivalence() instanceof ByteArrayEquivalence;
+            assert cfg.dataContainer().<byte[]>keyEquivalence() instanceof ByteArrayEquivalence;
+            assert cfg.dataContainer().<byte[]>valueEquivalence() instanceof ByteArrayEquivalence;
          }
       });
    }

--- a/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
+++ b/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
@@ -57,7 +57,7 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
    }
 
    protected DataContainer createContainer() {
-      DefaultDataContainer dc = new DefaultDataContainer(16, AnyEquivalence.OBJECT, AnyEquivalence.OBJECT);
+      DefaultDataContainer dc = new DefaultDataContainer(16, AnyEquivalence.getInstance(), AnyEquivalence.getInstance());
       dc.initialize(null, null, new InternalEntryFactoryImpl(), null, null);
       return dc;
    }

--- a/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
@@ -228,7 +228,7 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
    public void testReplicableCommandsMarshalling() throws Exception {
       String cacheName = EmbeddedCacheManager.DEFAULT_CACHE_NAME;
       ClusteredGetCommand c2 = new ClusteredGetCommand("key", cacheName,
-            Collections.<Flag>emptySet(), false, null, AnyEquivalence.OBJECT);
+            Collections.<Flag>emptySet(), false, null, AnyEquivalence.getInstance());
       marshallAndAssertEquality(c2);
 
       // SizeCommand does not have an empty constructor, so doesn't look to be one that is marshallable.
@@ -261,7 +261,7 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
       assert Arrays.equals(rc71.getParameters(), c71.getParameters()) : "Writen[" + c71.getParameters() + "] and read[" + rc71.getParameters() + "] objects should be the same";
 
       ReplaceCommand c8 = new ReplaceCommand("key", "oldvalue", "newvalue",
-            null, new EmbeddedMetadata.Builder().build(), Collections.EMPTY_SET, AnyEquivalence.OBJECT);
+            null, new EmbeddedMetadata.Builder().build(), Collections.EMPTY_SET, AnyEquivalence.getInstance());
       marshallAndAssertEquality(c8);
 
       ClearCommand c9 = new ClearCommand();
@@ -342,7 +342,7 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
    public void testMultiRpcCommand() throws Exception {
       String cacheName = EmbeddedCacheManager.DEFAULT_CACHE_NAME;
       ClusteredGetCommand c2 = new ClusteredGetCommand("key", cacheName,
-            Collections.<Flag>emptySet(), false, null, AnyEquivalence.OBJECT);
+            Collections.<Flag>emptySet(), false, null, AnyEquivalence.getInstance());
       PutKeyValueCommand c5 = new PutKeyValueCommand(
             "k", "v", false, null, new EmbeddedMetadata.Builder().build(), Collections.<Flag>emptySet());
       MultipleRpcCommand c99 = new MultipleRpcCommand(Arrays.<ReplicableCommand>asList(c2, c5), cacheName);

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
@@ -55,7 +55,7 @@ public class CacheNotifierImplTest extends AbstractInfinispanTest {
       cl = new CacheListener();
       n.start();
       n.addListener(cl);
-      ctx = new NonTxInvocationContext(AnyEquivalence.OBJECT);
+      ctx = new NonTxInvocationContext(AnyEquivalence.getInstance());
    }
 
    public void testNotifyCacheEntryCreated() {
@@ -262,7 +262,7 @@ public class CacheNotifierImplTest extends AbstractInfinispanTest {
    }
 
    public void testNotifyTransactionRegistered() {
-      InvocationContext ctx = new NonTxInvocationContext(AnyEquivalence.OBJECT);
+      InvocationContext ctx = new NonTxInvocationContext(AnyEquivalence.getInstance());
       GlobalTransaction tx = mock(GlobalTransaction.class);
       n.notifyTransactionRegistered(tx, ctx);
       n.notifyTransactionRegistered(tx, ctx);

--- a/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
@@ -34,6 +34,7 @@ import org.infinispan.transaction.xa.LocalXaTransaction;
 import org.infinispan.transaction.xa.TransactionFactory;
 import org.infinispan.transaction.xa.TransactionXaAdapter;
 import org.infinispan.transaction.xa.XaTransactionTable;
+import org.infinispan.util.AnyEquivalence;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -62,7 +63,7 @@ public class TransactionXaAdapterTmIntegrationTest {
       TransactionFactory gtf = new TransactionFactory();
       gtf.init(false, false, true, false);
       globalTransaction = gtf.newGlobalTransaction(null, false);
-      localTx = new LocalXaTransaction(new DummyTransaction(null), globalTransaction, false, 1);
+      localTx = new LocalXaTransaction(new DummyTransaction(null), globalTransaction, false, 1, AnyEquivalence.getInstance());
       xid = new DummyXid(uuid);
       localTx.setXid(xid);
       txTable.addLocalTransactionMapping(localTx);      

--- a/core/src/test/java/org/infinispan/util/DeadlockDetectingLockManagerTest.java
+++ b/core/src/test/java/org/infinispan/util/DeadlockDetectingLockManagerTest.java
@@ -66,7 +66,7 @@ public class DeadlockDetectingLockManagerTest extends AbstractInfinispanTest {
 
 
    public void testNoTransaction() throws Exception {
-      InvocationContext nonTx = new NonTxInvocationContext(AnyEquivalence.OBJECT);
+      InvocationContext nonTx = new NonTxInvocationContext(AnyEquivalence.getInstance());
 
       Lock mockLock = mock(Lock.class);
       when(lc.acquireLock(nonTx.getLockOwner(), "k", config.locking().lockAcquisitionTimeout(), TimeUnit.MILLISECONDS)).thenReturn(mockLock).thenReturn(null);
@@ -115,7 +115,7 @@ public class DeadlockDetectingLockManagerTest extends AbstractInfinispanTest {
    }
 
    private InvocationContext buildLocalTxIc(final DldGlobalTransaction ddgt) {
-      InvocationContext localTxContext = new LocalTxInvocationContext(AnyEquivalence.OBJECT) {
+      InvocationContext localTxContext = new LocalTxInvocationContext(AnyEquivalence.getInstance()) {
          @Override
          public Object getLockOwner() {
             return ddgt;

--- a/core/src/test/java/org/infinispan/util/EquivalentHashMapTest.java
+++ b/core/src/test/java/org/infinispan/util/EquivalentHashMapTest.java
@@ -366,7 +366,7 @@ public class EquivalentHashMapTest {
       }
 
       @Override
-      public int compare(Object obj, Object otherObj) {
+      public int compare(byte[] obj, byte[] otherObj) {
          return delegate.compare(obj, otherObj);
       }
 

--- a/core/src/test/java/org/infinispan/util/EquivalentHashSetTest.java
+++ b/core/src/test/java/org/infinispan/util/EquivalentHashSetTest.java
@@ -217,7 +217,7 @@ public class EquivalentHashSetTest {
       }
 
       @Override
-      public int compare(Object obj, Object otherObj) {
+      public int compare(byte[] obj, byte[] otherObj) {
          return delegate.compare(obj, otherObj);
       }
 

--- a/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolDecoder.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolDecoder.scala
@@ -210,14 +210,14 @@ abstract class AbstractProtocolDecoder[K, V](transport: NettyTransport)
       metadata.version(new ServerEntryVersion(generateVersion(cache)))
       (params.lifespan, params.maxIdle) match {
          case (EXPIRATION_DEFAULT, EXPIRATION_DEFAULT) =>
-            metadata.lifespan(defaultLifespanTime, DefaultTimeUnit)
-                    .maxIdle(defaultMaxIdleTime, DefaultTimeUnit)
+            metadata.lifespan(defaultLifespanTime)
+                    .maxIdle(defaultMaxIdleTime)
          case (_, EXPIRATION_DEFAULT) =>
-            metadata.lifespan(toMillis(params.lifespan), DefaultTimeUnit)
-                    .maxIdle(defaultMaxIdleTime, DefaultTimeUnit)
+            metadata.lifespan(toMillis(params.lifespan))
+                    .maxIdle(defaultMaxIdleTime)
          case (_, _) =>
-            metadata.lifespan(toMillis(params.lifespan), DefaultTimeUnit)
-                    .maxIdle(toMillis(params.maxIdle), DefaultTimeUnit)
+            metadata.lifespan(toMillis(params.lifespan))
+                    .maxIdle(toMillis(params.maxIdle))
       }
       metadata.build()
    }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
@@ -143,8 +143,8 @@ class HotRodServer extends AbstractProtocolServer("HotRod") with Log {
              .expiration().lifespan(-1).maxIdle(-1)
              // Topology cache uses Object based equals/hashCodes
              .dataContainer()
-                .keyEquivalence(AnyEquivalence.OBJECT)
-                .valueEquivalence(AnyEquivalence.OBJECT)
+                .keyEquivalence(AnyEquivalence.getInstance())
+                .valueEquivalence(AnyEquivalence.getInstance())
 
       if (configuration.topologyStateTransfer) {
          builder.clustering().stateTransfer().fetchInMemoryState(true)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3108
- Extend keyEquivalence usage to transaction collections.
- Add a getInstance() method to AnyEquivalence to provide a typesafe
  equivalence for any type that relies on the object's equals/hashCode()
  implementations.
- Byte arrays can now be stored in tree bins in EquivalentCHMv8
- Achieved by making sure that the keyEquivalence's isComparable method
  for byte arrays returns true, and a unsigned method to compare byte
  arrays is implemented.
- Make flag aware commands metadata aware. Makes it easier to pass down
  metadata information without having to do instanceof/cast of classes.
- Add lifespan(long) and maxIdle(long) to Metadata builder
- Use immutable metadata instance when no expiration parameters
- A side effect of this is that CacheImpl does no longer extend
  CacheSupport because that in itself does not extend AdvancedCache and
  the methods defined are defined as final.
