### PR TITLE
ISPN-3556 When LockControlCommand fails on an owner, the rollback comman...

### DIFF
--- a/core/src/test/java/org/infinispan/lock/OptimisticTxFailureAfterLockingTest.java
+++ b/core/src/test/java/org/infinispan/lock/OptimisticTxFailureAfterLockingTest.java
@@ -1,0 +1,82 @@
+package org.infinispan.lock;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.VersioningScheme;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+import javax.transaction.RollbackException;
+import javax.transaction.Transaction;
+
+/**
+ * Test the failures after lock acquired for Optimistic transactional caches.
+ *
+ * @author Pedro Ruivo
+ * @since 6.0
+ */
+@Test(groups = "functional", testName = "lock.OptimisticTxFailureAfterLockingTest")
+@CleanupAfterMethod
+public class OptimisticTxFailureAfterLockingTest extends MultipleCacheManagersTest {
+
+   /**
+    * ISPN-3556
+    */
+   public void testInOwner() throws Exception {
+      //primary owner is cache(0) and the failure is executed in cache(0)
+      doTest(0, 0);
+   }
+
+   /**
+    * ISPN-3556
+    */
+   public void testInNonOwner() throws Exception {
+      //primary owner is cache(1) and the failure is executed in cache(0)
+      doTest(1, 0);
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
+      builder.locking()
+            .isolationLevel(IsolationLevel.REPEATABLE_READ)
+            .writeSkewCheck(true);
+      builder.transaction()
+            .lockingMode(LockingMode.OPTIMISTIC);
+      builder.clustering().hash()
+            .numOwners(2);
+      builder.versioning()
+            .enable()
+            .scheme(VersioningScheme.SIMPLE);
+      createClusteredCaches(3, builder);
+   }
+
+   private void doTest(int primaryOwnerIndex, int execIndex) throws Exception {
+      final Object key = new MagicKey(cache(primaryOwnerIndex), cache(2));
+
+      cache(primaryOwnerIndex).put(key, "v1");
+
+      tm(execIndex).begin();
+      AssertJUnit.assertEquals("v1", cache(execIndex).get(key));
+      final Transaction transaction = tm(execIndex).suspend();
+
+      cache(primaryOwnerIndex).put(key, "v2");
+
+      tm(execIndex).resume(transaction);
+      AssertJUnit.assertEquals("v1", cache(execIndex).put(key, "v3"));
+      try {
+         tm(execIndex).commit();
+         AssertJUnit.fail("Exception expected!");
+      } catch (RollbackException e) {
+         //expected
+      }
+
+      assertNoTransactions();
+      assertNotLocked(cache(primaryOwnerIndex), key);
+   }
+}

