### PR TITLE
Replace mod operations with bitwise AND where possible

### DIFF
--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/TableManipulation.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/TableManipulation.java
@@ -26,7 +26,7 @@ public class TableManipulation implements Cloneable {
 
    public static final int DEFAULT_FETCH_SIZE = 100;
 
-   public static final int DEFAULT_BATCH_SIZE = 100;
+   public static final int DEFAULT_BATCH_SIZE = 128;
 
    private String identifierQuoteString;
    private String cacheName;
@@ -368,7 +368,7 @@ public class TableManipulation implements Cloneable {
    /**
     * When doing repetitive DB inserts (e.g. on {@link org.infinispan.loaders.spi.CacheStore#fromStream(java.io.ObjectInput)}
     * this will be batched according to this parameter. This is an optional parameter, and if it is not specified it
-    * will be defaulted to {@link #DEFAULT_BATCH_SIZE}.
+    * will be defaulted to {@link #DEFAULT_BATCH_SIZE}.  Guaranteed to be a power of two.
     */
    public int getBatchSize() {
       return config.batchSize();

--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/TableManipulationConfiguration.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/configuration/TableManipulationConfiguration.java
@@ -1,5 +1,6 @@
 package org.infinispan.loaders.jdbc.configuration;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.loaders.jdbc.DatabaseType;
 
 public class TableManipulationConfiguration {
@@ -29,7 +30,7 @@ public class TableManipulationConfiguration {
       this.timestampColumnName = timestampColumnName;
       this.timestampColumnType = timestampColumnType;
       this.databaseType = databaseType;
-      this.batchSize = batchSize;
+      this.batchSize = Util.findNextHighestPowerOfTwo(batchSize);
       this.fetchSize = fetchSize;
       this.createOnStart = createOnStart;
       this.dropOnExit = dropOnExit;
@@ -83,6 +84,9 @@ public class TableManipulationConfiguration {
       return fetchSize;
    }
 
+   /**
+    * @return the size of batches to process.  Guaranteed to be a power of two.
+    */
    public int batchSize() {
       return batchSize;
    }

--- a/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/configuration/XmlFileParsingTest.java
+++ b/cachestore/jdbc/src/test/java/org/infinispan/loaders/jdbc/configuration/XmlFileParsingTest.java
@@ -30,7 +30,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
             "     <loaders>\n" +
             "       <stringKeyedJdbcStore xmlns=\"urn:infinispan:config:jdbc:6.0\" key2StringMapper=\"org.infinispan.loaders.jdbc.configuration.DummyKey2StringMapper\">\n" +
             "         <connectionPool connectionUrl=\"jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=-1\" username=\"dbuser\" password=\"dbpass\" driverClass=\"org.h2.Driver\"/>\n" +
-            "         <stringKeyedTable prefix=\"entry\" fetchSize=\"34\" batchSize=\"99\" >\n" +
+            "         <stringKeyedTable prefix=\"entry\" fetchSize=\"34\" batchSize=\"128\" >\n" +
             "           <idColumn name=\"id\" type=\"VARCHAR\" />\n" +
             "           <dataColumn name=\"datum\" type=\"BINARY\" />\n" +
             "           <timestampColumn name=\"version\" type=\"BIGINT\" />\n" +
@@ -42,7 +42,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
             TestingUtil.INFINISPAN_END_TAG;
 
       JdbcStringBasedCacheStoreConfiguration store = (JdbcStringBasedCacheStoreConfiguration) buildCacheManagerWithCacheStore(config);
-      assertEquals(99, store.table().batchSize());
+      assertEquals(128, store.table().batchSize());
       assertEquals(34, store.table().fetchSize());
       assertEquals("BINARY", store.table().dataColumnType());
       assertEquals("version", store.table().timestampColumnName());
@@ -61,7 +61,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
             "     <loaders>\n" +
             "       <binaryKeyedJdbcStore xmlns=\"urn:infinispan:config:jdbc:6.0\" ignoreModifications=\"true\">\n" +
             "         <simpleConnection connectionUrl=\"jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=-1\" username=\"dbuser\" password=\"dbpass\" driverClass=\"org.h2.Driver\"/>\n" +
-            "         <binaryKeyedTable prefix=\"bucket\" fetchSize=\"34\" batchSize=\"99\">\n" +
+            "         <binaryKeyedTable prefix=\"bucket\" fetchSize=\"34\" batchSize=\"128\">\n" +
             "           <idColumn name=\"id\" type=\"BINARY\" />\n" +
             "           <dataColumn name=\"datum\" type=\"BINARY\" />\n" +
             "           <timestampColumn name=\"version\" type=\"BIGINT\" />\n" +
@@ -75,7 +75,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       JdbcBinaryCacheStoreConfiguration store = (JdbcBinaryCacheStoreConfiguration) buildCacheManagerWithCacheStore(config);
       assertTrue(store.ignoreModifications());
       assertEquals("bucket", store.table().tableNamePrefix());
-      assertEquals(99, store.table().batchSize());
+      assertEquals(128, store.table().batchSize());
       assertEquals(34, store.table().fetchSize());
       assertEquals("BINARY", store.table().dataColumnType());
       assertEquals("version", store.table().timestampColumnName());
@@ -93,12 +93,12 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
             "     <loaders>\n" +
             "       <mixedKeyedJdbcStore xmlns=\"urn:infinispan:config:jdbc:6.0\" key2StringMapper=\"org.infinispan.loaders.jdbc.configuration.DummyKey2StringMapper\">\n" +
             "         <dataSource jndiUrl=\"java:MyDataSource\" />\n" +
-            "         <stringKeyedTable prefix=\"entry\" fetchSize=\"34\" batchSize=\"99\">\n" +
+            "         <stringKeyedTable prefix=\"entry\" fetchSize=\"34\" batchSize=\"128\">\n" +
             "           <idColumn name=\"id\" type=\"VARCHAR\" />\n" +
             "           <dataColumn name=\"datum\" type=\"BINARY\" />\n" +
             "           <timestampColumn name=\"version\" type=\"BIGINT\" />\n" +
             "         </stringKeyedTable>\n" +
-            "         <binaryKeyedTable prefix=\"bucket\" fetchSize=\"44\" batchSize=\"79\">\n" +
+            "         <binaryKeyedTable prefix=\"bucket\" fetchSize=\"44\" batchSize=\"256\">\n" +
             "           <idColumn name=\"id\" type=\"BINARY\" />\n" +
             "           <dataColumn name=\"datum\" type=\"BINARY\" />\n" +
             "           <timestampColumn name=\"version\" type=\"BIGINT\" />\n" +
@@ -113,13 +113,13 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       JdbcMixedCacheStoreConfiguration store = (JdbcMixedCacheStoreConfiguration) buildCacheManagerWithCacheStore(config);
 
       assertEquals("entry", store.stringTable().tableNamePrefix());
-      assertEquals(99, store.stringTable().batchSize());
+      assertEquals(128, store.stringTable().batchSize());
       assertEquals(34, store.stringTable().fetchSize());
       assertEquals("BINARY", store.stringTable().dataColumnType());
       assertEquals("version", store.stringTable().timestampColumnName());
 
       assertEquals("bucket", store.binaryTable().tableNamePrefix());
-      assertEquals(79, store.binaryTable().batchSize());
+      assertEquals(256, store.binaryTable().batchSize());
       assertEquals(44, store.binaryTable().fetchSize());
       assertEquals("BINARY", store.binaryTable().dataColumnType());
       assertEquals("version", store.binaryTable().timestampColumnName());

--- a/commons/src/main/java/org/infinispan/commons/hash/MurmurHash3.java
+++ b/commons/src/main/java/org/infinispan/commons/hash/MurmurHash3.java
@@ -246,7 +246,8 @@ public class MurmurHash3 implements Hash {
 
       long tail = key[key.length - 1];
 
-      if (key.length % 2 != 0) {
+      // Key length is odd
+      if ((key.length & 1) == 1) {
          state.k1 ^= tail;
          bmix(state);
       }

--- a/commons/src/main/java/org/infinispan/commons/util/Util.java
+++ b/commons/src/main/java/org/infinispan/commons/util/Util.java
@@ -643,4 +643,14 @@ public final class Util {
 
       return sb.toString();
    }
+
+   /**
+    * Returns a number such that the number is a power of two that is equal to, or greater than, the number passed in as
+    * an argument.  The smallest number returned will be 1, not 0.
+    */
+   public static int findNextHighestPowerOfTwo(int num) {
+      if (num <= 0) return 1;
+      int highestBit = Integer.highestOneBit(num);
+      return num <= highestBit ? highestBit : highestBit << 1;
+   }
 }

--- a/core/src/main/java/org/infinispan/distexec/mapreduce/MapReduceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/distexec/mapreduce/MapReduceManagerImpl.java
@@ -53,7 +53,7 @@ import org.infinispan.util.logging.LogFactory;
 public class MapReduceManagerImpl implements MapReduceManager {
 
    private static final Log log = LogFactory.getLog(MapReduceManagerImpl.class);
-   private static final int CANCELLATION_CHECK_FREQUENCY = 20;
+   private static final int CANCELLATION_CHECK_FREQUENCY = 32; // Should be a power of two so that the compiler can replace a % with a bitmask
    private ClusteringDependentLogic cdl;
    private EmbeddedCacheManager cacheManager;
    private CacheLoaderManager cacheLoaderManager;

--- a/core/src/main/java/org/infinispan/io/FileChunkMapper.java
+++ b/core/src/main/java/org/infinispan/io/FileChunkMapper.java
@@ -23,6 +23,9 @@ class FileChunkMapper {
       this.cache = cache;
    }
 
+   /**
+    * Guaranteed to be a power of two
+    */
    public int getChunkSize() {
       return file.getChunkSize();
    }

--- a/core/src/main/java/org/infinispan/io/GridFile.java
+++ b/core/src/main/java/org/infinispan/io/GridFile.java
@@ -38,12 +38,19 @@ public class GridFile extends File {
    private final String path;
    private int chunkSize;
 
+   /**
+    * Creates a GridFile instance
+    * @param pathname path of file
+    * @param metadataCache cache to use to store metadata
+    * @param chunkSize chunk size.  Will be upgraded to next highest power of two.
+    * @param fs GridFilesystem instance
+    */
    GridFile(String pathname, Cache<String, Metadata> metadataCache, int chunkSize, GridFilesystem fs) {
       super(pathname);
       this.fs = fs;
       this.path = formatPath(pathname);
       this.metadataCache = metadataCache.getAdvancedCache();
-      this.chunkSize = chunkSize;
+      this.chunkSize = ModularArithmetic.CANNOT_ASSUME_DENOM_IS_POWER_OF_TWO ? chunkSize : org.infinispan.commons.util.Util.findNextHighestPowerOfTwo(chunkSize);
       initChunkSizeFromMetadata();
    }
 
@@ -163,6 +170,9 @@ public class GridFile extends File {
       metadataCache.put(getAbsolutePath(), metadata);
    }
 
+   /**
+    * Guaranteed to be a power of two
+    */
    public int getChunkSize() {
       return chunkSize;
    }
@@ -532,17 +542,19 @@ public class GridFile extends File {
 
       private int length = 0;
       private long modificationTime = 0;
-      private int chunkSize = 0;
-      private byte flags = 0;
+      private int chunkSize;
+      private byte flags;
 
 
       public Metadata() {
+         chunkSize = 1;
+         flags = 0;
       }
 
       public Metadata(int length, long modificationTime, int chunkSize, byte flags) {
          this.length = length;
          this.modificationTime = modificationTime;
-         this.chunkSize = chunkSize;
+         this.chunkSize = ModularArithmetic.CANNOT_ASSUME_DENOM_IS_POWER_OF_TWO ? chunkSize : org.infinispan.commons.util.Util.findNextHighestPowerOfTwo(chunkSize);
          this.flags = flags;
       }
 

--- a/core/src/main/java/org/infinispan/io/GridFilesystem.java
+++ b/core/src/main/java/org/infinispan/io/GridFilesystem.java
@@ -2,6 +2,7 @@ package org.infinispan.io;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.context.Flag;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -43,11 +44,11 @@ public class GridFilesystem {
       }
       this.data = data;
       this.metadata = metadata;
-      this.defaultChunkSize = defaultChunkSize;
+      this.defaultChunkSize = ModularArithmetic.CANNOT_ASSUME_DENOM_IS_POWER_OF_TWO ? defaultChunkSize : Util.findNextHighestPowerOfTwo(defaultChunkSize);
    }
 
    public GridFilesystem(Cache<String, byte[]> data, Cache<String, GridFile.Metadata> metadata) {
-      this(data, metadata, 8000);
+      this(data, metadata, ModularArithmetic.CANNOT_ASSUME_DENOM_IS_POWER_OF_TWO ? 8000 : 8192);
    }
 
    /**

--- a/core/src/main/java/org/infinispan/io/GridInputStream.java
+++ b/core/src/main/java/org/infinispan/io/GridInputStream.java
@@ -17,10 +17,12 @@ public class GridInputStream extends InputStream {
    private byte[] currentBuffer = null;
    private int fSize;
    private boolean streamClosed = false;
-   private FileChunkMapper fileChunkMapper;
+   private final FileChunkMapper fileChunkMapper;
+   private final int chunkSize; // Guaranteed to be a power of 2
 
    GridInputStream(GridFile file, Cache<String, byte[]> cache) {
       fileChunkMapper = new FileChunkMapper(file, cache);
+      chunkSize = fileChunkMapper.getChunkSize();
       fSize = (int)file.length();
    }
 
@@ -82,7 +84,7 @@ public class GridInputStream extends InputStream {
          localIndex += bytesToSkip;
       } else {
          getChunk();
-         localIndex = index % getChunkSize();
+         localIndex = ModularArithmetic.mod(index, chunkSize);
       }
       return bytesToSkip;
    }
@@ -121,10 +123,6 @@ public class GridInputStream extends InputStream {
    }
 
    private int getChunkNumber() {
-      return index / getChunkSize();
-   }
-
-   private int getChunkSize() {
-      return fileChunkMapper.getChunkSize();
+      return index / chunkSize;
    }
 }

--- a/core/src/main/java/org/infinispan/io/ModularArithmetic.java
+++ b/core/src/main/java/org/infinispan/io/ModularArithmetic.java
@@ -1,0 +1,25 @@
+package org.infinispan.io;
+
+/**
+ * For compatibility
+ *
+ * @author Manik Surtani
+ */
+public class ModularArithmetic {
+   public static final boolean CANNOT_ASSUME_DENOM_IS_POWER_OF_TWO = Boolean.getBoolean("infinispan.compat");
+
+   public static final int mod(int numerator, int denominator) {
+      if (CANNOT_ASSUME_DENOM_IS_POWER_OF_TWO)
+         return numerator % denominator;
+      else
+         return numerator & (denominator - 1);
+   }
+
+   public static final long mod(long numerator, int denominator) {
+      if (CANNOT_ASSUME_DENOM_IS_POWER_OF_TWO)
+         return numerator % denominator;
+      else
+         return numerator & (denominator - 1);
+   }
+
+}

--- a/core/src/test/java/org/infinispan/io/GridFileTest.java
+++ b/core/src/test/java/org/infinispan/io/GridFileTest.java
@@ -240,10 +240,10 @@ public class GridFileTest extends SingleCacheManagerTest {
    public void testOverwritingFileDoesNotLeaveExcessChunksInCache() throws Exception {
       assertEquals(numberOfChunksInCache(), 0);
 
-      writeToFile("leak.txt", "12345abcde12345", 5); // file length = 15, chunkSize = 5
-      assertEquals(numberOfChunksInCache(), 3);
+      writeToFile("leak.txt", "12345abcde12345", 5); // file length = 15, chunkSize = 5.  Chunk size should "upgrade" to 8
+      assertEquals(numberOfChunksInCache(), 2);
 
-      writeToFile("leak.txt", "12345", 5);           // file length = 5, chunkSize = 5
+      writeToFile("leak.txt", "12345678", 5);           // file length = 5, chunkSize = 5.  Chunk size should "upgrade" to 8
       assertEquals(numberOfChunksInCache(), 1);
    }
 
@@ -356,19 +356,19 @@ public class GridFileTest extends SingleCacheManagerTest {
    @SuppressWarnings("ResultOfMethodCallIgnored")
    public void testAvailable() throws Exception {
       String filePath = "available.txt";
-      writeToFile(filePath, "abcde" + "fghij" + "klmno" + "pqrst" + "uvwxy" + "z", 5);
+      writeToFile(filePath, "abcde" + "fghij" + "klmno" + "pqrst" + "uvwxy" + "z", 5); // Chunk size should get "upgraded" to 8
 
       InputStream in = fs.getInput(filePath);
       try {
          assertEquals(in.available(), 0); // since first chunk hasn't been fetched yet
          in.read();
-         assertEquals(in.available(), 4);
+         assertEquals(in.available(), 7);
          in.skip(3);
-         assertEquals(in.available(), 1);
-         in.read();
-         assertEquals(in.available(), 0);
-         in.read();
          assertEquals(in.available(), 4);
+         in.read();
+         assertEquals(in.available(), 3);
+         in.read();
+         assertEquals(in.available(), 2);
       } finally {
          in.close();
       }


### PR DESCRIPTION
This pull request replaces modular operations (%) with bitwise AND operations where used in a hot code path or in a loop. Modulus invokes division in most CPUs, and this is often 1 to 2 orders of magnitude slower than a bitwise AND.

Reflected in several places:

http://dhruba.name/2011/07/12/performance-pattern-modulo-and-powers-of-two/
http://scicomp.stackexchange.com/questions/187/why-is-division-so-much-more-complex-than-other-arithmetic-operations
http://disruptor.googlecode.com/files/Disruptor-1.0.pdf (Page 5, last paragraph)
