### PR TITLE
ISPN-3428 MemcachedTypeConverter does not work in clustered mode with no...

### DIFF
--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/CustomMemcachedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/CustomMemcachedHotRodTest.java
@@ -3,8 +3,8 @@ package org.infinispan.it.compatibility;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.configuration.cache.CacheMode;
-import org.infinispan.io.ByteBuffer;
-import org.infinispan.marshall.AbstractMarshaller;
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.marshall.AbstractMarshaller;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -182,7 +182,7 @@ public class CustomMemcachedHotRodTest extends AbstractInfinispanTest {
          out.flush();
       }
 
-      private void close() throws IOException {
+      public void close() throws IOException {
          socket.close();
       }
    }

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/DistMemcachedEmbeddedTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/DistMemcachedEmbeddedTest.java
@@ -1,0 +1,73 @@
+package org.infinispan.it.compatibility;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.it.compatibility.EmbeddedRestMemcachedHotRodTest.SpyMemcachedCompatibleMarshaller;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.assertArrayEquals;
+
+/**
+ * Tests embedded and Memcached compatibility in a distributed
+ * clustered environment, using SpyMemcachedCompatibleMarshaller.
+ *
+ * @author Martin Gencur
+ * @since 6.0
+ */
+@Test(groups = "functional", testName = "it.compatibility.DistMemcachedEmbeddedTest")
+public class DistMemcachedEmbeddedTest {
+
+   private final int numOwners = 1;
+   //make sure the number of entries is big enough so that at least on entry
+   //is stored on non-local node to the Memcached client
+   private final int numEntries = 100;
+   private final String cacheName = "memcachedCache";
+   private CompatibilityCacheFactory<String, Object> cacheFactory1;
+   private CompatibilityCacheFactory<String, Object> cacheFactory2;
+
+   @BeforeClass
+   protected void setup() throws Exception {
+      cacheFactory1 = new CompatibilityCacheFactory<String, Object>(cacheName, new SpyMemcachedCompatibleMarshaller(), CacheMode.DIST_SYNC, numOwners).setup();
+      cacheFactory2 = new CompatibilityCacheFactory<String, Object>(cacheName, new SpyMemcachedCompatibleMarshaller(), CacheMode.DIST_SYNC, numOwners)
+            .setup(cacheFactory1.getMemcachedPort(), 100);
+   }
+
+   @AfterClass
+   protected void teardown() {
+      CompatibilityCacheFactory.killCacheFactories(cacheFactory1, cacheFactory2);
+   }
+
+   public void testMemcachedPutEmbeddedGet() throws Exception {
+      // 1. Put with Memcached
+      for (int i=0; i != numEntries; i++) {
+         Future<Boolean> f = cacheFactory2.getMemcachedClient().set("k" + i, 0, "v" + i);
+         assertTrue(f.get(60, TimeUnit.SECONDS));
+      }
+
+      // 2. Get with Embedded from a different node
+      for (int i=0; i != numEntries; i++) {
+         assertEquals("v" + i, cacheFactory1.getEmbeddedCache().get("k" + i));
+         cacheFactory1.getEmbeddedCache().remove("k" + i);
+      }
+   }
+
+   public void testEmbeddedPutMemcachedGet() throws IOException {
+      // 1. Put with Embedded
+      for (int i=0; i != numEntries; i++) {
+         assertEquals(null, cacheFactory2.getEmbeddedCache().put("k" + i, "v" + i));
+      }
+
+      // 2. Get with Memcached from a different node
+      for (int i=0; i != numEntries; i++) {
+         assertEquals("v" + i, cacheFactory1.getMemcachedClient().get("k" + i));
+      }
+   }
+
+}

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestMemcachedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestMemcachedHotRodTest.java
@@ -193,7 +193,7 @@ public class EmbeddedRestMemcachedHotRodTest {
       assertTrue("The version (CAS) should have changed", oldValue.getCas() != newValue.getCas());
    }
 
-   private class SpyMemcachedCompatibleMarshaller extends AbstractMarshaller {
+   static class SpyMemcachedCompatibleMarshaller extends AbstractMarshaller {
 
       private final Transcoder<Object> transcoder = new SerializingTranscoder();
 

--- a/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedTypeConverter.scala
+++ b/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedTypeConverter.scala
@@ -11,7 +11,7 @@ import org.infinispan.commons.marshall.{JavaSerializationMarshaller, Marshaller}
  * @author Galder Zamarreño
  * @since 5.3
  */
-class MemcachedTypeConverter extends TypeConverter[String, Array[Byte], String, AnyRef] {
+class MemcachedTypeConverter extends TypeConverter[String, AnyRef, String, AnyRef] {
 
    // Default marshaller needed in case no custom marshaller is set
    // (e.g. not using Spy Memcached client). This is because in compatibility
@@ -24,7 +24,7 @@ class MemcachedTypeConverter extends TypeConverter[String, Array[Byte], String, 
 
    override def boxKey(key: String): String = key
 
-   override def boxValue(value: Array[Byte]): AnyRef = unmarshall(value)
+   override def boxValue(value: AnyRef): AnyRef = unmarshall(value)
 
    override def unboxKey(key: String): String = key
 
@@ -37,8 +37,10 @@ class MemcachedTypeConverter extends TypeConverter[String, Array[Byte], String, 
    override def supportsInvocation(flag: Flag): Boolean =
       if (flag == Flag.OPERATION_MEMCACHED) true else false
 
-   private def unmarshall(source: Array[Byte]): AnyRef =
-      if (source != null) marshaller.objectFromByteBuffer(source) else source
+   private def unmarshall(source: AnyRef): AnyRef = source match {
+      case bytes: Array[Byte] => marshaller.objectFromByteBuffer(bytes)
+      case _ => source
+   }
 
    private def marshall(source: AnyRef): Array[Byte] =
       if (source != null) marshaller.objectToByteBuffer(source) else null


### PR DESCRIPTION
...n-bytearray data

I can add a test for non-SpyMemcachedCompatibleMarshaller too (I have it already and it passes) but it does not seem necessary.