--- a/core/src/test/java/org/infinispan/lock/PessimistTxFailureAfterLockingTest.java
+++ b/core/src/test/java/org/infinispan/lock/PessimistTxFailureAfterLockingTest.java
@@ -1,0 +1,108 @@
+package org.infinispan.lock;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.commands.control.LockControlCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.util.AbstractControlledRpcManager;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.infinispan.util.concurrent.TimeoutException;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * Test the failures after lock acquired for Pessimistic transactional caches.
+ *
+ * @author Pedro Ruivo
+ * @since 6.0
+ */
+@Test(groups = "functional", testName = "lock.PessimistTxFailureAfterLockingTest")
+@CleanupAfterMethod
+public class PessimistTxFailureAfterLockingTest extends MultipleCacheManagersTest {
+
+   /**
+    * ISPN-3556
+    */
+   public void testReplyLostWithImplicitLocking() throws Exception {
+      doTest(false);
+   }
+
+   /**
+    * ISPN-3556
+    */
+   public void testReplyLostWithExplicitLocking() throws Exception {
+      doTest(true);
+   }
+
+   private void doTest(boolean explicitLocking) throws Exception {
+      final Object key = new MagicKey(cache(1), cache(2));
+      replaceRpcManagerInCache(cache(0));
+
+      boolean failed = false;
+      tm(0).begin();
+      try {
+         if (explicitLocking) {
+            cache(0).getAdvancedCache().lock(key);
+         } else {
+            cache(0).put(key, "value");
+         }
+      } catch (Exception e) {
+         failed = true;
+         //expected
+      }
+      tm(0).rollback();
+
+      assertTrue("Expected an exception", failed);
+      assertNoTransactions();
+      assertNotLocked(cache(1), key);
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
+      builder.locking()
+            .isolationLevel(IsolationLevel.READ_COMMITTED); //read committed is enough
+      builder.transaction()
+            .lockingMode(LockingMode.PESSIMISTIC);
+      builder.clustering().hash()
+            .numOwners(2);
+      createClusteredCaches(3, builder);
+   }
+
+   private void replaceRpcManagerInCache(Cache cache) {
+      RpcManager rpcManager = TestingUtil.extractComponent(cache, RpcManager.class);
+      TestControllerRpcManager testControllerRpcManager = new TestControllerRpcManager(rpcManager);
+      TestingUtil.replaceComponent(cache, RpcManager.class, testControllerRpcManager, true);
+   }
+
+   /**
+    * this RpcManager simulates a reply lost from LockControlCommand by throwing a TimeoutException. However, it is
+    * expected the command to acquire the remote lock.
+    */
+   private class TestControllerRpcManager extends AbstractControlledRpcManager {
+
+      public TestControllerRpcManager(RpcManager realOne) {
+         super(realOne);
+      }
+
+      @Override
+      protected Map<Address, Response> afterInvokeRemotely(ReplicableCommand command, Map<Address, Response> responseMap) {
+         if (command instanceof LockControlCommand) {
+            throw new TimeoutException("Exception expected!");
+         }
+         return responseMap;
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/tx/dld/ControlledRpcManager.java
+++ b/core/src/test/java/org/infinispan/tx/dld/ControlledRpcManager.java
@@ -2,25 +2,15 @@ package org.infinispan.tx.dld;
 
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commands.remote.SingleRpcCommand;
-import org.infinispan.remoting.RpcException;
 import org.infinispan.remoting.responses.Response;
-import org.infinispan.remoting.rpc.ResponseFilter;
-import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.rpc.RpcManager;
-import org.infinispan.remoting.rpc.RpcOptions;
-import org.infinispan.remoting.rpc.RpcOptionsBuilder;
 import org.infinispan.remoting.transport.Address;
-import org.infinispan.remoting.transport.Transport;
-import org.infinispan.commons.util.concurrent.NotifyingNotifiableFuture;
+import org.infinispan.util.AbstractControlledRpcManager;
 import org.infinispan.util.concurrent.ReclosableLatch;
-import org.infinispan.util.logging.Log;
-import org.infinispan.util.logging.LogFactory;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -29,21 +19,16 @@ import java.util.concurrent.TimeUnit;
  * @author Mircea.Markus@jboss.com
  * @since 4.2
  */
-public class ControlledRpcManager implements RpcManager {
-
-   private static final Log log = LogFactory.getLog(ControlledRpcManager.class);
+public class ControlledRpcManager extends AbstractControlledRpcManager {
 
    private final ReclosableLatch replicationLatch = new ReclosableLatch(true);
    private final ReclosableLatch blockingLatch = new ReclosableLatch(true);
    private volatile Set<Class> blockBeforeFilter = Collections.emptySet();
    private volatile Set<Class> blockAfterFilter = Collections.emptySet();
-
    private volatile Set<Class> failFilter = Collections.emptySet();
 
-   protected RpcManager realOne;
-
    public ControlledRpcManager(RpcManager realOne) {
-      this.realOne = realOne;
+      super(realOne);
    }
 
    public void failFor(Class... filter) {
@@ -85,6 +70,12 @@ public class ControlledRpcManager implements RpcManager {
       return blockingLatch.await(time, unit);
    }
 
+   public void failIfNeeded(ReplicableCommand rpcCommand) {
+      if (failFilter.contains(getActualClass(rpcCommand))) {
+         throw new IllegalStateException("Induced failure!");
+      }
+   }
+
    protected void waitBefore(ReplicableCommand rpcCommand) {
       waitForReplicationLatch(rpcCommand, blockBeforeFilter);
    }
@@ -113,198 +104,23 @@ public class ControlledRpcManager implements RpcManager {
       }
    }
 
+   @Override
+   protected void beforeInvokeRemotely(ReplicableCommand command) {
+      failIfNeeded(command);
+      waitBefore(command);
+   }
+
+   @Override
+   protected Map<Address, Response> afterInvokeRemotely(ReplicableCommand command, Map<Address, Response> responseMap) {
+      waitAfter(command);
+      return responseMap;
+   }
+
    private Class getActualClass(ReplicableCommand rpcCommand) {
       Class cmdClass = rpcCommand.getClass();
       if (cmdClass.equals(SingleRpcCommand.class)) {
          cmdClass = ((SingleRpcCommand) rpcCommand).getCommand().getClass();
       }
       return cmdClass;
-   }
-
-   @Override
-   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, ResponseMode mode, long timeout, boolean usePriorityQueue, ResponseFilter responseFilter) {
-      log.trace("ControlledRpcManager.invokeRemotely1");
-      failIfNeeded(rpcCommand);
-      waitBefore(rpcCommand);
-      Map<Address, Response> responseMap = realOne.invokeRemotely(recipients, rpcCommand, mode, timeout, usePriorityQueue, responseFilter);
-      waitAfter(rpcCommand);
-      return responseMap;
-   }
-
-   @Override
-   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, ResponseMode mode, long timeout, boolean usePriorityQueue) {
-      log.trace("ControlledRpcManager.invokeRemotely2");
-      failIfNeeded(rpcCommand);
-      waitBefore(rpcCommand);
-      Map<Address, Response> responseMap = realOne.invokeRemotely(recipients, rpcCommand, mode, timeout, usePriorityQueue);
-      waitAfter(rpcCommand);
-      return responseMap;
-   }
-
-   @Override
-   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, ResponseMode mode, long timeout) {
-      log.trace("ControlledRpcManager.invokeRemotely3");
-      failIfNeeded(rpcCommand);
-      waitBefore(rpcCommand);
-      Map<Address, Response> responseMap = realOne.invokeRemotely(recipients, rpcCommand, mode, timeout);
-      waitAfter(rpcCommand);
-      return responseMap;
-   }
-
-   @Override
-   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, boolean sync) throws RpcException {
-      log.trace("ControlledRpcManager.invokeRemotely4");
-      failIfNeeded(rpcCommand);
-      waitBefore(rpcCommand);
-      Map<Address, Response> responseMap = realOne.invokeRemotely(recipients, rpcCommand, sync);
-      waitAfter(rpcCommand);
-      return responseMap;
-   }
-
-   @Override
-   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, boolean sync, boolean usePriorityQueue) throws RpcException {
-      log.trace("ControlledRpcManager.invokeRemotely5");
-      failIfNeeded(rpcCommand);
-      waitBefore(rpcCommand);
-      Map<Address, Response> responses = realOne.invokeRemotely(recipients, rpcCommand, sync, usePriorityQueue);
-      waitAfter(rpcCommand);
-      return responses;
-   }
-
-   @Override
-   public void broadcastRpcCommand(ReplicableCommand rpcCommand, boolean sync) throws RpcException {
-      log.trace("ControlledRpcManager.broadcastRpcCommand1");
-      failIfNeeded(rpcCommand);
-      waitBefore(rpcCommand);
-      realOne.broadcastRpcCommand(rpcCommand, sync);
-      waitAfter(rpcCommand);
-   }
-
-   @Override
-   public void broadcastRpcCommand(ReplicableCommand rpcCommand, boolean sync, boolean usePriorityQueue) throws RpcException {
-      log.trace("ControlledRpcManager.broadcastRpcCommand2");
-      failIfNeeded(rpcCommand);
-      waitBefore(rpcCommand);
-      realOne.broadcastRpcCommand(rpcCommand, sync, usePriorityQueue);
-      waitAfter(rpcCommand);
-   }
-
-   @Override
-   public void broadcastRpcCommandInFuture(ReplicableCommand rpcCommand, NotifyingNotifiableFuture<Object> future) {
-      log.trace("ControlledRpcManager.broadcastRpcCommandInFuture1");
-      failIfNeeded(rpcCommand);
-      waitBefore(rpcCommand);
-      realOne.broadcastRpcCommandInFuture(rpcCommand, future);
-      waitAfter(rpcCommand);
-   }
-
-   @Override
-   public void broadcastRpcCommandInFuture(ReplicableCommand rpcCommand, boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future) {
-      log.trace("ControlledRpcManager.broadcastRpcCommandInFuture2");
-      failIfNeeded(rpcCommand);
-      waitBefore(rpcCommand);
-      realOne.broadcastRpcCommandInFuture(rpcCommand, usePriorityQueue, future);
-      waitAfter(rpcCommand);
-   }
-
-   @Override
-   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpcCommand, NotifyingNotifiableFuture<Object> future) {
-      log.trace("ControlledRpcManager.invokeRemotelyInFuture1");
-      failIfNeeded(rpcCommand);
-      waitBefore(rpcCommand);
-      realOne.invokeRemotelyInFuture(recipients, rpcCommand, future);
-      waitAfter(rpcCommand);
-   }
-
-   @Override
-   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpcCommand, boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future) {
-      log.trace("ControlledRpcManager.invokeRemotelyInFuture2");
-      failIfNeeded(rpcCommand);
-      waitBefore(rpcCommand);
-      realOne.invokeRemotelyInFuture(recipients, rpcCommand, usePriorityQueue, future);
-      waitAfter(rpcCommand);
-   }
-
-   @Override
-   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpcCommand, boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future, long timeout) {
-      log.trace("ControlledRpcManager.invokeRemotelyInFuture3");
-      failIfNeeded(rpcCommand);
-      waitBefore(rpcCommand);
-      realOne.invokeRemotelyInFuture(recipients, rpcCommand, usePriorityQueue, future, timeout);
-      waitAfter(rpcCommand);
-   }
-
-   @Override
-   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpcCommand, boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future, long timeout, boolean ignoreLeavers) {
-      log.trace("ControlledRpcManager.invokeRemotelyInFuture4");
-      failIfNeeded(rpcCommand);
-      waitBefore(rpcCommand);
-      realOne.invokeRemotelyInFuture(recipients, rpcCommand, usePriorityQueue, future, timeout, ignoreLeavers);
-      waitAfter(rpcCommand);
-   }
-
-   @Override
-   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpc, RpcOptions options) {
-      log.trace("ControlledRpcManager.invokeRemotely6");
-      failIfNeeded(rpc);
-      waitBefore(rpc);
-      Map<Address, Response> responses = realOne.invokeRemotely(recipients, rpc, options);
-      waitAfter(rpc);
-      return responses;
-   }
-
-   @Override
-   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpc, RpcOptions options, NotifyingNotifiableFuture<Object> future) {
-      log.trace("ControlledRpcManager.invokeRemotelyInFuture5");
-      failIfNeeded(rpc);
-      waitBefore(rpc);
-      realOne.invokeRemotelyInFuture(recipients, rpc, options, future);
-      waitAfter(rpc);
-   }
-
-   @Override
-   public Transport getTransport() {
-      return realOne.getTransport();
-   }
-
-   @Override
-   public Address getAddress() {
-      return realOne.getAddress();
-   }
-
-   public void failIfNeeded(ReplicableCommand rpcCommand) {
-      if (failFilter.contains(getActualClass(rpcCommand))) {
-         throw new IllegalStateException("Induced failure!");
-      }
-   }
-
-   @Override
-   public int getTopologyId() {
-      return realOne.getTopologyId();
-   }
-
-   @Override
-   public RpcOptionsBuilder getRpcOptionsBuilder(ResponseMode responseMode) {
-      return realOne.getRpcOptionsBuilder(responseMode);
-   }
-
-   @Override
-   public RpcOptionsBuilder getRpcOptionsBuilder(ResponseMode responseMode, boolean fifoOrder) {
-      return realOne.getRpcOptionsBuilder(responseMode, fifoOrder);
-   }
-
-   @Override
-   public RpcOptions getDefaultRpcOptions(boolean sync) {
-      return realOne.getDefaultRpcOptions(sync);
-   }
-
-   @Override
-   public RpcOptions getDefaultRpcOptions(boolean sync, boolean fifoOrder) {
-      return realOne.getDefaultRpcOptions(sync, fifoOrder);
-   }
-
-   @Override
-   public List<Address> getMembers() {
-      return realOne.getMembers();
    }
 }

