### PR TITLE
ISPN-3712 Add ByteArrayKey to the 5.2.x compatibility layer so that the HotRod target migrator can read keysets from 5.2.x servers

### DIFF
--- a/compatibility52x/adaptor52x/src/main/java/org/infinispan/util/ByteArrayKey.java
+++ b/compatibility52x/adaptor52x/src/main/java/org/infinispan/util/ByteArrayKey.java
@@ -1,0 +1,105 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.infinispan.util;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Set;
+
+import org.infinispan.commons.marshall.AbstractExternalizer;
+
+/**
+ * Wrapper class for byte[] keys.
+ *
+ * The class can be marshalled either via its externalizer or via the JVM
+ * serialization.  The reason for supporting both methods is to enable
+ * third-party libraries to be able to marshall/unmarshall them using standard
+ * JVM serialization rules.  The Infinispan marshalling layer will always
+ * chose the most performant one, aka the externalizer method.
+ *
+ * @author Galder Zamarreño
+ * @since 4.1
+ */
+public final class ByteArrayKey implements Serializable {
+
+   private static final long serialVersionUID = 7305972805432411725L;
+   private final byte[] data;
+   private final int hashCode;
+
+   public ByteArrayKey(byte[] data) {
+      this.data = data;
+      this.hashCode = 41 + Arrays.hashCode(data);
+   }
+
+   public byte[] getData() {
+      return data;
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj) return true;
+      if (obj == null || ByteArrayKey.class != obj.getClass()) return false;
+      ByteArrayKey key = (ByteArrayKey) obj;
+      return Arrays.equals(key.data, this.data);
+   }
+
+   @Override
+   public int hashCode() {
+      return hashCode;
+   }
+
+   @Override
+   public String toString() {
+      return new StringBuilder().append("ByteArrayKey").append("{")
+         .append("data=").append(Util.printArray(data, true))
+         .append("}").toString();
+   }
+
+   public static class Externalizer extends AbstractExternalizer<ByteArrayKey> {
+      @Override
+      public void writeObject(ObjectOutput output, ByteArrayKey key) throws IOException {
+         output.writeInt(key.data.length);
+         output.write(key.data);
+      }
+
+      @Override
+      public ByteArrayKey readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+         byte[] data = new byte[input.readInt()];
+         input.readFully(data);
+         return new ByteArrayKey(data);
+      }
+
+      @Override
+      public Integer getId() {
+         return 57;
+      }
+
+      @Override
+      public Set<Class<? extends ByteArrayKey>> getTypeClasses() {
+         return Util.<Class<? extends ByteArrayKey>>asSet(ByteArrayKey.class);
+      }
+   }
+}

--- a/persistence/remote/pom.xml
+++ b/persistence/remote/pom.xml
@@ -13,8 +13,6 @@
    <packaging>bundle</packaging>
    <name>Infinispan remote CacheStore</name>
    <description>Infinispan remote CacheStore based on Hotrod protocol</description>
-   <properties>
-   </properties>
 
    <dependencies>
       <dependency>
@@ -30,6 +28,11 @@
       <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-core</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>infinispan-adaptor52x</artifactId>
+         <optional>true</optional>
       </dependency>
       <dependency>
          <groupId>${project.groupId}</groupId>

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/upgrade/HotRodTargetMigrator.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/upgrade/HotRodTargetMigrator.java
@@ -18,6 +18,7 @@ import org.infinispan.persistence.remote.RemoteStore;
 import org.infinispan.persistence.remote.configuration.RemoteStoreConfiguration;
 import org.infinispan.persistence.remote.logging.Log;
 import org.infinispan.upgrade.TargetMigrator;
