### PR TITLE
ISPN-3192 Concurrent TreeCache.move() calls with the same destination lose data

### DIFF
--- a/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
@@ -31,9 +31,11 @@ import org.testng.annotations.AfterTest;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.testng.Assert.assertTrue;
@@ -134,6 +136,37 @@ public class AbstractInfinispanTest {
             return new Thread(r, threadName);
          }
       };
+   }
+
+   protected void runConcurrently(Callable<Object>... tasks) throws Exception {
+      Future<Object>[] movers = new Future[tasks.length];
+      final CountDownLatch latch = new CountDownLatch(1);
+      for (int i = 0; i < tasks.length; i++) {
+         final Callable<Object> task = tasks[i];
+         movers[i] = fork(new Callable<Object>() {
+            public Object call() throws Exception {
+               latch.await();
+
+               task.call();
+               return null;
+            }
+         });
+      }
+
+      latch.countDown();
+      // check for any errors
+      Exception exception = null;
+      for (Future<Object> t : movers) {
+         try {
+            t.get(10, TimeUnit.SECONDS);
+         } catch (Exception e) {
+            log.debug("Exception in concurrent task", e);
+            exception = e;
+         }
+      }
+      if (exception != null) {
+         throw exception;
+      }
    }
 
    public final class RunnableWrapper implements Runnable {

--- a/tree/src/main/java/org/infinispan/tree/NodeKey.java
+++ b/tree/src/main/java/org/infinispan/tree/NodeKey.java
@@ -84,8 +84,7 @@ public class NodeKey implements Serializable {
    }
 
    public String toString() {
-      return "NodeKey{" +
-            "contents=" + contents +
+      return "NodeKey{" + contents +
             ", fqn=" + fqn +
             '}';
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3192

Causes intermittent failures in NodeMoveAPIPessimisticTest.
Lock the destination node and the parent of the source node the first time
they are read (in pessimistic mode).
