### PR TITLE
ISPN-3168 Use createClusteredCacheManager instead of createCacheManager ...

### DIFF
--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -298,10 +298,16 @@ public class TestCacheManagerFactory {
    }
 
    public static EmbeddedCacheManager createCacheManager(GlobalConfigurationBuilder globalBuilder, ConfigurationBuilder builder) {
+      if (globalBuilder.transport().build().transport().transport() != null) {
+         throw new IllegalArgumentException("Use TestCacheManagerFactory.createClusteredCacheManager(...) for clustered cache managers");
+      }
       return newDefaultCacheManager(true, globalBuilder, builder, false);
    }
 
    public static EmbeddedCacheManager createCacheManager(GlobalConfigurationBuilder globalBuilder, ConfigurationBuilder builder, boolean keepJmxDomain) {
+      if (globalBuilder.transport().build().transport().transport() != null) {
+         throw new IllegalArgumentException("Use TestCacheManagerFactory.createClusteredCacheManager(...) for clustered cache managers");
+      }
       return newDefaultCacheManager(true, globalBuilder, builder, keepJmxDomain);
    }
 
@@ -419,7 +425,7 @@ public class TestCacheManagerFactory {
             .jmxDomain(jmxDomain)
             .mBeanServerLookup(mBeanServerLookup)
             .enabled(exposeGlobalJmx);
-      return createCacheManager(globalBuilder, builder, true);
+      return createClusteredCacheManager(globalBuilder, builder, new TransportFlags(), true);
    }
 
    /**

--- a/core/src/test/java/org/infinispan/tx/OnePhaseXATest.java
+++ b/core/src/test/java/org/infinispan/tx/OnePhaseXATest.java
@@ -86,7 +86,7 @@ public class OnePhaseXATest extends AbstractInfinispanTest {
             .transaction().invocationBatching().enable()
             .transaction().syncCommitPhase(true)
             .locking().lockAcquisitionTimeout(60000).useLockStriping(false);
-      EmbeddedCacheManager container = TestCacheManagerFactory.createCacheManager(gc, c);
+      EmbeddedCacheManager container = TestCacheManagerFactory.createClusteredCacheManager(gc, c);
       cacheContainers.add(container);
       return container.getCache("TestCache");
    }

--- a/spring/src/test/java/org/infinispan/spring/support/embedded/TestInfinispanEmbeddedCacheManagerFactoryBean.java
+++ b/spring/src/test/java/org/infinispan/spring/support/embedded/TestInfinispanEmbeddedCacheManagerFactoryBean.java
@@ -41,7 +41,7 @@ public class TestInfinispanEmbeddedCacheManagerFactoryBean extends InfinispanEmb
 
    @Override
    protected EmbeddedCacheManager createCacheManager(GlobalConfigurationBuilder globalBuilder, ConfigurationBuilder builder) {
-      return TestCacheManagerFactory.createCacheManager(globalBuilder, builder);
+      return TestCacheManagerFactory.createClusteredCacheManager(globalBuilder, builder);
    }
 
    @Override


### PR DESCRIPTION
...for clustered caches

https://issues.jboss.org/browse/ISPN-3168

OnePhaseXATest fails very often on my machine with a ClassCastException.
