### PR TITLE
ISPN-3218 Support non-byte array replication in compatibility mode

### DIFF
--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/CustomMemcachedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/CustomMemcachedHotRodTest.java
@@ -25,6 +25,7 @@ package org.infinispan.it.compatibility;
 
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.io.ByteBuffer;
 import org.infinispan.marshall.AbstractMarshaller;
 import org.infinispan.test.AbstractInfinispanTest;
@@ -59,13 +60,13 @@ public class CustomMemcachedHotRodTest extends AbstractInfinispanTest {
 
    @BeforeClass
    protected void setup() throws Exception {
-      cacheFactory = new CompatibilityCacheFactory<String, String>(CACHE_NAME, new StringMarshaller());
-      cacheFactory.setup();
+      cacheFactory = new CompatibilityCacheFactory<String, String>(
+            CACHE_NAME, new StringMarshaller(), CacheMode.LOCAL).setup();
    }
 
    @AfterClass
    protected void teardown() {
-      cacheFactory.teardown();
+      CompatibilityCacheFactory.killCacheFactories(cacheFactory);
    }
 
    public void testHotRodPutMemcachedGet() throws IOException {

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedHotRodTest.java
@@ -27,6 +27,7 @@ import org.infinispan.Cache;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.VersionedValue;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -47,13 +48,12 @@ public class EmbeddedHotRodTest extends AbstractInfinispanTest {
 
    @BeforeClass
    protected void setup() throws Exception {
-      cacheFactory = new CompatibilityCacheFactory<Integer, String>();
-      cacheFactory.setup();
+      cacheFactory = new CompatibilityCacheFactory<Integer, String>(CacheMode.LOCAL).setup();
    }
 
    @AfterClass
    protected void teardown() {
-      cacheFactory.teardown();
+      CompatibilityCacheFactory.killCacheFactories(cacheFactory);
    }
 
    public void testEmbeddedPutHotRodGet() {

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestHotRodTest.java
@@ -33,6 +33,7 @@ import org.apache.commons.httpclient.methods.HeadMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.configuration.cache.CacheMode;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -66,14 +67,13 @@ public class EmbeddedRestHotRodTest {
 
    @BeforeClass
    protected void setup() throws Exception {
-      cacheFactory = new CompatibilityCacheFactory<String, Object>();
-      cacheFactory.setup();
+      cacheFactory = new CompatibilityCacheFactory<String, Object>(CacheMode.LOCAL).setup();
       dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
    }
 
    @AfterClass
    protected void teardown() {
-      cacheFactory.teardown();
+      CompatibilityCacheFactory.killCacheFactories(cacheFactory);
    }
 
    public void testRestPutEmbeddedHotRodGet() throws Exception {

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestMemcachedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestMemcachedHotRodTest.java
@@ -36,6 +36,7 @@ import org.apache.commons.httpclient.methods.PutMethod;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.VersionedValue;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.io.ByteBuffer;
 import org.infinispan.marshall.AbstractMarshaller;
 import org.testng.annotations.AfterClass;
@@ -65,13 +66,12 @@ public class EmbeddedRestMemcachedHotRodTest {
    @BeforeClass
    protected void setup() throws Exception {
       cacheFactory = new CompatibilityCacheFactory<String, Object>(
-            CACHE_NAME, new SpyMemcachedCompatibleMarshaller());
-      cacheFactory.setup();
+            CACHE_NAME, new SpyMemcachedCompatibleMarshaller(), CacheMode.LOCAL).setup();
    }
 
    @AfterClass
    protected void teardown() {
-      cacheFactory.teardown();
+      CompatibilityCacheFactory.killCacheFactories(cacheFactory);
    }
 
    public void testMemcachedPutEmbeddedRestHotRodGetTest() throws Exception {

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/ReplEmbeddedRestHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/ReplEmbeddedRestHotRodTest.java
@@ -1,0 +1,123 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.infinispan.it.compatibility;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
+import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.methods.PutMethod;
+import org.infinispan.client.hotrod.Flag;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.HttpServletResponse;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
+
+/**
+ * Tests embedded, Hot Rod and REST compatibility in a replicated
+ * clustered environment.
+ *
+ * @author Galder Zamarreño
+ * @since 5.3
+ */
+@Test(groups = "functional", testName = "it.compatibility.ReplEmbeddedHotRodTest")
+public class ReplEmbeddedRestHotRodTest {
+
+   CompatibilityCacheFactory<String, Object> cacheFactory1;
+   CompatibilityCacheFactory<String, Object> cacheFactory2;
+
+   @BeforeClass
+   protected void setup() throws Exception {
+      cacheFactory1 = new CompatibilityCacheFactory<String, Object>(CacheMode.REPL_SYNC).setup();
+      cacheFactory2 = new CompatibilityCacheFactory<String, Object>(CacheMode.REPL_SYNC)
+            .setup(cacheFactory1.getHotRodPort(), 100);
+   }
+
+   @AfterClass
+   protected void teardown() {
+      CompatibilityCacheFactory.killCacheFactories(cacheFactory1, cacheFactory2);
+   }
+
+   public void testRestPutEmbeddedHotRodGet() throws Exception {
+      final String key = "1";
+
+      // 1. Put with REST
+      EntityEnclosingMethod put = new PutMethod(cacheFactory1.getRestUrl() + "/" + key);
+      put.setRequestEntity(new ByteArrayRequestEntity(
+            "<hey>ho</hey>".getBytes(), "application/octet-stream"));
+      HttpClient restClient = cacheFactory1.getRestClient();
+      restClient.executeMethod(put);
+      assertEquals(HttpServletResponse.SC_OK, put.getStatusCode());
+      assertEquals("", put.getResponseBodyAsString().trim());
+
+      // 2. Get with Embedded
+      assertArrayEquals("<hey>ho</hey>".getBytes(), (byte[])
+            cacheFactory2.getEmbeddedCache().get(key));
+
+      // 3. Get with Hot Rod
+      assertArrayEquals("<hey>ho</hey>".getBytes(), (byte[])
+            cacheFactory2.getHotRodCache().get(key));
+   }
+
+   public void testEmbeddedPutRestHotRodGet() throws Exception {
+      final String key = "2";
+
+      // 1. Put with Embedded
+      assertEquals(null, cacheFactory2.getEmbeddedCache().put(key, "v1"));
+
+      // 2. Get with Hot Rod
+      assertEquals("v1", cacheFactory2.getHotRodCache().get(key));
+
+      // 3. Get with REST
+      HttpMethod get = new GetMethod(cacheFactory2.getRestUrl() + "/" + key);
+      cacheFactory2.getRestClient().executeMethod(get);
+      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals("v1", get.getResponseBodyAsString());
+   }
+
+   public void testHotRodPutEmbeddedRestGet() throws Exception {
+      final String key = "3";
+
+      // 1. Put with Hot Rod
+      RemoteCache<String, Object> remote = cacheFactory1.getHotRodCache();
+      assertEquals(null, remote.withFlags(Flag.FORCE_RETURN_VALUE).put(key, "v1"));
+
+      // 2. Get with Embedded
+      assertEquals("v1", cacheFactory2.getEmbeddedCache().get(key));
+
+      // 3. Get with REST
+      HttpMethod get = new GetMethod(cacheFactory2.getRestUrl() + "/" + key);
+      cacheFactory2.getRestClient().executeMethod(get);
+      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals("v1", get.getResponseBodyAsString());
+   }
+
+}

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodTypeConverter.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodTypeConverter.scala
@@ -34,15 +34,15 @@ import org.infinispan.marshall.Marshaller
  * @author Galder Zamarreño
  * @since 5.3
  */
-class HotRodTypeConverter extends TypeConverter[Array[Byte], Array[Byte], AnyRef, AnyRef] {
+class HotRodTypeConverter extends TypeConverter[AnyRef, AnyRef, AnyRef, AnyRef] {
 
    // Default marshaller is the one used by the Hot Rod client,
    // but can be configured for compatibility use cases
    private var marshaller: Marshaller = new GenericJBossMarshaller
 
-   override def boxKey(key: Array[Byte]): AnyRef = unmarshall(key)
+   override def boxKey(key: AnyRef): AnyRef = unmarshall(key)
 
-   override def boxValue(value: Array[Byte]): AnyRef = unmarshall(value)
+   override def boxValue(value: AnyRef): AnyRef = unmarshall(value)
 
    override def unboxValue(target: AnyRef): Array[Byte] = marshall(target)
 
@@ -53,8 +53,13 @@ class HotRodTypeConverter extends TypeConverter[Array[Byte], Array[Byte], AnyRef
       this.marshaller = marshaller
    }
 
-   private def unmarshall(source: Array[Byte]): AnyRef =
-      if (source != null) marshaller.objectFromByteBuffer(source) else source
+   private def unmarshall(source: AnyRef): AnyRef = {
+      source match {
+         case bytes: Array[Byte] =>
+            marshaller.objectFromByteBuffer(bytes)
+         case _ => source
+      }
+   }
 
    private def marshall(source: AnyRef): Array[Byte] =
       if (source != null) marshaller.objectToByteBuffer(source) else null


### PR DESCRIPTION
- When replicating, the byte arrays might have been converted into
  POJOs, so those need to be handled when boxing data by the type
  converter.
