### PR TITLE
ISPN-3241 Don't make the memcached server overwrite the cache configuration if it already exists

### DIFF
--- a/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedServer.scala
+++ b/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedServer.scala
@@ -43,9 +43,11 @@ class MemcachedServer extends AbstractProtocolServer("Memcached") {
    private var memcachedCache: AdvancedCache[String, Array[Byte]] = _
 
    override def start(configuration: MemcachedServerConfiguration, cacheManager: EmbeddedCacheManager) {
-      // Define the Memcached cache as clone of the default one
-      cacheManager.defineConfiguration(configuration.cache,
-         new ConfigurationBuilder().read(cacheManager.getDefaultCacheConfiguration).build())
+      if (!cacheManager.cacheExists(configuration.cache)) {
+         // Define the Memcached cache as clone of the default one
+         cacheManager.defineConfiguration(configuration.cache,
+            new ConfigurationBuilder().read(cacheManager.getDefaultCacheConfiguration).build())
+      }
       memcachedCache = cacheManager.getCache[String, Array[Byte]](configuration.cache).getAdvancedCache
       super.start(configuration, cacheManager)
    }


### PR DESCRIPTION
This branch applies cleanly to both 5.3.x and master

Also ISPN-3241-5.2.x/memcached_cache_def for 5.2.x
