### PR TITLE
ISPN-3738 Entry version gets lost during topology change -> NPE

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManager.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManager.java
@@ -5,9 +5,11 @@ import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.jmx.annotations.DataType;
 import org.infinispan.jmx.annotations.ManagedAttribute;
+import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.topology.CacheTopology;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -49,7 +51,7 @@ public interface StateTransferManager {
     * If there is an state transfer happening at the moment, this method forwards the supplied
     * command to the nodes that are new owners of the data, in order to assure consistency.
     */
-   void forwardCommandIfNeeded(TopologyAffectedCommand command, Set<Object> affectedKeys, Address origin, boolean sync);
+   Map<Address, Response> forwardCommandIfNeeded(TopologyAffectedCommand command, Set<Object> affectedKeys, Address origin, boolean sync);
 
    void notifyEndOfRebalance(int topologyId);
 

--- a/core/src/test/java/org/infinispan/statetransfer/RemoteGetDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/RemoteGetDuringStateTransferTest.java
@@ -11,10 +11,8 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
-import org.infinispan.topology.CacheTopology;
-import org.infinispan.topology.LocalTopologyManager;
 import org.infinispan.tx.dld.ControlledRpcManager;
-import org.infinispan.util.AbstractControlledLocalTopologyManager;
+import org.infinispan.util.BlockingLocalTopologyManager;
 import org.infinispan.util.SingleSegmentConsistentHashFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -26,6 +24,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
 import static org.infinispan.distribution.DistributionTestHelper.isFirstOwner;
+import static org.infinispan.util.BlockingLocalTopologyManager.LatchType;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -39,8 +38,8 @@ import static org.testng.AssertJUnit.assertTrue;
 @CleanupAfterMethod
 public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest {
 
-   private final List<ControlledLocalTopologyManager> topologyManagerList =
-         Collections.synchronizedList(new ArrayList<ControlledLocalTopologyManager>(4));
+   private final List<BlockingLocalTopologyManager> topologyManagerList =
+         Collections.synchronizedList(new ArrayList<BlockingLocalTopologyManager>(4));
    private final List<ControlledRpcManager> rpcManagerList =
          Collections.synchronizedList(new ArrayList<ControlledRpcManager>(4));
 
@@ -65,7 +64,7 @@ public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest 
    public final void unblockAll() {
       //keep track of all controlled components. In case of failure, we need to unblock all otherwise we have to wait
       //long time until the test is able to stop all cache managers.
-      for (ControlledLocalTopologyManager topologyManager : topologyManagerList) {
+      for (BlockingLocalTopologyManager topologyManager : topologyManagerList) {
          topologyManager.stopBlockingAll();
       }
       topologyManagerList.clear();
@@ -85,7 +84,7 @@ public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest 
       ownerCheckAndInit(cache(1), key, "v");
 
       final ControlledRpcManager rpcManager = replaceRpcManager(cache(0));
-      final ControlledLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
+      final BlockingLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
       final int currentTopologyId = currentTopologyId(cache(0));
 
       rpcManager.blockBefore(ClusteredGetCommand.class);
@@ -119,7 +118,7 @@ public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest 
       final Object key = "key_s2";
       ownerCheckAndInit(cache(1), key, "v");
       final ControlledRpcManager rpcManager = replaceRpcManager(cache(0));
-      final ControlledLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
+      final BlockingLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
       final int currentTopologyId = currentTopologyId(cache(0));
 
       rpcManager.blockBefore(ClusteredGetCommand.class);
@@ -154,7 +153,7 @@ public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest 
       final Object key = "key_s3";
       ownerCheckAndInit(cache(1), key, "v");
       final ControlledRpcManager rpcManager = replaceRpcManager(cache(0));
-      final ControlledLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
+      final BlockingLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
       final int currentTopologyId = currentTopologyId(cache(0));
 
       rpcManager.blockBefore(ClusteredGetCommand.class);
@@ -191,7 +190,7 @@ public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest 
       final Object key = "key_s4";
       ownerCheckAndInit(cache(1), key, "v");
       final ControlledRpcManager rpcManager = replaceRpcManager(cache(0));
-      final ControlledLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
+      final BlockingLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
       final int currentTopologyId = currentTopologyId(cache(0));
 
       rpcManager.blockBefore(ClusteredGetCommand.class);
@@ -230,7 +229,7 @@ public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest 
       final Object key = "key_s4";
       ownerCheckAndInit(cache(1), key, "v");
       final ControlledRpcManager rpcManager = replaceRpcManager(cache(0));
-      final ControlledLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
+      final BlockingLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
       final int currentTopologyId = currentTopologyId(cache(0));
 
       rpcManager.blockBefore(ClusteredGetCommand.class);
@@ -336,7 +335,7 @@ public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest 
       final Object key = "key_s6";
       ownerCheckAndInit(cache(1), key, "v");
       final ControlledRpcManager rpcManager = replaceRpcManager(cache(0));
-      final ControlledLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
+      final BlockingLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
       final int currentTopologyId = currentTopologyId(cache(0));
 
       rpcManager.blockBefore(ClusteredGetCommand.class);
@@ -373,7 +372,7 @@ public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest 
       final Object key = "key_s6";
       ownerCheckAndInit(cache(1), key, "v");
       final ControlledRpcManager rpcManager = replaceRpcManager(cache(0));
-      final ControlledLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
+      final BlockingLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
       final int currentTopologyId = currentTopologyId(cache(0));
 
       rpcManager.blockBefore(ClusteredGetCommand.class);
@@ -415,7 +414,7 @@ public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest 
       final Object key = "key_s7";
       ownerCheckAndInit(cache(1), key, "v");
       final ControlledRpcManager rpcManager = replaceRpcManager(cache(0));
-      final ControlledLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
+      final BlockingLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
       final int currentTopologyId = currentTopologyId(cache(0));
 
       rpcManager.blockBefore(ClusteredGetCommand.class);
@@ -457,7 +456,7 @@ public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest 
       final Object key = "key_s7";
       ownerCheckAndInit(cache(1), key, "v");
       final ControlledRpcManager rpcManager = replaceRpcManager(cache(0));
-      final ControlledLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
+      final BlockingLocalTopologyManager topologyManager = replaceTopologyManager(manager(0));
       final int currentTopologyId = currentTopologyId(cache(0));
 
       rpcManager.blockBefore(ClusteredGetCommand.class);
@@ -569,12 +568,10 @@ public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest 
       return builder;
    }
 
-   private ControlledLocalTopologyManager replaceTopologyManager(CacheContainer cacheContainer) {
-      LocalTopologyManager manager = TestingUtil.extractGlobalComponent(cacheContainer, LocalTopologyManager.class);
-      ControlledLocalTopologyManager controlledLocalTopologyManager = new ControlledLocalTopologyManager(manager);
-      TestingUtil.replaceComponent(cacheContainer, LocalTopologyManager.class, controlledLocalTopologyManager, true);
-      topologyManagerList.add(controlledLocalTopologyManager);
-      return controlledLocalTopologyManager;
+   private BlockingLocalTopologyManager replaceTopologyManager(CacheContainer cacheContainer) {
+      BlockingLocalTopologyManager localTopologyManager = BlockingLocalTopologyManager.replaceTopologyManager(cacheContainer);
+      topologyManagerList.add(localTopologyManager);
+      return localTopologyManager;
    }
 
    private ControlledRpcManager replaceRpcManager(Cache cache) {
@@ -583,12 +580,6 @@ public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest 
       TestingUtil.replaceComponent(cache, RpcManager.class, controlledRpcManager, true);
       rpcManagerList.add(controlledRpcManager);
       return controlledRpcManager;
-   }
-
-   private static enum LatchType {
-      CONSISTENT_HASH_UPDATE,
-      CONFIRM_REBALANCE,
-      REBALANCE
    }
 
    @SuppressWarnings("unchecked")
@@ -603,7 +594,7 @@ public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest 
 
    private class NewNode {
       Future<Void> joinerFuture;
-      ControlledLocalTopologyManager localTopologyManager;
+      BlockingLocalTopologyManager localTopologyManager;
    }
 
    private class RemoteGetCallable implements Callable<Object> {
@@ -620,99 +611,5 @@ public class RemoteGetDuringStateTransferTest extends MultipleCacheManagersTest 
       public Object call() throws Exception {
          return cache.get(key);
       }
-   }
-
-   private class ControlledLocalTopologyManager extends AbstractControlledLocalTopologyManager {
-
-      private final Latch blockConfirmRebalance;
-      private final Latch blockConsistentHashUpdate;
-      private final Latch blockRebalanceStart;
-
-      public ControlledLocalTopologyManager(LocalTopologyManager delegate) {
-         super(delegate);
-         blockRebalanceStart = new Latch();
-         blockConsistentHashUpdate = new Latch();
-         blockConfirmRebalance = new Latch();
-      }
-
-      public void startBlocking(LatchType type) {
-         getLatch(type).enable();
-      }
-
-      public void stopBlocking(LatchType type) {
-         getLatch(type).disable();
-      }
-
-      public void waitToBlock(LatchType type) throws InterruptedException {
-         getLatch(type).waitToBlock();
-      }
-
-      public void stopBlockingAll() {
-         for (LatchType type : LatchType.values()) {
-            getLatch(type).disable();
-         }
-      }
-
-      @Override
-      protected final void beforeHandleConsistentHashUpdate(String cacheName, CacheTopology cacheTopology, int viewId) {
-         getLatch(LatchType.CONSISTENT_HASH_UPDATE).blockIfNeeded();
-      }
-
-      @Override
-      protected final void beforeHandleRebalance(String cacheName, CacheTopology cacheTopology, int viewId) {
-         getLatch(LatchType.REBALANCE).blockIfNeeded();
-      }
-
-      @Override
-      protected final void beforeConfirmRebalance(String cacheName, int topologyId, Throwable throwable) {
-         getLatch(LatchType.CONFIRM_REBALANCE).blockIfNeeded();
-      }
-
-      private Latch getLatch(LatchType type) {
-         switch (type) {
-            case CONSISTENT_HASH_UPDATE:
-               return blockConsistentHashUpdate;
-            case CONFIRM_REBALANCE:
-               return blockConfirmRebalance;
-            case REBALANCE:
-               return blockRebalanceStart;
-         }
-         throw new IllegalStateException("Should never happen!");
-      }
-   }
-
-   private class Latch {
-
-      private boolean enabled = false;
-      private boolean blocked = false;
-
-      public final synchronized void enable() {
-         this.enabled = true;
-      }
-
-      public final synchronized void disable() {
-         this.enabled = false;
-         notifyAll();
-      }
-
-      public final synchronized void blockIfNeeded() {
-         blocked = true;
-         notifyAll();
-         while (enabled) {
-            try {
-               wait();
-            } catch (InterruptedException e) {
-               Thread.currentThread().interrupt();
-               return;
-            }
-         }
-      }
-
-      public final synchronized void waitToBlock() throws InterruptedException {
-         while (!blocked) {
-            wait();
-         }
-      }
-
    }
 }

--- a/core/src/test/java/org/infinispan/statetransfer/WriteSkewDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/WriteSkewDuringStateTransferTest.java
@@ -1,0 +1,395 @@
+package org.infinispan.statetransfer;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.VisitableCommand;
+import org.infinispan.commands.tx.PrepareCommand;
+import org.infinispan.commands.tx.VersionedPrepareCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.VersioningScheme;
+import org.infinispan.container.DataContainer;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.interceptors.base.BaseCustomInterceptor;
+import org.infinispan.manager.CacheContainer;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.tx.dld.ControlledRpcManager;
+import org.infinispan.util.BlockingLocalTopologyManager;
+import org.infinispan.util.SingleSegmentConsistentHashFactory;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.infinispan.distribution.DistributionTestHelper.hasOwners;
+import static org.testng.AssertJUnit.*;
+
+/**
+ * Tests if the entry version is lost during the state transfer in which the primary owner changes.
+ *
+ * @author Pedro Ruivo
+ * @since 6.0
+ */
+@Test(groups = "functional", testName = "statetransfer.WriteSkewDuringStateTransferTest", singleThreaded = true)
+public class WriteSkewDuringStateTransferTest extends MultipleCacheManagersTest {
+
+   private final List<BlockingLocalTopologyManager> topologyManagerList =
+         Collections.synchronizedList(new ArrayList<BlockingLocalTopologyManager>(4));
+
+   @AfterMethod(alwaysRun = true)
+   public final void unblockAll() {
+      //keep track of all controlled components. In case of failure, we need to unblock all otherwise we have to wait
+      //long time until the test is able to stop all cache managers.
+      for (BlockingLocalTopologyManager topologyManager : topologyManagerList) {
+         topologyManager.stopBlockingAll();
+      }
+      topologyManagerList.clear();
+   }
+
+   /*
+   Replicated TX cache with WSC, A, B are in cluster, C is joining
+   0. The current CH already contains A and B as owners, C is joining (is not primary owner of anything yet).
+B is primary owner of K=V.
+   1. A sends PrepareCommand to B and C with put(K, V) (V is null on all nodes); //A has already received the
+rebalance_start
+   2. C receives PrepareCommand and responds with no versions (it is not primary owner); //C has already received the
+rebalance_start
+   3. topology changes on B - primary ownership of K is transferred to C; //B has already received the ch_update
+   4. B receives PrepareCommand, responds without K's version (it is not primary)
+   5. B forwards the Prepare to C as it sees that the command has lower topology ID
+   6. C responds to B's prepare with version of K; //at this point, C has received the ch_update
+   7. K version is not added to B's response, B responds to A
+   8. A finds out that topology has changed, forwards prepare to C; //A has received the ch_update
+   9. C responds to C's prepare with version of K
+   10. A receives C's response, but the versions are not added to transaction
+   11. A sends out CommitCommand missing version of K
+   12. all nodes record K=V without version as usual ImmortalCacheEntry
+   */
+
+   /**
+    * See description above or ISPN-3738
+    */
+   public void testVersionsAfterStateTransfer() throws Exception {
+      assertClusterSize("Wrong cluster size", 2);
+      final Object key = "key1";
+      assertKeyOwnership(key, cache(1), cache(0));
+      final int currentTopologyId = currentTopologyId(cache(0));
+
+      final ControlledRpcManager nodeARpcManager = replaceRpcManager(cache(0));
+      final NodeController nodeAController = setNodeControllerIn(cache(0));
+      setInitialPhaseForNodeA(nodeAController, currentTopologyId);
+      final NodeController nodeBController = setNodeControllerIn(cache(1));
+      setInitialPhaseForNodeB(nodeBController, currentTopologyId);
+      final NewNode nodeC = addNode(currentTopologyId);
+
+      //node A thinks that node B is the primary owner. Node B is blocking the prepare command until it thinks that
+      //node C is the primary owner
+      nodeAController.topologyManager.waitToBlock(BlockingLocalTopologyManager.LatchType.CONSISTENT_HASH_UPDATE);
+      nodeARpcManager.blockAfter(VersionedPrepareCommand.class);
+      //node C thinks that node B is the primary owner.
+      //nodeC.controller.topologyManager.waitToBlock(BlockingLocalTopologyManager.LatchType.CONSISTENT_HASH_UPDATE);
+
+      //after this waiting phase, node A thinks that node B is the primary owner, node B thinks that node C is the
+      // primary owner and node C thinks that node B is the primary owner
+      //lets execute the transaction...
+
+      Future<Object> tx = executeTransaction(cache(0), key);
+
+      //it waits until all nodes has replied. then, we change the topology ID and let it collect the responses.
+      nodeARpcManager.waitForCommandToBlock();
+      nodeAController.topologyManager.stopBlocking(BlockingLocalTopologyManager.LatchType.CONSISTENT_HASH_UPDATE);
+      awaitForTopology(currentTopologyId + 2, cache(0));
+
+      nodeARpcManager.stopBlocking();
+      assertNull("Wrong put() return value.", tx.get());
+
+      nodeAController.topologyManager.stopBlockingAll();
+      nodeBController.topologyManager.stopBlockingAll();
+      nodeC.controller.topologyManager.stopBlockingAll();
+
+      nodeC.joinerFuture.get();
+
+      awaitForTopology(currentTopologyId + 2, cache(0));
+      awaitForTopology(currentTopologyId + 2, cache(1));
+      awaitForTopology(currentTopologyId + 2, cache(2));
+
+      assertKeyVersionInDataContainer(key, cache(1), cache(2));
+      cache(0).put(key, "v2");
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createClusteredCaches(2, configuration());
+   }
+
+   private void assertKeyVersionInDataContainer(Object key, Cache... owners) {
+      for (Cache cache : owners) {
+         DataContainer dataContainer = TestingUtil.extractComponent(cache, DataContainer.class);
+         InternalCacheEntry entry = dataContainer.get(key);
+         assertNotNull("Entry cannot be null in " + address(cache) + ".", entry);
+         assertNotNull("Version cannot be null.", entry.getMetadata().version());
+      }
+   }
+
+   private ControlledRpcManager replaceRpcManager(Cache cache) {
+      RpcManager manager = TestingUtil.extractComponent(cache, RpcManager.class);
+      ControlledRpcManager controlledRpcManager = new ControlledRpcManager(manager);
+      TestingUtil.replaceComponent(cache, RpcManager.class, controlledRpcManager, true);
+      //rpcManagerList.add(controlledRpcManager);
+      return controlledRpcManager;
+   }
+
+   private void awaitForTopology(final int expectedTopologyId, final Cache cache) {
+      eventually(new Condition() {
+         @Override
+         public boolean isSatisfied() throws Exception {
+            return expectedTopologyId == currentTopologyId(cache);
+         }
+      });
+   }
+
+   private int currentTopologyId(Cache cache) {
+      return TestingUtil.extractComponent(cache, StateTransferManager.class).getCacheTopology().getTopologyId();
+   }
+
+   private Future<Object> executeTransaction(final Cache<Object, Object> cache, final Object key) {
+      return fork(new Callable<Object>() {
+         @Override
+         public Object call() throws Exception {
+            return TestingUtil.withTx(cache.getAdvancedCache().getTransactionManager(), new Callable<Object>() {
+               @Override
+               public Object call() throws Exception {
+                  return cache.put(key, "value");
+               }
+            });
+         }
+      });
+   }
+
+   private NewNode addNode(final int currentTopologyId) {
+      final NewNode newNode = new NewNode();
+      ConfigurationBuilder builder = configuration();
+      newNode.controller = new NodeController();
+      newNode.controller.interceptor = new ControlledCommandInterceptor();
+      builder.customInterceptors().addInterceptor().index(0).interceptor(newNode.controller.interceptor);
+      EmbeddedCacheManager embeddedCacheManager = addClusterEnabledCacheManager(builder);
+      newNode.controller.topologyManager = replaceTopologyManager(embeddedCacheManager);
+      newNode.controller.interceptor.addAction(new Action() {
+         @Override
+         public boolean isApplicable(InvocationContext context, VisitableCommand command) {
+            return !context.isOriginLocal() && command instanceof PrepareCommand;
+         }
+
+         @Override
+         public void before(InvocationContext context, VisitableCommand command, Cache cache) {
+            log.tracef("Before: command=%s. origin=%s", command, context.getOrigin());
+            if (context.getOrigin().equals(address(cache(1)))) {
+               //from node B, i.e, it is forwarded. it needs to wait until the topology changes
+               try {
+                  cache.getAdvancedCache().getComponentRegistry().getStateTransferLock().waitForTopology(currentTopologyId + 2,
+                                                                                                         10, TimeUnit.SECONDS);
+               } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+               }
+            }
+         }
+
+         @Override
+         public void after(InvocationContext context, VisitableCommand command, Cache cache) {
+            log.tracef("After: command=%s. origin=%s", command, context.getOrigin());
+            if (context.getOrigin().equals(address(cache(0)))) {
+               newNode.controller.topologyManager.stopBlocking(BlockingLocalTopologyManager.LatchType.CONSISTENT_HASH_UPDATE);
+            }
+         }
+      });
+
+      newNode.controller.topologyManager.startBlocking(BlockingLocalTopologyManager.LatchType.CONSISTENT_HASH_UPDATE);
+      newNode.joinerFuture = fork(new Callable<Void>() {
+         @Override
+         public Void call() throws Exception {
+            waitForClusterToForm();
+            return null;
+         }
+      });
+      return newNode;
+   }
+
+   private ConfigurationBuilder configuration() {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
+      builder.clustering()
+            .stateTransfer().fetchInMemoryState(true)
+            .hash().numSegments(1).numOwners(3).consistentHashFactory(new ConsistentHashFactoryImpl());
+      builder.locking()
+            .isolationLevel(IsolationLevel.REPEATABLE_READ)
+            .writeSkewCheck(true);
+      builder.versioning()
+            .enable()
+            .scheme(VersioningScheme.SIMPLE);
+      return builder;
+   }
+
+   private void assertKeyOwnership(Object key, Cache primaryOwner, Cache... backupOwners) {
+      assertTrue("Wrong ownership for " + key + ".", hasOwners(key, primaryOwner, backupOwners));
+   }
+
+   private BlockingLocalTopologyManager replaceTopologyManager(CacheContainer cacheContainer) {
+      BlockingLocalTopologyManager localTopologyManager = BlockingLocalTopologyManager.replaceTopologyManager(cacheContainer);
+      topologyManagerList.add(localTopologyManager);
+      return localTopologyManager;
+   }
+
+   private static NodeController setNodeControllerIn(Cache<Object, Object> cache) {
+      NodeController nodeController = new NodeController();
+      nodeController.interceptor = new ControlledCommandInterceptor(cache);
+      nodeController.topologyManager = BlockingLocalTopologyManager.replaceTopologyManager(cache.getCacheManager());
+      return nodeController;
+   }
+
+   private static void setInitialPhaseForNodeA(NodeController nodeA, final int currentTopology) {
+      //node A initial phase:
+      //* Node A sends the prepare for B and C. So, node A will send the prepare after the topologyId+1 is installed.
+      nodeA.interceptor.addAction(new Action() {
+         @Override
+         public boolean isApplicable(InvocationContext context, VisitableCommand command) {
+            return context.isOriginLocal() && command instanceof PrepareCommand;
+         }
+
+         @Override
+         public void before(InvocationContext context, VisitableCommand command, Cache cache) {
+            try {
+               cache.getAdvancedCache().getComponentRegistry().getStateTransferLock().waitForTopology(currentTopology + 1,
+                                                                                                      10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+               Thread.currentThread().interrupt();
+            }
+         }
+
+         @Override
+         public void after(InvocationContext context, VisitableCommand command, Cache cache) {
+            //no-op
+         }
+      });
+      nodeA.topologyManager.startBlocking(BlockingLocalTopologyManager.LatchType.CONSISTENT_HASH_UPDATE);
+   }
+
+   private static void setInitialPhaseForNodeB(NodeController nodeB, final int currentTopology) {
+      //node B initial phase:
+      //* Node B receives the prepare after it looses the primary owner to node C
+      nodeB.interceptor.addAction(new Action() {
+         @Override
+         public boolean isApplicable(InvocationContext context, VisitableCommand command) {
+            return !context.isOriginLocal() && command instanceof PrepareCommand;
+         }
+
+         @Override
+         public void before(InvocationContext context, VisitableCommand command, Cache cache) {
+            try {
+               cache.getAdvancedCache().getComponentRegistry().getStateTransferLock().waitForTopology(currentTopology + 2,
+                                                                                                      10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+               Thread.currentThread().interrupt();
+            }
+         }
+
+         @Override
+         public void after(InvocationContext context, VisitableCommand command, Cache cache) {
+            //no-op
+         }
+      });
+   }
+
+   public interface Action {
+
+      public boolean isApplicable(InvocationContext context, VisitableCommand command);
+
+      public void before(InvocationContext context, VisitableCommand command, Cache cache);
+
+      public void after(InvocationContext context, VisitableCommand command, Cache cache);
+
+   }
+
+   public static class ConsistentHashFactoryImpl extends SingleSegmentConsistentHashFactory {
+
+      @Override
+      protected final List<Address> createOwnersCollection(List<Address> members, int numberOfOwners) {
+         assertEquals("Wrong number of owners", 3, numberOfOwners);
+         //the primary owner is the last member.
+         final List<Address> owners = new ArrayList<Address>(3);
+         owners.add(members.get(members.size() - 1));
+         for (int i = 0; i < members.size() - 1; ++i) {
+            owners.add(members.get(i));
+         }
+         return owners;
+      }
+   }
+
+   public static class ControlledCommandInterceptor extends BaseCustomInterceptor {
+
+      private final List<Action> actionList;
+
+      public ControlledCommandInterceptor(Cache<Object, Object> cache) {
+         actionList = new ArrayList<Action>(3);
+         this.cache = cache;
+         this.cacheConfiguration = cache.getCacheConfiguration();
+         this.embeddedCacheManager = cache.getCacheManager();
+         cache.getAdvancedCache().addInterceptor(this, 0);
+      }
+
+      public ControlledCommandInterceptor() {
+         actionList = new ArrayList<Action>(3);
+      }
+
+      public void addAction(Action action) {
+         actionList.add(action);
+      }
+
+      @Override
+      protected Object handleDefault(InvocationContext ctx, VisitableCommand command) throws Throwable {
+         List<Action> actions = extractActions(ctx, command);
+         if (actions.isEmpty()) {
+            return invokeNextInterceptor(ctx, command);
+         }
+         for (Action action : actions) {
+            action.before(ctx, command, cache);
+         }
+         Object retVal = invokeNextInterceptor(ctx, command);
+         for (Action action : actions) {
+            action.after(ctx, command, cache);
+         }
+         return retVal;
+      }
+
+      private List<Action> extractActions(InvocationContext context, VisitableCommand command) {
+         if (actionList.isEmpty()) {
+            return Collections.emptyList();
+         }
+         List<Action> actions = new ArrayList<Action>(actionList.size());
+         for (Action action : actionList) {
+            if (action.isApplicable(context, command)) {
+               actions.add(action);
+            }
+         }
+         return actions;
+      }
+   }
+
+   private static class NodeController {
+      ControlledCommandInterceptor interceptor;
+      BlockingLocalTopologyManager topologyManager;
+   }
+
+   private static class NewNode {
+      Future<Void> joinerFuture;
+      NodeController controller;
+   }
+}

--- a/core/src/test/java/org/infinispan/util/BlockingLocalTopologyManager.java
+++ b/core/src/test/java/org/infinispan/util/BlockingLocalTopologyManager.java
@@ -1,0 +1,90 @@
+package org.infinispan.util;
+
+import org.infinispan.manager.CacheContainer;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.topology.CacheTopology;
+import org.infinispan.topology.LocalTopologyManager;
+
+/**
+ * Replaces the LocalTopologyManager and allows it to block the phases of the state transfer:
+ * <ul>
+ *    <li>Rebalance Start</li>
+ *    <li>Confirm Rebalance</li>
+ *    <li>Consistent Hash Update</li>
+ * </ul>
+ *
+ * @author Pedro Ruivo
+ * @since 6.0
+ */
+public class BlockingLocalTopologyManager extends AbstractControlledLocalTopologyManager {
+
+   private final NotifierLatch blockConfirmRebalance;
+   private final NotifierLatch blockConsistentHashUpdate;
+   private final NotifierLatch blockRebalanceStart;
+
+   public BlockingLocalTopologyManager(LocalTopologyManager delegate) {
+      super(delegate);
+      blockRebalanceStart = new NotifierLatch();
+      blockConsistentHashUpdate = new NotifierLatch();
+      blockConfirmRebalance = new NotifierLatch();
+   }
+
+   public static BlockingLocalTopologyManager replaceTopologyManager(CacheContainer cacheContainer) {
+      LocalTopologyManager manager = TestingUtil.extractGlobalComponent(cacheContainer, LocalTopologyManager.class);
+      BlockingLocalTopologyManager controlledLocalTopologyManager = new BlockingLocalTopologyManager(manager);
+      TestingUtil.replaceComponent(cacheContainer, LocalTopologyManager.class, controlledLocalTopologyManager, true);
+      return controlledLocalTopologyManager;
+   }
+
+   public void startBlocking(LatchType type) {
+      getLatch(type).startBlocking();
+   }
+
+   public void stopBlocking(LatchType type) {
+      getLatch(type).stopBlocking();
+   }
+
+   public void waitToBlock(LatchType type) throws InterruptedException {
+      getLatch(type).waitToBlock();
+   }
+
+   public void stopBlockingAll() {
+      for (LatchType type : LatchType.values()) {
+         getLatch(type).stopBlocking();
+      }
+   }
+
+   @Override
+   protected final void beforeHandleConsistentHashUpdate(String cacheName, CacheTopology cacheTopology, int viewId) {
+      getLatch(LatchType.CONSISTENT_HASH_UPDATE).blockIfNeeded();
+   }
+
+   @Override
+   protected final void beforeHandleRebalance(String cacheName, CacheTopology cacheTopology, int viewId) {
+      getLatch(LatchType.REBALANCE).blockIfNeeded();
+   }
+
+   @Override
+   protected final void beforeConfirmRebalance(String cacheName, int topologyId, Throwable throwable) {
+      getLatch(LatchType.CONFIRM_REBALANCE).blockIfNeeded();
+   }
+
+   private NotifierLatch getLatch(LatchType type) {
+      switch (type) {
+         case CONSISTENT_HASH_UPDATE:
+            return blockConsistentHashUpdate;
+         case CONFIRM_REBALANCE:
+            return blockConfirmRebalance;
+         case REBALANCE:
+            return blockRebalanceStart;
+      }
+      throw new IllegalStateException("Should never happen!");
+   }
+
+   public static enum LatchType {
+      CONSISTENT_HASH_UPDATE,
+      CONFIRM_REBALANCE,
+      REBALANCE
+   }
+
+}

--- a/core/src/test/java/org/infinispan/util/NotifierLatch.java
+++ b/core/src/test/java/org/infinispan/util/NotifierLatch.java
@@ -1,0 +1,42 @@
+package org.infinispan.util;
+
+/**
+ * A latch that can be open and close. It allows the notification when the some thread is blocking in it.
+ *
+ * @author Pedro Ruivo
+ * @since 6.0
+ */
+public class NotifierLatch {
+
+   private boolean enabled = false;
+   private boolean blocked = false;
+
+   public final synchronized void startBlocking() {
+      this.enabled = true;
+   }
+
+   public final synchronized void stopBlocking() {
+      this.enabled = false;
+      notifyAll();
+   }
+
+   public final synchronized void blockIfNeeded() {
+      blocked = true;
+      notifyAll();
+      while (enabled) {
+         try {
+            wait();
+         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+         }
+      }
+   }
+
+   public final synchronized void waitToBlock() throws InterruptedException {
+      while (!blocked) {
+         wait();
+      }
+   }
+
+}


### PR DESCRIPTION
- refactor some most used classes like BlockingLocalTopologyManager
  and NotifierLatch
- prepare forwarding during state transfer merges the forward response

https://issues.jboss.org/browse/ISPN-3738
