### PR TITLE
ISPN-3578 Missing component metadata in extended statistics module

### DIFF
--- a/extended-statistics/pom.xml
+++ b/extended-statistics/pom.xml
@@ -15,6 +15,11 @@
     <name>Infinispan Extended Statistics</name>
     <description>Infinispan Extended Statistics module</description>
 
+    <!-- This module declares components that either has lifecycle (@Start or @Stop) or uses @Inject to retrieve dependencies -->
+    <properties>
+        <module.skipComponentMetaDataProcessing>false</module.skipComponentMetaDataProcessing>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/extended-statistics/src/main/java/org/infinispan/stats/ExtendedStatisticsMetadataFileFinder.java
+++ b/extended-statistics/src/main/java/org/infinispan/stats/ExtendedStatisticsMetadataFileFinder.java
@@ -1,0 +1,14 @@
+package org.infinispan.stats;
+
+import org.infinispan.factories.components.ModuleMetadataFileFinder;
+
+/**
+ * @author Pedro Ruivo
+ * @since 6.0
+ */
+public class ExtendedStatisticsMetadataFileFinder implements ModuleMetadataFileFinder {
+   @Override
+   public String getMetadataFilename() {
+      return "infinispan-extended-statistics-component-metadata.dat";
+   }
+}

--- a/extended-statistics/src/main/resources/META-INF/services/org.infinispan.factories.components.ModuleMetadataFileFinder
+++ b/extended-statistics/src/main/resources/META-INF/services/org.infinispan.factories.components.ModuleMetadataFileFinder
@@ -1,0 +1,1 @@
+org.infinispan.stats.ExtendedStatisticsMetadataFileFinder


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3578
