### PR TITLE
ISPN-3498 Cannot construct org.infinispan.util.KeyValuePair as it does n...

### DIFF
--- a/core/src/main/java/org/infinispan/util/KeyValuePair.java
+++ b/core/src/main/java/org/infinispan/util/KeyValuePair.java
@@ -20,10 +20,6 @@ public class KeyValuePair<K,V> {
    private final K key;
    private final V value;
 
-   public KeyValuePair() {
-      this(null, null); //required by azul vm
-   }
-
    public KeyValuePair(K key, V value) {
       this.key = key;
       this.value = value;

--- a/core/src/test/java/org/infinispan/configuration/ConfigurationUnitTest.java
+++ b/core/src/test/java/org/infinispan/configuration/ConfigurationUnitTest.java
@@ -248,7 +248,8 @@ public class ConfigurationUnitTest {
 
    public void testConfigureMarshaller() {
       GlobalConfigurationBuilder gc = new GlobalConfigurationBuilder();
-      gc.serialization().marshaller(new TestObjectStreamMarshaller());
+      TestObjectStreamMarshaller marshaller = new TestObjectStreamMarshaller();
+      gc.serialization().marshaller(marshaller);
       withCacheManager(new CacheManagerCallable(
             createCacheManager(gc, new ConfigurationBuilder())) {
          @Override
@@ -256,5 +257,6 @@ public class ConfigurationUnitTest {
             cm.getCache();
          }
       });
+      marshaller.stop();
    }
 }

--- a/core/src/test/java/org/infinispan/expiry/ExpiryTest.java
+++ b/core/src/test/java/org/infinispan/expiry/ExpiryTest.java
@@ -243,11 +243,13 @@ public class ExpiryTest extends AbstractInfinispanTest {
    }
 
    public void testEntrySetAfterExpiryWithStore(Method m) throws Exception {
-      CacheContainer cc = createCacheContainerWithStore();
+      String location = TestingUtil.tmpDirectory(ExpiryTest.class);
+      CacheContainer cc = createCacheContainerWithStore(location);
       try {
          doTestEntrySetAfterExpiryInPut(m, cc);
       } finally {
          cc.stop();
+         TestingUtil.recursiveFileRemove(location);
       }
    }
 
@@ -255,9 +257,9 @@ public class ExpiryTest extends AbstractInfinispanTest {
       return TestCacheManagerFactory.createCacheManager(TestCacheManagerFactory.getDefaultCacheConfiguration(true));
    }
 
-   private CacheContainer createCacheContainerWithStore() {
+   private CacheContainer createCacheContainerWithStore(String location) {
       ConfigurationBuilder b = new ConfigurationBuilder();
-      b.persistence().addSingleFileStore();
+      b.persistence().addSingleFileStore().location(location);
       return TestCacheManagerFactory.createCacheManager(b);
    }
 

--- a/core/src/test/java/org/infinispan/persistence/BaseStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/BaseStoreTest.java
@@ -50,6 +50,8 @@ import static org.testng.AssertJUnit.assertFalse;
 @Test(groups = "unit", testName = "persistence.BaseStoreTest")
 public abstract class BaseStoreTest extends AbstractInfinispanTest {
 
+   private TestObjectStreamMarshaller marshaller;
+
    protected abstract AdvancedLoadWriteStore createStore() throws Exception;
 
    protected AdvancedLoadWriteStore cl;
@@ -63,6 +65,7 @@ public abstract class BaseStoreTest extends AbstractInfinispanTest {
 
    @BeforeMethod
    public void setUp() throws Exception {
+      marshaller = new TestObjectStreamMarshaller();
       try {
          cl = createStore();
       } catch (Exception e) {
@@ -79,6 +82,7 @@ public abstract class BaseStoreTest extends AbstractInfinispanTest {
             cl.clear();
             cl.stop();
          }
+         marshaller.stop();
       } finally {
          cl = null;
       }
@@ -88,7 +92,7 @@ public abstract class BaseStoreTest extends AbstractInfinispanTest {
     * @return a mock marshaller for use with the cache store impls
     */
    protected StreamingMarshaller getMarshaller() {
-      return new TestObjectStreamMarshaller(false);
+      return marshaller;
    }
 
    public void testLoadAndStoreImmortal() throws PersistenceException {

--- a/core/src/test/java/org/infinispan/persistence/UnnecessaryLoadingTest.java
+++ b/core/src/test/java/org/infinispan/persistence/UnnecessaryLoadingTest.java
@@ -146,20 +146,25 @@ public class UnnecessaryLoadingTest extends SingleCacheManagerTest {
    public void testSkipCacheLoadFlagUsage() throws PersistenceException {
       CountingStore countingCS = getCountingCacheStore();
 
-      store.write(new MarshalledEntryImpl("home", "Vermezzo", null, new TestObjectStreamMarshaller()));
-      store.write(new MarshalledEntryImpl("home-second", "Newcastle Upon Tyne", null, new TestObjectStreamMarshaller()));
+      TestObjectStreamMarshaller sm = new TestObjectStreamMarshaller();
+      try {
+         store.write(new MarshalledEntryImpl("home", "Vermezzo", null, sm));
+         store.write(new MarshalledEntryImpl("home-second", "Newcastle Upon Tyne", null, sm));
 
-      assert countingCS.numLoads == 0;
-      //load using SKIP_CACHE_LOAD should not find the object in the store
-      assert cache.getAdvancedCache().withFlags(Flag.SKIP_CACHE_LOAD).get("home") == null;
-      assert countingCS.numLoads == 0;
+         assert countingCS.numLoads == 0;
+         //load using SKIP_CACHE_LOAD should not find the object in the store
+         assert cache.getAdvancedCache().withFlags(Flag.SKIP_CACHE_LOAD).get("home") == null;
+         assert countingCS.numLoads == 0;
 
-      assert cache.getAdvancedCache().withFlags(Flag.SKIP_CACHE_LOAD).put("home", "Newcastle") == null;
-      assert countingCS.numLoads == 0;
+         assert cache.getAdvancedCache().withFlags(Flag.SKIP_CACHE_LOAD).put("home", "Newcastle") == null;
+         assert countingCS.numLoads == 0;
 
-      final Object put = cache.getAdvancedCache().put("home-second", "Newcastle Upon Tyne, second");
-      assertEquals(put, "Newcastle Upon Tyne");
-      assert countingCS.numLoads == 1;
+         final Object put = cache.getAdvancedCache().put("home-second", "Newcastle Upon Tyne, second");
+         assertEquals(put, "Newcastle Upon Tyne");
+         assert countingCS.numLoads == 1;
+      } finally {
+         sm.stop();
+      }
    }
 
    private void reset(Cache<?, ?> cache, CountingStore countingCS) {

--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -409,12 +409,13 @@ public class TestCacheManagerFactory {
 
       public void checkManagersClosed(String testName) {
          for (Map.Entry<EmbeddedCacheManager, Throwable> cmEntry : cacheManagers.entrySet()) {
-            if (cmEntry.getKey().getStatus().allowInvocations()) {
+            EmbeddedCacheManager key = cmEntry.getKey();
+            if (key.getStatus().allowInvocations()) {
                String thName = Thread.currentThread().getName();
                String errorMessage = '\n' +
                      "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n" +
                      "!!!!!! (" + thName + ") Exiting because " + testName + " has NOT shut down all the cache managers it has started !!!!!!!\n" +
-                     "!!!!!! (" + thName + ") See allocation stacktrace to find out where still-running cacheManager (" + cmEntry.getKey() + ") was created: !!!!!!!\n" +
+                     "!!!!!! (" + thName + ") See allocation stacktrace to find out where still-running cacheManager (" + key + ") was created: !!!!!!!\n" +
                      "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
                Throwable allocationThrowable = cmEntry.getValue();
                log.errorf(allocationThrowable, errorMessage);

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStoreVamAltMapperTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStoreVamAltMapperTest.java
@@ -22,7 +22,6 @@ public class JdbcStringBasedStoreVamAltMapperTest extends JdbcStringBasedStoreAl
    EmbeddedCacheManager cm;
    StreamingMarshaller marshaller;
 
-
    @BeforeTest
    @Override
    public void createCacheStore() throws PersistenceException {
@@ -36,11 +35,9 @@ public class JdbcStringBasedStoreVamAltMapperTest extends JdbcStringBasedStoreAl
    @Override
    public void destroyStore() throws PersistenceException {
       super.destroyStore();
-
       cm.stop();
    }
 
-   @Override
    protected StreamingMarshaller getMarshaller() {
       return marshaller;
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3498
- xstream-based serialization doesn't work nicely with azul. I've used an shared instance of the real StreamingMarshaller for instances of the TestObjectStreamMarshaller.
- this class builds an single local CacheManager instance in order to populate the StreamingMarshaller correctly. This shouldn't be a burden on the test suite and solves the azul problem nicely
