### PR TITLE
ISPN-3405 Cache stores hashing keys should use configured Equivalence

### DIFF
--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/JdbcUtil.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/JdbcUtil.java
@@ -52,18 +52,19 @@ public class JdbcUtil {
       }
    }
 
-   public static ByteBuffer marshall(StreamingMarshaller marshaller, Object bucket) throws CacheLoaderException, InterruptedException {
+   public static ByteBuffer marshall(StreamingMarshaller marshaller, Object obj) throws CacheLoaderException, InterruptedException {
       try {
-         return marshaller.objectToBuffer(bucket);
+         return marshaller.objectToBuffer(obj);
       } catch (IOException e) {
-         log.errorMarshallingBucket(e, bucket);
-         throw new CacheLoaderException("I/O failure while marshalling bucket: " + bucket, e);
+         log.errorMarshallingObject(e, obj);
+         throw new CacheLoaderException("I/O failure while marshalling object: " + obj, e);
       }
    }
 
-   public static Object unmarshall(StreamingMarshaller marshaller, InputStream inputStream) throws CacheLoaderException {
+   @SuppressWarnings("unchecked")
+   public static <T> T unmarshall(StreamingMarshaller marshaller, InputStream inputStream) throws CacheLoaderException {
       try {
-         return marshaller.objectFromInputStream(inputStream);
+         return (T) marshaller.objectFromInputStream(inputStream);
       } catch (IOException e) {
          log.ioErrorUnmarshalling(e);
          throw new CacheLoaderException("I/O error while unmarshalling from stream", e);

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStore.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/stringbased/JdbcStringBasedCacheStore.java
@@ -125,7 +125,7 @@ public class JdbcStringBasedCacheStore extends
          @Override
          public void loadAllProcess(ResultSet rs, Set<InternalCacheEntry> result) throws SQLException, CacheLoaderException {
             InputStream inputStream = rs.getBinaryStream(1);
-            InternalCacheValue icv = (InternalCacheValue) JdbcUtil.unmarshall(getMarshaller(), inputStream);
+            InternalCacheValue icv = JdbcUtil.unmarshall(getMarshaller(), inputStream);
             String keyStr = rs.getString(2);
             Object key = ((TwoWayKey2StringMapper) key2StringMapper).getKeyMapping(keyStr);
             result.add(icv.toInternalCacheEntry(key));
@@ -147,7 +147,7 @@ public class JdbcStringBasedCacheStore extends
 
          @Override
          public void toStreamProcess(ResultSet rs, InputStream is, ObjectOutput objectOutput) throws CacheLoaderException, SQLException, IOException {
-            InternalCacheValue icv = (InternalCacheValue) JdbcUtil.unmarshall(getMarshaller(), is);
+            InternalCacheValue icv = JdbcUtil.unmarshall(getMarshaller(), is);
             String key = rs.getString(2);//key is a string
             marshaller.objectToObjectStream(icv.toInternalCacheEntry(key), objectOutput);
          }
@@ -388,7 +388,7 @@ public class JdbcStringBasedCacheStore extends
          rs = ps.executeQuery();
          if (rs.next()) {
             InputStream inputStream = rs.getBinaryStream(2);
-            InternalCacheValue icv = (InternalCacheValue) JdbcUtil.unmarshall(getMarshaller(), inputStream);
+            InternalCacheValue icv = JdbcUtil.unmarshall(getMarshaller(), inputStream);
             storedEntry = icv.toInternalCacheEntry(key);
          }
       } catch (SQLException e) {

--- a/commons/src/main/java/org/infinispan/commons/equivalence/EquivalentLinkedHashMap.java
+++ b/commons/src/main/java/org/infinispan/commons/equivalence/EquivalentLinkedHashMap.java
@@ -1,0 +1,235 @@
+package org.infinispan.commons.equivalence;
+
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * Custom hash-based linked list map which accepts no null keys nor null values,
+ * where equality and hash code calculations are done based on passed
+ * {@link org.infinispan.commons.equivalence.Equivalence} function implementations for keys
+ * and values, as opposed to relying on their own equals/hashCode/toString
+ * implementations. This is handy when using key/values whose mentioned
+ * methods cannot be overriden, i.e. arrays, and in situations where users
+ * want to avoid using wrapper objects.
+ *
+ * In order to provide linked list behaviour, entries are linked with each
+ * other in a predictable order.
+ *
+ * @author Galder Zamarreño
+ * @since 6.0
+ */
+public class EquivalentLinkedHashMap<K, V> extends EquivalentHashMap<K, V> {
+
+   private transient LinkedNode<K, V> header;
+
+   private final IterationOrder iterationOrder;
+
+   public EquivalentLinkedHashMap(int initialCapacity, float loadFactor,
+         IterationOrder iterationOrder,
+         Equivalence<K> keyEq, Equivalence<V> valueEq) {
+      super(initialCapacity, loadFactor, keyEq, valueEq);
+      this.iterationOrder = iterationOrder;
+      addFirstEntry();
+   }
+
+   private void addFirstEntry() {
+      header = createLinkedNode();
+      header.before = header;
+      header.after = header;
+   }
+
+   @SuppressWarnings("unchecked")
+   private <K, V> LinkedNode<K, V> createLinkedNode() {
+      return new LinkedNode<K, V>(null, -1, null);
+   }
+
+   @Override
+   <T> T createNode(K key, V value, int hash) {
+      LinkedNode<K, V> linkedNode = new LinkedNode<K, V>(key, hash, value);
+      linkedNode.addBefore(header);
+      size++;
+      return (T) linkedNode;
+   }
+
+   @Override
+   public V get(Object key) {
+      LinkedNode<K, V> n = getNode(key);
+      return n == null ? null : n.recordAccess(this);
+   }
+
+   @Override
+   public V remove(Object key) {
+      LinkedNode<K, V> prevNode = removeNode(key);
+      return prevNode == null ? null : prevNode.remove();
+   }
+
+   @Override
+   public void clear() {
+      super.clear();
+      header.before = header;
+      header.after = header;
+   }
+
+   private static final class LinkedNode<K, V> {
+      final K key;
+      final int hash;
+      final V value;
+      LinkedNode<K, V> before;
+      LinkedNode<K, V> after;
+
+      LinkedNode(K key, int hash, V value) {
+         this.key = key;
+         this.hash = hash;
+         this.value = value;
+      }
+
+      private V remove() {
+         before.after = after;
+         after.before = before;
+         return value;
+      }
+
+      private void addBefore(LinkedNode<K, V> entry) {
+         after  = entry;
+         before = entry.before;
+         before.after = this;
+         after.before = this;
+      }
+
+      V recordAccess(EquivalentHashMap<K, V> m) {
+         EquivalentLinkedHashMap<K, V> linkedMap = (EquivalentLinkedHashMap<K, V>)m;
+         if (linkedMap.iterationOrder == IterationOrder.ACCESS_ORDER) {
+            linkedMap.modCount++;
+            remove();
+            addBefore(linkedMap.header);
+         }
+         return value;
+      }
+   }
+
+   public enum IterationOrder {
+      ACCESS_ORDER, INSERT_ORDER;
+
+      public boolean toJdkAccessOrder() {
+         return this == ACCESS_ORDER;
+      }
+   }
+
+   /**
+    * Exported Entry for iterators
+    */
+   private static class LinkedEntry<K,V> extends MapEntry<K,V> {
+      LinkedNode<K, V> before;
+      LinkedNode<K, V> after;
+
+      LinkedEntry(K key, V val, LinkedNode<K, V> before, LinkedNode<K, V> after, EquivalentHashMap<K, V> map) {
+         super(key, val, map);
+         this.before = before;
+         this.after = after;
+      }
+   }
+
+   private abstract class EquivalentLinkedHashIterator<T> implements Iterator<T> {
+      final EquivalentHashMap<K, V> map;
+      LinkedEntry<K, V> nextEntry;
+      LinkedEntry<K, V> lastReturned = null;
+
+      protected EquivalentLinkedHashIterator(EquivalentHashMap<K, V> map) {
+         this.map = map;
+         nextEntry = new LinkedEntry<K, V>(
+               header.after.key, header.after.value,
+               header.after.before, header.after.after, map);
+      }
+
+      /**
+       * The modCount value that the iterator believes that the backing
+       * List should have.  If this expectation is violated, the iterator
+       * has detected concurrent modification.
+       */
+      int expectedModCount = modCount;
+
+      public boolean hasNext() {
+         return !equals(nextEntry, header);
+      }
+
+      public void remove() {
+         if (lastReturned == null)
+            throw new IllegalStateException();
+         if (modCount != expectedModCount)
+            throw new ConcurrentModificationException();
+
+         EquivalentLinkedHashMap.this.remove(lastReturned.key);
+         lastReturned = null;
+         expectedModCount = modCount;
+      }
+
+      LinkedEntry<K,V> nextEntry() {
+         if (modCount != expectedModCount)
+            throw new ConcurrentModificationException();
+         if (equals(nextEntry, header))
+            throw new NoSuchElementException();
+
+         LinkedEntry<K, V> e = nextEntry;
+         lastReturned = nextEntry;
+         nextEntry = new LinkedEntry<K, V>(
+               e.after.key, e.after.value,
+               e.after.before, e.after.after, map);
+         return e;
+      }
+
+      boolean equals(LinkedEntry<K, V> entry, LinkedNode<K, V> node) {
+         return entry.key == node.key
+               && entry.val == node.value
+               && entry.before == node.before
+               && entry.after == node.after;
+      }
+   }
+
+   private class KeyIterator extends EquivalentLinkedHashIterator<K> {
+
+      protected KeyIterator(EquivalentHashMap<K, V> map) {
+         super(map);
+      }
+
+      public K next() {
+         return nextEntry().getKey();
+      }
+   }
+
+   private class ValueIterator extends EquivalentLinkedHashIterator<V> {
+
+      protected ValueIterator(EquivalentHashMap<K, V> map) {
+         super(map);
+      }
+
+      public V next() {
+         return nextEntry().val;
+      }
+   }
+
+   private class EntryIterator extends EquivalentLinkedHashIterator<Map.Entry<K, V>> {
+
+      protected EntryIterator(EquivalentHashMap<K, V> map) {
+         super(map);
+      }
+
+      public Map.Entry<K, V> next() {
+         return nextEntry();
+      }
+   }
+
+   Iterator<K> newKeyIterator() {
+      return new KeyIterator(this);
+   }
+
+   Iterator<V> newValueIterator() {
+      return new ValueIterator(this);
+   }
+
+   Iterator<Map.Entry<K,V>> newEntryIterator() {
+      return new EntryIterator(this);
+   }
+
+}

--- a/commons/src/main/java/org/infinispan/commons/util/CollectionFactory.java
+++ b/commons/src/main/java/org/infinispan/commons/util/CollectionFactory.java
@@ -4,10 +4,12 @@ import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.equivalence.EquivalentHashMap;
 import org.infinispan.commons.equivalence.EquivalentHashSet;
+import org.infinispan.commons.equivalence.EquivalentLinkedHashMap;
 import org.infinispan.commons.util.concurrent.jdk8backported.EquivalentConcurrentHashMapV8;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -179,6 +181,15 @@ public class CollectionFactory {
          return new EquivalentHashMap<K, V>(entries, keyEq, valueEq);
       else
          return new HashMap<K, V>(entries);
+   }
+
+   public static <K, V> Map<K, V> makeLinkedMap(int initialCapacity,
+         float loadFactor, EquivalentLinkedHashMap.IterationOrder iterationOrder,
+         Equivalence<K> keyEq, Equivalence<V> valueEq) {
+      if (requiresEquivalent(keyEq, valueEq))
+         return new EquivalentLinkedHashMap<K, V>(initialCapacity, loadFactor, iterationOrder, keyEq, valueEq);
+      else
+         return new LinkedHashMap<K, V>(initialCapacity, loadFactor, iterationOrder.toJdkAccessOrder());
    }
 
    public static <T> Set<T> makeSet(Equivalence<T> entryEq) {

--- a/core/src/main/java/org/infinispan/loaders/bucket/BucketBasedCacheStore.java
+++ b/core/src/main/java/org/infinispan/loaders/bucket/BucketBasedCacheStore.java
@@ -1,6 +1,5 @@
 package org.infinispan.loaders.bucket;
 
-import org.infinispan.configuration.cache.LockSupportStoreConfiguration;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.loaders.CacheLoaderException;
 import org.infinispan.loaders.spi.LockSupportCacheStore;
@@ -67,7 +66,7 @@ public abstract class BucketBasedCacheStore extends LockSupportCacheStore<Intege
          bucket.addEntry(entry);
          updateBucket(bucket);
       } else {
-         bucket = new Bucket(timeService);
+         bucket = new Bucket(timeService, keyEquivalence);
          bucket.setBucketId(lockingKey);
          bucket.addEntry(entry);
          insertBucket(bucket);
@@ -100,7 +99,10 @@ public abstract class BucketBasedCacheStore extends LockSupportCacheStore<Intege
     */
    @Override
    public Integer getLockFromKey(Object key) {
-      return key.hashCode() & 0xfffffc00; // To reduce the number of buckets/locks that may be created.  TODO: This should be configurable.
+      return (keyEquivalence != null
+                    ? keyEquivalence.hashCode(key)
+                    : key.hashCode())
+            & 0xfffffc00; // To reduce the number of buckets/locks that may be created.
    }
 
    /**

--- a/core/src/main/java/org/infinispan/loaders/spi/LockSupportCacheStore.java
+++ b/core/src/main/java/org/infinispan/loaders/spi/LockSupportCacheStore.java
@@ -5,6 +5,7 @@ import java.io.ObjectOutput;
 import java.util.Set;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.configuration.cache.CacheLoaderConfiguration;
 import org.infinispan.configuration.cache.LockSupportStoreConfiguration;
 import org.infinispan.container.entries.InternalCacheEntry;
@@ -45,6 +46,7 @@ public abstract class LockSupportCacheStore<L> extends AbstractCacheStore {
    private long globalLockTimeoutMillis;
 
    private LockSupportStoreConfiguration configuration;
+   protected Equivalence<Object> keyEquivalence;
 
    @Override
    public void init(CacheLoaderConfiguration configuration, Cache<?, ?> cache, StreamingMarshaller m) throws CacheLoaderException {
@@ -62,6 +64,7 @@ public abstract class LockSupportCacheStore<L> extends AbstractCacheStore {
 
       locks = new StripedLock(configuration.lockConcurrencyLevel());
       globalLockTimeoutMillis = configuration.lockAcquistionTimeout();
+      keyEquivalence = cache.getCacheConfiguration().dataContainer().keyEquivalence();
    }
 
    /**

--- a/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
+++ b/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
@@ -11,7 +11,6 @@ import org.infinispan.atomic.PutOperation;
 import org.infinispan.atomic.RemoveOperation;
 import org.infinispan.commands.RemoteCommandsFactory;
 import org.infinispan.commons.CacheConfigurationException;
-import org.infinispan.commons.CacheException;
 import org.infinispan.commons.hash.MurmurHash2;
 import org.infinispan.commons.hash.MurmurHash2Compat;
 import org.infinispan.commons.hash.MurmurHash3;
@@ -49,7 +48,6 @@ import org.infinispan.factories.annotations.Stop;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.commons.io.UnsignedNumeric;
-import org.infinispan.loaders.bucket.Bucket;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.commons.util.Immutables;
@@ -258,7 +256,6 @@ public class ExternalizerTable implements ObjectTable {
 
       addInternalExternalizer(new DeltaCompositeKey.DeltaCompositeKeyExternalizer());
       addInternalExternalizer(new AtomicHashMap.Externalizer());
-      addInternalExternalizer(new Bucket.Externalizer(gcr));
       addInternalExternalizer(new AtomicHashMapDelta.Externalizer());
       addInternalExternalizer(new PutOperation.Externalizer());
       addInternalExternalizer(new RemoveOperation.Externalizer());

--- a/core/src/main/java/org/infinispan/marshall/core/Ids.java
+++ b/core/src/main/java/org/infinispan/marshall/core/Ids.java
@@ -40,7 +40,7 @@ public interface Ids extends org.infinispan.commons.marshall.Ids {
    int JGROUPS_ADDRESS = 39;
    int MARSHALLED_VALUE = 40;
    // 41 no longer in use, used to be TransactionLog.LogEntry
-   int BUCKET = 42;
+   // 42 no longer in use
    int DEADLOCK_DETECTING_GLOBAL_TRANSACTION = 43;
 
    // 44 and 45 no longer in use, used to belong to tree module

--- a/core/src/main/java/org/infinispan/marshall/core/VersionAwareMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/core/VersionAwareMarshaller.java
@@ -77,7 +77,7 @@ public class VersionAwareMarshaller extends AbstractMarshaller implements Stream
             if (log.isTraceEnabled()) log.trace("Interrupted exception while marshalling", ioe.getCause());
             throw (InterruptedException) ioe.getCause();
          } else {
-            log.errorMarshallingObject(ioe);
+            log.errorMarshallingObject(ioe, obj);
             throw ioe;
          }
       } finally {

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -295,8 +295,8 @@ public interface Log extends BasicLogger {
    void problemsCreatingDirectory(File dir);
 
    @LogMessage(level = ERROR)
-   @Message(value = "Exception while marshalling object", id = 65)
-   void errorMarshallingObject(@Cause IOException ioe);
+   @Message(value = "Exception while marshalling object: %s", id = 65)
+   void errorMarshallingObject(@Cause IOException ioe, Object obj);
 
    @LogMessage(level = ERROR)
    @Message(value = "Unable to read version id from first two bytes of stream, barfing.", id = 66)

--- a/core/src/test/java/org/infinispan/loaders/AbstractCacheStoreTest.java
+++ b/core/src/test/java/org/infinispan/loaders/AbstractCacheStoreTest.java
@@ -7,16 +7,22 @@ import java.util.concurrent.ExecutorService;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
+import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.util.ReflectionUtil;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.CacheStoreConfiguration;
-import org.infinispan.configuration.cache.CacheStoreConfigurationBuilder;
+import org.infinispan.configuration.cache.ClusteringConfiguration;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.DataContainerConfiguration;
+import org.infinispan.configuration.cache.LoadersConfiguration;
+import org.infinispan.configuration.cache.LockingConfiguration;
+import org.infinispan.configuration.cache.TransactionConfiguration;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.loaders.dummy.DummyInMemoryCacheStoreConfigurationBuilder;
 import org.infinispan.loaders.spi.AbstractCacheStore;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.util.DefaultTimeService;
 import org.infinispan.util.concurrent.WithinThreadExecutor;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
@@ -72,12 +78,32 @@ public class AbstractCacheStoreTest extends AbstractInfinispanTest {
    public static Cache mockCache(final String name) {
       AdvancedCache cache = mock(AdvancedCache.class);
       ComponentRegistry registry = mock(ComponentRegistry.class);
+      Configuration configuration = mock(Configuration.class);
+      DataContainerConfiguration dataContainerConfiguration = mock(DataContainerConfiguration.class);
+      LockingConfiguration lockingConfiguration = mock(LockingConfiguration.class);
+      TransactionConfiguration transactionConfiguration = mock(TransactionConfiguration.class);
+      LoadersConfiguration loadersConfiguration = mock(LoadersConfiguration.class);
+      ClusteringConfiguration clusteringConfiguration = mock(ClusteringConfiguration.class);
+      CacheMode cacheMode = CacheMode.LOCAL;
 
       when(cache.getName()).thenReturn(name);
       when(cache.getAdvancedCache()).thenReturn(cache);
       when(cache.getComponentRegistry()).thenReturn(registry);
       when(registry.getTimeService()).thenReturn(TIME_SERVICE);
       when(cache.getStatus()).thenReturn(ComponentStatus.RUNNING);
+      when(cache.getCacheConfiguration()).thenReturn(configuration);
+      when(configuration.dataContainer()).thenReturn(dataContainerConfiguration);
+      when(configuration.locking()).thenReturn(lockingConfiguration);
+      when(configuration.loaders()).thenReturn(loadersConfiguration);
+      when(configuration.clustering()).thenReturn(clusteringConfiguration);
+      when(configuration.transaction()).thenReturn(transactionConfiguration);
+      when(configuration.dataContainer()).thenReturn(dataContainerConfiguration);
+      when(dataContainerConfiguration.keyEquivalence()).thenReturn(AnyEquivalence.getInstance());
+      when(lockingConfiguration.concurrencyLevel()).thenReturn(16);
+      when(transactionConfiguration.cacheStopTimeout()).thenReturn(30000L);
+      when(loadersConfiguration.preload()).thenReturn(false);
+      when(clusteringConfiguration.cacheMode()).thenReturn(cacheMode);
+
       return cache;
    }
 }

--- a/core/src/test/java/org/infinispan/loaders/dummy/DummyInMemoryCacheStore.java
+++ b/core/src/test/java/org/infinispan/loaders/dummy/DummyInMemoryCacheStore.java
@@ -1,6 +1,8 @@
 package org.infinispan.loaders.dummy;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.equivalence.Equivalence;
+import org.infinispan.commons.util.concurrent.jdk8backported.EquivalentConcurrentHashMapV8;
 import org.infinispan.configuration.cache.CacheLoaderConfiguration;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.loaders.CacheLoaderException;
@@ -219,11 +221,12 @@ public class DummyInMemoryCacheStore extends AbstractCacheStore {
    public void start() throws CacheLoaderException {
       super.start();
 
-
       if (store != null)
          return;
 
-      store = new ConcurrentHashMap<Object, byte[]>();
+      Equivalence<Object> keyEq = cache.getCacheConfiguration().dataContainer().keyEquivalence();
+      Equivalence<byte[]> valueEq = cache.getCacheConfiguration().dataContainer().valueEquivalence();
+      store = new EquivalentConcurrentHashMapV8<Object, byte[]>(keyEq, valueEq);
       stats = newStatsMap();
 
       if (storeName != null) {

--- a/core/src/test/java/org/infinispan/loaders/legacy/LegacyCacheStore.java
+++ b/core/src/test/java/org/infinispan/loaders/legacy/LegacyCacheStore.java
@@ -15,7 +15,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.util.Util;
+import org.infinispan.commons.util.concurrent.jdk8backported.EquivalentConcurrentHashMapV8;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.loaders.AbstractCacheStore;
 import org.infinispan.loaders.AbstractCacheStoreConfig;
@@ -226,7 +228,9 @@ public class LegacyCacheStore extends AbstractCacheStore {
       if (store != null)
          return;
 
-      store = new ConcurrentHashMap<Object, byte[]>();
+      Equivalence<Object> keyEq = cache.getCacheConfiguration().dataContainer().keyEquivalence();
+      Equivalence<byte[]> valueEq = cache.getCacheConfiguration().dataContainer().valueEquivalence();
+      store = new EquivalentConcurrentHashMapV8<Object, byte[]>(keyEq, valueEq);
       stats = newStatsMap();
 
       if (storeName != null) {

--- a/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
@@ -44,7 +44,6 @@ import org.infinispan.container.entries.TransientMortalCacheValue;
 import org.infinispan.context.Flag;
 import org.infinispan.distribution.ch.DefaultConsistentHash;
 import org.infinispan.distribution.ch.DefaultConsistentHashFactory;
-import org.infinispan.loaders.bucket.Bucket;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.core.MarshalledValue;
 import org.infinispan.marshall.core.JBossMarshallingTest.CustomReadObjectMethod;
@@ -365,23 +364,6 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
       bytes = marshaller.objectToByteBuffer(value4);
       TransientMortalCacheValue rvalue4 = (TransientMortalCacheValue) marshaller.objectFromByteBuffer(bytes);
       assert rvalue4.getValue().equals(value4.getValue()) : "Writen[" + rvalue4.getValue() + "] and read[" + value4.getValue() + "] objects should be the same";
-   }
-
-   public void testBucketMarshalling() throws Exception {
-      ImmortalCacheEntry entry1 = (ImmortalCacheEntry) TestInternalCacheEntryFactory.create("key", "value", System.currentTimeMillis() - 1000, -1, System.currentTimeMillis(), -1);
-      MortalCacheEntry entry2 = (MortalCacheEntry) TestInternalCacheEntryFactory.create("key", "value", System.currentTimeMillis() - 1000, 200000, System.currentTimeMillis(), -1);
-      TransientCacheEntry entry3 = (TransientCacheEntry) TestInternalCacheEntryFactory.create("key", "value", System.currentTimeMillis() - 1000, -1, System.currentTimeMillis(), 4000000);
-      TransientMortalCacheEntry entry4 = (TransientMortalCacheEntry) TestInternalCacheEntryFactory.create("key", "value", System.currentTimeMillis() - 1000, 200000, System.currentTimeMillis(), 4000000);
-      Bucket b = new Bucket(TIME_SERVICE);
-      b.setBucketId(0);
-      b.addEntry(entry1);
-      b.addEntry(entry2);
-      b.addEntry(entry3);
-      b.addEntry(entry4);
-
-      byte[] bytes = marshaller.objectToByteBuffer(b);
-      Bucket rb = (Bucket) marshaller.objectFromByteBuffer(bytes);
-      assert rb.getEntries().equals(b.getEntries()) : "Writen[" + b.getEntries() + "] and read[" + rb.getEntries() + "] objects should be the same";
    }
 
    public void testLongPutKeyValueCommand() throws Exception {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3405
- Removed Bucket externalizer since it complicated injection of per-cache equivalence function.
- Created EquivalentLinkedHashMap for the single file cache store to be able to locate keys requiring Equivalence function in memory.
