### PR TITLE
ISPN-3318 Embedded rolling upgrade using CLI enabling cache store data migration.

### DIFF
--- a/cli/cli-client/src/main/java/org/infinispan/cli/CommandBuffer.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/CommandBuffer.java
@@ -1,8 +1,13 @@
 package org.infinispan.cli;
 
+import org.infinispan.cli.commands.ProcessedCommand;
+
+import java.util.List;
+
 public interface CommandBuffer {
    void reset();
 
-   boolean addCommand(String command, int nesting);
+   boolean addCommand(ProcessedCommand commandLine, int nesting);
 
+   List<ProcessedCommand> getBufferedCommands();
 }

--- a/cli/cli-client/src/main/java/org/infinispan/cli/Context.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/Context.java
@@ -1,7 +1,10 @@
 package org.infinispan.cli;
 
+import org.infinispan.cli.commands.ProcessedCommand;
 import org.infinispan.cli.connection.Connection;
 import org.infinispan.cli.io.IOAdapter;
+
+import java.util.List;
 
 /**
  *
@@ -32,6 +35,8 @@ public interface Context {
    void error(String s);
 
    void error(Throwable t);
+
+   void result(List<ProcessedCommand> commands, String result, boolean isError);
 
    void refreshProperties();
 

--- a/cli/cli-client/src/main/java/org/infinispan/cli/commands/client/Connect.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/commands/client/Connect.java
@@ -8,6 +8,7 @@ import org.infinispan.cli.commands.Argument;
 import org.infinispan.cli.commands.ProcessedCommand;
 import org.infinispan.cli.connection.Connection;
 import org.infinispan.cli.connection.ConnectionFactory;
+import org.infinispan.commons.util.InfinispanCollections;
 
 public class Connect extends AbstractCommand {
 
@@ -35,7 +36,7 @@ public class Connect extends AbstractCommand {
          if (connection.needsCredentials()) {
             password = new String(context.getOutputAdapter().secureReadln("Password: "));
          }
-         connection.connect(context, password);
+         connection.connect(password);
          context.setConnection(connection);
       } catch (Exception e) {
          context.error(e);

--- a/cli/cli-client/src/main/java/org/infinispan/cli/commands/server/AbstractServerCommand.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/commands/server/AbstractServerCommand.java
@@ -16,7 +16,7 @@ public abstract class AbstractServerCommand extends AbstractCommand implements S
    @Override
    public void execute(Context context, ProcessedCommand commandLine) {
       CommandBuffer commandBuffer = context.getCommandBuffer();
-      if(commandBuffer.addCommand(commandLine.getCommandLine(), nesting())) {
+      if(commandBuffer.addCommand(commandLine, nesting())) {
          context.execute();
       }
    }

--- a/cli/cli-client/src/main/java/org/infinispan/cli/commands/server/Ping.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/commands/server/Ping.java
@@ -25,7 +25,7 @@ public class Ping extends AbstractServerCommand {
    @Override
    public void execute(Context context, ProcessedCommand commandLine) {
       CommandBuffer commandBuffer = new CommandBufferImpl();
-      commandBuffer.addCommand(getName(), nesting());
+      commandBuffer.addCommand(commandLine, nesting());
       context.getConnection().execute(context, commandBuffer);
    }
 }

--- a/cli/cli-client/src/main/java/org/infinispan/cli/connection/Connection.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/connection/Connection.java
@@ -8,7 +8,7 @@ import org.infinispan.cli.Context;
 
 public interface Connection extends Closeable {
 
-   void connect(Context context, String credentials) throws Exception;
+   void connect(String credentials) throws Exception;
 
    boolean needsCredentials();
 

--- a/cli/cli-client/src/main/java/org/infinispan/cli/impl/CommandBufferImpl.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/impl/CommandBufferImpl.java
@@ -1,27 +1,39 @@
 package org.infinispan.cli.impl;
 
 import org.infinispan.cli.CommandBuffer;
+import org.infinispan.cli.commands.ProcessedCommand;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class CommandBufferImpl implements CommandBuffer {
    private int nesting = 0;
-   StringBuilder commands = new StringBuilder(1024);
+   StringBuilder commandsString = new StringBuilder(1024);
+   List<ProcessedCommand> commands = new ArrayList<ProcessedCommand>(1);
 
    @Override
    public void reset() {
       nesting = 0;
-      commands.setLength(0);
+      commandsString.setLength(0);
+      commands.clear();
    }
 
    @Override
-   public boolean addCommand(String command, int nesting) {
+   public boolean addCommand(ProcessedCommand commandLine, int nesting) {
       this.nesting += nesting;
-      commands.append(command).append("\n");
+      commandsString.append(commandLine.getCommandLine()).append("\n");
+      commands.add(commandLine);
       return this.nesting == 0;
    }
 
    @Override
+   public List<ProcessedCommand> getBufferedCommands() {
+      return commands;
+   }
+
+   @Override
    public String toString() {
-      return commands.toString();
+      return commandsString.toString();
    }
 }

--- a/cli/cli-client/src/main/java/org/infinispan/cli/impl/ContextImpl.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/impl/ContextImpl.java
@@ -2,10 +2,12 @@ package org.infinispan.cli.impl;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.infinispan.cli.CommandBuffer;
 import org.infinispan.cli.CommandRegistry;
 import org.infinispan.cli.Context;
+import org.infinispan.cli.commands.ProcessedCommand;
 import org.infinispan.cli.connection.Connection;
 import org.infinispan.cli.io.IOAdapter;
 
@@ -87,6 +89,14 @@ public class ContextImpl implements Context {
    public void error(Throwable t) {
       try {
          outputAdapter.error(t.getMessage()!=null?t.getMessage():t.getClass().getName());
+      } catch (IOException e) {
+      }
+   }
+
+   @Override
+   public void result(List<ProcessedCommand> commands, String result, boolean isError) {
+      try {
+         outputAdapter.result(commands, result, isError);
       } catch (IOException e) {
       }
    }

--- a/cli/cli-client/src/main/java/org/infinispan/cli/io/ConsoleIOAdapter.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/io/ConsoleIOAdapter.java
@@ -1,8 +1,10 @@
 package org.infinispan.cli.io;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.fusesource.jansi.Ansi;
+import org.infinispan.cli.commands.ProcessedCommand;
 import org.jboss.aesh.console.Console;
 import org.jboss.aesh.console.Prompt;
 
@@ -39,6 +41,14 @@ public class ConsoleIOAdapter implements IOAdapter {
       Ansi ansi = new Ansi();
       ansi.fg(Ansi.Color.RED);
       println(ansi.render(s).reset().toString());
+   }
+
+   @Override
+   public void result(List<ProcessedCommand> commands, String result, boolean isError) throws IOException {
+      if (isError)
+         error(result);
+      else
+         println(result);
    }
 
    @Override

--- a/cli/cli-client/src/main/java/org/infinispan/cli/io/IOAdapter.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/io/IOAdapter.java
@@ -1,6 +1,9 @@
 package org.infinispan.cli.io;
 
+import org.infinispan.cli.commands.ProcessedCommand;
+
 import java.io.IOException;
+import java.util.List;
 
 public interface IOAdapter {
    boolean isInteractive();
@@ -8,6 +11,8 @@ public interface IOAdapter {
    void println(String s) throws IOException;
 
    void error(String s) throws IOException;
+
+   void result(List<ProcessedCommand> commands, String result, boolean isError) throws IOException;
 
    String readln(String s) throws IOException;
 

--- a/cli/cli-client/src/main/java/org/infinispan/cli/io/StreamIOAdapter.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/io/StreamIOAdapter.java
@@ -1,8 +1,11 @@
 package org.infinispan.cli.io;
 
+import org.infinispan.cli.commands.ProcessedCommand;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.List;
 
 public class StreamIOAdapter implements IOAdapter {
 
@@ -19,6 +22,14 @@ public class StreamIOAdapter implements IOAdapter {
    @Override
    public void error(String s) throws IOException {
       System.err.println(s);
+   }
+
+   @Override
+   public void result(List<ProcessedCommand> commands, String result, boolean isError) throws IOException {
+      if (isError)
+         error(result);
+      else
+         println(result);
    }
 
    @Override

--- a/cli/cli-client/src/main/java/org/infinispan/cli/shell/ShellImpl.java
+++ b/cli/cli-client/src/main/java/org/infinispan/cli/shell/ShellImpl.java
@@ -71,7 +71,7 @@ public class ShellImpl implements Shell {
                   exitWithError("Cannot read password non-interactively");
                }
             }
-            connection.connect(context, password);
+            connection.connect(password);
             context.setConnection(connection);
             break;
          case 'f':

--- a/compatibility52x/cli-migrator52x/pom.xml
+++ b/compatibility52x/cli-migrator52x/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <parent>
+      <artifactId>compatibility52x-parent</artifactId>
+      <groupId>org.infinispan</groupId>
+      <version>6.0.0-SNAPSHOT</version>
+   </parent>
+   <modelVersion>4.0.0</modelVersion>
+
+   <artifactId>infinispan-cli-migrator52x</artifactId>
+
+   <properties>
+      <version.infinispan52x>5.2.7.Final</version.infinispan52x>
+   </properties>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-core</artifactId>
+         <version>${version.infinispan52x}</version>
+      </dependency>
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-core</artifactId>
+         <type>test-jar</type>
+         <scope>test</scope>
+         <version>${version.infinispan52x}</version>
+      </dependency>
+   </dependencies>
+</project>

--- a/compatibility52x/cli-migrator52x/src/main/java/org/infinispan/cli/upgrade/CLInterfaceSourceMigrator.java
+++ b/compatibility52x/cli-migrator52x/src/main/java/org/infinispan/cli/upgrade/CLInterfaceSourceMigrator.java
@@ -1,0 +1,90 @@
+package org.infinispan.cli.upgrade;
+
+import org.infinispan.Cache;
+import org.infinispan.CacheException;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.distexec.DefaultExecutorService;
+import org.infinispan.distexec.DistributedCallable;
+import org.infinispan.distexec.DistributedExecutorService;
+import org.infinispan.upgrade.SourceMigrator;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+/**
+ * // TODO: Document this
+ *
+ * @author Galder Zamarreño
+ * @since // TODO
+ */
+public class CLInterfaceSourceMigrator implements SourceMigrator {
+
+   private static final String KNOWN_KEY = "___MigrationManager_CLI_KnownKeys___";
+
+   private final Cache<String, Set<Object>> cache;
+
+   public CLInterfaceSourceMigrator(Cache<?, ?> cache) {
+      this.cache = (Cache<String, Set<Object>>) cache;
+   }
+
+   @Override
+   public void recordKnownGlobalKeyset() {
+      try {
+         CacheMode cm = cache.getCacheConfiguration().clustering().cacheMode();
+         Set<Object> keys;
+         if (cm.isReplicated() || !cm.isClustered()) {
+            // If cache mode is LOCAL or REPL, dump local keyset.
+            // Defensive copy to serialize and transmit across a network
+            keys = new HashSet<Object>(cache.keySet());
+         } else {
+            // If cache mode is DIST, use a map/reduce task
+            DistributedExecutorService des = new DefaultExecutorService(cache);
+            List<Future<Set<Object>>> keysets = des.submitEverywhere(new GlobalKeysetTask(cache));
+            Set<Object> combinedKeyset = new HashSet<Object>();
+
+            for (Future<Set<Object>> keyset : keysets)
+               combinedKeyset.addAll(keyset.get());
+
+            keys = combinedKeyset;
+         }
+
+         // Remove KNOWN_KEY from the key set - just in case it is there from a previous run.
+         keys.remove(KNOWN_KEY);
+
+         cache.put(KNOWN_KEY, keys);
+      } catch (InterruptedException e) {
+         Thread.currentThread().interrupt(); // reset
+      } catch (ExecutionException e) {
+         throw new CacheException("Unable to record all known keys", e);
+      }
+   }
+
+   @Override
+   public String getCacheName() {
+      return cache.getName();
+   }
+
+   static class GlobalKeysetTask implements DistributedCallable<Object, Object, Set<Object>> {
+
+      final Cache<?, ?> cache;
+
+      GlobalKeysetTask(Cache<?, ?> cache) {
+         this.cache = cache;
+      }
+
+      @Override
+      public void setEnvironment(Cache<Object, Object> cache, Set<Object> inputKeys) {
+         // TODO: Customise this generated block
+      }
+
+      @Override
+      public Set<Object> call() throws Exception {
+         // Defensive copy to serialize and transmit across a network
+         return new HashSet<Object>(cache.keySet());
+      }
+   }
+
+}

