### PR TITLE
ISPN-3433 Versioned L1 values don't expire

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/locking/ClusteringDependentLogic.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/ClusteringDependentLogic.java
@@ -400,11 +400,23 @@ public interface ClusteringDependentLogic {
             if (isForeignOwned && !entry.isRemoved()) {
                if (configuration.clustering().l1().enabled()) {
                   // transform for L1
-                  if (entry.getLifespan() < 0 || entry.getLifespan() > configuration.clustering().l1().lifespan()) {
-                     Metadata newMetadata = entry.getMetadata().builder()
+                  long lifespan;
+                  if (metadata != null) {
+                     lifespan = metadata.lifespan();
+                  } else {
+                     lifespan = entry.getLifespan();
+                  }
+                  if (lifespan < 0 || lifespan > configuration.clustering().l1().lifespan()) {
+                     Metadata.Builder builder;
+                     if (metadata != null) {
+                        builder = metadata.builder();
+                     } else {
+                        builder = entry.getMetadata().builder();
+                     }
+                     Metadata newMetadata = builder
                            .lifespan(configuration.clustering().l1().lifespan())
                            .build();
-                     entry.setMetadata(newMetadata);
+                     metadata = newMetadata;
                   }
                } else {
                   doCommit = false;

--- a/core/src/test/java/org/infinispan/container/versioning/DistL1WriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/DistL1WriteSkewTest.java
@@ -2,9 +2,15 @@ package org.infinispan.container.versioning;
 
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.DistributionTestHelper;
+import org.infinispan.distribution.MagicKey;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.AssertJUnit.assertEquals;
 
 @Test(testName = "container.versioning.DistL1WriteSkewTest", groups = "functional")
 @CleanupAfterMethod
@@ -13,6 +19,41 @@ public class DistL1WriteSkewTest extends DistWriteSkewTest {
    protected void decorate(ConfigurationBuilder builder) {
       // Enable L1
       builder.clustering().l1().enable();
+      builder.clustering().sync().replTimeout(100, TimeUnit.MINUTES);
+   }
+
+   @Test
+   public void testL1ValuePutCanExpire() {
+      Cache<Object, Object> cache0 = cache(0);
+      Cache<Object, Object> cache1 = cache(1);
+      Cache<Object, Object> cache2 = cache(2);
+
+      MagicKey hello = new MagicKey("hello", cache0, cache1);
+
+      DistributionTestHelper.assertIsNotInL1(cache2, hello);
+
+      // Auto-commit is true
+      cache2.put(hello, "world 1");
+
+      DistributionTestHelper.assertIsInL1(cache2, hello);
+   }
+
+   @Test
+   public void testL1ValueGetCanExpire() {
+      Cache<Object, Object> cache0 = cache(0);
+      Cache<Object, Object> cache1 = cache(1);
+      Cache<Object, Object> cache2 = cache(2);
+
+      MagicKey hello = new MagicKey("hello", cache0, cache1);
+
+      DistributionTestHelper.assertIsNotInL1(cache2, hello);
+
+      // Auto-commit is true
+      cache0.put(hello, "world 1");
+
+      assertEquals("world 1", cache2.get(hello));
+
+      DistributionTestHelper.assertIsInL1(cache2, hello);
    }
 
    public void testL1Enabled() {


### PR DESCRIPTION
- Added tests that ensure L1 values on write an read operations are marked as being able to be expire
- Change ClusterDependentLogic class to apply the L1 lifespan when custom metadata is provided

https://issues.jboss.org/browse/ISPN-3433
