### PR TITLE
ISPN-2610 Use Query but disable automatic indexing

### DIFF
--- a/query/src/main/java/org/infinispan/query/backend/LocalQueryInterceptor.java
+++ b/query/src/main/java/org/infinispan/query/backend/LocalQueryInterceptor.java
@@ -32,7 +32,8 @@ public class LocalQueryInterceptor extends QueryInterceptor {
 
    @Override
    protected boolean shouldModifyIndexes(FlagAffectedCommand command, InvocationContext ctx) {
-      // will index only local updates that were not flagged with SKIP_INDEXING and are not caused internally by state transfer
-      return ctx.isOriginLocal() && !command.hasFlag(Flag.SKIP_INDEXING) && !command.hasFlag(Flag.PUT_FOR_STATE_TRANSFER);
+      // will index only local updates that were not flagged with SKIP_INDEXING,
+      // are not caused internally by state transfer and indexing strategy is not configured to 'manual'
+      return super.shouldModifyIndexes(command, ctx) && ctx.isOriginLocal() && !command.hasFlag(Flag.PUT_FOR_STATE_TRANSFER);
    }
 }

--- a/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
+++ b/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
@@ -19,6 +19,7 @@ import org.hibernate.search.backend.spi.Work;
 import org.hibernate.search.backend.spi.WorkType;
 import org.hibernate.search.backend.spi.Worker;
 import org.hibernate.search.engine.spi.EntityIndexBinding;
