### PR TITLE
ISPN-3352 - Issues with the M/Rs intermediate cache shut down

### DIFF
--- a/core/src/main/java/org/infinispan/distexec/mapreduce/MapReduceTask.java
+++ b/core/src/main/java/org/infinispan/distexec/mapreduce/MapReduceTask.java
@@ -8,6 +8,7 @@ import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.CreateCacheCommand;
 import org.infinispan.commands.read.MapCombineCommand;
 import org.infinispan.commands.read.ReduceCommand;
+import org.infinispan.context.Flag;
 import org.infinispan.distexec.mapreduce.spi.MapReduceTaskLifecycleService;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
@@ -349,7 +350,6 @@ public class MapReduceTask<KIn, VIn, KOut, VOut> {
             // cleanup tmp caches across cluster
             if(useIntermediatePerTaskCache()){
                EmbeddedCacheManager cm = cache.getCacheManager();
-               cm.getCache(intermediateCacheName).clear();
                cm.removeCache(intermediateCacheName);
             }
          }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3352

Should also fix some intermittent failures in XyzFourNodesMapReduceTest classes.
