### PR TITLE
ISPN-3680: Inconsistent way to use the column id in the JdbcBinaryCacheStore

### DIFF
--- a/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/binary/JdbcBinaryCacheStore.java
+++ b/cachestore/jdbc/src/main/java/org/infinispan/loaders/jdbc/binary/JdbcBinaryCacheStore.java
@@ -276,7 +276,7 @@ public class JdbcBinaryCacheStore extends BucketBasedCacheStore {
          }
          conn = connectionFactory.getConnection();
          ps = conn.prepareStatement(sql);
-         ps.setInt(1, keyHashCode);
+         ps.setString(1, keyHashCode.toString()); 
          rs = ps.executeQuery();
          if (!rs.next()) {
             return null;


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3680
