### PR TITLE
ISPN-3262 Fix LevelDBCacheStore loading keys after shutdown

### DIFF
--- a/cachestore/leveldb/src/main/java/org/infinispan/loaders/leveldb/LevelDBCacheStore.java
+++ b/cachestore/leveldb/src/main/java/org/infinispan/loaders/leveldb/LevelDBCacheStore.java
@@ -15,6 +15,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.util.InfinispanCollections;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.InternalCacheValue;
 import org.infinispan.loaders.CacheLoaderConfig;
@@ -241,7 +242,7 @@ public class LevelDBCacheStore extends LockSupportCacheStore<Integer> {
 	protected Set<InternalCacheEntry> loadLockSafe(int maxEntries)
 			throws CacheLoaderException {
 		if (maxEntries <= 0)
-			return Collections.emptySet();
+         return InfinispanCollections.emptySet();
 
 		Set<InternalCacheEntry> entries = new HashSet<InternalCacheEntry>();
 
@@ -268,6 +269,9 @@ public class LevelDBCacheStore extends LockSupportCacheStore<Integer> {
 	@Override
 	protected Set<Object> loadAllKeysLockSafe(Set<Object> keysToExclude)
 			throws CacheLoaderException {
+      if (!cache.getStatus().allowInvocations())
+         return InfinispanCollections.emptySet();
+
 		Set<Object> keys = new HashSet<Object>();
 
 		DBIterator it = db.iterator(new ReadOptions().fillCache(false));

--- a/cachestore/leveldb/src/test/java/org/infinispan/loaders/leveldb/LevelDBMultiCacheStoreFunctionalTest.java
+++ b/cachestore/leveldb/src/test/java/org/infinispan/loaders/leveldb/LevelDBMultiCacheStoreFunctionalTest.java
@@ -28,10 +28,11 @@ public class LevelDBMultiCacheStoreFunctionalTest extends MultiCacheStoreFunctio
    }
 
    @Override
-   protected LevelDBCacheStoreConfigurationBuilder buildCacheStoreConfig(LoadersConfigurationBuilder loaders, String discriminator) throws Exception {
+   protected LevelDBCacheStoreConfigurationBuilder buildCacheStoreConfig(LoadersConfigurationBuilder loaders, String discriminator) {
       LevelDBCacheStoreConfigurationBuilder store = loaders.addStore(LevelDBCacheStoreConfigurationBuilder.class);
       store.location(tmpDir.getAbsolutePath() + File.separator + "leveldb" + File.separator + "data-" + discriminator);
       store.expiredLocation(tmpDir.getAbsolutePath() + File.separator + "leveldb" + File.separator + "expired-data-" + discriminator);
+      store.implementationType(LevelDBCacheStoreConfig.ImplementationType.JAVA);
       return store;
    }
 }

--- a/core/src/test/java/org/infinispan/loaders/AbstractCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/AbstractCacheStoreTest.java
@@ -9,6 +9,7 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.commons.util.ReflectionUtil;
 import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.util.DefaultTimeService;
 import org.infinispan.util.concurrent.WithinThreadExecutor;
@@ -65,6 +66,7 @@ public class AbstractCacheStoreTest extends AbstractInfinispanTest {
       when(cache.getAdvancedCache()).thenReturn(cache);
       when(cache.getComponentRegistry()).thenReturn(registry);
       when(registry.getTimeService()).thenReturn(TIME_SERVICE);
+      when(cache.getStatus()).thenReturn(ComponentStatus.RUNNING);
       return cache;
    }
 }

--- a/core/src/test/java/org/infinispan/loaders/MultiCacheStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/loaders/MultiCacheStoreFunctionalTest.java
@@ -1,27 +1,7 @@
-/*
- * JBoss, Home of Professional Open Source
- * Copyright 2009 Red Hat Inc. and/or its affiliates and other
- * contributors as indicated by the @author tags. All rights reserved.
- * See the copyright.txt in the distribution for a full listing of
- * individual contributors.
- *
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
- *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
- */
 package org.infinispan.loaders;
 
+import static org.infinispan.test.TestingUtil.withCacheManager;
+import static org.infinispan.test.TestingUtil.withCacheManagers;
 import static org.junit.Assert.assertEquals;
 
 import java.lang.reflect.Method;
@@ -33,10 +13,10 @@ import org.infinispan.configuration.cache.AbstractStoreConfigurationBuilder;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.LoadersConfigurationBuilder;
-import org.infinispan.distribution.DistributionTestHelper;
-import org.infinispan.distribution.MagicKey;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.CacheManagerCallable;
+import org.infinispan.test.MultiCacheManagerCallable;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
@@ -79,33 +59,39 @@ public abstract class MultiCacheStoreFunctionalTest<TStoreConfigurationBuilder e
     * when a node that persisted KEY wakes up, it can't rewrite existing value.
     */
    public void testStartStopOfBackupDoesntRewriteValue(Method m) throws Exception {
-      List<ConfigurationBuilder> configs = configs(2, m);
-      EmbeddedCacheManager cacheManager0 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(0));
-      EmbeddedCacheManager cacheManager1 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(1));
-      try {
-         Cache<String, String> cache0 = cacheManager0.getCache();
-         Cache<String, String> cache1 = cacheManager1.getCache();
-         TestingUtil.blockUntilViewsChanged(TIMEOUT, 2, cache0, cache1);
+      final List<ConfigurationBuilder> configs = configs(2, m);
+      withCacheManagers(new MultiCacheManagerCallable(
+            TestCacheManagerFactory.createClusteredCacheManager(configs.get(0)),
+            TestCacheManagerFactory.createClusteredCacheManager(configs.get(1))) {
+         @Override
+         public void call() {
+            final EmbeddedCacheManager cacheManager0 = cms[0];
+            final EmbeddedCacheManager cacheManager1 = cms[1];
+            final Cache<String, String> cache0 = cacheManager0.getCache();
+            final Cache<String, String> cache1 = cacheManager1.getCache();
+            TestingUtil.blockUntilViewsChanged(TIMEOUT, 2, cache0, cache1);
 
-         cache0.put("KEY", "VALUE V1");
-         assertEquals("VALUE V1", cache1.get("KEY"));
+            cache0.put("KEY", "VALUE V1");
+            assertEquals("VALUE V1", cache1.get("KEY"));
 
-         TestingUtil.killCacheManagers(cacheManager1);
-         cacheManager1 = null;
-         cache1 = null;
-         TestingUtil.blockUntilViewsChanged(TIMEOUT, 1, cache0);
+            TestingUtil.killCacheManagers(cacheManager1);
+            TestingUtil.blockUntilViewsChanged(TIMEOUT, 1, cache0);
 
-         cache0.put("KEY", "VALUE V2");
-         assertEquals("VALUE V2", cache0.get("KEY"));
+            cache0.put("KEY", "VALUE V2");
+            assertEquals("VALUE V2", cache0.get("KEY"));
 
-         cacheManager1 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(1));
-         cache1 = cacheManager1.getCache();
-         TestingUtil.blockUntilViewsChanged(TIMEOUT, 2, cache0, cache1);
+            withCacheManager(new CacheManagerCallable(
+                  TestCacheManagerFactory.createClusteredCacheManager(configs.get(1))) {
+               @Override
+               public void call() {
+                  Cache<String, String> newCache = cm.getCache();
+                  TestingUtil.blockUntilViewsChanged(TIMEOUT, 2, cache0, newCache);
+                  assertEquals("VALUE V2", newCache.get("KEY"));
+               }
+            });
+         }
+      });
 
-         assertEquals("VALUE V2", cache1.get("KEY"));
-      } finally {
-         TestingUtil.killCacheManagers(cacheManager0, cacheManager1);
-      }
    }
 
    /**
@@ -114,154 +100,40 @@ public abstract class MultiCacheStoreFunctionalTest<TStoreConfigurationBuilder e
     * 
     */
    public void testStartStopOfBackupResurrectsDeletedKey(Method m) throws Exception {
-      List<ConfigurationBuilder> configs = configs(2, m);
-      EmbeddedCacheManager cacheManager0 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(0));
-      EmbeddedCacheManager cacheManager1 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(1));
-      try {
-         Cache<String, String> cache0 = cacheManager0.getCache();
-         Cache<String, String> cache1 = cacheManager1.getCache();
-         TestingUtil.blockUntilViewsChanged(TIMEOUT, 2, cache0, cache1);
+      final List<ConfigurationBuilder> configs = configs(2, m);
+      withCacheManagers(new MultiCacheManagerCallable(
+            TestCacheManagerFactory.createClusteredCacheManager(configs.get(0)),
+            TestCacheManagerFactory.createClusteredCacheManager(configs.get(1))) {
+         @Override
+         public void call() {
+            final EmbeddedCacheManager cacheManager0 = cms[0];
+            final EmbeddedCacheManager cacheManager1 = cms[1];
+            final Cache<String, String> cache0 = cacheManager0.getCache();
+            final Cache<String, String> cache1 = cacheManager1.getCache();
+            TestingUtil.blockUntilViewsChanged(TIMEOUT, 2, cache0, cache1);
 
-         cache0.put("KEY2", "VALUE2 V1");
-         assertEquals("VALUE2 V1", cache1.get("KEY2"));
+            cache0.put("KEY2", "VALUE2 V1");
+            assertEquals("VALUE2 V1", cache1.get("KEY2"));
 
-         TestingUtil.killCacheManagers(cacheManager1);
-         cacheManager1 = null;
-         cache1 = null;
-         TestingUtil.blockUntilViewsChanged(TIMEOUT, 1, cache0);
+            TestingUtil.killCacheManagers(cacheManager1);
+            TestingUtil.blockUntilViewsChanged(TIMEOUT, 1, cache0);
 
-         cache0.put("KEY2", "VALUE2 V2");
-         assertEquals("VALUE2 V2", cache0.get("KEY2"));
-         cache0.remove("KEY2");
-         assertEquals(null, cache0.get("KEY2"));
+            cache0.put("KEY2", "VALUE2 V2");
+            assertEquals("VALUE2 V2", cache0.get("KEY2"));
+            cache0.remove("KEY2");
+            assertEquals(null, cache0.get("KEY2"));
 
-         cacheManager1 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(1));
-         cache1 = cacheManager1.getCache();
-         TestingUtil.blockUntilViewsChanged(TIMEOUT, 2, cache0, cache1);
-
-         assertEquals("VALUE2 V1", cache1.get("KEY2"));
-      } finally {
-         TestingUtil.killCacheManagers(cacheManager0, cacheManager1);
-      }
-   }
-
-   /**
-    * 
-    * 1. start {n0, n1, n2} owners(k1) = {n0, n1} 2. stop n1 3. rewrite k1 value 4. start n1 5.
-    * check k1 value is the new one in all nodes
-    * 
-    * @throws Exception
-    */
-   public void testStartStopOfBackupDoesntRewriteValue2(Method m) throws Exception {
-      List<ConfigurationBuilder> configs = configs(3, m);
-      EmbeddedCacheManager cacheManager0 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(0));
-      EmbeddedCacheManager cacheManager1 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(1));
-      EmbeddedCacheManager cacheManager2 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(2));
-      try {
-         Cache<MagicKey, String> cache0 = cacheManager0.getCache();
-         Cache<MagicKey, String> cache1 = cacheManager1.getCache();
-         Cache<MagicKey, String> cache2 = cacheManager2.getCache();
-
-         TestingUtil.blockUntilViewsChanged(TIMEOUT, 3, cache0, cache1, cache2);
-
-         MagicKey k1 = new MagicKey(cache0, cache1);
-
-         cache0.put(k1, "VALUE V1");
-         assert DistributionTestHelper.isOwner(cache0, k1);
-         assert DistributionTestHelper.isOwner(cache1, k1);
-         assert !DistributionTestHelper.isOwner(cache2, k1);
-
-         assertEquals("VALUE V1", cache0.get(k1)); // primary owner
-         assertEquals("VALUE V1", cache1.get(k1)); // secondary owner
-         assertEquals("VALUE V1", cache2.get(k1)); // remotely fetched
-
-         TestingUtil.killCacheManagers(cacheManager1);
-         cacheManager1 = null;
-         cache1 = null;
-
-         TestingUtil.blockUntilViewsChanged(TIMEOUT, 2, cache0, cache2);
-         assert DistributionTestHelper.isOwner(cache0, k1);
-         assert DistributionTestHelper.isOwner(cache2, k1);
-
-         cache0.put(k1, "VALUE V2");
-         assertEquals("VALUE V2", cache0.get(k1));
-         assertEquals("VALUE V2", cache2.get(k1));
-
-         cacheManager1 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(1));
-         cache1 = cacheManager1.getCache();
-         TestingUtil.blockUntilViewsChanged(TIMEOUT, 3, cache0, cache1, cache2);
-
-         assertEquals("VALUE V2", cache0.get(k1));
-         assertEquals("VALUE V2", cache1.get(k1));
-         assertEquals("VALUE V2", cache2.get(k1));
-      } finally {
-         TestingUtil.killCacheManagers(cacheManager0, cacheManager1, cacheManager2);
-      }
-   }
-
-   /**
-    * 
-    * 1. start {n0, n1, n2} owners(k1) = {n0, n1} 2. stop n1 3. rewrite k1 value 4. start n3 5.
-    * start n1 check k1 value is the new one in all nodes
-    * 
-    * @throws Exception
-    */
-   public void testStartStopOfBackupDoesntRewriteValue3(Method m) throws Exception {
-      List<ConfigurationBuilder> configs = configs(4, m);
-      EmbeddedCacheManager cacheManager0 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(0));
-      EmbeddedCacheManager cacheManager1 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(1));
-      EmbeddedCacheManager cacheManager2 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(2));
-      EmbeddedCacheManager cacheManager3 = null;
-      Cache<MagicKey, String> cache3 = null; // soon
-      try {
-         Cache<MagicKey, String> cache0 = cacheManager0.getCache();
-         Cache<MagicKey, String> cache1 = cacheManager1.getCache();
-         Cache<MagicKey, String> cache2 = cacheManager2.getCache();
-
-         TestingUtil.blockUntilViewsChanged(TIMEOUT, 3, cache0, cache1, cache2);
-
-         MagicKey k1 = new MagicKey(cache0, cache1);
-
-         cache0.put(k1, "VALUE V1");
-         assert DistributionTestHelper.isOwner(cache0, k1);
-         assert DistributionTestHelper.isOwner(cache1, k1);
-         assert !DistributionTestHelper.isOwner(cache2, k1);
-
-         assertEquals("VALUE V1", cache0.get(k1)); // primary owner
-         assertEquals("VALUE V1", cache1.get(k1)); // secondary owner
-         assertEquals("VALUE V1", cache2.get(k1)); // remotely fetched
-
-         TestingUtil.killCacheManagers(cacheManager1);
-         cacheManager1 = null;
-         cache1 = null;
-
-         TestingUtil.blockUntilViewsChanged(TIMEOUT, 2, cache0, cache2);
-         assert DistributionTestHelper.isOwner(cache0, k1);
-         assert DistributionTestHelper.isOwner(cache2, k1);
-
-         cache0.put(k1, "VALUE V2");
-         assertEquals("VALUE V2", cache0.get(k1));
-         assertEquals("VALUE V2", cache2.get(k1));
-
-         cacheManager3 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(3));
-         cache3 = cacheManager3.getCache();
-         TestingUtil.blockUntilViewsChanged(TIMEOUT, 3, cache0, cache2, cache3);
-
-         assertEquals("VALUE V2", cache0.get(k1));
-         assertEquals("VALUE V2", cache2.get(k1));
-         assertEquals("VALUE V2", cache3.get(k1));
-
-         cacheManager1 = TestCacheManagerFactory.createClusteredCacheManager(configs.get(1));
-         cache1 = cacheManager1.getCache();
-         TestingUtil.blockUntilViewsChanged(TIMEOUT, 4, cache0, cache1, cache2, cache3);
-
-         assertEquals("VALUE V2", cache0.get(k1));
-         assertEquals("VALUE V2", cache1.get(k1));
-         assertEquals("VALUE V2", cache2.get(k1));
-         assertEquals("VALUE V2", cache3.get(k1));
-      } finally {
-         TestingUtil.killCacheManagers(cacheManager0, cacheManager1, cacheManager2);
-      }
+            withCacheManager(new CacheManagerCallable(
+                  TestCacheManagerFactory.createClusteredCacheManager(configs.get(1))) {
+               @Override
+               public void call() {
+                  Cache<String, String> newCache = cm.getCache();
+                  TestingUtil.blockUntilViewsChanged(TIMEOUT, 2, cache0, newCache);
+                  assertEquals("VALUE2 V1", newCache.get("KEY2"));
+               }
+            });
+         }
+      });
    }
 
 }


### PR DESCRIPTION
This fix could be potentially applied at a higher level, outside the cache store...

5.3.x branch: `t_3262_5`