--- a/core/src/test/java/org/infinispan/util/AbstractControlledRpcManager.java
+++ b/core/src/test/java/org/infinispan/util/AbstractControlledRpcManager.java
@@ -1,0 +1,215 @@
+package org.infinispan.util;
+
+import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.commons.util.concurrent.NotifyingNotifiableFuture;
+import org.infinispan.remoting.RpcException;
+import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.rpc.ResponseFilter;
+import org.infinispan.remoting.rpc.ResponseMode;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.remoting.rpc.RpcOptions;
+import org.infinispan.remoting.rpc.RpcOptionsBuilder;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.Transport;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Common rpc manager controls
+ *
+ * @author Pedro Ruivo
+ * @since 6.0
+ */
+public abstract class AbstractControlledRpcManager implements RpcManager {
+
+   protected final Log log = LogFactory.getLog(getClass());
+   protected final RpcManager realOne;
+
+   public AbstractControlledRpcManager(RpcManager realOne) {
+      this.realOne = realOne;
+   }
+
+   @Override
+   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, ResponseMode mode, long timeout, boolean usePriorityQueue, ResponseFilter responseFilter) {
+      log.trace("ControlledRpcManager.invokeRemotely1");
+      beforeInvokeRemotely(rpcCommand);
+      Map<Address, Response> responseMap = realOne.invokeRemotely(recipients, rpcCommand, mode, timeout, usePriorityQueue, responseFilter);
+      return afterInvokeRemotely(rpcCommand, responseMap);
+   }
+
+   @Override
+   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, ResponseMode mode, long timeout, boolean usePriorityQueue) {
+      log.trace("ControlledRpcManager.invokeRemotely2");
+      beforeInvokeRemotely(rpcCommand);
+      Map<Address, Response> responseMap = realOne.invokeRemotely(recipients, rpcCommand, mode, timeout, usePriorityQueue);
+      return afterInvokeRemotely(rpcCommand, responseMap);
+   }
+
+   @Override
+   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, ResponseMode mode, long timeout) {
+      log.trace("ControlledRpcManager.invokeRemotely3");
+      beforeInvokeRemotely(rpcCommand);
+      Map<Address, Response> responseMap = realOne.invokeRemotely(recipients, rpcCommand, mode, timeout);
+      return afterInvokeRemotely(rpcCommand, responseMap);
+   }
+
+   @Override
+   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, boolean sync) throws RpcException {
+      log.trace("ControlledRpcManager.invokeRemotely4");
+      beforeInvokeRemotely(rpcCommand);
+      Map<Address, Response> responseMap = realOne.invokeRemotely(recipients, rpcCommand, sync);
+      return afterInvokeRemotely(rpcCommand, responseMap);
+   }
+
+   @Override
+   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, boolean sync, boolean usePriorityQueue) throws RpcException {
+      log.trace("ControlledRpcManager.invokeRemotely5");
+      beforeInvokeRemotely(rpcCommand);
+      Map<Address, Response> responses = realOne.invokeRemotely(recipients, rpcCommand, sync, usePriorityQueue);
+      return afterInvokeRemotely(rpcCommand, responses);
+   }
+
+   @Override
+   public void broadcastRpcCommand(ReplicableCommand rpcCommand, boolean sync) throws RpcException {
+      log.trace("ControlledRpcManager.broadcastRpcCommand1");
+      beforeInvokeRemotely(rpcCommand);
+      realOne.broadcastRpcCommand(rpcCommand, sync);
+      afterInvokeRemotely(rpcCommand, null);
+   }
+
+   @Override
+   public void broadcastRpcCommand(ReplicableCommand rpcCommand, boolean sync, boolean usePriorityQueue) throws RpcException {
+      log.trace("ControlledRpcManager.broadcastRpcCommand2");
+      beforeInvokeRemotely(rpcCommand);
+      realOne.broadcastRpcCommand(rpcCommand, sync, usePriorityQueue);
+      afterInvokeRemotely(rpcCommand, null);
+   }
+
+   @Override
+   public void broadcastRpcCommandInFuture(ReplicableCommand rpcCommand, NotifyingNotifiableFuture<Object> future) {
+      log.trace("ControlledRpcManager.broadcastRpcCommandInFuture1");
+      beforeInvokeRemotely(rpcCommand);
+      realOne.broadcastRpcCommandInFuture(rpcCommand, future);
+      afterInvokeRemotely(rpcCommand, null);
+   }
+
+   @Override
+   public void broadcastRpcCommandInFuture(ReplicableCommand rpcCommand, boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future) {
+      log.trace("ControlledRpcManager.broadcastRpcCommandInFuture2");
+      beforeInvokeRemotely(rpcCommand);
+      realOne.broadcastRpcCommandInFuture(rpcCommand, usePriorityQueue, future);
+      afterInvokeRemotely(rpcCommand, null);
+   }
+
+   @Override
+   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpcCommand, NotifyingNotifiableFuture<Object> future) {
+      log.trace("ControlledRpcManager.invokeRemotelyInFuture1");
+      beforeInvokeRemotely(rpcCommand);
+      realOne.invokeRemotelyInFuture(recipients, rpcCommand, future);
+      afterInvokeRemotely(rpcCommand, null);
+   }
+
+   @Override
+   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpcCommand, boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future) {
+      log.trace("ControlledRpcManager.invokeRemotelyInFuture2");
+      beforeInvokeRemotely(rpcCommand);
+      realOne.invokeRemotelyInFuture(recipients, rpcCommand, usePriorityQueue, future);
+      afterInvokeRemotely(rpcCommand, null);
+   }
+
+   @Override
+   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpcCommand, boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future, long timeout) {
+      log.trace("ControlledRpcManager.invokeRemotelyInFuture3");
+      beforeInvokeRemotely(rpcCommand);
+      realOne.invokeRemotelyInFuture(recipients, rpcCommand, usePriorityQueue, future, timeout);
+      afterInvokeRemotely(rpcCommand, null);
+   }
+
+   @Override
+   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpcCommand, boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future, long timeout, boolean ignoreLeavers) {
+      log.trace("ControlledRpcManager.invokeRemotelyInFuture4");
+      beforeInvokeRemotely(rpcCommand);
+      realOne.invokeRemotelyInFuture(recipients, rpcCommand, usePriorityQueue, future, timeout, ignoreLeavers);
+      afterInvokeRemotely(rpcCommand, null);
+   }
+
+   @Override
+   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpc, RpcOptions options) {
+      log.trace("ControlledRpcManager.invokeRemotely6");
+      beforeInvokeRemotely(rpc);
+      Map<Address, Response> responses = realOne.invokeRemotely(recipients, rpc, options);
+      return afterInvokeRemotely(rpc, responses);
+   }
+
+   @Override
+   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpc, RpcOptions options, NotifyingNotifiableFuture<Object> future) {
+      log.trace("ControlledRpcManager.invokeRemotelyInFuture5");
+      beforeInvokeRemotely(rpc);
+      realOne.invokeRemotelyInFuture(recipients, rpc, options, future);
+      afterInvokeRemotely(rpc, null);
+   }
+
+   @Override
+   public Transport getTransport() {
+      return realOne.getTransport();
+   }
+
+   @Override
+   public Address getAddress() {
+      return realOne.getAddress();
+   }
+
+   @Override
+   public int getTopologyId() {
+      return realOne.getTopologyId();
+   }
+
+   @Override
+   public RpcOptionsBuilder getRpcOptionsBuilder(ResponseMode responseMode) {
+      return realOne.getRpcOptionsBuilder(responseMode);
+   }
+
+   @Override
+   public RpcOptionsBuilder getRpcOptionsBuilder(ResponseMode responseMode, boolean fifoOrder) {
+      return realOne.getRpcOptionsBuilder(responseMode, fifoOrder);
+   }
+
+   @Override
+   public RpcOptions getDefaultRpcOptions(boolean sync) {
+      return realOne.getDefaultRpcOptions(sync);
+   }
+
+   @Override
+   public RpcOptions getDefaultRpcOptions(boolean sync, boolean fifoOrder) {
+      return realOne.getDefaultRpcOptions(sync, fifoOrder);
+   }
+
+   @Override
+   public List<Address> getMembers() {
+      return realOne.getMembers();
+   }
+
+   /**
+    * method invoked before a remote invocation.
+    *
+    * @param command the command to be invoked remotely
+    */
+   protected void beforeInvokeRemotely(ReplicableCommand command) {
+      //no-op by default
+   }
+
+   /**
+    * method invoked after a successful remote invocation.
+    *
+    * @param command     the command invoked remotely.
+    * @param responseMap can be null if not response is expected.
+    * @return the new response map
+    */
+   protected Map<Address, Response> afterInvokeRemotely(ReplicableCommand command, Map<Address, Response> responseMap) {
+      return responseMap;
+   }
+}

