### PR TITLE
ISPN-3243 Memcached flush_all should not have flags

### DIFF
--- a/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedDecoder.scala
+++ b/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedDecoder.scala
@@ -350,8 +350,7 @@ class MemcachedDecoder(memcachedCache: AdvancedCache[String, Array[Byte]], sched
 
    private def flushAll(b: ChannelBuffer, ch: Channel, isReadParams: Boolean): AnyRef = {
       if (isReadParams) readParameters(ch, b)
-      val flushFunction = (cache: AdvancedCache[String, Array[Byte]]) =>
-         cache.withFlags(Flag.CACHE_MODE_LOCAL, Flag.SKIP_CACHE_STORE).clear()
+      val flushFunction = (cache: AdvancedCache[String, Array[Byte]]) => cache.clear()
       val flushDelay = if (params == null) 0 else params.flushDelay
       if (flushDelay == 0)
          flushFunction(cache)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3243
- It should work just like Hot Rod's clear operation.

5.3.x branch: t_3243_5
