### PR TITLE
Revert "ISPN-3583 When indexing is enabled but Query module isn't availa...

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/IndexingConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/IndexingConfigurationBuilder.java
@@ -133,15 +133,15 @@ public class IndexingConfigurationBuilder extends AbstractConfigurationChildBuil
    @Override
    public void validate() {
       if (enabled) {
-         //Indexing is not conceptually compatible with Invalidation mode
-         if (clustering().cacheMode().isInvalidation()) {
-            throw log.invalidConfigurationIndexingWithInvalidation();
-         }
          // Check that the query module is on the classpath.
          try {
             Util.loadClassStrict("org.infinispan.query.Search", getBuilder().classLoader());
          } catch (ClassNotFoundException e) {
-            throw log.invalidConfigurationIndexingWithoutModule();
+            log.warnf("Indexing can only be enabled if infinispan-query.jar is available on your classpath, and this jar has not been detected. Intended behavior may not be exhibited.");
+         }
+         //Indexing is not conceptually compatible with Invalidation mode
+         if (clustering().cacheMode().isInvalidation()) {
+            throw log.invalidConfigurationIndexingWithInvalidation();
          }
       }
    }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1014,8 +1014,5 @@ public interface Log extends BasicLogger {
    @Message(value = "Indexing can not be enabled on caches in Invalidation mode", id = 273)
    CacheConfigurationException invalidConfigurationIndexingWithInvalidation();
 
-   @Message(value = "Indexing can only be enabled if infinispan-query.jar is available on your classpath, and this jar has not been detected.", id = 274)
-   CacheConfigurationException invalidConfigurationIndexingWithoutModule();
-
 }
 

--- a/core/src/test/java/org/infinispan/configuration/ConfigurationValidationTest.java
+++ b/core/src/test/java/org/infinispan/configuration/ConfigurationValidationTest.java
@@ -81,20 +81,6 @@ public class ConfigurationValidationTest extends AbstractInfinispanTest {
       }
    }
 
-   @Test(expectedExceptions = CacheConfigurationException.class, expectedExceptionsMessageRegExp =
-         "ISPN(\\d)*: Indexing can only be enabled if infinispan-query.jar is available on your classpath, and this jar has not been detected.")
-   public void testIndexingRequiresOptionalModule() {
-      EmbeddedCacheManager ecm = null;
-      try {
-         ConfigurationBuilder c = new ConfigurationBuilder();
-         c.indexing().enable();
-         ecm = TestCacheManagerFactory.createClusteredCacheManager(c);
-         ecm.getCache();
-      } finally {
-         TestingUtil.killCacheManagers(ecm);
-      }
-   }
-
    private EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder config = new ConfigurationBuilder();
       config.clustering().cacheMode(CacheMode.REPL_ASYNC);

--- a/core/src/test/java/org/infinispan/configuration/SampleConfigFilesCorrectnessTest.java
+++ b/core/src/test/java/org/infinispan/configuration/SampleConfigFilesCorrectnessTest.java
@@ -4,6 +4,7 @@ import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -68,6 +69,17 @@ public class SampleConfigFilesCorrectnessTest {
          } finally {
             TestingUtil.killCacheManagers(dcm);
          }
+      }
+   }
+
+   public void testWarningForMissingQuery() {
+      EmbeddedCacheManager embeddedCacheManager = TestCacheManagerFactory.createCacheManager(CacheMode.LOCAL, true);
+      try {
+         embeddedCacheManager.getCache();
+         assert appender.isFoundUnknownWarning();
+         assert appender.unknownWarning().contains("infinispan-query.jar");
+      } finally {
+         TestingUtil.killCacheManagers(embeddedCacheManager);
       }
    }
 

--- a/core/src/test/java/org/infinispan/configuration/override/XMLConfigurationOverridingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/override/XMLConfigurationOverridingTest.java
@@ -234,18 +234,20 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
             Configuration cnf = cm.getCacheConfiguration(simpleCacheName);
             Assert.assertFalse(cnf.indexing().enabled());
 
-            Configuration conf = new ConfigurationBuilder().indexing().indexLocalOnly(false)
+            Configuration conf = new ConfigurationBuilder().indexing().enable().indexLocalOnly(false)
                   .addProperty("default.directory_provider", "infinispan").build();
 
             cm.defineConfiguration(simpleCacheName, conf);
 
             cnf = cm.getCacheConfiguration(simpleCacheName);
-            Assert.assertFalse(cnf.indexing().enabled());
+            Assert.assertTrue(cnf.indexing().enabled());
             Assert.assertFalse(cnf.indexing().indexLocalOnly());
             Assert.assertEquals("infinispan", cnf.indexing().properties().getProperty("default.directory_provider"));
             Assert.assertFalse(cm.getCacheNames().contains("LuceneIndexesMetadata"));
 
-            cm.getCache(simpleCacheName).put("key0", new NonIndexedClass("value0"));
+            for (int i = 0; i < 10; i++) {
+               cm.getCache(simpleCacheName + 1).put("key" + i, new NonIndexedClass("value" + i));
+            }
 
             Assert.assertFalse(cm.getCacheNames().contains("LuceneIndexesMetadata"));
          }


### PR DESCRIPTION
...ble configuration validation should fail"

This reverts commit e4b98117fdd01fa8cab7e419dc8abb53674cefc0.

The change was breaking Infinispan Server, because it tries to build() the
configuration before setting the appropriate classloader first.
