### PR TITLE
ISPN-3542 Read Only transaction optimization doesn't work properly for R...

### DIFF
--- a/core/src/main/java/org/infinispan/transaction/LocalTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/LocalTransaction.java
@@ -121,7 +121,7 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
    }
 
    public boolean isReadOnly() {
-      return (modifications == null || modifications.isEmpty()) && (lookedUpEntries == null || lookedUpEntries.isEmpty());
+      return modifications == null || modifications.isEmpty();
    }
 
    public abstract boolean isEnlisted();

--- a/core/src/test/java/org/infinispan/replication/SyncReplPessimisticLockingTest.java
+++ b/core/src/test/java/org/infinispan/replication/SyncReplPessimisticLockingTest.java
@@ -3,16 +3,23 @@ package org.infinispan.replication;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.context.Flag;
+import org.infinispan.distribution.MagicKey;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.transaction.LocalTransaction;
 import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.RemoteTransaction;
 import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
 import org.testng.annotations.Test;
 
 import javax.transaction.TransactionManager;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.jgroups.util.Util.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 
@@ -177,5 +184,61 @@ public class SyncReplPessimisticLockingTest extends MultipleCacheManagersTest {
       assertEquals(cache(0, "testcache").get("k"), null);
       assertEquals(cache(1, "testcache").get("k"), null);
       assert !lockManager(0, "testcache").isLocked("k");
+   }
+
+   @Test(enabled = false, description = "This test should work when ISPN-3266 is fixed")
+   public void testRemoteLocksReleasedWhenReadTransactionCommitted() throws Exception {
+      testRemoteLocksReleased(false, true);
+   }
+
+   @Test(enabled = false, description = "This test should work when ISPN-3266 is fixed")
+   public void testRemoteLocksReleasedWhenReadTransactionRolledBack() throws Exception {
+      testRemoteLocksReleased(false, false);
+   }
+
+   @Test
+   public void testRemoteLocksReleasedWhenWriteTransactionCommitted() throws Exception {
+      testRemoteLocksReleased(true, true);
+   }
+
+   @Test
+   public void testRemoteLocksReleasedWhenWriteTransactionRolledBack() throws Exception {
+      testRemoteLocksReleased(true, false);
+   }
+
+   private void testRemoteLocksReleased(boolean write, boolean commit) throws Exception {
+      MagicKey key = new MagicKey(cache(0, "testcache"));
+      tm(1, "testcache").begin();
+      if (write) {
+         cache(1, "testcache").put(key, "somevalue");
+      } else {
+         cache(1, "testcache").getAdvancedCache().withFlags(Flag.FORCE_WRITE_LOCK).get(key);
+      }
+
+      Collection<LocalTransaction> localTxs = TestingUtil.getTransactionTable(cache(1, "testcache")).getLocalTransactions();
+      assertEquals(1, localTxs.size());
+      LocalTransaction localTx = localTxs.iterator().next();
+      if (write) {
+         assertFalse(localTx.isReadOnly());
+      } else {
+         assertTrue(localTx.isReadOnly());
+      }
+
+      Collection<RemoteTransaction> remoteTxs = TestingUtil.getTransactionTable(cache(0, "testcache")).getRemoteTransactions();
+      assertEquals(1, remoteTxs.size());
+      RemoteTransaction remoteTx = remoteTxs.iterator().next();
+      assertTrue(remoteTx.getLockedKeys().contains(key));
+      assertTrue(TestingUtil.extractLockManager(cache(0, "testcache")).isLocked(key));
+
+      if (commit) {
+         tm(1, "testcache").commit();
+         // Hack since commit releases locks async
+         Thread.sleep(100);
+      } else {
+         tm(1, "testcache").rollback();
+      }
+
+      assertEquals(0, TestingUtil.getTransactionTable(cache(0, "testcache")).getRemoteTxCount());
+      assertFalse(TestingUtil.extractLockManager(cache(0, "testcache")).isLocked(key));
    }
 }

--- a/core/src/test/java/org/infinispan/tx/ReadOnlyRepeatableReadTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/ReadOnlyRepeatableReadTxTest.java
@@ -1,0 +1,29 @@
+package org.infinispan.tx;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.context.Flag;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.TransactionTable;
+import org.infinispan.transaction.xa.LocalXaTransaction;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+import javax.transaction.Transaction;
+
+/**
+ * @author William Burns
+ * @since 6.0
+ */
+@Test (groups = "functional", testName = "tx.ReadOnlyRepeatableReadTxTest")
+@CleanupAfterMethod
+public class ReadOnlyRepeatableReadTxTest extends ReadOnlyTxTest {
+   protected void configure(ConfigurationBuilder builder) {
+      super.configure(builder);
+      builder.locking().isolationLevel(IsolationLevel.REPEATABLE_READ);
+   }
+}


### PR DESCRIPTION
...epeatableRead
- Changed LocalTransaction readOnly optimization to be for modifications only.
- Added tests to ensure Locks are always released on commit async after it completes whether from 1PC or 2PC
- Added tests to ensure Locks are always released on rollback as global tx is marked complete
- Also added tests for FORCE_WRITE_LOCK to make sure it works properly with lock acquisition and release

https://issues.jboss.org/browse/ISPN-3542
