### PR TITLE
ISPN-3100 CommandAwareRpcDispatcher Future Collactor does not respect the timeout

### DIFF
--- a/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerTimeoutTest.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerTimeoutTest.java
@@ -1,0 +1,119 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.infinispan.remoting.rpc;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.util.concurrent.TimeoutException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Pedro Ruivo
+ * @since 5.3
+ */
+@Test(groups = "functional", testName = "remoting.rpc.RpcManagerTimeoutTest")
+public class RpcManagerTimeoutTest extends MultipleCacheManagersTest {
+
+   private static final String CACHE_NAME = "_cache_name_";
+
+   @Test(expectedExceptions = TimeoutException.class)
+   public void testTimeoutWithResponseFilter() {
+      RpcManager rpcManager = advancedCache(0, CACHE_NAME).getRpcManager();
+      final List<Address> members = rpcManager.getMembers();
+
+      //wait for the responses from the last two members.
+      ResponseFilter filter = new ResponseFilter() {
+
+         private int expectedResponses = 2;
+
+         @Override
+         public boolean isAcceptable(Response response, Address sender) {
+            if (sender.equals(members.get(2)) || sender.equals(members.get(3))) {
+               expectedResponses--;
+            }
+            return true;
+         }
+
+         @Override
+         public boolean needMoreResponses() {
+            return expectedResponses > 0;
+         }
+      };
+
+      doTest(filter, false, false);
+   }
+
+   @Test(expectedExceptions = TimeoutException.class)
+   public void testTimeoutWithoutFilter() {
+      doTest(null, false, false);
+   }
+
+   @Test(expectedExceptions = TimeoutException.class)
+   public void testTimeoutWithBroadcast() {
+      doTest(null, false, true);
+   }
+
+   @Test(expectedExceptions = TimeoutException.class)
+   public void testTimeoutWithTotalOrderBroadcast() {
+      doTest(null, true, true);
+   }
+
+   @Test(expectedExceptions = TimeoutException.class)
+   public void testTimeoutWithTotalOrderAnycast() {
+      doTest(null, true, false);
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
+      createClusteredCaches(4, CACHE_NAME, builder);
+      waitForClusterToForm(CACHE_NAME);
+   }
+
+   private void doTest(ResponseFilter filter, boolean totalOrder, boolean broadcast) {
+      RpcManager rpcManager = advancedCache(0, CACHE_NAME).getRpcManager();
+      RpcOptionsBuilder builder = rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS)
+            .timeout(1000, TimeUnit.MILLISECONDS)
+            .totalOrder(totalOrder);
+      ArrayList<Address> recipients = null;
+      if (!broadcast) {
+         List<Address> members = rpcManager.getMembers();
+         recipients = new ArrayList<Address>(2);
+         recipients.add(members.get(2));
+         recipients.add(members.get(3));
+      }
+      if (filter != null) {
+         builder.responseFilter(filter);
+      }
+      rpcManager.invokeRemotely(recipients, new SleepingCacheRpcCommand(CACHE_NAME, 5000), builder.build());
+      Assert.fail("Timeout exception wasn't thrown");
+   }
+
+
+}

--- a/core/src/test/java/org/infinispan/remoting/rpc/SleepingCacheRpcCommand.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/SleepingCacheRpcCommand.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.infinispan.remoting.rpc;
+
+import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.context.InvocationContext;
+
+/**
+ * @author Pedro Ruivo
+ * @since 5.3
+ */
+public class SleepingCacheRpcCommand extends BaseRpcCommand {
+
+   public static final byte COMMAND_ID = 125;
+   private long sleepTime;
+
+   public SleepingCacheRpcCommand() {
+      super(null);
+   }
+
+   public SleepingCacheRpcCommand(String cacheName) {
+      super(cacheName);
+   }
+
+   public SleepingCacheRpcCommand(String cacheName, long sleepTime) {
+      super(cacheName);
+      this.sleepTime = sleepTime;
+   }
+
+   @Override
+   public Object perform(InvocationContext ctx) throws Throwable {
+      Thread.sleep(sleepTime);
+      return null;
+   }
+
+   @Override
+   public byte getCommandId() {
+      return COMMAND_ID;
+   }
+
+   @Override
+   public Object[] getParameters() {
+      return new Object[]{sleepTime};
+   }
+
+   @Override
+   public void setParameters(int commandId, Object[] parameters) {
+      if (commandId != COMMAND_ID) {
+         throw new IllegalArgumentException("This is not the command id we expect: " + commandId);
+      }
+      this.sleepTime = (Long) parameters[0];
+   }
+
+   @Override
+   public boolean isReturnValueExpected() {
+      return true;
+   }
+}

--- a/core/src/test/java/org/infinispan/remoting/rpc/TestModuleCommandExtensions.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/TestModuleCommandExtensions.java
@@ -42,6 +42,7 @@ public class TestModuleCommandExtensions implements ModuleCommandExtensions {
             Map<Byte, Class<? extends ReplicableCommand>> map = new HashMap<Byte, Class<? extends ReplicableCommand>>(2);
             map.put(CustomReplicableCommand.COMMAND_ID, CustomReplicableCommand.class);
             map.put(CustomCacheRpcCommand.COMMAND_ID, CustomCacheRpcCommand.class);
+            map.put(SleepingCacheRpcCommand.COMMAND_ID, SleepingCacheRpcCommand.class);
             return map;
          }
 
@@ -65,6 +66,9 @@ public class TestModuleCommandExtensions implements ModuleCommandExtensions {
             switch (commandId) {
                case CustomCacheRpcCommand.COMMAND_ID:
                   c = new CustomCacheRpcCommand(cacheName);
+                  break;
+               case SleepingCacheRpcCommand.COMMAND_ID:
+                  c = new SleepingCacheRpcCommand(cacheName);
                   break;
                default:
                   throw new IllegalArgumentException("Not registered to handle command id " + commandId);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3100

Check for timeout in the FutureCollactor because JGroups does not notify if the timeout expires. 