+import org.infinispan.util.ByteArrayKey;
 import org.infinispan.util.logging.LogFactory;
 
 public class HotRodTargetMigrator implements TargetMigrator {
@@ -56,16 +57,17 @@ public class HotRodTargetMigrator implements TargetMigrator {
             }
 
 
-            Set<byte[]> keys;
+            Set<Object> keys;
             try {
-               keys = (Set<byte[]>) marshaller.objectFromByteBuffer((byte[])storeCache.get(knownKeys));
+               keys = (Set<Object>) marshaller.objectFromByteBuffer((byte[])storeCache.get(knownKeys));
             } catch (Exception e) {
                throw new CacheException(e);
             }
 
             ExecutorService es = Executors.newFixedThreadPool(threads);
             final AtomicInteger count = new AtomicInteger(0);
-            for (final byte[] key : keys) {
+            for (Object okey : keys) {
+               final byte[] key = (okey instanceof ByteArrayKey) ? ((ByteArrayKey)okey).getData() : ((byte[])okey);
                es.submit(new Runnable() {
 
                   @Override

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgrade52xSynchronizerTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/upgrade/HotRodUpgrade52xSynchronizerTest.java
@@ -1,0 +1,107 @@
+package org.infinispan.persistence.remote.upgrade;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.infinispan.Cache;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.TestHelper;
+import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.commons.marshall.jboss.GenericJBossMarshaller;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.context.Flag;
+import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.upgrade.RollingUpgradeManager;
+import org.infinispan.util.ByteArrayKey;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.*;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+
+@Test(testName = "upgrade.hotrod.HotRodUpgrade52xSynchronizerTest", groups = "functional")
+public class HotRodUpgrade52xSynchronizerTest extends AbstractInfinispanTest {
+
+   private HotRodServer sourceServer;
+   private HotRodServer targetServer;
+   private EmbeddedCacheManager sourceContainer;
+   private Cache<byte[], byte[]> sourceServerCache;
+   private EmbeddedCacheManager targetContainer;
+   private Cache<byte[], byte[]> targetServerCache;
+   private RemoteCacheManager sourceRemoteCacheManager;
+   private RemoteCache<String, String> sourceRemoteCache;
+   private RemoteCacheManager targetRemoteCacheManager;
+   private RemoteCache<String, String> targetRemoteCache;
+
+   @BeforeClass
+   public void setup() throws Exception {
+      ConfigurationBuilder serverBuilder = TestCacheManagerFactory.getDefaultCacheConfiguration(false);
+      sourceContainer = TestCacheManagerFactory
+            .createCacheManager(hotRodCacheConfiguration(serverBuilder));
+      sourceServerCache = sourceContainer.getCache();
+      sourceServer = TestHelper.startHotRodServer(sourceContainer);
+
+      ConfigurationBuilder targetConfigurationBuilder = TestCacheManagerFactory.getDefaultCacheConfiguration(false);
+      targetConfigurationBuilder.persistence().addStore(RemoteStoreConfigurationBuilder.class).hotRodWrapping(true).addServer().host("localhost").port(sourceServer.getPort());
+
+      targetContainer = TestCacheManagerFactory
+            .createCacheManager(hotRodCacheConfiguration(targetConfigurationBuilder));
+      targetServerCache = targetContainer.getCache();
+      targetServer = TestHelper.startHotRodServer(targetContainer);
+
+      sourceRemoteCacheManager = new RemoteCacheManager("localhost", sourceServer.getPort());
+      sourceRemoteCacheManager.start();
+      sourceRemoteCache = sourceRemoteCacheManager.getCache();
+
+      targetRemoteCacheManager = new RemoteCacheManager("localhost", targetServer.getPort());
+      targetRemoteCacheManager.start();
+      targetRemoteCache = targetRemoteCacheManager.getCache();
+   }
+
+   public void testSynchronization() throws Exception {
+      // Fill the old cluster with data
+      for (char ch = 'A'; ch <= 'Z'; ch++) {
+         String s = Character.toString(ch);
+         sourceRemoteCache.put(s, s);
+      }
+      // Verify access to some of the data from the new cluster
+      assertEquals("A", targetRemoteCache.get("A"));
+
+      // Simulate the behaviour of the 5.2.x HotRodSourceMigrator
+      GenericJBossMarshaller marshaller = new GenericJBossMarshaller();
+      Set<ByteArrayKey> keySet = new HashSet<ByteArrayKey>();
+      for(byte[] key : sourceServerCache.keySet()) {
+         keySet.add(new ByteArrayKey(key));
+      }
+      sourceServerCache.put(marshaller.objectToByteBuffer("___MigrationManager_HotRod_KnownKeys___"), marshaller.objectToByteBuffer(keySet));
+
+      RollingUpgradeManager targetUpgradeManager = targetServerCache.getAdvancedCache().getComponentRegistry().getComponent(RollingUpgradeManager.class);
+      targetUpgradeManager.synchronizeData("hotrod");
+      // The server contains one extra key: MIGRATION_MANAGER_HOT_ROD_KNOWN_KEYS
+      assertEquals(sourceServerCache.getAdvancedCache().withFlags(Flag.SKIP_CACHE_STORE).size() - 1, targetServerCache.getAdvancedCache().withFlags(Flag.SKIP_CACHE_STORE).size());
+
+      targetUpgradeManager.disconnectSource("hotrod");
+   }
+
+   @BeforeMethod
+   public void cleanup() {
+      sourceServerCache.clear();
+      targetServerCache.clear();
+   }
+
+   @AfterClass
+   public void tearDown() {
+      HotRodClientTestingUtil.killRemoteCacheManagers(sourceRemoteCacheManager, targetRemoteCacheManager);
+      HotRodClientTestingUtil.killServers(sourceServer, targetServer);
+      TestingUtil.killCacheManagers(targetContainer, sourceContainer);
+   }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3712

Pull https://github.com/infinispan/infinispan-server/pull/188 after this !
