### PR TITLE
ISPN-3148 BackupReceiver survives cache shutdown for implicit backups

### DIFF
--- a/core/src/main/java/org/infinispan/xsite/BackupReceiverRepositoryImpl.java
+++ b/core/src/main/java/org/infinispan/xsite/BackupReceiverRepositoryImpl.java
@@ -123,6 +123,7 @@ public class BackupReceiverRepositoryImpl implements BackupReceiverRepository {
 
       Cache<Object, Object> cache = cacheManager.getCache(remoteCache);
       backupReceivers.putIfAbsent(toLookFor, new BackupReceiverImpl(cache));
+      toLookFor.setLocalCacheName(cache.getName());
       return backupReceivers.get(toLookFor);
    }
 

--- a/core/src/test/java/org/infinispan/xsite/BackupCacheStoppedTest.java
+++ b/core/src/test/java/org/infinispan/xsite/BackupCacheStoppedTest.java
@@ -44,7 +44,6 @@ public class BackupCacheStoppedTest extends AbstractTwoSitesTest {
       Cache<Object,Object> backup = backup(site);
       final GlobalComponentRegistry gcr = backup.getAdvancedCache().getComponentRegistry().getGlobalComponentRegistry();
 
-      assertTrue(backup.getName().contains("lonBackup"));
       assertEquals(backup.get(key), val);
       assertTrue(backup.getStatus().allowInvocations());
 

--- a/core/src/test/java/org/infinispan/xsite/ImplicitBackupCacheStoppedTest.java
+++ b/core/src/test/java/org/infinispan/xsite/ImplicitBackupCacheStoppedTest.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *  Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ *  contributors as indicated by the @author tags. All rights reserved
+ *  See the copyright.txt in the distribution for a full listing of
+ *  individual contributors.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.xsite;
+
+import org.testng.annotations.Test;
+
+@Test(groups = "xsite", testName = "xsite.ImplicitBackupCacheStoppedTest")
+public class ImplicitBackupCacheStoppedTest extends BackupCacheStoppedTest {
+   public ImplicitBackupCacheStoppedTest() {
+      implicitBackupCache = true;
+   }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3148
