### PR TITLE
ISPN-3248 Cleaned up Tree module and deprecated ConfigurationException

### DIFF
--- a/core/src/main/java/org/infinispan/config/ConfigurationException.java
+++ b/core/src/main/java/org/infinispan/config/ConfigurationException.java
@@ -36,6 +36,7 @@ import java.util.List;
  * @see org.infinispan.manager.DefaultCacheManager
  * @since 4.0
  */
+@Deprecated
 public class ConfigurationException extends CacheException {
 
    private static final long serialVersionUID = -5576382839360927955L;

--- a/tree/src/main/java/org/infinispan/tree/TreeCacheFactory.java
+++ b/tree/src/main/java/org/infinispan/tree/TreeCacheFactory.java
@@ -23,7 +23,7 @@
 package org.infinispan.tree;
 
 import org.infinispan.Cache;
-import org.infinispan.config.ConfigurationException;
+import org.infinispan.CacheConfigurationException;
 
 /**
  * Factory class that contains API for users to create instances of {@link org.infinispan.tree.TreeCache}
@@ -38,7 +38,7 @@ public class TreeCacheFactory {
     * @param cache
     * @return instance of a {@link TreeCache}
     * @throws NullPointerException   if the cache parameter is null
-    * @throws ConfigurationException if the invocation batching configuration is not enabled.
+    * @throws CacheConfigurationException if the invocation batching configuration is not enabled.
     */
 
    public <K, V> TreeCache<K, V> createTreeCache(Cache<K, V> cache) {
@@ -51,7 +51,7 @@ public class TreeCacheFactory {
 
       // If invocationBatching is not enabled, throw a new configuration exception.
       if (!cache.getCacheConfiguration().invocationBatching().enabled()) {
-         throw new ConfigurationException("invocationBatching is not enabled for cache '" +
+         throw new CacheConfigurationException("invocationBatching is not enabled for cache '" +
                cache.getName() + "'. Make sure this is enabled by" +
                " calling configurationBuilder.invocationBatching().enable()");
       }

--- a/tree/src/main/java/org/infinispan/tree/TreeCacheImpl.java
+++ b/tree/src/main/java/org/infinispan/tree/TreeCacheImpl.java
@@ -24,9 +24,9 @@ package org.infinispan.tree;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
+import org.infinispan.CacheConfigurationException;
 import org.infinispan.CacheException;
 import org.infinispan.atomic.AtomicMap;
-import org.infinispan.config.ConfigurationException;
 import org.infinispan.context.Flag;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -49,7 +49,7 @@ public class TreeCacheImpl<K, V> extends TreeStructureSupport implements TreeCac
    public TreeCacheImpl(AdvancedCache<?, ?> cache) {
       super(cache, cache.getBatchContainer());
       if (cache.getCacheConfiguration().indexing().enabled())
-         throw new ConfigurationException("TreeCache cannot be used with a Cache instance configured to use indexing!");
+         throw new CacheConfigurationException("TreeCache cannot be used with a Cache instance configured to use indexing!");
       assertBatchingSupported(cache.getCacheConfiguration());
       createRoot();
    }


### PR DESCRIPTION
Found some assert keywords in TreeCacheAPITest as well. These were moved to AssertJUnit calls.

"assert object == null" was changed to "assertNull(object)"
