### PR TITLE
ISPN-3217 Rebalance doesn't store data into cache store

### DIFF
--- a/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
@@ -232,6 +232,8 @@ public class InterceptorChainFactory extends AbstractNamedCacheComponentFactory 
             switch (configuration.clustering().cacheMode()) {
                case DIST_SYNC:
                case DIST_ASYNC:
+               case REPL_SYNC:
+               case REPL_ASYNC:
                   interceptorChain.appendInterceptor(createInterceptor(new DistCacheStoreInterceptor(), DistCacheStoreInterceptor.class), false);
                   break;
                default:

--- a/core/src/main/java/org/infinispan/interceptors/DistCacheStoreInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/DistCacheStoreInterceptor.java
@@ -42,23 +42,22 @@ import org.infinispan.remoting.transport.Transport;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
-import java.util.List;
 import java.util.Map;
 
 /**
- * Cache store interceptor specific for the distribution cache mode. Put operations has been modified in such way that
- * if they put operation is the result of an L1 put, storing in the cache store is ignore. This is done so that immortal
- * entries that get converted into mortal ones when putting into L1 don't get propagated to the cache store.
- * <p/>
- * Secondly, in a replicated environment where a shared cache store is used, the node in which the cache operation is
- * executed is the one responsible for interacting with the cache. This doesn't work with distributed mode and instead,
- * in a shared cache store situation, the first owner of the key is the one responsible for storing it.
- * <p/>
- * In the particular case of putAll(), individual keys are checked and if a shared cache store environment has been
- * configured, only the first owner of that key will actually store it to the cache store. In a unshared environment
- * though, only those nodes that are owners of the key would store it to their local cache stores.
+ * Cache store interceptor specific for the distribution and replication cache modes.
+ *
+ * <p>If the cache store is shared, only the primary owner of the key writes to the cache store.</p>
+ * <p>If the cache store is not shared, every owner of a key writes to the cache store.</p>
+ * <p>In non-tx caches, if the originator is an owner, the command is executed there twice. The first time,
+ * ({@code isOriginLocal() == true}) we don't write anything to the cache store; the second time,
+ * the normal rules apply.</p>
+ * <p>For clear operations, either only the originator of the command clears the cache store (if it is
+ * shared), or every node clears its cache store (if it is not shared). Note that in non-tx caches, this
+ * happens without holding a lock on the primary owner of all the keys.</p>
  *
  * @author Galder Zamarreño
+ * @author Dan Berindei
  * @since 4.0
  */
 public class DistCacheStoreInterceptor extends CacheStoreInterceptor {
@@ -95,7 +94,9 @@ public class DistCacheStoreInterceptor extends CacheStoreInterceptor {
    public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) throws Throwable {
       Object returnValue = invokeNextInterceptor(ctx, command);
       Object key = command.getKey();
-      if (skip(ctx, key, command) || ctx.isInTxScope() || !command.isSuccessful()) return returnValue;
+      if (!isStoreEnabled(command) || ctx.isInTxScope() || !command.isSuccessful()) return returnValue;
+      if (!isProperWriter(ctx, command, command.getKey())) return returnValue;
+
       InternalCacheEntry se = getStoredEntry(key, ctx);
       store.store(se);
       log.tracef("Stored entry %s under key %s", se, key);
@@ -106,19 +107,24 @@ public class DistCacheStoreInterceptor extends CacheStoreInterceptor {
    @Override
    public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) throws Throwable {
       Object returnValue = invokeNextInterceptor(ctx, command);
-      if (skip(ctx, command) || ctx.isInTxScope()) return returnValue;
+      if (!isStoreEnabled(command) || ctx.isInTxScope()) return returnValue;
 
       Map<Object, Object> map = command.getMap();
-      if (!(command.isForwarded() && loaderConfig.shared())) {
-         for (Object key : map.keySet()) {
-            if (!skipKey(key)) {
-               InternalCacheEntry se = getStoredEntry(key, ctx);
-               store.store(se);
-               log.tracef("Stored entry %s under key %s", se, key);
-            }
+      int count = 0;
+      for (Object key : map.keySet()) {
+         // In non-tx mode, a node may receive the same forwarded PutMapCommand many times - but each time
+         // it must write only the keys locked on the primary owner that forwarded the command
+         if (isUsingLockDelegation && command.isForwarded() && !dm.getPrimaryLocation(key).equals(ctx.getOrigin()))
+            continue;
+
+         if (isProperWriter(ctx, command, key)) {
+            InternalCacheEntry se = getStoredEntry(key, ctx);
+            store.store(se);
+            log.tracef("Stored entry %s under key %s", se, key);
+            count++;
          }
       }
-      if (getStatisticsEnabled()) cacheStores.getAndAdd(map.size());
+      if (getStatisticsEnabled()) cacheStores.getAndAdd(count);
       return returnValue;
    }
 
@@ -126,10 +132,11 @@ public class DistCacheStoreInterceptor extends CacheStoreInterceptor {
    public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
       Object retval = invokeNextInterceptor(ctx, command);
       Object key = command.getKey();
-      if (!skip(ctx, key, command) && !ctx.isInTxScope() && command.isSuccessful()) {
-         boolean resp = store.remove(key);
-         log.tracef("Removed entry under key %s and got response %s from CacheStore", key, resp);
-      }
+      if (!isStoreEnabled(command) || ctx.isInTxScope() || !command.isSuccessful()) return retval;
+      if (!isProperWriter(ctx, command, key)) return retval;
+
+      boolean resp = store.remove(key);
+      log.tracef("Removed entry under key %s and got response %s from CacheStore", key, resp);
       return retval;
    }
 
@@ -138,7 +145,8 @@ public class DistCacheStoreInterceptor extends CacheStoreInterceptor {
          throws Throwable {
       Object returnValue = invokeNextInterceptor(ctx, command);
       Object key = command.getKey();
-      if (skip(ctx, key, command) || ctx.isInTxScope() || !command.isSuccessful()) return returnValue;
+      if (!isStoreEnabled(command) || ctx.isInTxScope() || !command.isSuccessful()) return returnValue;
+      if (!isProperWriter(ctx, command, command.getKey())) return returnValue;
 
       InternalCacheEntry se = getStoredEntry(key, ctx);
       store.store(se);
@@ -150,7 +158,7 @@ public class DistCacheStoreInterceptor extends CacheStoreInterceptor {
 
    @Override
    public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
-      if (!skip(ctx)) {
+      if (isStoreEnabled()) {
          if (getLog().isTraceEnabled()) getLog().trace("Transactional so don't put stuff in the cache store yet.");
          prepareCacheLoader(ctx, command.getGlobalTransaction(), ctx, command.isOnePhaseCommit());
       }
@@ -159,74 +167,46 @@ public class DistCacheStoreInterceptor extends CacheStoreInterceptor {
 
    @Override
    public Object visitClearCommand(InvocationContext ctx, ClearCommand command) throws Throwable {
-      // Clear is not key specific, so take into account origin of call
-      if ((ctx.isOriginLocal() || !loaderConfig.shared()) && !skip(ctx, command) && !ctx.isInTxScope())
+      if (isStoreEnabled(command) && !ctx.isInTxScope() && isProperWriterForClear(ctx)) {
          clearCacheStore();
+      }
 
       return invokeNextInterceptor(ctx, command);
    }
 
-   /**
-    * Method that skips invocation if: - No store defined or, - The context contains Flag.SKIP_CACHE_STORE or, - The
-    * store is a shared one and node storing the key is not the 1st owner of the key or, - This is an L1 put operation.
-    */
-   private boolean skip(InvocationContext ctx, Object key, FlagAffectedCommand command) {
-      return skip(ctx, command) || skipKey(key) || (isUsingLockDelegation && !cdl.localNodeIsPrimaryOwner(key) && (!cdl.localNodeIsOwner(key) || ctx.isOriginLocal()));
-   }
-
-   /**
-    * Method that skips invocation if: - No store defined or, - The context contains Flag.SKIP_CACHE_STORE or,
-    */
    @Override
-   protected boolean skip(InvocationContext ctx, FlagAffectedCommand command) {
-      if (skip(ctx)) return true;
-
-      if (command.hasFlag(Flag.SKIP_CACHE_STORE)) {
-         log.trace("Skipping cache store since the call contain a skip cache store flag");
+   protected boolean isProperWriter(InvocationContext ctx, FlagAffectedCommand command, Object key) {
+      if (command.hasFlag(Flag.SKIP_OWNERSHIP_CHECK))
          return true;
-      }
-      if (loaderConfig.shared() && command.hasFlag(Flag.SKIP_SHARED_CACHE_STORE)) {
-         log.trace("Skipping cache store since it is shared and the call contain a skip shared cache store flag");
-      }
-      return false;
-   }
 
-   @Override
-   protected boolean skip(InvocationContext ctx) {
-      if (!enabled) return true;
-
-      if (store == null) {
-         log.trace("Skipping cache store because the cache loader does not implement CacheStore");
-         return true;
-      }
-      return false;
-   }
-
-   /**
-    * Method that skips invocation if: - The store is a shared one and node storing the key is not the 1st owner of the
-    * key or, - This is an L1 put operation.
-    */
-   @Override
-   protected boolean skipKey(Object key) {
       if (loaderConfig.shared()) {
          if (!dm.getPrimaryLocation(key).equals(address)) {
-            log.trace("Skipping cache store since the cache loader is shared " +
-                  "and the caller is not the first owner of the key");
-            return true;
+            log.tracef("Skipping cache store since the cache loader is shared " +
+                  "and the caller is not the first owner of the key %s", key);
+            return false;
          }
       } else {
-         List<Address> addresses = dm.locate(key);
-         if (isL1Put(addresses)) {
-            log.trace("Skipping cache store since this is an L1 put");
-            return true;
+         if (isUsingLockDelegation && !command.hasFlag(Flag.CACHE_MODE_LOCAL)) {
+            if (ctx.isOriginLocal() && !dm.getPrimaryLocation(key).equals(address)) {
+               // The command will be forwarded back to the originator, and the value will be stored then
+               // (while holding the lock on the primary owner).
+               log.tracef("Skipping cache store on the originator because it is not the primary owner " +
+                     "of key %s", key);
+               return false;
+            }
+         }
+         if (!dm.getWriteConsistentHash().isKeyLocalToNode(address, key)) {
+            log.tracef("Skipping cache store since the key is not local: %s", key);
+            return false;
          }
       }
-      return false;
+      return true;
    }
 
-   private boolean isL1Put(List<Address> addresses) {
-      if (address == null) throw new NullPointerException("Local address cannot be null!");
-      return !addresses.contains(address);
+   protected boolean isProperWriterForClear(InvocationContext ctx) {
+      // Note: In non-tx mode, the originator doesn't acquire any locks - so other nodes may write
+      // to the cache store while we are clearing it.
+      return !loaderConfig.shared() || ctx.isOriginLocal();
    }
 
 }

--- a/core/src/test/java/org/infinispan/distribution/DistSyncCacheStoreNotSharedTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncCacheStoreNotSharedTest.java
@@ -22,6 +22,7 @@
  */
 package org.infinispan.distribution;
 
+import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.context.Flag;
 import org.infinispan.loaders.CacheLoaderException;
@@ -38,6 +39,7 @@ import java.util.concurrent.Future;
 
 import static org.infinispan.test.TestingUtil.k;
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * DistSyncSharedTest.
@@ -139,6 +141,18 @@ public class DistSyncCacheStoreNotSharedTest extends BaseDistCacheStoreTest {
             assert !store.containsKey(key);
          }
       }
+   }
+
+   public void testPutForStateTransfer() throws Exception {
+      MagicKey k1 = new MagicKey(c1, c2);
+      CacheStore store2 = TestingUtil.extractComponent(c2, CacheLoaderManager.class).getCacheStore();
+
+      c2.put(k1, v1);
+      assertTrue(store2.containsKey(k1));
+      assertEquals(v1, store2.load(k1).getValue());
+
+      c2.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).put(k1, v2);
+      assertEquals(v2, store2.load(k1).getValue());
    }
 
    public void testPutAll() throws Exception {

--- a/core/src/test/java/org/infinispan/loaders/SharedCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/SharedCacheStoreTest.java
@@ -77,7 +77,7 @@ public class SharedCacheStoreTest extends MultipleCacheManagersTest {
       for (CacheStore cs: cachestores) {
          assert !cs.containsKey("key");
          DummyInMemoryCacheStore dimcs = (DummyInMemoryCacheStore) cs;
-         assert dimcs.stats().get("remove") == 1 : "Entry should have been removed from the cache store just once, but was removed " + dimcs.stats().get("store") + " times";
+         assert dimcs.stats().get("remove") == 1 : "Entry should have been removed from the cache store just once, but was removed " + dimcs.stats().get("remove") + " times";
       }
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3217

In non-tx mode, if the originator of a put command is an owner, it will
only write the entry when the command is forwarded back to it by the
primary owner. But this rule shouldn't apply to state transfer puts,
which use the CACHE_MODE_LOCAL and SKIP_OWNERSHIP_CHECK flags.
