### PR TITLE
ISPN-3607 AdvancedCache.getEntry method doesn't work with passivated

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/compat/BaseTypeConverterInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/compat/BaseTypeConverterInterceptor.java
@@ -10,6 +10,7 @@ import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commons.util.Immutables;
 import org.infinispan.compat.TypeConverter;
 import org.infinispan.container.InternalEntryFactory;
+import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.versioning.VersionGenerator;
 import org.infinispan.context.Flag;
@@ -74,7 +75,7 @@ public abstract class BaseTypeConverterInterceptor extends CommandInterceptor {
       Object ret = invokeNextInterceptor(ctx, command);
       if (ret != null) {
          if (command.isReturnEntry()) {
-            InternalCacheEntry entry = (InternalCacheEntry) ret;
+            CacheEntry entry = (CacheEntry) ret;
             Object returnValue = entry.getValue();
             if (command.getRemotelyFetchedValue() == null) {
                returnValue = converter.unboxValue(entry.getValue());
@@ -150,11 +151,11 @@ public abstract class BaseTypeConverterInterceptor extends CommandInterceptor {
 
    @Override
    public Object visitEntrySetCommand(InvocationContext ctx, EntrySetCommand command) throws Throwable {
-      Set<InternalCacheEntry> set = (Set<InternalCacheEntry>) super.visitEntrySetCommand(ctx, command);
+      Set<CacheEntry> set = (Set<CacheEntry>) super.visitEntrySetCommand(ctx, command);
       TypeConverter<Object, Object, Object, Object> converter =
             determineTypeConverter(command.getFlags());
       Set<InternalCacheEntry> backingSet = new HashSet<InternalCacheEntry>(set.size());
-      for (InternalCacheEntry entry : set) {
+      for (CacheEntry entry : set) {
          Object key = converter.unboxKey(entry.getKey());
          Object value = converter.unboxValue(entry.getValue());
          InternalCacheEntry newEntry = entryFactory.create(

--- a/core/src/test/java/org/infinispan/persistence/LocalModeCompatibilityPassivationTest.java
+++ b/core/src/test/java/org/infinispan/persistence/LocalModeCompatibilityPassivationTest.java
@@ -1,0 +1,20 @@
+package org.infinispan.persistence;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Test if keys are properly passivated and reloaded in local mode with compatibility enabled
+ *
+ * @author William Burns
+ * @since 6.0
+ */
+@Test(groups = "functional", testName = "persistence.LocalModeCompatibilityPassivationTest")
+@CleanupAfterMethod
+public class LocalModeCompatibilityPassivationTest extends LocalModePassivationTest {
+   @Override
+   protected void configureConfiguration(ConfigurationBuilder cb) {
+      cb.compatibility().enable();
+   }
+}


### PR DESCRIPTION
entries
- Fixed issue where getEntry causes cast exception on passivated entry

https://issues.jboss.org/browse/ISPN-3607
