### PR TITLE
ISPN-761  Cache.keySet(),entrySet(),values(),size() ignore contents of c...

### DIFF
--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/NonStringKeyPreloadTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/stringbased/NonStringKeyPreloadTest.java
@@ -102,7 +102,7 @@ public class NonStringKeyPreloadTest extends AbstractInfinispanTest {
          @Override
          public void call() {
             AdvancedCache<Object, Object> cache = cm.getCache().getAdvancedCache();
-            assertEquals(3, cache.size());
+            assertEquals(3, cache.getDataContainer().size());
             int found = 0;
             for (int i = 0; i < 10; i++) {
                Person p = new Person("name" + i, "surname" + i, 30);

--- a/core/src/main/java/org/infinispan/Cache.java
+++ b/core/src/main/java/org/infinispan/Cache.java
@@ -170,16 +170,35 @@ public interface Cache<K, V> extends BasicCache<K, V>, Listenable {
    ComponentStatus getStatus();
 
    /**
-    * Returns a set view of the keys contained in this cache. This set is immutable, so it cannot be modified 
-    * and changes to the cache won't be reflected in the set. When this method is called on a cache configured with 
-    * distribution mode, the set returned only contains the keys locally available in the cache instance. To avoid 
-    * memory issues, there will be not attempt to bring keys from other nodes.
+    * Returns a count of all elements in this cache and cache loader.  To avoid performance issues, there will be no
+    * attempt to count keys from other nodes.
+    * <p/>
+    * If there are memory concerns then the {@link org.infinispan.context.Flag.SKIP_CACHE_LOAD} flag should be used to
+    * avoid hitting the cache store as all local keys will be loaded into memory at once.
+    * <p/>
+    * This method should only be used for debugging purposes such as to verify that the cache contains all the keys
+    * entered. Any other use involving execution of this method on a production system is not recommended.
+    * <p/>
+    *
+    * @return the number of key-value mappings in this cache and cache loader
+    */
+   @Override
+   int size();
+
+   /**
+    * Returns a set view of the keys contained in this cache and cache loader. This set is immutable, so it cannot be
+    * modified and changes to the cache won't be reflected in the set. When this method is called on a cache configured
+    * with distribution mode, the set returned only contains the keys locally available in the cache instance including
+    * the cache loader if provided. To avoid memory issues, there will be not attempt to bring keys from other nodes.
+    * <p/>
+    * If there are memory concerns then the {@link org.infinispan.context.Flag.SKIP_CACHE_LOAD} flag should be used to
+    * avoid hitting the cache store as all local keys will be in memory at once.
     * <p/>
     * This method should only be used for debugging purposes such as to verify that the cache contains all the keys 
     * entered. Any other use involving execution of this method on a production system is not recommended.
     * <p/>
     * 
-    * @return a set view of the keys contained in this cache.
+    * @return a set view of the keys contained in this cache and cache loader.
     */
    @Override
    Set<K> keySet();
@@ -187,30 +206,36 @@ public interface Cache<K, V> extends BasicCache<K, V>, Listenable {
    /**
     * Returns a collection view of the values contained in this cache. This collection is immutable, so it cannot be modified 
     * and changes to the cache won't be reflected in the set. When this method is called on a cache configured with 
-    * distribution mode, the collection returned only contains the values locally available in the cache instance. To avoid 
-    * memory issues, there is not attempt to bring values from other nodes.
+    * distribution mode, the collection returned only contains the values locally available in the cache instance
+    * including the cache loader if provided. To avoid memory issues, there is no attempt to bring values from other nodes.
+    * <p/>
+    * If there are memory concerns then the {@link org.infinispan.context.Flag.SKIP_CACHE_LOAD} flag should be used to
+    * avoid hitting the cache store as all local values will be in memory at once.
     * <p/>
     * This method should only be used for testing or debugging purposes such as to verify that the cache contains all the 
     * values entered. Any other use involving execution of this method on a production system is not recommended.
     * <p/>
     * 
-    * @return a collection view of the values contained in this map.
+    * @return a collection view of the values contained in this cache and cache loader.
     */
    @Override
    Collection<V> values();
    
    /**
-    * Returns a set view of the mappings contained in this cache. This set is immutable, so it cannot be modified 
-    * and changes to the cache won't be reflected in the set. Besides, each element in the returned set is an immutable 
-    * {@link Map.Entry}. When this method is called on a cache configured with distribution mode, the set returned only 
-    * contains the mappings locally available in the cache instance. To avoid memory issues, there will be not attempt 
-    * to bring mappings from other nodes.
+    * Returns a set view of the mappings contained in this cache and cache loader. This set is immutable, so it cannot
+    * be modified and changes to the cache won't be reflected in the set. Besides, each element in the returned set is
+    * an immutable {@link Map.Entry}. When this method is called on a cache configured with distribution mode, the set
+    * returned only contains the mappings locally available in the cache instance. To avoid memory issues, there will
+    * be not attempt to bring mappings from other nodes.
+    * <p/>
+    * If there are memory concerns then the {@link org.infinispan.context.Flag.SKIP_CACHE_LOAD} flag should be used to
+    * avoid hitting the cache store as all local entries will be in memory at once.
     * <p/>
     * This method should only be used for debugging purposes such as to verify that the cache contains all the mappings 
     * entered. Any other use involving execution of this method on a production system is not recommended.
     * <p/>
     * 
-    * @return a set view of the mappings contained in this cache.
+    * @return a set view of the mappings contained in this cache and cache loader
     */
    @Override
    Set<Map.Entry<K, V>> entrySet();

--- a/core/src/main/java/org/infinispan/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/CacheImpl.java
@@ -325,7 +325,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    }
 
    final int size(EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
-      SizeCommand command = commandsFactory.buildSizeCommand();
+      SizeCommand command = commandsFactory.buildSizeCommand(explicitFlags);
       return (Integer) invoker.invoke(getInvocationContextForRead(
             null, explicitClassLoader, UNBOUNDED), command);
    }
@@ -445,7 +445,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    @SuppressWarnings("unchecked")
    Set<K> keySet(EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
       InvocationContext ctx = getInvocationContextForRead(null, explicitClassLoader, UNBOUNDED);
-      KeySetCommand command = commandsFactory.buildKeySetCommand();
+      KeySetCommand command = commandsFactory.buildKeySetCommand(explicitFlags);
       return (Set<K>) invoker.invoke(ctx, command);
    }
 
@@ -457,7 +457,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    @SuppressWarnings("unchecked")
    Collection<V> values(EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
       InvocationContext ctx = getInvocationContextForRead(null, explicitClassLoader, UNBOUNDED);
-      ValuesCommand command = commandsFactory.buildValuesCommand();
+      ValuesCommand command = commandsFactory.buildValuesCommand(explicitFlags);
       return (Collection<V>) invoker.invoke(ctx, command);
    }
 
@@ -469,7 +469,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    @SuppressWarnings("unchecked")
    Set<Map.Entry<K, V>> entrySet(EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
       InvocationContext ctx = getInvocationContextForRead(null, explicitClassLoader, UNBOUNDED);
-      EntrySetCommand command = commandsFactory.buildEntrySetCommand();
+      EntrySetCommand command = commandsFactory.buildEntrySetCommand(explicitFlags);
       return (Set<Map.Entry<K, V>>) invoker.invoke(ctx, command);
    }
 

--- a/core/src/main/java/org/infinispan/commands/AbstractFlagAffectedCommand.java
+++ b/core/src/main/java/org/infinispan/commands/AbstractFlagAffectedCommand.java
@@ -13,35 +13,9 @@ import java.util.Set;
  * @author Galder Zamarreño
  * @since 5.1
  */
-public abstract class AbstractFlagAffectedCommand implements FlagAffectedCommand, TopologyAffectedCommand {
-
-   protected Set<Flag> flags;
+public abstract class AbstractFlagAffectedCommand extends AbstractLocalFlagAffectedCommand implements FlagAffectedCommand {
 
    private int topologyId = -1;
-
-   @Override
-   public Set<Flag> getFlags() {
-      return flags;
-   }
-
-   @Override
-   public void setFlags(Set<Flag> flags) {
-      this.flags = flags;
-   }
-
-   @Override
-   public void setFlags(Flag... flags) {
-      if (flags == null || flags.length == 0) return;
-      if (this.flags == null)
-         this.flags = EnumSet.copyOf(Arrays.asList(flags));
-      else
-         this.flags.addAll(Arrays.asList(flags));
-   }
-
-   @Override
-   public boolean hasFlag(Flag flag) {
-      return flags != null && flags.contains(flag);
-   }
 
    @Override
    public int getTopologyId() {

--- a/core/src/main/java/org/infinispan/commands/AbstractLocalFlagAffectedCommand.java
+++ b/core/src/main/java/org/infinispan/commands/AbstractLocalFlagAffectedCommand.java
@@ -1,0 +1,43 @@
+package org.infinispan.commands;
+
+import org.infinispan.context.Flag;
+import org.infinispan.metadata.Metadata;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Base class for those local commands that can carry flags.
+ *
+ * @author William Burns
+ * @since 6.0
+ */
+public abstract class AbstractLocalFlagAffectedCommand implements LocalFlagAffectedCommand {
+
+   protected Set<Flag> flags;
+
+   @Override
+   public Set<Flag> getFlags() {
+      return flags;
+   }
+
+   @Override
+   public void setFlags(Set<Flag> flags) {
+      this.flags = flags;
+   }
+
+   @Override
+   public void setFlags(Flag... flags) {
+      if (flags == null || flags.length == 0) return;
+      if (this.flags == null)
+         this.flags = EnumSet.copyOf(Arrays.asList(flags));
+      else
+         this.flags.addAll(Arrays.asList(flags));
+   }
+
+   @Override
+   public boolean hasFlag(Flag flag) {
+      return flags != null && flags.contains(flag);
+   }
+}

--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -61,6 +61,7 @@ public interface CommandsFactory {
     * @param key key to put
     * @param value value to put
     * @param metadata metadata of entry
+    * @param flags Command flags provided by cache
     * @return a PutKeyValueCommand
     */
    PutKeyValueCommand buildPutKeyValueCommand(Object key, Object value, Metadata metadata, Set<Flag> flags);
@@ -69,12 +70,14 @@ public interface CommandsFactory {
     * Builds a RemoveCommand
     * @param key key to remove
     * @param value value to check for ina  conditional remove, or null for an unconditional remove.
+    * @param flags Command flags provided by cache
     * @return a RemoveCommand
     */
    RemoveCommand buildRemoveCommand(Object key, Object value, Set<Flag> flags);
 
    /**
     * Builds an InvalidateCommand
+    * @param flags Command flags provided by cache
     * @param keys keys to invalidate
     * @return an InvalidateCommand
     */
@@ -99,19 +102,22 @@ public interface CommandsFactory {
     * @param oldValue existing value to check for if conditional, null if unconditional.
     * @param newValue value to replace with
     * @param metadata metadata of entry
+    * @param flags Command flags provided by cache
     * @return a ReplaceCommand
     */
    ReplaceCommand buildReplaceCommand(Object key, Object oldValue, Object newValue, Metadata metadata, Set<Flag> flags);
 
    /**
     * Builds a SizeCommand
+    * @param flags Command flags provided by cache
     * @return a SizeCommand
     */
-   SizeCommand buildSizeCommand();
+   SizeCommand buildSizeCommand(Set<Flag> flags);
 
    /**
     * Builds a GetKeyValueCommand
     * @param key key to get
+    * @param flags Command flags provided by cache
     * @param returnEntry boolean indicating whether entire cache entry is
     *                    returned, otherwise return just the value part
     * @return a GetKeyValueCommand
@@ -120,32 +126,37 @@ public interface CommandsFactory {
 
    /**
     * Builds a KeySetCommand
+    * @param flags Command flags provided by cache
     * @return a KeySetCommand
     */
-   KeySetCommand buildKeySetCommand();
+   KeySetCommand buildKeySetCommand(Set<Flag> flags);
 
    /**
     * Builds a ValuesCommand
+    * @param flags Command flags provided by cache
     * @return a ValuesCommand
     */
-   ValuesCommand buildValuesCommand();
+   ValuesCommand buildValuesCommand(Set<Flag> flags);
 
    /**
     * Builds a EntrySetCommand
+    * @param flags Command flags provided by cache
     * @return a EntrySetCommand
     */
-   EntrySetCommand buildEntrySetCommand();
+   EntrySetCommand buildEntrySetCommand(Set<Flag> flags);
 
    /**
     * Builds a PutMapCommand
     * @param map map containing key/value entries to put
     * @param metadata metadata of entry
+    * @param flags Command flags provided by cache
     * @return a PutMapCommand
     */
    PutMapCommand buildPutMapCommand(Map<?, ?> map, Metadata metadata, Set<Flag> flags);
 
    /**
     * Builds a ClearCommand
+    * @param flags Command flags provided by cache
     * @return a ClearCommand
     */
    ClearCommand buildClearCommand(Set<Flag> flags);
@@ -153,6 +164,7 @@ public interface CommandsFactory {
    /**
     * Builds an EvictCommand
     * @param key key to evict
+    * @param flags Command flags provided by cache
     * @return an EvictCommand
     */
    EvictCommand buildEvictCommand(Object key, Set<Flag> flags);
@@ -336,7 +348,7 @@ public interface CommandsFactory {
    ApplyDeltaCommand buildApplyDeltaCommand(Object deltaAwareValueKey, Delta delta, Collection keys);
 
    /**
-    * Same as {@link #buildCreateCacheCommand(String, String, false)}.
+    * Same as {@link #buildCreateCacheCommand(String, String, false, 0)}.
     */
    CreateCacheCommand buildCreateCacheCommand(String cacheName, String cacheConfigurationName);
 

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -100,11 +100,6 @@ public class CommandsFactoryImpl implements CommandsFactory {
    private String cacheName;
    private boolean totalOrderProtocol;
 
-   // some stateless commands can be reused so that they aren't constructed again all the time.
-   private SizeCommand cachedSizeCommand;
-   private KeySetCommand cachedKeySetCommand;
-   private ValuesCommand cachedValuesCommand;
-   private EntrySetCommand cachedEntrySetCommand;
    private InterceptorChain interceptorChain;
    private DistributionManager distributionManager;
    private InvocationContextContainer icc;
@@ -191,35 +186,23 @@ public class CommandsFactoryImpl implements CommandsFactory {
    }
 
    @Override
-   public SizeCommand buildSizeCommand() {
-      if (cachedSizeCommand == null) {
-         cachedSizeCommand = new SizeCommand(dataContainer);
-      }
-      return cachedSizeCommand;
+   public SizeCommand buildSizeCommand(Set<Flag> flags) {
+      return new SizeCommand(dataContainer, flags);
    }
 
    @Override
-   public KeySetCommand buildKeySetCommand() {
-      if (cachedKeySetCommand == null) {
-         cachedKeySetCommand = new KeySetCommand(dataContainer);
-      }
-      return cachedKeySetCommand;
+   public KeySetCommand buildKeySetCommand(Set<Flag> flags) {
+      return new KeySetCommand(dataContainer, flags);
    }
 
    @Override
-   public ValuesCommand buildValuesCommand() {
-      if (cachedValuesCommand == null) {
-         cachedValuesCommand = new ValuesCommand(dataContainer, timeService);
-      }
-      return cachedValuesCommand;
+   public ValuesCommand buildValuesCommand(Set<Flag> flags) {
+      return new ValuesCommand(dataContainer, timeService, flags);
    }
 
    @Override
-   public EntrySetCommand buildEntrySetCommand() {
-      if (cachedEntrySetCommand == null) {
-         cachedEntrySetCommand = new EntrySetCommand(dataContainer, entryFactory, timeService);
-      }
-      return cachedEntrySetCommand;
+   public EntrySetCommand buildEntrySetCommand(Set<Flag> flags) {
+      return new EntrySetCommand(dataContainer, entryFactory, timeService, flags);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/FlagAffectedCommand.java
+++ b/core/src/main/java/org/infinispan/commands/FlagAffectedCommand.java
@@ -9,35 +9,10 @@ import org.infinispan.context.Flag;
  * 
  * By implementing this interface the remote handler will read them out and restore in context;
  * flags should still be evaluated in the InvocationContext.
- * 
+ *
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
  * @since 5.0
  */
-public interface FlagAffectedCommand extends VisitableCommand, TopologyAffectedCommand, MetadataAwareCommand {
-   
-   /**
-    * @return the Flags which where set in the context - only valid to invoke after {@link #setFlags(Set)}
-    */
-   Set<Flag> getFlags();
-   
-   /**
-    * Use it to store the flags from the InvocationContext into the Command before remoting the Command.
-    * @param flags
-    */
-   void setFlags(Set<Flag> flags);
-
-   /**
-    * Use it to store the flags from the InvocationContext into the Command before remoting the Command.
-    * @param flags
-    */
-   void setFlags(Flag... flags);
-
-   /**
-    * Check whether a particular flag is present in the command
-    *
-    * @param flag to lookup in the command
-    * @return true if the flag is present
-    */
-   boolean hasFlag(Flag flag);
-
+public interface FlagAffectedCommand extends VisitableCommand, TopologyAffectedCommand, MetadataAwareCommand,
+                                             LocalFlagAffectedCommand {
 }

--- a/core/src/main/java/org/infinispan/commands/LocalFlagAffectedCommand.java
+++ b/core/src/main/java/org/infinispan/commands/LocalFlagAffectedCommand.java
@@ -1,0 +1,39 @@
+package org.infinispan.commands;
+
+import org.infinispan.context.Flag;
+
+import java.util.Set;
+
+/**
+ * Commands affected by Flags will be checked locally to control certain behaviors such whether or not to invoke
+ * certain commands remotely, check cache store etc.
+ *
+ * @author William Burns
+ * @since 6.0
+ */
+public interface LocalFlagAffectedCommand {
+   /**
+    * @return the Flags which where set in the context - only valid to invoke after {@link #setFlags(java.util.Set)}
+    */
+   Set<Flag> getFlags();
+
+   /**
+    * Use it to store the flags from the InvocationContext into the Command before remoting the Command.
+    * @param flags
+    */
+   void setFlags(Set<Flag> flags);
+
+   /**
+    * Use it to store the flags from the InvocationContext into the Command before remoting the Command.
+    * @param flags
+    */
+   void setFlags(Flag... flags);
+
+   /**
+    * Check whether a particular flag is present in the command
+    *
+    * @param flag to lookup in the command
+    * @return true if the flag is present
+    */
+   boolean hasFlag(Flag flag);
+}

--- a/core/src/main/java/org/infinispan/commands/read/AbstractLocalCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/AbstractLocalCommand.java
@@ -1,5 +1,6 @@
 package org.infinispan.commands.read;
 
+import org.infinispan.commands.AbstractLocalFlagAffectedCommand;
 import org.infinispan.commands.LocalCommand;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
@@ -12,7 +13,7 @@ import org.infinispan.lifecycle.ComponentStatus;
  * @author Mircea.Markus@jboss.com
  * @since 4.1
  */
-public class AbstractLocalCommand implements LocalCommand {
+public abstract class AbstractLocalCommand extends AbstractLocalFlagAffectedCommand implements LocalCommand {
    private static final Object[] EMPTY_ARRAY = new Object[0];
 
    public byte getCommandId() {

--- a/core/src/main/java/org/infinispan/commands/read/EntrySetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/EntrySetCommand.java
@@ -6,6 +6,7 @@ import org.infinispan.container.DataContainer;
 import org.infinispan.container.InternalEntryFactory;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.util.TimeService;
 import static org.infinispan.util.CoreImmutables.immutableInternalCacheEntry;
@@ -29,7 +30,8 @@ public class EntrySetCommand extends AbstractLocalCommand implements VisitableCo
    private final InternalEntryFactory entryFactory;
    private final TimeService timeService;
 
-   public EntrySetCommand(DataContainer container, InternalEntryFactory internalEntryFactory, TimeService timeService) {
+   public EntrySetCommand(DataContainer container, InternalEntryFactory internalEntryFactory, TimeService timeService, Set<Flag> flags) {
+      setFlags(flags);
       this.container = container;
       this.entryFactory = internalEntryFactory;
       this.timeService = timeService;

--- a/core/src/main/java/org/infinispan/commands/read/KeySetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/KeySetCommand.java
@@ -4,6 +4,7 @@ import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.Visitor;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 
 import java.util.AbstractSet;
@@ -24,7 +25,8 @@ import java.util.Set;
 public class KeySetCommand extends AbstractLocalCommand implements VisitableCommand {
    private final DataContainer container;
 
-   public KeySetCommand(DataContainer container) {
+   public KeySetCommand(DataContainer container, Set<Flag> flags) {
+      setFlags(flags);
       this.container = container;
    }
 

--- a/core/src/main/java/org/infinispan/commands/read/SizeCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/SizeCommand.java
@@ -4,7 +4,10 @@ import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.Visitor;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
+
+import java.util.Set;
 
 /**
  * Command to calculate the size of the cache
@@ -17,7 +20,8 @@ import org.infinispan.context.InvocationContext;
 public class SizeCommand extends AbstractLocalCommand implements VisitableCommand {
    private final DataContainer container;
 
-   public SizeCommand(DataContainer container) {
+   public SizeCommand(DataContainer container, Set<Flag> flags) {
+      setFlags(flags);
       this.container = container;
    }
 

--- a/core/src/main/java/org/infinispan/commands/read/ValuesCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/ValuesCommand.java
@@ -5,6 +5,7 @@ import org.infinispan.commands.Visitor;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.util.TimeService;
 
@@ -27,7 +28,8 @@ public class ValuesCommand extends AbstractLocalCommand implements VisitableComm
    private final DataContainer container;
    private final TimeService timeService;
 
-   public ValuesCommand(DataContainer container, TimeService timeService) {
+   public ValuesCommand(DataContainer container, TimeService timeService, Set<Flag> flags) {
+      setFlags(flags);
       this.container = container;
       this.timeService = timeService;
    }

--- a/core/src/test/java/org/infinispan/configuration/override/XMLConfigurationOverridingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/override/XMLConfigurationOverridingTest.java
@@ -216,7 +216,7 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
                cache.put("key" + i, "value" + i);
             }
 
-            Assert.assertTrue(cache.size() <= 5);
+            Assert.assertTrue(cache.getAdvancedCache().getDataContainer().size() <= 5);
             for (int i = 0; i < 10; i++) {
                Assert.assertNotNull(cache.get("key" + i));
             }

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashAfterJoinWithPreloadTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashAfterJoinWithPreloadTest.java
@@ -91,7 +91,8 @@ public class RehashAfterJoinWithPreloadTest extends MultipleCacheManagersTest {
       for (int i = 0; i < getCacheManagers().size(); i++) {
          Cache<String, String> testCache = manager(i).getCache(testCacheName);
          DistributionManager dm = testCache.getAdvancedCache().getDistributionManager();
-         for (String key : testCache.keySet()) {
+         // Note there is stale data in the cache store that this owner no longer owns
+         for (Object key : testCache.getAdvancedCache().getDataContainer().keySet()) {
             // each key must only occur once (numOwners is one)
             assertTrue("Key '" + key + "' is not owned by node " + address(i) + " but it still appears there",
                   dm.getLocality(key).isLocal());

--- a/core/src/test/java/org/infinispan/eviction/EvictionWithPassivationTest.java
+++ b/core/src/test/java/org/infinispan/eviction/EvictionWithPassivationTest.java
@@ -84,9 +84,9 @@ public class EvictionWithPassivationTest extends SingleCacheManagerTest {
       testCache.put("Z", "4569");
 
       if (!s.equals(EvictionStrategy.NONE)) {
-         assert EVICTION_MAX_ENTRIES == testCache.size() : "Cache size should be " + EVICTION_MAX_ENTRIES;
+         assert EVICTION_MAX_ENTRIES == testCache.getAdvancedCache().getDataContainer().size() : "Cache size should be " + EVICTION_MAX_ENTRIES;
          testCache.get("X");
-         assert EVICTION_MAX_ENTRIES == testCache.size() : "Cache size should be " + EVICTION_MAX_ENTRIES;
+         assert EVICTION_MAX_ENTRIES == testCache.getAdvancedCache().getDataContainer().size() : "Cache size should be " + EVICTION_MAX_ENTRIES;
       }
 
       assert "4567".equals(testCache.get("X")) : "Failure on test " + name;

--- a/core/src/test/java/org/infinispan/loaders/CacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/loaders/CacheLoaderFunctionalTest.java
@@ -29,6 +29,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.infinispan.api.mvcc.LockAssert.assertNoLocks;
 import static org.infinispan.test.TestingUtil.k;
 import static org.infinispan.test.TestingUtil.v;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Tests the interceptor chain and surrounding logic
@@ -257,7 +258,7 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
       // make sure we have no stale locks!!
       assertNoLocks(cache);
 
-      assert cache.isEmpty(); // cache size ops will not trigger a load
+      assertEquals(0, cache.getAdvancedCache().getDataContainer().size()); // cache size ops will not trigger a load
 
       cache.clear(); // this should propagate to the loader though
       assertNotInCacheAndStore("k1", "k2", "k3", "k4");

--- a/core/src/test/java/org/infinispan/loaders/decorators/AsyncStoreEvictionTest.java
+++ b/core/src/test/java/org/infinispan/loaders/decorators/AsyncStoreEvictionTest.java
@@ -16,6 +16,9 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 
 import org.testng.annotations.Test;
 
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+
 @Test(groups = "unit", testName = "loaders.decorators.AsyncStoreEvictionTest")
 public class AsyncStoreEvictionTest {
 
@@ -217,7 +220,7 @@ public class AsyncStoreEvictionTest {
             cache.put("k1", "v1");
             cache.put("k2", "v2");
 
-            assert cache.size() == 1 : "cache size must be 1, was: " + cache.size();
+            assertEquals("cache size must be 1", 1, cache.getAdvancedCache().getDataContainer().size());
          }
       });
    }
@@ -230,7 +233,7 @@ public class AsyncStoreEvictionTest {
             cache.put("k2", "v2");
             TestingUtil.sleepThread(200);
 
-            assert !(cache.size() == 2) : "expiry doesn't work even after expiration";
+            assertFalse("expiry doesn't work even after expiration", 2 == cache.getAdvancedCache().getDataContainer().size());
          }
       });
    }
@@ -242,7 +245,7 @@ public class AsyncStoreEvictionTest {
             cache.put("k1", "v1");
             cache.evict("k1");
 
-            assert cache.size() == 0 : "cache size must be 0, was: " + cache.size();
+            assertEquals("cache size must be 0", 0, cache.getAdvancedCache().getDataContainer().size());
          }
       });
    }
@@ -254,7 +257,7 @@ public class AsyncStoreEvictionTest {
             cache.put("k1", "v1");
             cache.remove("k1");
 
-            assert cache.size() == 0 : "cache size must be 0, was: " + cache.size();
+            assertEquals("cache size must be 0", 0, cache.getAdvancedCache().getDataContainer().size());
          }
       });
    }
@@ -268,7 +271,7 @@ public class AsyncStoreEvictionTest {
             int size = cache.size();
             TestingUtil.sleepThread(200);
 
-            assert !(size == 1 && cache.size() == 0) : "remove only works after expiration";
+            assertFalse("remove only works after expiration", size == 1 && cache.size() == 0);
          }
       });
    }

--- a/core/src/test/java/org/infinispan/loaders/decorators/BatchAsyncCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/decorators/BatchAsyncCacheStoreTest.java
@@ -81,7 +81,7 @@ public class BatchAsyncCacheStoreTest extends SingleCacheManagerTest {
    @Test(dependsOnMethods = "sequantialOvewritingInBatches")
    public void indexWasStored() {
       cache = cacheManager.getCache();
-      Assert.assertTrue(cache.isEmpty());
+      Assert.assertEquals(0, cache.getAdvancedCache().getDataContainer().size());
       boolean failed = false;
       for (Object key : cacheCopy.keySet()) {
          Object expected = cacheCopy.get(key);

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -146,8 +146,8 @@ public class ControlledCommandFactory implements CommandsFactory {
    }
 
    @Override
-   public SizeCommand buildSizeCommand() {
-      return actual.buildSizeCommand();
+   public SizeCommand buildSizeCommand(Set<Flag> flags) {
+      return actual.buildSizeCommand(flags);
    }
 
    @Override
@@ -156,18 +156,18 @@ public class ControlledCommandFactory implements CommandsFactory {
    }
 
    @Override
-   public KeySetCommand buildKeySetCommand() {
-      return actual.buildKeySetCommand();
+   public KeySetCommand buildKeySetCommand(Set<Flag> flags) {
+      return actual.buildKeySetCommand(flags);
    }
 
    @Override
-   public ValuesCommand buildValuesCommand() {
-      return actual.buildValuesCommand();
+   public ValuesCommand buildValuesCommand(Set<Flag> flags) {
+      return actual.buildValuesCommand(flags);
    }
 
    @Override
-   public EntrySetCommand buildEntrySetCommand() {
-      return actual.buildEntrySetCommand();
+   public EntrySetCommand buildEntrySetCommand(Set<Flag> flags) {
+      return actual.buildEntrySetCommand(flags);
    }
 
    @Override

--- a/lucene/lucene-v3/src/test/java/org/infinispan/lucene/DatabaseStoredIndexTest.java
+++ b/lucene/lucene-v3/src/test/java/org/infinispan/lucene/DatabaseStoredIndexTest.java
@@ -82,7 +82,7 @@ public class DatabaseStoredIndexTest extends SingleCacheManagerTest {
    @Test(dependsOnMethods="testIndexUsage")
    public void indexWasStored() throws IOException {
       cache = cacheManager.getCache();
-      AssertJUnit.assertTrue(cache.isEmpty());
+      AssertJUnit.assertEquals(0, cache.getAdvancedCache().getDataContainer().size());
       boolean failed = false;
       for (Object key : cacheCopy.keySet()) {
          if (key instanceof FileReadLockKey) {

--- a/lucene/lucene-v4/src/test/java/org/infinispan/lucene/DatabaseStoredIndexTest.java
+++ b/lucene/lucene-v4/src/test/java/org/infinispan/lucene/DatabaseStoredIndexTest.java
@@ -85,7 +85,7 @@ public class DatabaseStoredIndexTest extends SingleCacheManagerTest {
    @Test(dependsOnMethods="testIndexUsage")
    public void indexWasStored() throws IOException {
       cache = cacheManager.getCache();
-      assert cache.isEmpty();
+      AssertJUnit.assertEquals(0, cache.getAdvancedCache().getDataContainer().size());
       boolean failed = false;
       for (Object key : cacheCopy.keySet()) {
          if (key instanceof FileReadLockKey) {


### PR DESCRIPTION
...ache loader
- Added support for entrySet, keySet, values and size to include passivated entries
- Added test cases for each method

I had thought about the calling the notifier as well, but these are not loaded into the cache and also there is no way to really say they are passivated again.
