### PR TITLE
performance optimisation for non-tx caches

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/locking/ClusteringDependentLogic.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/ClusteringDependentLogic.java
@@ -352,6 +352,11 @@ public interface ClusteringDependentLogic {
       }
 
       @Override
+      public boolean localNodeIsOwner(Object key) {
+         return true;
+      }
+
+      @Override
       public EntryVersionsMap createNewVersionsAndCheckForWriteSkews(VersionGenerator versionGenerator, TxInvocationContext context, VersionedPrepareCommand prepareCommand) {
          if (configuration.transaction().transactionProtocol().isTotalOrder()) {
             return totalOrderCreateNewVersionsAndCheckForWriteSkews(context, prepareCommand, keySpecificLogic);


### PR DESCRIPTION
- don't initiate the remote get unless you're the primary owner
- ReplicationLogic.localNodeIsOwner should always return true
