### PR TITLE
ISPN-3773 State transfer thread can stop even though there are pending transfer tasks

### DIFF
--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -788,7 +788,7 @@ public interface Log extends BasicLogger {
 
    @LogMessage(level = WARN)
    @Message(value = "Failed to request segments %s of cache %s from node %s (node will not be retried)", id=210)
-   void failedToRequestSegments(Collection<Integer> segments, String cacheName, Address source, @Cause Exception e);
+   void failedToRequestSegments(Collection<Integer> segments, String cacheName, Address source, @Cause Throwable e);
 
    @LogMessage(level = WARN)
    @Message(value = "Transactions were requested by node %s with topology %d, older than the local topology (%d)", id=211)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3773

Put the empty queue check and the thread stop in a synchronized block.
Simplify the state transfer loop by retrying failed tasks immediately.

No test for this, I think it would depend too much on the actual implementation.
