### PR TITLE
ISPN-3285 Remove dependency to Lucene Analyzers

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -289,11 +289,6 @@
          </dependency>
          <dependency>
             <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-search-analyzers</artifactId>
-            <version>${version.hibernate.search}</version>
-         </dependency>
-         <dependency>
-            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-search-infinispan</artifactId>
             <version>${version.hibernate.search}</version>
          </dependency>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -48,12 +48,6 @@
 
       <dependency>
          <groupId>org.hibernate</groupId>
-         <artifactId>hibernate-search-analyzers</artifactId>
-         <optional>true</optional>
-      </dependency>
-
-      <dependency>
-         <groupId>org.hibernate</groupId>
          <artifactId>hibernate-search-infinispan</artifactId>
       </dependency>
 


### PR DESCRIPTION
These were already optional and not really used, so it's probably best to remove them.

Jira: https://issues.jboss.org/browse/ISPN-3285

Please integrate in master.
