### PR TITLE
ISPN-3335 JMX statistics for Queries do not work after adding new classe...

### DIFF
--- a/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
+++ b/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
@@ -268,7 +268,10 @@ public class QueryInterceptor extends CommandInterceptor {
       if (locked) {
          final Transaction transaction = suspend();
          try {
+            // we need to preserve the state of this flag manually because addClasses will cause reconfiguration and the flag is lost
+            boolean isStatisticsEnabled = searchFactory.getStatistics().isStatisticsEnabled();
             searchFactory.addClasses(toAdd.toArray(new Class[toAdd.size()]));
+            searchFactory.getStatistics().setStatisticsEnabled(isStatisticsEnabled);
          } finally {
             resume(transaction);
          }

--- a/query/src/main/java/org/infinispan/query/impl/InfinispanQueryStatisticsInfo.java
+++ b/query/src/main/java/org/infinispan/query/impl/InfinispanQueryStatisticsInfo.java
@@ -1,0 +1,142 @@
+package org.infinispan.query.impl;
+
+import org.hibernate.search.spi.SearchFactoryIntegrator;
+import org.infinispan.commons.util.concurrent.jdk8backported.LongAdder;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This MBean accumulates query statistics from the Hibernate Search statistics object. The only difference is this
+ * statistics continue to accumulate and are not reset when the Search Factory is reconfigured. They are still reset if
+ * {@code clear()} is explicitly called though.
+ *
+ * @author anistor@redhat.com
+ * @since 6.1
+ */
+public class InfinispanQueryStatisticsInfo implements InfinispanQueryStatisticsInfoMBean {
+
+   private final SearchFactoryIntegrator sf;
+   private final LongAdder searchQueryExecutionCount = new LongAdder();
+   private final LongAdder searchQueryTotalTime = new LongAdder();
+   private volatile long searchQueryExecutionMaxTime = 0;
+   private volatile String searchQueryExecutionMaxTimeQueryString = null;
+   private final LongAdder objectLoadingTotalTime = new LongAdder();
+   private volatile long objectLoadingExecutionMaxTime = 0;
+   private final LongAdder objectLoadedCount = new LongAdder();
+
+   public InfinispanQueryStatisticsInfo(SearchFactoryIntegrator sf) {
+      this.sf = sf;
+   }
+
+   @Override
+   public void clear() {
+      searchQueryExecutionCount.reset();
+      searchQueryTotalTime.reset();
+      searchQueryExecutionMaxTime = 0;
+      searchQueryExecutionMaxTimeQueryString = null;
+      objectLoadingTotalTime.reset();
+      objectLoadingExecutionMaxTime = 0;
+      objectLoadedCount.reset();
+      sf.getStatistics().clear();
+   }
+
+   @Override
+   public long getSearchQueryExecutionCount() {
+      searchQueryExecutionCount.add(sf.getStatistics().getSearchQueryExecutionCount());
+      return searchQueryExecutionCount.sum();
+   }
+
+   @Override
+   public long getSearchQueryTotalTime() {
+      searchQueryTotalTime.add(sf.getStatistics().getSearchQueryTotalTime());
+      return searchQueryTotalTime.sum();
+   }
+
+   @Override
+   public long getSearchQueryExecutionMaxTime() {
+      long temp = sf.getStatistics().getSearchQueryExecutionMaxTime();
+      if (searchQueryExecutionMaxTime < temp) {
+         searchQueryExecutionMaxTime = temp;
+      }
+      return searchQueryExecutionMaxTime;
+   }
+
+   @Override
+   public long getSearchQueryExecutionAvgTime() {
+      long count = getSearchQueryExecutionCount();
+      if (count == 0) {
+         return 0;
+      }
+      return getSearchQueryTotalTime() / count;
+   }
+
+   @Override
+   public String getSearchQueryExecutionMaxTimeQueryString() {
+      String temp = sf.getStatistics().getSearchQueryExecutionMaxTimeQueryString();
+      if (temp != null) {
+         searchQueryExecutionMaxTimeQueryString = temp;
+      }
+      return searchQueryExecutionMaxTimeQueryString;
+   }
+
+   @Override
+   public long getObjectLoadingTotalTime() {
+      objectLoadingTotalTime.add(sf.getStatistics().getObjectLoadingTotalTime());
+      return objectLoadingTotalTime.sum();
+   }
+
+   @Override
+   public long getObjectLoadingExecutionMaxTime() {
+      long temp = sf.getStatistics().getObjectLoadingExecutionMaxTime();
+      if (objectLoadingExecutionMaxTime < temp) {
+         objectLoadingExecutionMaxTime = temp;
+      }
+      return objectLoadingExecutionMaxTime;
+   }
+
+   @Override
+   public long getObjectLoadingExecutionAvgTime() {
+      long count = getObjectsLoadedCount();
+      if (count == 0) {
+         return 0;
+      }
+      return getObjectLoadingTotalTime() / count;
+   }
+
+   @Override
+   public long getObjectsLoadedCount() {
+      objectLoadedCount.add(sf.getStatistics().getObjectsLoadedCount());
+      return objectLoadedCount.sum();
+   }
+
+   @Override
+   public boolean isStatisticsEnabled() {
+      return sf.getStatistics().isStatisticsEnabled();
+   }
+
+   @Override
+   public void setStatisticsEnabled(boolean isStatisticsEnabled) {
+      sf.getStatistics().setStatisticsEnabled(isStatisticsEnabled);
+   }
+
+   @Override
+   public String getSearchVersion() {
+      return sf.getStatistics().getSearchVersion();
+   }
+
+   @Override
+   public Set<String> getIndexedClassNames() {
+      return sf.getStatistics().getIndexedClassNames();
+   }
+
+   @Override
+   public int getNumberOfIndexedEntities(String entity) {
+      return sf.getStatistics().getNumberOfIndexedEntities(entity);
+   }
+
+   @Override
+   public Map<String, Integer> indexedEntitiesCount() {
+      return sf.getStatistics().indexedEntitiesCount();
+   }
+}

--- a/query/src/main/java/org/infinispan/query/impl/InfinispanQueryStatisticsInfoMBean.java
+++ b/query/src/main/java/org/infinispan/query/impl/InfinispanQueryStatisticsInfoMBean.java
@@ -1,0 +1,11 @@
+package org.infinispan.query.impl;
+
+/**
+ * MBean interface as required by JMX rules. It duplicates org.hibernate.search.jmx.StatisticsInfoMBean
+ * just to be in the same package as org.infinispan.query.impl.InfinispanQueryStatisticsInfo.
+ *
+ * @author anistor@redhat.com
+ * @since 6.1
+ */
+public interface InfinispanQueryStatisticsInfoMBean extends org.hibernate.search.jmx.StatisticsInfoMBean {
+}

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -9,10 +9,8 @@ import java.util.TreeMap;
 import org.hibernate.search.Environment;
 import org.hibernate.search.cfg.SearchMapping;
 import org.hibernate.search.cfg.spi.SearchConfiguration;
-import org.hibernate.search.jmx.StatisticsInfo;
 import org.hibernate.search.spi.SearchFactoryBuilder;
 import org.hibernate.search.spi.SearchFactoryIntegrator;
-import org.hibernate.search.stat.Statistics;
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
@@ -163,12 +161,12 @@ public class LifecycleManager extends AbstractModuleLifecycle {
       jmxDomain = JmxUtil.buildJmxDomain(globalCfg, mbeanServer, queryGroupName);
 
       // Register statistics MBean, but only enable if Infinispan config says so
-      Statistics stats = sf.getStatistics();
+      InfinispanQueryStatisticsInfo stats = new InfinispanQueryStatisticsInfo(sf);
       stats.setStatisticsEnabled(cfg.jmxStatistics().enabled());
       try {
          ObjectName statsObjName = new ObjectName(
                jmxDomain + ":" + queryGroupName + ",component=Statistics");
-         JmxUtil.registerMBean(new StatisticsInfo(stats), statsObjName, mbeanServer);
+         JmxUtil.registerMBean(stats, statsObjName, mbeanServer);
       } catch (Exception e) {
          throw new CacheException(
                "Unable to register query module statistics mbean", e);


### PR DESCRIPTION
...s to SearchFactory

In Infinispan we use SearchFactory reconfiguration when adding new classes. This process actually builds a new SearchFactory behind the scenes which should preserve all state and config of the old one, plus the new added classes. Unfortunatelly this does not work correctly due to https://hibernate.atlassian.net/browse/HSEARCH-1461. The statistics are lost on each reconfiguration. Also the the status of Statistics.isStatisticsEnabled is lost.  

This is worked around by constructing a new MBean statistics implementtion, with identical interface. The new implementation accumulates its own statistics counters and gathers current data from the current Statistics object of the SearchFactory.

Please integrate in master.

Jira: https://issues.jboss.org/browse/ISPN-3335
