### PR TITLE
ISPN-3206 REST endpoint returns Expiry header in default locale for the server

### DIFF
--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestHotRodTest.java
@@ -43,9 +43,10 @@ import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 import static org.testng.AssertJUnit.*;
@@ -59,7 +60,7 @@ import static org.testng.AssertJUnit.*;
 @Test(groups = "functional", testName = "it.compatibility.EmbeddedRestHotRodTest")
 public class EmbeddedRestHotRodTest {
 
-   private static final DateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
+   private static final DateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
 
    CompatibilityCacheFactory<String, Object> cacheFactory;
 
@@ -67,6 +68,7 @@ public class EmbeddedRestHotRodTest {
    protected void setup() throws Exception {
       cacheFactory = new CompatibilityCacheFactory<String, Object>();
       cacheFactory.setup();
+      dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
    }
 
    @AfterClass


### PR DESCRIPTION
This should be pulled after https://github.com/infinispan/infinispan/pull/1879 otherwise there will be conflicts.
- Due to a bug in RESTEasy, set the Expires and Last-Modified headers manually (besides that, Last-Modified's generation is correct in 2.3.2 version (which is currently used by ISPN) but in recent versions it uses toString on the passed date to generate the header -> if we ever upgrade to newer RESTEasy, we'll be safe)
