### PR TITLE
ISPN-3617 Inconsistent L1 in non-tx distributed cache

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1LastChanceInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1LastChanceInterceptor.java
@@ -76,7 +76,7 @@ public class L1LastChanceInterceptor extends BaseRpcInterceptor {
       Object returnValue = invokeNextInterceptor(ctx, command);
       Object key;
       if (shouldUpdateOnWriteCommand(command) && command.isSuccessful() &&
-            cdl.localNodeIsPrimaryOwner((key = command.getKey()))) {
+            cdl.localNodeIsOwner((key = command.getKey()))) {
          if (trace) {
             log.trace("Sending additional invalidation for requestors if necessary.");
          }
@@ -94,7 +94,7 @@ public class L1LastChanceInterceptor extends BaseRpcInterceptor {
          Set<Object> keys = command.getMap().keySet();
          Set<Object> toInvalidate = new HashSet<Object>(keys.size());
          for (Object k : keys) {
-            if (cdl.localNodeIsPrimaryOwner(k)) {
+            if (cdl.localNodeIsOwner(k)) {
                toInvalidate.add(k);
             }
          }

--- a/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
@@ -207,7 +207,13 @@ public abstract class BaseDistFunctionalTest<K, V> extends MultipleCacheManagers
       Cache<K, V>[] owners = new Cache[expectedNumberOwners];
       int i = 0;
       for (Cache<K, V> c : caches) {
-         if (isOwner(c, key)) owners[i++] = c;
+         if (isFirstOwner(c, key)) {
+            owners[i++] = c;
+            break;
+         }
+      }
+      for (Cache<K, V> c : caches) {
+         if (isOwner(c, key) && !isFirstOwner(c, key)) owners[i++] = c;
       }
       for (Cache<?, ?> c : owners) assert c != null : "Have not found enough owners for key [" + key + "]";
       return owners;


### PR DESCRIPTION
- Fixed issue with non tx cache not clearing out if in specific order
- Added tests to verify fix
- Fixed broken tests that wouldn't provide primary owner
- Also fixed a test that would fail sometimes depending on timing

https://issues.jboss.org/browse/ISPN-3617
