### PR TITLE
ISPN-2836 org.jgroups.TimeoutException after invoking MapCombineCommand ...

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcOptionsBuilder.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcOptionsBuilder.java
@@ -76,6 +76,15 @@ public class RpcOptionsBuilder {
    }
 
    /**
+    * See {@link #timeout(long, java.util.concurrent.TimeUnit)}
+    *
+    * @return the timeout in {@link TimeUnit}.
+    */
+   public long timeout(TimeUnit outputTimeUnit) {
+      return outputTimeUnit.convert(timeout, unit);
+   }
+
+   /**
     * Note: this option may be set to {@code false} if by the current {@link org.infinispan.remoting.transport.Transport}
     * if the {@link org.infinispan.remoting.rpc.ResponseMode#isSynchronous()} returns {@code true}.
     *

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/SimpleMapReduceTaskTimeoutTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/SimpleMapReduceTaskTimeoutTest.java
@@ -1,0 +1,212 @@
+package org.infinispan.distexec.mapreduce;
+
+import org.infinispan.Cache;
+import org.infinispan.CacheException;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.util.concurrent.TimeoutException;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.infinispan.distribution.DistributionTestHelper.isFirstOwner;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * @author Pedro Ruivo
+ * @since 5.3
+ */
+@Test(groups = "functional", testName = "distexec.mapreduce.SimpleMapReduceTaskTimeoutTest")
+public class SimpleMapReduceTaskTimeoutTest extends MultipleCacheManagersTest {
+
+   private static final int REPLICATION_TIMEOUT = 5000;
+
+   public SimpleMapReduceTaskTimeoutTest() {
+      this.cleanup = CleanupPhase.AFTER_METHOD;
+   }
+
+   /**
+    * Tests a map/reduce task with duration between replication timeout and task timeout (no exception should be
+    * thrown)
+    */
+   public void testTimeout() {
+      final int taskTimeout = REPLICATION_TIMEOUT * 4;
+      final int sleepTime = REPLICATION_TIMEOUT * 2;
+      final String sleepOnKey = init();
+
+      MapReduceTask<String, String, String, Integer> task = createMapReduceTask(this.<String, String>cache(0));
+      assertEquals("Wrong task timeout.", REPLICATION_TIMEOUT, task.timeout(MILLISECONDS));
+      assertEquals("Wrong replication timeout.", REPLICATION_TIMEOUT,
+                   cache(0).getCacheConfiguration().clustering().sync().replTimeout());
+      task.timeout(taskTimeout, MILLISECONDS);
+      assertEquals("Wrong new task timeout.", taskTimeout, task.timeout(MILLISECONDS));
+
+      task.mappedWith(new SleepMapper(sleepTime, sleepOnKey))
+            .reducedWith(new DummyReducer());
+
+      long start = System.nanoTime();
+      task.execute();
+      long duration = System.nanoTime() - start;
+      assertTrue(NANOSECONDS.toMillis(duration) >= sleepTime);
+   }
+
+   /**
+    * Tests a map/reduce task with duration between task timeout and replication timeout (exception expected!)
+    */
+   public void testTimeout2() {
+      final int taskTimeout = REPLICATION_TIMEOUT / 4;
+      final int sleepTime = REPLICATION_TIMEOUT / 2;
+      final String sleepOnKey = init();
+
+      MapReduceTask<String, String, String, Integer> task = createMapReduceTask(this.<String, String>cache(0));
+      assertEquals("Wrong task timeout.", REPLICATION_TIMEOUT, task.timeout(MILLISECONDS));
+      assertEquals("Wrong replication timeout.", REPLICATION_TIMEOUT,
+                   cache(0).getCacheConfiguration().clustering().sync().replTimeout());
+      task.timeout(taskTimeout, MILLISECONDS);
+      assertEquals("Wrong new task timeout.", taskTimeout, task.timeout(MILLISECONDS));
+
+      task.mappedWith(new SleepMapper(sleepTime, sleepOnKey))
+            .reducedWith(new DummyReducer());
+
+      long start = System.nanoTime();
+      try {
+         task.execute();
+      } catch (CacheException expected) {
+         assertTrue(hasTimeoutException(expected));
+      }
+      long duration = System.nanoTime() - start;
+      assertTrue(NANOSECONDS.toMillis(duration) >= taskTimeout);
+   }
+
+   /**
+    * Tests a map/reduce task with duration higher than replication timeout and waiting forever (no exception should be
+    * thrown)
+    */
+   public void testNegativeTimeout() {
+      final int taskTimeout = -1;
+      final int sleepTime = REPLICATION_TIMEOUT * 2; //higher thant the replication timeout
+      final String sleepOnKey = init();
+
+      MapReduceTask<String, String, String, Integer> task = createMapReduceTask(this.<String, String>cache(0));
+      assertEquals("Wrong task timeout.", REPLICATION_TIMEOUT, task.timeout(MILLISECONDS));
+      assertEquals("Wrong replication timeout.", REPLICATION_TIMEOUT,
+                   cache(0).getCacheConfiguration().clustering().sync().replTimeout());
+      task.timeout(taskTimeout, MILLISECONDS);
+      assertEquals("Wrong new task timeout.", taskTimeout, task.timeout(MILLISECONDS));
+
+      task.mappedWith(new SleepMapper(sleepTime, sleepOnKey))
+            .reducedWith(new DummyReducer());
+
+      long start = System.nanoTime();
+      task.execute();
+      long duration = System.nanoTime() - start;
+      assertTrue(NANOSECONDS.toMillis(duration) >= sleepTime);
+   }
+
+   /**
+    * Tests a map/reduce task with duration higher than replication timeout and waiting forever (no exception should be
+    * thrown)
+    */
+   public void testZeroTimeout() {
+      final int taskTimeout = 0;
+      final int sleepTime = REPLICATION_TIMEOUT * 2; //higher thant the replication timeout
+      final String sleepOnKey = init();
+
+      MapReduceTask<String, String, String, Integer> task = createMapReduceTask(this.<String, String>cache(0));
+      assertEquals("Wrong task timeout.", REPLICATION_TIMEOUT, task.timeout(MILLISECONDS));
+      assertEquals("Wrong replication timeout.", REPLICATION_TIMEOUT,
+                   cache(0).getCacheConfiguration().clustering().sync().replTimeout());
+      task.timeout(taskTimeout, MILLISECONDS);
+      assertEquals("Wrong new task timeout.", taskTimeout, task.timeout(MILLISECONDS));
+
+      task.mappedWith(new SleepMapper(sleepTime, sleepOnKey))
+            .reducedWith(new DummyReducer());
+
+      long start = System.nanoTime();
+      task.execute();
+      long duration = System.nanoTime() - start;
+      assertTrue(NANOSECONDS.toMillis(duration) >= sleepTime);
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
+      builder.clustering().sync().replTimeout(REPLICATION_TIMEOUT);
+      createClusteredCaches(4, builder);
+   }
+
+   protected MapReduceTask<String, String, String, Integer> createMapReduceTask(Cache<String, String> c) {
+      return new MapReduceTask<String, String, String, Integer>(c);
+   }
+
+   private boolean hasTimeoutException(CacheException exception) {
+      Throwable iterator = exception;
+      while (iterator != null) {
+         if (iterator instanceof TimeoutException) {
+            return true;
+         }
+         iterator = iterator.getCause();
+      }
+      return false;
+   }
+
+   /**
+    * Initializes all the caches with some data.
+    *
+    * @return a key owned by cache(1).
+    */
+   private String init() {
+      String sleepOnKey = null;
+      for (int i = 0; i < 100; ++i) {
+         String key = String.valueOf(i);
+         cache(0).put(key, "v" + (i % 4));
+         if (sleepOnKey == null && isFirstOwner(cache(1), key)) {
+            sleepOnKey = key;
+         }
+      }
+      return sleepOnKey;
+   }
+
+   public static class SleepMapper implements Mapper<String, String, String, Integer> {
+
+      private final long sleepTime;
+      private final String sleepOnKey;
+      private boolean alreadySlept;
+
+      public SleepMapper(long sleepTime, String sleepOnKey) {
+         this.sleepTime = sleepTime;
+         this.sleepOnKey = sleepOnKey;
+         this.alreadySlept = false;
+      }
+
+      @Override
+      public void map(String key, String value, Collector<String, Integer> collector) {
+         if (!alreadySlept && key.equals(sleepOnKey)) {
+            try {
+               Thread.sleep(sleepTime);
+            } catch (InterruptedException e) {
+               //no-op
+               Thread.currentThread().interrupt();
+            }
+            alreadySlept = true;
+         }
+         collector.emit(value, 1);
+      }
+   }
+
+   public static class DummyReducer implements Reducer<String, Integer> {
+
+      @Override
+      public Integer reduce(String reducedKey, Iterator<Integer> iter) {
+         int sum = 0;
+         while (iter.hasNext()) {
+            sum += iter.next();
+         }
+         return sum;
+      }
+   }
+}


### PR DESCRIPTION
...in Map/Reduce task with 2 nodes

https://issues.jboss.org/browse/ISPN-2836

Since we have no control how long the map/reduce tasks can run, I've created a separate timeout for them (instead of using the replication timeout). 

ps. Sorry, I let IntelliJ to trim the lines in MapReduceManagerImpl. The only real modifications is some logging in the map/reduce phase duration times. 
