### PR TITLE
ISPN-3232 Avoid marshalling twice LevelDBCacheStore entries

### DIFF
--- a/cachestore/leveldb/src/main/java/org/infinispan/loaders/leveldb/LevelDBCacheStore.java
+++ b/cachestore/leveldb/src/main/java/org/infinispan/loaders/leveldb/LevelDBCacheStore.java
@@ -413,7 +413,7 @@ public class LevelDBCacheStore extends LockSupportCacheStore<Integer> {
 						expiredDb.put(expiryBytes, marshall(al));
 					}
 				} else {
-					expiredDb.put(marshall(expiryBytes), keyBytes);
+					expiredDb.put(expiryBytes, keyBytes);
 				}
 			}
 
@@ -469,7 +469,9 @@ public class LevelDBCacheStore extends LockSupportCacheStore<Integer> {
 			      log.warnUnableToCloseDbIterator(e);
 			   }
 			}
-		} catch (Exception e) {
+		} catch (CacheLoaderException e) {
+         throw e;
+      } catch (Exception e) {
 			throw new CacheLoaderException(e);
 		}
 	}

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -888,5 +888,12 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Configuration parser %s does not declare any Namespace annotations", id = 235)
    CacheConfigurationException parserDoesNotDeclareNamespaces(String name);
+
+   @Message(value = "Purging expired entries failed", id = 236)
+   CacheLoaderException purgingExpiredEntriesFailed(@Cause Throwable cause);
+
+   @Message(value = "Waiting for expired entries to be purge timed out", id = 237)
+   CacheLoaderException timedOutWaitingForExpiredEntriesToBePurged(@Cause Throwable cause);
+
 }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3232

5.3.x branch: `t_3232_5`
- Switched purgeExpired() to submit a callable and if the purge is synchronous, use the future to verify if the purge completed.
