### PR TITLE
ISPN-3282: Optimize get() operations for null values

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/ReplicationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/ReplicationInterceptor.java
@@ -211,7 +211,13 @@ public class ReplicationInterceptor extends ClusteringInterceptor {
       if (!responses.isEmpty()) {
          for (Response r : responses.values()) {
             if (r instanceof SuccessfulResponse) {
-               InternalCacheValue cacheValue = (InternalCacheValue) ((SuccessfulResponse) r).getResponseValue();
+               
+               // The response value might be null.
+               SuccessfulResponse response = (SuccessfulResponse)r;
+               if( response.getResponseValue() == null )
+                  return null;
+               
+               InternalCacheValue cacheValue = (InternalCacheValue) response.getResponseValue();
                return cacheValue.toInternalCacheEntry(key);
             }
          }

--- a/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
@@ -92,7 +92,13 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
       if (!responses.isEmpty()) {
          for (Response r : responses.values()) {
             if (r instanceof SuccessfulResponse) {
-               InternalCacheValue cacheValue = (InternalCacheValue) ((SuccessfulResponse) r).getResponseValue();
+               
+               // The response value might be null.
+               SuccessfulResponse response = (SuccessfulResponse)r;
+               if( response.getResponseValue() == null )
+                  return null;
+               
+               InternalCacheValue cacheValue = (InternalCacheValue) response.getResponseValue();
                return cacheValue.toInternalCacheEntry(key);
             }
          }

--- a/core/src/main/java/org/infinispan/remoting/responses/DistributionResponseGenerator.java
+++ b/core/src/main/java/org/infinispan/remoting/responses/DistributionResponseGenerator.java
@@ -30,6 +30,7 @@ import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.commands.remote.ClusteredGetCommand;
 import org.infinispan.commands.remote.SingleRpcCommand;
 import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.util.logging.Log;
@@ -51,8 +52,7 @@ public class DistributionResponseGenerator implements ResponseGenerator {
 
    @Override
    public Response getResponse(CacheRpcCommand command, Object returnValue) {
-      if (command.getCommandId() == ClusteredGetCommand.COMMAND_ID) {
-         if (returnValue == null) return null;
+      if (command.getCommandId() == ClusteredGetCommand.COMMAND_ID) {         
          ClusteredGetCommand clusteredGet = (ClusteredGetCommand) command;
          if (distributionManager.isAffectedByRehash(clusteredGet.getKey()))
             return UnsureResponse.INSTANCE;


### PR DESCRIPTION
This is for the 5.2.x branch, which we're using in production.  This actually is a large problem in our environment, since we have to wait for both owners to return on a null value.  And more often than not, the values returned are null (i.e. not present in the cache).  
