### PR TITLE
ISPN-3670 Any commands received before the initial topology is installed...

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
@@ -110,10 +110,7 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
       StateTransferManager stm = cr.getStateTransferManager();
       // We must have completed the join before handling commands
       // (even if we didn't complete the initial state transfer)
-      if (!stm.isJoinComplete()) {
-         reply(response, null);
-         return;
-      } else if (cmd instanceof TotalOrderPrepareCommand && !stm.ownsData()) {
+      if (cmd instanceof TotalOrderPrepareCommand && !stm.ownsData()) {
          reply(response, null);
          return;
       }

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferLockImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferLockImpl.java
@@ -24,11 +24,11 @@ public class StateTransferLockImpl implements StateTransferLock {
 
    private final ReadWriteLock ownershipLock = new ReentrantReadWriteLock();
 
-   private volatile int topologyId;
+   private volatile int topologyId = -1;
    private final Lock topologyLock = new ReentrantLock();
    private final Condition topologyCondition = topologyLock.newCondition();
 
-   private volatile int transactionDataTopologyId;
+   private volatile int transactionDataTopologyId = -1;
    private final Lock transactionDataLock = new ReentrantLock();
    private final Condition transactionDataCondition = transactionDataLock.newCondition();
 

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/BaseWordCountMapReduceTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/BaseWordCountMapReduceTest.java
@@ -259,6 +259,7 @@ public abstract class BaseWordCountMapReduceTest extends MultipleCacheManagersTe
 
          @Override
          public Integer collate(final Map<String, Integer> reducedResults) {
+            log.tracef("Executing collator");
             int sum = 0;
             for (Entry<String, Integer> e : reducedResults.entrySet()) {
                sum += e.getValue();


### PR DESCRIPTION
... should block
https://issues.jboss.org/browse/ISPN-3670

Because the initial cache topology is installed in a single phase,
it's possible to receive a StateRequestCommand from another node before
receiving the JOIN response from the coordinator and installing the initial
cache topology. As such, commands received before we have a cache topology
should block instead of being ignored.

No specific tests, sorry, but it should stop the random failures in the Map/Reduce tests (e.g. ReplicatedTwoNodesMapReduceTest).
