### PR TITLE
ISPN-3140 JMX operation to suppress state transfer

### DIFF
--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -122,7 +122,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
    }
 
    @Override
-   public void triggerRebalance(final String cacheName) throws Exception {
+   public void triggerRebalance(final String cacheName) {
       asyncTransportExecutor.submit(new Callable<Object>() {
          @Override
          public Object call() throws Exception {
@@ -130,7 +130,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
                startRebalance(cacheName);
                return null;
             } catch (Throwable t) {
-               log.errorf(t, "Failed to start rebalance: %s", t.getMessage());
+               log.rebalanceStartError(cacheName, t);
                throw new Exception(t);
             }
          }

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -35,6 +35,9 @@ import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
+import org.infinispan.jmx.annotations.DataType;
+import org.infinispan.jmx.annotations.MBean;
+import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.remoting.responses.ExceptionResponse;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.responses.SuccessfulResponse;
@@ -54,6 +57,7 @@ import static org.infinispan.factories.KnownComponentNames.ASYNC_TRANSPORT_EXECU
  * @author Dan Berindei
  * @since 5.2
  */
+@MBean(objectName = "LocalTopologyManager", description = "Controls the cache membership and state transfer")
 public class LocalTopologyManagerImpl implements LocalTopologyManager {
    private static Log log = LogFactory.getLog(LocalTopologyManagerImpl.class);
    private static final boolean trace = log.isTraceEnabled();
@@ -259,6 +263,22 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
       }
    }
 
+   @ManagedAttribute(description = "Rebalancing enabled", displayName = "Rebalancing enabled",
+         dataType = DataType.TRAIT, writable = true)
+   public boolean isRebalancingEnabled() throws Exception {
+      ReplicableCommand command = new CacheTopologyControlCommand(null,
+            CacheTopologyControlCommand.Type.POLICY_GET_STATUS, transport.getAddress(), transport.getViewId());
+      return (Boolean) executeOnCoordinator(command, getGlobalTimeout());
+   }
+
+   public void setRebalancingEnabled(boolean enabled) throws Exception {
+      CacheTopologyControlCommand.Type type = enabled ? CacheTopologyControlCommand.Type.POLICY_ENABLE
+            : CacheTopologyControlCommand.Type.POLICY_DISABLE;
+      ReplicableCommand command = new CacheTopologyControlCommand(null, type, transport.getAddress(),
+            transport.getViewId());
+      executeOnCoordinator(command, getGlobalTimeout());
+   }
+
    private Object executeOnCoordinator(ReplicableCommand command, long timeout) throws Exception {
       Response response;
       if (transport.isCoordinator()) {
@@ -307,6 +327,10 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
       }
    }
 
+   private int getGlobalTimeout() {
+      // TODO Rename setting to something like globalRpcTimeout
+      return (int) gcr.getGlobalConfiguration().transport().distributedSyncTimeout();
+   }
 }
 
 class LocalCacheStatus {

--- a/core/src/main/java/org/infinispan/topology/RebalancePolicy.java
+++ b/core/src/main/java/org/infinispan/topology/RebalancePolicy.java
@@ -48,4 +48,17 @@ public interface RebalancePolicy {
     * Called when the status of a cache changes. It could be a node joining or leaving, or a merge, or a
     */
    void updateCacheStatus(String cacheName, ClusterCacheStatus cacheStatus) throws Exception;
+
+   /**
+    * @return {@code true} if rebalancing is allowed, {@code false} if rebalancing is suspended.
+    * @since 5.3
+    */
+   boolean isRebalancingEnabled();
+
+   /**
+    * @param enabled {@code true} to start rebalancing (immediately starting the rebalance if necessary),
+    *                {@code false} to suspend it.
+    * @since 5.3
+    */
+   void setRebalancingEnabled(boolean enabled);
 }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -888,5 +888,8 @@ public interface Log extends BasicLogger {
    @Message(value = "Unexpected initial version type (only NumericVersion instances supported): %s", id = 229)
    IllegalArgumentException unexpectedInitialVersion(String className);
 
+   @LogMessage(level = ERROR)
+   @Message(value = "Failed to start rebalance for cache %s", id = 230)
+   void rebalanceStartError(String cacheName, @Cause Throwable cause);
 }
 

--- a/core/src/test/java/org/infinispan/jmx/CacheClearTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheClearTest.java
@@ -41,7 +41,7 @@ import static org.testng.AssertJUnit.assertTrue;
 @Test (groups = "functional", testName = "jmx.CacheClearTest")
 public class CacheClearTest extends SingleCacheManagerTest {
 
-   public static final String JMX_DOMAIN = CacheMBeanTest.class.getSimpleName();
+   public static final String JMX_DOMAIN = CacheClearTest.class.getSimpleName();
    private MBeanServer server;
 
    @Override

--- a/core/src/test/java/org/infinispan/statetransfer/RebalancePolicyJmxTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/RebalancePolicyJmxTest.java
@@ -1,0 +1,153 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.infinispan.statetransfer;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.jmx.PerThreadMBeanServerLookup;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import javax.management.Attribute;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import static org.infinispan.test.TestingUtil.killCacheManagers;
+import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * @author Dan Berindei
+ */
+@Test(groups = "functional", testName = "jmx.RebalancePolicyJmxTest")
+public class RebalancePolicyJmxTest extends MultipleCacheManagersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      addClusterEnabledCacheManager(getGlobalConfigurationBuilder("r1"), getConfigurationBuilder());
+      addClusterEnabledCacheManager(getGlobalConfigurationBuilder("r1"), getConfigurationBuilder());
+      waitForClusterToForm();
+   }
+
+   private ConfigurationBuilder getConfigurationBuilder() {
+      ConfigurationBuilder cb = new ConfigurationBuilder();
+      cb.clustering().cacheMode(CacheMode.DIST_SYNC)
+         .stateTransfer().awaitInitialTransfer(false);
+      return cb;
+   }
+
+   private GlobalConfigurationBuilder getGlobalConfigurationBuilder(String rackId) {
+      GlobalConfigurationBuilder gcb = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      gcb.globalJmxStatistics()
+            .enable()
+            //.allowDuplicateDomains(true)
+            //.jmxDomain(JMX_DOMAIN)
+            .mBeanServerLookup(new PerThreadMBeanServerLookup())
+         .transport().rackId(rackId);
+      return gcb;
+   }
+
+   public void testRebalanceSuspend() throws Exception {
+      MBeanServer mBeanServer = PerThreadMBeanServerLookup.getThreadMBeanServer();
+      String domain0 = manager(1).getCacheManagerConfiguration().globalJmxStatistics().domain();
+      ObjectName ltmName0 = TestingUtil.getCacheManagerObjectName(domain0, "DefaultCacheManager", "LocalTopologyManager");
+      String domain1 = manager(1).getCacheManagerConfiguration().globalJmxStatistics().domain();
+      ObjectName ltmName1 = TestingUtil.getCacheManagerObjectName(domain1, "DefaultCacheManager", "LocalTopologyManager");
+
+      // Check initial state
+      StateTransferManager stm0 = TestingUtil.extractComponent(cache(0), StateTransferManager.class);
+      assertEquals(Arrays.asList(address(0), address(1)), stm0.getCacheTopology().getCurrentCH().getMembers());
+      assertNull(stm0.getCacheTopology().getPendingCH());
+
+      assertTrue(mBeanServer.isRegistered(ltmName0));
+      assertTrue((Boolean) mBeanServer.getAttribute(ltmName0, "RebalancingEnabled"));
+
+      // Suspend rebalancing
+      mBeanServer.setAttribute(ltmName0, new Attribute("RebalancingEnabled", false));
+      assertFalse((Boolean) mBeanServer.getAttribute(ltmName0, "RebalancingEnabled"));
+
+      // Add 2 nodes
+      addClusterEnabledCacheManager(getGlobalConfigurationBuilder("r2"), getConfigurationBuilder());
+      addClusterEnabledCacheManager(getGlobalConfigurationBuilder("r2"), getConfigurationBuilder());
+
+      // Check that no rebalance happened after 1 second
+      Thread.sleep(1000);
+      assertFalse((Boolean) mBeanServer.getAttribute(ltmName1, "RebalancingEnabled"));
+      assertNull(stm0.getCacheTopology().getPendingCH());
+      assertEquals(Arrays.asList(address(0), address(1)), stm0.getCacheTopology().getCurrentCH().getMembers());
+
+      // Re-enable rebalancing
+      mBeanServer.setAttribute(ltmName0, new Attribute("RebalancingEnabled", true));
+      assertTrue((Boolean) mBeanServer.getAttribute(ltmName0, "RebalancingEnabled"));
+      // Duplicate request to enable rebalancing - should be ignored
+      mBeanServer.setAttribute(ltmName0, new Attribute("RebalancingEnabled", true));
+
+      // Check that the cache now has 4 nodes, and the CH is balanced
+      TestingUtil.waitForRehashToComplete(cache(0), cache(1), cache(2), cache(3));
+      assertNull(stm0.getCacheTopology().getPendingCH());
+      ConsistentHash ch = stm0.getCacheTopology().getCurrentCH();
+      assertEquals(Arrays.asList(address(0), address(1), address(2), address(3)), ch.getMembers());
+      for (int i = 0; i < ch.getNumSegments(); i++) {
+         assertEquals(2, ch.locateOwnersForSegment(i).size());
+      }
+
+      // Suspend rebalancing again
+      mBeanServer.setAttribute(ltmName1, new Attribute("RebalancingEnabled", false));
+      assertFalse((Boolean) mBeanServer.getAttribute(ltmName1, "RebalancingEnabled"));
+      // Duplicate request to enable rebalancing - should be ignored
+      mBeanServer.setAttribute(ltmName1, new Attribute("RebalancingEnabled", false));
+
+      // Kill the previously added 2 nodes
+      killCacheManagers(manager(2), manager(3));
+
+      // Check that the nodes are no longer in the CH, but every segment only has one copy
+      // Implicitly, this also checks that no data has been lost - if both a segment's owners had left,
+      // the CH factory would have assigned 2 owners.
+      Thread.sleep(1000);
+      assertNull(stm0.getCacheTopology().getPendingCH());
+      ch = stm0.getCacheTopology().getCurrentCH();
+      assertEquals(Arrays.asList(address(0), address(1)), ch.getMembers());
+      for (int i = 0; i < ch.getNumSegments(); i++) {
+         assertEquals(1, ch.locateOwnersForSegment(i).size());
+      }
+
+      // Enable rebalancing again
+      mBeanServer.setAttribute(ltmName1, new Attribute("RebalancingEnabled", true));
+      assertTrue((Boolean) mBeanServer.getAttribute(ltmName1, "RebalancingEnabled"));
+
+      // Check that the CH is now balanced (and every segment has 2 copies)
+      TestingUtil.waitForRehashToComplete(cache(0), cache(1));
+      assertNull(stm0.getCacheTopology().getPendingCH());
+      ch = stm0.getCacheTopology().getCurrentCH();
+      assertEquals(Arrays.asList(address(0), address(1)), ch.getMembers());
+      for (int i = 0; i < ch.getNumSegments(); i++) {
+         assertEquals(2, ch.locateOwnersForSegment(i).size());
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -70,6 +70,7 @@ import org.infinispan.loaders.CacheLoader;
 import org.infinispan.loaders.CacheLoaderManager;
 import org.infinispan.loaders.CacheStore;
 import org.infinispan.manager.CacheContainer;
+import org.infinispan.manager.CacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.AbstractDelegatingMarshaller;
 import org.infinispan.marshall.StreamingMarshaller;
@@ -1127,8 +1128,12 @@ public class TestingUtil {
    }
 
    public static ObjectName getCacheManagerObjectName(String jmxDomain, String cacheManagerName) {
+      return getCacheManagerObjectName(jmxDomain, cacheManagerName, "CacheManager");
+   }
+
+   public static ObjectName getCacheManagerObjectName(String jmxDomain, String cacheManagerName, String component) {
       try {
-         return new ObjectName(jmxDomain + ":type=CacheManager,name=" + ObjectName.quote(cacheManagerName) + ",component=CacheManager");
+         return new ObjectName(jmxDomain + ":type=CacheManager,name=" + ObjectName.quote(cacheManagerName) + ",component=" + component);
       } catch (Exception e) {
          throw new RuntimeException(e);
       }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3140

Make LocalTopologyManagerImpl a MBean and add a RebalancingEnabled
JMX attribute to suppress/enable rebalancing in the cluster from any node.
If the coordinator dies, however, the new coordinator will not remember
if rebalancing was suppressed on the old coordinator.
