### PR TITLE
added Serializable interface, need it for Azul JDK

### DIFF
--- a/core/src/main/java/org/infinispan/container/entries/InternalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/InternalCacheEntry.java
@@ -1,5 +1,7 @@
 package org.infinispan.container.entries;
 
+import java.io.Serializable;
+
 /**
  * Interface for internal cache entries that expose whether an entry has expired.
  *
@@ -7,7 +9,7 @@ package org.infinispan.container.entries;
  * @author Sanne Grinovero
  * @since 4.0
  */
-public interface InternalCacheEntry extends CacheEntry, Cloneable {
+public interface InternalCacheEntry extends CacheEntry, Cloneable, Serializable {
 
    /**
     * @param now the current time as defined by {@link System#currentTimeMillis()} or {@link

--- a/core/src/main/java/org/infinispan/container/entries/InternalCacheValue.java
+++ b/core/src/main/java/org/infinispan/container/entries/InternalCacheValue.java
@@ -3,6 +3,8 @@ package org.infinispan.container.entries;
 import org.infinispan.metadata.InternalMetadata;
 import org.infinispan.metadata.Metadata;
 
+import java.io.Serializable;
+
 /**
  * A representation of an InternalCacheEntry that does not have a reference to the key.  This should be used if the key
  * is either not needed or available elsewhere as it is more efficient to marshall and unmarshall.  Probably most useful
@@ -19,7 +21,7 @@ import org.infinispan.metadata.Metadata;
  * @author Manik Surtani
  * @since 4.0
  */
-public interface InternalCacheValue {
+public interface InternalCacheValue extends Serializable {
 
    /**
     * @return the value represented by this internal wrapper

--- a/core/src/main/java/org/infinispan/persistence/support/Bucket.java
+++ b/core/src/main/java/org/infinispan/persistence/support/Bucket.java
@@ -8,6 +8,7 @@ import org.infinispan.persistence.spi.AdvancedCacheLoader;
 import org.infinispan.persistence.spi.MarshalledEntry;
 import org.infinispan.util.TimeService;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -17,7 +18,7 @@ import java.util.Set;
 /**
  * A bucket is where entries are stored.
  */
-public final class Bucket {
+public final class Bucket implements Serializable {
    final Map<Object, MarshalledEntry> entries;
    private transient Integer bucketId;
    private transient String bucketIdStr;


### PR DESCRIPTION
There is a problem when running infinispan testuite with Azul JDK, xstream library complies 
Stacktrace
com.thoughtworks.xstream.converters.ConversionException: Cannot construct org.infinispan.container.entries.ImmortalCacheValue as it does not have a no-args constructor : Cannot construct org.infinispan.container.entries.ImmortalCacheValue as it does not have a no-args constructor
---- Debugging information ----
message             : Cannot construct org.infinispan.container.entries.ImmortalCacheValue as it does not have a no-args constructor
cause-exception     : com.thoughtworks.xstream.converters.reflection.ObjectAccessException
cause-message       : Cannot construct org.infinispan.container.entries.ImmortalCacheValue as it does not have a no-args constructor
class               : org.infinispan.container.entries.ImmortalCacheValue
required-type       : org.infinispan.container.entries.ImmortalCacheValue
converter-type      : com.thoughtworks.xstream.converters.reflection.ReflectionConverter
path                : /org.infinispan.container.entries.ImmortalCacheValue
line number         : 1
version             : 1.4.1-redhat-2
You can see it here https://jenkins.mw.lab.eng.bos.redhat.com/hudson/view/JDG/view/FUNC/job/jdg-62-ispn-testsuite-rhel-azul/4/#showFailuresLink
