### PR TITLE
ISPN-3051 Allow configuring the number of segments per node

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
@@ -1,11 +1,9 @@
 package org.infinispan.client.hotrod;
 
-import org.infinispan.Cache;
 import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransport;
 import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.container.DataContainer;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.lifecycle.ComponentStatus;
@@ -17,8 +15,6 @@ import org.infinispan.util.logging.LogFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
-
-import com.sun.source.tree.AssertTree;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;

--- a/core/src/main/java/org/infinispan/configuration/cache/HashConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/HashConfiguration.java
@@ -15,15 +15,18 @@ public class HashConfiguration {
    private final Hash hash;
    private final int numOwners;
    private final int numSegments;
+   private final float capacityFactor;
    private final GroupsConfiguration groupsConfiguration;
    private final StateTransferConfiguration stateTransferConfiguration;
 
    HashConfiguration(ConsistentHashFactory consistentHashFactory, Hash hash, int numOwners, int numSegments,
-                     GroupsConfiguration groupsConfiguration, StateTransferConfiguration stateTransferConfiguration) {
+                     float capacityFactor, GroupsConfiguration groupsConfiguration,
+                     StateTransferConfiguration stateTransferConfiguration) {
       this.consistentHashFactory = consistentHashFactory;
       this.hash = hash;
       this.numOwners = numOwners;
       this.numSegments = numSegments;
+      this.capacityFactor = capacityFactor;
       this.groupsConfiguration = groupsConfiguration;
       this.stateTransferConfiguration = stateTransferConfiguration;
    }
@@ -109,6 +112,15 @@ public class HashConfiguration {
    }
 
    /**
+    * Controls the proportion of entries that will reside on the local node, compared to the other nodes in the
+    * cluster. This is just a suggestion, there is no guarantee that a node with a capacity factor of {@code 2} will
+    * have twice as many entries as a node with a capacity factor of {@code 1}.
+    */
+   public float capacityFactor() {
+      return capacityFactor;
+   }
+
+   /**
     * Configuration for various grouper definitions. See the user guide for more information.
     */
    public GroupsConfiguration groups() {
@@ -158,5 +170,4 @@ public class HashConfiguration {
       result = 31 * result + (stateTransferConfiguration != null ? stateTransferConfiguration.hashCode() : 0);
       return result;
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/HashConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/HashConfigurationBuilder.java
@@ -23,6 +23,7 @@ public class HashConfigurationBuilder extends AbstractClusteringConfigurationChi
    // With the default consistent hash factory, this default gives us an even spread for clusters
    // up to 6 members and the difference between nodes stays under 20% up to 12 members.
    private int numSegments = 60;
+   private float capacityFactor = 1;
 
    private final GroupsConfigurationBuilder groupsConfigurationBuilder;
 
@@ -149,6 +150,18 @@ public class HashConfigurationBuilder extends AbstractClusteringConfigurationChi
       return this;
    }
 
+   /**
+    * Controls the proportion of entries that will reside on the local node, compared to the other nodes in the
+    * cluster. This is just a suggestion, there is no guarantee that a node with a capacity factor of {@code 2} will
+    * have twice as many entries as a node with a capacity factor of {@code 1}.
+    * @param capacityFactor the capacity factor for the local node. Must be positive.
+    */
+   public HashConfigurationBuilder capacityFactor(float capacityFactor) {
+      if (capacityFactor < 0) throw new IllegalArgumentException("capacityFactor must be positive");
+      this.capacityFactor = capacityFactor;
+      return this;
+   }
+
    public GroupsConfigurationBuilder groups() {
       return groupsConfigurationBuilder;
    }
@@ -161,7 +174,7 @@ public class HashConfigurationBuilder extends AbstractClusteringConfigurationChi
    @Override
    public HashConfiguration create() {
       // TODO stateTransfer().create() will create a duplicate StateTransferConfiguration instance. That's ok as long as none of the stateTransfer settings are modifiable at runtime.
-      return new HashConfiguration(consistentHashFactory, hash, numOwners, numSegments,
+      return new HashConfiguration(consistentHashFactory, hash, numOwners, numSegments, capacityFactor,
             groupsConfigurationBuilder.create(), stateTransfer().create());
    }
 

--- a/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
@@ -20,6 +20,7 @@ public enum Attribute {
     BEFORE("before"),
     CACHE_MANAGER_NAME("cacheManagerName"),
     CACHE_STOP_TIMEOUT("cacheStopTimeout"),
+    CAPACITY_FACTOR("capacityFactor"),
     CHUNK_SIZE("chunkSize"),
     CLASS("class"),
     CLUSTER_NAME("clusterName"),

--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser60.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser60.java
@@ -1248,6 +1248,9 @@ public class Parser60 implements ConfigurationParser {
             case NUM_SEGMENTS:
                builder.clustering().hash().numSegments(Integer.parseInt(value));
                break;
+            case CAPACITY_FACTOR:
+               builder.clustering().hash().capacityFactor(Float.parseFloat(value));
+               break;
             default:
                throw ParseUtils.unexpectedAttribute(reader, i);
          }

--- a/core/src/main/java/org/infinispan/distribution/ch/ConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/ConsistentHashFactory.java
@@ -1,9 +1,10 @@
 package org.infinispan.distribution.ch;
 
-import java.util.List;
-
 import org.infinispan.commons.hash.Hash;
 import org.infinispan.remoting.transport.Address;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Factory for {@link ConsistentHash} instances.
@@ -24,8 +25,12 @@ public interface ConsistentHashFactory<CH extends ConsistentHash> {
     * @param numSegments Number of hash-space segments. The implementation may round up the number
     *                    of segments for performance, or may ignore the parameter altogether.
     * @param members A list of addresses representing the new cache members.
+    * @param capacityFactors The capacity factor of each member. Determines the relative capacity of each node compared
+    *                        to the others. The implementation may ignore this parameter.
+    *                        If {@code null}, all the members are assumed to have a capacity factor of 1.
     */
-   CH create(Hash hashFunction, int numOwners, int numSegments, List<Address> members);
+   CH create(Hash hashFunction, int numOwners, int numSegments, List<Address> members,
+             Map<Address, Float> capacityFactors);
 
    /**
     * Create a new consistent hash instance, based on an existing instance, but with a new list of members.
@@ -36,10 +41,13 @@ public interface ConsistentHashFactory<CH extends ConsistentHash> {
     *
     * @param baseCH An existing consistent hash instance, should not be {@code null}
     * @param newMembers A list of addresses representing the new cache members.
+    * @param capacityFactors The capacity factor of each member. Determines the relative capacity of each node compared
+    *                        to the others. The implementation may ignore this parameter.
+    *                        If {@code null}, all the members are assumed to have a capacity factor of 1.
     * @return A new {@link ConsistentHash} instance, or {@code baseCH} if the existing instance
     *         does not need any changes.
     */
-   CH updateMembers(CH baseCH, List<Address> newMembers);
+   CH updateMembers(CH baseCH, List<Address> newMembers, Map<Address, Float> capacityFactors);
 
    /**
     * Create a new consistent hash instance, based on an existing instance, but "balanced" according to

--- a/core/src/main/java/org/infinispan/distribution/ch/ReplicatedConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/ReplicatedConsistentHashFactory.java
@@ -11,6 +11,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
@@ -23,15 +24,9 @@ import java.util.Set;
  */
 public class ReplicatedConsistentHashFactory implements ConsistentHashFactory<ReplicatedConsistentHash> {
 
-   /**
-    * @param hashFunction The hash function to use on top of the keys' own {@code hashCode()} implementation.
-    * @param numOwners    this implementation ignores this parameter.
-    * @param numSegments  number of hash-space segments.
-    * @param members      the list of cache members.
-    * @see ConsistentHashFactory#create(org.infinispan.commons.hash.Hash, int, int, java.util.List)
-    */
    @Override
-   public ReplicatedConsistentHash create(Hash hashFunction, int numOwners, int numSegments, List<Address> members) {
+   public ReplicatedConsistentHash create(Hash hashFunction, int numOwners, int numSegments, List<Address> members,
+                                          Map<Address, Float> capacityFactors) {
       int[] primaryOwners = new int[numSegments];
       for (int i = 0; i < numSegments; i++) {
          primaryOwners[i] = i % members.size();
@@ -40,7 +35,8 @@ public class ReplicatedConsistentHashFactory implements ConsistentHashFactory<Re
    }
 
    @Override
-   public ReplicatedConsistentHash updateMembers(ReplicatedConsistentHash baseCH, List<Address> newMembers) {
+   public ReplicatedConsistentHash updateMembers(ReplicatedConsistentHash baseCH, List<Address> newMembers,
+                                                 Map<Address, Float> actualCapacityFactors) {
       if (newMembers.equals(baseCH.getMembers()))
          return baseCH;
 

--- a/core/src/main/java/org/infinispan/distribution/ch/SyncConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/SyncConsistentHashFactory.java
@@ -4,6 +4,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -11,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 import org.infinispan.commons.hash.Hash;
 import org.infinispan.commons.marshall.AbstractExternalizer;
@@ -30,47 +32,62 @@ import org.infinispan.remoting.transport.Address;
 public class SyncConsistentHashFactory implements ConsistentHashFactory<DefaultConsistentHash> {
 
    @Override
-   public DefaultConsistentHash create(Hash hashFunction, int numOwners, int numSegments, List<Address> members) {
+   public DefaultConsistentHash create(Hash hashFunction, int numOwners, int numSegments, List<Address> members,
+                                       Map<Address, Float> capacityFactors) {
+      checkCapacityFactors(members, capacityFactors);
 
-      Builder builder = new Builder(hashFunction, numOwners, numSegments, members);
-      SortedMap<Integer, Address> primarySegments = populatePrimarySegments(builder);
-      if (numSegments >= members.size()) {
+      Builder builder = new Builder(hashFunction, numOwners, numSegments, members, capacityFactors);
+      SortedMap<Integer, Address> primarySegments = populatePrimarySegments(builder, numSegments);
+      if (numSegments >= builder.nodesWithLoad()) {
          populateOwnersManySegments(builder, primarySegments);
       } else {
          populateOwnersFewSegments(builder, primarySegments);
       }
 
-      return new DefaultConsistentHash(hashFunction, numOwners, numSegments, members, builder.getAllOwners());
+      return new DefaultConsistentHash(hashFunction, numOwners, numSegments, members, capacityFactors, builder.getAllOwners());
+   }
+
+   private void checkCapacityFactors(List<Address> members, Map<Address, Float> capacityFactors) {
+      if (capacityFactors != null) {
+         float totalCapacity = 0;
+         for (Address node : members) {
+            Float capacityFactor = capacityFactors.get(node);
+            if (capacityFactor == null || capacityFactor < 0)
+               throw new IllegalArgumentException("Invalid capacity factor for node " + node);
+            totalCapacity += capacityFactor;
+         }
+         if (totalCapacity == 0)
+            throw new IllegalArgumentException("There must be at least one node with a non-zero capacity factor");
+      }
    }
 
    protected void populateOwnersFewSegments(Builder builder, SortedMap<Integer, Address> primarySegments) {
       // Too few segments for each member to have one "primary segment",
       // but we may still have enough segments for each member to be a backup owner.
-
       // Populate the primary owners first - because numSegments < numMembers we're guaranteed to
       // set the primary owner of each segment
+      int actualNumOwners = builder.getActualNumOwners();
+      TreeSet<Address> sortedMembers = new TreeSet<Address>(builder.getSortedMembers());
       for (Map.Entry<Integer, Address> e : primarySegments.entrySet()) {
          Integer segment = e.getKey();
          Address primaryOwner = e.getValue();
-         builder.getOwners(segment).add(primaryOwner);
-      }
+         List<Address> owners = builder.getOwners(segment);
+         owners.add(primaryOwner);
+         if (owners.size() >= actualNumOwners)
+            continue;
 
-      // Continue with the backup owners. Assign each member as owner to one segment,
-      // then repeat until each segment has numOwners owners.
-      boolean modified = true;
-      while (modified) {
-         modified = false;
-         for (Address member : builder.getSortedMembers()) {
-            // Compute an initial segment and iterate backwards to make it more like the other case
-            int initSegment = normalizedHash(builder.getHashFunction(), member.hashCode()) / builder.getSegmentSize();
-            for (int i = 0; i < builder.getNumSegments(); i++) {
-               int segment = (builder.getNumSegments() + initSegment - i) % builder.getNumSegments();
-               List<Address> owners = builder.getOwners(segment);
-               if (owners.size() < builder.getActualNumOwners() && !owners.contains(member)) {
-                  owners.add(member);
-                  modified = true;
-                  break;
-               }
+         for (Address a : sortedMembers.tailSet(primaryOwner, false)) {
+            if (owners.size() >= actualNumOwners)
+               break;
+            if (builder.getCapacityFactor(a) > 0 && !owners.contains(a)) {
+               owners.add(a);
+            }
+         }
+         for (Address a : sortedMembers.headSet(primaryOwner, false)) {
+            if (owners.size() >= actualNumOwners)
+               break;
+            if (builder.getCapacityFactor(a) > 0 && !owners.contains(a)) {
+               owners.add(a);
             }
          }
       }
@@ -84,18 +101,19 @@ public class SyncConsistentHashFactory implements ConsistentHashFactory<DefaultC
       // Each member is present at least once in the primary segments map, so we can use that
       // to populate the owner lists. For each segment assign the owners of the next numOwners
       // "primary segments" as owners.
+      int actualNumOwners = builder.getActualNumOwners();
       for (int segment = 0; segment < builder.getNumSegments(); segment++) {
          List<Address> owners = builder.getOwners(segment);
          for (Address a : primarySegments.tailMap(segment).values()) {
-            if (owners.size() >= builder.getActualNumOwners())
+            if (owners.size() >= actualNumOwners)
                break;
             if (!owners.contains(a)) {
                owners.add(a);
             }
          }
-         if (owners.size() < builder.getActualNumOwners()) {
+         if (owners.size() < actualNumOwners) {
             for (Address a : primarySegments.headMap(segment).values()) {
-               if (owners.size() >= builder.getActualNumOwners())
+               if (owners.size() >= actualNumOwners)
                   break;
                if (!owners.contains(a)) {
                   owners.add(a);
@@ -108,22 +126,49 @@ public class SyncConsistentHashFactory implements ConsistentHashFactory<DefaultC
    /**
     * Finds a unique "primary segment" for each virtual member
     */
-   private SortedMap<Integer, Address> populatePrimarySegments(Builder builder) {
+   private SortedMap<Integer, Address> populatePrimarySegments(Builder builder, int numSegments) {
       // Only used for debugging
       int collisions = 0;
+
+      List<Address> sortedMembers = builder.getSortedMembers();
+      int nodesWithLoad = builder.nodesWithLoad();
+      int numNodes = sortedMembers.size();
+
+      float maxCapacityFactor = 1;
+      float totalCapacity = 0;
+      for (Address member : sortedMembers) {
+         Float capacityFactor = builder.getCapacityFactor(member);
+         if (capacityFactor > maxCapacityFactor) {
+            maxCapacityFactor = capacityFactor;
+         }
+         totalCapacity += capacityFactor;
+      }
 
       // Since the number of segments is potentially much larger than the number of members,
       // we need a concept of "virtual nodes" to help split the segments more evenly.
       // However, we don't have a "numVirtualNodes" setting any more, so we try to guess it
       // based on numSegments. This is not perfect because we may end up with too many virtual nodes,
       // but the only downside in that is a little more shuffling when a node joins/leaves.
-      int numSegments = builder.getNumSegments();
-      int numVirtualNodes = (int) (Math.log(builder.getNumOwners() * numSegments + 1) / Math.log(2)) + 1;
-      int numNodes = builder.getSortedMembers().size();
-      Map<Integer, Address> primarySegments = new HashMap<Integer, Address>(numNodes * numVirtualNodes);
+      double totalVirtualNodes = nodesWithLoad * Math.sqrt(numSegments);
+      // Determine how many virtual nodes each node has based on its capacity factor compared to the maximum capacity factor
+      // (which has numVirtualNodes virtual nodes).
+      Map<Address, Integer> virtualNodeCounts = new HashMap<Address, Integer>(numNodes);
+      for (Address member : sortedMembers) {
+         Float capacityFactor = builder.getCapacityFactor(member);
+         int vn = 0;
+         // Every node should have at least one virtual node, unless its capacity factor is 0
+         if (capacityFactor > 0) {
+            vn = (int) Math.round(capacityFactor / totalCapacity * totalVirtualNodes + 1);
+         }
+         virtualNodeCounts.put(member, vn);
+      }
 
-      for (int virtualNode = 0; virtualNode < numVirtualNodes; virtualNode++) {
-         for (Address member : builder.getSortedMembers()) {
+      HashMap<Integer, Address> primarySegments = new HashMap<Integer, Address>();
+      for (int virtualNode = 0; virtualNode < totalVirtualNodes; virtualNode++) {
+         for (Address member : sortedMembers) {
+            if (virtualNode >= virtualNodeCounts.get(member))
+               continue;
+
             // Add the virtual node count after applying MurmurHash on the node's hashCode
             // to make up for badly spread test addresses.
             int virtualNodeHash = normalizedHash(builder.getHashFunction(), member.hashCode());
@@ -140,28 +185,35 @@ public class SyncConsistentHashFactory implements ConsistentHashFactory<DefaultC
                }
             }
          }
+         if (primarySegments.size() >= numSegments)
+            break;
       }
 
       return new TreeMap<Integer, Address>(primarySegments);
    }
 
    @Override
-   public DefaultConsistentHash updateMembers(DefaultConsistentHash baseCH, List<Address> newMembers) {
-      // the ConsistentHashFactory contract says we should return the same instance if we're not making changes
-      if (newMembers.equals(baseCH.getMembers()))
+   public DefaultConsistentHash updateMembers(DefaultConsistentHash baseCH, List<Address> newMembers,
+                                              Map<Address, Float> actualCapacityFactors) {
+      checkCapacityFactors(newMembers, actualCapacityFactors);
+
+      // The ConsistentHashFactory contract says we should return the same instance if we're not making changes
+      boolean sameCapacityFactors = actualCapacityFactors == null ? baseCH.getCapacityFactors() == null :
+            actualCapacityFactors.equals(baseCH.getCapacityFactors());
+      if (newMembers.equals(baseCH.getMembers()) && sameCapacityFactors)
          return baseCH;
 
       int numSegments = baseCH.getNumSegments();
       int numOwners = baseCH.getNumOwners();
 
-      // we assume leavers are far fewer than members, so it makes sense to check for leavers
+      // We assume leavers are far fewer than members, so it makes sense to check for leavers
       HashSet<Address> leavers = new HashSet<Address>(baseCH.getMembers());
       leavers.removeAll(newMembers);
 
-      // create a new "balanced" CH in case we need to allocate new owners for segments with 0 owners
-      DefaultConsistentHash rebalancedCH = create(baseCH.getHashFunction(), numOwners, numSegments, newMembers);
+      // Create a new "balanced" CH in case we need to allocate new owners for segments with 0 owners
+      DefaultConsistentHash rebalancedCH = null;
 
-      // remove leavers
+      // Remove leavers
       List<Address>[] newSegmentOwners = new List[numSegments];
       for (int i = 0; i < numSegments; i++) {
          List<Address> owners = new ArrayList<Address>(baseCH.locateOwnersForSegment(i));
@@ -170,17 +222,21 @@ public class SyncConsistentHashFactory implements ConsistentHashFactory<DefaultC
             newSegmentOwners[i] = owners;
          } else {
             // this segment has 0 owners, fix it
+            if (rebalancedCH == null) {
+               rebalancedCH = create(baseCH.getHashFunction(), numOwners, numSegments, newMembers, actualCapacityFactors);
+            }
             newSegmentOwners[i] = rebalancedCH.locateOwnersForSegment(i);
          }
       }
 
       return new DefaultConsistentHash(baseCH.getHashFunction(), numOwners, numSegments, newMembers,
-            newSegmentOwners);
+            actualCapacityFactors, newSegmentOwners);
    }
 
    @Override
    public DefaultConsistentHash rebalance(DefaultConsistentHash baseCH) {
-      DefaultConsistentHash rebalancedCH = create(baseCH.getHashFunction(), baseCH.getNumOwners(), baseCH.getNumSegments(), baseCH.getMembers());
+      DefaultConsistentHash rebalancedCH = create(baseCH.getHashFunction(), baseCH.getNumOwners(),
+            baseCH.getNumSegments(), baseCH.getMembers(), baseCH.getCapacityFactors());
 
       // the ConsistentHashFactory contract says we should return the same instance if we're not making changes
       if (rebalancedCH.equals(baseCH))
@@ -197,18 +253,21 @@ public class SyncConsistentHashFactory implements ConsistentHashFactory<DefaultC
    protected static class Builder {
       private final Hash hashFunction;
       private final int numOwners;
+      private final Map<Address, Float> capacityFactors;
       private final int actualNumOwners;
       private final int numSegments;
       private final List<Address> sortedMembers;
       private final int segmentSize;
       private final List<Address>[] segmentOwners;
 
-      private Builder(Hash hashFunction, int numOwners, int numSegments, List<Address> members) {
+      private Builder(Hash hashFunction, int numOwners, int numSegments, List<Address> members,
+                      Map<Address, Float> capacityFactors) {
          this.hashFunction = hashFunction;
          this.numSegments = numSegments;
          this.numOwners = numOwners;
+         this.capacityFactors = capacityFactors;
          this.actualNumOwners = Math.min(numOwners, members.size());
-         this.sortedMembers = sort(members);
+         this.sortedMembers = sort(members, capacityFactors);
          this.segmentSize = (int)Math.ceil((double)Integer.MAX_VALUE / numSegments);
          this.segmentOwners = new List[numSegments];
          for (int i = 0; i < numSegments; i++) {
@@ -248,10 +307,34 @@ public class SyncConsistentHashFactory implements ConsistentHashFactory<DefaultC
          return segmentOwners[i];
       }
 
-      private List<Address> sort(List<Address> list) {
-         ArrayList<Address> result = new ArrayList<Address>(list);
-         Collections.sort(result);
+      public float getCapacityFactor(Address node) {
+         return capacityFactors != null ? capacityFactors.get(node) : 1;
+      }
+
+      private List<Address> sort(List<Address> members, final Map<Address, Float> capacityFactors) {
+         ArrayList<Address> result = new ArrayList<Address>(members);
+         Collections.sort(result, new Comparator<Address>() {
+            @Override
+            public int compare(Address o1, Address o2) {
+               // Sort descending by capacity factor and ascending by address (UUID)
+               int capacityComparison = capacityFactors != null ? capacityFactors.get(o1).compareTo(capacityFactors.get(o2)) : 0;
+               return capacityComparison != 0 ? -capacityComparison : o1.compareTo(o2);
+            }
+         });
          return result;
+      }
+
+      private int nodesWithLoad() {
+         int nodesWithLoad = sortedMembers.size();
+         if (capacityFactors != null) {
+            nodesWithLoad = 0;
+            for (Address node : sortedMembers) {
+               if (capacityFactors.get(node) != 0) {
+                  nodesWithLoad++;
+               }
+            }
+         }
+         return nodesWithLoad;
       }
    }
 

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -91,7 +91,8 @@ public class StateTransferManagerImpl implements StateTransferManager {
             configuration.clustering().hash().numOwners(),
             configuration.clustering().stateTransfer().timeout(),
             configuration.transaction().transactionProtocol().isTotalOrder(),
-            configuration.clustering().cacheMode().isDistributed());
+            configuration.clustering().cacheMode().isDistributed(),
+            configuration.clustering().hash().capacityFactor());
 
       CacheTopology initialTopology = localTopologyManager.join(cacheName, joinInfo, new CacheTopologyHandler() {
          @Override

--- a/core/src/main/java/org/infinispan/topology/CacheJoinInfo.java
+++ b/core/src/main/java/org/infinispan/topology/CacheJoinInfo.java
@@ -18,6 +18,7 @@ import org.infinispan.marshall.core.Ids;
  * @since 5.2
  */
 public class CacheJoinInfo {
+   // Global configuration
    private final ConsistentHashFactory consistentHashFactory;
    private final Hash hashFunction;
    private final int numSegments;
@@ -26,8 +27,11 @@ public class CacheJoinInfo {
    private final boolean totalOrder;
    private final boolean distributed;
 
+   // Per-node configuration
+   private final float capacityFactor;
+
    public CacheJoinInfo(ConsistentHashFactory consistentHashFactory, Hash hashFunction, int numSegments,
-                        int numOwners, long timeout, boolean totalOrder, boolean distributed) {
+                        int numOwners, long timeout, boolean totalOrder, boolean distributed, float capacityFactor) {
       this.consistentHashFactory = consistentHashFactory;
       this.hashFunction = hashFunction;
       this.numSegments = numSegments;
@@ -35,6 +39,7 @@ public class CacheJoinInfo {
       this.timeout = timeout;
       this.totalOrder = totalOrder;
       this.distributed = distributed;
+      this.capacityFactor = capacityFactor;
    }
 
    public ConsistentHashFactory getConsistentHashFactory() {
@@ -65,6 +70,10 @@ public class CacheJoinInfo {
       return distributed;
    }
 
+   public float getCapacityFactor() {
+      return capacityFactor;
+   }
+
    @Override
    public String toString() {
       return "CacheJoinInfo{" +
@@ -88,6 +97,7 @@ public class CacheJoinInfo {
          output.writeLong(cacheJoinInfo.timeout);
          output.writeBoolean(cacheJoinInfo.totalOrder);
          output.writeBoolean(cacheJoinInfo.distributed);
+         output.writeFloat(cacheJoinInfo.capacityFactor);
       }
 
       @Override
@@ -99,7 +109,9 @@ public class CacheJoinInfo {
          long timeout = unmarshaller.readLong();
          boolean totalOrder = unmarshaller.readBoolean();
          boolean distributed = unmarshaller.readBoolean();
-         return new CacheJoinInfo(consistentHashFactory, hashFunction, numSegments, numOwners, timeout, totalOrder, distributed);
+         float capacityFactor = unmarshaller.readFloat();
+         return new CacheJoinInfo(consistentHashFactory, hashFunction, numSegments, numOwners, timeout,
+               totalOrder, distributed, capacityFactor);
       }
 
       @Override

--- a/core/src/main/resources/schema/infinispan-config-6.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-6.0.xsd
@@ -986,6 +986,15 @@
                     </xs:documentation>
                   </xs:annotation>
                 </xs:attribute>
+                <xs:attribute name="capacityFactor" type="xs:float" default="1">
+                  <xs:annotation>
+                    <xs:documentation>
+                      Controls the proportion of entries that will reside on the local node, compared to the other nodes
+                      in the cluster. This is just a suggestion, there is no guarantee that a node with a capacity
+                      factor of 2 will have twice as many entries as a node with a capacity factor of 1.
+                    </xs:documentation>
+                  </xs:annotation>
+                </xs:attribute>
               </xs:complexType>
             </xs:element>
           </xs:all>

--- a/core/src/test/java/org/infinispan/configuration/XmlFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/XmlFileParsingTest.java
@@ -542,7 +542,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       assertEquals(3, c.clustering().hash().numOwners());
       assertTrue(c.clustering().l1().enabled());
 
-      c = cm.getCacheConfiguration("dist_with_vnodes");
+      c = cm.getCacheConfiguration("dist_with_capacity_factors");
       assertEquals(CacheMode.DIST_SYNC, c.clustering().cacheMode());
       assertEquals(600000, c.clustering().l1().lifespan());
       if (deprecated) assertEquals(120000, c.clustering().hash().rehashRpcTimeout());
@@ -550,7 +550,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       assertEquals(null, c.clustering().hash().consistentHash()); // this is just an override.
       assertEquals(3, c.clustering().hash().numOwners());
       assertTrue(c.clustering().l1().enabled());
-      assertEquals(1, c.clustering().hash().numVirtualNodes());
+      assertEquals(0.0f, c.clustering().hash().capacityFactor());
       if (!deprecated) assertEquals(1000, c.clustering().hash().numSegments());
 
       c = cm.getCacheConfiguration("groups");

--- a/core/src/test/java/org/infinispan/distribution/ConsistentHashPerfTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ConsistentHashPerfTest.java
@@ -33,7 +33,8 @@ public class ConsistentHashPerfTest extends AbstractInfinispanTest {
    private ConsistentHash createNewConsistentHash(List<Address> servers) {
       try {
          // TODO Revisit after we have replaced the CH with the CHFactory in the configuration
-         return new DefaultConsistentHashFactory().create(new org.infinispan.commons.hash.MurmurHash3(), 2, 10, servers);
+         return new DefaultConsistentHashFactory().create(new org.infinispan.commons.hash.MurmurHash3(), 2, 10,
+               servers, null);
       } catch (RuntimeException re) {
          throw re;
       } catch (Exception e) {

--- a/core/src/test/java/org/infinispan/distribution/ch/DefaultConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/DefaultConsistentHashFactoryTest.java
@@ -1,12 +1,5 @@
 package org.infinispan.distribution.ch;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.infinispan.commons.hash.Hash;
 import org.infinispan.commons.hash.MurmurHash3;
 import org.infinispan.distribution.TestAddress;
@@ -14,7 +7,20 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Test the even distribution and number of moved segments after rebalance for {@link DefaultConsistentHashFactory}
@@ -32,61 +38,86 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
    }
 
    public void testConsistentHashDistribution() {
-      int[] numSegments = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512};
-      int[] numNodes = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100, 1000};
+      int[] numSegments = {1, 2, 4, 8, 16, 50, 100, 500};
+      int[] numNodes = {1, 2, 3, 4, 5, 7, 10, 100};
       int[] numOwners = {1, 2, 3, 5};
+      // Since the number of nodes changes, the capacity factors are repeated
+      float[][] capacityFactors = {null, {1}, {2}, {1, 100}, {2, 0, 1}};
 
-      ConsistentHashFactory<DefaultConsistentHash> chf = createConsistentHashFactory();
+      ConsistentHashFactory <DefaultConsistentHash> chf = createConsistentHashFactory();
       Hash hashFunction = new MurmurHash3();
 
       for (int nn : numNodes) {
          List<Address> nodes = new ArrayList<Address>(nn);
          for (int j = 0; j < nn; j++) {
-            nodes.add(new TestAddress(j));
+            nodes.add(new TestAddress(j, "TA"));
          }
 
          for (int ns : numSegments) {
             if (nn < ns) {
                for (int no : numOwners) {
-                  DefaultConsistentHash ch = chf.create(hashFunction, no, ns, nodes);
-                  checkDistribution(ch, false);
-
-                  testConsistentHashModifications(chf, ch);
+                  for (float[] lf : capacityFactors) {
+                     Map<Address, Float> lfMap = null;
+                     if (lf != null) {
+                        lfMap = new HashMap<Address, Float>();
+                        for (int i = 0; i < nn; i++) {
+                           lfMap.put(nodes.get(i), lf[i % lf.length]);
+                        }
+                     }
+                     testConsistentHashModifications(chf, hashFunction, nodes, ns, no, lfMap);
+                  }
                }
             }
          }
       }
    }
 
-   private void testConsistentHashModifications(ConsistentHashFactory<DefaultConsistentHash> chf, DefaultConsistentHash baseCH) {
+   private void testConsistentHashModifications(ConsistentHashFactory<DefaultConsistentHash> chf, Hash hashFunction, List<Address> nodes, int ns, int no, Map<Address, Float> lfMap) {
+      DefaultConsistentHash baseCH = chf.create(hashFunction, no, ns, nodes, lfMap);
+      assertEquals(lfMap, baseCH.getCapacityFactors());
+      checkDistribution(baseCH, lfMap, false);
+
       // each element in the array is a pair of numbers: the first is the number of nodes to add
       // the second is the number of nodes to remove (the index of the removed nodes are pseudo-random)
       int[][] nodeChanges = {{1, 0}, {2, 0}, {0, 1}, {0, 2}, {1, 1}, {1, 2}, {2, 1}, {10, 0}, {0, 10}};
 
       // check that the base CH is already balanced
-      assertSame(baseCH, chf.updateMembers(baseCH, baseCH.getMembers()));
+      List<Address> baseMembers = baseCH.getMembers();
+      assertSame(baseCH, chf.updateMembers(baseCH, baseMembers, lfMap));
       assertSame(baseCH, chf.rebalance(baseCH));
 
       // starting point, so that we don't confuse nodes
-      int nodeIndex = baseCH.getMembers().size();
+      int nodeIndex = baseMembers.size();
+
       for (int i = 0; i < nodeChanges.length; i++) {
          int nodesToAdd = nodeChanges[i][0];
          int nodesToRemove = nodeChanges[i][1];
-         if (nodesToRemove > baseCH.getMembers().size())
+         if (nodesToRemove > baseMembers.size())
+            break;
+         if (nodesToRemove == baseMembers.size() && nodesToAdd == 0)
             break;
 
-         List<Address> newMembers = new ArrayList<Address>(baseCH.getMembers());
+         List<Address> newMembers = new ArrayList<Address>(baseMembers);
+         HashMap<Address, Float> newCapacityFactors = lfMap != null ?
+               new HashMap<Address, Float>(lfMap) : null;
          for (int k = 0; k < nodesToRemove; k++) {
-            newMembers.remove(Math.abs(baseCH.getHashFunction().hash(k) % newMembers.size()));
+            int indexToRemove = Math.abs(baseCH.getHashFunction().hash(k) % newMembers.size());
+            if (newCapacityFactors != null) {
+               newCapacityFactors.remove(newMembers.get(indexToRemove));
+            }
+            newMembers.remove(indexToRemove);
          }
          for (int k = 0; k < nodesToAdd; k++) {
-            newMembers.add(new TestAddress(nodeIndex++));
+            TestAddress address = new TestAddress(nodeIndex++, "TA");
+            newMembers.add(address);
+            if (newCapacityFactors != null) {
+               newCapacityFactors.put(address, lfMap.get(baseMembers.get(k % baseMembers.size())));
+            }
          }
 
          log.tracef("Testing consistent hash modifications iteration %d. Initial CH is %s. New members are %s",
                iterationCount, baseCH, newMembers);
-         baseCH = checkModificationsIteration(chf, baseCH, nodesToAdd, nodesToRemove, newMembers);
-
+         baseCH = checkModificationsIteration(chf, baseCH, nodesToAdd, nodesToRemove, newMembers, newCapacityFactors);
 
          iterationCount++;
       }
@@ -94,12 +125,14 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
 
    private DefaultConsistentHash checkModificationsIteration(ConsistentHashFactory<DefaultConsistentHash> chf,
                                                              DefaultConsistentHash baseCH, int nodesToAdd,
-                                                             int nodesToRemove, List<Address> newMembers) {
-      int actualNumOwners = Math.min(newMembers.size(), baseCH.getNumOwners());
+                                                             int nodesToRemove, List<Address> newMembers,
+                                                             Map<Address, Float> lfMap) {
+      int actualNumOwners = computeActualNumOwners(baseCH.getNumOwners(), newMembers, lfMap);
 
       // first phase: just update the members list, removing the leavers
       // and adding new owners, but not necessarily assigning segments to them
-      DefaultConsistentHash updatedMembersCH = chf.updateMembers(baseCH, newMembers);
+      DefaultConsistentHash updatedMembersCH = chf.updateMembers(baseCH, newMembers, lfMap);
+      assertEquals(lfMap, updatedMembersCH.getCapacityFactors());
       if (nodesToRemove > 0) {
          for (int l = 0; l < updatedMembersCH.getNumSegments(); l++) {
             assertTrue(updatedMembersCH.locateOwnersForSegment(l).size() > 0);
@@ -109,13 +142,13 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
 
       // second phase: rebalance with the new members list
       DefaultConsistentHash rebalancedCH = chf.rebalance(updatedMembersCH);
-      checkDistribution(rebalancedCH, false);
+      checkDistribution(rebalancedCH, lfMap, false);
 
       for (int l = 0; l < rebalancedCH.getNumSegments(); l++) {
          assertTrue(rebalancedCH.locateOwnersForSegment(l).size() >= actualNumOwners);
       }
 
-      checkMovedSegments(baseCH, rebalancedCH, nodesToAdd);
+      checkMovedSegments(baseCH, rebalancedCH);
 
       // union doesn't have to keep the CH balanced, but it does have to include owners from both CHs
       DefaultConsistentHash unionCH = chf.union(updatedMembersCH, rebalancedCH);
@@ -132,11 +165,11 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
       return baseCH;
    }
 
-   private void checkDistribution(ConsistentHash ch, boolean allowExtraOwners) {
+   private void checkDistribution(ConsistentHash ch, Map<Address, Float> lfMap, boolean allowExtraOwners) {
       int numSegments = ch.getNumSegments();
       List<Address> nodes = ch.getMembers();
       int numNodes = nodes.size();
-      int actualNumOwners = Math.min(ch.getNumOwners(), numNodes);
+      int actualNumOwners = computeActualNumOwners(ch.getNumOwners(), nodes, lfMap);
 
       OwnershipStatistics stats = new OwnershipStatistics(nodes);
       for (int i = 0; i < numSegments; i++) {
@@ -154,83 +187,163 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
          }
       }
 
-      int minPrimaryOwned = minPrimaryOwned(numSegments, numNodes);
-      int maxPrimaryOwned = maxPrimaryOwned(numSegments, numNodes);
-      int minOwned = minOwned(numSegments, numNodes, actualNumOwners);
-      int maxOwned = maxOwned(numSegments, numNodes, actualNumOwners);
+      float totalCapacity = computeTotalCapacity(nodes, lfMap);
+      float maxCapacityFactor = computeMaxCapacityFactor(nodes, lfMap);
+      Map<Address, Float> expectedOwnedMap = computeExpectedOwned(numSegments, numNodes, actualNumOwners, nodes, lfMap);
       for (Address node : nodes) {
+         float capacityFactor = lfMap != null ? lfMap.get(node) : 1;
+         float expectedPrimaryOwned = expectedPrimaryOwned(numSegments, numNodes, totalCapacity, capacityFactor);
+         float deviationPrimaryOwned = allowedDeviationPrimaryOwned(numSegments, numNodes, totalCapacity, maxCapacityFactor);
+         int minPrimaryOwned = (int) Math.floor(expectedPrimaryOwned - deviationPrimaryOwned);
+         int maxPrimaryOwned = (int) Math.ceil(expectedPrimaryOwned + deviationPrimaryOwned);
          if (!allowExtraOwners) {
             int primaryOwned = stats.getPrimaryOwned(node);
             assertTrue(minPrimaryOwned <= primaryOwned);
             assertTrue(primaryOwned <= maxPrimaryOwned);
          }
 
+         float expectedOwned = expectedOwnedMap.get(node);
+         float deviationOwned = allowedDeviationOwned(numSegments, actualNumOwners, numNodes, totalCapacity, maxCapacityFactor);
+         int minOwned = (int) Math.floor(expectedOwned - deviationOwned);
+         int maxOwned = (int) Math.ceil(expectedOwned + deviationOwned);
          int owned = stats.getOwned(node);
-         assertTrue(minOwned <= owned);
+         assertTrue(Math.floor(minOwned) <= owned);
          if (!allowExtraOwners) {
-            assertTrue(owned <= maxOwned);
+            assertTrue(owned <= Math.ceil(maxOwned));
          }
       }
    }
 
-   protected int minPrimaryOwned(int numSegments, int numNodes) {
-      return numSegments / numNodes;
+   public int computeActualNumOwners(int numOwners, List<Address> members, Map<Address, Float> capacityFactors) {
+      if (capacityFactors == null)
+         return Math.min(numOwners, members.size());
+
+      int nodesWithLoad = 0;
+      for (Address node : members) {
+         if (capacityFactors.get(node) != 0) {
+            nodesWithLoad++;
+         }
+      }
+      return Math.min(numOwners, nodesWithLoad);
    }
 
-   protected int maxPrimaryOwned(int numSegments, int numNodes) {
-      return (int) Math.ceil((double)numSegments / numNodes);
+   protected float expectedPrimaryOwned(int numSegments, int numNodes, float totalCapacity, float nodeLoad) {
+      return Math.min(numSegments * nodeLoad / totalCapacity, numSegments);
    }
 
-   protected int minOwned(int numSegments, int numNodes, int actualNumOwners) {
-      return Math.min(numSegments, numSegments * actualNumOwners / numNodes);
+   protected float allowedDeviationPrimaryOwned(int numSegments, int numNodes, float totalCapacity, float maxCapacityFactor) {
+      return numNodes * maxCapacityFactor / totalCapacity;
    }
 
-   protected int maxOwned(int numSegments, int numNodes, int actualNumOwners) {
-      return Math.min(numSegments, (int) Math.ceil((double)numSegments * actualNumOwners / numNodes));
-   }
-
-   protected int allowedMoves(int numSegments, int numOwners, Collection<Address> oldMembers,
-                                 Collection<Address> newMembers) {
-      int minMembers = Math.min(oldMembers.size(), newMembers.size());
-      int maxMembers = Math.max(oldMembers.size(), newMembers.size());
-      if (maxMembers > numSegments)
-         return numSegments * numOwners; // don't do any checks in this case
-
-      Set<Address> addedMembers = new HashSet<Address>(newMembers);
-      addedMembers.removeAll(oldMembers);
-      Set<Address> removedMembers = new HashSet<Address>(oldMembers);
-      removedMembers.removeAll(newMembers);
-
-      // TODO removedMembers should not matter
-      int minMoves = (addedMembers.size() + removedMembers.size()) * numSegments * numOwners / minMembers;
-      // need to account for changes in the number of assigned segments based on a node's position in the members list
-      int extraMoves = maxMembers % numSegments;
-      // 1.5 is a "inefficiency factor"
-      return (int) (1.5 * (minMoves + extraMoves));
-   }
-
-   private void checkMovedSegments(DefaultConsistentHash oldCH, DefaultConsistentHash newCH, int addedNodes) {
-      int numSegments = oldCH.getNumSegments();
-      int numOwners = oldCH.getNumOwners();
-      List<Address> oldMembers = oldCH.getMembers();
-      List<Address> newMembers = newCH.getMembers();
-
-      // compute the number of segments that changed owners even though their old owners were still members
-      int movedSegments = 0;
-      for (int i = 0; i < numSegments; i++) {
-         ArrayList<Address> lostOwners = new ArrayList<Address>(oldCH.locateOwnersForSegment(i));
-         lostOwners.removeAll(newCH.locateOwnersForSegment(i));
-         lostOwners.retainAll(newMembers);
-         movedSegments += lostOwners.size();
+   protected Map<Address, Float> computeExpectedOwned(int numSegments, int numNodes, int actualNumOwners,
+                                                       Collection<Address> nodes,
+                                                       final Map<Address, Float> capacityFactors) {
+      Map<Address, Float> expectedOwned = new HashMap<Address, Float>();
+      if (capacityFactors == null) {
+         float expected = Math.min(numSegments, (float) numSegments * actualNumOwners / numNodes);
+         for (Address node : nodes) {
+            expectedOwned.put(node, expected);
+         }
+         return expectedOwned;
       }
 
-      int expectedMoves = allowedMoves(numSegments, numOwners, oldMembers, newMembers);
-      assert movedSegments <= expectedMoves
-            : String.format("Two many moved segments between %s and %s: expected %d, got %d",
-                            oldCH, newCH, expectedMoves, movedSegments);
+      List<Address> sortedNodes = new ArrayList<Address>(nodes);
+      Collections.sort(sortedNodes, new Comparator<Address>() {
+         @Override
+         public int compare(Address o1, Address o2) {
+            // Reverse order
+            return (int) Math.signum(capacityFactors.get(o2) - capacityFactors.get(o1));
+         }
+      });
+
+      float totalCapacity = computeTotalCapacity(nodes, capacityFactors);
+
+      int remainingCopies = actualNumOwners * numSegments;
+      for (Address node : sortedNodes) {
+         float nodeLoad = capacityFactors.get(node);
+         float nodeSegments;
+         if (remainingCopies * nodeLoad / totalCapacity > numSegments) {
+            nodeSegments = numSegments;
+            totalCapacity -= nodeLoad;
+            remainingCopies -= nodeSegments;
+         } else {
+            nodeSegments = nodeLoad != 0 ? remainingCopies * nodeLoad / totalCapacity : 0;
+         }
+         expectedOwned.put(node, nodeSegments);
+      }
+      return expectedOwned;
    }
 
-   protected <T> Set<T> symmetricalDiff(Collection<T> set1, Collection<T> set2) {
+   protected float allowedDeviationOwned(int numSegments, int actualNumOwners, int numNodes, float totalCapacity,
+                                          float maxCapacityFactor) {
+      return numNodes * maxCapacityFactor / totalCapacity;
+   }
+
+   private float computeTotalCapacity(Collection<Address> nodes, Map<Address, Float> capacityFactors) {
+      if (capacityFactors == null)
+         return nodes.size();
+
+      float totalCapacity = 0;
+      for (Address node : nodes) {
+         totalCapacity += capacityFactors.get(node);
+      }
+      return totalCapacity;
+   }
+
+   private float computeMaxCapacityFactor(Collection<Address> nodes, Map<Address, Float> capacityFactors) {
+      if (capacityFactors == null)
+         return 1;
+
+      float maxCapacityFactor = 0;
+      for (Address node : nodes) {
+         Float capacityFactor = capacityFactors.get(node);
+         if (capacityFactor > maxCapacityFactor) {
+            maxCapacityFactor = capacityFactor;
+         }
+      }
+      return maxCapacityFactor;
+   }
+
+   protected int allowedExtraMoves(DefaultConsistentHash oldCH, DefaultConsistentHash newCH,
+                                   int leaverSegments) {
+      return (int) Math.ceil(0.25 * oldCH.getNumSegments());
+   }
+
+   private void checkMovedSegments(DefaultConsistentHash oldCH, DefaultConsistentHash newCH) {
+      int numSegments = oldCH.getNumSegments();
+      int numOwners = oldCH.getNumOwners();
+      Set<Address> oldMembers = new HashSet<Address>(oldCH.getMembers());
+      Set<Address> newMembers = new HashSet<Address>(newCH.getMembers());
+
+      // Compute the number of segments owned by members that left
+      int leaverSegments = 0;
+      for (Address node : oldMembers) {
+         if (!newMembers.contains(node)) {
+            leaverSegments += oldCH.getSegmentsForOwner(node).size();
+         }
+      }
+
+      // Compute the number of segments where an old node became an owner
+      int oldMembersAddedSegments = 0;
+      for (int segment = 0; segment < numSegments; segment++) {
+         ArrayList<Address> oldMembersAdded = new ArrayList<Address>(newCH.locateOwnersForSegment(segment));
+         oldMembersAdded.removeAll(oldCH.locateOwnersForSegment(segment));
+         oldMembersAdded.retainAll(oldMembers);
+         oldMembersAddedSegments += oldMembersAdded.size();
+      }
+
+      int movedSegments = oldMembersAddedSegments - leaverSegments;
+      int expectedExtraMoves = allowedExtraMoves(oldCH, newCH, leaverSegments);
+      if (movedSegments > expectedExtraMoves) {
+         log.debugf("%d of %d segments moved, %d (%fx) more than expected (%d)", movedSegments, numSegments,
+               movedSegments - expectedExtraMoves, (float) movedSegments / expectedExtraMoves, expectedExtraMoves);
+      }
+      assert movedSegments <= expectedExtraMoves
+               : String.format("Two many moved segments between %s and %s: expected %d, got %d",
+            oldCH, newCH, expectedExtraMoves, oldMembersAddedSegments);
+   }
+
+   protected <T> Set<T> symmetricalDiff(Collection <T> set1, Collection<T> set2) {
       HashSet<T> commonMembers = new HashSet<T>(set1);
       commonMembers.retainAll(set2);
       HashSet<T> symDiffMembers = new HashSet<T>(set1);
@@ -246,18 +359,18 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
       TestAddress C = new TestAddress(2, "C");
       TestAddress D = new TestAddress(3, "D");
 
-      DefaultConsistentHash ch1 = chf.create(new MurmurHash3(), 2, 60, Arrays.<Address>asList(A));
+      DefaultConsistentHash ch1 = chf.create(new MurmurHash3(), 2, 60, Arrays.<Address>asList(A), null);
       //System.out.println(ch1);
 
-      DefaultConsistentHash ch2 = chf.updateMembers(ch1, Arrays.<Address>asList(A, B));
+      DefaultConsistentHash ch2 = chf.updateMembers(ch1, Arrays.<Address>asList(A, B), null);
       ch2 = chf.rebalance(ch2);
       //System.out.println(ch2);
 
-      DefaultConsistentHash ch3 = chf.updateMembers(ch2, Arrays.<Address>asList(A, B, C));
+      DefaultConsistentHash ch3 = chf.updateMembers(ch2, Arrays.<Address>asList(A, B, C), null);
       ch3 = chf.rebalance(ch3);
       //System.out.println(ch3);
 
-      DefaultConsistentHash ch4 = chf.updateMembers(ch3, Arrays.<Address>asList(A, B, C, D));
+      DefaultConsistentHash ch4 = chf.updateMembers(ch3, Arrays.<Address>asList(A, B, C, D), null);
       ch4 = chf.rebalance(ch4);
       //System.out.println(ch4);
    }

--- a/core/src/test/java/org/infinispan/distribution/ch/ReplicatedConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/ReplicatedConsistentHashFactoryTest.java
@@ -35,22 +35,22 @@ public class ReplicatedConsistentHashFactoryTest {
       List<Address> c = Arrays.asList(C);
 
       for (int segments : testSegments) {
-         ReplicatedConsistentHash ch = factory.create(new MurmurHash3(), 0, segments, a);
+         ReplicatedConsistentHash ch = factory.create(new MurmurHash3(), 0, segments, a, null);
          checkDistribution(ch);
 
-         ch = factory.updateMembers(ch, ab);
+         ch = factory.updateMembers(ch, ab, null);
          checkDistribution(ch);
 
-         ch = factory.updateMembers(ch, abc);
+         ch = factory.updateMembers(ch, abc, null);
          checkDistribution(ch);
 
-         ch = factory.updateMembers(ch, abcd);
+         ch = factory.updateMembers(ch, abcd, null);
          checkDistribution(ch);
 
-         ch = factory.updateMembers(ch, bcd);
+         ch = factory.updateMembers(ch, bcd, null);
          checkDistribution(ch);
 
-         ch = factory.updateMembers(ch, c);
+         ch = factory.updateMembers(ch, c, null);
          checkDistribution(ch);
       }
    }

--- a/core/src/test/java/org/infinispan/distribution/ch/SyncConsistentHashFactoryKeyDistributionTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/SyncConsistentHashFactoryKeyDistributionTest.java
@@ -57,7 +57,7 @@ public class SyncConsistentHashFactoryKeyDistributionTest extends AbstractInfini
    private DefaultConsistentHash createConsistentHash(int numSegments, int numOwners, int numNodes) {
       MurmurHash3 hash = new MurmurHash3();
       SyncConsistentHashFactory chf = new SyncConsistentHashFactory();
-      DefaultConsistentHash ch = chf.create(hash, numOwners, numSegments, createAddresses(numNodes));
+      DefaultConsistentHash ch = chf.create(hash, numOwners, numSegments, createAddresses(numNodes), null);
       return ch;
    }
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/WorkDuringJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/WorkDuringJoinTest.java
@@ -58,7 +58,7 @@ public class WorkDuringJoinTest extends BaseDistFunctionalTest<Object, String> {
       List<Address> newMembers = new ArrayList<Address>(chOld.getMembers());
       newMembers.add(joinerAddress);
       DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
-      ConsistentHash chNew = chf.rebalance(chf.updateMembers((DefaultConsistentHash) chOld, newMembers));
+      ConsistentHash chNew = chf.rebalance(chf.updateMembers((DefaultConsistentHash) chOld, newMembers, null));
       // which key should me mapped to the joiner?
       MagicKey keyToTest = null;
       for (MagicKey k: keys) {

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareSyncConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareSyncConsistentHashFactoryTest.java
@@ -39,7 +39,7 @@ public class TopologyAwareSyncConsistentHashFactoryTest extends TopologyAwareCon
       log.tracef("Ownership stats: " + stats);
       int maxPrimarySegments = numSegments / currentMembers.size() + 1;
       for (Address node : currentMembers) {
-         int maxSegments = stats.computeMaxSegments(numSegments, numOwners, node);
+         int maxSegments = stats.computeExpectedSegments(numSegments, numOwners, node);
          log.tracef("Primary segments ratio: %f, total segments ratio: %f",
                stats.getPrimaryOwned(node) / maxPrimarySegments, stats.getOwned(node) / maxSegments);
          assertTrue(maxPrimarySegments * 0.4 <= stats.getPrimaryOwned(node));

--- a/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
@@ -303,12 +303,12 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
       oldAddresses.add(a1);
       oldAddresses.add(a2);
       DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
-      DefaultConsistentHash oldCh = chf.create(new MurmurHash3(), 2, 3, oldAddresses);
+      DefaultConsistentHash oldCh = chf.create(new MurmurHash3(), 2, 3, oldAddresses, null);
       List<Address> newAddresses = new ArrayList<Address>();
       newAddresses.add(a1);
       newAddresses.add(a2);
       newAddresses.add(a3);
-      DefaultConsistentHash newCh = chf.create(new MurmurHash3(), 2, 3, newAddresses);
+      DefaultConsistentHash newCh = chf.create(new MurmurHash3(), 2, 3, newAddresses, null);
       StateRequestCommand c14 = new StateRequestCommand(cacheName, StateRequestCommand.Type.START_STATE_TRANSFER, a1, 99, null);
       byte[] bytes = marshaller.objectToByteBuffer(c14);
       marshaller.objectFromByteBuffer(bytes);

--- a/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
@@ -112,8 +112,8 @@ public class StateConsumerTest extends AbstractInfinispanTest {
 
       // create CHes
       DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
-      DefaultConsistentHash ch1 = chf.create(new MurmurHash3(), 2, 40, members1);
-      final DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2);
+      DefaultConsistentHash ch1 = chf.create(new MurmurHash3(), 2, 40, members1, null);
+      final DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2, null);
       DefaultConsistentHash ch3 = chf.rebalance(ch2);
 
       log.debug(ch1);

--- a/core/src/test/java/org/infinispan/statetransfer/StateProviderTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateProviderTest.java
@@ -140,8 +140,8 @@ public class StateProviderTest {
 
       // create CHes
       DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
-      DefaultConsistentHash ch1 = chf.create(new MurmurHash3(), 2, numSegments, members1);
-      DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2);
+      DefaultConsistentHash ch1 = chf.create(new MurmurHash3(), 2, numSegments, members1, null);
+      DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2, null);
 
       // create dependencies
       when(mockExecutorService.submit(any(Runnable.class))).thenAnswer(new Answer<Future<?>>() {
@@ -228,8 +228,9 @@ public class StateProviderTest {
 
       // create CHes
       DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
-      DefaultConsistentHash ch1 = chf.create(new MurmurHash3(), 2, numSegments, members1);
-      DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2);   //todo [anistor] it seems that address 6 is not used for un-owned segments
+      DefaultConsistentHash ch1 = chf.create(new MurmurHash3(), 2, numSegments, members1, null);
+      //todo [anistor] it seems that address 6 is not used for un-owned segments
+      DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2, null);
 
       when(commandsFactory.buildStateResponseCommand(any(Address.class), anyInt(), any(Collection.class))).thenAnswer(new Answer<StateResponseCommand>() {
          @Override

--- a/core/src/test/resources/configs/named-cache-test.xml
+++ b/core/src/test/resources/configs/named-cache-test.xml
@@ -200,11 +200,11 @@
       </clustering>
    </namedCache>
 
-   <namedCache name="dist_with_vnodes">
+   <namedCache name="dist_with_capacity_factors">
       <clustering mode="distribution">
          <stateTransfer timeout="120000" />
          <sync/>
-         <hash numOwners="3" numSegments="1000"/>
+         <hash numOwners="3" numSegments="1000" capacityFactor="0"/>
          <l1 enabled="true" lifespan="600000"/>
       </clustering>
    </namedCache>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3051

Because the algorithm for allocating segments changed, some tests had to
change as well. E.g. we can't always find a MagicKey that will be owned
by 3 particular members, as in StateResponseOrderingTest.
