### PR TITLE
ISPN-3200 Allow KeyFilters to be applied to listeners and ISPN-3201 Allo...

### DIFF
--- a/core/src/main/java/org/infinispan/AbstractDelegatingCache.java
+++ b/core/src/main/java/org/infinispan/AbstractDelegatingCache.java
@@ -2,6 +2,7 @@ package org.infinispan;
 
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.notifications.KeyFilter;
 import org.infinispan.util.concurrent.NotifyingFuture;
 
 import java.util.Collection;
@@ -323,6 +324,11 @@ public abstract class AbstractDelegatingCache<K, V> implements Cache<K, V> {
    @Override
    public void addListener(Object listener) {
       cache.addListener(listener);
+   }
+
+   @Override
+   public void addListener(Object listener, KeyFilter filter) {
+      cache.addListener(listener, filter);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/Cache.java
+++ b/core/src/main/java/org/infinispan/Cache.java
@@ -7,7 +7,7 @@ import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.loaders.spi.CacheStore;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.notifications.Listenable;
+import org.infinispan.notifications.FilteringListenable;
 import org.infinispan.util.concurrent.NotifyingFuture;
 
 import java.util.Collection;
@@ -86,7 +86,7 @@ import java.util.concurrent.ConcurrentMap;
  * @see <a href="http://www.jboss.org/community/wiki/5minutetutorialonInfinispan">5 Minute Usage Tutorial</a>
  * @since 4.0
  */
-public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, Listenable {
+public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringListenable {
    /**
     * Under special operating behavior, associates the value with the specified key. <ul> <li> Only goes through if the
     * key specified does not exist; no-op otherwise (similar to {@link ConcurrentMap#putIfAbsent(Object, Object)})</i>

--- a/core/src/main/java/org/infinispan/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/CacheImpl.java
@@ -49,6 +49,7 @@ import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.commons.util.Util;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.metadata.Metadata;
+import org.infinispan.notifications.KeyFilter;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.stats.Stats;
@@ -530,6 +531,11 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    @Override
    public void addListener(Object listener) {
       notifier.addListener(listener);
+   }
+
+   @Override
+   public void addListener(Object listener, KeyFilter filter) {
+      notifier.addListener(listener, filter);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/DecoratedCache.java
+++ b/core/src/main/java/org/infinispan/DecoratedCache.java
@@ -15,7 +15,9 @@ import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.metadata.Metadata;
+import org.infinispan.notifications.ClassLoaderAwareFilteringListenable;
 import org.infinispan.notifications.ClassLoaderAwareListenable;
+import org.infinispan.notifications.KeyFilter;
 import org.infinispan.util.concurrent.NotifyingFuture;
 
 /**
@@ -458,11 +460,12 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
 
    @Override
    public void addListener(Object listener) {
-      if (cacheImplementation.notifier instanceof ClassLoaderAwareListenable) {
-         ((ClassLoaderAwareListenable)cacheImplementation.notifier).addListener(listener, classLoader.get());
-      } else {
-         throw new IllegalStateException("The CacheNotifier does not implement the ClassLoaderAwareListenable interface");
-      }
+      cacheImplementation.notifier.addListener(listener, classLoader.get());
+   }
+
+   @Override
+   public void addListener(Object listener, KeyFilter filter) {
+      cacheImplementation.notifier.addListener(listener, filter, classLoader.get());
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/notifications/AbstractListenerImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/AbstractListenerImpl.java
@@ -7,6 +7,8 @@ import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
+import org.infinispan.interceptors.locking.ClusteringDependentLogic;
+import org.infinispan.notifications.cachelistener.event.EventImpl;
 import org.infinispan.util.concurrent.WithinThreadExecutor;
 import org.infinispan.util.logging.Log;
 
@@ -17,6 +19,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.BitSet;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -89,11 +92,11 @@ public abstract class AbstractListenerImpl {
    }
 
    public void addListener(Object listener) {
-      addListener(listener, null);
+      validateAndAddListenerInvocation(listener, null, null);
    }
 
    public void addListener(Object listener, ClassLoader classLoader) {
-      validateAndAddListenerInvocation(listener, classLoader);
+      validateAndAddListenerInvocation(listener, null, classLoader);
    }
 
    public Set<Object> getListeners() {
@@ -110,9 +113,8 @@ public abstract class AbstractListenerImpl {
     *
     * @param listener object to be considered as a listener.
     */
-   @SuppressWarnings("unchecked")
-   private void validateAndAddListenerInvocation(Object listener, ClassLoader classLoader) {
-      boolean sync = testListenerClassValidity(listener.getClass());
+   protected void validateAndAddListenerInvocation(Object listener, KeyFilter filter, ClassLoader classLoader) {
+      Listener l = testListenerClassValidity(listener.getClass());
       boolean foundMethods = false;
       Map<Class<? extends Annotation>, Class<?>> allowedListeners = getAllowedMethodAnnotations();
       // now try all methods on the listener for anything that we like.  Note that only PUBLIC methods are scanned.
@@ -123,7 +125,7 @@ public abstract class AbstractListenerImpl {
             Class<?> value = annotationEntry.getValue();
             if (m.isAnnotationPresent(key)) {
                testListenerMethodValidity(m, value, key.getName());
-               addListenerInvocation(key, new ListenerInvocation(listener, m, sync, classLoader));
+               addListenerInvocation(key, new ListenerInvocation(listener, m, l.sync(), l.primaryOnly(), filter, classLoader));
                foundMethods = true;
             }
          }
@@ -139,19 +141,18 @@ public abstract class AbstractListenerImpl {
    }
 
    /**
-    * Tests if a class is properly annotated as a CacheListener and returns whether callbacks on this class should be
-    * invoked synchronously or asynchronously.
+    * Tests if a class is properly annotated as a CacheListener and returns the Listener annotation.
     *
     * @param listenerClass class to inspect
-    * @return true if callbacks on this class should use the syncProcessor; false if it should use the asyncProcessor.
+    * @return the Listener annotation
     */
-   protected static boolean testListenerClassValidity(Class<?> listenerClass) {
+   protected static Listener testListenerClassValidity(Class<?> listenerClass) {
       Listener l = ReflectionUtil.getAnnotation(listenerClass, Listener.class);
       if (l == null)
          throw new IncorrectListenerException(String.format("Cache listener class %s must be annotated with org.infinispan.notifications.annotation.Listener", listenerClass.getName()));
       if (!Modifier.isPublic(listenerClass.getModifiers()))
          throw new IncorrectListenerException(String.format("Cache listener class %s must be public!", listenerClass.getName()));
-      return l.sync();
+      return l;
    }
 
    protected static void testListenerMethodValidity(Method m, Class<?> allowedParameter, String annotationName) {
@@ -169,53 +170,71 @@ public abstract class AbstractListenerImpl {
       public final Object target;
       public final Method method;
       public final boolean sync;
+      public final boolean onlyPrimary;
       public final WeakReference<ClassLoader> classLoader;
+      public final KeyFilter filter;
 
-      public ListenerInvocation(Object target, Method method, boolean sync, ClassLoader classLoader) {
+      public ListenerInvocation(Object target, Method method, boolean sync, boolean onlyPrimary, KeyFilter filter, ClassLoader classLoader) {
          this.target = target;
          this.method = method;
          this.sync = sync;
+         this.onlyPrimary = onlyPrimary;
+         this.filter = filter;
          this.classLoader = new WeakReference<ClassLoader>(classLoader);
       }
 
       public void invoke(final Object event) {
-         Runnable r = new Runnable() {
+         invoke(event, false, true);
+      }
 
-            @Override
-            public void run() {
-               ClassLoader contextClassLoader = null;
-               if (classLoader != null && classLoader.get() != null) {
-                  contextClassLoader = setContextClassLoader(classLoader.get());
-               }
-               try {
-                  method.invoke(target, event);
-               }
-               catch (InvocationTargetException exception) {
-                  Throwable cause = getRealException(exception);
-                  if (sync) {
-                     throw new CacheException(String.format(
-                        "Caught exception [%s] while invoking method [%s] on listener instance: %s"
-                        , cause.getClass().getName(), method, target
-                     ), cause);
-                  } else {
-                     getLog().unableToInvokeListenerMethod(method, target, cause);
-                  }
-               }
-               catch (IllegalAccessException exception) {
-                  getLog().unableToInvokeListenerMethod(method, target, exception);
-                  removeListener(target);
-               } finally {
+      public void invoke(final Object event, boolean isLocalNodePrimaryOwner) {
+         invoke(event, isLocalNodePrimaryOwner, false);
+      }
+
+      private void invoke(final Object event, boolean isLocalNodePrimaryOwner, boolean unKeyed) {
+         if (unKeyed || shouldInvoke(event, isLocalNodePrimaryOwner)) {
+            Runnable r = new Runnable() {
+
+               @Override
+               public void run() {
+                  ClassLoader contextClassLoader = null;
                   if (classLoader != null && classLoader.get() != null) {
-                     setContextClassLoader(contextClassLoader);
+                     contextClassLoader = setContextClassLoader(classLoader.get());
+                  }
+                  try {
+                     method.invoke(target, event);
+                  } catch (InvocationTargetException exception) {
+                     Throwable cause = getRealException(exception);
+                     if (sync) {
+                        throw new CacheException(String.format(
+                              "Caught exception [%s] while invoking method [%s] on listener instance: %s"
+                              , cause.getClass().getName(), method, target
+                        ), cause);
+                     } else {
+                        getLog().unableToInvokeListenerMethod(method, target, cause);
+                     }
+                  } catch (IllegalAccessException exception) {
+                     getLog().unableToInvokeListenerMethod(method, target, exception);
+                     removeListener(target);
+                  } finally {
+                     if (classLoader != null && classLoader.get() != null) {
+                        setContextClassLoader(contextClassLoader);
+                     }
                   }
                }
-            }
-         };
+            };
 
-         if (sync)
-            syncProcessor.execute(r);
-         else
-            asyncProcessor.execute(r);
+            if (sync)
+               syncProcessor.execute(r);
+            else
+               asyncProcessor.execute(r);
+         }
+      }
+
+      private boolean shouldInvoke(Object event, boolean isLocalNodePrimaryOwner) {
+         if (onlyPrimary && !isLocalNodePrimaryOwner) return false;
+         return filter == null ||
+               ((event instanceof EventImpl) && filter.accept(((EventImpl) event).getKey()));
       }
    }
 

--- a/core/src/main/java/org/infinispan/notifications/ClassLoaderAwareFilteringListenable.java
+++ b/core/src/main/java/org/infinispan/notifications/ClassLoaderAwareFilteringListenable.java
@@ -1,0 +1,25 @@
+package org.infinispan.notifications;
+
+/**
+ * Interface that enhances {@link FilteringListenable} with the possibility of specifying the
+ * {@link ClassLoader} which should be set as the context class loader for the invoked
+ * listener method
+ *
+ * @author Manik Surtani
+ * @since 6.0
+ * @see ClassLoaderAwareListenable
+ * @see FilteringListenable
+ */
+public interface ClassLoaderAwareFilteringListenable extends FilteringListenable {
+   /**
+    * Adds a listener to the component.  Typically, listeners would need to be annotated with {@link org.infinispan.notifications.Listener} and
+    * further to that, contain methods annotated appropriately, otherwise the listener will not be registered.
+    * <p/>
+    * See the {@link org.infinispan.notifications.Listener} annotation for more information.
+    * <p/>
+    *
+    * @param listener must not be null.
+    * @param classLoader class loader
+    */
+   void addListener(Object listener, KeyFilter filter, ClassLoader classLoader);
+}

--- a/core/src/main/java/org/infinispan/notifications/ClassLoaderAwareListenable.java
+++ b/core/src/main/java/org/infinispan/notifications/ClassLoaderAwareListenable.java
@@ -9,5 +9,10 @@ package org.infinispan.notifications;
  * @since 5.2
  */
 public interface ClassLoaderAwareListenable extends Listenable {
-   public void addListener(Object listener, ClassLoader classLoader);
+   /**
+    * Adds a listener along with a class loader to use for the invocation
+    * @param listener
+    * @param classLoader
+    */
+   void addListener(Object listener, ClassLoader classLoader);
 }

--- a/core/src/main/java/org/infinispan/notifications/FilteringListenable.java
+++ b/core/src/main/java/org/infinispan/notifications/FilteringListenable.java
@@ -1,0 +1,20 @@
+package org.infinispan.notifications;
+
+/**
+ * A Listable that can also filter events based on key
+ *
+ * @author Manik Surtani
+ * @since 6.0
+ */
+public interface FilteringListenable extends Listenable {
+   /**
+    * Adds a listener to the component.  Typically, listeners would need to be annotated with {@link org.infinispan.notifications.Listener} and
+    * further to that, contain methods annotated appropriately, otherwise the listener will not be registered.
+    * <p/>
+    * See the {@link org.infinispan.notifications.Listener} annotation for more information.
+    * <p/>
+    *
+    * @param listener must not be null.
+    */
+   void addListener(Object listener, KeyFilter filter);
+}

--- a/core/src/main/java/org/infinispan/notifications/KeyFilter.java
+++ b/core/src/main/java/org/infinispan/notifications/KeyFilter.java
@@ -1,0 +1,16 @@
+package org.infinispan.notifications;
+
+/**
+ * A filter for keys.
+ *
+ * @author Manik Surtani
+ * @since 6.0
+ */
+public interface KeyFilter {
+
+   /**
+    * @param key key to test
+    * @return true if the given key is accepted by this filter.
+    */
+   boolean accept(Object key);
+}

--- a/core/src/main/java/org/infinispan/notifications/Listener.java
+++ b/core/src/main/java/org/infinispan/notifications/Listener.java
@@ -202,4 +202,15 @@ public @interface Listener {
     * @since 4.0
     */
    boolean sync() default true;
+
+   /**
+    * Specifies whether the event should be fired on the primary data owner of the affected key, or all nodes that see
+    * the update.  In the case of replication, this would be the coordinator.
+    *
+    * @return true if the expectation is that only the primary data owner will fire the event, false if all nodes that
+    *         see the update fire the event.
+    *
+    *  @since 5.3
+    */
+   boolean primaryOnly() default false;
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifier.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifier.java
@@ -6,7 +6,9 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
-import org.infinispan.notifications.Listenable;
+import org.infinispan.notifications.ClassLoaderAwareFilteringListenable;
+import org.infinispan.notifications.ClassLoaderAwareListenable;
+import org.infinispan.notifications.FilteringListenable;
 import org.infinispan.transaction.xa.GlobalTransaction;
 
 import java.util.Collection;
@@ -18,7 +20,7 @@ import java.util.Collection;
  * @since 4.0
  */
 @Scope(Scopes.NAMED_CACHE)
-public interface CacheNotifier extends Listenable {
+public interface CacheNotifier extends ClassLoaderAwareFilteringListenable, ClassLoaderAwareListenable {
 
    /**
     * Notifies all registered listeners of a CacheEntryCreated event.

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
@@ -3,6 +3,7 @@ package org.infinispan.notifications.cachelistener;
 import org.infinispan.Cache;
 import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.NonTxInvocationContext;
@@ -29,7 +30,7 @@ public class CacheNotifierImplTest extends AbstractInfinispanTest {
    public void setUp() {
       n = new CacheNotifierImpl();
       mockCache = mock(Cache.class);
-      n.injectDependencies(mockCache);
+      n.injectDependencies(mockCache, new ClusteringDependentLogic.LocalLogic());
       cl = new CacheListener();
       n.start();
       n.addListener(cl);

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/KeyFilterTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/KeyFilterTest.java
@@ -1,0 +1,65 @@
+package org.infinispan.notifications.cachelistener;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.equivalence.AnyEquivalence;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.context.impl.NonTxInvocationContext;
+import org.infinispan.interceptors.locking.ClusteringDependentLogic;
+import org.infinispan.notifications.KeyFilter;
+import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
+import org.infinispan.notifications.cachelistener.event.Event;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+
+@Test(testName = "notifications.cachelistener.KeyFilterTest", groups = "unit")
+public class KeyFilterTest extends AbstractInfinispanTest {
+   CacheNotifierImpl n;
+   Cache mockCache;
+   CacheListener cl;
+   InvocationContext ctx;
+
+   @BeforeMethod
+   public void setUp() {
+      KeyFilter kf = new KeyFilter() {
+         @Override
+         public boolean accept(Object key) {
+            return key.toString().equals("accept");
+         }
+      };
+
+      n = new CacheNotifierImpl();
+      mockCache = mock(Cache.class);
+      n.injectDependencies(mockCache, new ClusteringDependentLogic.LocalLogic());
+      cl = new CacheListener();
+      n.start();
+      n.addListener(cl, kf);
+      ctx = new NonTxInvocationContext(AnyEquivalence.getInstance());
+   }
+
+   public void testFilters() {
+      n.notifyCacheEntryCreated("reject", null, true, ctx, null);
+      n.notifyCacheEntryCreated("reject", "v1", false, ctx, null);
+
+      assert !cl.isReceivedPost();
+      assert !cl.isReceivedPre();
+      assert cl.getInvocationCount() == 0;
+
+      n.notifyCacheEntryCreated("accept", null, true, ctx, null);
+      n.notifyCacheEntryCreated("accept", "v1", false, ctx, null);
+
+      assert cl.isReceivedPost();
+      assert cl.isReceivedPre();
+      assert cl.getInvocationCount() == 2;
+      assert cl.getEvents().get(0).getCache() == mockCache;
+      assert cl.getEvents().get(0).getType() == Event.Type.CACHE_ENTRY_CREATED;
+      assert ((CacheEntryCreatedEvent) cl.getEvents().get(0)).getKey().equals("accept");
+      assert ((CacheEntryCreatedEvent) cl.getEvents().get(0)).getValue() == null;
+      assert cl.getEvents().get(1).getCache() == mockCache;
+      assert cl.getEvents().get(1).getType() == Event.Type.CACHE_ENTRY_CREATED;
+      assert ((CacheEntryCreatedEvent) cl.getEvents().get(1)).getKey().equals("accept");
+      assert ((CacheEntryCreatedEvent) cl.getEvents().get(1)).getValue().equals("v1");
+   }
+}

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
@@ -1,0 +1,130 @@
+package org.infinispan.notifications.cachelistener;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.FlagAffectedCommand;
+import org.infinispan.commands.tx.VersionedPrepareCommand;
+import org.infinispan.commons.equivalence.AnyEquivalence;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.container.versioning.EntryVersionsMap;
+import org.infinispan.container.versioning.VersionGenerator;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.context.impl.NonTxInvocationContext;
+import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.interceptors.locking.ClusteringDependentLogic;
+import org.infinispan.metadata.Metadata;
+import org.infinispan.notifications.KeyFilter;
+import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
+import org.infinispan.notifications.cachelistener.event.Event;
+import org.infinispan.remoting.transport.Address;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+@Test(testName = "notifications.cachelistener.OnlyPrimaryOwnerTest", groups = "unit")
+public class OnlyPrimaryOwnerTest {
+   CacheNotifierImpl n;
+   Cache mockCache;
+   PrimaryOwnerCacheListener cl;
+   InvocationContext ctx;
+   MockCDL cdl = new MockCDL();
+
+   @BeforeMethod
+   public void setUp() {
+      n = new CacheNotifierImpl();
+      mockCache = mock(Cache.class);
+      n.injectDependencies(mockCache, cdl);
+      cl = new PrimaryOwnerCacheListener();
+      n.start();
+      n.addListener(cl);
+      ctx = new NonTxInvocationContext(AnyEquivalence.getInstance());
+   }
+
+   private static class MockCDL implements ClusteringDependentLogic {
+      boolean isOwner, isPrimaryOwner;
+      @Override
+      public boolean localNodeIsOwner(Object key) {
+         return isOwner;
+      }
+
+      @Override
+      public boolean localNodeIsPrimaryOwner(Object key) {
+         return isPrimaryOwner;
+      }
+
+      @Override
+      public Address getPrimaryOwner(Object key) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void commitEntry(CacheEntry entry, Metadata metadata, FlagAffectedCommand command, InvocationContext ctx) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public List<Address> getOwners(Collection<Object> keys) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public List<Address> getOwners(Object key) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public EntryVersionsMap createNewVersionsAndCheckForWriteSkews(VersionGenerator versionGenerator, TxInvocationContext context, VersionedPrepareCommand prepareCommand) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Address getAddress() {
+         throw new UnsupportedOperationException();
+      }
+   }
+
+   public void testOwnership() {
+      // Is not owner nor primary owner
+      cdl.isOwner = false;
+      cdl.isPrimaryOwner = false;
+      n.notifyCacheEntryCreated("reject", null, true, ctx, null);
+      n.notifyCacheEntryCreated("reject", "v1", false, ctx, null);
+
+      assert !cl.isReceivedPost();
+      assert !cl.isReceivedPre();
+      assert cl.getInvocationCount() == 0;
+
+      // Is an owner but not primary owner
+      cdl.isOwner = true;
+      cdl.isPrimaryOwner = false;
+      n.notifyCacheEntryCreated("reject", null, true, ctx, null);
+      n.notifyCacheEntryCreated("reject", "v1", false, ctx, null);
+
+      assert !cl.isReceivedPost();
+      assert !cl.isReceivedPre();
+      assert cl.getInvocationCount() == 0;
+
+      // Is primary owner
+      cdl.isOwner = true;
+      cdl.isPrimaryOwner = true;
+      n.notifyCacheEntryCreated("accept", null, true, ctx, null);
+      n.notifyCacheEntryCreated("accept", "v1", false, ctx, null);
+
+      assert cl.isReceivedPost();
+      assert cl.isReceivedPre();
+      assert cl.getInvocationCount() == 2;
+      assert cl.getEvents().get(0).getCache() == mockCache;
+      assert cl.getEvents().get(0).getType() == Event.Type.CACHE_ENTRY_CREATED;
+      assert ((CacheEntryCreatedEvent) cl.getEvents().get(0)).getKey().equals("accept");
+      assert ((CacheEntryCreatedEvent) cl.getEvents().get(0)).getValue() == null;
+      assert cl.getEvents().get(1).getCache() == mockCache;
+      assert cl.getEvents().get(1).getType() == Event.Type.CACHE_ENTRY_CREATED;
+      assert ((CacheEntryCreatedEvent) cl.getEvents().get(1)).getKey().equals("accept");
+      assert ((CacheEntryCreatedEvent) cl.getEvents().get(1)).getValue().equals("v1");
+
+   }
+
+}

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/PrimaryOwnerCacheListener.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/PrimaryOwnerCacheListener.java
@@ -1,0 +1,73 @@
+package org.infinispan.notifications.cachelistener;
+
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntriesEvicted;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryInvalidated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryLoaded;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryPassivated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryVisited;
+import org.infinispan.notifications.cachelistener.annotation.TransactionCompleted;
+import org.infinispan.notifications.cachelistener.annotation.TransactionRegistered;
+import org.infinispan.notifications.cachelistener.event.Event;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Listener(primaryOnly = true)
+public class PrimaryOwnerCacheListener {
+   List<Event> events = new ArrayList<Event>();
+   boolean receivedPre;
+   boolean receivedPost;
+   int invocationCount;
+
+   public void reset() {
+      events.clear();
+      receivedPost = false;
+      receivedPre = false;
+      invocationCount = 0;
+   }
+
+   public List<Event> getEvents() {
+      return events;
+   }
+
+   public boolean isReceivedPre() {
+      return receivedPre;
+   }
+
+   public boolean isReceivedPost() {
+      return receivedPost;
+   }
+
+   public int getInvocationCount() {
+      return invocationCount;
+   }
+
+
+   // handler
+
+   @CacheEntryActivated
+   @CacheEntryCreated
+   @CacheEntriesEvicted
+   @CacheEntryInvalidated
+   @CacheEntryLoaded
+   @CacheEntryModified
+   @CacheEntryPassivated
+   @CacheEntryRemoved
+   @CacheEntryVisited
+   @TransactionCompleted
+   @TransactionRegistered
+   public void handle(Event e) {
+      events.add(e);
+      if (e.isPre())
+         receivedPre = true;
+      else
+         receivedPost = true;
+
+      invocationCount++;
+   }
+}


### PR DESCRIPTION
...w listeners to be invoked only by a primary data owner

Combined into a single commit since both commits affect the same code in AbstractListenerImpl

https://issues.jboss.org/browse/ISPN-3200
https://issues.jboss.org/browse/ISPN-3201
