### PR TITLE
ISPN-3721 Extend remote get test scenarios to test the joiner state

### DIFF
--- a/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
@@ -100,7 +100,6 @@ public class ClusteredGetCommand extends BaseRpcCommand implements FlagAffectedC
    @Override
    public InternalCacheValue perform(InvocationContext context) throws Throwable {
       acquireLocksIfNeeded();
-      if (distributionManager != null && distributionManager.isAffectedByRehash(key)) return null;
       // make sure the get command doesn't perform a remote call
       // as our caller is already calling the ClusteredGetCommand on all the relevant nodes
       Set<Flag> commandFlags = EnumSet.of(Flag.SKIP_REMOTE_LOOKUP, Flag.CACHE_MODE_LOCAL);

--- a/core/src/main/java/org/infinispan/remoting/responses/DistributionResponseGenerator.java
+++ b/core/src/main/java/org/infinispan/remoting/responses/DistributionResponseGenerator.java
@@ -29,7 +29,7 @@ public class DistributionResponseGenerator implements ResponseGenerator {
    public Response getResponse(CacheRpcCommand command, Object returnValue) {
       if (command.getCommandId() == ClusteredGetCommand.COMMAND_ID) {         
          ClusteredGetCommand clusteredGet = (ClusteredGetCommand) command;
-         if (distributionManager.isAffectedByRehash(clusteredGet.getKey()))
+         if (returnValue == null && distributionManager.isAffectedByRehash(clusteredGet.getKey()))
             return UnsureResponse.INSTANCE;
          return SuccessfulResponse.create(returnValue);
       } else if (command instanceof SingleRpcCommand) {

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -65,12 +65,18 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
    // Arbitrary value, only need to start after JGroupsTransport
    @Start(priority = 100)
    public void start() {
+      if (trace) {
+         log.tracef("Starting LocalCacheManager on %s", transport.getAddress());
+      }
       running = true;
    }
 
    // Need to stop before the JGroupsTransport
    @Stop(priority = 9)
    public void stop() {
+      if (trace) {
+         log.tracef("Stopping LocalCacheManager on %s", transport.getAddress());
+      }
       running = false;
    }
 

--- a/core/src/main/java/org/infinispan/util/AbstractControlledLocalTopologyManager.java
+++ b/core/src/main/java/org/infinispan/util/AbstractControlledLocalTopologyManager.java
@@ -1,15 +1,18 @@
 package org.infinispan.util;
 
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.Stop;
 import org.infinispan.topology.CacheJoinInfo;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.topology.CacheTopologyHandler;
 import org.infinispan.topology.LocalTopologyManager;
+import org.infinispan.topology.LocalTopologyManagerImpl;
 
 import java.util.Map;
 
 /**
  * Class to be extended to allow some control over the local topology manager when testing Infinispan.
- *
+ * <p/>
  * Note: create before/after method lazily when need.
  *
  * @author Pedro Ruivo
@@ -59,6 +62,22 @@ public abstract class AbstractControlledLocalTopologyManager implements LocalTop
    @Override
    public final CacheTopology getCacheTopology(String cacheName) {
       return delegate.getCacheTopology(cacheName);
+   }
+
+   // Arbitrary value, only need to start after JGroupsTransport
+   @Start(priority = 100)
+   public final void startDelegate() {
+      if (delegate instanceof LocalTopologyManagerImpl) {
+         ((LocalTopologyManagerImpl) delegate).start();
+      }
+   }
+
+   // Need to stop before the JGroupsTransport
+   @Stop(priority = 9)
+   public final void stopDelegate() {
+      if (delegate instanceof LocalTopologyManagerImpl) {
+         ((LocalTopologyManagerImpl) delegate).stop();
+      }
    }
 
    protected void beforeHandleConsistentHashUpdate(String cacheName, CacheTopology cacheTopology, int viewId) {


### PR DESCRIPTION
- Moved AbstractControlledLocalTopologyManager to main to delegate the
  start and stop methods

https://issues.jboss.org/browse/ISPN-3721

I've extended the scenario 4 to 7 in order to the new owner receive the remote get request during and after the state transfer.
