### PR TITLE
ISPN-3737 L1 requestor registered after value read

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
@@ -116,12 +116,12 @@ public class L1NonTxInterceptor extends BaseRpcInterceptor {
             returnValue = performL1Lookup(ctx, shouldAlwaysRunNextInterceptor, key, command);
          }
       } else {
-         returnValue = invokeNextInterceptor(ctx, command);
          // If this is a remote command, and we found a value in our cache
          // we store it so that we can later invalidate it
          if (registerL1) {
             l1Manager.addRequestor(command.getKey(), ctx.getOrigin());
          }
+         returnValue = invokeNextInterceptor(ctx, command);
       }
       return returnValue;
    }

--- a/core/src/test/java/org/infinispan/distribution/DistSyncL1RepeatableReadFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncL1RepeatableReadFuncTest.java
@@ -1,0 +1,12 @@
+package org.infinispan.distribution;
+
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "distribution.DistSyncL1RepeatableReadFuncTest")
+public class DistSyncL1RepeatableReadFuncTest extends DistSyncL1FuncTest {
+   public DistSyncL1RepeatableReadFuncTest() {
+      super();
+      isolationLevel = IsolationLevel.REPEATABLE_READ;
+   }
+}

--- a/core/src/test/java/org/infinispan/distribution/DistSyncTxL1RepeatableReadFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncTxL1RepeatableReadFuncTest.java
@@ -1,0 +1,12 @@
+package org.infinispan.distribution;
+
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "distribution.DistSyncTxL1RepeatableReadFuncTest")
+public class DistSyncTxL1RepeatableReadFuncTest extends DistSyncTxL1FuncTest {
+   public DistSyncTxL1RepeatableReadFuncTest() {
+      super();
+      isolationLevel = IsolationLevel.REPEATABLE_READ;
+   }
+}


### PR DESCRIPTION
- Fixed issue with RR that L1 cached wrong value with concurrent write
- Added tests for issue as well as RR test cases

https://issues.jboss.org/browse/ISPN-3737
