### PR TITLE
ISPN-3542 Read Only transaction optimization doesn't work properly for R...

### DIFF
--- a/core/src/test/java/org/infinispan/tx/OptimisticReadOnlyTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/OptimisticReadOnlyTxTest.java
@@ -1,0 +1,37 @@
+package org.infinispan.tx;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.transaction.LockingMode;
+import org.testng.annotations.Test;
+
+/**
+ * @author Pedro Ruivo
+ * @since 6.0
+ */
+@Test(groups = "functional", testName = "tx.OptimisticReadOnlyTxTest")
+@CleanupAfterMethod
+public class OptimisticReadOnlyTxTest extends ReadOnlyTxTest {
+
+   @Override
+   public void testROWhenHasOnlyLocksAndReleasedProperly() throws Exception {
+      //no-op. not valid for optimistic transactions
+   }
+
+   @Override
+   public void testNotROWhenHasWrites() throws Exception {
+      //no-op. not valid for optimistic transactions
+   }
+
+   @Override
+   protected void configure(ConfigurationBuilder builder) {
+      super.configure(builder);
+      builder.transaction().lockingMode(LockingMode.OPTIMISTIC);
+   }
+
+   @Override
+   protected int numberCommitCommand() {
+      //with optimistic locking, the transactions are committed in 2 phases. So 1 CommitCommand is expected
+      return 1;
+   }
+}

--- a/core/src/test/java/org/infinispan/tx/ReadOnlyTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/ReadOnlyTxTest.java
@@ -1,8 +1,11 @@
 package org.infinispan.tx;
 
+import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.Flag;
+import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.interceptors.base.BaseCustomInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
@@ -11,9 +14,13 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionTable;
 import org.infinispan.transaction.xa.LocalXaTransaction;
+import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 
+import javax.transaction.NotSupportedException;
+import javax.transaction.SystemException;
 import javax.transaction.Transaction;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Mircea.Markus@jboss.com
@@ -68,8 +75,37 @@ public class ReadOnlyTxTest extends SingleCacheManagerTest {
       assert !TestingUtil.extractLockManager(cache).isLocked("k");
    }
 
+   public void testSingleCommitCommand() throws Exception {
+      cache.put("k", "v");
+      CommitCommandCounterInterceptor counterInterceptor = new CommitCommandCounterInterceptor();
+      cache.getAdvancedCache().addInterceptor(counterInterceptor, 0);
+      try {
+         tm().begin();
+         AssertJUnit.assertEquals("Wrong value for key k.", "v", cache.get("k"));
+         tm().commit();
+      } finally {
+         cache.getAdvancedCache().getAdvancedCache().removeInterceptor(counterInterceptor.getClass());
+      }
+      AssertJUnit.assertEquals("Wrong number of CommitCommand.", numberCommitCommand(), counterInterceptor.counter.get());
+   }
+
+   protected int numberCommitCommand() {
+      //in this case, the transactions are committed in 1 phase due to pessimistic locking.
+      return 0;
+   }
 
    private TransactionTable txTable() {
       return TestingUtil.getTransactionTable(cache);
+   }
+
+   private class CommitCommandCounterInterceptor extends BaseCustomInterceptor {
+
+      public final AtomicInteger counter = new AtomicInteger(0);
+
+      @Override
+      public Object visitCommitCommand(TxInvocationContext ctx, CommitCommand command) throws Throwable {
+         counter.incrementAndGet();
+         return invokeNextInterceptor(ctx, command);
+      }
    }
 }


### PR DESCRIPTION
...epeatableRead
- fix: CommitCommand was sent twice for read-only transactions

fix for https://issues.jboss.org/browse/ISPN-3542. 
also fixes the extended statistics tests failures. 
