### PR TITLE
ISPN-3629 SingleFileStore.start() often fails on File.mkdirs() during concurrent cache startup

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
+++ b/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
@@ -97,10 +97,10 @@ public class SingleFileStore implements AdvancedLoadWriteStore {
 
          File f = new File(location + File.separator + ctx.getCache().getName() + ".dat");
          if (!f.exists()) {
-             File dir = f.getParentFile();
-             if (!dir.exists() && !dir.mkdirs()) {
-                 throw log.directoryCannotBeCreated(dir.getAbsolutePath());
-             }
+            File dir = f.getParentFile();
+            if (!dir.mkdirs() && !dir.exists()) {
+               throw log.directoryCannotBeCreated(dir.getAbsolutePath());
+            }
          }
          file = new RandomAccessFile(f, "rw").getChannel();
 


### PR DESCRIPTION
File.mkdirs() can fail if multiple concurrent threads attempt to create the same directory
