### PR TITLE
ISPN-2475 When L1.onRehash is enabled, L1 invalidations should be sent

### DIFF
--- a/core/src/main/java/org/infinispan/commands/write/InvalidateL1Command.java
+++ b/core/src/main/java/org/infinispan/commands/write/InvalidateL1Command.java
@@ -87,13 +87,6 @@ public class InvalidateL1Command extends InvalidateCommand {
          if (ice != null) {
             DataLocality locality = dm.getLocality(k);
 
-            if (!forRehash) {
-               while (locality.isUncertain() && dm.isRehashInProgress()) {
-                  LockSupport.parkNanos(MILLISECONDS.toNanos(50));
-                  locality = dm.getLocality(k);
-               }
-            }
-
             if (!locality.isLocal()) {
                if (forRehash && config.clustering().l1().onRehash()) {
                   if (trace) log.trace("Not removing, instead entry will be stored in L1");

--- a/core/src/test/java/org/infinispan/distribution/rehash/L1OnRehashTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/L1OnRehashTest.java
@@ -90,12 +90,9 @@ public class L1OnRehashTest extends BaseDistFunctionalTest<Object, String> {
 
       for (int i = 0; i < keys.size(); i++) {
          Object key = keys.get(i);
-         // TODO Change the 2nd parameter to false when https://issues.jboss.org/browse/ISPN-2475 is fixed
-         assertOwnershipAndNonOwnership(key, l1OnRehash);
-         // TODO Remove this check when https://issues.jboss.org/browse/ISPN-2475 is fixed
-         if (!l1OnRehash) {
-            assertOnAllCaches(key, "nv" + (i + 1));
-         }
+         // All the L1 values should be invalidated from the above puts
+         assertOwnershipAndNonOwnership(key, false);
+         assertOnAllCaches(key, "nv" + (i + 1));
       }
    }
 }

--- a/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
@@ -15,6 +15,7 @@ import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.ImmortalCacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.InvocationContextContainer;
+import org.infinispan.distribution.L1Manager;
 import org.infinispan.distribution.TestAddress;
 import org.infinispan.distribution.ch.DefaultConsistentHash;
 import org.infinispan.distribution.ch.DefaultConsistentHashFactory;
@@ -148,6 +149,7 @@ public class StateConsumerTest extends AbstractInfinispanTest {
       InvocationContextContainer icc = mock(InvocationContextContainer.class);
       TotalOrderManager totalOrderManager = mock(TotalOrderManager.class);
       BlockingTaskAwareExecutorService remoteCommandsExecutor = mock(BlockingTaskAwareExecutorService.class);
+      L1Manager l1Manager = mock(L1Manager.class);
 
       when(commandsFactory.buildStateRequestCommand(any(StateRequestCommand.Type.class), any(Address.class), anyInt(), any(Set.class))).thenAnswer(new Answer<StateRequestCommand>() {
          @Override
@@ -195,7 +197,7 @@ public class StateConsumerTest extends AbstractInfinispanTest {
       final StateConsumerImpl stateConsumer = new StateConsumerImpl();
       stateConsumer.init(cache, pooledExecutorService, stateTransferManager, interceptorChain, icc, configuration, rpcManager, null,
             commandsFactory, persistenceManager, dataContainer, transactionTable, stateTransferLock, cacheNotifier,
-            totalOrderManager, remoteCommandsExecutor);
+            totalOrderManager, remoteCommandsExecutor, l1Manager);
       stateConsumer.start();
 
       final List<InternalCacheEntry> cacheEntries = new ArrayList<InternalCacheEntry>();


### PR DESCRIPTION
to the previous owners
- Changed L1 on rehash to properly add requestors for previous owners
- Reenabled tests for L1 on rehash to confirm working
- Removed unneeded looping in InvalidateL1Command as track modified keys

https://issues.jboss.org/browse/ISPN-2475
