### PR TITLE
ISPN-2950 In distributed mode cache store data should be read through th...

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/DistSyncCacheStoreNotSharedTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncCacheStoreNotSharedTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.distribution;
 
-import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.container.DataContainer;
 import org.infinispan.context.Flag;
@@ -9,6 +8,7 @@ import org.infinispan.loaders.CacheLoaderManager;
 import org.infinispan.loaders.CacheStore;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
@@ -17,8 +17,7 @@ import java.util.Map;
 import java.util.concurrent.Future;
 
 import static org.infinispan.test.TestingUtil.k;
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.*;
 
 /**
  * DistSyncSharedTest.
@@ -338,6 +337,21 @@ public class DistSyncCacheStoreNotSharedTest extends BaseDistCacheStoreTest {
             }
          }
       }
+   }
+
+   public void testGetOnlyQueriesCacheOnOwners() throws CacheLoaderException {
+      // Make a key that own'ers is c1 and c2
+      final MagicKey k = new MagicKey("key1", c1, c2);
+      final String v1 = "real-data";
+      final String v2 = "stale-data";
+
+      // Simulate c3 was by itself and someone wrote a value that is now stale
+      CacheStore store = TestingUtil.extractComponent(c3, CacheLoaderManager.class).getCacheStore();
+      store.store(TestInternalCacheEntryFactory.create(k, v2));
+
+      c1.put(k, v1);
+
+      assertEquals(v1, c3.get(k));
    }
    
    /*---    test helpers      ---*/

--- a/core/src/test/java/org/infinispan/invalidation/BaseInvalidationTest.java
+++ b/core/src/test/java/org/infinispan/invalidation/BaseInvalidationTest.java
@@ -23,6 +23,8 @@ import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.commands.write.InvalidateCommand;
 import org.infinispan.config.Configuration;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.remoting.rpc.ResponseFilter;
 import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.rpc.RpcManager;
@@ -44,15 +46,15 @@ public abstract class BaseInvalidationTest extends MultipleCacheManagersTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      Configuration c = getDefaultClusteredConfig(isSync ? Configuration.CacheMode.INVALIDATION_SYNC : Configuration.CacheMode.INVALIDATION_ASYNC, false);
-      c.setStateRetrievalTimeout(10000);
-      c.setLockAcquisitionTimeout(500);
-      createClusteredCaches(2, "invalidation", c);
+      ConfigurationBuilder cb = getDefaultClusteredCacheConfig(isSync ? CacheMode.INVALIDATION_SYNC : CacheMode.INVALIDATION_ASYNC, false);
+      cb.clustering().stateTransfer().timeout(10000);
+      cb.locking().lockAcquisitionTimeout(500);
+      createClusteredCaches(2, "invalidation", cb);
 
-      c = getDefaultClusteredConfig(isSync ? Configuration.CacheMode.INVALIDATION_SYNC : Configuration.CacheMode.INVALIDATION_ASYNC, true);
-      c.setStateRetrievalTimeout(10000);
-      c.setLockAcquisitionTimeout(500);
-      defineConfigurationOnAllManagers("invalidationTx", c);
+      cb = getDefaultClusteredCacheConfig(isSync ? CacheMode.INVALIDATION_SYNC : CacheMode.INVALIDATION_ASYNC, true);
+      cb.clustering().stateTransfer().timeout(10000);
+      cb.locking().lockAcquisitionTimeout(500);
+      defineConfigurationOnAllManagers("invalidationTx", cb);
       waitForClusterToForm("invalidationTx");
 
    }

