### PR TITLE
ISPN-2161 InitiatorCrashPessimisticReplTest.testInitiatorNodeCrashesBefo...

### DIFF
--- a/core/src/test/java/org/infinispan/lock/singlelock/AbstractCrashTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/AbstractCrashTest.java
@@ -60,7 +60,7 @@ public abstract class AbstractCrashTest extends MultipleCacheManagersTest {
       return c;
    }
 
-   protected Object beginAndPrepareTx(final Object k, final int cacheIndex) {
+   protected void beginAndPrepareTx(final Object k, final int cacheIndex) {
       fork(new Runnable() {
          @Override
          public void run() {
@@ -68,16 +68,16 @@ public abstract class AbstractCrashTest extends MultipleCacheManagersTest {
                tm(cacheIndex).begin();
                cache(cacheIndex).put(k,"v");
                final DummyTransaction transaction = (DummyTransaction) tm(cacheIndex).getTransaction();
+               transaction.notifyBeforeCompletion();
                transaction.runPrepare();
             } catch (Throwable e) {
-               e.printStackTrace();
+               log.errorf(e, "Error preparing transaction for key %s on cache %s", k, cache(cacheIndex));
             }
          }
       }, false);
-      return k;
    }
 
-   protected Object beginAndCommitTx(final Object k, final int cacheIndex) {
+   protected void beginAndCommitTx(final Object k, final int cacheIndex) {
       fork(new Runnable() {
          @Override
          public void run() {
@@ -90,7 +90,6 @@ public abstract class AbstractCrashTest extends MultipleCacheManagersTest {
             }
          }
       }, false);
-      return k;
    }
 
    public static class TxControlInterceptor extends CommandInterceptor {

--- a/core/src/test/java/org/infinispan/lock/singlelock/AbstractInitiatorCrashTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/AbstractInitiatorCrashTest.java
@@ -6,6 +6,9 @@ import org.infinispan.transaction.tm.DummyTransaction;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author Mircea Markus
@@ -27,9 +30,9 @@ public abstract class AbstractInitiatorCrashTest extends AbstractCrashTest {
       beginAndCommitTx(k, 1);
       releaseLocksLatch.await();
 
-      assert checkTxCount(0, 0, 1);
-      assert checkTxCount(1, 0, 0);
-      assert checkTxCount(2, 0, 1);
+      assertTrue("Wrong tx count for " + cache(0), checkTxCount(0, 0, 1));
+      assertTrue("Wrong tx count for " + cache(1), checkTxCount(1, 0, 0));
+      assertTrue("Wrong tx count for " + cache(2), checkTxCount(2, 0, 1));
 
       assertNotLocked(cache(0), k);
       assertNotLocked(cache(1), k);
@@ -60,9 +63,9 @@ public abstract class AbstractInitiatorCrashTest extends AbstractCrashTest {
       assertNotLocked(cache(1), k);
       assertLocked(cache(2), k);
 
-      checkTxCount(0, 0, 1);
-      checkTxCount(1, 1, 0);
-      checkTxCount(2, 0, 1);
+      assertTrue("Wrong tx count for " + cache(0), checkTxCount(0, 0, 1));
+      assertTrue("Wrong tx count for " + cache(1), checkTxCount(1, 1, 0));
+      assertTrue("Wrong tx count for " + cache(2), checkTxCount(2, 0, 1));
 
       killMember(1);
 

--- a/core/src/test/java/org/infinispan/lock/singlelock/AbstractLockOwnerCrashTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/AbstractLockOwnerCrashTest.java
@@ -9,6 +9,8 @@ import org.testng.annotations.Test;
 import javax.transaction.Status;
 import javax.transaction.Transaction;
 
+import static org.testng.AssertJUnit.assertEquals;
+
 /**
  * @author Mircea Markus
  * @since 5.1
@@ -58,7 +60,7 @@ public abstract class AbstractLockOwnerCrashTest extends AbstractCrashTest {
       });
 
       killMember(2);
-      assert caches().size() == 2;
+      assertEquals("Wrong number of caches", 2, caches().size());
 
 
       tm(secondTxNode).begin();

--- a/core/src/test/java/org/infinispan/lock/singlelock/optimistic/InitiatorCrashOptimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/optimistic/InitiatorCrashOptimisticTest.java
@@ -6,6 +6,9 @@ import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.LockingMode;
 import org.testng.annotations.Test;
 
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
 /**
  * @author Mircea Markus
  * @since 5.1
@@ -28,13 +31,13 @@ public class InitiatorCrashOptimisticTest extends AbstractInitiatorCrashTest {
       beginAndPrepareTx(k, 1);
 
       txControlInterceptor.preparedReceived.await();
-      assert checkTxCount(0, 0, 1);
-      assert checkTxCount(1, 1, 0);
-      assert checkTxCount(2, 0, 1);
+      assertTrue("Wrong tx count for " + cache(0), checkTxCount(0, 0, 1));
+      assertTrue("Wrong tx count for " + cache(1), checkTxCount(1, 1, 0));
+      assertTrue("Wrong tx count for " + cache(2), checkTxCount(2, 0, 1));
 
       killMember(1);
 
-      assert caches().size() == 2;
+      assertEquals("Wrong number of caches", 2, caches().size());
       txControlInterceptor.prepareProgress.countDown();
 
       assertNotLocked(k);

--- a/core/src/test/java/org/infinispan/lock/singlelock/optimistic/LockOwnerCrashOptimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/optimistic/LockOwnerCrashOptimisticTest.java
@@ -7,8 +7,8 @@ import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.tm.DummyTransaction;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author Mircea Markus
@@ -47,13 +47,13 @@ public class LockOwnerCrashOptimisticTest extends AbstractLockOwnerCrashTest {
       });
 
       killMember(2);
-      assert caches().size() == 2;
+      assertEquals("Wrong number of caches", 2, caches().size());
 
       tm(1).resume(transaction);
       tm(1).commit();
 
-      assertEquals(cache(0).get(k), "v");
-      assertEquals(cache(1).get(k), "v");
+      assertEquals("Wrong value for key 'k' in " + cache(0), "v", cache(0).get(k));
+      assertEquals("Wrong value for key 'k' in " + cache(1), "v", cache(1).get(k));
 
       assertNotLocked(k);
       eventually(new Condition() {
@@ -89,7 +89,7 @@ public class LockOwnerCrashOptimisticTest extends AbstractLockOwnerCrashTest {
       });
 
       killMember(2);
-      assert caches().size() == 2;
+      assertEquals("Wrong number of caches", 2, caches().size());
 
 
       tm(1).begin();

--- a/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/InitiatorCrashPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/InitiatorCrashPessimisticTest.java
@@ -7,6 +7,9 @@ import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.LockingMode;
 import org.testng.annotations.Test;
 
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
 /**
  * @author Mircea Markus
  * @since 5.1
@@ -19,7 +22,7 @@ public class InitiatorCrashPessimisticTest extends AbstractInitiatorCrashTest {
       super(CacheMode.DIST_SYNC, LockingMode.PESSIMISTIC, false);
    }
 
- public void testInitiatorNodeCrashesBeforePrepare2() throws Exception {
+   public void testInitiatorNodeCrashesBeforePrepare2() throws Exception {
 
       Object k0 = getKeyForCache(0);
       Object k1 = getKeyForCache(1);
@@ -42,13 +45,13 @@ public class InitiatorCrashPessimisticTest extends AbstractInitiatorCrashTest {
       assertNotLocked(cache(1), k2);
       assertLocked(cache(2), k2);
 
-      assert checkTxCount(0, 0, 1);
-      assert checkTxCount(1, 1, 0);
-      assert checkTxCount(2, 0, 1);
+      assertTrue("Wrong tx count for " + cache(0), checkTxCount(0, 0, 1));
+      assertTrue("Wrong tx count for " + cache(1), checkTxCount(1, 1, 0));
+      assertTrue("Wrong tx count for " + cache(2), checkTxCount(2, 0, 1));
 
       killMember(1);
 
-      assert caches().size() == 2;
+      assertEquals("Wrong number of caches", 2, caches().size());
 
       assertNotLocked(k0);
       assertNotLocked(k1);

--- a/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/LockOwnerCrashPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/LockOwnerCrashPessimisticTest.java
@@ -15,7 +15,8 @@ import javax.transaction.NotSupportedException;
 import javax.transaction.RollbackException;
 import javax.transaction.SystemException;
 
-import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.fail;
 
 /**
  * @author Mircea Markus
@@ -59,13 +60,13 @@ public class LockOwnerCrashPessimisticTest extends AbstractLockOwnerCrashTest {
       });
 
       killMember(2);
-      assert caches().size() == 2;
+      assertEquals("Wrong number of caches", 2, caches().size());
 
       tm(1).resume(transaction);
       tm(1).commit();
 
-      assertEquals(cache(0).get(k), "v");
-      assertEquals(cache(1).get(k), "v");
+      assertEquals("Wrong value for key 'k' in " + cache(0), "v", cache(0).get(k));
+      assertEquals("Wrong value for key 'k' in " + cache(1), "v", cache(1).get(k));
 
       assertNotLocked(k);
       eventually(new AbstractInfinispanTest.Condition() {
@@ -99,12 +100,12 @@ public class LockOwnerCrashPessimisticTest extends AbstractLockOwnerCrashTest {
       });
 
       killMember(2);
-      assert caches().size() == 2;
+      assertEquals("Wrong number of caches", 2, caches().size());
 
       tm(0).begin();
       try {
          cache(0).put(k, "v1");
-         assert false;
+         fail("Exception expected as lock cannot be acquired on k=" + k);
       } catch (Exception e) {
          tm(0).rollback();
       }
@@ -112,8 +113,8 @@ public class LockOwnerCrashPessimisticTest extends AbstractLockOwnerCrashTest {
       tm(1).resume(transaction);
       tm(1).commit();
 
-      assertEquals(cache(0).get(k), "v");
-      assertEquals(cache(1).get(k), "v");
+      assertEquals("Wrong value for key 'k' in " + cache(0), "v", cache(0).get(k));
+      assertEquals("Wrong value for key 'k' in " + cache(1), "v", cache(1).get(k));
 
       assertNotLocked(k);
       eventually(new AbstractInfinispanTest.Condition() {
@@ -167,13 +168,13 @@ public class LockOwnerCrashPessimisticTest extends AbstractLockOwnerCrashTest {
 
 
       killMember(2);
-      assert caches().size() == 2;
+      assertEquals("Wrong number of caches", 2, caches().size());
 
 
       tm(1).begin();
       try {
          cache(1).put(k, "v2");
-         assert false : "Exception expected as lock cannot be acquired on k=" + k;
+         fail("Exception expected as lock cannot be acquired on k=" + k);
       } catch (Exception e) {
          tm(1).rollback();
       }
@@ -181,7 +182,7 @@ public class LockOwnerCrashPessimisticTest extends AbstractLockOwnerCrashTest {
       tm(0).begin();
       try {
          cache(0).put(k, "v3");
-         assert false : "Exception expected as lock cannot be acquired on k=" + k;
+         fail("Exception expected as lock cannot be acquired on k=" + k);
       } catch (Exception e) {
          tm(0).rollback();
       }
@@ -193,8 +194,8 @@ public class LockOwnerCrashPessimisticTest extends AbstractLockOwnerCrashTest {
       } else {
          tm(1).commit();
       }
-      assert cache(0).get(k).equals("v");
-      assert cache(1).get(k).equals("v");
+      assertEquals("Wrong value for key 'k' in " + cache(0), "v", cache(0).get(k));
+      assertEquals("Wrong value for key 'k' in " + cache(1), "v", cache(1).get(k));
       assertNotLocked(k);
    }
 }

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/optimistic/InitiatorCrashOptimisticReplTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/optimistic/InitiatorCrashOptimisticReplTest.java
@@ -8,11 +8,14 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.CountDownLatch;
 
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
 /**
  * @author Mircea Markus
  * @since 5.1
  */
-@Test(groups = "functional", testName = "lock.singlelock.replicated.optimistic.InitiatorCrashOptimisticReplTest", enabled = false, description = "See ISPN-2161")
+@Test(groups = "functional", testName = "lock.singlelock.replicated.optimistic.InitiatorCrashOptimisticReplTest")
 @CleanupAfterMethod
 public class InitiatorCrashOptimisticReplTest extends AbstractCrashTest {
 
@@ -37,9 +40,9 @@ public class InitiatorCrashOptimisticReplTest extends AbstractCrashTest {
       assertNotLocked(cache(1), "k");
       assertNotLocked(cache(2), "k");
 
-      checkTxCount(0, 0, 1);
-      checkTxCount(1, 1, 0);
-      checkTxCount(2, 0, 1);
+      assertTrue("Wrong tx count for " + cache(0), checkTxCount(0, 0, 1));
+      assertTrue("Wrong tx count for " + cache(1), checkTxCount(1, 1, 0));
+      assertTrue("Wrong tx count for " + cache(2), checkTxCount(2, 0, 1));
 
       killMember(1);
 
@@ -60,9 +63,9 @@ public class InitiatorCrashOptimisticReplTest extends AbstractCrashTest {
       beginAndCommitTx("k", 1);
       releaseLocksLatch.await();
 
-      assert checkTxCount(0, 0, 1);
-      assert checkTxCount(1, 0, 0);
-      assert checkTxCount(2, 0, 1);
+      assertTrue("Wrong tx count for " + cache(0), checkTxCount(0, 0, 1));
+      assertTrue("Wrong tx count for " + cache(1), checkTxCount(1, 0, 0));
+      assertTrue("Wrong tx count for " + cache(2), checkTxCount(2, 0, 1));
 
       assertLocked(cache(0), "k");
       assertNotLocked(cache(1), "k");
@@ -77,8 +80,8 @@ public class InitiatorCrashOptimisticReplTest extends AbstractCrashTest {
          }
       });
       assertNotLocked("k");
-      assert cache(0).get("k").equals("v");
-      assert cache(1).get("k").equals("v");
+      assertEquals("Wrong value for key 'k' in " + cache(0), "v", cache(0).get("k"));
+      assertEquals("Wrong value for key 'k' in " + cache(1), "v", cache(1).get("k"));
    }
 
    public void testInitiatorNodeCrashesBeforePrepare() throws Exception {
@@ -90,13 +93,13 @@ public class InitiatorCrashOptimisticReplTest extends AbstractCrashTest {
       beginAndPrepareTx("k", 1);
 
       txControlInterceptor.preparedReceived.await();
-      assert checkTxCount(0, 0, 1);
-      assert checkTxCount(1, 1, 0);
-      assert checkTxCount(2, 0, 1);
+      assertTrue("Wrong tx count for " + cache(0), checkTxCount(0, 0, 1));
+      assertTrue("Wrong tx count for " + cache(1), checkTxCount(1, 1, 0));
+      assertTrue("Wrong tx count for " + cache(2), checkTxCount(2, 0, 1));
 
       killMember(1);
 
-      assert caches().size() == 2;
+      assertEquals("Wrong number of caches", 2, caches().size());
       txControlInterceptor.prepareProgress.countDown();
 
       assertNotLocked("k");


### PR DESCRIPTION
...reCommit fails randomly
- Cleanup by replacing all the assert keywords by AssertJUnit.assertEquals()
- Problematic test implementation is no-op. See code commentary.

https://issues.jboss.org/browse/ISPN-2161
