### PR TITLE
ISPN-3197 Message ordering of Get and Invalidation can cause L1 to be in...

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
@@ -1,29 +1,32 @@
 package org.infinispan.interceptors.distribution;
 
-import org.infinispan.metadata.Metadata;
-import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.write.DataWriteCommand;
+import org.infinispan.commands.write.InvalidateL1Command;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
+import org.infinispan.commons.util.CollectionFactory;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.container.DataContainer;
 import org.infinispan.container.EntryFactory;
-import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.distribution.L1Manager;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
 import org.infinispan.interceptors.base.BaseRpcInterceptor;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
-import org.infinispan.util.concurrent.locks.LockManager;
+import org.infinispan.statetransfer.StateTransferLock;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -31,54 +34,86 @@ import java.util.concurrent.Future;
  * Interceptor that handles L1 logic for non-transactional caches.
  *
  * @author Mircea Markus
+ * @author William Burns
  * @since 5.2
  */
 public class L1NonTxInterceptor extends BaseRpcInterceptor {
 
-   private static Log log = LogFactory.getLog(L1NonTxInterceptor.class);
+   private static final Log log = LogFactory.getLog(L1NonTxInterceptor.class);
+   private static final boolean trace = log.isTraceEnabled();
 
    private L1Manager l1Manager;
    private ClusteringDependentLogic cdl;
-   private CommandsFactory cf;
-   private LockManager lockManager;
    private EntryFactory entryFactory;
+   private DataContainer dataContainer;
+   private Configuration config;
+   private StateTransferLock stateTransferLock;
+
+   private long l1Lifespan;
+
+   private final ConcurrentMap<Object, L1WriteSynchronizer> concurrentWrites = CollectionFactory.makeConcurrentMap();
 
    @Inject
-   public void init(L1Manager l1Manager, ClusteringDependentLogic cdl, LockManager lockManager,
-                    EntryFactory entryFactory, CommandsFactory cf) {
+   public void init(L1Manager l1Manager, ClusteringDependentLogic cdl, EntryFactory entryFactory,
+                    DataContainer dataContainer, Configuration config, StateTransferLock stateTransferLock) {
       this.l1Manager = l1Manager;
       this.cdl = cdl;
-      this.lockManager = lockManager;
       this.entryFactory = entryFactory;
-      this.cf = cf;
+      this.dataContainer = dataContainer;
+      this.config = config;
+      this.stateTransferLock = stateTransferLock;
+   }
+
+   @Start
+   public void start() {
+      l1Lifespan = config.clustering().l1().lifespan();
    }
 
    @Override
    public Object visitGetKeyValueCommand(InvocationContext ctx, GetKeyValueCommand command) throws Throwable {
-      Object returnValue = invokeNextInterceptor(ctx, command);
-      InternalCacheEntry ice = command.getRemotelyFetchedValue();
-      if (ctx.isOriginLocal() && ice != null) {
-         log.tracef("Caching remotely retrieved entry for key %s in L1", command.getKey());
-         // This should be fail-safe
-         try {
-            long l1Lifespan = cacheConfiguration.clustering().l1().lifespan();
-            long lifespan = ice.getLifespan() < 0 ? l1Lifespan : Math.min(ice.getLifespan(), l1Lifespan);
-            // Make a copy of the metadata stored internally, adjust
-            // lifespan/maxIdle settings and send them a modification
-            Metadata newMetadata = ice.getMetadata().builder()
-                  .lifespan(lifespan).maxIdle(-1).build();
-            PutKeyValueCommand put = cf.buildPutKeyValueCommand(ice.getKey(), ice.getValue(),
-                  newMetadata, Collections.singleton(Flag.CACHE_MODE_LOCAL));
-            lockAndWrap(ctx, command.getKey(), ice, command);
-            invokeNextInterceptor(ctx, put);
-         } catch (Exception e) {
-            // Couldn't store in L1 for some reason.  But don't fail the transaction!
-            log.infof("Unable to store entry %s in L1 cache", command.getKey());
-            log.debug("Inability to store in L1 caused by", e);
+      Object returnValue;
+      if (ctx.isOriginLocal()) {
+         Object key = command.getKey();
+         // If the command isn't going to return a remote value - just pass it down the interceptor chain
+         if (command.hasFlag(Flag.CACHE_MODE_LOCAL) || command.hasFlag(Flag.SKIP_REMOTE_LOOKUP)
+               || command.hasFlag(Flag.IGNORE_RETURN_VALUES) || cdl.localNodeIsOwner(key)
+               || dataContainer.containsKey(key)) {
+            return invokeNextInterceptor(ctx, command);
          }
-
-      } else if (!ctx.isOriginLocal() && returnValue != null) {
-         l1Manager.addRequestor(command.getKey(), ctx.getOrigin());
+         // Most times the putIfAbsent will be successful, so not doing a get first
+         L1WriteSynchronizer l1WriteSync = new L1WriteSynchronizer(dataContainer, l1Lifespan, stateTransferLock,
+                                                                   cdl);
+         L1WriteSynchronizer presentSync = concurrentWrites.putIfAbsent(key, l1WriteSync);
+         if (presentSync == null) {
+            try {
+               returnValue = invokeNextInterceptor(ctx, command);
+               l1WriteSync.runL1UpdateIfPossible(returnValue, command);
+            }
+            catch (Throwable t) {
+               l1WriteSync.retrievalEncounteredException(t);
+               throw t;
+            }
+            finally {
+               concurrentWrites.remove(key);
+            }
+         }
+         else {
+            if (trace) {
+               log.tracef("Found current request for key %s, waiting for their invocation's response", key);
+            }
+            try {
+               returnValue = presentSync.get();
+            }
+            catch (ExecutionException e) {
+               throw e.getCause();
+            }
+         }
+      }
+      else {
+         returnValue = invokeNextInterceptor(ctx, command);
+         if (returnValue != null) {
+            l1Manager.addRequestor(command.getKey(), ctx.getOrigin());
+         }
       }
       return returnValue;
    }
@@ -123,9 +158,50 @@ public class L1NonTxInterceptor extends BaseRpcInterceptor {
       return result;
    }
 
+   @Override
+   public Object visitInvalidateL1Command(InvocationContext ctx, InvalidateL1Command invalidateL1Command) throws Throwable {
+      for (Object key : invalidateL1Command.getKeys()) {
+         abortL1UpdateOrWait(key);
+      }
+      return super.visitInvalidateL1Command(ctx, invalidateL1Command);
+   }
+
+   private void abortL1UpdateOrWait(Object key) throws InterruptedException {
+      L1WriteSynchronizer sync = concurrentWrites.remove(key);
+      if (sync != null) {
+         if (sync.trySkipL1Update()) {
+            if (trace) {
+               log.tracef("Aborted possible L1 update due to concurrent invalidation for key %s", key);
+            }
+         }
+         else {
+            if (trace) {
+               log.tracef("L1 invalidation found a pending update for key %s - need to block until finished", key);
+            }
+            // We have to wait for the pending L1 update to complete before we can properly invalidate.  Any additional
+            // gets that come in after this invalidation we ignore for now.
+            // TODO: Additional gets should be fixed with ISPN-2965
+            boolean success;
+            try {
+               sync.get();
+               success = true;
+            }
+            catch (ExecutionException e) {
+               // We don't care what the L1 update exception was
+               success = false;
+            }
+            if (trace) {
+               log.tracef("Pending L1 update completed successfully: %b - L1 invalidation can occur for key %s", success, key);
+            }
+         }
+      }
+   }
+
    private Object handleDataWriteCommand(InvocationContext ctx, DataWriteCommand command, boolean assumeOriginKeptEntryInL1) throws Throwable {
       if (command.hasFlag(Flag.CACHE_MODE_LOCAL)) {
-         log.tracef("local mode forced, suppressing L1 calls.");
+         if (trace) {
+            log.tracef("local mode forced, suppressing L1 calls.");
+         }
          return invokeNextInterceptor(ctx, command);
       }
       Future<Object> l1InvalidationFuture = invalidateL1(ctx, command, assumeOriginKeptEntryInL1);
@@ -138,13 +214,16 @@ public class L1NonTxInterceptor extends BaseRpcInterceptor {
    private void removeFromLocalL1(InvocationContext ctx, DataWriteCommand command) throws InterruptedException {
       if (ctx.isOriginLocal() && !cdl.localNodeIsOwner(command.getKey())) {
          removeFromL1(ctx, command.getKey());
-      } else {
+      } else if (trace) {
          log.trace("Allowing entry to commit as local node is owner");
       }
    }
 
    private void removeFromL1(InvocationContext ctx, Object key) throws InterruptedException {
-      log.tracef("Removing entry from L1 for key %s", key);
+      if (trace) {
+         log.tracef("Removing entry from L1 for key %s", key);
+      }
+      abortL1UpdateOrWait(key);
       ctx.removeLookedUpEntry(key);
       entryFactory.wrapEntryForRemove(ctx, key, true);
    }
@@ -161,16 +240,9 @@ public class L1NonTxInterceptor extends BaseRpcInterceptor {
       Future<Object> l1InvalidationFuture = null;
       if (cdl.localNodeIsOwner(command.getKey())) {
          l1InvalidationFuture = l1Manager.flushCache(Collections.singletonList(command.getKey()), ctx.getOrigin(), assumeOriginKeptEntryInL1);
-      } else  {
+      } else if (trace) {
          log.tracef("Not invalidating key '%' as local node(%s) is not owner", command.getKey(), rpcManager.getAddress());
       }
       return l1InvalidationFuture;
-   }
-
-   private void lockAndWrap(InvocationContext ctx, Object key, InternalCacheEntry ice, FlagAffectedCommand command) throws InterruptedException {
-      boolean skipLocking = hasSkipLocking(command);
-      long lockTimeout = getLockAcquisitionTimeout(command, skipLocking);
-      lockManager.acquireLock(ctx, key, lockTimeout, skipLocking);
-      entryFactory.wrapEntryForPut(ctx, key, ice, false, command, true);
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1WriteSynchronizer.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1WriteSynchronizer.java
@@ -1,0 +1,200 @@
+package org.infinispan.interceptors.distribution;
+
+import org.infinispan.commands.read.GetKeyValueCommand;
+import org.infinispan.container.DataContainer;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.interceptors.locking.ClusteringDependentLogic;
+import org.infinispan.metadata.Metadata;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.statetransfer.StateTransferLock;
+import org.infinispan.statetransfer.StateTransferManager;
+import org.jboss.logging.Logger;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.AbstractQueuedSynchronizer;
+
+/**
+* A write synchronizer that allows for a single thread to run the L1 update while others can block until it is
+* completed.  Also allows for someone to attempt to cancel the write to the L1.  If they are unable to, they should
+* really wait until the L1 write has completed so they can guarantee their update will be ordered properly.
+*
+* @author wburns
+* @since 6.0
+*/
+class L1WriteSynchronizer {
+   private static final Logger log = Logger.getLogger(L1WriteSynchronizer.class);
+   private final L1ReadSync sync = new L1ReadSync();
+
+   private final long l1Lifespan;
+   private final DataContainer dc;
+   private final StateTransferLock stateTransferLock;
+   private final ClusteringDependentLogic cdl;
+
+   public L1WriteSynchronizer(DataContainer dc, long l1Lifespan, StateTransferLock stateTransferLock,
+                              ClusteringDependentLogic cdl) {
+      this.dc = dc;
+      this.l1Lifespan = l1Lifespan;
+      this.stateTransferLock = stateTransferLock;
+      this.cdl = cdl;
+   }
+
+   private static class L1ReadSync extends AbstractQueuedSynchronizer {
+      private static final int READY = 0;
+      private static final int RUNNING = 1;
+      private static final int SKIP = 2;
+      private static final int COMPLETED = 4;
+
+      private Object result;
+      private Throwable exception;
+
+      /**
+       * Implements AQS base acquire to succeed when completed
+       */
+      protected int tryAcquireShared(int ignore) {
+         return getState() == COMPLETED ? 1 : -1;
+      }
+
+      /**
+       * Implements AQS base release to always signal after setting
+       * value
+       */
+      protected boolean tryReleaseShared(int ignore) {
+         return true;
+      }
+
+      /**
+       * Attempt to update the sync to signal that we want to update L1 with value
+       * @return whether it should continue with running L1 update
+       */
+      boolean attemptUpdateToRunning() {
+         // Multiple invocations should say it is marked as running
+         if (getState() == RUNNING) {
+            return true;
+         }
+         return compareAndSetState(READY, RUNNING);
+      }
+
+      /**
+       * Attempt to update the sync to signal that we want to cancel the L1 update
+       * @return whether the L1 run was skipped
+       */
+      boolean attemptToSkipFullRun() {
+         // Multiple invocations should say it skipped
+         if (getState() == SKIP) {
+            return true;
+         }
+         return compareAndSetState(READY, SKIP);
+      }
+
+      Object innerGet() throws InterruptedException, ExecutionException {
+         acquireSharedInterruptibly(0);
+         if (exception != null) {
+            throw new ExecutionException(exception);
+         }
+         return result;
+      }
+
+      Object innerGet(long time, TimeUnit unit) throws InterruptedException, TimeoutException, ExecutionException {
+         if (!tryAcquireSharedNanos(0, unit.toNanos(time))) {
+            throw new TimeoutException();
+         }
+         if (exception != null) {
+            throw new ExecutionException(exception);
+         }
+         return result;
+      }
+
+      void innerSet(Object value) {
+         // This should never have to loop, but just in case :P
+         for (;;) {
+            int s = getState();
+            if (s == COMPLETED) {
+               return;
+            }
+            if (compareAndSetState(s, COMPLETED)) {
+               result = value;
+               releaseShared(0);
+               return;
+            }
+         }
+      }
+
+      void innerException(Throwable t) {
+         // This should never have to loop, but just in case :P
+         for (;;) {
+            int s = getState();
+            if (s == COMPLETED) {
+               return;
+            }
+            if (compareAndSetState(s, COMPLETED)) {
+               exception = t;
+               releaseShared(0);
+               return;
+            }
+         }
+      }
+   }
+
+   public Object get() throws InterruptedException, ExecutionException {
+      return sync.innerGet();
+   }
+
+   public Object get(long time, TimeUnit unit) throws TimeoutException, InterruptedException, ExecutionException {
+      return sync.innerGet(time, unit);
+   }
+
+   /**
+    * Attempts to mark the L1 update to only retrieve the value and not to actually update the L1 cache.
+    * If the L1 skipping is not successful, that means it is currently running, which means for consistency
+    * any writes should wait until this update completes since the update doesn't acquire any locks
+    * @return Whether or not it was successful in skipping L1 update
+    */
+   public boolean trySkipL1Update() {
+      return sync.attemptToSkipFullRun();
+   }
+
+   public void retrievalEncounteredException(Throwable t) {
+      sync.innerException(t);
+   }
+
+   /**
+    * Attempts to the L1 update and set the value.  If the L1 update was marked as being skipped this will instead
+    * just set the value to release blockers
+    */
+   public void runL1UpdateIfPossible(Object value, GetKeyValueCommand command) {
+      try {
+         InternalCacheEntry ice;
+         if ((ice = command.getRemotelyFetchedValue()) != null) {
+            Object key;
+            if (sync.attemptUpdateToRunning() && !dc.containsKey((key = command.getKey()))) {
+               // Acquire the transfer lock to ensure that we don't have a rehash and change to become an owner,
+               // note we check the ownership in following if
+               stateTransferLock.acquireSharedTopologyLock();
+               try {
+                  // Now we can update the L1 if there isn't a value already there and we haven't now become a write
+                  // owner
+                  if (!dc.containsKey(key) && !cdl.localNodeIsOwner(key)) {
+                     log.tracef("Caching remotely retrieved entry for key %s in L1", key);
+                     long lifespan = ice.getLifespan() < 0 ? l1Lifespan : Math.min(ice.getLifespan(), l1Lifespan);
+                     // Make a copy of the metadata stored internally, adjust
+                     // lifespan/maxIdle settings and send them a modification
+                     Metadata newMetadata = ice.getMetadata().builder()
+                           .lifespan(lifespan).maxIdle(-1).build();
+                     dc.put(key, ice.getValue(), newMetadata);
+                  } else {
+                     log.tracef("Data container contained value after rehash for key %s", key);
+                  }
+               }
+               finally {
+                  stateTransferLock.releaseSharedTopologyLock();
+               }
+            }
+         }
+      }
+      finally {
+         sync.innerSet(value);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
@@ -11,6 +11,8 @@ import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.MortalCacheEntry;
 import org.infinispan.distribution.group.Grouper;
 import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.interceptors.InterceptorChain;
+import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
@@ -265,5 +267,12 @@ public abstract class BaseDistFunctionalTest extends MultipleCacheManagersTest {
 
    protected TransactionManager getTransactionManager(Cache<?, ?> cache) {
       return TestingUtil.getTransactionManager(cache);
+   }
+
+   protected static void removeAllBlockingInterceptorsFromCache(Cache<?, ?> cache) {
+      InterceptorChain chain = TestingUtil.extractComponent(cache, InterceptorChain.class);
+      for (CommandInterceptor interceptor : chain.getInterceptorsWhichExtend(BlockingInterceptor.class)) {
+         chain.removeInterceptor(interceptor.getClass());
+      }
    }
 }

--- a/core/src/test/java/org/infinispan/distribution/BlockingInterceptor.java
+++ b/core/src/test/java/org/infinispan/distribution/BlockingInterceptor.java
@@ -1,0 +1,64 @@
+package org.infinispan.distribution;
+
+import org.infinispan.commands.VisitableCommand;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.interceptors.base.CommandInterceptor;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+
+/**
+ * Interceptor that allows for waiting for a command to be invoked, blocking that command and subsequently
+ * allowing that command to be released.
+ *
+ * @author William Burns
+ * @since 6.0
+ */
+public class BlockingInterceptor extends CommandInterceptor {
+   private final CyclicBarrier barrier;
+   private final AtomicBoolean firstBlocked = new AtomicBoolean();
+   private final Class<? extends VisitableCommand> commandClass;
+   private final boolean blockAfter;
+
+   public BlockingInterceptor(CyclicBarrier barrier, Class<? extends VisitableCommand> commandClass,
+                              boolean blockAfter) {
+      this.barrier = barrier;
+      this.commandClass = commandClass;
+      this.blockAfter = blockAfter;
+   }
+
+   private void blockIfNeeded(VisitableCommand command) throws BrokenBarrierException, InterruptedException {
+      if (commandClass.isInstance(command)) {
+         if (firstBlocked.compareAndSet(false, true)) {
+            try {
+               getLog().tracef("Command blocking %s completion of %s", blockAfter ? "after" : "before", command);
+               // The first arrive and await is to sync with main thread
+               barrier.await();
+               // Now we actually block until main thread lets us go
+               barrier.await();
+               getLog().tracef("Command completed blocking completion of %s", command);
+            } finally {
+               firstBlocked.set(false);
+            }
+         } else {
+            getLog().trace("Command arrived but already found a blocker");
+         }
+      }
+   }
+
+   @Override
+   protected Object handleDefault(InvocationContext ctx, VisitableCommand command) throws Throwable {
+      try {
+         if (!blockAfter) {
+            blockIfNeeded(command);
+         }
+         return super.handleDefault(ctx, command);
+      } finally {
+         if (blockAfter) {
+            blockIfNeeded(command);
+         }
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/distribution/DistSyncL1FuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncL1FuncTest.java
@@ -1,0 +1,397 @@
+package org.infinispan.distribution;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.VisitableCommand;
+import org.infinispan.commands.read.GetKeyValueCommand;
+import org.infinispan.commands.write.InvalidateL1Command;
+import org.infinispan.commands.write.PutKeyValueCommand;
+import org.infinispan.commands.write.RemoveCommand;
+import org.infinispan.commands.write.ReplaceCommand;
+import org.infinispan.interceptors.InterceptorChain;
+import org.infinispan.interceptors.base.CommandInterceptor;
+import org.infinispan.interceptors.distribution.NonTxDistributionInterceptor;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.tx.dld.ControlledRpcManager;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@Test(groups = "functional", testName = "distribution.DistSyncL1FuncTest")
+public class DistSyncL1FuncTest extends BaseDistFunctionalTest {
+
+   public DistSyncL1FuncTest() {
+      sync = true;
+      tx = false;
+      testRetVals = true;
+   }
+
+   protected final static String key = "key-to-the-cache";
+   protected static final String firstValue = "first-put";
+   protected static final String secondValue = "second-put";
+
+   private void addBlockingInterceptorBeforeTx(Cache<?, ?> cache, final CyclicBarrier barrier,
+                                               Class<? extends VisitableCommand> commandClass) {
+      addBlockingInterceptorBeforeTx(cache, barrier, commandClass, true);
+   }
+
+   private void addBlockingInterceptorBeforeTx(Cache<?, ?> cache, final CyclicBarrier barrier,
+                                                Class<? extends VisitableCommand> commandClass, boolean blockAfter) {
+      cache.getAdvancedCache().addInterceptorBefore(new BlockingInterceptor(barrier, commandClass, blockAfter), NonTxDistributionInterceptor.class);
+   }
+
+   protected void assertL1GetWithConcurrentUpdate(final Cache<Object, String> nonOwnerCache, Cache<Object, String> ownerCache,
+                                                  final Object key, String originalValue, String updateValue)
+         throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      CyclicBarrier barrier = new CyclicBarrier(2);
+      addBlockingInterceptorBeforeTx(nonOwnerCache, barrier, GetKeyValueCommand.class);
+
+      try {
+         Future<String> future = nonOwnerCache.getAsync(key);
+
+         // Now wait for the get to return and block it for now
+         barrier.await(5, TimeUnit.SECONDS);
+
+         assertEquals(originalValue, ownerCache.put(key, updateValue));
+
+         // Now let owner key->updateValue go through
+         barrier.await(5, TimeUnit.SECONDS);
+
+         // This should be originalValue still as we did the get
+         assertEquals(originalValue, future.get(5, TimeUnit.SECONDS));
+
+         // Remove the interceptor now since we don't want to block ourselves - if using phaser this isn't required
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+
+         assertIsNotInL1(nonOwnerCache, key);
+         // The nonOwnerCache should retrieve new value as it isn't in L1
+         assertEquals(updateValue, nonOwnerCache.get(key));
+         assertIsInL1(nonOwnerCache, key);
+      }
+      finally {
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+      }
+   }
+
+   protected void assertL1PutWithConcurrentUpdate(final Cache<Object, String> nonOwnerCache, Cache<Object, String> ownerCache,
+                                                  final boolean replace, final Object key, final String originalValue,
+                                                  final String nonOwnerValue, String updateValue) throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      CyclicBarrier barrier = new CyclicBarrier(2);
+      addBlockingInterceptorBeforeTx(nonOwnerCache, barrier, replace ? ReplaceCommand.class : PutKeyValueCommand.class);
+
+      try {
+         Future<String> future = fork(new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+               if (replace) {
+                  // This should always be true
+                  if (nonOwnerCache.replace(key, originalValue, nonOwnerValue)) {
+                     return originalValue;
+                  }
+                  return nonOwnerCache.get(key);
+               }
+               else {
+                  return nonOwnerCache.put(key, nonOwnerValue);
+               }
+            }
+         });
+
+         // Now wait for the get to return and block it for now
+         barrier.await(5, TimeUnit.SECONDS);
+
+         // Owner should have the new value
+         assertEquals(nonOwnerValue, ownerCache.put(key, updateValue));
+
+         // Now let owner key->updateValue go through
+         barrier.await(5, TimeUnit.SECONDS);
+
+         // This should be originalValue still as we did the get
+         assertEquals(originalValue, future.get(5, TimeUnit.SECONDS));
+
+         // Remove the interceptor now since we don't want to block ourselves - if using phaser this isn't required
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+
+         assertIsNotInL1(nonOwnerCache, key);
+         // The nonOwnerCache should retrieve new value as it isn't in L1
+         assertEquals(updateValue, nonOwnerCache.get(key));
+         assertIsInL1(nonOwnerCache, key);
+      }
+      finally {
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+      }
+   }
+
+   @Test
+   public void testNoEntryInL1GetWithConcurrentInvalidation() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in the owner, so the L1 is empty
+      ownerCache.put(key, firstValue);
+
+      assertL1GetWithConcurrentUpdate(nonOwnerCache, ownerCache, key, firstValue, secondValue);
+   }
+
+   @Test
+   public void testEntryInL1GetWithConcurrentInvalidation() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in a non owner, so the L1 has the key
+      ownerCache.put(key, firstValue);
+      nonOwnerCache.get(key);
+
+      assertIsInL1(nonOwnerCache, key);
+
+      assertL1GetWithConcurrentUpdate(nonOwnerCache, ownerCache, key, firstValue, secondValue);
+   }
+
+   @Test
+   public void testNoEntryInL1GetWithConcurrentPut() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in the owner, so the L1 is empty
+      ownerCache.put(key, firstValue);
+
+      assertL1GetWithConcurrentUpdate(nonOwnerCache, nonOwnerCache, key, firstValue, secondValue);
+   }
+
+   @Test
+   public void testEntryInL1GetWithConcurrentPut() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in a non owner, so the L1 has the key
+      ownerCache.put(key, firstValue);
+      nonOwnerCache.get(key);
+
+      assertIsInL1(nonOwnerCache, key);
+
+      assertL1GetWithConcurrentUpdate(nonOwnerCache, nonOwnerCache, key, firstValue, secondValue);
+   }
+
+   @Test
+   public void testNoEntryInL1PutWithConcurrentInvalidation() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in the owner, so the L1 is empty
+      ownerCache.put(key, firstValue);
+
+      assertL1PutWithConcurrentUpdate(nonOwnerCache, ownerCache, false, key, firstValue, "intermediate-put", secondValue);
+   }
+
+   @Test
+   public void testEntryInL1PutWithConcurrentInvalidation() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in a non owner, so the L1 has the key
+      ownerCache.put(key, firstValue);
+      nonOwnerCache.get(key);
+
+      assertIsInL1(nonOwnerCache, key);
+
+      assertL1PutWithConcurrentUpdate(nonOwnerCache, ownerCache, false, key, firstValue, "intermediate-put", secondValue);
+   }
+
+   @Test
+   public void testNoEntryInL1PutWithConcurrentPut() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in the owner, so the L1 is empty
+      ownerCache.put(key, firstValue);
+
+      assertL1PutWithConcurrentUpdate(nonOwnerCache, nonOwnerCache, false, key, firstValue, "intermediate-put", secondValue);
+   }
+
+   @Test
+   public void testEntryInL1PutWithConcurrentPut() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in a non owner, so the L1 has the key
+      ownerCache.put(key, firstValue);
+      nonOwnerCache.get(key);
+
+      assertIsInL1(nonOwnerCache, key);
+
+      assertL1PutWithConcurrentUpdate(nonOwnerCache, nonOwnerCache, false, key, firstValue, "intermediate-put", secondValue);
+   }
+
+   @Test
+   public void testNoEntryInL1ReplaceWithConcurrentInvalidation() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in the owner, so the L1 is empty
+      ownerCache.put(key, firstValue);
+
+      assertL1PutWithConcurrentUpdate(nonOwnerCache, ownerCache, true, key, firstValue, "intermediate-put", secondValue);
+   }
+
+   @Test
+   public void testEntryInL1ReplaceWithConcurrentInvalidation() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in a non owner, so the L1 has the key
+      ownerCache.put(key, firstValue);
+      nonOwnerCache.get(key);
+
+      assertIsInL1(nonOwnerCache, key);
+
+      assertL1PutWithConcurrentUpdate(nonOwnerCache, ownerCache, true, key, firstValue, "intermediate-put", secondValue);
+   }
+
+   @Test
+   public void testNoEntryInL1ReplaceWithConcurrentPut() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in the owner, so the L1 is empty
+      ownerCache.put(key, firstValue);
+
+      assertL1PutWithConcurrentUpdate(nonOwnerCache, nonOwnerCache, true, key, firstValue, "intermediate-put", secondValue);
+   }
+
+   @Test
+   public void testEntryInL1ReplaceWithConcurrentPut() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in a non owner, so the L1 has the key
+      ownerCache.put(key, firstValue);
+      nonOwnerCache.get(key);
+
+      assertIsInL1(nonOwnerCache, key);
+
+      assertL1PutWithConcurrentUpdate(nonOwnerCache, nonOwnerCache, true, key, firstValue, "intermediate-put", secondValue);
+   }
+
+   @Test
+   public void testNoEntryInL1GetWithConcurrentRemove() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in a non owner, so the L1 has the key
+      ownerCache.put(key, firstValue);
+      nonOwnerCache.get(key);
+
+      assertIsInL1(nonOwnerCache, key);
+
+      assertL1PutWithConcurrentUpdate(nonOwnerCache, nonOwnerCache, true, key, firstValue, "intermediate-put", secondValue);
+   }
+
+   @Test
+   public void testNoEntryInL1PutReplacedNullValueConcurrently() throws InterruptedException, ExecutionException, TimeoutException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      RpcManager rm = TestingUtil.extractComponent(nonOwnerCache, RpcManager.class);
+      ControlledRpcManager crm = new ControlledRpcManager(rm);
+      // Make our node block and not return the get yet
+      crm.blockAfter(PutKeyValueCommand.class);
+      TestingUtil.replaceComponent(nonOwnerCache, RpcManager.class, crm, true);
+
+      try {
+         Future<String> future = nonOwnerCache.putIfAbsentAsync(key, firstValue);
+
+         // Now wait for the get to return and block it for now
+         crm.waitForCommandToBlock(5, TimeUnit.SECONDS);
+
+         // Owner should have the new value
+         assertEquals(firstValue, ownerCache.remove(key));
+
+         // Now let owner key->updateValue go through
+         crm.stopBlocking();
+
+         // This should be originalValue still as we did the get
+         assertNull(future.get(5, TimeUnit.SECONDS));
+
+         // Remove the interceptor now since we don't want to block ourselves - if using phaser this isn't required
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+
+         assertIsNotInL1(nonOwnerCache, key);
+         // The nonOwnerCache should retrieve new value as it isn't in L1
+         assertNull(nonOwnerCache.get(key));
+         assertIsNotInL1(nonOwnerCache, key);
+      } finally {
+         TestingUtil.replaceComponent(nonOwnerCache, RpcManager.class, rm, true);
+      }
+   }
+
+   // TODO: this test fails beacuse ISPN-2965 needs to be fixed to send another invalidation if a requestor came
+   // while the invalidation was still being processed - once it is fixed this should work when enabled
+   @Test(enabled = false, description = "This test is disabled as it will always fail until ISPN-2965 is fixed")
+   public void testNoEntryInL1MultipleConcurrentGetsWithInvalidation() throws TimeoutException, InterruptedException, ExecutionException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      ownerCache.put(key, firstValue);
+
+      CyclicBarrier invalidationBarrier = new CyclicBarrier(2);
+      addBlockingInterceptorBeforeTx(nonOwnerCache, invalidationBarrier, InvalidateL1Command.class);
+
+      try {
+         assertEquals(firstValue, nonOwnerCache.get(key));
+
+         Future<String> futurePut = ownerCache.putAsync(key, secondValue);
+
+         // Wait for the invalidation to be processing
+         invalidationBarrier.await(5, TimeUnit.SECONDS);
+
+         // Now remove the value - assimilates that a get came earlier to owner registering as a invalidatee, however
+         // the invalidation blocked the update from going through
+         nonOwnerCache.getAdvancedCache().getDataContainer().remove(key);
+
+         // Hack, but we remove the blocking interceptor while a call is in it, it still retains a reference to the next
+         // interceptor to invoke and when we unblock it will continue forward
+         // This is done because we can't have 2 interceptors of the same class.
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+
+         CyclicBarrier getBarrier = new CyclicBarrier(2);
+         addBlockingInterceptorBeforeTx(nonOwnerCache, getBarrier, GetKeyValueCommand.class);
+
+         Future<String> futureGet = nonOwnerCache.getAsync(key);
+
+         // Wait for the get to retrieve the remote value but not try to update L1 yet
+         getBarrier.await(5, TimeUnit.SECONDS);
+
+         // Let the invalidation unblock now
+         invalidationBarrier.await(5, TimeUnit.SECONDS);
+
+         // Wait for the invalidation complete fully
+         assertEquals(firstValue, futurePut.get(5, TimeUnit.SECONDS));
+
+         // Now let our get go through
+         getBarrier.await(5, TimeUnit.SECONDS);
+
+         // This should be originalValue still as we did the get before the invalidation completed
+         assertEquals(firstValue, futureGet.get(5, TimeUnit.SECONDS));
+
+         // Remove the interceptor now since we don't want to block ourselves - if using phaser this isn't required
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+
+         // The value shouldn't be in the L1 still
+         assertIsNotInL1(nonOwnerCache, key);
+         // The nonOwnerCache should retrieve new value as it isn't in L1
+         assertEquals(secondValue, nonOwnerCache.get(key));
+         assertIsInL1(nonOwnerCache, key);
+      }
+      finally {
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/interceptors/distribution/L1WriteSynchronizerTest.java
+++ b/core/src/test/java/org/infinispan/interceptors/distribution/L1WriteSynchronizerTest.java
@@ -1,0 +1,269 @@
+package org.infinispan.interceptors.distribution;
+
+import org.infinispan.commands.read.GetKeyValueCommand;
+import org.infinispan.container.DataContainer;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.interceptors.locking.ClusteringDependentLogic;
+import org.infinispan.metadata.Metadata;
+import org.infinispan.statetransfer.StateTransferLock;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test to ensure proper behavior of {@link L1WriteSynchronizer}
+ *
+ * @author wburns
+ * @since 6.0
+ */
+public class L1WriteSynchronizerTest extends AbstractInfinispanTest {
+   private L1WriteSynchronizer sync;
+   private DataContainer dc;
+   private StateTransferLock stl;
+   private ClusteringDependentLogic cdl;
+   private final long l1Timeout = 1000;
+
+
+   @BeforeMethod
+   public void beforeMethod() {
+      dc = Mockito.mock(DataContainer.class);
+      stl = Mockito.mock(StateTransferLock.class);
+      cdl = Mockito.mock(ClusteringDependentLogic.class);
+
+      sync = new L1WriteSynchronizer(dc, l1Timeout, stl, cdl);
+   }
+
+   @Test
+   public void testGetReturnValueWait() throws InterruptedException, ExecutionException, TimeoutException {
+      Object value = new Object();
+      sync.runL1UpdateIfPossible(value, Mockito.mock(GetKeyValueCommand.class));
+
+      assertEquals(value, sync.get());
+   }
+
+   @Test
+   public void testGetReturnValueTimeWait() throws InterruptedException, ExecutionException, TimeoutException {
+      Object value = new Object();
+      sync.runL1UpdateIfPossible(value, Mockito.mock(GetKeyValueCommand.class));
+
+      assertEquals(value, sync.get(1, TimeUnit.SECONDS));
+   }
+
+   @Test
+   public void testExceptionWait() throws InterruptedException {
+      Throwable t = mock(Throwable.class);
+      sync.retrievalEncounteredException(t);
+
+      try {
+         sync.get();
+      } catch (ExecutionException e) {
+         assertEquals(t, e.getCause());
+      }
+   }
+
+   @Test
+   public void testExceptionTimeWait() throws InterruptedException, TimeoutException {
+      Throwable t = mock(Throwable.class);
+      sync.retrievalEncounteredException(t);
+
+      try {
+         sync.get(1, TimeUnit.SECONDS);
+         fail("Should have thrown an execution exception");
+      } catch (ExecutionException e) {
+         assertEquals(t, e.getCause());
+      }
+   }
+
+   @Test
+   public void testSpawnedThreadBlockingValue() throws InterruptedException, ExecutionException, TimeoutException {
+      Object value = new Object();
+      Future future = fork(new Callable<Object>() {
+
+         @Override
+         public Object call() throws Exception {
+            return sync.get();
+         }
+      });
+
+      try {
+         future.get(50, TimeUnit.MILLISECONDS);
+         fail("Should have thrown a timeout exception");
+      } catch (TimeoutException e) {
+         // This should time out exception
+      }
+
+      sync.runL1UpdateIfPossible(value, Mockito.mock(GetKeyValueCommand.class));
+
+      assertEquals(value, future.get(1, TimeUnit.SECONDS));
+   }
+
+   @Test
+   public void testSpawnedThreadBlockingValueTimeWait() throws InterruptedException, ExecutionException, TimeoutException {
+      Object value = new Object();
+      Future future = fork(new Callable<Object>() {
+
+         @Override
+         public Object call() throws Exception {
+            return sync.get(500, TimeUnit.MILLISECONDS);
+         }
+      });
+
+      // This should not return since we haven't signaled the sync yet
+      try {
+         future.get(50, TimeUnit.MILLISECONDS);
+         fail("Should have thrown a timeout exception");
+      } catch (TimeoutException e) {
+         // This should time out exception
+      }
+
+      sync.runL1UpdateIfPossible(value, Mockito.mock(GetKeyValueCommand.class));
+
+      assertEquals(value, future.get(1, TimeUnit.SECONDS));
+   }
+
+   @Test
+   public void testSpawnedThreadBlockingException() throws InterruptedException, ExecutionException, TimeoutException {
+      Throwable t = Mockito.mock(Throwable.class);
+
+      Future future = fork(new Callable<Object>() {
+
+         @Override
+         public Object call() throws Exception {
+            return sync.get();
+         }
+      });
+
+      // This should not return since we haven't signaled the sync yet
+      try {
+         future.get(50, TimeUnit.MILLISECONDS);
+         fail("Should have thrown a timeout exception");
+      } catch (TimeoutException e) {
+         // This should time out exception
+      }
+
+      sync.retrievalEncounteredException(t);
+
+      try {
+         sync.get(1, TimeUnit.SECONDS);
+         fail("Should have thrown an execution exception");
+      } catch (ExecutionException e) {
+         assertEquals(t, e.getCause());
+      }
+   }
+
+   @Test
+   public void testSpawnedThreadBlockingExceptionTimeWait() throws InterruptedException, ExecutionException, TimeoutException {
+      Throwable t = Mockito.mock(Throwable.class);
+
+      Future future = fork(new Callable<Object>() {
+
+         @Override
+         public Object call() throws Exception {
+            return sync.get(500, TimeUnit.MILLISECONDS);
+         }
+      });
+
+      try {
+         future.get(50, TimeUnit.MILLISECONDS);
+         fail("Should have thrown a timeout exception");
+      } catch (TimeoutException e) {
+         // This should time out exception
+      }
+
+      sync.retrievalEncounteredException(t);
+
+      try {
+         sync.get(1, TimeUnit.SECONDS);
+         fail("Should have thrown an execution exception");
+      } catch (ExecutionException e) {
+         assertEquals(t, e.getCause());
+      }
+   }
+
+   @Test
+   public void testWriteCancelled() {
+      assertTrue(sync.trySkipL1Update());
+
+      sync.runL1UpdateIfPossible(new Object(), mock(GetKeyValueCommand.class));
+
+      // The dc shouldn't have been updated
+      verify(dc, never()).put(Mockito.any(), Mockito.any(), Mockito.any(Metadata.class));
+   }
+
+   @Test
+   public void testWriteCannotCancel() throws InterruptedException, TimeoutException, BrokenBarrierException, ExecutionException {
+      final CyclicBarrier barrier = new CyclicBarrier(2);
+
+      // We use the topology lock as a sync point to know when the write is being attempted - note this is after
+      // the synchronizer has been marked as a write occurring
+      doAnswer(new Answer<Void>() {
+
+         @Override
+         public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+            barrier.await();
+            return null;
+         }
+      }).when(stl).acquireSharedTopologyLock();
+
+      Future<Void> future = fork(new Runnable() {
+         @Override
+         public void run() {
+            sync.runL1UpdateIfPossible(new Object(), mock(GetKeyValueCommand.class, RETURNS_MOCKS));
+         }
+      }, null);
+
+      // wait for the thread to try updating
+      barrier.await(1, TimeUnit.SECONDS);
+
+      assertFalse(sync.trySkipL1Update());
+
+      future.get(1, TimeUnit.SECONDS);
+
+      // The dc should have been updated
+      verify(dc).put(Mockito.any(), Mockito.any(), Mockito.any(Metadata.class));
+   }
+
+   @Test
+   public void testDCUpdatedHigherICELifespan() {
+      verifyDCUpdate(Long.MAX_VALUE, false);
+   }
+
+
+   @Test
+   public void testDCUpdatedLowerICELifespan() {
+      verifyDCUpdate(50, true);
+   }
+
+   private void verifyDCUpdate(long iceLifespan, boolean shouldBeIceLifespan) {
+      Object value = new Object();
+      Object key = new Object();
+
+      GetKeyValueCommand mockedCommand = when(mock(GetKeyValueCommand.class).getKey()).thenReturn(key).getMock();
+
+      InternalCacheEntry ice = when(mock(InternalCacheEntry.class, RETURNS_DEEP_STUBS).getValue()).thenReturn(value).getMock();
+      when(ice.getLifespan()).thenReturn(iceLifespan);
+      when(mockedCommand.getRemotelyFetchedValue()).thenReturn(ice);
+
+      sync.runL1UpdateIfPossible(value, mockedCommand);
+
+      verify(dc).put(eq(key), eq(value), Mockito.any(Metadata.class));
+
+      Metadata.Builder verifier = verify(ice.getMetadata().builder());
+      verifier.lifespan(shouldBeIceLifespan ? iceLifespan : l1Timeout);
+      verifier.maxIdle(-1);
+   }
+}


### PR DESCRIPTION
...consistent.
- Implemented single entry point for concurrent gets.
- Also support concurrent invalidation for reads with limited blocking
- Added tests for various concurrency/edge issues
