### PR TITLE
ISPN-3809 Manual indexing cannot be triggered when running in server mod...

### DIFF
--- a/query/src/test/java/org/infinispan/query/api/ManualIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/api/ManualIndexingTest.java
@@ -61,6 +61,7 @@ public class ManualIndexingTest extends MultipleCacheManagersTest {
          Query query = sm.buildQueryBuilderForClass(Car.class).get().keyword().onField("make").matching(carMake).createQuery();
          CacheQuery cacheQuery = sm.getQuery(query, Car.class);
          Assert.assertEquals("Expected count not met on cache " + cache, expectedCount, cacheQuery.getResultSize());
+         Assert.assertEquals("Expected count not met on cache " + cache, expectedCount, cacheQuery.list().size());
       }
    }
 }

--- a/server/integration/build/src/main/resources-ispn/modules/system/layers/base/org/infinispan/main/module.xml
+++ b/server/integration/build/src/main/resources-ispn/modules/system/layers/base/org/infinispan/main/module.xml
@@ -33,7 +33,7 @@
         <module name="org.jboss.logging"/>
         <module name="org.infinispan.adaptor52x" export="true" optional="true"/>
         <module name="org.infinispan.commons" export="true"/>
-        <module name="org.infinispan.query" optional="true"/>
+        <module name="org.infinispan.query" optional="true" services="import"/>
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.marshalling.river" services="import"/>
         <module name="org.jgroups"/>

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/ManualIndexingTest.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/ManualIndexingTest.java
@@ -1,0 +1,126 @@
+package org.infinispan.server.test.query;
+
+import org.infinispan.arquillian.core.InfinispanResource;
+import org.infinispan.arquillian.core.RemoteInfinispanServer;
+import org.infinispan.arquillian.core.WithRunningServer;
+import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.Search;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
+import org.infinispan.commons.util.Util;
+import org.infinispan.protostream.sampledomain.User;
+import org.infinispan.protostream.sampledomain.marshallers.MarshallerRegistration;
+import org.infinispan.query.dsl.QueryBuilder;
+import org.infinispan.query.remote.ProtobufMetadataManagerMBean;
+import org.infinispan.server.test.util.RemoteCacheManagerFactory;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.management.JMX;
+import javax.management.ObjectName;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests manual indexing in server.
+ *
+ * @author anistor@redhat.com
+ */
+@RunWith(Arquillian.class)
+@WithRunningServer("remote-query")
+public class ManualIndexingTest {
+
+   private static final String CACHE_MANAGER_NAME = "local";
+   private static final String CACHE_NAME = "testcache_manual";
+
+   @InfinispanResource("remote-query")
+   private RemoteInfinispanServer server;
+
+   private RemoteCacheManager remoteCacheManager;
+   private RemoteCache<Integer, User> remoteCache;
+   private MBeanServerConnectionProvider provider;
+   private RemoteCacheManagerFactory rcmFactory;
+
+   @Before
+   public void setUp() throws Exception {
+      provider = new MBeanServerConnectionProvider(server.getHotrodEndpoint().getInetAddress().getHostName(), 9999);
+      rcmFactory = new RemoteCacheManagerFactory();
+      ConfigurationBuilder clientBuilder = new ConfigurationBuilder();
+      clientBuilder.addServer()
+            .host(server.getHotrodEndpoint().getInetAddress().getHostName())
+            .port(server.getHotrodEndpoint().getPort())
+            .marshaller(new ProtoStreamMarshaller());
+      remoteCacheManager = rcmFactory.createManager(clientBuilder);
+      remoteCache = remoteCacheManager.getCache(CACHE_NAME);
+
+      //initialize server-side serialization context via JMX
+      ObjectName protobufMetadataManagerName = new ObjectName("jboss.infinispan:type=RemoteQuery,name="
+                                                                    + ObjectName.quote(CACHE_MANAGER_NAME)
+                                                                    + ",component=ProtobufMetadataManager");
+      ProtobufMetadataManagerMBean protobufMetadataManagerMBean = JMX.newMBeanProxy(provider.getConnection(),
+                                                                                    protobufMetadataManagerName,
+                                                                                    ProtobufMetadataManagerMBean.class);
+      protobufMetadataManagerMBean.registerProtofile(readClasspathResource("/bank.protobin"));
+
+      //initialize client-side serialization context
+      MarshallerRegistration.registerMarshallers(ProtoStreamMarshaller.getSerializationContext(remoteCacheManager));
+   }
+
+   @After
+   public void tearDown() {
+      if (remoteCache != null) {
+         remoteCache.clear();
+      }
+      if (rcmFactory != null) {
+         rcmFactory.stopManagers();
+      }
+      rcmFactory = null;
+   }
+
+   @Test
+   public void testManualIndexing() throws Exception {
+      QueryBuilder qb = Search.getQueryFactory(remoteCache).from(User.class)
+            .having("name").eq("Tom").toBuilder();
+
+      User user = new User();
+      user.setId(1);
+      user.setName("Tom");
+      user.setSurname("Cat");
+      user.setGender(User.Gender.MALE);
+      remoteCache.put(1, user);
+
+      assertEquals(0, qb.build().list().size());
+
+      //manual indexing
+      ObjectName massIndexerName = new ObjectName("jboss.infinispan:type=Query,manager="
+                                                        + ObjectName.quote(CACHE_MANAGER_NAME)
+                                                        + ",cache=" + ObjectName.quote(CACHE_NAME)
+                                                        + ",component=MassIndexer");
+      provider.getConnection().invoke(massIndexerName, "start", null, null);
+
+      List<User> list = qb.build().list();
+      assertEquals(1, list.size());
+      User foundUser = list.get(0);
+      assertEquals(1, foundUser.getId());
+      assertEquals("Tom", foundUser.getName());
+      assertEquals("Cat", foundUser.getSurname());
+      assertEquals(User.Gender.MALE, foundUser.getGender());
+   }
+
+   private byte[] readClasspathResource(String c) throws IOException {
+      InputStream is = getClass().getResourceAsStream(c);
+      try {
+         return Util.readStream(is);
+      } finally {
+         is.close();
+      }
+   }
+}

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryTest.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.server.test.query;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
@@ -15,6 +14,7 @@ import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.Search;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
+import org.infinispan.commons.util.Util;
 import org.infinispan.protostream.sampledomain.Address;
 import org.infinispan.protostream.sampledomain.User;
 import org.infinispan.protostream.sampledomain.marshallers.MarshallerRegistration;