--- a/core/src/test/java/org/infinispan/util/CountingRpcManager.java
+++ b/core/src/test/java/org/infinispan/util/CountingRpcManager.java
@@ -5,38 +5,23 @@ import org.infinispan.Cache;
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commands.control.LockControlCommand;
 import org.infinispan.commands.remote.ClusteredGetCommand;
-import org.infinispan.remoting.RpcException;
-import org.infinispan.remoting.responses.Response;
-import org.infinispan.remoting.rpc.ResponseFilter;
-import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.rpc.RpcManager;
-import org.infinispan.remoting.rpc.RpcOptions;
-import org.infinispan.remoting.rpc.RpcOptionsBuilder;
-import org.infinispan.remoting.transport.Address;
-import org.infinispan.remoting.transport.Transport;
-import org.infinispan.commons.util.concurrent.NotifyingNotifiableFuture;
-import org.infinispan.util.logging.Log;
-import org.infinispan.util.logging.LogFactory;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 /**
-* Use the {@link CountingRpcManager#replaceRpcManager(org.infinispan.Cache)}.
-* @author Mircea Markus
-* @since 5.2
-*/
-public class CountingRpcManager implements RpcManager {
-
-   private static final Log log = LogFactory.getLog(CountingRpcManager.class);
+ * Use the {@link CountingRpcManager#replaceRpcManager(org.infinispan.Cache)}.
+ *
+ * @author Mircea Markus
+ * @since 5.2
+ */
+public class CountingRpcManager extends AbstractControlledRpcManager {
 
    public volatile int lockCount;
    public volatile int clusterGet;
    public volatile int otherCount;
 
-   protected final RpcManager realOne;
-
+   public CountingRpcManager(RpcManager realOne) {
+      super(realOne);
+   }
 
    public static CountingRpcManager replaceRpcManager(Cache c) {
       AdvancedCache advancedCache = c.getAdvancedCache();
@@ -47,20 +32,6 @@ public class CountingRpcManager implements RpcManager {
       return crm;
    }
 
-   public CountingRpcManager(RpcManager realOne) {
-      this.realOne = realOne;
-   }
-
-   protected void aboutToInvokeRpc(ReplicableCommand rpcCommand) {
-      if (rpcCommand instanceof LockControlCommand) {
-         lockCount++;
-      } else if (rpcCommand instanceof ClusteredGetCommand) {
-         clusterGet++;
-      } else {
-         otherCount++;
-      }
-   }
-
    public void resetStats() {
       lockCount = 0;
       clusterGet = 0;
@@ -68,152 +39,13 @@ public class CountingRpcManager implements RpcManager {
    }
 
    @Override
-   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, ResponseMode mode, long timeout, boolean usePriorityQueue, ResponseFilter responseFilter) {
-      log.trace("invokeRemotely1");
-      aboutToInvokeRpc(rpcCommand);
-      return realOne.invokeRemotely(recipients, rpcCommand, mode, timeout, usePriorityQueue, responseFilter);
-   }
-
-   @Override
-   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, ResponseMode mode, long timeout, boolean usePriorityQueue) {
-      log.trace("invokeRemotely2");
-      aboutToInvokeRpc(rpcCommand);
-      return realOne.invokeRemotely(recipients, rpcCommand, mode, timeout, usePriorityQueue);
-   }
-
-   @Override
-   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpcCommand, ResponseMode mode, long timeout) {
-      log.trace("invokeRemotely3");
-      aboutToInvokeRpc(rpcCommand);
-      return realOne.invokeRemotely(recipients, rpcCommand, mode, timeout);
-   }
-
-   @Override
-   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpc, boolean sync) throws RpcException {
-      log.trace("invokeRemotely4");
-      aboutToInvokeRpc(rpc);
-      realOne.invokeRemotely(recipients, rpc, sync);
-      return null;
-   }
-
-   @Override
-   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpc, boolean sync, boolean usePriorityQueue) throws RpcException {
-      log.trace("invokeRemotely5");
-      aboutToInvokeRpc(rpc);
-      Map<Address, Response> responses = realOne.invokeRemotely(recipients, rpc, sync, usePriorityQueue);
-      return responses;
-   }
-
-
-   @Override
-   public void broadcastRpcCommand(ReplicableCommand rpc, boolean sync) throws RpcException {
-      log.trace("ControlledRpcManager.broadcastRpcCommand1");
-      aboutToInvokeRpc(rpc);
-      realOne.broadcastRpcCommand(rpc, sync);
-   }
-
-   @Override
-   public void broadcastRpcCommand(ReplicableCommand rpc, boolean sync, boolean usePriorityQueue) throws RpcException {
-      log.trace("ControlledRpcManager.broadcastRpcCommand2");
-      aboutToInvokeRpc(rpc);
-      realOne.broadcastRpcCommand(rpc, sync, usePriorityQueue);
-   }
-
-
-   @Override
-   public void broadcastRpcCommandInFuture(ReplicableCommand rpc, NotifyingNotifiableFuture<Object> future) {
-      log.trace("ControlledRpcManager.broadcastRpcCommandInFuture1");
-      aboutToInvokeRpc(rpc);
-      realOne.broadcastRpcCommandInFuture(rpc, future);
-   }
-
-   @Override
-   public void broadcastRpcCommandInFuture(ReplicableCommand rpc, boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future) {
-      log.trace("ControlledRpcManager.broadcastRpcCommandInFuture2");
-      aboutToInvokeRpc(rpc);
-      realOne.broadcastRpcCommandInFuture(rpc, usePriorityQueue, future);
-   }
-
-
-   @Override
-   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpc, NotifyingNotifiableFuture<Object> future) {
-      log.trace("ControlledRpcManager.invokeRemotelyInFuture1");
-      aboutToInvokeRpc(rpc);
-      realOne.invokeRemotelyInFuture(recipients, rpc, future);
-   }
-
-   @Override
-   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpc, boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future) {
-      log.trace("ControlledRpcManager.invokeRemotelyInFuture2");
-      aboutToInvokeRpc(rpc);
-      realOne.invokeRemotelyInFuture(recipients, rpc, usePriorityQueue, future);
-   }
-
-   @Override
-   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpc, boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future, long timeout) {
-      log.trace("ControlledRpcManager.invokeRemotelyInFuture3");
-      aboutToInvokeRpc(rpc);
-      realOne.invokeRemotelyInFuture(recipients, rpc, usePriorityQueue, future, timeout);
-   }
-
-   @Override
-   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpc, boolean usePriorityQueue, NotifyingNotifiableFuture<Object> future, long timeout, boolean ignoreLeavers) {
-      log.trace("ControlledRpcManager.invokeRemotelyInFuture4");
-      aboutToInvokeRpc(rpc);
-      realOne.invokeRemotelyInFuture(recipients, rpc, usePriorityQueue, future, timeout, ignoreLeavers);
-   }
-
-   @Override
-   public Map<Address, Response> invokeRemotely(Collection<Address> recipients, ReplicableCommand rpc, RpcOptions options) {
-      log.trace("CountingRpcManager.invokeRemotely6");
-      aboutToInvokeRpc(rpc);
-      return realOne.invokeRemotely(recipients, rpc, options);
-   }
-
-   @Override
-   public void invokeRemotelyInFuture(Collection<Address> recipients, ReplicableCommand rpc, RpcOptions options, NotifyingNotifiableFuture<Object> future) {
-      log.trace("CountingRpcManager.invokeRemotelyInFuture5");
-      aboutToInvokeRpc(rpc);
-      realOne.invokeRemotelyInFuture(recipients, rpc, options, future);
-   }
-
-   @Override
-   public Transport getTransport() {
-      return realOne.getTransport();
-   }
-
-   @Override
-   public Address getAddress() {
-      return realOne.getAddress();
-   }
-
-   @Override
-   public int getTopologyId() {
-      return realOne.getTopologyId();
-   }
-
-   @Override
-   public RpcOptionsBuilder getRpcOptionsBuilder(ResponseMode responseMode) {
-      return realOne.getRpcOptionsBuilder(responseMode);
-   }
-
-   @Override
-   public RpcOptionsBuilder getRpcOptionsBuilder(ResponseMode responseMode, boolean fifoOrder) {
-      return realOne.getRpcOptionsBuilder(responseMode, fifoOrder);
-   }
-
-   @Override
-   public RpcOptions getDefaultRpcOptions(boolean sync) {
-      return realOne.getDefaultRpcOptions(sync);
-   }
-
-   @Override
-   public RpcOptions getDefaultRpcOptions(boolean sync, boolean fifoOrder) {
-      return realOne.getDefaultRpcOptions(sync, fifoOrder);
-   }
-
-   @Override
-   public List<Address> getMembers() {
-      return realOne.getMembers();
+   protected void beforeInvokeRemotely(ReplicableCommand rpcCommand) {
+      if (rpcCommand instanceof LockControlCommand) {
+         lockCount++;
+      } else if (rpcCommand instanceof ClusteredGetCommand) {
+         clusterGet++;
+      } else {
+         otherCount++;
+      }
    }
 }


### PR DESCRIPTION
...d is not sent
- small issue with Pessimistic transactions but it works fine with Optimistics
  transactions.
- refactor ControlledRpcManager and created a base abstract class for it.

As you can see I changed a little the ControlledRpcManager to make it easy to extended if needed in the future. 

https://issues.jboss.org/browse/ISPN-3556
