### PR TITLE
ISPN-3299 ReplTotalOrderStateTransferFunctional1PcTest.testSTWithThirdWritingTxCache random failures

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
@@ -96,8 +96,7 @@ public class RpcManagerImpl implements RpcManager {
       statisticsEnabled = configuration.jmxStatistics().enabled();
 
       if (configuration.transaction().transactionProtocol().isTotalOrder())
-         t.checkTotalOrderSupported(configuration.clustering().cacheMode().isDistributed()
-               || configuration.clustering().cacheMode().isReplicated());
+         t.checkTotalOrderSupported();
    }
 
    @ManagedAttribute(description = "Retrieves the committed view.", displayName = "Committed view", dataType = DataType.TRAIT)

--- a/core/src/main/java/org/infinispan/remoting/transport/Transport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/Transport.java
@@ -111,7 +111,6 @@ public interface Transport extends Lifecycle {
    /**
     * check if the transport has configured with total order deliver properties (has the sequencer in JGroups
     * protocol stack.
-    * @param anycast   if true, check is Total Order protocol for distributed mode is in the protocol stack
     */
-   void checkTotalOrderSupported(boolean anycast);
+   void checkTotalOrderSupported();
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -486,11 +486,11 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
       if (broadcast || (totalOrder && !anycast)) {
          rsps = dispatcher.broadcastRemoteCommands(rpcCommand, toJGroupsMode(mode), timeout,
                                                    usePriorityQueue, toJGroupsFilter(responseFilter),
-                                                   asyncMarshalling, ignoreLeavers, totalOrder, anycast);
+                                                   asyncMarshalling, ignoreLeavers, totalOrder);
       } else if (totalOrder && anycast) {
          rsps = dispatcher.invokeRemoteCommands(jgAddressList, rpcCommand, toJGroupsMode(mode), timeout,
                                                 usePriorityQueue, toJGroupsFilter(responseFilter),
-                                                asyncMarshalling, ignoreLeavers, totalOrder, anycast);
+                                                asyncMarshalling, ignoreLeavers, totalOrder);
       } else {
          if (jgAddressList == null || !jgAddressList.isEmpty()) {
             boolean singleRecipient = !ignoreLeavers && jgAddressList != null && jgAddressList.size() == 1;
@@ -510,7 +510,7 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
                } else {
                   rsps = dispatcher.invokeRemoteCommands(jgAddressList, rpcCommand, toJGroupsMode(mode), timeout,
                                                          usePriorityQueue, toJGroupsFilter(responseFilter),
-                                                         asyncMarshalling, ignoreLeavers, totalOrder, anycast);
+                                                         asyncMarshalling, ignoreLeavers, totalOrder);
                }
             }
          }
@@ -720,8 +720,9 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
    }
 
    @Override
-   public final void checkTotalOrderSupported(boolean anycast) {
-      if (anycast && channel.getProtocolStack().findProtocol(TOA.class) == null) {
+   public final void checkTotalOrderSupported() {
+      //For replicated and distributed tx caches, we use TOA as total order protocol.
+      if (channel.getProtocolStack().findProtocol(TOA.class) == null) {
          throw new CacheConfigurationException("In order to support total order based transaction, the TOA protocol " +
                                                 "must be present in the JGroups's config.");
       }

--- a/core/src/test/java/org/infinispan/xsite/offline/DelegatingTransport.java
+++ b/core/src/test/java/org/infinispan/xsite/offline/DelegatingTransport.java
@@ -128,7 +128,7 @@ public class DelegatingTransport implements Transport {
    }
 
    @Override
-   public void checkTotalOrderSupported(boolean anycast) {
-      actual.checkTotalOrderSupported(anycast);
+   public void checkTotalOrderSupported() {
+      actual.checkTotalOrderSupported();
    }
 }

--- a/spring/src/test/java/org/infinispan/spring/mock/MockTransport.java
+++ b/spring/src/test/java/org/infinispan/spring/mock/MockTransport.java
@@ -67,7 +67,7 @@ public final class MockTransport implements Transport {
    }
 
    @Override
-   public void checkTotalOrderSupported(boolean anycast) {
+   public void checkTotalOrderSupported() {
    }
 
    @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3299

A little mismatch, the code as assuming that the SEQUENCER is there. That was not true and an unordered deliver was blocking everything. 

for 5.3.x branch: https://github.com/pruivo/infinispan/tree/ISPN-3299-5.3.x
