### PR TITLE
ISPN-3740 AbstractCacheTest.getDefaultClusteredCacheConfig() should not ...

### DIFF
--- a/core/src/test/java/org/infinispan/test/AbstractCacheTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractCacheTest.java
@@ -49,7 +49,7 @@ public class AbstractCacheTest extends AbstractInfinispanTest {
       builder.
          clustering()
             .cacheMode(mode)
-            .stateTransfer().fetchInMemoryState(false)
+            .stateTransfer().fetchInMemoryState(true)
          .transaction().syncCommitPhase(true).syncRollbackPhase(true)
          .cacheStopTimeout(0L);
 


### PR DESCRIPTION
...disable state transfer

https://issues.jboss.org/browse/ISPN-3740
