### PR TITLE
ISPN-3242 Enforce building against JDK7

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -26,7 +26,7 @@
       <version.netty>3.6.5.Final</version.netty>
       <version.osgi>4.3.0</version.osgi>
       <version.rhq>4.2.0</version.rhq>
-      <version.scala>2.10.0</version.scala>
+      <version.scala>2.10.2</version.scala>
    </properties>
    
    <dependencyManagement>

--- a/cachestore/jpa/pom.xml
+++ b/cachestore/jpa/pom.xml
@@ -1,53 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.infinispan</groupId>
-		<artifactId>infinispan-cachestore-parent</artifactId>
-		<version>6.0.0-SNAPSHOT</version>
-		<relativePath>../pom.xml</relativePath>
-	</parent>
-	<artifactId>infinispan-cachestore-jpa</artifactId>
-	<packaging>bundle</packaging>
-	<name>Infinispan JPA CacheStore</name>
-	<description>Infinispan JPA CacheStore module</description>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+   <parent>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-cachestore-parent</artifactId>
+      <version>6.0.0-SNAPSHOT</version>
+      <relativePath>../pom.xml</relativePath>
+   </parent>
+   <artifactId>infinispan-cachestore-jpa</artifactId>
+   <packaging>bundle</packaging>
+   <name>Infinispan JPA CacheStore</name>
+   <description>Infinispan JPA CacheStore module</description>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<configuration>
-					<instructions>
-						<Export-Package>
-							${project.groupId}.loaders.jpa.*;version=${project.version};-split-package:=error
-						</Export-Package>
-					</instructions>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-	<dependencies>
-		<dependency>
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <configuration>
+               <instructions>
+                  <Export-Package>
+                     ${project.groupId}.loaders.jpa.*;version=${project.version};-split-package:=error
+                  </Export-Package>
+               </instructions>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+   <dependencies>
+      <dependency>
+         <groupId>org.hibernate.javax.persistence</groupId>
+         <artifactId>hibernate-jpa-2.0-api</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
          <groupId>com.h2database</groupId>
          <artifactId>h2</artifactId>
          <scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+      </dependency>
+      <dependency>
+         <groupId>mysql</groupId>
+         <artifactId>mysql-connector-java</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.slf4j</groupId>
+         <artifactId>slf4j-simple</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.hibernate</groupId>
+         <artifactId>hibernate-entitymanager</artifactId>
+         <scope>test</scope>
+      </dependency>
+   </dependencies>
 </project>

--- a/cachestore/mongodb/pom.xml
+++ b/cachestore/mongodb/pom.xml
@@ -32,7 +32,6 @@
                         <MONGODB_HOSTNAME>${env.MONGODB_HOSTNAME}</MONGODB_HOSTNAME>
                         <MONGODB_PORT>${env.MONGODB_PORT}</MONGODB_PORT>
                     </environmentVariables>
-                    <forkMode>once</forkMode>
                 </configuration>
             </plugin>
         </plugins>

--- a/demos/lucene-directory-demo/pom.xml
+++ b/demos/lucene-directory-demo/pom.xml
@@ -61,7 +61,6 @@
             <configuration>
                <parallel>false</parallel>
                <threadCount>1</threadCount>
-               <forkMode>never</forkMode>
                <trimStackTrace>false</trimStackTrace>
             </configuration>
          </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -113,7 +113,7 @@
       <version.h2.driver>1.3.166</version.h2.driver>
       <version.hadoop.core>1.0.3</version.hadoop.core>
       <version.hbase>0.94.1</version.hbase>
-      <version.hibernate.core>3.5.6-Final</version.hibernate.core>
+      <version.hibernate.core>4.2.2.Final</version.hibernate.core>
       <version.hibernate.annotations>${version.hibernate.core}</version.hibernate.annotations>
       <version.hibernate.entitymanager>${version.hibernate.core}</version.hibernate.entitymanager>
       <version.hibernate.search>4.3.0.Final</version.hibernate.search>
@@ -157,6 +157,7 @@
       <version.weld>1.1.8.Final</version.weld>
       <version.xstream>1.4.1</version.xstream>
       <version.javassist>3.15.0-GA</version.javassist>
+      <version.maven.animal.sniffer>1.9</version.maven.animal.sniffer>
       <version.maven.bundle>2.3.7</version.maven.bundle>
       <version.maven.source>2.2.1</version.maven.source>
       <version.maven.scala>2.15.2</version.maven.scala>
@@ -541,19 +542,16 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>${version.hibernate.core}</version>
-            <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
             <version>${version.hibernate.entitymanager}</version>
-            <scope>provided</scope>
-            </dependency>
+         </dependency>
          <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-annotations</artifactId>
             <version>${version.hibernate.annotations}</version>
-            <scope>provided</scope>
          </dependency>
          <dependency>
             <groupId>org.hibernate</groupId>
@@ -578,6 +576,11 @@
             <version>${version.hibernate.search}</version>
             <type>test-jar</type>
             <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.hibernate.javax.persistence</groupId>
+            <artifactId>hibernate-jpa-2.0-api</artifactId>
+            <version>${version.hibernate.javax.persistence}</version>
          </dependency>
          <dependency>
             <groupId>org.jboss.arquillian</groupId>
