### PR TITLE
ISPN-3518 1PC can cause a window of inconsistency with L1 invalidation

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1TxInterceptor.java
@@ -47,7 +47,7 @@ public class L1TxInterceptor extends L1NonTxInterceptor {
    @Override
    public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
       if (command.isOnePhaseCommit() && shouldFlushL1(ctx)) {
-         flushL1Caches(ctx); // if we are one-phase, don't block on this future.
+         blockOnL1FutureIfNeeded(flushL1Caches(ctx));
       }
 
       return invokeNextInterceptor(ctx, command);

--- a/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
@@ -48,6 +48,7 @@ public abstract class BaseDistFunctionalTest<K, V> extends MultipleCacheManagers
    protected boolean groupsEnabled = false;
    protected List<Grouper<?>> groupers;
    protected LockingMode lockingMode;
+   protected boolean onePhaseCommitOptimization = false;
 
    protected void createCacheManagers() throws Throwable {
       cacheName = "dist";
@@ -83,6 +84,9 @@ public abstract class BaseDistFunctionalTest<K, V> extends MultipleCacheManagers
       }
       if (tx) {
          configuration.invocationBatching().enable();
+         if (onePhaseCommitOptimization) {
+            configuration.transaction().use1PcForAutoCommitTransactions(true);
+         }
       }
       if (sync) configuration.clustering().sync().replTimeout(60, TimeUnit.SECONDS);
       configuration.locking().lockAcquisitionTimeout(lockTimeout, TimeUnit.SECONDS);

--- a/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
@@ -142,7 +142,7 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
       assertL1GetWithConcurrentUpdate(nonOwnerCache, nonOwnerCache, key, firstValue, secondValue);
    }
 
-   @Test()
+   @Test
    public void testNoEntryInL1MultipleConcurrentGetsWithInvalidation() throws TimeoutException, InterruptedException, ExecutionException, BrokenBarrierException {
       final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
       final Cache<Object, String> ownerCache = getFirstOwner(key);

--- a/core/src/test/java/org/infinispan/distribution/DistSyncL1FuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncL1FuncTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.distribution;
 
-import org.apache.log4j.Logger;
 import org.infinispan.Cache;
 import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.write.PutKeyValueCommand;
@@ -11,7 +10,6 @@ import org.infinispan.interceptors.distribution.NonTxDistributionInterceptor;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.tx.dld.ControlledRpcManager;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.BrokenBarrierException;
@@ -23,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 
 @Test(groups = "functional", testName = "distribution.DistSyncL1FuncTest")

--- a/core/src/test/java/org/infinispan/distribution/DistSyncTx1PCL1FuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncTx1PCL1FuncTest.java
@@ -1,0 +1,47 @@
+package org.infinispan.distribution;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.VisitableCommand;
+import org.infinispan.commands.read.GetKeyValueCommand;
+import org.infinispan.commands.tx.CommitCommand;
+import org.infinispan.commands.tx.PrepareCommand;
+import org.infinispan.commands.write.InvalidateL1Command;
+import org.infinispan.commands.write.PutKeyValueCommand;
+import org.infinispan.commands.write.ReplaceCommand;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.interceptors.base.CommandInterceptor;
+import org.infinispan.interceptors.distribution.L1TxInterceptor;
+import org.infinispan.interceptors.distribution.TxDistributionInterceptor;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.tx.dld.ControlledRpcManager;
+import org.testng.annotations.Test;
+
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.*;
+
+@Test(groups = "functional", testName = "distribution.DistSyncTx1PCL1FuncTest")
+public class DistSyncTx1PCL1FuncTest extends DistSyncTxL1FuncTest {
+   public DistSyncTx1PCL1FuncTest() {
+      super();
+      onePhaseCommitOptimization = true;
+   }
+
+   @Override
+   protected Class<? extends VisitableCommand> getCommitCommand() {
+      return PrepareCommand.class;
+   }
+}


### PR DESCRIPTION
- Changed 1PC L1 invalidation to be synchronous for invalidation in tx cache
- Also change L1LastChanceInterceptor to be sync in tx cache
- Added tests for 1PC TX as well

https://issues.jboss.org/browse/ISPN-3518
