### PR TITLE
Reducing AbstractClusteredWriteSkewTest.testSharedCounter duration

### DIFF
--- a/core/src/test/java/org/infinispan/container/versioning/AbstractClusteredWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/AbstractClusteredWriteSkewTest.java
@@ -35,7 +35,7 @@ public abstract class AbstractClusteredWriteSkewTest extends MultipleCacheManage
 
    private static final String SHARED_COUNTER_TEST_CACHE_NAME = "shared_counter_test";
    private static final String SHARED_COUNTER_TEST_KEY = "counter";
-   private static final int SHARED_COUNTER_TEST_MAX_COUNTER_VALUE = 200;
+   private static final int SHARED_COUNTER_TEST_MAX_COUNTER_VALUE = 100;
 
    @Override
    protected void createCacheManagers() throws Throwable {


### PR DESCRIPTION
- looking at the logs in CI, it looks the test is taking too
  long.
- both threads stop after incrementing the counter until 100

no JIRA for this. I only reduced the max number of counter value to avoid the failures with master JDK6: http://ci.infinispan.org/viewLog.html?buildId=3033&tab=buildResultsDiv&buildTypeId=bt2
