### PR TITLE
Update to JBoss Marshalling 2.0.0.Beta1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -56,7 +56,7 @@
       <!-- Versions for dependencies -->
       <version.aesh>0.33.1</version.aesh>
       <version.antlr>3.4</version.antlr>
-      <version.jboss.marshalling>1.3.15.GA</version.jboss.marshalling>
+      <version.jboss.marshalling>2.0.0.Beta1</version.jboss.marshalling>
       <version.jboss.logging>3.1.1.GA</version.jboss.logging>
       <version.jgroups>3.3.1.Final</version.jgroups>
       <version.json>20090211</version.json>

--- a/commons/src/main/java/org/infinispan/commons/marshall/jboss/AbstractJBossMarshaller.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/jboss/AbstractJBossMarshaller.java
@@ -11,7 +11,6 @@ import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;
 import org.jboss.marshalling.TraceInformation;
 import org.jboss.marshalling.Unmarshaller;
-import org.jboss.marshalling.reflect.SunReflectiveCreator;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -64,7 +63,6 @@ public abstract class AbstractJBossMarshaller extends AbstractMarshaller impleme
    public AbstractJBossMarshaller() {
       // Class resolver now set when marshaller/unmarshaller will be created
       baseCfg = new MarshallingConfiguration();
-      baseCfg.setExternalizerCreator(new SunReflectiveCreator());
       baseCfg.setExceptionListener(new DebuggingExceptionListener());
       baseCfg.setClassExternalizerFactory(new SerializeWithExtFactory());
       baseCfg.setInstanceCount(DEF_INSTANCE_COUNT);

--- a/commons/src/main/java/org/infinispan/commons/marshall/jboss/JBossExternalizerAdapter.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/jboss/JBossExternalizerAdapter.java
@@ -1,7 +1,6 @@
 package org.infinispan.commons.marshall.jboss;
 
 import org.infinispan.commons.marshall.Externalizer;
-import org.jboss.marshalling.Creator;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -21,13 +20,7 @@ public class JBossExternalizerAdapter implements org.jboss.marshalling.Externali
    }
 
    @Override
-   public Object createExternal(Class<?> subjectType, ObjectInput input, Creator defaultCreator) throws IOException, ClassNotFoundException {
+   public Object createExternal(Class<?> subjectType, ObjectInput input) throws IOException, ClassNotFoundException {
       return externalizer.readObject(input);
    }
-
-   @Override
-   public void readExternal(Object subject, ObjectInput input) throws IOException, ClassNotFoundException {
-      // No-op
-   }
-
 }

--- a/core/src/test/java/org/infinispan/commons/marshall/PojoWithJBossExternalize.java
+++ b/core/src/test/java/org/infinispan/commons/marshall/PojoWithJBossExternalize.java
@@ -1,6 +1,5 @@
 package org.infinispan.commons.marshall;
 
-import org.jboss.marshalling.Creator;
 import org.jboss.marshalling.Externalize;
 
 import java.io.IOException;
@@ -52,12 +51,8 @@ public class PojoWithJBossExternalize {
       }
 
       @Override
-      public Object createExternal(Class<?> subjectType, ObjectInput input, Creator defaultCreator) throws IOException, ClassNotFoundException {
+      public Object createExternal(Class<?> subjectType, ObjectInput input) throws IOException, ClassNotFoundException {
          return new PojoWithJBossExternalize(PojoWithAttributes.readObject(input));
-      }
-
-      @Override
-      public void readExternal(Object subject, ObjectInput input) throws IOException, ClassNotFoundException {
       }
    }
 }

--- a/core/src/test/java/org/infinispan/marshall/core/JBossMarshallingTest.java
+++ b/core/src/test/java/org/infinispan/marshall/core/JBossMarshallingTest.java
@@ -15,7 +15,6 @@ import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;
 import org.jboss.marshalling.Unmarshaller;
-import org.jboss.marshalling.reflect.SunReflectiveCreator;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -35,7 +34,6 @@ public class JBossMarshallingTest extends AbstractInfinispanTest {
    public void setUp() throws Exception {
       factory = (MarshallerFactory) Thread.currentThread().getContextClassLoader().loadClass("org.jboss.marshalling.river.RiverMarshallerFactory").newInstance();
       MarshallingConfiguration configuration = new MarshallingConfiguration();
-      configuration.setCreator(new SunReflectiveCreator());
       configuration.setClassResolver(new ContextClassResolver());
       
       marshaller = factory.createMarshaller(configuration);


### PR DESCRIPTION
This PR is to update to the new 2.x series of JBoss Marshalling. The plan is to update WildFly to 2.x as well, but unless we are going to support both 1.x and 2.x (something I really don't want), then these updates have to happen at the same time.  Since Infinispan is the only external(ish) project which uses JBMAR, we can essentially wait for (and coordinate with) you only, which seems doable.

The following things should be known about this update:
- There are some API incompatibilities (in particular, Creators are gone, and Externalizers changed a little bit)
- The binary protocol is 100% identical
- 2.x can interoperate with 1.x over the wire with no problems
- The changes to Infinispan seem pretty minimal

That said, there are also the following disclaimers:
- For some reason I can't make the Infinispan test suite work on my local system, so I don't really know if there are any regressions
- Even build doesn't complete all the way due to odd missing artifact errors

So I'm not 100% sure that there aren't problems that just stem from my lack of understanding of the code base, _but_ they should be minimal.

Thanks for listening.
