### PR TITLE
ISPN-3709 ClusteredCacheTest.testPutForExternalRead is failing randomly

### DIFF
--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
@@ -292,6 +292,12 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       person4.setBlurb("Also eats grass");
 
       cache2.putForExternalRead("newGoat", person4);
+      eventually(new Condition() {
+         @Override
+         public boolean isSatisfied() throws Exception {
+            return cache2.get("newGoat") != null;
+         }
+      });
       List found = searchManager.getQuery(allQuery, Person.class).list();
       AssertJUnit.assertEquals(4, found.size());
 


### PR DESCRIPTION
the putForExternalRead is asynchronous so we have to make sure that it
arrives to cache2 before perform the query.

https://issues.jboss.org/browse/ISPN-3709
