### PR TITLE
ISPN-3490 Extend compatatibility mode tests

### DIFF
--- a/core/src/test/java/org/infinispan/distexec/mapreduce/CompatModeDistributedTwoNodesMapReduceTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/CompatModeDistributedTwoNodesMapReduceTest.java
@@ -1,0 +1,36 @@
+package org.infinispan.distexec.mapreduce;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * CompatModeDistributedTwoNodesMapReduceTest tests Map/Reduce functionality using two Infinispan nodes,
+ * distributed reduce and individual per task intermediate key/value cache, in compatibility mode.
+ *
+ * @author Martin Gencur
+ * @since 6.0
+ */
+@Test(groups = "functional", testName = "distexec.mapreduce.CompatModeDistributedTwoNodesMapReduceTest")
+public class CompatModeDistributedTwoNodesMapReduceTest extends BaseWordCountMapReduceTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = TestCacheManagerFactory.getDefaultCacheConfiguration(true, false);
+      builder.compatibility().enable()
+            .clustering()
+            .cacheMode(CacheMode.DIST_SYNC)
+            .stateTransfer().fetchInMemoryState(false)
+            .transaction().syncCommitPhase(true).syncRollbackPhase(true)
+            .cacheStopTimeout(0L);
+      createClusteredCaches(2, cacheName(), builder);
+   }
+
+   @SuppressWarnings({ "rawtypes", "unchecked" })
+   protected MapReduceTask<String, String, String, Integer> createMapReduceTask(Cache c){
+      //run distributed reduce with per task cache
+      return new MapReduceTask<String, String, String, Integer>(c, true, false);
+   }
+}

--- a/core/src/test/java/org/infinispan/tx/CompatModeTransactionsSpanningDistributedCachesTest.java
+++ b/core/src/test/java/org/infinispan/tx/CompatModeTransactionsSpanningDistributedCachesTest.java
@@ -1,0 +1,30 @@
+package org.infinispan.tx;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Test basic functionality of transactional caches in compatibility mode.
+ *
+ * @author Martin Gencur
+ * @since 6.0
+ */
+@Test(groups = "functional", testName = "tx.CompatModeTransactionsSpanningDistributedCachesTest")
+public class CompatModeTransactionsSpanningDistributedCachesTest extends TransactionsSpanningDistributedCachesTest {
+
+   @Override
+   protected ConfigurationBuilder getConfiguration() {
+      ConfigurationBuilder builder = TestCacheManagerFactory.getDefaultCacheConfiguration(true, false);
+      builder.compatibility().enable()
+            .clustering()
+            .cacheMode(CacheMode.DIST_SYNC)
+            .stateTransfer().fetchInMemoryState(false)
+            .transaction().syncCommitPhase(true).syncRollbackPhase(true)
+            .cacheStopTimeout(0L);
+      return builder;
+   }
+
+}
+

--- a/query/src/test/java/org/infinispan/query/blackbox/CompatModeClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/CompatModeClusteredCacheTest.java
@@ -1,0 +1,36 @@
+package org.infinispan.query.blackbox;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.query.test.Person;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * Verify queries in compatibility mode.
+ *
+ * @author Martin Gencur
+ * @since 6.0
+ */
+@Test(groups = "functional", testName = "query.blackbox.CompatModeClusteredCacheTest")
+public class CompatModeClusteredCacheTest extends ClusteredCacheTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder cacheCfg = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, transactionsEnabled());
+      cacheCfg
+            .compatibility().enable()
+            .indexing()
+            .enable()
+            .indexLocalOnly(false)
+            .addProperty("default.directory_provider", "ram")
+            .addProperty("lucene_version", "LUCENE_CURRENT");
+      enhanceConfig(cacheCfg);
+      List<Cache<String, Person>> caches = createClusteredCaches(2, cacheCfg);
+      cache1 = caches.get(0);
+      cache2 = caches.get(1);
+   }
+
+}

--- a/query/src/test/java/org/infinispan/query/blackbox/CompatModeLocalCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/CompatModeLocalCacheTest.java
@@ -1,0 +1,30 @@
+package org.infinispan.query.blackbox;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Verify queries in compatibility mode.
+ *
+ * @author Martin Gencur
+ * @since 6.0
+ */
+@Test(groups = "functional", testName = "query.blackbox.CompatModeLocalCacheTest")
+public class CompatModeLocalCacheTest extends LocalCacheTest {
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      ConfigurationBuilder cfg = getDefaultStandaloneCacheConfig(true);
+      cfg
+            .compatibility().enable()
+            .indexing()
+            .enable()
+            .indexLocalOnly(false)
+            .addProperty("default.directory_provider", "ram")
+            .addProperty("lucene_version", "LUCENE_CURRENT");
+      enhanceConfig(cfg);
+      return TestCacheManagerFactory.createCacheManager(cfg);
+   }
+}

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCacheTest.java
@@ -595,7 +595,8 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       assert found.size() == 1;
       assert found.get(0).equals(anotherGrassEater);
    }
-   
+
+   @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder cfg = getDefaultStandaloneCacheConfig(true);
       cfg

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/CompatModeQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/CompatModeQueryDslConditionsTest.java
@@ -1,0 +1,31 @@
+package org.infinispan.query.dsl.embedded;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.TransactionMode;
+import org.testng.annotations.Test;
+
+/**
+ * Verify query DSL in compatibility mode.
+ *
+ * @author Martin Gencur
+ * @since 6.0
+ */
+@Test(groups = "functional", testName = "query.dsl.CompatModeQueryDslConditionsTest")
+public class CompatModeQueryDslConditionsTest extends QueryDslConditionsTest {
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      ConfigurationBuilder cfg = getDefaultStandaloneCacheConfig(true);
+      cfg.compatibility().enable()
+            .transaction()
+            .transactionMode(TransactionMode.TRANSACTIONAL)
+            .indexing().enable()
+            .indexLocalOnly(false)
+            .addProperty("default.directory_provider", "ram")
+            .addProperty("lucene_version", "LUCENE_CURRENT");
+      return TestCacheManagerFactory.createCacheManager(cfg);
+   }
+
+}


### PR DESCRIPTION
Reasonably cover the following functionality in compatibility mode:
- map/reduce
- library mode queries (old and new API)
- basic transactions

Please don't close the JIRA as we're planning to add tests for remote query DSL in compatibility mode.

Martin
