### PR TITLE
ISPN-3182 Make the AbstractDelegatingAdvancedCache use flags in the getCacheEntry(key) invocation

### DIFF
--- a/core/src/main/java/org/infinispan/AbstractDelegatingAdvancedCache.java
+++ b/core/src/main/java/org/infinispan/AbstractDelegatingAdvancedCache.java
@@ -200,7 +200,7 @@ public class AbstractDelegatingAdvancedCache<K, V> extends AbstractDelegatingCac
 
    @Override
    public CacheEntry getCacheEntry(K key) {
-      return cache.getCacheEntry(key, null, null);
+      return cache.getCacheEntry(key);
    }
 
    @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3182

Also pull https://github.com/infinispan/infinispan-server/pull/111
