### PR TITLE
ISPN-2771 WriteSkewTest.testWriteSkewWithOnlyPut fails randomly

### DIFF
--- a/core/src/main/java/org/infinispan/container/EntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/EntryFactoryImpl.java
@@ -37,7 +37,6 @@ public class EntryFactoryImpl implements EntryFactory {
    
    protected boolean useRepeatableRead;
    private DataContainer container;
-   protected boolean localModeWriteSkewCheck;
    protected boolean clusterModeWriteSkewCheck;
    private Configuration configuration;
    private CacheNotifier notifier;
@@ -52,7 +51,6 @@ public class EntryFactoryImpl implements EntryFactory {
    @Start (priority = 8)
    public void init() {
       useRepeatableRead = configuration.locking().isolationLevel() == IsolationLevel.REPEATABLE_READ;
-      localModeWriteSkewCheck = configuration.locking().writeSkewCheck();
       clusterModeWriteSkewCheck = useRepeatableRead && configuration.locking().writeSkewCheck() &&
             configuration.clustering().cacheMode().isClustered() && configuration.versioning().scheme() == VersioningScheme.SIMPLE &&
             configuration.versioning().enabled();
@@ -140,7 +138,7 @@ public class EntryFactoryImpl implements EntryFactory {
          // make sure we record this! Null value since this is a forced lock on the key
          ctx.putLookedUpEntry(key, null);
       } else {
-         mvccEntry.copyForUpdate(container, localModeWriteSkewCheck);
+         mvccEntry.copyForUpdate(container);
       }
       if (trace) {
          log.tracef("Wrap %s for remove. Entry=%s", key, mvccEntry);
@@ -197,7 +195,7 @@ public class EntryFactoryImpl implements EntryFactory {
              wrapInternalCacheEntryForPut(ctx, key, ice, providedMetadata, skipRead) :
              newMvccEntryForPut(ctx, key, cmd, providedMetadata, skipRead);
       }
-      mvccEntry.copyForUpdate(container, localModeWriteSkewCheck);
+      mvccEntry.copyForUpdate(container);
       if (trace) {
          log.tracef("Wrap %s for put. Entry=%s", key, mvccEntry);
       }
@@ -307,7 +305,7 @@ public class EntryFactoryImpl implements EntryFactory {
          }
       }
       if (mvccEntry != null)
-         mvccEntry.copyForUpdate(container, localModeWriteSkewCheck);
+         mvccEntry.copyForUpdate(container);
       return mvccEntry;
    }
 

--- a/core/src/main/java/org/infinispan/container/IncrementalVersionableEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/IncrementalVersionableEntryFactoryImpl.java
@@ -25,7 +25,6 @@ public class IncrementalVersionableEntryFactoryImpl extends EntryFactoryImpl {
 
    @Start (priority = 9)
    public void setWriteSkewCheckFlag() {
-      localModeWriteSkewCheck = false;
       useRepeatableRead = true;
    }
 

--- a/core/src/main/java/org/infinispan/container/entries/MVCCEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/MVCCEntry.java
@@ -14,10 +14,8 @@ public interface MVCCEntry extends CacheEntry, StateChangingEntry {
     * Makes internal copies of the entry for updates
     *
     * @param container      data container
-    * @param writeSkewCheck if true, write skews are tested for and exceptions are thrown if detected.  Only applicable
-    *                       to {@link org.infinispan.util.concurrent.IsolationLevel#REPEATABLE_READ}.
     */
-   void copyForUpdate(DataContainer container, boolean writeSkewCheck);
+   void copyForUpdate(DataContainer container);
 
    void setChanged(boolean isChanged);
 }

--- a/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
@@ -124,7 +124,7 @@ public class ReadCommittedEntry implements MVCCEntry {
    }
 
    @Override
-   public void copyForUpdate(DataContainer container, boolean writeSkewCheck) {
+   public void copyForUpdate(DataContainer container) {
       if (isFlagSet(COPIED)) return; // already copied
 
       setFlag(COPIED); //mark as copied

--- a/core/src/main/java/org/infinispan/container/entries/RepeatableReadEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/RepeatableReadEntry.java
@@ -23,14 +23,11 @@ public class RepeatableReadEntry extends ReadCommittedEntry {
    }
 
    @Override
-   public void copyForUpdate(DataContainer container, boolean localModeWriteSkewCheck) {
+   public void copyForUpdate(DataContainer container) {
       if (isFlagSet(COPIED)) return; // already copied
 
       setFlag(COPIED); //mark as copied
 
-      if (localModeWriteSkewCheck) {
-         performLocalWriteSkewCheck(container, false);
-      }
       // make a backup copy
       oldValue = value;
    }

--- a/core/src/test/java/org/infinispan/api/mvcc/repeatable_read/WriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/api/mvcc/repeatable_read/WriteSkewTest.java
@@ -4,7 +4,6 @@ import org.infinispan.Cache;
 import org.infinispan.api.mvcc.LockAssert;
 import org.infinispan.atomic.AtomicMapLookup;
 import org.infinispan.atomic.FineGrainedAtomicMap;
-import org.infinispan.commons.CacheException;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.VersioningScheme;
 import org.infinispan.context.Flag;
@@ -487,7 +486,7 @@ public class WriteSkewTest extends AbstractInfinispanTest {
          combined.addAll(w2exceptions);
          assertFalse("Exceptions are expected!", combined.isEmpty());
          assertEquals("Expects one exception.", 1, combined.size());
-         assertTrue("Wrong exception type.", combined.iterator().next() instanceof CacheException);
+         assertTrue("Wrong exception type.", combined.iterator().next() instanceof RollbackException);
       }
    }
 

--- a/extended-statistics/src/test/java/org/infinispan/stats/topK/LocalTopKeyTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/stats/topK/LocalTopKeyTest.java
@@ -15,8 +15,7 @@ import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import javax.transaction.NotSupportedException;
-import javax.transaction.SystemException;
+import javax.transaction.RollbackException;
 import javax.transaction.Transaction;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -98,7 +97,7 @@ public class LocalTopKeyTest extends SingleCacheManagerTest {
       assertWriteSkew(cache(), "key", 0);
    }
 
-   public void testWriteSkew() throws InterruptedException, SystemException, NotSupportedException {
+   public void testWriteSkew() throws Exception {
       resetStreamSummary(cache());
 
       cache().put("key", "init");
@@ -114,8 +113,7 @@ public class LocalTopKeyTest extends SingleCacheManagerTest {
          cache().put("key", "value1");
          tm().commit();
          Assert.fail("The write skew should be detected");
-      } catch (Exception t) {
-         tm().rollback();
+      } catch (RollbackException t) {
          //expected
       }
 
@@ -123,7 +121,7 @@ public class LocalTopKeyTest extends SingleCacheManagerTest {
       assertTopKeyAccesses(cache(), "key", 1, true);
 
       //the last put will originate an write skew
-      assertLockInformation(cache(), "key", 2, 0, 0);
+      assertLockInformation(cache(), "key", 3, 0, 0);
 
       assertWriteSkew(cache(), "key", 1);
    }


### PR DESCRIPTION
- Removed write skew check from put operation. Now, the write skew check
  it is only performed during prepare time for local or clustered mode.
- Adapt the local mode tests to support this modification

Also, I've replaced all the assert keywords to assertEquals.

https://issues.jboss.org/browse/ISPN-2771
