### PR TITLE
ISPN-3274 Cleared legacy Configuration imports in Server modules

### DIFF
--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/CrashedMemberDetectorTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/CrashedMemberDetectorTest.scala
@@ -20,7 +20,7 @@ import org.infinispan.notifications.cachemanagerlistener.event.EventImpl
 class CrashedMemberDetectorTest extends SingleCacheManagerTest {
 
    protected def createCacheManager() =
-      TestCacheManagerFactory.createLocalCacheManager(false)
+      TestCacheManagerFactory.createCacheManager()
 
    def testDetectCrashedMembers() {
       val cache = cacheManager.getCache[Address, ServerAddress]()

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodFunctionalTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodFunctionalTest.scala
@@ -8,10 +8,10 @@ import java.util.Arrays
 import org.infinispan.server.hotrod.OperationStatus._
 import org.infinispan.server.hotrod.test._
 import org.infinispan.test.TestingUtil.generateRandomString
-import org.infinispan.config.Configuration
 import java.util.concurrent.TimeUnit
 import org.infinispan.server.core.test.Stoppable
 import org.infinispan.server.hotrod.configuration.HotRodServerConfiguration
+import org.infinispan.test.fwk.TestCacheManagerFactory
 
 /**
  * Hot Rod server functional test.
@@ -473,10 +473,12 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
       Stoppable.useCacheManager(createTestCacheManager) { cm =>
          Stoppable.useServer(startHotRodServer(cm, server.getPort + 33)) { server =>
             val cacheName = "cache-" + m.getName
-            val namedCfg = new Configuration().fluent.storeAsBinary.build
-            assertTrue(namedCfg.isStoreAsBinary)
+            val namedBuilder = TestCacheManagerFactory.getDefaultCacheConfiguration(false)
+              .storeAsBinary.enable
+            val namedCfg = namedBuilder.build
+            assertTrue(namedCfg.storeAsBinary().enabled())
             cm.defineConfiguration(cacheName, namedCfg)
-            assertFalse(cm.getCache(cacheName).getConfiguration.isStoreAsBinary)
+            assertFalse(cm.getCache(cacheName).getCacheConfiguration.storeAsBinary().enabled())
          }
       }
    }

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodSharedContainerTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodSharedContainerTest.scala
@@ -2,15 +2,13 @@ package org.infinispan.server.hotrod
 
 import test.HotRodClient
 import java.lang.reflect.Method
-import org.infinispan.server.hotrod.OperationStatus._
 import org.infinispan.test.MultipleCacheManagersTest
 import test.HotRodTestingUtil._
 import org.infinispan.test.AbstractCacheTest._
-import org.testng.annotations.{AfterClass, BeforeClass, AfterMethod, Test}
+import org.testng.annotations.{AfterMethod, Test}
 import org.infinispan.server.core.test.ServerTestingUtil._
 import org.infinispan.test.fwk.TestCacheManagerFactory
 import org.infinispan.configuration.cache.CacheMode
-import org.infinispan.commons.equivalence.ByteArrayEquivalence
 import org.infinispan.commons.CacheConfigurationException
 import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder
 import org.infinispan.configuration.global.GlobalConfigurationBuilder

--- a/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedFunctionalTest.scala
+++ b/server/memcached/src/test/scala/org/infinispan/server/memcached/MemcachedFunctionalTest.scala
@@ -11,7 +11,6 @@ import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved
 import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 import org.infinispan.test.fwk.TestCacheManagerFactory
-import org.infinispan.config.Configuration
 import org.infinispan.Version
 import test.MemcachedTestingUtil._
 import org.infinispan.server.memcached.configuration.MemcachedServerConfigurationBuilder
@@ -530,14 +529,16 @@ class MemcachedFunctionalTest extends MemcachedSingleNodeTest {
    }
 
    def testStoreAsBinaryOverride {
-      val cm = TestCacheManagerFactory.createLocalCacheManager(false)
-      val cfg = new Configuration().fluent.storeAsBinary.build
+      val builder = TestCacheManagerFactory.getDefaultCacheConfiguration(false)
+      builder.storeAsBinary.enable
+      val cm = TestCacheManagerFactory.createCacheManager(builder)
+      val cfg = builder.build
       cm.defineConfiguration(new MemcachedServerConfigurationBuilder().build.cache, cfg)
-      assertTrue(cfg.isStoreAsBinary)
+      assertTrue(cfg.storeAsBinary.enabled)
       val testServer = startMemcachedTextServer(cm, server.getPort + 33)
       try {
          val memcachedCache = cm.getCache(testServer.getConfiguration.cache)
-         assertFalse(memcachedCache.getConfiguration.isStoreAsBinary)
+         assertFalse(memcachedCache.getCacheConfiguration.storeAsBinary.enabled)
       } finally {
          cm.stop
          testServer.stop


### PR DESCRIPTION
Cleared imports of org.infinispan.config.\* in server modules. All modified tests pass locally.
