### PR TITLE
ISPN-3483 CacheLoaderAPITest is falling randomly

### DIFF
--- a/lucene/lucene-v3/src/test/java/org/infinispan/lucene/cachestore/CacheLoaderAPITest.java
+++ b/lucene/lucene-v3/src/test/java/org/infinispan/lucene/cachestore/CacheLoaderAPITest.java
@@ -272,7 +272,7 @@ public class CacheLoaderAPITest extends SingleCacheManagerTest {
       Set keyList = PersistenceUtil.toKeySet(cacheLoader, null);
       checkIfExists(keyList, exclusionSet, true, false);
 
-      PersistenceUtil.toKeySet(cacheLoader, null);
+      keyList = PersistenceUtil.toKeySet(cacheLoader, new CollectionKeyFilter(exclusionSet));
       checkIfExists(keyList, exclusionSet, false, true);
    }
 

--- a/lucene/lucene-v4/src/test/java/org/infinispan/lucene/cachestore/CacheLoaderAPITest.java
+++ b/lucene/lucene-v4/src/test/java/org/infinispan/lucene/cachestore/CacheLoaderAPITest.java
@@ -272,7 +272,7 @@ public class CacheLoaderAPITest extends SingleCacheManagerTest {
       Set keyList = PersistenceUtil.toKeySet(cacheLoader, null);
       checkIfExists(keyList, exclusionSet, true, false);
 
-      keyList = PersistenceUtil.toKeySet(cacheLoader, null);
+      keyList = PersistenceUtil.toKeySet(cacheLoader, new CollectionKeyFilter(exclusionSet));
       checkIfExists(keyList, exclusionSet, false, true);
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3483

the exclusion list was missing when load the keys...
