### PR TITLE
ISPN-1540 Refactor distribution interceptor

### DIFF
--- a/core/src/main/java/org/infinispan/commands/DataCommand.java
+++ b/core/src/main/java/org/infinispan/commands/DataCommand.java
@@ -8,6 +8,6 @@ package org.infinispan.commands;
  * @author Manik Surtani (<a href="mailto:manik@jboss.org">manik@jboss.org</a>)
  * @since 4.0
  */
-public interface DataCommand extends VisitableCommand, TopologyAffectedCommand {
+public interface DataCommand extends VisitableCommand, TopologyAffectedCommand, LocalFlagAffectedCommand {
    Object getKey();
 }

--- a/core/src/main/java/org/infinispan/commands/read/GetKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/GetKeyValueCommand.java
@@ -100,6 +100,7 @@ public class GetKeyValueCommand extends AbstractDataCommand {
    /**
     * If the cache needs to go remotely in order to obtain the value associated to this key, then the remote value
     * is stored in this field.
+    * TODO: this method should be able to removed with the refactoring from ISPN-2177
     */
    public InternalCacheEntry getRemotelyFetchedValue() {
       return remotelyFetchedValue;

--- a/core/src/main/java/org/infinispan/distribution/L1Manager.java
+++ b/core/src/main/java/org/infinispan/distribution/L1Manager.java
@@ -2,6 +2,7 @@ package org.infinispan.distribution;
 
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.interceptors.distribution.L1WriteSynchronizer;
 import org.infinispan.remoting.transport.Address;
 
 import java.util.Collection;
@@ -27,4 +28,20 @@ public interface L1Manager {
                                              boolean assumeOriginKeptEntryInL1);
 
    Future<Object> flushCache(Collection<Object> key, Address origin, boolean assumeOriginKeptEntryInL1);
+
+   /**
+    * Registers the given write synchronizer to be notified whenever a remote value is looked up for the given key.
+    * If the synchronizer is no longer needed to be signaled, the user should unregister it using
+    * {#unregisterL1WriteSynchronizer}
+    * @param key The key that is desired to trigger the synchronizer
+    * @param sync The synchronizer to update
+    * @throws IllegalStateException This is thrown if there is already a synchronizer associated with the L1 Manager.
+    */
+   void registerL1WriteSynchronizer(Object key, L1WriteSynchronizer sync);
+
+   /**
+    * Unregister the given write synchronizer if present.
+    * @param key The key to unregister the given synchronizer if present.
+    */
+   void unregisterL1WriteSynchronizer(Object key);
 }

--- a/core/src/main/java/org/infinispan/distribution/RemoteValueRetrievedListener.java
+++ b/core/src/main/java/org/infinispan/distribution/RemoteValueRetrievedListener.java
@@ -1,0 +1,20 @@
+package org.infinispan.distribution;
+
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+
+/**
+ * Listener that is notified when a remote value is looked up
+ *
+ * @author William Burns
+ * @since 6.0
+ */
+@Scope(Scopes.NAMED_CACHE)
+public interface RemoteValueRetrievedListener {
+   /**
+    * Invoked when a remote value is found from a remote source
+    * @param ice The cache entry that was found
+    */
+   public void remoteValueFound(InternalCacheEntry ice);
+}

--- a/core/src/main/java/org/infinispan/factories/EmptyConstructorNamedCacheFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EmptyConstructorNamedCacheFactory.java
@@ -13,6 +13,7 @@ import org.infinispan.context.NonTransactionalInvocationContextContainer;
 import org.infinispan.context.TransactionalInvocationContextContainer;
 import org.infinispan.distribution.L1Manager;
 import org.infinispan.distribution.L1ManagerImpl;
+import org.infinispan.distribution.RemoteValueRetrievedListener;
 import org.infinispan.eviction.ActivationManager;
 import org.infinispan.eviction.ActivationManagerImpl;
 import org.infinispan.eviction.EvictionManager;
@@ -57,7 +58,8 @@ import static org.infinispan.commons.util.Util.getInstance;
                               TransactionCoordinator.class, RecoveryAdminOperations.class, StateTransferLock.class,
                               ClusteringDependentLogic.class, LockContainer.class,
                               L1Manager.class, TransactionFactory.class, BackupSender.class,
-                              TotalOrderManager.class, ByteBufferFactory.class, MarshalledEntryFactory.class})
+                              TotalOrderManager.class, ByteBufferFactory.class, MarshalledEntryFactory.class,
+                              RemoteValueRetrievedListener.class})
 public class EmptyConstructorNamedCacheFactory extends AbstractNamedCacheComponentFactory implements AutoInstantiableFactory {
 
    @Override
@@ -119,8 +121,11 @@ public class EmptyConstructorNamedCacheFactory extends AbstractNamedCacheCompone
             return (T) new TotalOrderManager();
          } else if (componentType.equals(ByteBufferFactory.class)) {
             return (T) new ByteBufferFactoryImpl();
-         }else if (componentType.equals(MarshalledEntryFactory.class)) {
+         } else if (componentType.equals(MarshalledEntryFactory.class)) {
             return (T) new MarshalledEntryFactoryImpl();
+         } else if (componentType.equals(RemoteValueRetrievedListener.class)) {
+            // L1Manager is currently only listener for remotely retrieved values
+            return (T) componentRegistry.getComponent(L1Manager.class);
          }
       }
 

