### PR TITLE
Tests for cache listeners in compatibility mode [ISPN-3430]

### DIFF
--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CustomClassLoaderListenerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CustomClassLoaderListenerTest.java
@@ -4,20 +4,27 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.loaders.dummy.DummyInMemoryCacheStoreConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.notifications.Listener;
-import org.infinispan.notifications.cachelistener.annotation.CacheEntriesEvicted;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryEvicted;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryLoaded;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryPassivated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryVisited;
-import org.infinispan.notifications.cachelistener.event.Event;
+import org.infinispan.notifications.cachelistener.event.CacheEntryActivatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryEvictedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryLoadedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryPassivatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
-import static org.testng.AssertJUnit.*;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * CustomClassLoaderListenerTest.
@@ -42,16 +49,61 @@ public class CustomClassLoaderListenerTest extends SingleCacheManagerTest {
       ccl = new CustomClassLoader(Thread.currentThread().getContextClassLoader());
       ClassLoaderListener listener = new ClassLoaderListener();
       cache().getAdvancedCache().with(ccl).addListener(listener);
+
       cache().put("a", "a"); // Created + Modified
+      assertEquals(1, listener.createdCounter);
+      assertEquals(1, listener.modifiedCounter);
+      assertEquals(0, listener.removedCounter);
+      assertEquals(0, listener.visitedCounter);
+      assertEquals(0, listener.activatedCounter);
+      assertEquals(0, listener.passivatedCounter);
+      assertEquals(0, listener.evictedCounter);
+      assertEquals(0, listener.loadedCounter);
+      listener.reset();
+
       cache().replace("a", "b"); // Modified
+      assertEquals(0, listener.createdCounter);
+      assertEquals(1, listener.modifiedCounter);
+      assertEquals(0, listener.removedCounter);
+      assertEquals(0, listener.visitedCounter);
+      assertEquals(0, listener.activatedCounter);
+      assertEquals(0, listener.passivatedCounter);
+      assertEquals(0, listener.evictedCounter);
+      assertEquals(0, listener.loadedCounter);
+      listener.reset();
+
 
       cache().evict("a"); // Passivated + Evicted
+      assertEquals(0, listener.createdCounter);
+      assertEquals(0, listener.modifiedCounter);
+      assertEquals(0, listener.removedCounter);
+      assertEquals(0, listener.visitedCounter);
+      assertEquals(0, listener.activatedCounter);
+      assertEquals(1, listener.passivatedCounter);
+      assertEquals(1, listener.evictedCounter);
+      assertEquals(0, listener.loadedCounter);
+      listener.reset();
 
       cache().get("a"); // Loaded +  Activated + Visited
+      assertEquals(0, listener.createdCounter);
+      assertEquals(0, listener.modifiedCounter);
+      assertEquals(0, listener.removedCounter);
+      assertEquals(1, listener.visitedCounter);
+      assertEquals(1, listener.activatedCounter);
+      assertEquals(0, listener.passivatedCounter);
+      assertEquals(0, listener.evictedCounter);
+      assertEquals(1, listener.loadedCounter);
+      listener.reset();
 
-      cache().remove("a"); // Modified + Removed
-
-      assertEquals(10, listener.invocationCount);
+      cache().remove("a"); // Removed
+      assertEquals(0, listener.createdCounter);
+      assertEquals(0, listener.modifiedCounter);
+      assertEquals(1, listener.removedCounter);
+      assertEquals(0, listener.visitedCounter);
+      assertEquals(0, listener.activatedCounter);
+      assertEquals(0, listener.passivatedCounter);
+      assertEquals(0, listener.evictedCounter);
+      assertEquals(0, listener.loadedCounter);
    }
 
    public static class CustomClassLoader extends ClassLoader {
@@ -62,21 +114,89 @@ public class CustomClassLoaderListenerTest extends SingleCacheManagerTest {
 
    @Listener
    public class ClassLoaderListener {
-      int invocationCount = 0;
+      int createdCounter = 0;
+      int removedCounter = 0;
+      int modifiedCounter = 0;
+      int visitedCounter = 0;
+      int evictedCounter = 0;
+      int passivatedCounter = 0;
+      int loadedCounter = 0;
+      int activatedCounter = 0;
+
+
+      @CacheEntryCreated
+      public void handleCreated(CacheEntryCreatedEvent e) {
+         assertEquals(ccl, Thread.currentThread().getContextClassLoader());
+         if (!e.isPre()) {
+            createdCounter++;
+         }
+      }
+
+      @CacheEntryRemoved
+      public void handleRemoved(CacheEntryRemovedEvent e) {
+         assertEquals(ccl, Thread.currentThread().getContextClassLoader());
+         if (!e.isPre()) {
+            removedCounter++;
+         }
+      }
+
+      @CacheEntryModified
+      public void handleModified(CacheEntryModifiedEvent e) {
+         assertEquals(ccl, Thread.currentThread().getContextClassLoader());
+         if (!e.isPre()) {
+            modifiedCounter++;
+         }
+      }
+
+      @CacheEntryVisited
+      public void handleVisited(CacheEntryVisitedEvent e) {
+         assertEquals(ccl, Thread.currentThread().getContextClassLoader());
+         if (!e.isPre()) {
+            visitedCounter++;
+         }
+      }
+
+      @CacheEntryEvicted
+      public void handleEvicted(CacheEntryEvictedEvent e) {
+         assertEquals(ccl, Thread.currentThread().getContextClassLoader());
+         if (!e.isPre()) {
+            evictedCounter++;
+         }
+      }
+
+      @CacheEntryPassivated
+      public void handlePassivated(CacheEntryPassivatedEvent e) {
+         assertEquals(ccl, Thread.currentThread().getContextClassLoader());
+         if (!e.isPre()) {
+            passivatedCounter++;
+         }
+      }
 
       @CacheEntryActivated
-      @CacheEntryCreated
-      @CacheEntriesEvicted
-      @CacheEntryLoaded
-      @CacheEntryModified
-      @CacheEntryPassivated
-      @CacheEntryRemoved
-      @CacheEntryVisited
-      public void handle(Event e) {
+      public void handleActivated(CacheEntryActivatedEvent e) {
          assertEquals(ccl, Thread.currentThread().getContextClassLoader());
-         if(!e.isPre()) {
-            ++invocationCount;
+         if (!e.isPre()) {
+            activatedCounter++;
          }
+      }
+
+      @CacheEntryLoaded
+      public void handleLoaded(CacheEntryLoadedEvent e) {
+         assertEquals(ccl, Thread.currentThread().getContextClassLoader());
+         if (!e.isPre()) {
+            loadedCounter++;
+         }
+      }
+
+      void reset() {
+         createdCounter = 0;
+         removedCounter = 0;
+         modifiedCounter = 0;
+         visitedCounter = 0;
+         evictedCounter = 0;
+         passivatedCounter = 0;
+         loadedCounter = 0;
+         activatedCounter = 0;
       }
    }
 }

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedHotRotCacheListenerTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedHotRotCacheListenerTest.java
@@ -1,0 +1,280 @@
+package org.infinispan.it.compatibility;
+
+import org.infinispan.Cache;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.VersionedValue;
+import org.infinispan.commons.util.concurrent.NotifyingFuture;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryVisited;
+import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.jgroups.util.Util.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Test cache listeners bound to embedded cache and operation over HotRod cache.
+ *
+ * @author Jiri Holusa [jholusa@redhat.com]
+ */
+@Test(groups = "functional", testName = "it.compatibility.EmbeddedHotRodCacheListenerTest")
+public class EmbeddedHotRotCacheListenerTest extends AbstractInfinispanTest {
+
+   CompatibilityCacheFactory<String, String> cacheFactory;
+
+   @BeforeMethod
+   protected void setup() throws Exception {
+      cacheFactory = new CompatibilityCacheFactory<String, String>(CacheMode.LOCAL).setup();
+   }
+
+   @AfterMethod
+   protected void teardown() {
+      CompatibilityCacheFactory.killCacheFactories(cacheFactory);
+   }
+
+   public void testLoadingAndStoringEventsHotRod1() {
+      Cache<String, String> embedded = cacheFactory.getEmbeddedCache();
+      RemoteCache<String, String> remote = cacheFactory.getHotRodCache();
+
+      TestCacheListener l = new TestCacheListener();
+      embedded.addListener(l);
+
+      assertTrue(l.created.isEmpty());
+      assertTrue(l.removed.isEmpty());
+      assertTrue(l.modified.isEmpty());
+      assertTrue(l.visited.isEmpty());
+
+      remote.put("k", "v");
+      assertEquals(1, l.createdCounter);
+      assertEquals("v", l.created.get("k"));
+      assertTrue(l.removed.isEmpty());
+      assertEquals(1, l.modifiedCounter);
+      assertEquals("v", l.modified.get("k"));
+      assertTrue(l.visited.isEmpty());
+
+      remote.put("key", "value");
+      assertEquals(2, l.createdCounter);
+      assertTrue(l.removed.isEmpty());
+      assertEquals(2, l.modifiedCounter);
+      assertTrue(l.visited.isEmpty());
+
+      remote.put("key", "modifiedValue");
+      assertEquals(2, l.createdCounter);
+      assertTrue(l.removed.isEmpty());
+      assertEquals(3, l.modifiedCounter);
+      assertEquals("modifiedValue", l.modified.get("key"));
+      assertTrue(l.visited.isEmpty());
+
+      remote.replace("k", "replacedValue");
+      assertEquals(2, l.createdCounter);
+      assertTrue(l.removed.isEmpty());
+      assertEquals(4, l.modifiedCounter);
+      assertEquals("replacedValue", l.modified.get("k"));
+      assertTrue(l.visited.isEmpty());
+
+      //resetting so don't have to type "== 2" etc. all over again
+      l.reset();
+
+      remote.remove("key");
+      assertTrue(l.created.isEmpty());
+      assertEquals(1, l.removedCounter);
+      assertEquals("modifiedValue", l.removed.get("key"));
+      assertTrue(l.modified.isEmpty());
+
+      l.reset();
+
+      String value = remote.get("k");
+      assertTrue(l.created.isEmpty());
+      assertTrue(l.removed.isEmpty());
+      assertTrue(l.modified.isEmpty());
+      assertEquals(1, l.visitedCounter);
+      assertEquals("replacedValue", l.visited.get("k"));
+
+      l.reset();
+   }
+
+   public void testLoadingAndStoringEventsHotRod2() {
+      Cache<String, String> embedded = cacheFactory.getEmbeddedCache();
+      RemoteCache<String, String> remote = cacheFactory.getHotRodCache();
+
+      TestCacheListener l = new TestCacheListener();
+      embedded.addListener(l);
+
+      Map<String, String> tmp = new HashMap<String, String>();
+      tmp.put("key", "value");
+      tmp.put("key2", "value2");
+
+      remote.putAll(tmp);
+      assertEquals(2, l.createdCounter); //one event for every put
+      assertEquals("value", l.created.get("key"));
+      assertEquals("value2", l.created.get("key2"));
+      assertEquals(2, l.modifiedCounter);
+      assertEquals("value", l.modified.get("key"));
+      assertEquals("value2", l.modified.get("key2"));
+      assertTrue(l.removed.isEmpty());
+      assertTrue(l.visited.isEmpty());
+
+      l.reset();
+
+      remote.putIfAbsent("newKey", "newValue");
+      assertEquals(1, l.createdCounter);
+      assertEquals("newValue", l.created.get("newKey"));
+      assertEquals(1, l.modifiedCounter);
+      assertEquals("newValue", l.modified.get("newKey"));
+      assertTrue(l.removed.isEmpty());
+      assertTrue(l.visited.isEmpty());
+
+      l.reset();
+
+      remote.putIfAbsent("newKey", "shouldNotBeAdded");
+      assertTrue(l.created.isEmpty());
+      assertTrue(l.modified.isEmpty());
+      assertTrue(l.removed.isEmpty());
+      assertEquals(1, l.visitedCounter);
+
+      l.reset();
+   }
+
+   public void testLoadingAndStoringWithVersionEventsHotRod() {
+      Cache<String, String> embedded = cacheFactory.getEmbeddedCache();
+      RemoteCache<String, String> remote = cacheFactory.getHotRodCache();
+
+      TestCacheListener l = new TestCacheListener();
+      embedded.addListener(l);
+
+      remote.put("key", "value");
+      VersionedValue oldVersionedValue = remote.getVersioned("key");
+      assertEquals("value", oldVersionedValue.getValue());
+      assertEquals(1, l.createdCounter);
+      assertEquals(1, l.modifiedCounter);
+      assertTrue(l.removed.isEmpty());
+      assertEquals(1, l.visitedCounter);
+      assertEquals("value", l.visited.get("key"));
+
+      remote.put("key2", "value2");
+      remote.put("key", "outOfVersionValue");
+      VersionedValue newVersionedValue = remote.getVersioned("key2");
+
+      l.reset();
+
+      remote.removeWithVersion("key", oldVersionedValue.getVersion());
+      assertTrue(l.created.isEmpty());
+      assertTrue(l.modified.isEmpty());
+      assertTrue(l.removed.isEmpty());
+      assertEquals(1, l.visitedCounter);
+
+      l.reset();
+
+      remote.removeWithVersion("key2", newVersionedValue.getVersion());
+      assertTrue(l.created.isEmpty());
+      assertTrue(l.modified.isEmpty());
+      assertEquals(1, l.removedCounter);
+      assertEquals("value2", l.removed.get("key2"));
+      assertEquals(1, l.visitedCounter);
+
+      remote.put("newKey", "willBeOutOfDate");
+      VersionedValue oldVersionedValueToBeReplaced = remote.getVersioned("newKey");
+      remote.put("newKey", "changedValue");
+
+      l.reset();
+
+      remote.replaceWithVersion("newKey", "tryingToChangeButShouldNotSucceed", oldVersionedValueToBeReplaced.getVersion());
+      assertTrue(l.created.isEmpty());
+      assertTrue(l.modified.isEmpty());
+      assertTrue(l.removed.isEmpty());
+      assertTrue(l.visited.isEmpty());
+
+      remote.put("newKey2", "willBeSuccessfullyChanged");
+      VersionedValue newVersionedValueToBeReplaced = remote.getVersioned("newKey2");
+
+      l.reset();
+
+      remote.replaceWithVersion("newKey2", "successfulChange", newVersionedValueToBeReplaced.getVersion());
+      assertTrue(l.created.isEmpty());
+      assertEquals(1, l.modifiedCounter);
+      assertEquals("successfulChange", l.modified.get("newKey2"));
+      assertTrue(l.removed.isEmpty());
+      assertTrue(l.visited.isEmpty());
+
+      l.reset();
+   }
+
+   public void testLoadingAndStoringAsyncEventsHotRod() throws InterruptedException, ExecutionException, TimeoutException {
+      Cache<String, String> embedded = cacheFactory.getEmbeddedCache();
+      RemoteCache<String, String> remote = cacheFactory.getHotRodCache();
+
+      TestCacheListener l = new TestCacheListener();
+      embedded.addListener(l);
+
+      NotifyingFuture future = remote.putAsync("k", "v");
+      future.get(60, TimeUnit.SECONDS);
+      assertEquals(1, l.createdCounter);
+      assertEquals("v", l.created.get("k"));
+      assertTrue(l.removed.isEmpty());
+      assertEquals(1, l.modifiedCounter);
+      assertEquals("v", l.modified.get("k"));
+      assertTrue(l.visited.isEmpty());
+
+      NotifyingFuture future2 = remote.putAsync("key", "value");
+      future2.get(60, TimeUnit.SECONDS);
+      assertEquals(2, l.createdCounter);
+      assertTrue(l.removed.isEmpty());
+      assertEquals(2, l.modifiedCounter);
+      assertTrue(l.visited.isEmpty());
+
+      NotifyingFuture future3 = remote.putAsync("key", "modifiedValue");
+      future3.get(60, TimeUnit.SECONDS);
+      assertEquals(2, l.createdCounter);
+      assertTrue(l.removed.isEmpty());
+      assertEquals(3, l.modifiedCounter);
+      assertEquals("modifiedValue", l.modified.get("key"));
+      assertTrue(l.visited.isEmpty());
+
+      NotifyingFuture future4 = remote.replaceAsync("k", "replacedValue");
+      future4.get(60, TimeUnit.SECONDS);
+      assertEquals(2, l.createdCounter);
+      assertTrue(l.removed.isEmpty());
+      assertEquals(4, l.modifiedCounter);
+      assertEquals("replacedValue", l.modified.get("k"));
+      assertTrue(l.visited.isEmpty());
+
+      //resetting so don't have to type "== 2" etc. all over again
+      l.reset();
+
+      NotifyingFuture future5 = remote.removeAsync("key");
+      future5.get(60, TimeUnit.SECONDS);
+      assertTrue(l.created.isEmpty());
+      assertEquals(1, l.removedCounter);
+      assertEquals("modifiedValue", l.removed.get("key"));
+      assertTrue(l.modified.isEmpty());
+
+      l.reset();
+
+      NotifyingFuture future6 = remote.getAsync("k");
+      future6.get(60, TimeUnit.SECONDS);
+      assertTrue(l.created.isEmpty());
+      assertTrue(l.removed.isEmpty());
+      assertTrue(l.modified.isEmpty());
+      assertEquals(1, l.visitedCounter);
+      assertEquals("replacedValue", l.visited.get("k"));
+
+      l.reset();
+   }
+
+}

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedMemcachedCacheListenerTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedMemcachedCacheListenerTest.java
@@ -1,0 +1,156 @@
+package org.infinispan.it.compatibility;
+
+import net.spy.memcached.CachedData;
+import net.spy.memcached.MemcachedClient;
+import net.spy.memcached.transcoders.SerializingTranscoder;
+import net.spy.memcached.transcoders.Transcoder;
+import org.infinispan.Cache;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.VersionedValue;
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.marshall.AbstractMarshaller;
+import org.infinispan.commons.util.concurrent.NotifyingFuture;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryVisited;
+import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.jgroups.util.Util.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Test cache listeners bound to embedded cache and operation over Memcached cache.
+ *
+ * @author Jiri Holusa [jholusa@redhat.com]
+ */
+@Test(groups = "functional", testName = "it.compatibility.EmbeddedMemcachedCacheListenerTest")
+public class EmbeddedMemcachedCacheListenerTest extends AbstractInfinispanTest {
+
+   CompatibilityCacheFactory<String, String> cacheFactory;
+
+   @BeforeMethod
+   protected void setup() throws Exception {
+      cacheFactory = new CompatibilityCacheFactory<String, String>(
+            "memcachedCache", new SpyMemcachedCompatibleMarshaller(), CacheMode.LOCAL).setup();
+   }
+
+   @AfterMethod
+   protected void teardown() {
+      CompatibilityCacheFactory.killCacheFactories(cacheFactory);
+   }
+
+   public void testLoadingAndStoringEventsMemcached() throws InterruptedException, ExecutionException, TimeoutException {
+      Cache<String, String> embedded = cacheFactory.getEmbeddedCache();
+      MemcachedClient remote = cacheFactory.getMemcachedClient();
+
+      TestCacheListener l = new TestCacheListener();
+      embedded.addListener(l);
+
+      assertTrue(l.created.isEmpty());
+      assertTrue(l.removed.isEmpty());
+      assertTrue(l.modified.isEmpty());
+      assertTrue(l.visited.isEmpty());
+
+      Future<Boolean> future1 = remote.add("k", 0, "v");
+      assertTrue(future1.get(60, TimeUnit.SECONDS));
+
+      assertEquals(1, l.createdCounter);
+      assertEquals("v", l.created.get("k"));
+      assertTrue(l.removed.isEmpty());
+      assertEquals(1, l.modifiedCounter);
+      assertEquals("v", l.modified.get("k"));
+      assertTrue(l.visited.isEmpty());
+
+      Future<Boolean> future2 = remote.set("key", 0, "value");
+      assertTrue(future2.get(60, TimeUnit.SECONDS));
+
+      assertEquals(2, l.createdCounter);
+      assertTrue(l.removed.isEmpty());
+      assertEquals(2, l.modifiedCounter);
+      assertTrue(l.visited.isEmpty());
+
+      Future<Boolean> future3 = remote.set("key", 0, "modifiedValue");
+      assertTrue(future3.get(60, TimeUnit.SECONDS));
+
+      assertEquals(2, l.createdCounter);
+      assertTrue(l.removed.isEmpty());
+      assertEquals(3, l.modifiedCounter);
+      assertEquals("modifiedValue", l.modified.get("key"));
+      assertTrue(l.visited.isEmpty());
+
+      Future<Boolean> future4 = remote.replace("k", 0, "replacedValue");
+      assertTrue(future4.get(60, TimeUnit.SECONDS));
+
+      assertEquals(2, l.createdCounter);
+      assertTrue(l.removed.isEmpty());
+      assertEquals(4, l.modifiedCounter);
+      assertEquals("replacedValue", l.modified.get("k"));
+      assertTrue(l.visited.isEmpty());
+
+      //resetting so don't have to type "== 2" etc. all over again
+      l.reset();
+
+      Future<Boolean> future5 = remote.delete("key");
+      assertTrue(future5.get(60, TimeUnit.SECONDS));
+
+      assertTrue(l.created.isEmpty());
+      assertEquals(1, l.removedCounter);
+      assertEquals("modifiedValue", l.removed.get("key"));
+      assertTrue(l.modified.isEmpty());
+
+      l.reset();
+
+      String value = (String) remote.get("k");
+      assertTrue(l.created.isEmpty());
+      assertTrue(l.removed.isEmpty());
+      assertTrue(l.modified.isEmpty());
+      assertEquals(1, l.visitedCounter);
+      assertEquals("replacedValue", l.visited.get("k"));
+      assertEquals("replacedValue", value);
+
+      l.reset();
+   }
+
+   private class SpyMemcachedCompatibleMarshaller extends AbstractMarshaller {
+
+      private final Transcoder<Object> transcoder = new SerializingTranscoder();
+
+      @Override
+      protected ByteBuffer objectToBuffer(Object o, int estimatedSize) {
+         CachedData encoded = transcoder.encode(o);
+         return new ByteBuffer(encoded.getData(), 0, encoded.getData().length);
+      }
+
+      @Override
+      public Object objectFromByteBuffer(byte[] buf, int offset, int length) {
+         return transcoder.decode(new CachedData(0, buf, length));
+      }
+
+      @Override
+      public boolean isMarshallable(Object o) throws Exception {
+         try {
+            transcoder.encode(o);
+            return true;
+         } catch (Throwable t) {
+            return false;
+         }
+      }
+   }
+}

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestCacheListenerTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestCacheListenerTest.java
@@ -1,0 +1,142 @@
+package org.infinispan.it.compatibility;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
+import org.apache.commons.httpclient.methods.DeleteMethod;
+import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.methods.PutMethod;
+import org.infinispan.Cache;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.VersionedValue;
+import org.infinispan.commons.util.concurrent.NotifyingFuture;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryVisited;
+import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.jgroups.util.Util.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Test cache listeners bound to embedded cache and operation over REST cache.
+ *
+ * @author Jiri Holusa [jholusa@redhat.com]
+ */
+@Test(groups = "functional", testName = "it.compatibility.EmbeddedRestCacheListenerTest")
+public class EmbeddedRestCacheListenerTest extends AbstractInfinispanTest {
+
+   CompatibilityCacheFactory<String, String> cacheFactory;
+
+   @BeforeMethod
+   protected void setup() throws Exception {
+      cacheFactory = new CompatibilityCacheFactory<String, String>(CacheMode.LOCAL).setup();
+   }
+
+   @AfterMethod
+   protected void teardown() {
+      CompatibilityCacheFactory.killCacheFactories(cacheFactory);
+   }
+
+   public void testLoadingAndStoringEventsRest() throws IOException {
+      Cache<String, String> embedded = cacheFactory.getEmbeddedCache();
+      HttpClient remote = cacheFactory.getRestClient();
+      String restUrl = cacheFactory.getRestUrl();
+
+      TestCacheListener l = new TestCacheListener();
+      embedded.addListener(l);
+
+      assertTrue(l.created.isEmpty());
+      assertTrue(l.removed.isEmpty());
+      assertTrue(l.modified.isEmpty());
+      assertTrue(l.visited.isEmpty());
+
+      EntityEnclosingMethod put = new PutMethod(restUrl + "/k");
+      put.setRequestEntity(new ByteArrayRequestEntity(
+            "v".getBytes(), "application/octet-stream"));
+      remote.executeMethod(put);
+
+      assertEquals(1, l.createdCounter);
+      assertEquals("v".getBytes(), (byte[]) l.created.get("k"));
+      assertTrue(l.removed.isEmpty());
+      assertEquals(1, l.modifiedCounter);
+      assertEquals("v".getBytes(), (byte[]) l.modified.get("k"));
+      assertTrue(l.visited.isEmpty());
+
+
+      EntityEnclosingMethod put2 = new PutMethod(restUrl + "/key");
+      put2.setRequestEntity(new ByteArrayRequestEntity(
+            "value".getBytes(), "application/octet-stream"));
+      remote.executeMethod(put2);
+
+      assertEquals(2, l.createdCounter);
+      assertTrue(l.removed.isEmpty());
+      assertEquals(2, l.modifiedCounter);
+      assertTrue(l.visited.isEmpty());
+
+      EntityEnclosingMethod put3 = new PutMethod(restUrl + "/key");
+      put3.setRequestEntity(new ByteArrayRequestEntity(
+            "modifiedValue".getBytes(), "application/octet-stream"));
+      remote.executeMethod(put3);
+
+      assertEquals(2, l.createdCounter);
+      assertTrue(l.removed.isEmpty());
+      assertEquals(3, l.modifiedCounter);
+      assertEquals("modifiedValue".getBytes(), (byte[]) l.modified.get("key"));
+      assertTrue(l.visited.isEmpty());
+
+      EntityEnclosingMethod post = new PutMethod(restUrl + "/k");
+      post.setRequestEntity(new ByteArrayRequestEntity(
+            "replacedValue".getBytes(), "application/octet-stream"));
+      remote.executeMethod(post);
+
+      assertEquals(2, l.createdCounter);
+      assertTrue(l.removed.isEmpty());
+      assertEquals(4, l.modifiedCounter);
+      assertEquals("replacedValue".getBytes(), (byte[]) l.modified.get("k"));
+      assertTrue(l.visited.isEmpty());
+
+      //resetting so don't have to type "== 2" etc. all over again
+      l.reset();
+
+      DeleteMethod delete = new DeleteMethod(restUrl + "/key");
+      remote.executeMethod(delete);
+
+      assertTrue(l.created.isEmpty());
+      assertEquals(1, l.removedCounter);
+      assertEquals("modifiedValue".getBytes(), (byte[]) l.removed.get("key"));
+      assertTrue(l.modified.isEmpty());
+
+      l.reset();
+
+      GetMethod get = new GetMethod(restUrl + "/k");
+      remote.executeMethod(get);
+
+      assertTrue(l.created.isEmpty());
+      assertTrue(l.removed.isEmpty());
+      assertTrue(l.modified.isEmpty());
+      assertEquals(1, l.visitedCounter);
+      assertEquals("replacedValue".getBytes(), (byte[]) l.visited.get("k"));
+
+      l.reset();
+   }
+
+}

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/TestCacheListener.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/TestCacheListener.java
@@ -1,0 +1,78 @@
+package org.infinispan.it.compatibility;
+
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryVisited;
+import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Cache listener for testing purposes with dedicated counter and field for every event so it can assure
+ * that correct event was fired and data is readable.
+ *
+ * @author Jiri Holusa [jholusa@redhat.com]
+ */
+@Listener
+public class TestCacheListener {
+   //Map is used instead of List so we could test if key is correct too
+   Map<Object, Object> created = new HashMap<Object, Object>();
+   Map<Object, Object> removed = new HashMap<Object, Object>();
+   Map<Object, Object> modified = new HashMap<Object, Object>();
+   Map<Object, Object> visited = new HashMap<Object, Object>();
+
+   int createdCounter = 0;
+   int removedCounter = 0;
+   int modifiedCounter = 0;
+   int visitedCounter = 0;
+
+   @CacheEntryCreated
+   public void handleCreated(CacheEntryCreatedEvent e) {
+      if (!e.isPre()) {
+         created.put(e.getKey(), e.getValue());
+         createdCounter++;
+      }
+   }
+
+   @CacheEntryRemoved
+   public void handleRemoved(CacheEntryRemovedEvent e) {
+      if (!e.isPre()) {
+         removed.put(e.getKey(), e.getOldValue());
+         removedCounter++;
+      }
+   }
+
+   @CacheEntryModified
+   public void handleModified(CacheEntryModifiedEvent e) {
+      if (!e.isPre()) {
+         modified.put(e.getKey(), e.getValue());
+         modifiedCounter++;
+      }
+   }
+
+   @CacheEntryVisited
+   public void handleVisited(CacheEntryVisitedEvent e) {
+      if (!e.isPre()) {
+         visited.put(e.getKey(), e.getValue());
+         visitedCounter++;
+      }
+   }
+
+   void reset() {
+      created.clear();
+      removed.clear();
+      modified.clear();
+      visited.clear();
+
+      createdCounter = 0;
+      removedCounter = 0;
+      modifiedCounter = 0;
+      visitedCounter = 0;
+   }
+}


### PR DESCRIPTION
This pull request contains tests to several bugs/inconsistent things related to CacheEntryEvents in library mode and mainly in compatibility mode.

Fixes test for library mode listeners where methods remove() and get() (get() after eviction) fires different events that the test says (via comments).

Main part is directed to compatibility mode where it tests if correct events are fired, successfully propagated to embedded cache and contain correct readable data.
The assumption "which events should be fired" was made based on library mode, so it would be consistent. 
All remote caches (HotRot, Memcached, Rest) fire CacheEntryVisitedEvent on replace() which is inconsistent with library mode. Additionally, via Rest cache, it fires CacheEntryVisitedEvent when simply modifying entry via put() which is inconsistent even with other remote caches.

These tests are supposed to fail over these things.
