### PR TITLE
ISPN-3620 Move the programmatic search mappings required by remote query...

### DIFF
--- a/query/src/main/java/org/infinispan/query/spi/ProgrammaticSearchMappingProvider.java
+++ b/query/src/main/java/org/infinispan/query/spi/ProgrammaticSearchMappingProvider.java
@@ -1,0 +1,13 @@
+package org.infinispan.query.spi;
+
+import org.hibernate.search.cfg.SearchMapping;
+import org.infinispan.Cache;
+
+/**
+ * @author anistor@redhat.com
+ * @since 6.0
+ */
+public interface ProgrammaticSearchMappingProvider {
+
+   void defineMappings(Cache cache, SearchMapping searchMapping);
+}

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/ProgrammaticSearchMappingProviderImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/ProgrammaticSearchMappingProviderImpl.java
@@ -1,0 +1,27 @@
+package org.infinispan.query.remote;
+
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Norms;
+import org.hibernate.search.annotations.Store;
+import org.hibernate.search.cfg.SearchMapping;
+import org.infinispan.Cache;
+import org.infinispan.query.remote.indexing.ProtobufValueWrapper;
+import org.infinispan.query.remote.indexing.ProtobufValueWrapperFieldBridge;
+import org.infinispan.query.spi.ProgrammaticSearchMappingProvider;
+
+/**
+ * @author anistor@redhat.com
+ * @since 6.0
+ */
+public class ProgrammaticSearchMappingProviderImpl implements ProgrammaticSearchMappingProvider {
+
+   @Override
+   public void defineMappings(Cache cache, SearchMapping searchMapping) {
+      searchMapping.entity(ProtobufValueWrapper.class)
+            .indexed()
+            .classBridgeInstance(new ProtobufValueWrapperFieldBridge(cache))
+            .norms(Norms.NO)
+            .analyze(Analyze.YES)
+            .store(Store.YES);
+   }
+}

--- a/remote-query/remote-query-server/src/main/resources/META-INF/services/org.infinispan.query.spi.ProgrammaticSearchMappingProvider
+++ b/remote-query/remote-query-server/src/main/resources/META-INF/services/org.infinispan.query.spi.ProgrammaticSearchMappingProvider
@@ -1,0 +1,1 @@
+org.infinispan.query.remote.ProgrammaticSearchMappingProviderImpl


### PR DESCRIPTION
... out of query module ModuleLifecycle
- Introduce ProgrammaticSearchMappingProvider, used by query module's lifecycle callbacks to load and execute SearchMapping customizations provided by other modules (or user code)
- Implement the registration of custom field bridges used by remote query module as a ProgrammaticSearchMappingProvider

Warning: this could impact the server (classloading issues), but so far it seems ok.

Jira: https://issues.jboss.org/browse/ISPN-3620

Please integrate in master.
