### PR TITLE
[5.2.x] ISPN-3698 Instantiate default marshaller on every start() call

### DIFF
--- a/core/src/main/java/org/infinispan/marshall/VersionAwareMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/VersionAwareMarshaller.java
@@ -56,12 +56,13 @@ public class VersionAwareMarshaller extends AbstractMarshaller implements Stream
 
    private static final int VERSION_510 = 510;
 
-   private final JBossMarshaller defaultMarshaller;
+   private JBossMarshaller defaultMarshaller;
    private String cacheName;
 
-   public VersionAwareMarshaller() {
-      defaultMarshaller = new JBossMarshaller();
-   }
+   private ExternalizerTable extTable;
+   private GlobalConfiguration globalCfg;
+   private Configuration cfg;
+   private InvocationContextContainer icc;
 
    public void inject(Cache cache, Configuration cfg, InvocationContextContainer icc,
          ExternalizerTable extTable, GlobalConfiguration globalCfg) {
@@ -71,11 +72,15 @@ public class VersionAwareMarshaller extends AbstractMarshaller implements Stream
          this.cacheName = cache.getName();
       }
 
-      this.defaultMarshaller.inject(extTable, cfg, icc, globalCfg);
+      this.extTable = extTable;
+      this.globalCfg = globalCfg;
+      this.cfg = cfg;
+      this.icc = icc;
    }
 
    @Override
    public void start() {
+      defaultMarshaller = new JBossMarshaller(extTable, cfg, icc, globalCfg);
       defaultMarshaller.start();
    }
 

--- a/core/src/main/java/org/infinispan/marshall/jboss/JBossMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/jboss/JBossMarshaller.java
@@ -60,9 +60,12 @@ public class JBossMarshaller extends AbstractJBossMarshaller implements Streamin
    Configuration cfg;
    InvocationContextContainer icc;
 
-   public void inject(ExternalizerTable externalizerTable, Configuration cfg,
+   public JBossMarshaller() {
+      // No-op constructor, mainly for testing
+   }
+
+   public JBossMarshaller(ExternalizerTable externalizerTable, Configuration cfg,
          InvocationContextContainer icc, GlobalConfiguration globalCfg) {
-      log.debug("Using JBoss Marshalling");
       this.externalizerTable = externalizerTable;
       this.globalCfg = globalCfg;
       this.cfg = cfg;


### PR DESCRIPTION
- This avoids having marshaller instances lingering around after a cache manager has been stopped which could be left in an unusable state.
