### PR TITLE
ISPN-3300 PutForExternalRead doesn't supress exceptions with TotalOrder

### DIFF
--- a/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadDistPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadDistPessimisticTest.java
@@ -14,8 +14,7 @@ public class PutForExternalReadDistPessimisticTest extends PutForExternalReadTes
    protected ConfigurationBuilder createCacheConfigBuilder() {
       ConfigurationBuilder c = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
       c.clustering().hash().numOwners(100).numSegments(4).l1().disable();
-      c.transaction().lockingMode(LockingMode.PESSIMISTIC).useSynchronization(false)
-            .recovery().disable().locking().useLockStriping(false);
+      c.transaction().lockingMode(LockingMode.PESSIMISTIC);
       return c;
    }
 }

--- a/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadDistTotalOrderTest.java
+++ b/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadDistTotalOrderTest.java
@@ -18,10 +18,4 @@ public class PutForExternalReadDistTotalOrderTest extends PutForExternalReadTest
             .recovery().disable();
       return c;
    }
-
-   @Override
-   @Test(enabled = false, description = "Exception suppression doesn't work with TO, see ISPN-3300")
-   public void testExceptionSuppression() throws Exception {
-      super.testExceptionSuppression();
-   }
 }

--- a/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadReplPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadReplPessimisticTest.java
@@ -14,8 +14,7 @@ public class PutForExternalReadReplPessimisticTest extends PutForExternalReadTes
    protected ConfigurationBuilder createCacheConfigBuilder() {
       ConfigurationBuilder c = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
       c.clustering().hash().numSegments(4);
-      c.transaction().lockingMode(LockingMode.PESSIMISTIC).useSynchronization(false)
-            .recovery().disable().locking().useLockStriping(false);
+      c.transaction().lockingMode(LockingMode.PESSIMISTIC);
       return c;
    }
 }

--- a/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadReplTotalOrderTest.java
+++ b/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadReplTotalOrderTest.java
@@ -10,17 +10,12 @@ import org.testng.annotations.Test;
 @CleanupAfterMethod
 public class PutForExternalReadReplTotalOrderTest extends PutForExternalReadTest {
 
+   @Override
    protected ConfigurationBuilder createCacheConfigBuilder() {
       ConfigurationBuilder c = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
       c.clustering().hash().numSegments(4);
       c.transaction().transactionProtocol(TransactionProtocol.TOTAL_ORDER)
             .recovery().disable();
       return c;
-   }
-
-   @Override
-   @Test(enabled = false, description = "Exception suppression doesn't work with TO, see ISPN-3300")
-   public void testExceptionSuppression() throws Exception {
-      super.testExceptionSuppression();
    }
 }


### PR DESCRIPTION
- the test is throwing an exception for the put() operation but the transaction
  manager is supressing it when synchronization is used.
- Besides that, PFER is working ok.

https://issues.jboss.org/browse/ISPN-3300
