### PR TITLE
ISPN-3366 Data loss when entry forwarding to primary owner and primary owner shutdown

### DIFF
--- a/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
+++ b/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
@@ -61,6 +61,7 @@ import org.infinispan.marshall.exts.MapExternalizer;
 import org.infinispan.marshall.exts.ReplicableCommandExternalizer;
 import org.infinispan.marshall.exts.SetExternalizer;
 import org.infinispan.marshall.exts.SingletonListExternalizer;
+import org.infinispan.remoting.responses.CacheNotFoundResponse;
 import org.infinispan.statetransfer.StateChunk;
 import org.infinispan.statetransfer.TransactionInfo;
 import org.infinispan.remoting.responses.ExceptionResponse;
@@ -229,6 +230,7 @@ public class ExternalizerTable implements ObjectTable {
       addInternalExternalizer(new ExceptionResponse.Externalizer());
       addInternalExternalizer(new UnsuccessfulResponse.Externalizer());
       addInternalExternalizer(new UnsureResponse.Externalizer());
+      addInternalExternalizer(new CacheNotFoundResponse.Externalizer());
 
       ReplicableCommandExternalizer cmExt =
             new ReplicableCommandExternalizer(cmdFactory, gcr);

--- a/core/src/main/java/org/infinispan/marshall/core/Ids.java
+++ b/core/src/main/java/org/infinispan/marshall/core/Ids.java
@@ -107,4 +107,5 @@ public interface Ids extends org.infinispan.commons.marshall.Ids {
 
    int NON_EXISTING_VERSION = 101;
 
+   int CACHE_NOT_FOUND_RESPONSE = 102;
 }

--- a/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
@@ -19,7 +19,7 @@ import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.interceptors.totalorder.RetryPrepareException;
-import org.infinispan.manager.NamedCacheNotFoundException;
+import org.infinispan.remoting.responses.CacheNotFoundResponse;
 import org.infinispan.statetransfer.StateTransferManager;
 import org.infinispan.remoting.responses.ExceptionResponse;
 import org.infinispan.remoting.responses.Response;
@@ -76,13 +76,10 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
       if (cr == null) {
          if (!globalConfiguration.transport().strictPeerToPeer()) {
             if (trace) log.tracef("Strict peer to peer off, so silently ignoring that %s cache is not defined", cacheName);
-            reply(response, null);
-            return;
+         } else {
+            log.namedCacheDoesNotExist(cacheName);
          }
-
-         log.namedCacheDoesNotExist(cacheName);
-         Response retVal = new ExceptionResponse(new NamedCacheNotFoundException(cacheName, "Cache has not been started on node " + transport.getAddress()));
-         reply(response, retVal);
+         reply(response, CacheNotFoundResponse.INSTANCE);
          return;
       }
 

--- a/core/src/main/java/org/infinispan/remoting/responses/CacheNotFoundResponse.java
+++ b/core/src/main/java/org/infinispan/remoting/responses/CacheNotFoundResponse.java
@@ -1,0 +1,44 @@
+package org.infinispan.remoting.responses;
+
+import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.util.Util;
+import org.infinispan.marshall.core.Ids;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Set;
+
+/**
+ * A response that signals the named cache is not running on the target node.
+ *
+ * @author Dan Berindei
+ * @since 6.0
+ */
+public class CacheNotFoundResponse extends InvalidResponse {
+   public static CacheNotFoundResponse INSTANCE = new CacheNotFoundResponse();
+
+   public CacheNotFoundResponse() {
+   }
+
+   public static class Externalizer extends AbstractExternalizer<CacheNotFoundResponse> {
+      @Override
+      public void writeObject(ObjectOutput output, CacheNotFoundResponse response) throws IOException {
+      }
+
+      @Override
+      public CacheNotFoundResponse readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+         return new CacheNotFoundResponse();
+      }
+
+      @Override
+      public Integer getId() {
+         return Ids.CACHE_NOT_FOUND_RESPONSE;
+      }
+
+      @Override
+      public Set<Class<? extends CacheNotFoundResponse>> getTypeClasses() {
+         return Util.<Class<? extends CacheNotFoundResponse>>asSet(CacheNotFoundResponse.class);
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/remoting/transport/AbstractTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/AbstractTransport.java
@@ -3,7 +3,6 @@ package org.infinispan.remoting.transport;
 import org.infinispan.commons.CacheException;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.manager.NamedCacheNotFoundException;
 import org.infinispan.remoting.responses.ExceptionResponse;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.transport.jgroups.SuspectException;
@@ -28,14 +27,6 @@ public abstract class AbstractTransport implements Transport {
       this.configuration = globalConfiguration;
    }
 
-   private boolean shouldThrowException(Exception ce) {
-      if (!configuration.transport().strictPeerToPeer()) {
-         if (ce instanceof NamedCacheNotFoundException) return false;
-         if (ce.getCause() != null && ce.getCause() instanceof NamedCacheNotFoundException) return false;
-      }
-      return true;
-   }
-
    public final boolean checkResponse(Object responseObject, Address sender) throws Exception {
       Log log = getLog();
       if (responseObject instanceof Response) {
@@ -44,12 +35,7 @@ public abstract class AbstractTransport implements Transport {
             ExceptionResponse exceptionResponse = (ExceptionResponse) response;
             Exception e = exceptionResponse.getException();
             // if we have any application-level exceptions make sure we throw them!!
-            if (shouldThrowException(e)) {
-               throw log.remoteException(sender, e);
-            } else {
-               if (log.isDebugEnabled())
-                  log.debug("Received exception from " + sender, e);
-            }
+            throw log.remoteException(sender, e);
          }
          return true;
       } else if (responseObject != null) {

--- a/core/src/main/java/org/infinispan/statetransfer/OutdatedTopologyException.java
+++ b/core/src/main/java/org/infinispan/statetransfer/OutdatedTopologyException.java
@@ -1,0 +1,23 @@
+package org.infinispan.statetransfer;
+
+import org.infinispan.commons.CacheException;
+
+/**
+ * An exception signalling that a command should be retried because it was executed with an outdated
+ * topology.
+ *
+ * This can happen for non-tx caches, if the primary owner doesn't respond (either because it left the
+ * cluster or because this particular cache is no longer running).
+ *
+ * @author Dan Berindei
+ * @since 6.0
+ */
+public class OutdatedTopologyException extends CacheException {
+   public OutdatedTopologyException(String msg) {
+      super(msg);
+   }
+
+   public OutdatedTopologyException(String msg, Throwable cause) {
+      super(msg, cause);
+   }
+}

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
@@ -189,7 +189,7 @@ public class StateTransferInterceptor extends CommandInterceptor {   //todo [ani
       updateTopologyIdAndWaitForTransactionData((TopologyAffectedCommand) command);
 
       // TODO we may need to skip local invocation for read/write/tx commands if the command is too old and none of its keys are local
-      Object localResult = invokeNextInterceptor(ctx, command);
+      Object localResult = invokeNextWithRetry(ctx, command);
 
       boolean isNonTransactionalWrite = !ctx.isInTxScope() && command instanceof WriteCommand;
       boolean isTransactionalAndNotRolledBack = false;
@@ -202,6 +202,15 @@ public class StateTransferInterceptor extends CommandInterceptor {   //todo [ani
       }
 
       return localResult;
+   }
+
+   private Object invokeNextWithRetry(InvocationContext ctx, VisitableCommand command) throws Throwable {
+      try {
+         return invokeNextInterceptor(ctx, command);
+      } catch (OutdatedTopologyException e) {
+         log.debugf("Retrying command because of topology change: %s", command);
+         return invokeNextWithRetry(ctx, command);
+      }
    }
 
    private void updateTopologyIdAndWaitForTransactionData(TopologyAffectedCommand command) throws InterruptedException {

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxPrimaryOwnerLeavingTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxPrimaryOwnerLeavingTest.java
@@ -1,0 +1,85 @@
+package org.infinispan.distribution.rehash;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.commands.write.PutKeyValueCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.tx.dld.ControlledRpcManager;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * Tests data loss during state transfer when the primary owner of a key leaves during a put operation.
+ *
+ * @author Dan Berindei
+ */
+@Test(groups = "functional", testName = "distribution.rehash.NonTxPrimaryOwnerLeavingTest")
+public class NonTxPrimaryOwnerLeavingTest extends MultipleCacheManagersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder c = new ConfigurationBuilder();
+      c.clustering().cacheMode(CacheMode.DIST_SYNC);
+      c.transaction().transactionMode(TransactionMode.NON_TRANSACTIONAL);
+
+      addClusterEnabledCacheManager(c);
+      addClusterEnabledCacheManager(c);
+      waitForClusterToForm();
+   }
+
+   public void testPrimaryOwnerLeavingDuringPut() throws Exception {
+      doTest(false);
+   }
+
+   public void testPrimaryOwnerLeavingDuringPutIfAbsent() throws Exception {
+      doTest(true);
+   }
+
+   private void doTest(final boolean conditional) throws Exception {
+      final AdvancedCache<Object, Object> cache0 = advancedCache(0);
+      AdvancedCache<Object, Object> cache1 = advancedCache(1);
+
+      // block remote put commands invoked from cache0
+      ControlledRpcManager crm = new ControlledRpcManager(cache0.getRpcManager());
+      cache0.getComponentRegistry().registerComponent(crm, RpcManager.class);
+      cache0.getComponentRegistry().rewire();
+      crm.blockBefore(PutKeyValueCommand.class);
+
+      // try to put a key/value from cache0 with cache1 the primary owner
+      final MagicKey key = new MagicKey(cache1);
+      Future<Object> future = fork(new Callable<Object>() {
+         @Override
+         public Object call() throws Exception {
+            return conditional ? cache0.put(key, "v") : cache0.putIfAbsent(key, "v");
+         }
+      });
+
+      // after the put command was sent, kill cache1
+      crm.waitForCommandToBlock();
+      cache1.stop();
+
+      // now that cache1 is stopped, unblock the put command
+      crm.stopBlocking();
+
+      // check that the put command didn't fail
+      Object result = future.get(10, TimeUnit.SECONDS);
+      assertNull(result);
+      log.tracef("Put operation is done");
+
+      // check the value on the remaining node
+      assertEquals("v", cache0.get(key));
+   }
+}

--- a/core/src/test/java/org/infinispan/tx/dld/ControlledRpcManager.java
+++ b/core/src/test/java/org/infinispan/tx/dld/ControlledRpcManager.java
@@ -69,6 +69,7 @@ public class ControlledRpcManager implements RpcManager {
    }
 
    public void stopBlocking() {
+      log.tracef("Stop blocking commands");
       blockBeforeFilter = Collections.emptySet();
       blockAfterFilter = Collections.emptySet();
       replicationLatch.open();
@@ -76,6 +77,7 @@ public class ControlledRpcManager implements RpcManager {
    }
 
    public void waitForCommandToBlock() throws InterruptedException {
+      log.tracef("Waiting for at least one command to block");
       blockingLatch.await();
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3366
- Always reply with a CacheNotFoundResponse when the requested cache is not running.
- Throw a RemoteException(NamedCacheNotFoundException) from RpcManagerImpl, if strictPeerToPeer = true.
- Throw an OutdatedTopologyException from NonTxConcurrentDistributionInterceptor, if strictPeerToPeer = false.
- Catch OutdatedTopologyException in StateTransferInterceptor and retry the operation.
