### PR TITLE
ISPN-3648 Inconsistent L1 in tx distributed cache

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1LastChanceInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1LastChanceInterceptor.java
@@ -129,11 +129,15 @@ public class L1LastChanceInterceptor extends BaseRpcInterceptor {
    }
 
    private void handleLastChanceL1InvalidationOnCommit(TxInvocationContext ctx) {
-      if (shouldInvokeRemoteTxCommand(ctx)) {
+      if (shouldFlushL1(ctx)) {
          if (trace) {
             log.tracef("Sending additional invalidation for requestors if necessary.");
          }
-         l1Manager.flushCache(ctx.getLockedKeys(), ctx.getOrigin(), true);
+         l1Manager.flushCache(ctx.getAffectedKeys(), ctx.getOrigin(), true);
       }
+   }
+
+   private boolean shouldFlushL1(TxInvocationContext ctx) {
+      return !ctx.getAffectedKeys().isEmpty();
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1TxInterceptor.java
@@ -68,14 +68,11 @@ public class L1TxInterceptor extends L1NonTxInterceptor {
    }
 
    private boolean shouldFlushL1(TxInvocationContext ctx) {
-      return shouldInvokeRemoteTxCommand(ctx) ||
-      // We fall into this situation if we are a remote node, happen to be the primary data owner and have locked keys.
-      // it is still our responsibility to invalidate L1 caches in the cluster.
-      !ctx.isOriginLocal() && !ctx.getLockedKeys().isEmpty();
+      return !ctx.getAffectedKeys().isEmpty();
    }
 
-   private Future<?> flushL1Caches(InvocationContext ctx) {
-      return l1Manager.flushCacheWithSimpleFuture(ctx.getLockedKeys(), null, ctx.getOrigin(), true);
+   private Future<?> flushL1Caches(TxInvocationContext ctx) {
+      return l1Manager.flushCacheWithSimpleFuture(ctx.getAffectedKeys(), null, ctx.getOrigin(), true);
    }
 
    private void blockOnL1FutureIfNeeded(Future<?> f) {


### PR DESCRIPTION
- Changed backup owners to also invalidate L1 like non tx caches

https://issues.jboss.org/browse/ISPN-3648
