### PR TITLE
ISPN-3454 Third party suspect exceptions should be thrown as they are

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/AbstractTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/AbstractTransport.java
@@ -34,6 +34,9 @@ public abstract class AbstractTransport implements Transport {
          if (response instanceof ExceptionResponse) {
             ExceptionResponse exceptionResponse = (ExceptionResponse) response;
             Exception e = exceptionResponse.getException();
+            if (e instanceof SuspectException)
+               throw log.thirdpartySuspected(sender, (SuspectException) e);
+
             // if we have any application-level exceptions make sure we throw them!!
             throw log.remoteException(sender, e);
          }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -13,6 +13,7 @@ import org.infinispan.persistence.support.SingletonCacheWriter;
 import org.infinispan.remoting.RemoteException;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.jgroups.SuspectException;
 import org.infinispan.transaction.LocalTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryAwareRemoteTransaction;
@@ -1036,5 +1037,8 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Caught exception [%s] while invoking method [%s] on listener instance: %s", id = 280)
    CacheListenerException exceptionInvokingListener(String name, Method m, Object target, @Cause Throwable cause);
+
+   @Message(value = "%s reported that a third node was suspected, see cause for info on the node that was suspected", id = 281)
+   SuspectException thirdpartySuspected(Address sender, @Cause SuspectException e);
 
 }


### PR DESCRIPTION
- Third party suspect exceptions when you have 3 or more nodes, e.g. node A, B and C, and one of the nodes, say node A, receives a message from node B saying that node C was suspected. This could happen with distributed caches.
- Third party suspect exceptions should not be transformed into remote exceptions since these are application level errors.