--- a/compatibility52x/cli-migrator52x/src/main/java/org/infinispan/cli/upgrade/SourceMigratorInstaller.java
+++ b/compatibility52x/cli-migrator52x/src/main/java/org/infinispan/cli/upgrade/SourceMigratorInstaller.java
@@ -1,0 +1,30 @@
+package org.infinispan.cli.upgrade;
+
+import org.infinispan.Cache;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.lifecycle.AbstractModuleLifecycle;
+import org.infinispan.upgrade.RollingUpgradeManager;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * // TODO: Document this
+ *
+ * @author Galder Zamarreño
+ * @since // TODO
+ */
+public class SourceMigratorInstaller extends AbstractModuleLifecycle {
+
+   private static final Log log = LogFactory.getLog(SourceMigratorInstaller.class);
+
+   @Override
+   public void cacheStarted(ComponentRegistry cr, String cacheName) {
+      Cache<?, ?> cache = cr.getComponent(Cache.class);
+      RollingUpgradeManager migrationManager = cr.getComponent(RollingUpgradeManager.class);
+      if (migrationManager != null) {
+         log.debug("Register CLI source migrator");
+         migrationManager.addSourceMigrator(new CLInterfaceSourceMigrator(cache));
+      }
+   }
+
+}

--- a/compatibility52x/cli-migrator52x/src/main/resources/META-INF/services/org.infinispan.lifecycle.ModuleLifecycle
+++ b/compatibility52x/cli-migrator52x/src/main/resources/META-INF/services/org.infinispan.lifecycle.ModuleLifecycle
@@ -1,0 +1,1 @@
+org.infinispan.cli.upgrade.SourceMigratorInstaller

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1020,7 +1020,14 @@ public interface Log extends BasicLogger {
    @Message(value = "Persistence enabled without any CacheWriteInterceptor in InterceptorChain!", id = 275)
    void persistenceWithoutCacheWriteInterceptor();
 
-   @Message(value = "Indexing can only be enabled if infinispan-query.jar is available on your classpath, and this jar has not been detected.", id = 276)
+   @Message(value = "Could not find migration data in cache %s", id = 276)
+   CacheException missingMigrationData(String name);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Could not migrate key %s", id = 277)
+   void keyMigrationFailed(String key, @Cause Throwable cause);
+
+   @Message(value = "Indexing can only be enabled if infinispan-query.jar is available on your classpath, and this jar has not been detected.", id = 278)
    CacheConfigurationException invalidConfigurationIndexingWithoutModule();
    
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -303,6 +303,16 @@
             <version>${project.version}</version>
          </dependency>
          <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>infinispan-cli-client</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>infinispan-cli-server</artifactId>
+            <version>${project.version}</version>
+         </dependency>
+         <dependency>
             <groupId>c3p0</groupId>
             <artifactId>c3p0</artifactId>
             <version>${version.c3p0}</version>

--- a/persistence/cli/pom.xml
+++ b/persistence/cli/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+   <parent>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-persistence-parent</artifactId>
+      <version>6.0.0-SNAPSHOT</version>
+      <relativePath>../pom.xml</relativePath>
+   </parent>
+   <artifactId>infinispan-persistence-cli</artifactId>
+   <packaging>bundle</packaging>
+   <name>Infinispan Command Line Interface persistence</name>
+   <description>Infinispan Command Line Interface persistence</description>
+   <properties>
+   </properties>
+
+   <dependencies>
+      <dependency>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>infinispan-cli-client</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.codehaus.jackson</groupId>
+         <artifactId>jackson-mapper-asl</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>infinispan-cli-server</artifactId>
+         <scope>test</scope>
+      </dependency>
+   </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <configuration>
+               <instructions>
+                  <Export-Package>
+                     ${project.groupId}.persistence.cli.*;version=${project.version};-split-package:=error
+                  </Export-Package>
+               </instructions>
+            </configuration>
+         </plugin>
+
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <!-- Remote JMX properties will only be properly applied when
+               passed via argLine. If passed via systemPropertyVariables,
+               they're applied too late for them to have an effect on the JVM
+               -->
+               <argLine>
+                  -Dcom.sun.management.jmxremote=true
+                  -Djava.rmi.server.hostname=localhost
+                  -Dcom.sun.management.jmxremote.port=2626
+                  -Dcom.sun.management.jmxremote.authenticate=false
+                  -Dcom.sun.management.jmxremote.ssl=false
+               </argLine>
+               <forkMode>once</forkMode>
+            </configuration>
+         </plugin>
+
+      </plugins>
+   </build>
+</project>

--- a/persistence/cli/src/main/java/org/infinispan/persistence/cli/CLInterfaceLoader.java
+++ b/persistence/cli/src/main/java/org/infinispan/persistence/cli/CLInterfaceLoader.java
@@ -1,0 +1,186 @@
+package org.infinispan.persistence.cli;
+
+import org.codehaus.jackson.annotate.JsonTypeInfo;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.infinispan.cli.Context;
+import org.infinispan.cli.commands.Command;
+import org.infinispan.cli.commands.ProcessedCommand;
+import org.infinispan.cli.connection.Connection;
+import org.infinispan.cli.connection.ConnectionFactory;
+import org.infinispan.cli.impl.CommandBufferImpl;
+import org.infinispan.cli.impl.ContextImpl;
+import org.infinispan.cli.io.IOAdapter;
+import org.infinispan.commons.CacheException;
+import org.infinispan.commons.util.CollectionFactory;
+import org.infinispan.marshall.core.MarshalledEntry;
+import org.infinispan.persistence.cli.configuration.CLInterfaceLoaderConfiguration;
+import org.infinispan.persistence.spi.CacheLoader;
+import org.infinispan.persistence.spi.InitializationContext;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A read-only cache loader retrieving data from another cache(s) using the
+ * Command Line Interface.
+ *
+ * @author Galder Zamarreño
+ * @since 6.0
+ */
+public class CLInterfaceLoader<K, V> implements CacheLoader<K, V> {
+
+   private InitializationContext ctx;
+   private Connection connection;
+   private CLInterfaceLoaderConfiguration cfg;
+
+   private ObjectMapper jsonMapper = new ObjectMapper().enableDefaultTyping(
+         ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.WRAPPER_OBJECT);
+
+   @Override
+   public void init(InitializationContext ctx) {
+      this.ctx = ctx;
+      this.cfg = ctx.getConfiguration();
+   }
+
+   @Override
+   public MarshalledEntry<K, V> load(K key) {
+      // TODO: a CLI command to retrieve value + metadata is needed
+      ProcessedCommand parsed = new ProcessedCommand("get " + key.toString() + ";");
+
+      // Having CLI context as field of this cache loader produces all sorts of
+      // issues when paralell requests are received, since the commands get
+      // bunched up. This is valid in shell mode, but a bit problematic for
+      // the cache loader. So, instead create a context instance for each
+      // operation. This is obviously not very efficient, but this cache loader
+      // should only be used during migration, so any inefficiencies should
+      // only be temporary.
+      Context cliCtx = createContext();
+      Command command = cliCtx.getCommandRegistry().getCommand(parsed.getCommand());
+      command.execute(cliCtx, parsed);
+      ResponseMatcher.Result result = ((ResponseMatcher) cliCtx.getOutputAdapter())
+            .getResult(Collections.singletonList(parsed));
+      if (result.isError)
+         throw new CacheException("Unable to load entry: " + result.result);
+
+      if (result.result.equals("null"))
+         return null;
+
+      // The value returned could be JSON when custom classes are used,
+      // so try reading it. If the read fails, just use the given String.
+      Object value = result.result;
+      try {
+         value = jsonMapper.readValue(result.result, Object.class);
+      } catch (IOException e) {
+         // Ignore if it fails
+      }
+
+      return ctx.getMarshalledEntryFactory().newMarshalledEntry(key, value, null);
+   }
+
+   private Context createContext() {
+      ResponseMatcher responseMatcher = new ResponseMatcher();
+      Context cliCtx = new ContextImpl(responseMatcher, new CommandBufferImpl());
+      cliCtx.setConnection(connection);
+      return cliCtx;
+   }
+
+   @Override
+   public boolean contains(K key) {
+      return load(key) != null;
+   }
+
+   @Override
+   public void start() {
+      // i.e. "jmx://localhost:2626/Source-CacheManager-1/___defaultcache"
+      String serviceUrl = cfg.connectionString();
+      connection = ConnectionFactory.getConnection(serviceUrl);
+      try {
+         connection.connect(null);
+      } catch (Exception e) {
+         throw new CacheException("Unable to connect to URL: " + serviceUrl, e);
+      }
+   }
+
+
+   @Override
+   public void stop() {
+      if (connection != null && connection.isConnected()) {
+         try {
+            connection.close();
+         } catch (IOException e) {
+         }
+         connection = null;
+      }
+   }
+
+   private static class ResponseMatcher implements IOAdapter {
+
+      private static final Log log = LogFactory.getLog(ResponseMatcher.class);
+
+      ConcurrentMap<List<ProcessedCommand>, Result> results = CollectionFactory.makeConcurrentMap();
+
+      @Override
+      public boolean isInteractive() {
+         return false;
+      }
+
+      @Override
+      public void error(String error) {
+         log.error(error);
+      }
+
+      @Override
+      public void println(String s) {
+         log.debug(s);
+      }
+
+      @Override
+      public void result(List<ProcessedCommand> commands, String result, boolean isError) {
+         results.put(commands, new Result().isError(isError).result(result));
+      }
+
+      @Override
+      public String readln(String s) throws IOException {
+         return null;  // TODO: Customise this generated block
+      }
+
+      @Override
+      public String secureReadln(String s) throws IOException {
+         return null;  // TODO: Customise this generated block
+      }
+
+      @Override
+      public int getWidth() {
+         return 0;  // TODO: Customise this generated block
+      }
+
+      @Override
+      public void close() throws IOException {
+         // TODO: Customise this generated block
+      }
+
+      Result getResult(List<ProcessedCommand> commands) {
+         return results.remove(commands);
+      }
+
+      static class Result {
+         boolean isError;
+         String result;
+
+         Result isError(boolean isError) {
+            this.isError = isError;
+            return this;
+         }
+
+         Result result(String result) {
+            this.result = result;
+            return this;
+         }
+      }
+   }
+
+}

--- a/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/Attribute.java
+++ b/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/Attribute.java
@@ -1,0 +1,51 @@
+package org.infinispan.persistence.cli.configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Enumerates the attributes used by the CLI cache loader configuration
+ *
+ * @author Galder Zamarreño
+ * @since 6.0
+ */
+public enum Attribute {
+   // must be first
+   UNKNOWN(null),
+
+   CONNECTION("connection"),
+   ;
+
+   private final String name;
+
+   private Attribute(final String name) {
+      this.name = name;
+   }
+
+   /**
+    * Get the local name of this element.
+    *
+    * @return the local name
+    */
+   public String getLocalName() {
+      return name;
+   }
+
+   private static final Map<String, Attribute> attributes;
+
+   static {
+      final Map<String, Attribute> map = new HashMap<String, Attribute>(64);
+      for (Attribute attribute : values()) {
+         final String name = attribute.getLocalName();
+         if (name != null) {
+            map.put(name, attribute);
+         }
+      }
+      attributes = map;
+   }
+
+   public static Attribute forName(final String localName) {
+      final Attribute attribute = attributes.get(localName);
+      return attribute == null ? UNKNOWN : attribute;
+   }
+}

--- a/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/CLInterfaceLoaderConfiguration.java
+++ b/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/CLInterfaceLoaderConfiguration.java
@@ -1,0 +1,47 @@
+package org.infinispan.persistence.cli.configuration;
+
+import org.infinispan.commons.configuration.BuiltBy;
+import org.infinispan.commons.configuration.ConfigurationFor;
+import org.infinispan.configuration.cache.AbstractStoreConfiguration;
+import org.infinispan.configuration.cache.AsyncStoreConfiguration;
+import org.infinispan.configuration.cache.ClusterLoaderConfigurationBuilder;
+import org.infinispan.configuration.cache.SingletonStoreConfiguration;
+import org.infinispan.persistence.cli.CLInterfaceLoader;
+
+import java.util.Properties;
+
+/**
+ * // TODO: Document this
+ *
+ * @author Galder Zamarreño
+ * @since // TODO
+ */
+@BuiltBy(CLInterfaceLoaderConfigurationBuilder.class)
+@ConfigurationFor(CLInterfaceLoader.class)
+public class CLInterfaceLoaderConfiguration extends AbstractStoreConfiguration {
+
+   private final String connectionString;
+
+   public CLInterfaceLoaderConfiguration(
+         boolean purgeOnStartup, boolean fetchPersistentState,
+         boolean ignoreModifications, AsyncStoreConfiguration async,
+         SingletonStoreConfiguration singletonStore, boolean preload,
+         boolean shared, Properties properties,
+         String connectionString) {
+      super(purgeOnStartup, fetchPersistentState, ignoreModifications, async,
+            singletonStore, preload, shared, properties);
+      this.connectionString = connectionString;
+   }
+
+   public String connectionString() {
+      return connectionString;
+   }
+
+   @Override
+   public String toString() {
+      return "CLInterfaceLoaderConfiguration{" +
+            "connectionString='" + connectionString + '\'' +
+            '}';
+   }
+
+}

--- a/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/CLInterfaceLoaderConfigurationBuilder.java
+++ b/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/CLInterfaceLoaderConfigurationBuilder.java
@@ -1,0 +1,46 @@
+package org.infinispan.persistence.cli.configuration;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.cache.AbstractStoreConfigurationBuilder;
+import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+
+/**
+ * // TODO: Document this
+ *
+ * @author Galder Zamarreño
+ * @since // TODO
+ */
+public class CLInterfaceLoaderConfigurationBuilder
+      extends AbstractStoreConfigurationBuilder
+                    <CLInterfaceLoaderConfiguration, CLInterfaceLoaderConfigurationBuilder> {
+
+   private String connectionString;
+
+   public CLInterfaceLoaderConfigurationBuilder(PersistenceConfigurationBuilder builder) {
+      super(builder);
+   }
+
+   public CLInterfaceLoaderConfigurationBuilder connectionString(String connectionString) {
+      this.connectionString = connectionString;
+      return this;
+   }
+
+   @Override
+   public CLInterfaceLoaderConfiguration create() {
+      return new CLInterfaceLoaderConfiguration(purgeOnStartup, fetchPersistentState,
+            ignoreModifications, async.create(), singletonStore.create(),
+            preload, shared, properties, connectionString);
+   }
+
+   @Override
+   public Builder<?> read(CLInterfaceLoaderConfiguration template) {
+      this.connectionString = template.connectionString();
+      return this;
+   }
+
+   @Override
+   public CLInterfaceLoaderConfigurationBuilder self() {
+      return this;
+   }
+
+}

--- a/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/CLInterfaceLoaderConfigurationParser60.java
+++ b/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/CLInterfaceLoaderConfigurationParser60.java
@@ -1,0 +1,76 @@
+package org.infinispan.persistence.cli.configuration;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
+import org.infinispan.configuration.parsing.ConfigurationParser;
+import org.infinispan.configuration.parsing.Namespace;
+import org.infinispan.configuration.parsing.Namespaces;
+import org.infinispan.configuration.parsing.ParseUtils;
+import org.infinispan.configuration.parsing.Parser60;
+import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
+
+import javax.xml.stream.XMLStreamException;
+
+import static org.infinispan.commons.util.StringPropertyReplacer.replaceProperties;
+
+/**
+ * XML parser for CLI cache loader configuration.
+ *
+ * @author Galder Zamarreño
+ * @since 6.0
+ */
+@Namespaces({
+      @Namespace(uri = "urn:infinispan:config:cli:6.0", root = "cliLoader"),
+      @Namespace(root = "cliLoader"),
+})
+public class CLInterfaceLoaderConfigurationParser60 implements ConfigurationParser {
+
+   @Override
+   public void readElement(XMLExtendedStreamReader reader, ConfigurationBuilderHolder holder)
+         throws XMLStreamException {
+      ConfigurationBuilder builder = holder.getCurrentConfigurationBuilder();
+
+      Element element = Element.forName(reader.getLocalName());
+      switch (element) {
+         case CLI_LOADER: {
+            parseCliLoader(reader, builder.persistence(), holder.getClassLoader());
+            break;
+         }
+         default: {
+            throw ParseUtils.unexpectedElement(reader);
+         }
+      }
+
+   }
+
+   private void parseCliLoader(XMLExtendedStreamReader reader,
+         PersistenceConfigurationBuilder persistence, ClassLoader classLoader)
+         throws XMLStreamException {
+      CLInterfaceLoaderConfigurationBuilder builder = new CLInterfaceLoaderConfigurationBuilder(persistence);
+      parseCliLoaderAttributes(reader, builder, classLoader);
+      persistence.addStore(builder);
+   }
+
+   private void parseCliLoaderAttributes(XMLExtendedStreamReader reader,
+         CLInterfaceLoaderConfigurationBuilder builder, ClassLoader classLoader)
+         throws XMLStreamException  {
+      for (int i = 0; i < reader.getAttributeCount(); i++) {
+         ParseUtils.requireNoNamespaceAttribute(reader, i);
+         String value = replaceProperties(reader.getAttributeValue(i));
+         String attrName = reader.getAttributeLocalName(i);
+         Attribute attribute = Attribute.forName(attrName);
+         switch (attribute) {
+            case CONNECTION: {
+               builder.connectionString(value);
+               break;
+            }
+            default: {
+               Parser60.parseCommonStoreAttributes(reader, builder, attrName, value, i);
+               break;
+            }
+         }
+      }
+   }
+
+}

--- a/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/Element.java
+++ b/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/Element.java
@@ -1,0 +1,52 @@
+package org.infinispan.persistence.cli.configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An enumeration of all the recognized XML element local names for the
+ * {@link org.infinispan.persistence.cli.CLInterfaceLoader}
+ *
+ * @author Galder Zamarreño
+ * @since 6.0
+ */
+public enum Element {
+    // must be first
+    UNKNOWN(null),
+
+    CLI_LOADER("cliLoader")
+    ;
+
+    private final String name;
+
+    Element(final String name) {
+        this.name = name;
+    }
+
+    /**
+     * Get the local name of this element.
+     *
+     * @return the local name
+     */
+    public String getLocalName() {
+        return name;
+    }
+
+    private static final Map<String, Element> MAP;
+
+    static {
+        final Map<String, Element> map = new HashMap<String, Element>(8);
+        for (Element element : values()) {
+            final String name = element.getLocalName();
+            if (name != null) {
+               map.put(name, element);
+            }
+        }
+        MAP = map;
+    }
+
+    public static Element forName(final String localName) {
+        final Element element = MAP.get(localName);
+        return element == null ? UNKNOWN : element;
+    }
+}

--- a/persistence/cli/src/main/java/org/infinispan/persistence/cli/upgrade/CLInterfaceTargetMigrator.java
+++ b/persistence/cli/src/main/java/org/infinispan/persistence/cli/upgrade/CLInterfaceTargetMigrator.java
@@ -1,0 +1,103 @@
+package org.infinispan.persistence.cli.upgrade;
+
+import org.codehaus.jackson.annotate.JsonTypeInfo;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.infinispan.Cache;
+import org.infinispan.commons.CacheException;
+import org.infinispan.commons.util.Util;
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.marshall.core.MarshalledEntry;
+import org.infinispan.persistence.cli.CLInterfaceLoader;
+import org.infinispan.persistence.manager.PersistenceManager;
+import org.infinispan.upgrade.TargetMigrator;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * // TODO: Document this
+ *
+ * @author Galder Zamarreño
+ * @since // TODO
+ */
+public class CLInterfaceTargetMigrator implements TargetMigrator {
+
+   private static final Log log = LogFactory.getLog(CLInterfaceTargetMigrator.class);
+
+   private static final String KNOWN_KEY = "___MigrationManager_CLI_KnownKeys___";
+
+   private ObjectMapper jsonMapper = new ObjectMapper().enableDefaultTyping(
+         ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.WRAPPER_OBJECT);
+
+   @Override
+   public String getName() {
+      return "cli";
+   }
+
+   @Override
+   public long synchronizeData(final Cache<Object, Object> cache) throws CacheException {
+      int threads = Runtime.getRuntime().availableProcessors();
+      PersistenceManager loaderManager = getPersistenceManager(cache);
+      Set<CLInterfaceLoader> loaders = loaderManager.getStores(CLInterfaceLoader.class);
+
+      for (CLInterfaceLoader loader : loaders) {
+         MarshalledEntry loadedKnownKey = loader.load(KNOWN_KEY);
+         if (loadedKnownKey != null) {
+            Set<Object> keys;
+            try {
+               keys = jsonMapper
+                     .readValue((String) loadedKnownKey.getValue(), HashSet.class);
+            } catch (IOException e) {
+               throw new CacheException(
+                     "Unable to read JSON value: " + loadedKnownKey.getValue(), e);
+            }
+
+            ExecutorService es = Executors.newFixedThreadPool(threads);
+            final AtomicInteger count = new AtomicInteger(0);
+            for (final Object key : keys) {
+               es.submit(new Runnable() {
+                  @Override
+                  public void run() {
+                     try {
+                        cache.get(key);
+                        int i = count.getAndIncrement();
+                        if (log.isDebugEnabled() && i % 100 == 0)
+                           log.debugf(">>    Moved %s keys\n", i);
+                     } catch (Exception e) {
+                        log.keyMigrationFailed(Util.toStr(key), e);
+                     }
+            }
+               });
+
+            }
+            es.shutdown();
+            try {
+               while (!es.awaitTermination(500, TimeUnit.MILLISECONDS));
+            } catch (InterruptedException e) {
+               throw new CacheException(e);
+            }
+            return count.longValue();
+         }
+      }
+      throw log.missingMigrationData(cache.getName());
+   }
+
+   private PersistenceManager getPersistenceManager(Cache<Object, Object> cache) {
+      ComponentRegistry cr = cache.getAdvancedCache().getComponentRegistry();
+      return cr.getComponent(PersistenceManager.class);
+   }
+
+   @Override
+   public void disconnectSource(Cache<Object, Object> cache) throws CacheException {
+      PersistenceManager loaderManager = getPersistenceManager(cache);
+      loaderManager.disableStore(CLInterfaceLoader.class.getName());
+   }
+
+}

--- a/persistence/cli/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
+++ b/persistence/cli/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
@@ -1,0 +1,1 @@
+org.infinispan.persistence.cli.configuration.CLInterfaceLoaderConfigurationParser60

--- a/persistence/cli/src/main/resources/META-INF/services/org.infinispan.upgrade.TargetMigrator
+++ b/persistence/cli/src/main/resources/META-INF/services/org.infinispan.upgrade.TargetMigrator
@@ -1,0 +1,1 @@
+org.infinispan.persistence.cli.upgrade.CLInterfaceTargetMigrator

--- a/persistence/cli/src/main/resources/schema/infinispan-cacheloader-cli-config-6.0.xsd
+++ b/persistence/cli/src/main/resources/schema/infinispan-cacheloader-cli-config-6.0.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" version="1.0"
+           targetNamespace="urn:infinispan:config:remote:6.0"
+           xmlns:tns="urn:infinispan:config:remote:6.0"
+           xmlns:config="urn:infinispan:config:6.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import namespace="urn:infinispan:config:6.0"
+             schemaLocation="http://www.infinispan.org/schemas/infinispan-config-6.0.xsd" />
+
+  <xs:element name="cliLoader">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="config:store">
+          <xs:attribute name="connection" type="xs:string" default="">
+            <xs:annotation>
+              <xs:documentation>
+                Defines one or multiple URLs via which the cache loader will
+                connect to other caches via the CLI.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/persistence/cli/src/test/java/org/infinispan/persistence/cli/CLInterfaceLoaderFunctionalTest.java
+++ b/persistence/cli/src/test/java/org/infinispan/persistence/cli/CLInterfaceLoaderFunctionalTest.java
@@ -1,0 +1,174 @@
+package org.infinispan.persistence.cli;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.persistence.cli.configuration.CLInterfaceLoaderConfigurationBuilder;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.CacheManagerCallable;
+import org.infinispan.test.MultiCacheManagerCallable;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.data.Key;
+import org.infinispan.test.data.Person;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.infinispan.test.TestingUtil.withCacheManager;
+import static org.infinispan.test.TestingUtil.withCacheManagers;
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * // TODO: Document this
+ *
+ * @author Galder Zamarreño
+ * @since // TODO
+ */
+@Test(groups = "unit", testName = "persistence.cli.CLInterfaceLoaderFunctionalTest")
+public class CLInterfaceLoaderFunctionalTest extends AbstractInfinispanTest {
+
+   static final String SOURCE_CONNECTION_STRING = "jmx://localhost:2626/SourceCacheManager/___defaultcache";
+
+   public void testSequentialGet() {
+      withCacheManager(new CacheManagerCallable(createSourceCacheManager()) {
+         @Override
+         public void call() {
+            Cache<Integer, String> sourceCache = cm.getCache();
+            sourceCache.put(1, "v1");
+            sourceCache.put(2, "v2");
+            sourceCache.put(3, "v3");
+
+            withCacheManager(new CacheManagerCallable(createTargetCacheManager()) {
+               @Override
+               public void call() {
+                  Cache<Object, Object> targetCache = cm.getCache();
+                  assertEquals("v1", targetCache.get(1));
+                  assertEquals("v2", targetCache.get(2));
+                  assertEquals("v3", targetCache.get(3));
+               }
+            });
+         }
+      });
+   }
+
+   public void testMultiThreadGet() {
+      withCacheManager(new CacheManagerCallable(createSourceCacheManager()) {
+         @Override
+         public void call() {
+            Cache<Integer, String> sourceCache = cm.getCache();
+            sourceCache.put(1, "v1");
+            sourceCache.put(2, "v2");
+            sourceCache.put(3, "v3");
+
+            withCacheManager(new CacheManagerCallable(createTargetCacheManager()) {
+               @Override
+               public void call() {
+                  final Cache<Integer, String> targetCache = cm.getCache();
+                  Future<String> f1 = asyncGet(targetCache, 1);
+                  Future<String> f2 = asyncGet(targetCache, 2);
+                  Future<String> f3 = asyncGet(targetCache, 3);
+
+                  assertFutureEquals("v1", f1);
+                  assertFutureEquals("v2", f2);
+                  assertFutureEquals("v3", f3);
+               }
+            });
+         }
+      });
+   }
+
+   @Test(enabled = false) // Needs a way to convert keys to JSON format
+   public void testCustomKey() {
+      withCacheManager(new CacheManagerCallable(createSourceCacheManager()) {
+         @Override
+         public void call() {
+            Cache<Key, Integer> sourceCache = cm.getCache();
+            final Key k1 = new Key("k1", false);
+            final Key k2 = new Key("k2", false);
+            final Key k3 = new Key("k3", false);
+            sourceCache.put(k1, 1);
+            sourceCache.put(k2, 2);
+            sourceCache.put(k3, 3);
+
+            withCacheManager(new CacheManagerCallable(createTargetCacheManager()) {
+               @Override
+               public void call() {
+                  Cache<Key, Integer> targetCache = cm.getCache();
+                  assertEquals(new Integer(1), targetCache.get(k1));
+                  assertEquals(new Integer(2), targetCache.get(k2));
+                  assertEquals(new Integer(3), targetCache.get(k3));
+               }
+            });
+         }
+      });
+   }
+
+   public void testCustomValue() {
+      withCacheManager(new CacheManagerCallable(createSourceCacheManager()) {
+         @Override
+         public void call() {
+            Cache<Integer, Person> sourceCache = cm.getCache();
+            final Person p1 = new Person("Jose Garza");
+            final Person p2 = new Person("Willard Rogers");
+            final Person p3 = new Person("B. Cunningham");
+            sourceCache.put(1, p1);
+            sourceCache.put(2, p2);
+            sourceCache.put(3, p3);
+
+            withCacheManager(new CacheManagerCallable(createTargetCacheManager()) {
+               @Override
+               public void call() {
+                  Cache<Key, Integer> targetCache = cm.getCache();
+                  assertEquals(p1, targetCache.get(1));
+                  assertEquals(p2, targetCache.get(2));
+                  assertEquals(p3, targetCache.get(3));
+               }
+            });
+         }
+      });
+   }
+
+   private Future<String> asyncGet(
+         final Cache<Integer, String> targetCache, final Integer key) {
+      return fork(new Callable<String>() {
+         @Override
+         public String call() throws Exception {
+            return targetCache.get(key);
+         }
+      });
+   }
+
+   private void assertFutureEquals(String expected, Future<String> f) {
+      try {
+         assertEquals(expected, f.get());
+      } catch (Exception e) {
+         throw new AssertionError(e);
+      }
+   }
+
+   private EmbeddedCacheManager createSourceCacheManager() {
+      GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
+      global.globalJmxStatistics().cacheManagerName("SourceCacheManager");
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.jmxStatistics().enable();
+      return TestCacheManagerFactory.createCacheManager(global, builder);
+   }
+
+   private EmbeddedCacheManager createTargetCacheManager() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      // Configure target cache manager with the CLI cache loader pointing to source
+      builder.persistence()
+            .addStore(CLInterfaceLoaderConfigurationBuilder.class)
+            .connectionString(SOURCE_CONNECTION_STRING);
+
+      return TestCacheManagerFactory.createCacheManager(builder);
+   }
+
+}