+import org.hibernate.search.engine.spi.SearchFactoryImplementor;
 import org.hibernate.search.spi.SearchFactoryIntegrator;
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.tx.PrepareCommand;
@@ -58,6 +59,7 @@ import org.infinispan.util.logging.LogFactory;
  */
 public class QueryInterceptor extends CommandInterceptor {
 
+   private final boolean isManualIndexing;
    private final SearchFactoryIntegrator searchFactory;
    private final ConcurrentMap<Class<?>,Boolean> knownClasses = CollectionFactory.makeConcurrentMap();
    private final Lock mutating = new ReentrantLock();
@@ -78,6 +80,7 @@ public class QueryInterceptor extends CommandInterceptor {
 
    public QueryInterceptor(SearchFactoryIntegrator searchFactory) {
       this.searchFactory = searchFactory;
+      isManualIndexing = ((SearchFactoryImplementor)searchFactory).getIndexingStrategy().equals("manual");
    }
 
    @Inject
@@ -94,7 +97,7 @@ public class QueryInterceptor extends CommandInterceptor {
    }
 
    protected boolean shouldModifyIndexes(FlagAffectedCommand command, InvocationContext ctx) {
-      return !command.hasFlag(Flag.SKIP_INDEXING);
+      return !isManualIndexing && !command.hasFlag(Flag.SKIP_INDEXING);
    }
 
    /**

--- a/query/src/test/java/org/infinispan/query/api/ManualIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/api/ManualIndexingTest.java
@@ -1,0 +1,66 @@
+package org.infinispan.query.api;
+
+import org.apache.lucene.search.Query;
+import org.infinispan.Cache;
+import org.infinispan.commons.api.BasicCacheContainer;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.CacheQuery;
+import org.infinispan.query.Search;
+import org.infinispan.query.SearchManager;
+import org.infinispan.query.queries.faceting.Car;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Test(groups = "functional", testName = "query.api.ManualIndexingTest")
+public class ManualIndexingTest extends MultipleCacheManagersTest {
+
+   protected static final int NUM_NODES = 4;
+   protected List<Cache<String, Car>> caches = new ArrayList<Cache<String, Car>>(NUM_NODES);
+
+   protected static final String[] neededCacheNames = new String[]{
+         BasicCacheContainer.DEFAULT_CACHE_NAME,
+         "LuceneIndexesMetadata",
+         "LuceneIndexesData",
+         "LuceneIndexesLocking",
+   };
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      for (int i = 0; i < NUM_NODES; i++) {
+         EmbeddedCacheManager cacheManager = TestCacheManagerFactory.fromXml("manual-indexing-distribution.xml");
+         registerCacheManager(cacheManager);
+         Cache<String, Car> cache = cacheManager.getCache();
+         caches.add(cache);
+      }
+      waitForClusterToForm(neededCacheNames);
+   }
+
+   public void testManualIndexing() throws Exception {
+      caches.get(0).put("car A", new Car("ford", "blue", 400));
+      caches.get(0).put("car B", new Car("megane", "white", 300));
+      caches.get(0).put("car C", new Car("megane", "red", 500));
+
+      assertNumberOfCars(0, "megane");
+      assertNumberOfCars(0, "ford");
+
+      // rebuild index
+      Search.getSearchManager(caches.get(0)).getMassIndexer().start();
+
+      assertNumberOfCars(2, "megane");
+      assertNumberOfCars(1, "ford");
+   }
+
+   private void assertNumberOfCars(int expectedCount, String carMake) {
+      for (Cache cache : caches) {
+         SearchManager sm = Search.getSearchManager(cache);
+         Query query = sm.buildQueryBuilderForClass(Car.class).get().keyword().onField("make").matching(carMake).createQuery();
+         CacheQuery cacheQuery = sm.getQuery(query, Car.class);
+         Assert.assertEquals("Expected count not met on cache " + cache, expectedCount, cacheQuery.getResultSize());
+      }
+   }
+}

--- a/query/src/test/resources/manual-indexing-distribution.xml
+++ b/query/src/test/resources/manual-indexing-distribution.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:infinispan:config:6.0 http://www.infinispan.org/schemas/infinispan-config-6.0.xsd"
+    xmlns="urn:infinispan:config:6.0">
+
+    <!-- *************************** -->
+    <!-- System-wide global settings -->
+    <!-- *************************** -->
+
+    <global>
+
+        <globalJmxStatistics
+            enabled="true"
+            cacheManagerName="QueryEnabledGrid-Manual-Dist"
+            allowDuplicateDomains="true"
+            />
+
+        <!-- If the transport is omitted, there is no way to create distributed or clustered
+            caches. There is no added cost to defining a transport but not creating a cache that uses one,
+            since the transport is created and initialized lazily. -->
+        <transport
+            clusterName="Infinispan-Query-Cluster"
+            >
+
+            <!-- Note that the JGroups transport uses sensible defaults if no configuration 
+                property is defined. See the JGroupsTransport javadocs for more flags -->
+        </transport>
+
+    </global>
+
+    <!-- *************************************** -->
+    <!--  Default Cache, with indexing enabled.  -->
+    <!-- *************************************** -->
+    <default>
+
+        <locking
+            lockAcquisitionTimeout="20000"
+            writeSkewCheck="false"
+            concurrencyLevel="500"
+            useLockStriping="false" />
+
+        <!-- This element specifies that the cache is clustered. modes supported: distribution 
+            (d), replication (r) or invalidation (i). Don't use invalidation to store Lucene indexes (as 
+            with Hibernate Search DirectoryProvider). Replication is recommended for best performance of 
+            Lucene indexes, but make sure you have enough memory to store the index in your heap.
+            Also distribution scales much better than replication on high number of nodes in the cluster. -->
+        <clustering
+            mode="distribution">
+
+            <!-- Prefer loading all data at startup than later -->
+            <stateTransfer
+                timeout="480000"
+                fetchInMemoryState="true" />
+
+            <!-- Network calls are synchronous by default -->
+            <sync
+                replTimeout="20000" />
+        </clustering>
+
+        <jmxStatistics
+            enabled="true" />
+
+        <eviction
+            maxEntries="-1"
+            strategy="NONE" />
+
+        <expiration
+            maxIdle="-1"
+            reaperEnabled="false" />
+
+        <indexing enabled="true" indexLocalOnly="true">
+            <properties>
+
+                <!-- Use our custom IndexManager; TODO autoinject by default? -->
+                <property name="hibernate.search.default.indexmanager" value="org.infinispan.query.indexmanager.InfinispanIndexManager" />
+
+                <!-- specify the managed index is to be shared across the nodes -->
+                <property name="hibernate.search.default.directory_provider" value="infinispan" />
+
+                <property name="hibernate.search.indexing_strategy" value="manual" />
+
+                <!-- Supporting exclusive index usage will require lock cleanup on crashed nodes to be implemented -->
+                <property name="hibernate.search.default.exclusive_index_use" value="false" />
+
+                <!-- Use latest Lucene version -->
+                <property name="hibernate.search.lucene_version" value="LUCENE_CURRENT" />
+            </properties>
+        </indexing>
+    </default>
+
+    
+    <!-- ******************************************************************************* -->
+    <!-- Individually configured "named" caches.                                         -->
+    <!--                                                                                 -->
+    <!-- While default configuration happens to be fine with similar settings across the -->
+    <!-- three caches, they should generally be different in a production environment.   -->
+    <!--                                                                                 -->
+    <!-- Current settings could easily lead to OutOfMemory exception as a CacheStore     -->
+    <!-- should be enabled, and maybe distribution is more suited for LuceneIndexesData. -->
+    <!-- ******************************************************************************* -->
+
+    <!-- *************************************** -->
+    <!--  Cache to store Lucene's file metadata  -->
+    <!-- *************************************** -->
+    <namedCache
+        name="LuceneIndexesMetadata">
+        <clustering
+            mode="replication">
+            <stateTransfer
+                fetchInMemoryState="true" />
+            <sync
+                replTimeout="25000" />
+        </clustering>
+        <indexing enabled="false" />
+    </namedCache>
+
+    <!-- **************************** -->
+    <!--  Cache to store Lucene data  -->
+    <!-- **************************** -->
+    <namedCache
+        name="LuceneIndexesData">
+        <clustering
+            mode="distribution">
+            <stateTransfer
+                fetchInMemoryState="true" />
+            <sync
+                replTimeout="25000" />
+        </clustering>
+        <indexing enabled="false" />
+    </namedCache>
+
+    <!-- ***************************** -->
+    <!--  Cache to store Lucene locks  -->
+    <!-- ***************************** -->
+    <namedCache
+        name="LuceneIndexesLocking">
+        <clustering
+            mode="replication">
+            <stateTransfer
+                fetchInMemoryState="true" />
+            <sync
+                replTimeout="25000" />
+        </clustering>
+        <indexing enabled="false" />
+    </namedCache>
+
+</infinispan>


### PR DESCRIPTION
If 'hibernate.search.indexing_strategy' configuration property of SearchFactory is set to 'manual' no index updates should be automatically performed when cache data is modified. The actual indexing is done only after being triggered via MassIndexer.

Jira: https://issues.jboss.org/browse/ISPN-2610