@@ -1205,6 +1208,54 @@
          </plugins>
       </pluginManagement>
       <plugins>
+         <!-- enforce java 1.6 and maven 2.1.0 -->
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>1.0</version>
+            <executions>
+               <execution>
+                  <id>enforce-java</id>
+                  <goals>
+                     <goal>enforce</goal>
+                  </goals>
+                  <configuration>
+                     <rules>
+                        <requireJavaVersion>
+                           <version>[1.7,)</version>
+                        </requireJavaVersion>
+                        <requireMavenVersion>
+                           <version>[3.0.3,)</version>
+                        </requireMavenVersion>
+                     </rules>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-maven-plugin</artifactId>
+            <version>${version.maven.animal.sniffer}</version>
+            <configuration>
+               <signature>
+                  <groupId>org.codehaus.mojo.signature</groupId>
+                  <artifactId>java16</artifactId>
+                  <version>1.0</version>
+               </signature>
+               <ignores>
+                  <ignore>sun.misc.Unsafe</ignore>
+                  <ignore>org.apache.lucene.store.IOContext</ignore>
+               </ignores>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>process-classes</phase>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+         </plugin>
          <plugin>
             <artifactId>maven-remote-resources-plugin</artifactId>
             <version>1.1</version>
@@ -1463,30 +1514,6 @@
          </activation>
          <build>
             <plugins>
-               <!-- enforce java 1.6 and maven 2.1.0 -->
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-enforcer-plugin</artifactId>
-                  <version>1.0</version>
-                  <executions>
-                     <execution>
-                        <id>enforce-java</id>
-                        <goals>
-                           <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                           <rules>
-                              <requireJavaVersion>
-                                 <version>[1.6,)</version>
-                              </requireJavaVersion>
-                              <requireMavenVersion>
-                                 <version>[2.1.0,)</version>
-                              </requireMavenVersion>
-                           </rules>
-                        </configuration>
-                     </execution>
-                  </executions>
-               </plugin>
                <!-- Make sure we generate src jars too -->
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
@@ -1884,6 +1911,47 @@
                   </plugin>
                </plugins>
             </pluginManagement>
+         </build>
+      </profile>
+      
+      <profile>
+         <id>jdk6testsuite</id>
+         <activation>
+            <property>
+               <name>env.JAVA_HOME_16</name>
+            </property>
+         </activation>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                     <jvm>${env.JAVA_HOME_16}/bin/java</jvm>  
+                     <parallel>tests</parallel>
+                     <threadCount>${infinispan.test.parallel.threads}</threadCount>
+                     <forkCount>1</forkCount>
+                     <reuseForks>true</reuseForks>
+                     <groups>${defaultTestGroup}</groups>
+                     <systemPropertyVariables>
+                        <infinispan.test.jgroups.protocol>${infinispan.test.jgroups.protocol}</infinispan.test.jgroups.protocol>
+                        <jgroups.bind_addr>127.0.0.1</jgroups.bind_addr>
+                        <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+                        <infinispan.unsafe.allow_jdk8_chm>true</infinispan.unsafe.allow_jdk8_chm>
+                        <log4j.configuration>${log4j.configuration}</log4j.configuration>
+                     </systemPropertyVariables>
+                     <trimStackTrace>false</trimStackTrace>
+                     <properties>
+                        <property>
+                           <name>listener</name>
+                           <value>${testNGListener}</value>
+                        </property>
+                     </properties>
+                     <!-- -Dsun.nio.ch.bugLevel needed because of http://bugs.sun.com/view_bug.do?bug_id=6427854 -->
+                     <argLine>-Xmx1024m -XX:MaxPermSize=256m -Dsun.nio.ch.bugLevel</argLine>
+                  </configuration>
+               </plugin>
+            </plugins>
          </build>
       </profile>
 

--- a/rhq-plugin/pom.xml
+++ b/rhq-plugin/pom.xml
@@ -75,27 +75,8 @@
       </dependency>
 
       <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <scope>provided</scope>
-      </dependency>
-
-      <!-- Crazy dependencies to solve the usual compiler bug with unavailable annotations -->
-      <dependency>
-         <groupId>javax.persistence</groupId>
-         <artifactId>persistence-api</artifactId>
-         <scope>provided</scope>
-      </dependency>
-      
-      <dependency>
-         <groupId>org.hibernate</groupId>
-         <artifactId>hibernate-core</artifactId>
-         <scope>provided</scope>
-      </dependency>
-      
-      <dependency>
-         <groupId>org.hibernate</groupId>
-         <artifactId>hibernate-annotations</artifactId>
+         <groupId>org.jboss.logging</groupId>
+         <artifactId>jboss-logging</artifactId>
          <scope>provided</scope>
       </dependency>
       


### PR DESCRIPTION
ISPN-3242 Enforce building against JDK7 but verify that we are compatible with JDK6. Run testsuite against JDK6 if the JAVA_HOME_16 environment variable is set

ISPN-3284 Drop useless dependencies which we had to keep around because of http://bugs.sun.com/view_bug.do?bug_id=6550655

Other minor pom cleanups

https://issues.jboss.org/browse/ISPN-3242
https://issues.jboss.org/browse/ISPN-3284
