### PR TITLE
ISPN-3152 Clear the list of stores in LoadersConfigurationBuilder when read()ing an existing configuration

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/LoadersConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LoadersConfigurationBuilder.java
@@ -237,6 +237,7 @@ public class LoadersConfigurationBuilder extends AbstractConfigurationChildBuild
    @SuppressWarnings("unchecked")
    @Override
    public LoadersConfigurationBuilder read(LoadersConfiguration template) {
+      clearCacheLoaders();
       for (CacheLoaderConfiguration c : template.cacheLoaders()) {
          Class<? extends CacheLoaderConfigurationBuilder<?, ?>> builderClass = (Class<? extends CacheLoaderConfigurationBuilder<?, ?>>) ConfigurationUtils.builderFor(c);
          Builder<Object> builder = (Builder<Object>) this.addLoader(builderClass);

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -418,8 +418,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
 
    @Override
    public Configuration defineConfiguration(String cacheName, Configuration configuration) {
-      defineConfiguration(cacheName, configuration, defaultConfiguration, true);
-      return configuration;
+      return defineConfiguration(cacheName, configuration, defaultConfiguration, true);
    }
 
    /**


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3152
