### PR TITLE
ISPN-3698 Instantiate default marshaller on every start() call

### DIFF
--- a/core/src/main/java/org/infinispan/marshall/core/JBossMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/core/JBossMarshaller.java
@@ -34,20 +34,14 @@ import org.jboss.marshalling.Unmarshaller;
  */
 public class JBossMarshaller extends AbstractJBossMarshaller implements StreamingMarshaller {
 
-   ExternalizerTable externalizerTable;
+   final ExternalizerTable externalizerTable;
    ExternalizerTableProxy proxy;
-   GlobalConfiguration globalCfg;
-   Configuration cfg;
-   InvocationContextContainer icc;
+   final GlobalConfiguration globalCfg;
+   final Configuration cfg;
+   final InvocationContextContainer icc;
 
-   public JBossMarshaller() {
-      super();
-      baseCfg.setClassExternalizerFactory(new SerializeWithExtFactory());
-   }
-
-   public void inject(ExternalizerTable externalizerTable, Configuration cfg,
+   public JBossMarshaller(ExternalizerTable externalizerTable, Configuration cfg,
          InvocationContextContainer icc, GlobalConfiguration globalCfg) {
-      log.debug("Using JBoss Marshalling");
       this.externalizerTable = externalizerTable;
       this.globalCfg = globalCfg;
       this.cfg = cfg;
@@ -58,6 +52,7 @@ public class JBossMarshaller extends AbstractJBossMarshaller implements Streamin
    public void start() {
       super.start();
 
+      baseCfg.setClassExternalizerFactory(new SerializeWithExtFactory());
       baseCfg.setObjectTable(externalizerTable);
 
       proxy = new ExternalizerTableProxy(externalizerTable);

--- a/core/src/main/java/org/infinispan/marshall/core/VersionAwareMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/core/VersionAwareMarshaller.java
@@ -36,12 +36,13 @@ public class VersionAwareMarshaller extends AbstractMarshaller implements Stream
 
    private static final int VERSION_510 = 510;
 
-   private final JBossMarshaller defaultMarshaller;
+   private JBossMarshaller defaultMarshaller;
    private String cacheName;
 
-   public VersionAwareMarshaller() {
-      defaultMarshaller = new JBossMarshaller();
-   }
+   private ExternalizerTable extTable;
+   private GlobalConfiguration globalCfg;
+   private Configuration cfg;
+   private InvocationContextContainer icc;
 
    public void inject(Cache cache, Configuration cfg, InvocationContextContainer icc,
          ExternalizerTable extTable, GlobalConfiguration globalCfg) {
@@ -51,11 +52,15 @@ public class VersionAwareMarshaller extends AbstractMarshaller implements Stream
          this.cacheName = cache.getName();
       }
 
-      this.defaultMarshaller.inject(extTable, cfg, icc, globalCfg);
+      this.extTable = extTable;
+      this.globalCfg = globalCfg;
+      this.cfg = cfg;
+      this.icc = icc;
    }
 
    @Override
    public void start() {
+      defaultMarshaller = new JBossMarshaller(extTable, cfg, icc, globalCfg);
       defaultMarshaller.start();
    }
 

--- a/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
@@ -6,6 +6,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.InterceptorConfiguration;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.container.DataContainer;
 import org.infinispan.eviction.EvictionStrategy;
@@ -25,6 +26,7 @@ import java.util.Set;
 
 import static org.infinispan.test.TestingUtil.*;
 import static org.infinispan.test.fwk.TestCacheManagerFactory.createCacheManager;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author Manik Surtani
@@ -312,6 +314,34 @@ public class CacheManagerTest extends AbstractInfinispanTest {
             killCacheManagers(cacheManager);
          }
       }
+   }
+
+   public void testCacheManagerRestartReusingConfigurations() {
+      withCacheManagers(new MultiCacheManagerCallable(
+            TestCacheManagerFactory.createCacheManager(CacheMode.REPL_SYNC, false),
+            TestCacheManagerFactory.createCacheManager(CacheMode.REPL_SYNC, false)) {
+         @Override
+         public void call() {
+            EmbeddedCacheManager cm1 = cms[0];
+            EmbeddedCacheManager cm2 = cms[1];
+            Cache<Object, Object> c1 = cm1.getCache();
+            cm2.getCache();
+
+            GlobalConfiguration globalCfg = cm1.getCacheManagerConfiguration();
+            Configuration cfg = c1.getCacheConfiguration();
+            cm1.stop();
+
+            withCacheManager(new CacheManagerCallable(
+                  new DefaultCacheManager(globalCfg, cfg)) {
+               @Override
+               public void call() {
+                  Cache<Object, Object> c = cm.getCache();
+                  c.put(1, "v1");
+                  assertEquals("v1", c.get(1));
+               }
+            });
+         }
+      });
    }
 
    public void testRemoveCacheClusteredLocalStores(Method m) throws Exception {


### PR DESCRIPTION
- This avoids having marshaller instances lingering around after a cache manager has been stopped which could be left in an unusable state.
