### PR TITLE
ISPN-3366 Data loss when entry forwarding to primary owner and primary o...

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
@@ -7,6 +7,7 @@ import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.control.LockControlCommand;
 import org.infinispan.commands.tx.*;
 import org.infinispan.commands.write.*;
+import org.infinispan.commons.CacheException;
 import org.infinispan.commons.util.InfinispanCollections;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.context.Flag;
@@ -14,11 +15,11 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.interceptors.base.CommandInterceptor;
+import org.infinispan.remoting.RemoteException;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.RemoteTransaction;
-import org.infinispan.transaction.WriteSkewHelper;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -26,14 +27,29 @@ import java.util.Set;
 
 //todo [anistor] command forwarding breaks the rule that we have only one originator for a command. this opens now the possibility to have two threads processing incoming remote commands for the same TX
 /**
- * // TODO: Document this
+ * This interceptor has two tasks:
+ * <ol>
+ *    <li>If the command's topology id is higher than the current topology id,
+ *    wait for the node to receive transaction data for the new topology id.</li>
+ *    <li>If the topology id changed during a command's execution, forward the command to the new owners.</li>
+ * </ol>
+ *
+ * Note that we don't keep track of old cache topologies (yet), so we actually forward the command to all the owners
+ * -- not just the ones added in the new topology. Transactional commands are idempotent, so this is fine.
+ *
+ * In non-transactional mode, the semantic of these tasks changes:
+ * <ol>
+ *    <li>We don't have transaction data, so the interceptor only waits for the new topology to be installed.</li>
+ *    <li>Instead of forwarding commands from any owner, we retry the command on the originator.</li>
+ * </ol>
  *
  * @author anistor@redhat.com
  * @since 5.2
  */
-public class StateTransferInterceptor extends CommandInterceptor {   //todo [anistor] this interceptor should be added to stack only if we have state transfer. maybe we need this for invalidation mode too!
+public class StateTransferInterceptor extends CommandInterceptor {
 
    private static final Log log = LogFactory.getLog(StateTransferInterceptor.class);
+   private static boolean trace = log.isTraceEnabled();
 
    private StateTransferLock stateTransferLock;
 
@@ -109,32 +125,32 @@ public class StateTransferInterceptor extends CommandInterceptor {   //todo [ani
 
    @Override
    public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) throws Throwable {
-      return handleWriteCommand(ctx, command);
+      return handleNonTxWriteCommand(ctx, command);
    }
 
    @Override
    public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) throws Throwable {
-      return handleWriteCommand(ctx, command);
+      return handleNonTxWriteCommand(ctx, command);
    }
 
    @Override
    public Object visitApplyDeltaCommand(InvocationContext ctx, ApplyDeltaCommand command) throws Throwable {
-      return handleWriteCommand(ctx, command);
+      return handleNonTxWriteCommand(ctx, command);
    }
 
    @Override
    public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
-      return handleWriteCommand(ctx, command);
+      return handleNonTxWriteCommand(ctx, command);
    }
 
    @Override
    public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) throws Throwable {
-      return handleWriteCommand(ctx, command);
+      return handleNonTxWriteCommand(ctx, command);
    }
 
    @Override
    public Object visitClearCommand(InvocationContext ctx, ClearCommand command) throws Throwable {
-      return handleWriteCommand(ctx, command);
+      return handleNonTxWriteCommand(ctx, command);
    }
 
    @Override
@@ -165,9 +181,45 @@ public class StateTransferInterceptor extends CommandInterceptor {   //todo [ani
       return handleTopologyAffectedCommand(ctx, command, address, true);
    }
 
