### PR TITLE
ISPN-3324 JDBC cache store test suite can hang because of c3p0 bug

### DIFF
--- a/cachestore/jdbc/pom.xml
+++ b/cachestore/jdbc/pom.xml
@@ -49,6 +49,17 @@
                </instructions>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <!-- Run the test with a single thread, otherwise the suite might hang due to a
+            concurrency issue in c3p0: https://sourceforge.net/p/c3p0/bugs/119/. Once this is fixed
+             this can be switched back to parallel execution -->
+            <configuration>
+               <threadCount>1</threadCount>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
+
 </project>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3324
- the suite runs single threaded now. It can be switched back to multi-threaded once https://sourceforge.net/p/c3p0/bugs/119/ is fixed
- the added test execution duration is about 1 min up from 1min 30 secs
