### PR TITLE
ISPN-3323 Make the RemoteCache.getVersion() method return the actual implementation version

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCache.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCache.java
@@ -270,4 +270,10 @@ public interface RemoteCache<K, V> extends BasicCache<K, V> {
     * guarantee that "size" elements are returned( e.g. if the number of elements in the back-end server is smaller that "size")
     */
    Map<K, V> getBulk(int size);
+
+
+   /**
+    * Returns the HotRod protocol version supported by this RemoteCache implementation
+    */
+   String getProtocolVersion();
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/Version.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/Version.java
@@ -8,7 +8,7 @@ package org.infinispan.client.hotrod;
  */
 public class Version {
 
-   private static final String PROTOCOL_VERSION = "1.0"; 
+   private static final String PROTOCOL_VERSION = "1.2";
 
    public static String getProtocolVersion() {
       return "HotRod client, protocol version :" + PROTOCOL_VERSION;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -395,6 +395,11 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
 
    @Override
    public String getVersion() {
+      return RemoteCacheImpl.class.getPackage().getImplementationVersion();
+   }
+
+   @Override
+   public String getProtocolVersion() {
       return Version.getProtocolVersion();
    }
 


### PR DESCRIPTION
ISPN-3323 Make the RemoteCache.getVersion() method return the actual implementation version
Add a getProtocolVersion() method to return the HotRod protocol version
Fix the HotRod protocol (we're now on 1.2)

https://issues.jboss.org/browse/ISPN-3323