--- a/persistence/cli/src/test/java/org/infinispan/persistence/cli/configuration/ConfigurationTest.java
+++ b/persistence/cli/src/test/java/org/infinispan/persistence/cli/configuration/ConfigurationTest.java
@@ -1,0 +1,22 @@
+package org.infinispan.persistence.cli.configuration;
+
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+@Test(groups = "unit", testName = "persistence.remote.configuration.ConfigurationTest")
+public class ConfigurationTest {
+
+   public void testCacheLoaderConfiguration() {
+      ConfigurationBuilder b = new ConfigurationBuilder();
+      b.persistence().addStore(CLInterfaceLoaderConfigurationBuilder.class)
+         .connectionString("jmx://1.2.3.4:4444/MyCacheManager/myCache");
+      Configuration configuration = b.build();
+      CLInterfaceLoaderConfiguration store = (CLInterfaceLoaderConfiguration)
+            configuration.persistence().stores().get(0);
+      assertEquals("jmx://1.2.3.4:4444/MyCacheManager/myCache", store.connectionString());
+   }
+
+}

--- a/persistence/cli/src/test/java/org/infinispan/persistence/cli/configuration/XmlFileParsingTest.java
+++ b/persistence/cli/src/test/java/org/infinispan/persistence/cli/configuration/XmlFileParsingTest.java
@@ -1,0 +1,49 @@
+package org.infinispan.persistence.cli.configuration;
+
+import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.infinispan.test.TestingUtil.INFINISPAN_START_TAG;
+import static org.testng.AssertJUnit.assertEquals;
+
+@Test(groups = "unit", testName = "persistence.remote.configuration.XmlFileParsingTest")
+public class XmlFileParsingTest extends AbstractInfinispanTest {
+
+   private EmbeddedCacheManager cacheManager;
+
+   @AfterMethod
+   public void cleanup() {
+      TestingUtil.killCacheManagers(cacheManager);
+   }
+
+   public void testRemoteCacheStore() throws Exception {
+      String config = INFINISPAN_START_TAG +
+            "   <default>\n" +
+            "     <persistence>\n" +
+            "       <cliLoader xmlns=\"urn:infinispan:config:cli:6.0\" " +
+            "                  connection=\"jmx://1.2.3.4:4444/MyCacheManager/myCache\">\n" +
+            "       </cliLoader>\n" +
+            "     </persistence>\n" +
+            "   </default>\n" +
+            TestingUtil.INFINISPAN_END_TAG;
+
+      CLInterfaceLoaderConfiguration store = (CLInterfaceLoaderConfiguration) buildCacheManagerWithCacheStore(config);
+      assertEquals("jmx://1.2.3.4:4444/MyCacheManager/myCache", store.connectionString());
+   }
+
+   private StoreConfiguration buildCacheManagerWithCacheStore(final String config) throws IOException {
+      InputStream is = new ByteArrayInputStream(config.getBytes());
+      cacheManager = TestCacheManagerFactory.fromStream(is);
+      assert cacheManager.getDefaultCacheConfiguration().persistence().stores().size() == 1;
+      return cacheManager.getDefaultCacheConfiguration().persistence().stores().get(0);
+   }
+}

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/logging/Log.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/logging/Log.java
@@ -36,10 +36,4 @@ public interface Log extends org.infinispan.util.logging.Log {
    @Message(value = "The RemoteCacheStore for cache %s should be configured with hotRodWrapping enabled", id = 10007)
    CacheException remoteStoreNoHotRodWrapping(String cacheName);
 
-   @Message(value = "Could not find migration data in cache %s", id = 10008)
-   CacheException missingMigrationData(String name);
-
-   @LogMessage(level = WARN)
-   @Message(value = "Could not migrate key %s", id = 10009)
-   void keyMigrationFailed(String key, @Cause Throwable cause);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
       <module>persistence</module>
       <module>persistence/jdbc</module>
       <module>persistence/remote</module>
+      <module>persistence/cli</module>
       <module>server</module>
       <module>server/core</module>
       <module>server/memcached</module>
@@ -66,6 +67,7 @@
       <module>compatibility52x</module>
       <module>compatibility52x/adaptor52x</module>
       <module>compatibility52x/custom52x-store</module>
+      <module>compatibility52x/cli-migrator52x</module>
    </modules>
 
    <profiles>


### PR DESCRIPTION
- Providing rolling upgrade capabilities for embedded caches is the key step for providing on-the-fly cache store data migration.
- Data stored in old formats in embedded Infinispan 5.2.x instances can easily be migrated to Infinispan 6.x embedded instances plugged with different cache stores, or cache stores with updated storage format.

For testing rolling upgrades, a created a [small app](https://github.com/galderz/rolling) that shows rolling upgrades in action. I hope to enhance it further to show a rolling upgrade of an application using Infinispan 5.2.x, configured with a file cache store, to Infinispan 6.x with single file cache store, which is the core of what ISPN-3318 is trying to show off.

The code is not complete, there's a few things missing:
- CLI cache loader XML parser, schema, unit tests (!!) and rest of bells and whistles.
- Testing (and support if any changes required?) for custom types in the cache.

Putting this out there so that it can be reviewed in parallel before heading out for vacation on Friday.
