### PR TITLE
ISPN-3191 - TopologyAwareDistributedCacheTest failing randomly

### DIFF
--- a/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareDistributedCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/TopologyAwareDistributedCacheTest.java
@@ -27,7 +27,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.testng.annotations.Test;
 
 /**
- * Testing query functionality on InfinispanIndexManager enabled Topology aware nodes.
+ * Testing query functionality on RAM directory for DIST_SYNC cache mode with enabled Topology aware nodes.
  *
  * @author Anna Manukyan
  */
@@ -38,15 +38,4 @@ public class TopologyAwareDistributedCacheTest extends TopologyAwareClusteredCac
    public CacheMode getCacheMode() {
       return CacheMode.DIST_SYNC;
    }
-
-   @Override
-   public boolean isIndexLocalOnly() {
-      return true;
-   }
-
-   @Override
-   public boolean isRamDirectory() {
-      return false;
-   }
-
 }


### PR DESCRIPTION
- The test is changed so that it tests the same functionality which does it's parent, only for different cache mode - DIST_SYNC.
  Bug ISPN-3191 is a duplicate for ISPN-2842.
