### PR TITLE
ISPN-3144 Reduce per-entry memory consumption

### DIFF
--- a/core/src/main/java/org/infinispan/container/InternalEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/InternalEntryFactoryImpl.java
@@ -44,8 +44,6 @@ import org.infinispan.container.versioning.EntryVersion;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.util.TimeService;
 
-import java.util.concurrent.TimeUnit;
-
 /**
  * An implementation that generates non-versioned entries
  *

--- a/core/src/main/java/org/infinispan/container/entries/ImmortalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ImmortalCacheEntry.java
@@ -42,16 +42,12 @@ import static org.infinispan.util.Util.toStr;
  * @since 4.0
  */
 public class ImmortalCacheEntry extends AbstractInternalCacheEntry {
-   protected ImmortalCacheValue cacheValue;
 
-   protected ImmortalCacheEntry(Object key, ImmortalCacheValue value) {
-      super(key);
-      this.cacheValue = value;
-   }
+   public Object value;
 
    public ImmortalCacheEntry(Object key, Object value) {
       super(key);
-      this.cacheValue = new ImmortalCacheValue(value);
+      this.value = value;
    }
 
    @Override
@@ -116,17 +112,17 @@ public class ImmortalCacheEntry extends AbstractInternalCacheEntry {
 
    @Override
    public InternalCacheValue toInternalCacheValue() {
-      return cacheValue;
+      return new ImmortalCacheValue(value);
    }
 
    @Override
    public Object getValue() {
-      return cacheValue.value;
+      return value;
    }
 
    @Override
    public Object setValue(Object value) {
-      return this.cacheValue.setValue(value);
+      return this.value = value;
    }
 
    @Override
@@ -148,7 +144,7 @@ public class ImmortalCacheEntry extends AbstractInternalCacheEntry {
       ImmortalCacheEntry that = (ImmortalCacheEntry) o;
 
       if (key != null ? !key.equals(that.key) : that.key != null) return false;
-      if (cacheValue != null ? !cacheValue.equals(that.cacheValue) : that.cacheValue != null) return false;
+      if (value != null ? !value.equals(that.value) : that.value != null) return false;
 
       return true;
    }
@@ -156,22 +152,20 @@ public class ImmortalCacheEntry extends AbstractInternalCacheEntry {
    @Override
    public int hashCode() {
       int result = key != null ? key.hashCode() : 0;
-      result = 31 * result + (cacheValue != null ? cacheValue.hashCode() : 0);
+      result = 31 * result + (value != null ? value.hashCode() : 0);
       return result;
    }
 
    @Override
    public ImmortalCacheEntry clone() {
-      ImmortalCacheEntry clone = (ImmortalCacheEntry) super.clone();
-      clone.cacheValue = cacheValue.clone();
-      return clone;
+      return (ImmortalCacheEntry) super.clone();
    }
 
    public static class Externalizer extends AbstractExternalizer<ImmortalCacheEntry> {
       @Override
       public void writeObject(ObjectOutput output, ImmortalCacheEntry ice) throws IOException {
          output.writeObject(ice.key);
-         output.writeObject(ice.cacheValue.value);
+         output.writeObject(ice.value);
       }
 
       @Override
@@ -196,7 +190,7 @@ public class ImmortalCacheEntry extends AbstractInternalCacheEntry {
    public String toString() {
       return "ImmortalCacheEntry{" +
             "key=" + toStr(key) +
-            ", value=" + cacheValue +
+            ", value=" + toStr(value) +
             "}";
    }
 

--- a/core/src/main/java/org/infinispan/container/entries/metadata/MetadataImmortalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/metadata/MetadataImmortalCacheEntry.java
@@ -19,6 +19,7 @@
 
 package org.infinispan.container.entries.metadata;
 
+import org.infinispan.container.entries.InternalCacheValue;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.container.entries.ImmortalCacheEntry;
 import org.infinispan.marshall.AbstractExternalizer;
@@ -39,30 +40,34 @@ import java.util.Set;
  */
 public class MetadataImmortalCacheEntry extends ImmortalCacheEntry implements MetadataAware {
 
-   public MetadataImmortalCacheEntry(Object key, Object value, Metadata metadata) {
-      super(key, new MetadataImmortalCacheValue(value, metadata));
-   }
+   protected Metadata metadata;
 
-   MetadataImmortalCacheEntry(Object key, MetadataImmortalCacheValue cacheValue) {
-      super(key, cacheValue);
+   public MetadataImmortalCacheEntry(Object key, Object value, Metadata metadata) {
+      super(key, value);
+      this.metadata = metadata;
    }
 
    @Override
    public Metadata getMetadata() {
-      return ((MetadataAware) cacheValue).getMetadata();
+      return metadata;
    }
 
    @Override
    public void setMetadata(Metadata metadata) {
-      ((MetadataAware) cacheValue).setMetadata(metadata);
+      this.metadata = metadata;
+   }
+
+   @Override
+   public InternalCacheValue toInternalCacheValue() {
+      return new MetadataImmortalCacheValue(value, metadata);
    }
 
    public static class Externalizer extends AbstractExternalizer<MetadataImmortalCacheEntry> {
       @Override
       public void writeObject(ObjectOutput output, MetadataImmortalCacheEntry ice) throws IOException {
          output.writeObject(ice.key);
-         output.writeObject(ice.cacheValue.value);
-         output.writeObject(((MetadataAware) ice.cacheValue).getMetadata());
+         output.writeObject(ice.value);
+         output.writeObject(ice.metadata);
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/container/entries/metadata/MetadataImmortalCacheValue.java
+++ b/core/src/main/java/org/infinispan/container/entries/metadata/MetadataImmortalCacheValue.java
@@ -51,7 +51,7 @@ public class MetadataImmortalCacheValue extends ImmortalCacheValue implements Me
 
    @Override
    public InternalCacheEntry toInternalCacheEntry(Object key) {
-      return new MetadataImmortalCacheEntry(key, this);
+      return new MetadataImmortalCacheEntry(key, value, metadata);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/container/entries/metadata/MetadataMortalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/metadata/MetadataMortalCacheEntry.java
@@ -41,32 +41,30 @@ import java.util.Set;
  */
 public class MetadataMortalCacheEntry extends AbstractInternalCacheEntry implements MetadataAware {
 
-   protected MetadataMortalCacheValue cacheValue;
+   protected Object value;
+   protected Metadata metadata;
+   protected long created;
 
    public MetadataMortalCacheEntry(Object key, Object value, Metadata metadata, long created) {
       super(key);
-      cacheValue = new MetadataMortalCacheValue(value, metadata, created);
-   }
-
-   MetadataMortalCacheEntry(Object key, MetadataMortalCacheValue cacheValue) {
-      super(key);
-      this.cacheValue = cacheValue;
+      this.value = value;
+      this.metadata = metadata;
+      this.created = created;
    }
 
    @Override
    public Object getValue() {
-      return cacheValue.value;
+      return value;
    }
 
    @Override
    public Object setValue(Object value) {
-      return cacheValue.setValue(value);
+      return this.value = value;
    }
 
    @Override
    public final boolean isExpired(long now) {
-      return ExpiryHelper.isExpiredMortal(
-            cacheValue.metadata.lifespan(), cacheValue.created, now);
+      return ExpiryHelper.isExpiredMortal(metadata.lifespan(), created, now);
    }
 
    @Override
@@ -81,7 +79,7 @@ public class MetadataMortalCacheEntry extends AbstractInternalCacheEntry impleme
 
    @Override
    public final long getCreated() {
-      return cacheValue.created;
+      return created;
    }
 
    @Override
@@ -91,7 +89,7 @@ public class MetadataMortalCacheEntry extends AbstractInternalCacheEntry impleme
 
    @Override
    public final long getLifespan() {
-      return cacheValue.metadata.lifespan();
+      return metadata.lifespan();
    }
 
    @Override
@@ -101,8 +99,8 @@ public class MetadataMortalCacheEntry extends AbstractInternalCacheEntry impleme
 
    @Override
    public final long getExpiryTime() {
-      long lifespan = cacheValue.metadata.lifespan();
-      return lifespan > -1 ? cacheValue.created + lifespan : -1;
+      long lifespan = metadata.lifespan();
+      return lifespan > -1 ? created + lifespan : -1;
    }
 
    @Override
@@ -122,31 +120,31 @@ public class MetadataMortalCacheEntry extends AbstractInternalCacheEntry impleme
 
    @Override
    public void reincarnate(long now) {
-      cacheValue.setCreated(now);
+      this.created = now;
    }
 
    @Override
    public InternalCacheValue toInternalCacheValue() {
-      return cacheValue;
+      return new MetadataMortalCacheValue(value, metadata, created);
    }
 
    @Override
    public Metadata getMetadata() {
-      return cacheValue.getMetadata();
+      return metadata;
    }
 
    @Override
    public void setMetadata(Metadata metadata) {
-      cacheValue.setMetadata(metadata);
+      this.metadata = metadata;
    }
 
    public static class Externalizer extends AbstractExternalizer<MetadataMortalCacheEntry> {
       @Override
       public void writeObject(ObjectOutput output, MetadataMortalCacheEntry ice) throws IOException {
          output.writeObject(ice.key);
-         output.writeObject(ice.cacheValue.value);
-         output.writeObject(ice.cacheValue.getMetadata());
-         UnsignedNumeric.writeUnsignedLong(output, ice.cacheValue.getCreated());
+         output.writeObject(ice.value);
+         output.writeObject(ice.metadata);
+         UnsignedNumeric.writeUnsignedLong(output, ice.created);
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/container/entries/metadata/MetadataMortalCacheValue.java
+++ b/core/src/main/java/org/infinispan/container/entries/metadata/MetadataMortalCacheValue.java
@@ -53,7 +53,7 @@ public class MetadataMortalCacheValue extends ImmortalCacheValue implements Meta
 
    @Override
    public InternalCacheEntry toInternalCacheEntry(Object key) {
-      return new MetadataMortalCacheEntry(key, this);
+      return new MetadataMortalCacheEntry(key, value, metadata, created);
    }
 
    @Override
@@ -71,17 +71,9 @@ public class MetadataMortalCacheValue extends ImmortalCacheValue implements Meta
       return created;
    }
 
-   public final void setCreated(long created) {
-      this.created = created;
-   }
-
    @Override
    public final long getLifespan() {
       return metadata.lifespan();
-   }
-
-   public final void setLifespan(long lifespan) {
-      throw new IllegalStateException("Not allowed, use setMetadata instead!");
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/container/entries/metadata/MetadataTransientCacheValue.java
+++ b/core/src/main/java/org/infinispan/container/entries/metadata/MetadataTransientCacheValue.java
@@ -54,7 +54,7 @@ public class MetadataTransientCacheValue extends ImmortalCacheValue implements M
 
    @Override
    public InternalCacheEntry toInternalCacheEntry(Object key) {
-      return new MetadataTransientCacheEntry(key, this);
+      return new MetadataTransientCacheEntry(key, value, metadata, lastUsed);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/container/entries/metadata/MetadataTransientMortalCacheValue.java
+++ b/core/src/main/java/org/infinispan/container/entries/metadata/MetadataTransientMortalCacheValue.java
@@ -42,10 +42,6 @@ public class MetadataTransientMortalCacheValue extends MetadataMortalCacheValue 
 
    long lastUsed;
 
-   public MetadataTransientMortalCacheValue(Object value, Metadata metadata, long created) {
-      super(value, metadata, created);
-   }
-
    public MetadataTransientMortalCacheValue(Object v, Metadata metadata, long created, long lastUsed) {
       super(v, metadata, created);
       this.lastUsed = lastUsed;
@@ -53,7 +49,7 @@ public class MetadataTransientMortalCacheValue extends MetadataMortalCacheValue 
 
    @Override
    public InternalCacheEntry toInternalCacheEntry(Object key) {
-      return new MetadataTransientMortalCacheEntry(key, this);
+      return new MetadataTransientMortalCacheEntry(key, value, metadata, lastUsed, created);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/marshall/Ids.java
+++ b/core/src/main/java/org/infinispan/marshall/Ids.java
@@ -97,7 +97,7 @@ public interface Ids {
 
    int CACHE_TOPOLOGY = 75;
 
-   // Versioned entries and values
+   // Metadata entries and values
    int METADATA_IMMORTAL_ENTRY = 76;
    int METADATA_MORTAL_ENTRY = 77;
    int METADATA_TRANSIENT_ENTRY = 78;
@@ -129,4 +129,5 @@ public interface Ids {
    int EMBEDDED_METADATA = 98;
 
    int NUMERIC_VERSION = 99;
+
 }

--- a/core/src/test/java/org/infinispan/loaders/BaseCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/BaseCacheStoreTest.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import org.infinispan.Cache;
 import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.entries.InternalCacheValue;
 import org.infinispan.io.UnclosableObjectInputStream;
 import org.infinispan.io.UnclosableObjectOutputStream;
 import org.infinispan.loaders.modifications.Clear;
@@ -216,6 +217,9 @@ public abstract class BaseCacheStoreTest extends AbstractInfinispanTest {
       long lifespan = 200000;
       long idle = 120000;
       InternalCacheEntry se = TestInternalCacheEntryFactory.create("k", "v", lifespan, idle);
+      InternalCacheValue icv = se.toInternalCacheValue();
+      assertEquals(se.getCreated(), icv.getCreated());
+      assertEquals(se.getLastUsed(), icv.getLastUsed());
       cs.store(se);
 
       assert cs.containsKey("k");

--- a/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedDecoder.scala
+++ b/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedDecoder.scala
@@ -27,6 +27,7 @@ import org.infinispan.server.core.Operation._
 import org.infinispan.server.memcached.MemcachedOperation._
 import org.infinispan.context.Flag
 import java.util.concurrent.{TimeUnit, ScheduledExecutorService}
+import java.util.concurrent.TimeUnit.{MILLISECONDS => MILLIS}
 import java.nio.channels.ClosedChannelException
 import java.util.concurrent.atomic.AtomicLong
 import org.infinispan.server.core._
@@ -355,7 +356,7 @@ class MemcachedDecoder(memcachedCache: AdvancedCache[String, Array[Byte]], sched
       if (flushDelay == 0)
          flushFunction(cache)
       else
-         scheduler.schedule(new DelayedFlushAll(cache, flushFunction), toMillis(flushDelay), TimeUnit.MILLISECONDS)
+         scheduler.schedule(new DelayedFlushAll(cache, flushFunction), toMillis(flushDelay), MILLIS)
       val ret = if (params == null || !params.noReply) OK else null
       writeResponse(ch, ret)
    }
@@ -473,7 +474,8 @@ class MemcachedDecoder(memcachedCache: AdvancedCache[String, Array[Byte]], sched
 
    override protected def buildMetadata(): Metadata = {
       val version = generateVersion(cache)
-      MemcachedMetadata(params.flags, toMillis(params.lifespan), defaultMaxIdleTime, version)
+      MemcachedMetadata(params.flags, version,
+         toMillis(params.lifespan), MILLIS, defaultMaxIdleTime, MILLIS)
    }
 
    private def logAndCreateErrorMessage(sb: StringBuilder, m: MemcachedException): StringBuilder = {
@@ -501,7 +503,7 @@ class MemcachedDecoder(memcachedCache: AdvancedCache[String, Array[Byte]], sched
          buildStat("pid", 0, sb),
          buildStat("uptime", stats.getTimeSinceStart, sb),
          buildStat("uptime", stats.getTimeSinceStart, sb),
-         buildStat("time", TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis), sb),
+         buildStat("time", MILLIS.toSeconds(System.currentTimeMillis), sb),
          buildStat("version", cache.getVersion, sb),
          buildStat("pointer_size", 0, sb), // Unsupported
          buildStat("rusage_user", 0, sb), // Unsupported

--- a/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedMetadata.scala
+++ b/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedMetadata.scala
@@ -24,13 +24,15 @@
 package org.infinispan.server.memcached
 
 import org.infinispan.container.versioning.EntryVersion
-import org.infinispan.metadata.Metadata
+import org.infinispan.metadata.{EmbeddedMetadata, Metadata}
 import Metadata.Builder
 import org.infinispan.marshall.AbstractExternalizer
 import java.util
 import java.io.{ObjectInput, ObjectOutput}
 import scala.collection.JavaConversions.setAsJavaSet
-import org.infinispan.metadata.Metadata
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.{MILLISECONDS => MILLIS}
+import org.jboss.marshalling.util.IdentityIntMap
 
 /**
  * Memcached metadata information.
@@ -38,32 +40,129 @@ import org.infinispan.metadata.Metadata
  * @author Galder Zamarreño
  * @since 5.3
  */
-case class MemcachedMetadata(
-   flags: Long,
-   lifespan: Long, maxIdle: Long,
-   version: EntryVersion = null, builder: Builder = null) extends Metadata
+class MemcachedMetadata(val flags: Long, val version: EntryVersion) extends Metadata {
+
+   def lifespan(): Long = -1
+
+   def maxIdle(): Long = -1
+
+   def builder(): Builder = new MemcachedMetadataBuilder().flags(flags).version(version)
+
+   override def equals(obj: Any): Boolean = {
+      obj match {
+         case that: MemcachedMetadata =>
+            (that.canEqual(this)) &&
+                    flags == that.flags &&
+                    version == that.version
+         case _ => false
+      }
+   }
+
+   def canEqual(other: Any): Boolean = other.isInstanceOf[MemcachedMetadata]
+
+   override def hashCode(): Int = 41 * (41 + flags.hashCode) + version.hashCode()
+
+   override def toString: String = s"MemcachedMetadata(flags=$flags, version=$version)"
+
+}
+
+private class MemcachedExpirableMetadata(
+        override val flags: Long, override val version: EntryVersion,
+        lifespanTime: Long, lifespanUnit: TimeUnit,
+        maxIdleTime: Long, maxIdleUnit: TimeUnit) extends MemcachedMetadata(flags, version) {
+
+   override final val lifespan = lifespanUnit.toMillis(lifespanTime)
+
+   override final val maxIdle = maxIdleUnit.toMillis(maxIdleTime)
+
+   override def equals(obj: Any): Boolean = {
+      obj match {
+         case that: MemcachedExpirableMetadata =>
+            (that.canEqual(this)) &&
+                    flags == that.flags &&
+                    version == that.version &&
+                    lifespan == that.lifespan &&
+                    maxIdle == that.maxIdle
+         case _ => false
+      }
+   }
+
+   override def canEqual(other: Any): Boolean = other.isInstanceOf[MemcachedExpirableMetadata]
+
+   override def hashCode(): Int =
+      41 * (41 * (41 * (41 + flags.hashCode) + version.hashCode) + lifespan.toInt) + maxIdle.toInt
+
+   override def toString: String =
+      s"MemcachedExpirableMetadata(flags=$flags, version=$version, lifespan=$lifespan, maxIdle=$maxIdle)"
+
+}
+
+private class MemcachedMetadataBuilder extends EmbeddedMetadata.Builder {
+
+   private var flags: Long = _
+
+   def flags(flags: Long): MemcachedMetadataBuilder = {
+      this.flags = flags
+      this
+   }
+
+   override def build(): Metadata =
+      MemcachedMetadata(flags, version, lifespan, lifespanUnit, maxIdle, maxIdleUnit)
+
+}
+
 
 object MemcachedMetadata {
 
+   def apply(flags: Long, version: EntryVersion,
+           lifespan: Long, lifespanUnit: TimeUnit,
+           maxIdle: Long, maxIdleUnit: TimeUnit): MemcachedMetadata = {
+      if (lifespan < 0 && maxIdle < 0)
+         new MemcachedMetadata(flags, version)
+      else
+         new MemcachedExpirableMetadata(flags, version, lifespan, lifespanUnit, maxIdle, maxIdleUnit)
+   }
+
+   def apply(flags: Long, version: EntryVersion): MemcachedMetadata =
+      new MemcachedMetadata(flags, version)
+
    class Externalizer extends AbstractExternalizer[MemcachedMetadata] {
+
+      final val Immortal = 0
+      final val Expirable = 1
+
+      final val numbers = new IdentityIntMap[Class[_]](2)
+
+      numbers.put(classOf[MemcachedMetadata], Immortal)
+      numbers.put(classOf[MemcachedExpirableMetadata], Expirable)
 
       def readObject(input: ObjectInput): MemcachedMetadata = {
          val flags = input.readLong()
-         val lifespan = input.readLong()
-         val maxIdle = input.readLong()
-         val entryVersion = input.readObject().asInstanceOf[EntryVersion]
-         MemcachedMetadata(flags, lifespan, maxIdle, entryVersion)
+         val version = input.readObject().asInstanceOf[EntryVersion]
+         val number = input.readUnsignedByte()
+         number match {
+            case Immortal => MemcachedMetadata(flags, version)
+            case Expirable =>
+               val lifespan = input.readLong()
+               val maxIdle = input.readLong()
+               MemcachedMetadata(flags, version, lifespan, MILLIS, maxIdle, MILLIS)
+         }
       }
 
       def writeObject(output: ObjectOutput, meta: MemcachedMetadata) {
          output.writeLong(meta.flags)
-         output.writeLong(meta.lifespan)
-         output.writeLong(meta.maxIdle)
          output.writeObject(meta.version)
+         val number = numbers.get(meta.getClass, -1)
+         output.write(number)
+         if (number == Expirable) {
+            output.writeLong(meta.lifespan())
+            output.writeLong(meta.maxIdle())
+         }
       }
 
       def getTypeClasses: util.Set[Class[_ <: MemcachedMetadata]] =
-         setAsJavaSet(Set[java.lang.Class[_ <: MemcachedMetadata]](classOf[MemcachedMetadata]))
+         setAsJavaSet(Set[java.lang.Class[_ <: MemcachedMetadata]](
+            classOf[MemcachedMetadata], classOf[MemcachedExpirableMetadata]))
 
    }
 

--- a/server/rest/src/main/scala/org/infinispan/rest/MimeMetadata.scala
+++ b/server/rest/src/main/scala/org/infinispan/rest/MimeMetadata.scala
@@ -26,13 +26,13 @@ package org.infinispan.rest
 import org.infinispan.container.versioning.EntryVersion
 import java.util.concurrent.TimeUnit.{MILLISECONDS => MILLIS}
 import java.util.concurrent.TimeUnit
-import org.infinispan.metadata.Metadata
+import org.infinispan.metadata.{EmbeddedMetadata, Metadata}
 import Metadata.Builder
 import org.infinispan.marshall.AbstractExternalizer
 import java.util
 import java.io.{ObjectInput, ObjectOutput}
 import scala.collection.JavaConversions.setAsJavaSet
-import org.infinispan.metadata.Metadata
+import org.jboss.marshalling.util.IdentityIntMap
 
 /**
  * Metadata for MIME data stored in REST servers.
@@ -40,36 +40,123 @@ import org.infinispan.metadata.Metadata
  * @author Galder Zamarreño
  * @since 5.3
  */
-case class MimeMetadata(
-        contentType: String,
-        lifespanParam: Long, lifespanUnit: TimeUnit,
-        memcachedParam: Long, maxIdleUnit: TimeUnit,
-        version: EntryVersion = null, builder: Builder = null) extends Metadata {
+class MimeMetadata(val contentType: String) extends Metadata {
 
-   override val lifespan = lifespanUnit.toMillis(lifespanParam)
-   override val maxIdle = maxIdleUnit.toMillis(memcachedParam)
+   def lifespan(): Long = -1
+
+   def maxIdle(): Long = -1
+
+   def version(): EntryVersion = null
+
+   def builder(): Builder = new MimeMetadataBuilder().contentType(contentType)
+
+   override def equals(obj: Any): Boolean = {
+      obj match {
+         case that: MimeMetadata =>
+            (that.canEqual(this)) && contentType == that.contentType
+         case _ => false
+      }
+   }
+
+   def canEqual(other: Any): Boolean = other.isInstanceOf[MimeMetadata]
+
+   override def hashCode(): Int = 41 + contentType.hashCode
+
+   override def toString: String = s"MimeMetadata(contentType=$contentType)"
+
+}
+
+private class MimeExpirableMetadata(override val contentType: String,
+        lifespanTime: Long, lifespanUnit: TimeUnit,
+        maxIdleTime: Long, maxIdleUnit: TimeUnit) extends MimeMetadata(contentType) {
+
+   override final val lifespan = lifespanUnit.toMillis(lifespanTime)
+
+   override final val maxIdle = maxIdleUnit.toMillis(maxIdleTime)
+
+   override def equals(obj: Any): Boolean = {
+      obj match {
+         case that: MimeExpirableMetadata =>
+            (that.canEqual(this)) &&
+                    contentType == that.contentType &&
+                    lifespan == that.lifespan &&
+                    maxIdle == that.maxIdle
+         case _ => false
+      }
+   }
+
+   override def canEqual(other: Any): Boolean = other.isInstanceOf[MimeExpirableMetadata]
+
+   override def hashCode(): Int =
+      41 * (41 * (41 + contentType.hashCode) + lifespan.toInt) + maxIdle.toInt
+
+   override def toString: String =
+      s"MimeExpirableMetadata(contentType=$contentType, lifespan=$lifespan, maxIdle=$maxIdle)"
+
+}
+
+private class MimeMetadataBuilder extends EmbeddedMetadata.Builder {
+
+   private var contentType: String = _
+
+   def contentType(contentType: String): MimeMetadataBuilder = {
+      this.contentType = contentType
+      this
+   }
+
+   override def build(): Metadata =
+      MimeMetadata(contentType, lifespan, lifespanUnit, maxIdle, maxIdleUnit)
 
 }
 
 object MimeMetadata {
 
+   def apply(contentType: String,
+           lifespan: Long, lifespanUnit: TimeUnit,
+           maxIdle: Long, maxIdleUnit: TimeUnit): MimeMetadata = {
+      if (lifespan < 0 && maxIdle < 0)
+         new MimeMetadata(contentType)
+      else
+         new MimeExpirableMetadata(contentType, lifespan, lifespanUnit, maxIdle, maxIdleUnit)
+   }
+
+   private def apply(contentType: String): MimeMetadata = new MimeMetadata(contentType)
+
    class Externalizer extends AbstractExternalizer[MimeMetadata] {
+
+      final val Immortal = 0
+      final val Expirable = 1
+
+      final val numbers = new IdentityIntMap[Class[_]](2)
+
+      numbers.put(classOf[MimeMetadata], Immortal)
+      numbers.put(classOf[MimeExpirableMetadata], Expirable)
 
       def readObject(input: ObjectInput): MimeMetadata = {
          val contentType = input.readUTF()
-         val lifespan = input.readLong()
-         val maxIdle = input.readLong()
-         MimeMetadata(contentType, lifespan, MILLIS, maxIdle, MILLIS)
+         val number = input.readUnsignedByte()
+         number match {
+            case Immortal => MimeMetadata(contentType)
+            case Expirable =>
+               val lifespan = input.readLong()
+               val maxIdle = input.readLong()
+               MimeMetadata(contentType, lifespan, MILLIS, maxIdle, MILLIS)
+         }
       }
 
       def writeObject(output: ObjectOutput, meta: MimeMetadata) {
          output.writeUTF(meta.contentType)
-         output.writeLong(meta.lifespan)
-         output.writeLong(meta.maxIdle)
+         val number = numbers.get(meta.getClass, -1)
+         output.write(number)
+         if (number == Expirable) {
+            output.writeLong(meta.lifespan())
+            output.writeLong(meta.maxIdle())
+         }
       }
 
       def getTypeClasses: util.Set[Class[_ <: MimeMetadata]] =
-         setAsJavaSet(Set[java.lang.Class[_ <: MimeMetadata]](classOf[MimeMetadata]))
+         setAsJavaSet(Set[java.lang.Class[_ <: MimeMetadata]](
+            classOf[MimeMetadata], classOf[MimeExpirableMetadata]))
 
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3144
- For Embedded, Hot Rod, REST and Memcached endpoints.
- Internal cache entries no longer have a internal cache value
  reference, instead they store data directly.
- Made mime metadata for REST more space efficient.
- Adjust externalizer implementations for Mime and Memcached so
  that they avoid sending expiration info if not needed.

Results:
- Hot Rod reduced to 151 bytes per entry
- REST reduced to 172 bytes
- Memcached is 180 bytes
