### PR TITLE
Skip TransactionCompletionNotification for autoCommit transactions with 1PC commit

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/TransactionConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TransactionConfiguration.java
@@ -260,6 +260,10 @@ public class TransactionConfiguration {
     * that has been started by Infinispan as a result of enabling autoCommit,
     * to commit in a single phase. So only 1 RPC instead of 2RPCs as in the
     * case of a full 2 Phase Commit (2PC).
+    * <p/>
+    * <b>N.B.</b> this option should NOT be used when modifying the
+    * same key from multiple transactions as 1PC does not offer any consistency
+    * guarantees under concurrent access.
     */
    public boolean use1PcForAutoCommitTransactions() {
       return use1PcForAutoCommitTransactions;

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderInterceptor.java
@@ -141,7 +141,7 @@ public class TotalOrderInterceptor extends CommandInterceptor {
          if (state != null && state.isFinished()) {
             totalOrderManager.release(state);
             if (commit) {
-               transactionTable.remoteTransactionCommitted(command.getGlobalTransaction());
+               transactionTable.remoteTransactionCommitted(command.getGlobalTransaction(), false);
             } else {
                transactionTable.remoteTransactionRollback(command.getGlobalTransaction());
             }

--- a/core/src/main/java/org/infinispan/transaction/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/TransactionTable.java
@@ -354,8 +354,9 @@ public class TransactionTable {
    /**
     * Removes the {@link RemoteTransaction} corresponding to the given tx.
     */
-   public void remoteTransactionCommitted(GlobalTransaction gtx) {
-      if (Configurations.isSecondPhaseAsync(configuration) || configuration.transaction().transactionProtocol().isTotalOrder()) {
+   public void remoteTransactionCommitted(GlobalTransaction gtx, boolean onePc) {
+      boolean optimisticWih1Pc = onePc && (configuration.transaction().lockingMode() == LockingMode.OPTIMISTIC);
+      if (Configurations.isSecondPhaseAsync(configuration) || configuration.transaction().transactionProtocol().isTotalOrder() || optimisticWih1Pc) {
          removeRemoteTransaction(gtx);
       }
    }

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareTransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareTransactionTable.java
@@ -101,12 +101,12 @@ public class RecoveryAwareTransactionTable extends XaTransactionTable {
    }
 
    @Override
-   public void remoteTransactionCommitted(GlobalTransaction gtx) {
+   public void remoteTransactionCommitted(GlobalTransaction gtx, boolean onePc) {
       RecoveryAwareRemoteTransaction remoteTransaction = (RecoveryAwareRemoteTransaction) getRemoteTransaction(gtx);
       if (remoteTransaction == null)
          throw new CacheException(String.format("Remote transaction for global transaction (%s) not found", gtx));
       remoteTransaction.markCompleted(true);
-      super.remoteTransactionCommitted(gtx);
+      super.remoteTransactionCommitted(gtx, onePc);
    }
 
    public List<Xid> getLocalPreparedXids() {

--- a/core/src/test/java/org/infinispan/tx/Use1PcForInducedTxLockingTest.java
+++ b/core/src/test/java/org/infinispan/tx/Use1PcForInducedTxLockingTest.java
@@ -1,0 +1,30 @@
+package org.infinispan.tx;
+
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.annotations.Test;
+
+@Test (groups = "functional", testName = "tx.Use1PcForInducedTxLockingTest")
+public class Use1PcForInducedTxLockingTest extends MultipleCacheManagersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
+      dcc.transaction().use1PcForAutoCommitTransactions(true);
+      dcc.clustering().hash().numOwners(1);
+      createCluster(dcc, 2);
+      waitForClusterToForm();
+   }
+
+   public void testCorrectLocking() {
+      Object k0 = getKeyForCache(0);
+      cache(1).put(k0, "v0");
+      assertNotLocked(k0);
+      assertNoTransactions();
+      cache(0).put(k0, "v0");
+      assertNotLocked(k0);
+      assertNoTransactions();
+   }
+}


### PR DESCRIPTION
Hopefully this should mitigate the performance regressions for replicated caches. 
https://issues.jboss.org/browse/ISPN-3231
