### PR TITLE
Incorrectly removed EmbeddedCacheManager.defineConfiguration() method

### DIFF
--- a/core/src/main/java/org/infinispan/manager/AbstractDelegatingEmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/AbstractDelegatingEmbeddedCacheManager.java
@@ -1,6 +1,7 @@
 package org.infinispan.manager;
 
 import org.infinispan.Cache;
+import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.remoting.transport.Address;
@@ -32,6 +33,11 @@ public class AbstractDelegatingEmbeddedCacheManager implements EmbeddedCacheMana
    public org.infinispan.configuration.cache.Configuration defineConfiguration(String cacheName,
          org.infinispan.configuration.cache.Configuration configuration) {
       return cm.defineConfiguration(cacheName, configuration);
+   }
+
+   @Override
+   public Configuration defineConfiguration(String cacheName, String templateCacheName, Configuration configurationOverride) {
+      return cm.defineConfiguration(cacheName, templateCacheName, configurationOverride);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -318,6 +318,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager, CacheManager {
       return defineConfiguration(cacheName, configuration, defaultConfiguration, true);
    }
 
+   @Override
    public Configuration defineConfiguration(String cacheName, String templateName, Configuration configurationOverride) {
       if (templateName != null) {
          Configuration c = configurationOverrides.get(templateName);

--- a/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
@@ -61,6 +61,31 @@ public interface EmbeddedCacheManager extends CacheContainer, Listenable {
    Configuration defineConfiguration(String cacheName, Configuration configurationOverride);
 
    /**
+    * Defines a named cache's configuration using the following algorithm:
+    * <p/>
+    * Regardless of whether the cache name has been defined or not, this method creates a clone of the configuration of
+    * the cache whose name matches the given template cache name, then applies a clone of the configuration overrides
+    * passed in and finally returns this configuration instance.
+    * <p/>
+    * The other way to define named cache's configuration is declaratively, in the XML file passed in to the cache
+    * manager. This method enables you to override certain properties that have previously been defined via XML.
+    * <p/>
+    * Passing a brand new Configuration instance as configuration override without having called any of its setters will
+    * effectively return the named cache's configuration since no overrides where passed to it.
+    * <p/>
+    * If templateName is null or there isn't any named cache with that name, this methods works exactly like {@link
+    * #defineConfiguration(String, Configuration)} in the sense that the base configuration used is the default cache
+    * configuration.
+    *
+    * @param cacheName             name of cache whose configuration is being defined
+    * @param templateCacheName     name of cache to which to which apply overrides if cache name has not been previously
+    *                              defined
+    * @param configurationOverride configuration overrides to use
+    * @return a cloned configuration instance
+    */
+   Configuration defineConfiguration(String cacheName, String templateCacheName, Configuration configurationOverride);
+
+   /**
     * @return the name of the cluster.  Null if running in local mode.
     */
    String getClusterName();


### PR DESCRIPTION
wrongly removed by https://issues.jboss.org/browse/ISPN-3516 

(no jira for this)
