### PR TITLE
ISPN-3140 JMX operation to suppress state transfer

### DIFF
--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -333,7 +333,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
       broadcastConsistentHashUpdate(cacheName, cacheStatus);
 
       // Trigger another rebalance in case the CH is not balanced
-      triggerRebalance(cacheName);
+      rebalancePolicy.updateCacheStatus(cacheName, cacheStatus);
    }
 
    private void broadcastConsistentHashUpdate(String cacheName, ClusterCacheStatus cacheStatus) throws Exception {
@@ -448,6 +448,14 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
             // but didn't get a response back yet
             if (cacheTopology != null) {
                topologyList.add(cacheTopology);
+            }
+
+            // Add all the members of the topology that have sent responses first
+            // If we only added the sender, we could end up with a different member order
+            for (Address member : cacheTopology.getMembers()) {
+               if (statusResponses.containsKey(member)) {
+                  cacheStatusMap.get(cacheName).addMember(member);
+               }
             }
 
             // This node may have joined, and still not be in the current or pending CH


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3140

Part 2: Broadcast the rebalance suspend/enable requests, so that when the
coordinator dies, the new coordinator would keep the same status.