--- a/core/src/test/java/org/infinispan/invalidation/ClusteredCacheLoaderInvalidationTest.java
+++ b/core/src/test/java/org/infinispan/invalidation/ClusteredCacheLoaderInvalidationTest.java
@@ -1,0 +1,53 @@
+package org.infinispan.invalidation;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ClusterCacheLoaderConfigurationBuilder;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.loaders.dummy.DummyInMemoryCacheStoreConfigurationBuilder;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNull;
+
+/**
+ * Tests to ensure that invalidation caches with a cluster cache loader properly retrieve the value from the remote
+ * cache
+ *
+ * @author William burns
+ * @since 6.0
+ */
+public class ClusteredCacheLoaderInvalidationTest extends MultipleCacheManagersTest {
+   private static final String key = "key";
+   private static final String value = "value";
+   private static final String changedValue = "changed-value";
+
+   private static final String cacheName = "inval-write-cache-store";
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder cb = getDefaultClusteredCacheConfig(CacheMode.INVALIDATION_SYNC, false);
+      cb.loaders().addLoader(ClusterCacheLoaderConfigurationBuilder.class);
+      createClusteredCaches(2, cacheName, cb);
+   }
+
+   @Test
+   public void testCacheLoaderBeforeAfterInvalidation() {
+      assertNull(cache(0, cacheName).get(key));
+
+      cache(0, cacheName).put(key, value);
+
+      assertFalse("Invalidation should not contain the value in memory",
+                  cache(1, cacheName).getAdvancedCache().getDataContainer().containsKey(key));
+
+      assertEquals(value, cache(1, cacheName).get(key));
+
+      cache(1, cacheName).put(key, changedValue);
+
+      assertFalse("Invalidation should not contain the value in memory after other node put",
+                  cache(0, cacheName).getAdvancedCache().getDataContainer().containsKey(key));
+
+      assertEquals(changedValue, cache(0, cacheName).get(key));
+   }
+}

--- a/core/src/test/java/org/infinispan/invalidation/WriteCacheStoreInvalidationTest.java
+++ b/core/src/test/java/org/infinispan/invalidation/WriteCacheStoreInvalidationTest.java
@@ -1,0 +1,48 @@
+package org.infinispan.invalidation;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.loaders.dummy.DummyInMemoryCacheStoreConfigurationBuilder;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertFalse;
+
+/**
+ * Tests to ensure that invalidation caches operate properly with a shared cache store with various operations.
+ *
+ * @author William Burns
+ * @since 6.0
+ */
+public class WriteCacheStoreInvalidationTest extends MultipleCacheManagersTest {
+   private static final String key = "key";
+   private static final String value = "value";
+   private static final String changedValue = "changed-value";
+
+   private static final String cacheName = "inval-write-cache-store";
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder cb = getDefaultClusteredCacheConfig(CacheMode.INVALIDATION_SYNC, false);
+      cb.loaders().shared(true).addStore(DummyInMemoryCacheStoreConfigurationBuilder.class)
+            .storeName(getClass().getSimpleName());
+      createClusteredCaches(2, cacheName, cb);
+   }
+
+   @Test
+   public void testSharedCacheStoreAfterInvalidation() {
+      assertNull(cache(0, cacheName).get(key));
+
+      cache(0, cacheName).put(key, value);
+
+      assertEquals(value, cache(1, cacheName).get(key));
+
+      cache(1, cacheName).put(key, changedValue);
+
+      assertFalse(cache(0, cacheName).getAdvancedCache().getDataContainer().containsKey(key));
+
+      assertEquals(changedValue, cache(0, cacheName).get(key));
+   }
+}

--- a/core/src/test/java/org/infinispan/jmx/CacheLoaderAndCacheStoreInterceptorMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheLoaderAndCacheStoreInterceptorMBeanTest.java
@@ -3,6 +3,7 @@ package org.infinispan.jmx;
 import org.infinispan.config.CacheLoaderManagerConfig;
 import org.infinispan.config.Configuration;
 import org.infinispan.config.GlobalConfiguration;
+import org.infinispan.context.Flag;
 import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.loaders.CacheLoaderManager;
 import org.infinispan.loaders.CacheStore;
@@ -133,6 +134,14 @@ public class CacheLoaderAndCacheStoreInterceptorMBeanTest extends SingleCacheMan
 
       assert cache.replace("no_such_key", "c") == null;
       assertStoreAccess(1, 1, 3);
+   }
+
+   public void testFlagMissNotCounted() throws Exception {
+      assertStoreAccess(0, 0, 0);
+      cache.put("key", "value");
+      assertStoreAccess(0, 0, 1);
+      cache.getAdvancedCache().withFlags(Flag.SKIP_CACHE_LOAD).get("no_such_key");
+      assertStoreAccess(0, 0, 1);
    }
 
    private void assertStoreAccess(int loadsCount, int missesCount, int storeCount) throws Exception {


### PR DESCRIPTION
...e main data owner (vs directly from the store)
- Changed ClusteredCacheLoader to only read from primary owner
- Added tests to verify non owner doesn't read from cache store
- Also fixed up cache statistics so skips aren't counted as misses

https://issues.jboss.org/browse/ISPN-2950
