### PR TITLE
Correct spelling of parameter in DistributedExecuteCommand.perform

### DIFF
--- a/core/src/main/java/org/infinispan/commands/read/DistributedExecuteCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/DistributedExecuteCommand.java
@@ -80,7 +80,7 @@ public class DistributedExecuteCommand<V> extends BaseRpcCommand implements Visi
    /**
     * Performs invocation of Callable and returns result
     *
-    * @param ctx
+    * @param context
     *           invocation context
     * @return result of Callable invocations
     */


### PR DESCRIPTION
Minor JavaDoc item was misspelled, went ahead and corrected
