### PR TITLE
ISPN-2973 Make SuspectedExceptions trigger HotRod's retry mechanism

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/AbstractTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/AbstractTransport.java
@@ -67,7 +67,7 @@ public abstract class AbstractTransport implements Transport {
             Exception e = exceptionResponse.getException();
             // if we have any application-level exceptions make sure we throw them!!
             if (shouldThrowException(e)) {
-               throw log.remoteException(sender, e);
+               throw log.remoteException(e.getClass().getSimpleName(), sender, e);
             } else {
                if (log.isDebugEnabled())
                   log.debug("Received exception from " + sender, e);
@@ -81,8 +81,8 @@ public abstract class AbstractTransport implements Transport {
          throw new CacheException(String.format("Unexpected response object type from %s: %s", sender, responseClass));
       }
       return false;
-   } 
-   
+   }
+
    protected final boolean parseResponseAndAddToResponseList(Object responseObject, Throwable exception, Map<Address, Response> responseListToAddTo, boolean wasSuspected,
                                                        boolean wasReceived, Address sender, boolean usedResponseFilter, boolean ignoreLeavers)
            throws Exception
@@ -95,7 +95,7 @@ public abstract class AbstractTransport implements Transport {
             log.tracef(exception, "Unexpected exception from %s", sender);
             throw new CacheException("Remote (" + sender + ") failed unexpectedly", exception);
          }
-         
+
          if (checkResponse(responseObject, sender)) responseListToAddTo.put(sender, (Response) responseObject);
       } else if (wasSuspected) {
          if (!ignoreLeavers) {

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -841,8 +841,8 @@ public interface Log extends BasicLogger {
    @Message(value = "%d entries migrated to cache %s in %s", id = 216)
    void entriesMigrated(long count, String name, String prettyTime);
 
-   @Message(value = "Received exception from %s, see cause for remote stack trace", id = 217)
-   RemoteException remoteException(Address sender, @Cause Exception e);
+   @Message(value = "Received %s exception from %s, see cause for remote stack trace", id = 217)
+   RemoteException remoteException(String cause, Address sender, @Cause Exception e);
 
    @LogMessage(level = INFO)
    @Message(value = "Timeout while waiting for the transaction validation. The command will not be processed. " +


### PR DESCRIPTION
Make sure the Exception type is included in the message, so that the HotRod client's retry logic works as expected.

https://issues.jboss.org/browse/ISPN-2973

Apply to 5.2.x as well
