### PR TITLE
ISPN-3297 RemoteCaches cannot be assigned to BasicCaches anymore in the CDI module

### DIFF
--- a/cdi/extension/src/test/java/org/infinispan/cdi/test/cache/remote/DefaultCacheTest.java
+++ b/cdi/extension/src/test/java/org/infinispan/cdi/test/cache/remote/DefaultCacheTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.cdi.test.cache.remote;
 
-import org.infinispan.api.BasicCache;
 import org.infinispan.cdi.Remote;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
@@ -46,7 +45,7 @@ public class DefaultCacheTest extends Arquillian {
 
    @Inject
    @Remote
-   private BasicCache<String, String> cache;
+   private RemoteCache<String, String> cache;
 
    @Inject
    private RemoteCache<String, String> remoteCache;

--- a/cdi/extension/src/test/java/org/infinispan/cdi/test/cache/remote/NamedCacheTest.java
+++ b/cdi/extension/src/test/java/org/infinispan/cdi/test/cache/remote/NamedCacheTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.cdi.test.cache.remote;
 
-import org.infinispan.api.BasicCache;
 import org.infinispan.cdi.Remote;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
@@ -45,19 +44,11 @@ public class NamedCacheTest extends Arquillian {
 
    @Inject
    @Remote("small")
-   private BasicCache<String, String> cache;
-
-   @Inject
-   @Remote("small")
-   private RemoteCache<String, String> remoteCache;
+   private RemoteCache<String, String> cache;
 
    @Inject
    @Small
-   private BasicCache<String, String> cacheWithQualifier;
-
-   @Inject
-   @Small
-   private RemoteCache<String, String> remoteCacheWithQualifier;
+   private RemoteCache<String, String> cacheWithQualifier;
 
    @BeforeTest
    public void beforeMethod() {
@@ -82,20 +73,12 @@ public class NamedCacheTest extends Arquillian {
       assertEquals(cache.get("pete"), "British");
       assertEquals(cache.get("manik"), "Sri Lankan");
 
-      assertEquals(remoteCache.getName(), "small");
-      assertEquals(remoteCache.get("pete"), "British");
-      assertEquals(remoteCache.get("manik"), "Sri Lankan");
-
       // here we check that the cache injection with the @Small qualifier works
       // like the injection with the @Remote qualifier
 
       assertEquals(cacheWithQualifier.getName(), "small");
       assertEquals(cacheWithQualifier.get("pete"), "British");
       assertEquals(cacheWithQualifier.get("manik"), "Sri Lankan");
-
-      assertEquals(remoteCacheWithQualifier.getName(), "small");
-      assertEquals(remoteCacheWithQualifier.get("pete"), "British");
-      assertEquals(remoteCacheWithQualifier.get("manik"), "Sri Lankan");
    }
 
    /**

--- a/cdi/extension/src/test/java/org/infinispan/cdi/test/cache/remote/SpecificCacheManagerTest.java
+++ b/cdi/extension/src/test/java/org/infinispan/cdi/test/cache/remote/SpecificCacheManagerTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.cdi.test.cache.remote;
 
-import org.infinispan.api.BasicCache;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -44,11 +43,7 @@ public class SpecificCacheManagerTest extends Arquillian {
 
    @Inject
    @Small
-   private BasicCache<String, String> cache;
-
-   @Inject
-   @Small
-   private RemoteCache<String, String> remoteCache;
+   private RemoteCache<String, String> cache;
 
    @BeforeTest
    public void beforeMethod() {
@@ -72,10 +67,6 @@ public class SpecificCacheManagerTest extends Arquillian {
       assertEquals(cache.getName(), "small");
       assertEquals(cache.get("pete"), "British");
       assertEquals(cache.get("manik"), "Sri Lankan");
-
-      assertEquals(remoteCache.getName(), "small");
-      assertEquals(remoteCache.get("pete"), "British");
-      assertEquals(remoteCache.get("manik"), "Sri Lankan");
    }
 
    /**


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3297
