### PR TITLE
ISPN-3697 Improved lifecycle control of JGroupsChannelLookup

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsChannelLookup.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsChannelLookup.java
@@ -20,14 +20,20 @@ public interface JGroupsChannelLookup {
    Channel getJGroupsChannel(Properties p);
 
    /**
-    * @return true if the JGroupsTransport should start and connect the channel before using it; false if the transport
-    * should assume that the channel is connected and started.
+    * @return true if the JGroupsTransport should connect the channel before using it; false if the transport
+    * should assume that the channel is connected.
     */
-   boolean shouldStartAndConnect();
+   boolean shouldConnect();
 
    /**
-    * @return true if the JGroupsTransport should stop and disconnect the channel once it is done with it; false if
-    * the channel is to be left open/connected.
+    * @return true if the JGroupsTransport should disconnect the channel once it is done with it; false if
+    * the channel is to be left connected.
     */
-   boolean shouldStopAndDisconnect();
+   boolean shouldDisconnect();
+
+   /**
+    * @return true if the JGroupsTransport should close the channel once it is done with it; false if
+    * the channel is to be left open.
+    */
+   boolean shouldClose();
 }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -321,8 +321,8 @@ public interface Log extends BasicLogger {
    void localAndPhysicalAddress(Address address, List<Address> physicalAddresses);
 
    @LogMessage(level = INFO)
-   @Message(value = "Disconnecting and closing JGroups Channel", id = 80)
-   void disconnectAndCloseJGroups();
+   @Message(value = "Disconnecting JGroups Channel", id = 80)
+   void disconnectJGroups();
 
    @LogMessage(level = ERROR)
    @Message(value = "Problem closing channel; setting it to null", id = 81)

--- a/core/src/test/java/org/infinispan/remoting/jgroups/ChannelLookupTest.java
+++ b/core/src/test/java/org/infinispan/remoting/jgroups/ChannelLookupTest.java
@@ -72,12 +72,17 @@ public class ChannelLookupTest extends AbstractInfinispanTest {
       }
 
       @Override
-      public boolean shouldStartAndConnect() {
+      public boolean shouldConnect() {
          return false;
       }
 
       @Override
-      public boolean shouldStopAndDisconnect() {
+      public boolean shouldDisconnect() {
+         return false;
+      }
+
+      @Override
+      public boolean shouldClose() {
          return false;
       }
    }


### PR DESCRIPTION
Also, add missing removal of up_handler from channel after stopping rpc dispatcher.
