### PR TITLE
ISPN-3365 Fix failing DatabaseStoredIndexTest by using a keepalive database connection instead of relying on timeouts

### DIFF
--- a/lucene/lucene-v3/src/test/java/org/infinispan/lucene/profiling/CacheStoreStressTest.java
+++ b/lucene/lucene-v3/src/test/java/org/infinispan/lucene/profiling/CacheStoreStressTest.java
@@ -16,15 +16,15 @@ import org.testng.annotations.Test;
 /**
  * Testcase verifying that the index is usable under stress even when a cachestore is configured.
  * See ISPN-575 (Corruption in data when using a permanent store)
- * 
+ *
  * @author Sanne Grinovero
  * @since 4.1
  */
-@Test(groups = "profiling", testName = "lucene.profiling.CacheStoreStressTest", sequential = true)
+@Test(groups = "profiling", testName = "lucene.profiling.CacheStoreStressTest", singleThreaded = true)
 public class CacheStoreStressTest extends SingleCacheManagerTest {
-   
+
    private static final String indexName = "tempIndexName";
-   
+
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder cb = TestCacheManagerFactory.getDefaultCacheConfiguration(false);
@@ -41,11 +41,11 @@ public class CacheStoreStressTest extends SingleCacheManagerTest {
             .timestampColumnType("BIGINT")
             .connectionPool()
             .driverClass(org.h2.Driver.class)
-            .connectionUrl("jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=1")
+            .connectionUrl("jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=0")
             .username("sa");
       return TestCacheManagerFactory.createClusteredCacheManager(cb);
    }
-   
+
    @Test
    public void stressTestOnStore() throws InterruptedException, IOException {
       cache = cacheManager.getCache();
@@ -54,5 +54,5 @@ public class CacheStoreStressTest extends SingleCacheManagerTest {
       PerformanceCompareStressTest.stressTestDirectory(dir, "InfinispanClusteredWith-Store");
       DirectoryIntegrityCheck.verifyDirectoryStructure(cache, indexName, true);
    }
-   
+
 }

--- a/lucene/lucene-v4/src/test/java/org/infinispan/lucene/profiling/CacheStoreStressTest.java
+++ b/lucene/lucene-v4/src/test/java/org/infinispan/lucene/profiling/CacheStoreStressTest.java
@@ -18,17 +18,17 @@ import org.testng.annotations.Test;
 /**
  * Testcase verifying that the index is usable under stress even when a cachestore is configured.
  * See ISPN-575 (Corruption in data when using a permanent store)
- * 
+ *
  * @author Sanne Grinovero
  * @since 4.1
  */
-@Test(groups = "profiling", testName = "lucene.profiling.CacheStoreStressTest", sequential = true)
+@Test(groups = "profiling", testName = "lucene.profiling.CacheStoreStressTest", singleThreaded = true)
 public class CacheStoreStressTest extends SingleCacheManagerTest {
-   
+
    private final ConnectionFactoryConfig connectionFactoryConfig = UnitTestDatabaseManager.getUniqueConnectionFactoryConfig();
 
    private static final String indexName = "tempIndexName";
-   
+
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder cb = TestCacheManagerFactory.getDefaultCacheConfiguration(false);
@@ -45,11 +45,11 @@ public class CacheStoreStressTest extends SingleCacheManagerTest {
             .timestampColumnType("BIGINT")
             .connectionPool()
             .driverClass(org.h2.Driver.class)
-            .connectionUrl("jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=1")
+            .connectionUrl("jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=0")
             .username("sa");
       return TestCacheManagerFactory.createClusteredCacheManager(cb);
    }
-   
+
    @Test
    public void stressTestOnStore() throws InterruptedException, IOException {
       cache = cacheManager.getCache();
@@ -58,5 +58,5 @@ public class CacheStoreStressTest extends SingleCacheManagerTest {
       PerformanceCompareStressTest.stressTestDirectory(dir, "InfinispanClusteredWith-Store");
       DirectoryIntegrityCheck.verifyDirectoryStructure(cache, indexName, true);
    }
-   
+
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3365