@@ -35,7 +35,6 @@ import static org.junit.Assert.assertNotNull;
  *
  * @author Adrian Nistor
  * @author Martin Gencur
- *
  */
 @RunWith(Arquillian.class)
 @WithRunningServer("remote-query")
@@ -190,18 +189,12 @@ public class RemoteQueryTest {
     }
 
     private byte[] readClasspathResource(String c) throws IOException {
-        InputStream is = getClass().getResourceAsStream(c);
-        try {
-            ByteArrayOutputStream os = new ByteArrayOutputStream();
-            byte[] buf = new byte[1024];
-            int len;
-            while ((len = is.read(buf)) != -1) {
-                os.write(buf, 0, len);
-            }
-            return os.toByteArray();
-        } finally {
-            is.close();
-        }
+       InputStream is = getClass().getResourceAsStream(c);
+       try {
+          return Util.readStream(is);
+       } finally {
+          is.close();
+       }
     }
 
     private Object invokeOperation(MBeanServerConnectionProvider provider, String mbean, String operationName, Object[] params,

--- a/server/integration/testsuite/src/test/resources/config/infinispan/indexing.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/indexing.xml
@@ -13,6 +13,18 @@
                         <property name="lucene_version">LUCENE_CURRENT</property>
                     </indexing>
                 </local-cache>
+                <local-cache
+                    name="testcache_manual"
+                    start="EAGER"
+                    batching="false">
+                   <transaction mode="NONE" />
+                   <indexing index="ALL">
+                      <property name="default.directory_provider">ram</property>
+                      <property name="lucene_version">LUCENE_CURRENT</property>
+                      <property name="hibernate.search.indexing_strategy">manual</property>
+                      <property name="hibernate.search.jmx_enabled">true</property>
+                   </indexing>
+                </local-cache>
                 <local-cache name="memcachedCache" start="EAGER">
                     <locking isolation="NONE" acquire-timeout="30000" concurrency-level="1000" striping="false"/>
                     <transaction mode="NONE"/>


### PR DESCRIPTION
...e

The MapReduceInitializer is not loaded from server classpath due to improper module config and as a consequence the m/r task is not properly initialized.
- Add ManualIndexingTest for server
- Fix module dependencies so MapReduceInitializer gets loaded and executed properly
- Also modify RemoteQueryTest.readClasspathResource to use Util.readStream instead of duplicating the code

Please integrate in master.

Jira: https://issues.jboss.org/browse/ISPN-3809
