### PR TITLE
ISPN-3345 Track installed cache managers and pass to cache resolver

### DIFF
--- a/cdi/extension/src/main/java/org/infinispan/cdi/util/defaultbean/DefaultBeanExtension.java
+++ b/cdi/extension/src/main/java/org/infinispan/cdi/util/defaultbean/DefaultBeanExtension.java
@@ -397,6 +397,7 @@ public class DefaultBeanExtension implements Extension {
                 Bean<?> db = DefaultManagedBean.of(defaultManagedBeans.get(qual), beanInfo.getType(), types, qualifiers, manager);
                 log.debug("Installing default managed bean " + db);
                 event.addBean(db);
+                fireBeanInstalledEvent(db, manager);
             } else if (defaultProducerMethods.containsKey(qual)) {
                 Synthetic declaringDefaultBean = this.producerToDeclaringDefaultBean.get(qual).getSyntheticQualifier();
                 Set<Annotation> declaringBeanQualifiers;
@@ -411,6 +412,7 @@ public class DefaultBeanExtension implements Extension {
                 Bean<?> db = createDefaultProducerMethod(defaultProducerMethods.get(qual), qual, beanInfo, types, qualifiers, declaringBeanQualifiers, info, manager);
                 log.debug("Installing default producer bean " + db);
                 event.addBean(db);
+                fireBeanInstalledEvent(db, manager);
             } else if (defaultProducerFields.containsKey(qual)) {
                 Synthetic declaringDefaultBean = this.producerToDeclaringDefaultBean.get(qual).getSyntheticQualifier();
                 Set<Annotation> declaringBeanQualifiers;
@@ -424,11 +426,16 @@ public class DefaultBeanExtension implements Extension {
                 Bean<?> db = DefaultProducerField.of(defaultProducerFields.get(qual), beanInfo.getType(), types, qualifiers, declaringBeanQualifiers, producerAnnotatedFields.get(qual), manager);
                 log.debug("Installing default producer bean " + db);
                 event.addBean(db);
+                fireBeanInstalledEvent(db, manager);
             }
         }
         for (Throwable e : deploymentProblems) {
             event.addDefinitionError(e);
         }
+    }
+    
+    private <X> void fireBeanInstalledEvent(Bean<?> bean,  BeanManager beanManager) {
+        beanManager.fireEvent(new DefaultBeanHolder(bean), InstalledLiteral.INSTANCE);
     }
 
     void afterDeploymentValidation(@Observes AfterDeploymentValidation event) {

--- a/cdi/extension/src/main/java/org/infinispan/cdi/util/defaultbean/DefaultBeanHolder.java
+++ b/cdi/extension/src/main/java/org/infinispan/cdi/util/defaultbean/DefaultBeanHolder.java
@@ -1,0 +1,17 @@
+package org.infinispan.cdi.util.defaultbean;
+
+import javax.enterprise.inject.spi.Bean;
+
+public class DefaultBeanHolder {
+
+    private final Bean<?> bean;
+    
+    public DefaultBeanHolder(Bean<?> bean) {
+        this.bean = bean;
+    }
+    
+    public Bean<?> getBean() {
+        return bean;
+    }
+    
+}

--- a/cdi/extension/src/main/java/org/infinispan/cdi/util/defaultbean/Installed.java
+++ b/cdi/extension/src/main/java/org/infinispan/cdi/util/defaultbean/Installed.java
@@ -1,0 +1,21 @@
+package org.infinispan.cdi.util.defaultbean;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Qualifier
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+@Documented
+public @interface Installed {
+
+}

--- a/cdi/extension/src/main/java/org/infinispan/cdi/util/defaultbean/InstalledLiteral.java
+++ b/cdi/extension/src/main/java/org/infinispan/cdi/util/defaultbean/InstalledLiteral.java
@@ -1,0 +1,9 @@
+package org.infinispan.cdi.util.defaultbean;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+public class InstalledLiteral extends AnnotationLiteral<Installed> implements Installed {
+
+    public static final Installed INSTANCE = new InstalledLiteral(); 
+    
+}

--- a/cdi/extension/src/test/java/org/infinispan/cdi/test/cache/embedded/specific/SpecificCacheManagerTest.java
+++ b/cdi/extension/src/test/java/org/infinispan/cdi/test/cache/embedded/specific/SpecificCacheManagerTest.java
@@ -1,12 +1,16 @@
 package org.infinispan.cdi.test.cache.embedded.specific;
 
 import org.infinispan.Cache;
+import org.infinispan.cdi.InfinispanExtension;
 import org.infinispan.cdi.test.DefaultTestEmbeddedCacheManagerProducer;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.testng.annotations.Test;
 
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 
 import static org.infinispan.cdi.test.testutil.Deployments.baseDeployment;
@@ -42,6 +46,16 @@ public class SpecificCacheManagerTest extends Arquillian {
    @Inject
    @Small
    private Cache<?, ?> smallCache;
+   
+   @Inject
+   private InfinispanExtension infinispanExtension;
+   
+   @Inject 
+   private BeanManager beanManager;
+   
+   public void testCorrectCacheManagersRegistered() {
+       assertEquals(infinispanExtension.getInstalledEmbeddedCacheManagers(beanManager).size(), 2);
+   }
 
    public void testSpecificCacheManager() throws Exception {
       assertEquals(largeCache.getCacheConfiguration().eviction().maxEntries(), 2000);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3345
- No more unnecessary cache managers are created
- Add method to return installed embedded cache managers
- Add public Set<EmbeddedCacheManager> getInstalledEmbeddedCacheManagers(BeanManager beanManager)

Thanks to @pmuir for finding a workaround to avoid leading cache managers. I slightly tweaked his fix to determine which was the default cache manager.
