### PR TITLE
ISPN-3406 Reading entry via HotRod in compatibility mode fails for non-l...

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/compat/BaseTypeConverterInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/compat/BaseTypeConverterInterceptor.java
@@ -71,14 +71,20 @@ public abstract class BaseTypeConverterInterceptor extends CommandInterceptor {
       if (ret != null) {
          if (command.isReturnEntry()) {
             InternalCacheEntry entry = (InternalCacheEntry) ret;
-            Object returnValue = converter.unboxValue(entry.getValue());
+            Object returnValue = entry.getValue();
+            if (command.getRemotelyFetchedValue() == null) {
+               returnValue = converter.unboxValue(entry.getValue());
+            }
             // Create a copy of the entry to avoid modifying the internal entry
             return entryFactory.create(
                   entry.getKey(), returnValue, entry.getMetadata(),
                   entry.getLifespan(), entry.getMaxIdle());
+         } else {
+            if (command.getRemotelyFetchedValue() == null) {
+               return converter.unboxValue(ret);
+            }
+            return ret;
          }
-
-         return converter.unboxValue(ret);
       }
 
       return null;

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/CompatibilityCacheFactory.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/CompatibilityCacheFactory.java
@@ -20,7 +20,6 @@ import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
-
 import javax.servlet.ServletContext;
 import java.util.Collections;
 
@@ -64,6 +63,11 @@ public class CompatibilityCacheFactory<K, V> {
       this.cacheName = "";
       this.marshaller = null;
       this.cacheMode = cacheMode;
+   }
+
+   CompatibilityCacheFactory(CacheMode cacheMode, int numOwners) {
+      this(cacheMode);
+      this.numOwners = numOwners;
    }
 
    CompatibilityCacheFactory(String cacheName, Marshaller marshaller, CacheMode cacheMode) {

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/DistEmbeddedRestHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/DistEmbeddedRestHotRodTest.java
@@ -1,0 +1,34 @@
+package org.infinispan.it.compatibility;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Tests embedded, Hot Rod and REST compatibility in a distributed
+ * clustered environment.
+ *
+ * @author Martin Gencur
+ * @since 6.0
+ */
+@Test(groups = "functional", testName = "it.compatibility.DistEmbeddedHotRodTest")
+public class DistEmbeddedRestHotRodTest extends ReplEmbeddedRestHotRodTest {
+
+   private final int numOwners = 1;
+
+   @Override
+   @BeforeClass
+   protected void setup() throws Exception {
+      cacheFactory1 = new CompatibilityCacheFactory<String, Object>(CacheMode.DIST_SYNC, numOwners).setup();
+      cacheFactory2 = new CompatibilityCacheFactory<String, Object>(CacheMode.DIST_SYNC, numOwners)
+            .setup(cacheFactory1.getHotRodPort(), 100);
+   }
+
+   @Override
+   @AfterClass
+   protected void teardown() {
+      CompatibilityCacheFactory.killCacheFactories(cacheFactory1, cacheFactory2);
+   }
+
+}

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/ReplEmbeddedRestHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/ReplEmbeddedRestHotRodTest.java
@@ -71,7 +71,7 @@ public class ReplEmbeddedRestHotRodTest {
       assertEquals(null, cacheFactory2.getEmbeddedCache().put(key, "v1"));
 
       // 2. Get with Hot Rod
-      assertEquals("v1", cacheFactory2.getHotRodCache().get(key));
+      assertEquals("v1", cacheFactory1.getHotRodCache().get(key));
 
       // 3. Get with REST
       HttpMethod get = new GetMethod(cacheFactory2.getRestUrl() + "/" + key);


### PR DESCRIPTION
...ocal entry if stored via Embedded cache

The problem was that unboxValue method on type converters is called twice on the same value in this scenario. While this is not a problem for memcached (it returns again the same byte array), JBoss marshaller returns different byte array every time. That's why the client could not understand the returned value (it was marshalled twice).

Martin