-   private Object handleWriteCommand(InvocationContext ctx, WriteCommand command) throws Throwable {
-      // ISPN-2473 - forward non-transactional commands asynchronously
-      return handleTopologyAffectedCommand(ctx, command, ctx.getOrigin(), false);
+   /**
+    * For non-tx write commands, we retry the command locally if the topology changed, instead of forwarding to the
+    * new owners like we do for tx commands. But we only retry on the originator, and only if the command doesn't have
+    * the {@code CACHE_MODE_LOCAL} flag.
+    */
+   private Object handleNonTxWriteCommand(InvocationContext ctx, WriteCommand command) throws Throwable {
+      log.tracef("handleNonTxWriteCommand for command %s", command);
+
+      if (isLocalOnly(ctx, command)) {
+         return invokeNextInterceptor(ctx, command);
+      }
+
+      updateTopologyIdAndWaitForTransactionData(command);
+
+      // Only catch OutdatedTopologyExceptions on the originator
+      if (!ctx.isOriginLocal()) {
+         return invokeNextInterceptor(ctx, command);
+      }
+
+      int commandTopologyId = command.getTopologyId();
+      Object localResult;
+      try {
+         localResult = invokeNextInterceptor(ctx, command);
+         return localResult;
+      } catch (CacheException e) {
+         if (!(e instanceof OutdatedTopologyException ||
+               (e instanceof RemoteException && e.getCause() instanceof OutdatedTopologyException)))
+            throw e;
+
+         log.tracef("Retrying command because of topology change: %s", command);
+         // We increment the topology id so that updateTopologyIdAndWaitForTransactionData waits for the next topology.
+         // Without this, we could retry the command too fast and we could get the OutdatedTopologyException again.
+         int newTopologyId = Math.max(stateTransferManager.getCacheTopology().getTopologyId(), commandTopologyId + 1);
+         command.setTopologyId(newTopologyId);
+         localResult = handleNonTxWriteCommand(ctx, command);
+      }
+
+      stateTransferManager.forwardCommandIfNeeded(command, command.getAffectedKeys(), ctx.getOrigin(), false);
+      return localResult;
    }
 
    @Override
@@ -189,7 +241,7 @@ public class StateTransferInterceptor extends CommandInterceptor {   //todo [ani
       updateTopologyIdAndWaitForTransactionData((TopologyAffectedCommand) command);
 
       // TODO we may need to skip local invocation for read/write/tx commands if the command is too old and none of its keys are local
-      Object localResult = invokeNextWithRetry(ctx, command);
+      Object localResult = invokeNextInterceptor(ctx, command);
 
       boolean isNonTransactionalWrite = !ctx.isInTxScope() && command instanceof WriteCommand;
       boolean isTransactionalAndNotRolledBack = false;
@@ -202,15 +254,6 @@ public class StateTransferInterceptor extends CommandInterceptor {   //todo [ani
       }
 
       return localResult;
-   }
-
-   private Object invokeNextWithRetry(InvocationContext ctx, VisitableCommand command) throws Throwable {
-      try {
-         return invokeNextInterceptor(ctx, command);
-      } catch (OutdatedTopologyException e) {
-         log.debugf("Retrying command because of topology change: %s", command);
-         return invokeNextWithRetry(ctx, command);
-      }
    }
 
    private void updateTopologyIdAndWaitForTransactionData(TopologyAffectedCommand command) throws InterruptedException {

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferLockImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferLockImpl.java
@@ -62,13 +62,14 @@ public class StateTransferLockImpl implements StateTransferLock {
 
    @Override
    public void waitForTransactionData(int expectedTopologyId) throws InterruptedException {
-      if (transactionDataTopologyId >= expectedTopologyId)
-         return;
-
       if (trace) {
          log.tracef("Waiting for transaction data for topology %d, current topology is %d", expectedTopologyId,
                transactionDataTopologyId);
       }
+
+      if (transactionDataTopologyId >= expectedTopologyId)
+         return;
+
       synchronized (transactionDataLock) {
          // Do the comparison inside the synchronized lock
          // otherwise the setter might be able to call notifyAll before we wait()

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxOriginatorBecomingPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxOriginatorBecomingPrimaryOwnerTest.java
@@ -1,0 +1,127 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.infinispan.distribution.rehash;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.commands.write.PutKeyValueCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.BlockingInterceptor;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.interceptors.distribution.NonTxDistributionInterceptor;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.tx.dld.ControlledRpcManager;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+
+/**
+ * Tests data loss during state transfer when the originator of a put operation becomes the primary owner of the
+ * modified key. See https://issues.jboss.org/browse/ISPN-3366
+ *
+ * @author Dan Berindei
+ */
+@Test(groups = "functional", testName = "distribution.rehash.NonTxPrimaryOwnerLeavingTest")
+@CleanupAfterMethod
+public class NonTxOriginatorBecomingPrimaryOwnerTest extends MultipleCacheManagersTest {
+
+   private static final int NUM_KEYS = 10;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder c = new ConfigurationBuilder();
+      c.clustering().cacheMode(CacheMode.DIST_SYNC);
+      c.transaction().transactionMode(TransactionMode.NON_TRANSACTIONAL);
+
+      addClusterEnabledCacheManager(c);
+      addClusterEnabledCacheManager(c);
+      addClusterEnabledCacheManager(c);
+      waitForClusterToForm();
+   }
+
+   public void testPrimaryOwnerLeavingDuringPut() throws Exception {
+      doTest(false);
+   }
+
+   public void testPrimaryOwnerLeavingDuringPutIfAbsent() throws Exception {
+      doTest(true);
+   }
+
+   private void doTest(final boolean conditional) throws Exception {
+      final AdvancedCache<Object, Object> cache0 = advancedCache(0);
+      AdvancedCache<Object, Object> cache1 = advancedCache(1);
+      AdvancedCache<Object, Object> cache2 = advancedCache(2);
+
+      // Every PutKeyValueCommand will be blocked before reaching the distribution interceptor
+      CyclicBarrier distInterceptorBarrier = new CyclicBarrier(2);
+      BlockingInterceptor blockingInterceptor = new BlockingInterceptor(distInterceptorBarrier, PutKeyValueCommand.class, false);
+      cache0.addInterceptorBefore(blockingInterceptor, NonTxDistributionInterceptor.class);
+
+      for (int i = 0; i < NUM_KEYS; i++) {
+         // Try to put a key/value from cache0 with cache1 the primary owner
+         final MagicKey key = new MagicKey("key" + i, cache1);
+         Future<Object> future = fork(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+               return conditional ? cache0.putIfAbsent(key, "v") : cache0.put(key, "v");
+            }
+         });
+
+         // After the put command passed through EntryWrappingInterceptor, kill cache1
+         distInterceptorBarrier.await(10, TimeUnit.SECONDS);
+         cache1.stop();
+
+         // Wait for the new topology to be installed and unblock the command
+         TestingUtil.waitForRehashToComplete(cache0, cache2);
+         distInterceptorBarrier.await(10, TimeUnit.SECONDS);
+
+         // StateTransferInterceptor retries the command, and it should block again in BlockingInterceptor.
+         distInterceptorBarrier.await(10, TimeUnit.SECONDS);
+         distInterceptorBarrier.await(10, TimeUnit.SECONDS);
+
+         if (cache2.getAdvancedCache().getDistributionManager().getPrimaryLocation(key).equals(address(2))) {
+            // cache2 forwards the command back to cache0, blocking again
+            distInterceptorBarrier.await(10, TimeUnit.SECONDS);
+            distInterceptorBarrier.await(10, TimeUnit.SECONDS);
+         }
+         // Check that the put command didn't fail
+         Object result = future.get(10, TimeUnit.SECONDS);
+         assertNull(result);
+         log.tracef("Put operation is done");
+
+         // Check the value on the remaining node
+         assertEquals("v", cache0.get(key));
+
+         // Prepare for the next iteration...
+         cache1.start();
+         TestingUtil.waitForRehashToComplete(cache0, cache1, cache2);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxPrimaryOwnerLeavingTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxPrimaryOwnerLeavingTest.java
@@ -7,26 +7,26 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.TransactionMode;
 import org.infinispan.tx.dld.ControlledRpcManager;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
-import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Tests data loss during state transfer when the primary owner of a key leaves during a put operation.
+ * See https://issues.jboss.org/browse/ISPN-3366
  *
  * @author Dan Berindei
  */
 @Test(groups = "functional", testName = "distribution.rehash.NonTxPrimaryOwnerLeavingTest")
+@CleanupAfterMethod
 public class NonTxPrimaryOwnerLeavingTest extends MultipleCacheManagersTest {
 
    @Override
@@ -52,34 +52,34 @@ public class NonTxPrimaryOwnerLeavingTest extends MultipleCacheManagersTest {
       final AdvancedCache<Object, Object> cache0 = advancedCache(0);
       AdvancedCache<Object, Object> cache1 = advancedCache(1);
 
-      // block remote put commands invoked from cache0
+      // Block remote put commands invoked from cache0
       ControlledRpcManager crm = new ControlledRpcManager(cache0.getRpcManager());
       cache0.getComponentRegistry().registerComponent(crm, RpcManager.class);
       cache0.getComponentRegistry().rewire();
       crm.blockBefore(PutKeyValueCommand.class);
 
-      // try to put a key/value from cache0 with cache1 the primary owner
+      // Try to put a key/value from cache0 with cache1 the primary owner
       final MagicKey key = new MagicKey(cache1);
       Future<Object> future = fork(new Callable<Object>() {
          @Override
          public Object call() throws Exception {
-            return conditional ? cache0.put(key, "v") : cache0.putIfAbsent(key, "v");
+            return conditional ? cache0.putIfAbsent(key, "v") : cache0.put(key, "v");
          }
       });
 
-      // after the put command was sent, kill cache1
+      // After the put command was sent, kill cache1
       crm.waitForCommandToBlock();
       cache1.stop();
 
-      // now that cache1 is stopped, unblock the put command
+      // Now that cache1 is stopped, unblock the put command
       crm.stopBlocking();
 
-      // check that the put command didn't fail
+      // Check that the put command didn't fail
       Object result = future.get(10, TimeUnit.SECONDS);
       assertNull(result);
       log.tracef("Put operation is done");
 
-      // check the value on the remaining node
+      // Check the value on the remaining node
       assertEquals("v", cache0.get(key));
    }
 }


### PR DESCRIPTION
...wner shutdown

https://issues.jboss.org/browse/ISPN-3366

Fix another problem when the originator node becomes a primary owner just
before forwarding the command to the backup owners (instead of the old
primary owner).
