### PR TITLE
ISPN-3373 Allow configuration of the await initial transfer attribute for Hot Rod topology caches

### DIFF
--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
@@ -115,8 +115,12 @@ class HotRodServer extends AbstractProtocolServer("HotRod") with Log {
                 .valueEquivalence(AnyEquivalence.getInstance())
 
       if (configuration.topologyStateTransfer) {
-         builder.clustering().stateTransfer().fetchInMemoryState(true)
-                 .timeout(distSyncTimeout + configuration.topologyReplTimeout)
+         builder
+            .clustering()
+               .stateTransfer()
+                  .awaitInitialTransfer(configuration.topologyAwaitInitialTransfer)
+                  .fetchInMemoryState(true)
+                  .timeout(distSyncTimeout + configuration.topologyReplTimeout)
       } else {
          builder.loaders().addClusterCacheLoader().remoteCallTimeout(configuration.topologyReplTimeout)
       }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/configuration/HotRodServerConfiguration.java
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/configuration/HotRodServerConfiguration.java
@@ -12,9 +12,10 @@ public class HotRodServerConfiguration extends ProtocolServerConfiguration {
    private final String topologyCacheName;
    private final long topologyLockTimeout;
    private final long topologyReplTimeout;
+   private final boolean topologyAwaitInitialTransfer;
    private final boolean topologyStateTransfer;
 
-   HotRodServerConfiguration(String proxyHost, int proxyPort, long topologyLockTimeout, long topologyReplTimeout, boolean topologyStateTransfer,
+   HotRodServerConfiguration(String proxyHost, int proxyPort, long topologyLockTimeout, long topologyReplTimeout, boolean topologyAwaitInitialTransfer, boolean topologyStateTransfer,
          String name, String host, int port, int idleTimeout, int recvBufSize, int sendBufSize, SslConfiguration ssl, boolean tcpNoDelay, int workerThreads) {
       super(name, host, port, idleTimeout, recvBufSize, sendBufSize, ssl, tcpNoDelay, workerThreads);
       this.proxyHost = proxyHost;
@@ -23,6 +24,7 @@ public class HotRodServerConfiguration extends ProtocolServerConfiguration {
       this.topologyLockTimeout = topologyLockTimeout;
       this.topologyReplTimeout = topologyReplTimeout;
       this.topologyStateTransfer = topologyStateTransfer;
+      this.topologyAwaitInitialTransfer = topologyAwaitInitialTransfer;
    }
 
    public String proxyHost() {
@@ -45,13 +47,18 @@ public class HotRodServerConfiguration extends ProtocolServerConfiguration {
       return topologyReplTimeout;
    }
 
+   public boolean topologyAwaitInitialTransfer() {
+      return topologyAwaitInitialTransfer;
+   }
+
    public boolean topologyStateTransfer() {
       return topologyStateTransfer;
    }
 
    @Override
    public String toString() {
-      return "HotRodServerConfiguration [proxyHost=" + proxyHost + ", proxyPort=" + proxyPort + ", topologyLockTimeout="
-            + topologyLockTimeout + ", topologyReplTimeout=" + topologyReplTimeout + ", topologyStateTransfer=" + topologyStateTransfer + ", " + super.toString() + "]";
+      return "HotRodServerConfiguration [proxyHost=" + proxyHost + ", proxyPort=" + proxyPort + ", topologyCacheName=" + topologyCacheName + ", topologyLockTimeout="
+            + topologyLockTimeout + ", topologyReplTimeout=" + topologyReplTimeout + ", topologyAwaitInitialTransfer=" + topologyAwaitInitialTransfer + ", topologyStateTransfer="
+            + topologyStateTransfer + "]";
    }
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/configuration/HotRodServerConfigurationBuilder.java
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/configuration/HotRodServerConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.server.hotrod.configuration;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.configuration.cache.LockingConfigurationBuilder;
+import org.infinispan.configuration.cache.StateTransferConfigurationBuilder;
 import org.infinispan.configuration.cache.SyncConfigurationBuilder;
 import org.infinispan.loaders.cluster.ClusterCacheLoader;
 import org.infinispan.server.core.configuration.ProtocolServerConfigurationBuilder;
@@ -18,6 +19,7 @@ public class HotRodServerConfigurationBuilder extends ProtocolServerConfiguratio
    private int proxyPort = -1;
    private long topologyLockTimeout = 10000L;
    private long topologyReplTimeout = 10000L;
+   private boolean topologyAwaitInitialTransfer = true;
    private boolean topologyStateTransfer = true;
 
    public HotRodServerConfigurationBuilder() {
@@ -62,6 +64,14 @@ public class HotRodServerConfigurationBuilder extends ProtocolServerConfiguratio
    }
 
    /**
+    * Configures whether to enable waiting for initial state transfer for the topology cache. See {@link StateTransferConfigurationBuilder#awaitInitialTransfer(boolean)}
+    */
+   public HotRodServerConfigurationBuilder topologyAwaitInitialTransfer(boolean topologyAwaitInitialTransfer) {
+      this.topologyAwaitInitialTransfer = topologyAwaitInitialTransfer;
+      return this;
+   }
+
+   /**
     * Configures whether to enable state transfer for the topology cache. If disabled, a {@link ClusterCacheLoader} will be used to lazily retrieve topology information from the other nodes.
     * Defaults to true.
     */
@@ -72,7 +82,7 @@ public class HotRodServerConfigurationBuilder extends ProtocolServerConfiguratio
 
    @Override
    public HotRodServerConfiguration create() {
-      return new HotRodServerConfiguration(proxyHost, proxyPort, topologyLockTimeout, topologyReplTimeout, topologyStateTransfer, name, host, port, idleTimeout,
+      return new HotRodServerConfiguration(proxyHost, proxyPort, topologyLockTimeout, topologyReplTimeout, topologyAwaitInitialTransfer, topologyStateTransfer, name, host, port, idleTimeout,
             recvBufSize, sendBufSize, ssl.create(), tcpNoDelay, workerThreads);
    }
 
@@ -83,6 +93,7 @@ public class HotRodServerConfigurationBuilder extends ProtocolServerConfiguratio
       this.proxyPort = template.proxyPort();
       this.topologyLockTimeout = template.topologyLockTimeout();
       this.topologyReplTimeout = template.topologyReplTimeout();
+      this.topologyAwaitInitialTransfer = template.topologyAwaitInitialTransfer();
       this.topologyStateTransfer = template.topologyStateTransfer();
       return this;
    }


### PR DESCRIPTION
Before closing the issue, handle https://github.com/infinispan/infinispan-server/pull/126 on server after this

https://issues.jboss.org/browse/ISPN-3373