--- a/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
@@ -3,12 +3,7 @@ package org.infinispan.factories;
 
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.CacheException;
-import org.infinispan.configuration.cache.CompatibilityModeConfiguration;
-import org.infinispan.configuration.cache.Configuration;
-import org.infinispan.configuration.cache.Configurations;
-import org.infinispan.configuration.cache.CustomInterceptorsConfiguration;
-import org.infinispan.configuration.cache.InterceptorConfiguration;
-import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.configuration.cache.*;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.interceptors.*;
 import org.infinispan.interceptors.base.CommandInterceptor;
@@ -222,8 +217,13 @@ public class InterceptorChainFactory extends AbstractNamedCacheComponentFactory 
          interceptorChain.appendInterceptor(createInterceptor(new DeadlockDetectingInterceptor(), DeadlockDetectingInterceptor.class), false);
       }
 
-      if (configuration.clustering().l1().enabled() && !configuration.transaction().transactionMode().isTransactional()) {
-         interceptorChain.appendInterceptor(createInterceptor(new L1NonTxInterceptor(), L1NonTxInterceptor.class), false);
+      if (configuration.clustering().l1().enabled()) {
+         if (configuration.transaction().transactionMode().isTransactional()) {
+            interceptorChain.appendInterceptor(createInterceptor(new L1TxInterceptor(), L1TxInterceptor.class), false);
+         }
+         else {
+            interceptorChain.appendInterceptor(createInterceptor(new L1NonTxInterceptor(), L1NonTxInterceptor.class), false);
+         }
       }
 
       switch (configuration.clustering().cacheMode()) {

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1TxInterceptor.java
@@ -1,0 +1,93 @@
+package org.infinispan.interceptors.distribution;
+
+import org.infinispan.commands.LocalFlagAffectedCommand;
+import org.infinispan.commands.tx.CommitCommand;
+import org.infinispan.commands.tx.PrepareCommand;
+import org.infinispan.commands.write.PutKeyValueCommand;
+import org.infinispan.commands.write.PutMapCommand;
+import org.infinispan.commands.write.RemoveCommand;
+import org.infinispan.commands.write.ReplaceCommand;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.remoting.transport.jgroups.SuspectException;
+
+import java.util.concurrent.Future;
+
+import static org.infinispan.commons.util.Util.toStr;
+
+/**
+ * Interceptor that handles L1 logic for transactional caches.
+ *
+ * @author William Burns
+ * @since 6.0
+ */
+public class L1TxInterceptor extends L1NonTxInterceptor {
+
+   @Override
+   public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) throws Throwable {
+      return performCommandWithL1WriteIfAble(ctx, command, true, true);
+   }
+
+   @Override
+   public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) throws Throwable {
+      // TODO: need to figure out if we do anything here? - is the prepare/commmit L1 invalidation sufficient?
+      return invokeNextInterceptor(ctx, command);
+   }
+
+   @Override
+   public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) throws Throwable {
+      return performCommandWithL1WriteIfAble(ctx, command, true, true);
+   }
+
+   @Override
+   public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
+      return performCommandWithL1WriteIfAble(ctx, command, true, false);
+   }
+
+   @Override
+   public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
+      if (command.isOnePhaseCommit() && shouldFlushL1(ctx)) {
+         flushL1Caches(ctx); // if we are one-phase, don't block on this future.
+      }
+
+      return invokeNextInterceptor(ctx, command);
+   }
+
+   @Override
+   public Object visitCommitCommand(TxInvocationContext ctx, CommitCommand command) throws Throwable {
+      if (shouldFlushL1(ctx)) {
+         blockOnL1FutureIfNeeded(flushL1Caches(ctx));
+      }
+      return invokeNextInterceptor(ctx, command);
+   }
+
+   @Override
+   protected boolean skipL1Lookup(LocalFlagAffectedCommand command, Object key) {
+      // TODO: need to skip L1 lookups when the command doesn't require the value to be returned like unsafe return values or write skew check ??
+      return super.skipL1Lookup(command, key);
+   }
+
+   private boolean shouldFlushL1(TxInvocationContext ctx) {
+      return shouldInvokeRemoteTxCommand(ctx) ||
+      // We fall into this situation if we are a remote node, happen to be the primary data owner and have locked keys.
+      // it is still our responsibility to invalidate L1 caches in the cluster.
+      !ctx.isOriginLocal() && !ctx.getLockedKeys().isEmpty();
+   }
+
+   private Future<?> flushL1Caches(InvocationContext ctx) {
+      return l1Manager.flushCacheWithSimpleFuture(ctx.getLockedKeys(), null, ctx.getOrigin(), true);
+   }
+
+   private void blockOnL1FutureIfNeeded(Future<?> f) {
+      if (f != null && cacheConfiguration.transaction().syncCommitPhase()) {
+         try {
+            f.get();
+         } catch (Exception e) {
+            // Ignore SuspectExceptions - if the node has gone away then there is nothing to invalidate anyway.
+            if (!(e.getCause() instanceof SuspectException)) {
+               getLog().failedInvalidatingRemoteCache(e);
+            }
+         }
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/container/versioning/DistWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/DistWriteSkewTest.java
@@ -12,6 +12,8 @@ import org.testng.annotations.Test;
 import javax.transaction.RollbackException;
 import javax.transaction.Transaction;
 
+import static org.testng.AssertJUnit.*;
+
 @Test(testName = "container.versioning.DistWriteSkewTest", groups = "functional")
 @CleanupAfterMethod
 public class DistWriteSkewTest extends AbstractClusteredWriteSkewTest {
@@ -38,31 +40,31 @@ public class DistWriteSkewTest extends AbstractClusteredWriteSkewTest {
       cache1.put(hello, "world 1");
 
       tm(1).begin();
-      assert "world 1".equals(cache1.get(hello));
+      assertEquals("world 1", cache1.get(hello));
       Transaction t = tm(1).suspend();
 
       // Induce a write skew
       cache3.put(hello, "world 3");
 
-      assert cache0.get(hello).equals("world 3");
-      assert cache1.get(hello).equals("world 3");
-      assert cache2.get(hello).equals("world 3");
-      assert cache3.get(hello).equals("world 3");
+      assertEquals("world 3", cache0.get(hello));
+      assertEquals("world 3", cache1.get(hello));
+      assertEquals("world 3", cache2.get(hello));
+      assertEquals("world 3", cache3.get(hello));
 
       tm(1).resume(t);
       cache1.put(hello, "world 2");
 
       try {
          tm(1).commit();
-         assert false : "Transaction should roll back";
+         fail("Transaction should roll back");
       } catch (RollbackException re) {
          // expected
       }
 
-      assert "world 3".equals(cache0.get(hello));
-      assert "world 3".equals(cache1.get(hello));
-      assert "world 3".equals(cache2.get(hello));
-      assert "world 3".equals(cache3.get(hello));
+      assertEquals("world 3", cache0.get(hello));
+      assertEquals("world 3", cache1.get(hello));
+      assertEquals("world 3", cache2.get(hello));
+      assertEquals("world 3", cache3.get(hello));
    }
 
    public void testWriteSkewOnNonOwner() throws Exception {
@@ -93,25 +95,25 @@ public class DistWriteSkewTest extends AbstractClusteredWriteSkewTest {
       // Induce a write skew
       cache(nonOwners[1]).put(hello, "world 3");
 
-      assert cache0.get(hello).equals("world 3");
-      assert cache1.get(hello).equals("world 3");
-      assert cache2.get(hello).equals("world 3");
-      assert cache3.get(hello).equals("world 3");
+      assertEquals("world 3", cache0.get(hello));
+      assertEquals("world 3", cache1.get(hello));
+      assertEquals("world 3", cache2.get(hello));
+      assertEquals("world 3", cache3.get(hello));
 
       tm(nonOwners[0]).resume(t);
       cache(nonOwners[0]).put(hello, "world 2");
 
       try {
          tm(nonOwners[0]).commit();
-         assert false : "Transaction should roll back";
+         fail("Transaction should roll back");
       } catch (RollbackException re) {
          // expected
       }
 
-      assert "world 3".equals(cache0.get(hello));
-      assert "world 3".equals(cache1.get(hello));
-      assert "world 3".equals(cache2.get(hello));
-      assert "world 3".equals(cache3.get(hello));
+      assertEquals("world 3", cache0.get(hello));
+      assertEquals("world 3", cache1.get(hello));
+      assertEquals("world 3", cache2.get(hello));
+      assertEquals("world 3", cache3.get(hello));
    }
 
    public void testWriteSkewMultiEntries() throws Exception {
@@ -133,9 +135,9 @@ public class DistWriteSkewTest extends AbstractClusteredWriteSkewTest {
       tm(1).begin();
       cache1.put(hello2, "world 2");
       cache1.put(hello3, "world 2");
-      assert "world 1".equals(cache1.get(hello));
-      assert "world 2".equals(cache1.get(hello2));
-      assert "world 2".equals(cache1.get(hello3));
+      assertEquals("world 1", cache1.get(hello));
+      assertEquals("world 2", cache1.get(hello2));
+      assertEquals("world 2", cache1.get(hello3));
       Transaction t = tm(1).suspend();
 
       // Induce a write skew
@@ -143,9 +145,9 @@ public class DistWriteSkewTest extends AbstractClusteredWriteSkewTest {
       cache3.put(hello, "world 3");
 
       for (Cache<Object, Object> c : caches()) {
-         assert "world 3".equals(c.get(hello));
-         assert "world 1".equals(c.get(hello2));
-         assert "world 1".equals(c.get(hello3));
+         assertEquals("world 3", c.get(hello));
+         assertEquals("world 1", c.get(hello2));
+         assertEquals("world 1", c.get(hello3));
       }
 
       tm(1).resume(t);
@@ -153,15 +155,15 @@ public class DistWriteSkewTest extends AbstractClusteredWriteSkewTest {
 
       try {
          tm(1).commit();
-         assert false : "Transaction should roll back";
+         fail("Transaction should roll back");
       } catch (RollbackException re) {
          // expected
       }
 
       for (Cache<Object, Object> c : caches()) {
-         assert "world 3".equals(c.get(hello));
-         assert "world 1".equals(c.get(hello2));
-         assert "world 1".equals(c.get(hello3));
+         assertEquals("world 3", c.get(hello));
+         assertEquals("world 1", c.get(hello2));
+         assertEquals("world 1", c.get(hello3));
       }
    }
 
@@ -171,36 +173,36 @@ public class DistWriteSkewTest extends AbstractClusteredWriteSkewTest {
       Cache<Object, Object> cache2 = cache(2);
       Cache<Object, Object> cache3 = cache(3);
 
-      MagicKey hello = new MagicKey("hello", cache(2));
+      MagicKey hello = new MagicKey("hello", cache2, cache1);
 
       // Auto-commit is true
       cache0.put(hello, "world");
 
       tm(0).begin();
-      assert "world".equals(cache0.get(hello));
+      assertEquals("world", cache0.get(hello));
       Transaction t = tm(0).suspend();
 
       cache1.remove(hello);
 
-      assert null == cache0.get(hello);
-      assert null == cache1.get(hello);
-      assert null == cache2.get(hello);
-      assert null == cache3.get(hello);
+      assertNull(cache0.get(hello));
+      assertNull(cache1.get(hello));
+      assertNull(cache2.get(hello));
+      assertNull(cache3.get(hello));
 
       tm(0).resume(t);
       cache0.put(hello, "world2");
 
       try {
          tm(0).commit();
-         assert false : "This transaction should roll back";
+         fail("This transaction should roll back");
       } catch (RollbackException expected) {
          // expected
       }
 
-      assert null == cache0.get(hello);
-      assert null == cache1.get(hello);
-      assert null == cache2.get(hello);
-      assert null == cache3.get(hello);
+      assertNull(cache0.get(hello));
+      assertNull(cache1.get(hello));
+      assertNull(cache2.get(hello));
+      assertNull(cache3.get(hello));
    }
 
    public void testResendPrepare() throws Exception {
@@ -216,31 +218,31 @@ public class DistWriteSkewTest extends AbstractClusteredWriteSkewTest {
 
       // create a write skew
       tm(2).begin();
-      assert "world".equals(cache2.get(hello));
+      assertEquals("world", cache2.get(hello));
       Transaction t = tm(2).suspend();
 
       // Implicit tx.  Prepare should be retried.
       cache(0).put(hello, "world 2");
 
-      assert cache0.get(hello).equals("world 2");
-      assert cache1.get(hello).equals("world 2");
-      assert cache2.get(hello).equals("world 2");
-      assert cache3.get(hello).equals("world 2");
+      assertEquals("world 2", cache0.get(hello));
+      assertEquals("world 2", cache1.get(hello));
+      assertEquals("world 2", cache2.get(hello));
+      assertEquals("world 2", cache3.get(hello));
 
       tm(2).resume(t);
       cache2.put(hello, "world 3");
 
       try {
          tm(2).commit();
-         assert false : "This transaction should roll back";
+         fail("This transaction should roll back");
       } catch (RollbackException expected) {
          // expected
       }
 
-      assert cache0.get(hello).equals("world 2");
-      assert cache1.get(hello).equals("world 2");
-      assert cache2.get(hello).equals("world 2");
-      assert cache3.get(hello).equals("world 2");
+      assertEquals("world 2", cache0.get(hello));
+      assertEquals("world 2", cache1.get(hello));
+      assertEquals("world 2", cache2.get(hello));
+      assertEquals("world 2", cache3.get(hello));
    }
 
    public void testLocalOnlyPut() {

--- a/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
@@ -1,0 +1,199 @@
+package org.infinispan.distribution;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.VisitableCommand;
+import org.infinispan.commands.read.GetKeyValueCommand;
+import org.infinispan.commands.write.InvalidateL1Command;
+import org.infinispan.interceptors.base.CommandInterceptor;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+
+/**
+ * Base class for various L1 tests for use with distributed cache.  Note these only currently work for synchronous based
+ * caches
+ *
+ * @author wburns
+ * @since 6.0
+ */
+public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest {
+
+   protected static final String key = "key-to-the-cache";
+   protected static final String firstValue = "first-put";
+   protected static final String secondValue = "second-put";
+
+   protected void addBlockingInterceptorBeforeTx(Cache<?, ?> cache, final CyclicBarrier barrier,
+                                                 Class<? extends VisitableCommand> commandClass) {
+      addBlockingInterceptorBeforeTx(cache, barrier, commandClass, true);
+   }
+
+   protected void addBlockingInterceptorBeforeTx(Cache<?, ?> cache, final CyclicBarrier barrier,
+                                                 Class<? extends VisitableCommand> commandClass, boolean blockAfterCommand) {
+      cache.getAdvancedCache().addInterceptorBefore(new BlockingInterceptor(barrier, commandClass, blockAfterCommand), getDistributionInterceptorClass());
+   }
+
+   protected abstract Class<? extends CommandInterceptor> getDistributionInterceptorClass();
+
+   protected abstract Class<? extends CommandInterceptor> getL1InterceptorClass();
+
+   protected void assertL1StateOnLocalWrite(Cache<?,?> cache, Cache<?, ?> updatingCache, Object key, Object valueWrite) {
+      // Default just assumes it invalidated the cache
+      assertIsNotInL1(cache, key);
+   }
+
+   protected void assertL1GetWithConcurrentUpdate(final Cache<Object, String> nonOwnerCache, Cache<Object, String> ownerCache,
+                                                  final Object key, String originalValue, String updateValue)
+         throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      CyclicBarrier barrier = new CyclicBarrier(2);
+      addBlockingInterceptorBeforeTx(nonOwnerCache, barrier, GetKeyValueCommand.class);
+
+      try {
+         Future<String> future = nonOwnerCache.getAsync(key);
+
+         // Now wait for the get to return and block it for now
+         barrier.await(5, TimeUnit.SECONDS);
+
+         assertEquals(originalValue, ownerCache.put(key, updateValue));
+
+         // Now let owner key->updateValue go through
+         barrier.await(5, TimeUnit.SECONDS);
+
+         // This should be originalValue still as we did the get
+         assertEquals(originalValue, future.get(5, TimeUnit.SECONDS));
+
+         // Remove the interceptor now since we don't want to block ourselves - if using phaser this isn't required
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+
+         assertL1StateOnLocalWrite(nonOwnerCache, ownerCache, key, updateValue);
+         // The nonOwnerCache should retrieve new value as it isn't in L1
+         assertEquals(updateValue, nonOwnerCache.get(key));
+         assertIsInL1(nonOwnerCache, key);
+      }
+      finally {
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+      }
+   }
+
+   @Test
+   public void testNoEntryInL1GetWithConcurrentInvalidation() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in the owner, so the L1 is empty
+      ownerCache.put(key, firstValue);
+
+      assertL1GetWithConcurrentUpdate(nonOwnerCache, ownerCache, key, firstValue, secondValue);
+   }
+
+   @Test
+   public void testEntryInL1GetWithConcurrentInvalidation() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in a non owner, so the L1 has the key
+      ownerCache.put(key, firstValue);
+      nonOwnerCache.get(key);
+
+      assertIsInL1(nonOwnerCache, key);
+
+      assertL1GetWithConcurrentUpdate(nonOwnerCache, ownerCache, key, firstValue, secondValue);
+   }
+
+   @Test
+   public void testEntryInL1GetWithConcurrentPut() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in a non owner, so the L1 has the key
+      ownerCache.put(key, firstValue);
+      nonOwnerCache.get(key);
+
+      assertIsInL1(nonOwnerCache, key);
+
+      assertL1GetWithConcurrentUpdate(nonOwnerCache, nonOwnerCache, key, firstValue, secondValue);
+   }
+
+   @Test
+   public void testNoEntryInL1GetWithConcurrentPut() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      // Put the first value in the owner, so the L1 is empty
+      ownerCache.put(key, firstValue);
+
+      assertL1GetWithConcurrentUpdate(nonOwnerCache, nonOwnerCache, key, firstValue, secondValue);
+   }
+
+   @Test()
+   public void testNoEntryInL1MultipleConcurrentGetsWithInvalidation() throws TimeoutException, InterruptedException, ExecutionException, BrokenBarrierException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      ownerCache.put(key, firstValue);
+
+      CyclicBarrier invalidationBarrier = new CyclicBarrier(2);
+      // We want to block right before the invalidation would hit the L1 interceptor to prevent it from invaliding until we want
+      nonOwnerCache.getAdvancedCache().addInterceptorBefore(
+            new BlockingInterceptor(invalidationBarrier, InvalidateL1Command.class, false), getL1InterceptorClass());
+
+      try {
+         assertEquals(firstValue, nonOwnerCache.get(key));
+
+         Future<String> futurePut = ownerCache.putAsync(key, secondValue);
+
+         // Wait for the invalidation to be processing
+         invalidationBarrier.await(5, TimeUnit.SECONDS);
+
+         // Now remove the value - assimilates that a get came earlier to owner registering as a invalidatee, however
+         // the invalidation blocked the update from going through
+         nonOwnerCache.getAdvancedCache().getDataContainer().remove(key);
+
+         // Hack, but we remove the blocking interceptor while a call is in it, it still retains a reference to the next
+         // interceptor to invoke and when we unblock it will continue forward
+         // This is done because we can't have 2 interceptors of the same class.
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+
+         CyclicBarrier getBarrier = new CyclicBarrier(2);
+         addBlockingInterceptorBeforeTx(nonOwnerCache, getBarrier, GetKeyValueCommand.class);
+
+         Future<String> futureGet = nonOwnerCache.getAsync(key);
+
+         // Wait for the get to retrieve the remote value but not try to update L1 yet
+         getBarrier.await(5, TimeUnit.SECONDS);
+
+         // Let the invalidation unblock now
+         invalidationBarrier.await(5, TimeUnit.SECONDS);
+
+         // Wait for the invalidation complete fully
+         assertEquals(firstValue, futurePut.get(5, TimeUnit.SECONDS));
+
+         // Now let our get go through
+         getBarrier.await(5, TimeUnit.SECONDS);
+
+         // Technically this could be firstValue or secondValue depending on the ordering of if the put has updated
+         // it's in memory contents (since the L1 is sent asynchronously with the update) - For Tx this is always
+         // firstValue - the point though is to ensure it doesn't write to the L1
+         assertNotNull(futureGet.get(5, TimeUnit.SECONDS));
+
+         // Remove the interceptor now since we don't want to block ourselves - if using phaser this isn't required
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+
+         // The value shouldn't be in the L1 still
+         assertIsNotInL1(nonOwnerCache, key);
+         // The nonOwnerCache should retrieve new value as it isn't in L1
+         assertEquals(secondValue, nonOwnerCache.get(key));
+         assertIsInL1(nonOwnerCache, key);
+      }
+      finally {
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/distribution/DistSyncL1FuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncL1FuncTest.java
@@ -9,6 +9,7 @@ import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.interceptors.InterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
+import org.infinispan.interceptors.distribution.L1NonTxInterceptor;
 import org.infinispan.interceptors.distribution.NonTxDistributionInterceptor;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.test.TestingUtil;
@@ -27,7 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @Test(groups = "functional", testName = "distribution.DistSyncL1FuncTest")
-public class DistSyncL1FuncTest extends BaseDistFunctionalTest {
+public class DistSyncL1FuncTest extends BaseDistSyncL1Test {
 
    public DistSyncL1FuncTest() {
       sync = true;
@@ -35,51 +36,14 @@ public class DistSyncL1FuncTest extends BaseDistFunctionalTest {
       testRetVals = true;
    }
 
-   protected final static String key = "key-to-the-cache";
-   protected static final String firstValue = "first-put";
-   protected static final String secondValue = "second-put";
-
-   private void addBlockingInterceptorBeforeTx(Cache<?, ?> cache, final CyclicBarrier barrier,
-                                               Class<? extends VisitableCommand> commandClass) {
-      addBlockingInterceptorBeforeTx(cache, barrier, commandClass, true);
+   @Override
+   protected Class<? extends CommandInterceptor> getDistributionInterceptorClass() {
+      return NonTxDistributionInterceptor.class;
    }
 
-   private void addBlockingInterceptorBeforeTx(Cache<?, ?> cache, final CyclicBarrier barrier,
-                                                Class<? extends VisitableCommand> commandClass, boolean blockAfter) {
-      cache.getAdvancedCache().addInterceptorBefore(new BlockingInterceptor(barrier, commandClass, blockAfter), NonTxDistributionInterceptor.class);
-   }
-
-   protected void assertL1GetWithConcurrentUpdate(final Cache<Object, String> nonOwnerCache, Cache<Object, String> ownerCache,
-                                                  final Object key, String originalValue, String updateValue)
-         throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
-      CyclicBarrier barrier = new CyclicBarrier(2);
-      addBlockingInterceptorBeforeTx(nonOwnerCache, barrier, GetKeyValueCommand.class);
-
-      try {
-         Future<String> future = nonOwnerCache.getAsync(key);
-
-         // Now wait for the get to return and block it for now
-         barrier.await(5, TimeUnit.SECONDS);
-
-         assertEquals(originalValue, ownerCache.put(key, updateValue));
-
-         // Now let owner key->updateValue go through
-         barrier.await(5, TimeUnit.SECONDS);
-
-         // This should be originalValue still as we did the get
-         assertEquals(originalValue, future.get(5, TimeUnit.SECONDS));
-
-         // Remove the interceptor now since we don't want to block ourselves - if using phaser this isn't required
-         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
-
-         assertIsNotInL1(nonOwnerCache, key);
-         // The nonOwnerCache should retrieve new value as it isn't in L1
-         assertEquals(updateValue, nonOwnerCache.get(key));
-         assertIsInL1(nonOwnerCache, key);
-      }
-      finally {
-         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
-      }
+   @Override
+   protected Class<? extends CommandInterceptor> getL1InterceptorClass() {
+      return L1NonTxInterceptor.class;
    }
 
    protected void assertL1PutWithConcurrentUpdate(final Cache<Object, String> nonOwnerCache, Cache<Object, String> ownerCache,
@@ -105,7 +69,7 @@ public class DistSyncL1FuncTest extends BaseDistFunctionalTest {
             }
          });
 
-         // Now wait for the get to return and block it for now
+         // Now wait for the put/replace to return and block it for now
          barrier.await(5, TimeUnit.SECONDS);
 
          // Owner should have the new value
@@ -120,7 +84,7 @@ public class DistSyncL1FuncTest extends BaseDistFunctionalTest {
          // Remove the interceptor now since we don't want to block ourselves - if using phaser this isn't required
          removeAllBlockingInterceptorsFromCache(nonOwnerCache);
 
-         assertIsNotInL1(nonOwnerCache, key);
+         assertL1StateOnLocalWrite(nonOwnerCache, ownerCache, key, updateValue);
          // The nonOwnerCache should retrieve new value as it isn't in L1
          assertEquals(updateValue, nonOwnerCache.get(key));
          assertIsInL1(nonOwnerCache, key);
@@ -128,56 +92,6 @@ public class DistSyncL1FuncTest extends BaseDistFunctionalTest {
       finally {
          removeAllBlockingInterceptorsFromCache(nonOwnerCache);
       }
-   }
-
-   @Test
-   public void testNoEntryInL1GetWithConcurrentInvalidation() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
-      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
-      final Cache<Object, String> ownerCache = getFirstOwner(key);
-
-      // Put the first value in the owner, so the L1 is empty
-      ownerCache.put(key, firstValue);
-
-      assertL1GetWithConcurrentUpdate(nonOwnerCache, ownerCache, key, firstValue, secondValue);
-   }
-
-   @Test
-   public void testEntryInL1GetWithConcurrentInvalidation() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
-      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
-      final Cache<Object, String> ownerCache = getFirstOwner(key);
-
-      // Put the first value in a non owner, so the L1 has the key
-      ownerCache.put(key, firstValue);
-      nonOwnerCache.get(key);
-
-      assertIsInL1(nonOwnerCache, key);
-
-      assertL1GetWithConcurrentUpdate(nonOwnerCache, ownerCache, key, firstValue, secondValue);
-   }
-
-   @Test
-   public void testNoEntryInL1GetWithConcurrentPut() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
-      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
-      final Cache<Object, String> ownerCache = getFirstOwner(key);
-
-      // Put the first value in the owner, so the L1 is empty
-      ownerCache.put(key, firstValue);
-
-      assertL1GetWithConcurrentUpdate(nonOwnerCache, nonOwnerCache, key, firstValue, secondValue);
-   }
-
-   @Test
-   public void testEntryInL1GetWithConcurrentPut() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
-      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
-      final Cache<Object, String> ownerCache = getFirstOwner(key);
-
-      // Put the first value in a non owner, so the L1 has the key
-      ownerCache.put(key, firstValue);
-      nonOwnerCache.get(key);
-
-      assertIsInL1(nonOwnerCache, key);
-
-      assertL1GetWithConcurrentUpdate(nonOwnerCache, nonOwnerCache, key, firstValue, secondValue);
    }
 
    @Test
@@ -281,7 +195,7 @@ public class DistSyncL1FuncTest extends BaseDistFunctionalTest {
    }
 
    @Test
-   public void testNoEntryInL1GetWithConcurrentRemove() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
+   public void testNoEntryInL1GetWithConcurrentReplace() throws InterruptedException, ExecutionException, TimeoutException, BrokenBarrierException {
       final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
       final Cache<Object, String> ownerCache = getFirstOwner(key);
 
@@ -329,69 +243,6 @@ public class DistSyncL1FuncTest extends BaseDistFunctionalTest {
          assertIsNotInL1(nonOwnerCache, key);
       } finally {
          TestingUtil.replaceComponent(nonOwnerCache, RpcManager.class, rm, true);
-      }
-   }
-
-   // TODO: this test fails beacuse ISPN-2965 needs to be fixed to send another invalidation if a requestor came
-   // while the invalidation was still being processed - once it is fixed this should work when enabled
-   @Test(enabled = false, description = "This test is disabled as it will always fail until ISPN-2965 is fixed")
-   public void testNoEntryInL1MultipleConcurrentGetsWithInvalidation() throws TimeoutException, InterruptedException, ExecutionException, BrokenBarrierException {
-      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
-      final Cache<Object, String> ownerCache = getFirstOwner(key);
-
-      ownerCache.put(key, firstValue);
-
-      CyclicBarrier invalidationBarrier = new CyclicBarrier(2);
-      addBlockingInterceptorBeforeTx(nonOwnerCache, invalidationBarrier, InvalidateL1Command.class);
-
-      try {
-         assertEquals(firstValue, nonOwnerCache.get(key));
-
-         Future<String> futurePut = ownerCache.putAsync(key, secondValue);
-
-         // Wait for the invalidation to be processing
-         invalidationBarrier.await(5, TimeUnit.SECONDS);
-
-         // Now remove the value - assimilates that a get came earlier to owner registering as a invalidatee, however
-         // the invalidation blocked the update from going through
-         nonOwnerCache.getAdvancedCache().getDataContainer().remove(key);
-
-         // Hack, but we remove the blocking interceptor while a call is in it, it still retains a reference to the next
-         // interceptor to invoke and when we unblock it will continue forward
-         // This is done because we can't have 2 interceptors of the same class.
-         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
-
-         CyclicBarrier getBarrier = new CyclicBarrier(2);
-         addBlockingInterceptorBeforeTx(nonOwnerCache, getBarrier, GetKeyValueCommand.class);
-
-         Future<String> futureGet = nonOwnerCache.getAsync(key);
-
-         // Wait for the get to retrieve the remote value but not try to update L1 yet
-         getBarrier.await(5, TimeUnit.SECONDS);
-
-         // Let the invalidation unblock now
-         invalidationBarrier.await(5, TimeUnit.SECONDS);
-
-         // Wait for the invalidation complete fully
-         assertEquals(firstValue, futurePut.get(5, TimeUnit.SECONDS));
-
-         // Now let our get go through
-         getBarrier.await(5, TimeUnit.SECONDS);
-
-         // This should be originalValue still as we did the get before the invalidation completed
-         assertEquals(firstValue, futureGet.get(5, TimeUnit.SECONDS));
-
-         // Remove the interceptor now since we don't want to block ourselves - if using phaser this isn't required
-         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
-
-         // The value shouldn't be in the L1 still
-         assertIsNotInL1(nonOwnerCache, key);
-         // The nonOwnerCache should retrieve new value as it isn't in L1
-         assertEquals(secondValue, nonOwnerCache.get(key));
-         assertIsInL1(nonOwnerCache, key);
-      }
-      finally {
-         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
       }
    }
 }

--- a/core/src/test/java/org/infinispan/distribution/DistSyncTxL1FuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncTxL1FuncTest.java
@@ -1,0 +1,197 @@
+package org.infinispan.distribution;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.write.PutKeyValueCommand;
+import org.infinispan.commands.write.ReplaceCommand;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.interceptors.base.CommandInterceptor;
+import org.infinispan.interceptors.distribution.L1TxInterceptor;
+import org.infinispan.interceptors.distribution.TxDistributionInterceptor;
+import org.testng.annotations.Test;
+
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.testng.AssertJUnit.*;
+
+@Test(groups = "functional", testName = "distribution.DistSyncTxL1FuncTest")
+public class DistSyncTxL1FuncTest extends BaseDistSyncL1Test {
+   public DistSyncTxL1FuncTest() {
+      sync = true;
+      tx = true;
+      testRetVals = true;
+   }
+
+   @Override
+   protected Class<? extends CommandInterceptor> getDistributionInterceptorClass() {
+      return TxDistributionInterceptor.class;
+   }
+
+   @Override
+   protected Class<? extends CommandInterceptor> getL1InterceptorClass() {
+      return L1TxInterceptor.class;
+   }
+
+   @Override
+   protected void assertL1StateOnLocalWrite(Cache<?, ?> cache, Cache<?, ?> updatingCache, Object key, Object valueWrite) {
+      if (cache != updatingCache) {
+         super.assertL1StateOnLocalWrite(cache, updatingCache, key, valueWrite);
+      }
+      else {
+         InternalCacheEntry ice = cache.getAdvancedCache().getDataContainer().get(key);
+         assertNotNull(ice);
+         assertEquals(valueWrite, ice.getValue());
+      }
+   }
+
+   @Test
+   public void testL1UpdatedOnReplaceOperationFailure() {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      ownerCache.put(key, firstValue);
+
+      assertIsNotInL1(nonOwnerCache, key);
+
+      assertFalse(nonOwnerCache.replace(key, "not-same", secondValue));
+
+      assertIsInL1(nonOwnerCache, key);
+   }
+
+   @Test
+   public void testL1UpdatedOnRemoveOperationFailure() {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      ownerCache.put(key, firstValue);
+
+      assertIsNotInL1(nonOwnerCache, key);
+
+      assertFalse(nonOwnerCache.remove(key, "not-same"));
+
+      assertIsInL1(nonOwnerCache, key);
+   }
+
+   @Test
+   public void testL1UpdatedBeforePutCommits() throws InterruptedException, TimeoutException, BrokenBarrierException,
+                                                        ExecutionException, SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      ownerCache.put(key, firstValue);
+
+      assertIsNotInL1(nonOwnerCache, key);
+
+      nonOwnerCache.getAdvancedCache().getTransactionManager().begin();
+      assertEquals(firstValue, nonOwnerCache.put(key, secondValue));
+
+      InternalCacheEntry ice = nonOwnerCache.getAdvancedCache().getDataContainer().get(key);
+      assertNotNull(ice);
+      assertEquals(firstValue, ice.getValue());
+      // Commit the put which should now update
+      nonOwnerCache.getAdvancedCache().getTransactionManager().commit();
+      ice = nonOwnerCache.getAdvancedCache().getDataContainer().get(key);
+      assertNotNull(ice);
+      assertEquals(secondValue, ice.getValue());
+   }
+
+   @Test
+   public void testL1UpdatedBeforeRemoveCommits() throws InterruptedException, TimeoutException, BrokenBarrierException,
+                                                      ExecutionException, SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      ownerCache.put(key, firstValue);
+
+      assertIsNotInL1(nonOwnerCache, key);
+
+      nonOwnerCache.getAdvancedCache().getTransactionManager().begin();
+      assertEquals(firstValue, nonOwnerCache.remove(key));
+
+      InternalCacheEntry ice = nonOwnerCache.getAdvancedCache().getDataContainer().get(key);
+      assertNotNull(ice);
+      assertEquals(firstValue, ice.getValue());
+      // Commit the put which should now update
+      nonOwnerCache.getAdvancedCache().getTransactionManager().commit();
+      assertIsNotInL1(nonOwnerCache, key);
+   }
+
+   @Test
+   public void testGetOccursAfterReplaceRunningBeforeRetrievedRemote() throws ExecutionException, InterruptedException, BrokenBarrierException, TimeoutException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      ownerCache.put(key, firstValue);
+
+      CyclicBarrier barrier = new CyclicBarrier(2);
+      addBlockingInterceptorBeforeTx(nonOwnerCache, barrier, ReplaceCommand.class, false);
+      try {
+         // The replace will internally block the get until it gets the remote value
+         Future<Boolean> futureReplace = nonOwnerCache.replaceAsync(key, firstValue, secondValue);
+
+         barrier.await(5, TimeUnit.SECONDS);
+
+         Future<String> futureGet = nonOwnerCache.getAsync(key);
+
+         try {
+            futureGet.get(100, TimeUnit.MILLISECONDS);
+            fail("Get shouldn't return until after the replace completes");
+         } catch (TimeoutException e) {
+
+         }
+
+         // Let the replace now finish
+         barrier.await(5, TimeUnit.SECONDS);
+
+         assertTrue(futureReplace.get());
+
+         assertEquals(firstValue, futureGet.get(5, TimeUnit.SECONDS));
+      } finally {
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+      }
+   }
+
+   @Test
+   public void testGetOccursBeforePutCompletesButRetrievesRemote() throws InterruptedException, TimeoutException, BrokenBarrierException, ExecutionException {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
+
+      ownerCache.put(key, firstValue);
+
+      CyclicBarrier barrier = new CyclicBarrier(2);
+      // This way the put should retrieve remote value, but before it has actually tried to update the value
+      addBlockingInterceptorBeforeTx(nonOwnerCache, barrier, PutKeyValueCommand.class, true);
+      try {
+         // The replace will internally block the get until it gets the remote value
+         Future<String> futureReplace = nonOwnerCache.putAsync(key, secondValue);
+
+         barrier.await(5, TimeUnit.SECONDS);
+
+         Future<String> futureGet = nonOwnerCache.getAsync(key);
+
+         // If this errors here it means the get was blocked by the write operation even though it already retrieved
+         // the remoteValue and should have unblocked any other waiters
+         assertEquals(firstValue, futureGet.get(3, TimeUnit.SECONDS));
+         // Just make sure it was put into L1 properly as well
+         assertIsInL1(nonOwnerCache, key);
+
+         // Let the put now finish
+         barrier.await(5, TimeUnit.SECONDS);
+
+         assertEquals(firstValue, futureReplace.get());
+
+         assertEquals(firstValue, futureGet.get(5, TimeUnit.SECONDS));
+      } finally {
+         removeAllBlockingInterceptorsFromCache(nonOwnerCache);
+      }
+   }
+}


### PR DESCRIPTION
- Create new TxL1Interceptor that contains L1 logic that is now removed from TxDistributionInterceptor
- Added L1WriteSynchronizer support to Tx cache that works for put, remove and replace methods
- Added tests for L1 TX sync tests

https://issues.jboss.org/browse/ISPN-1540

There are a couple checks in here that have TODO's if you guys want to look.  Also this commit has part of ISPN-3433 in it.
