### PR TITLE
add support for tcp transport stack

### DIFF
--- a/server/integration/testsuite/build-testsuite.xml
+++ b/server/integration/testsuite/build-testsuite.xml
@@ -17,11 +17,13 @@
     <property name="log.level.infinispan" value="INFO"/>
     <property name="log.level.jgroups" value="INFO"/>
     <property name="log.level.console" value="INFO"/>
+    <property name="transport.stack" value="udp"/>
 
     <filterset id="commonFilters" begintoken="${" endtoken="}">
         <filter token="leveldb.compression" value="${leveldb.compression}" />
         <filter token="leveldb.impl" value="${leveldb.impl}" />
         <filter token="resources.dir" value="${resources.dir}" />
+        <filter token="transport.stack" value="${transport.stack}" />
     </filterset>
 
     <target name="create-distro1" description="Create first distribution of Infinispan server by copying the one from build/target directory or unpacking a distro zip">

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryJONRegisterTest.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryJONRegisterTest.java
@@ -1,5 +1,7 @@
 package org.infinispan.server.test.query;
 
+import java.net.URL;
+
 import org.infinispan.arquillian.core.WithRunningServer;
 import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
@@ -7,26 +9,18 @@ import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
 import org.infinispan.protostream.sampledomain.marshallers.MarshallerRegistration;
 import org.infinispan.server.test.util.RemoteCacheManagerFactory;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.clustering.infinispan.subsystem.CacheContainerResource;
 import org.jboss.as.clustering.infinispan.subsystem.InfinispanExtension;
-import org.jboss.as.clustering.infinispan.subsystem.ModelKeys;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
-import org.jboss.logging.Logger;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 
-import javax.management.ObjectName;
-import java.net.URL;
-
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 
 /**

--- a/server/integration/testsuite/src/test/resources/config/infinispan/default-dist.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/default-dist.xml
@@ -3,7 +3,7 @@
                 name="clustered"
                 default-cache="testcache">
                 <transport 
-                    stack="udp"
+                    stack="${transport.stack}"
                     executor="infinispan-transport"
                     lock-timeout="240000"/>
                 <distributed-cache 

--- a/server/integration/testsuite/src/test/resources/config/infinispan/default-repl.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/default-repl.xml
@@ -3,7 +3,7 @@
                 name="clustered"
                 default-cache="testcache">
                 <transport 
-                    stack="udp"
+                    stack="${transport.stack}"
                     executor="infinispan-transport"
                     lock-timeout="240000"/>
                 <replicated-cache 

--- a/server/integration/testsuite/src/test/resources/config/infinispan/leveldb-dist.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/leveldb-dist.xml
@@ -3,7 +3,7 @@
                 name="clustered"
                 default-cache="testcache">
                 <transport 
-                    stack="udp"
+                    stack="${transport.stack}"
                     executor="infinispan-transport"
                     lock-timeout="240000"/>
                 <distributed-cache 

--- a/server/integration/testsuite/src/test/resources/config/infinispan/leveldb-repl.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/leveldb-repl.xml
@@ -3,7 +3,7 @@
                 name="clustered"
                 default-cache="testcache">
                 <transport 
-                    stack="udp"
+                    stack="${transport.stack}"
                     executor="infinispan-transport"
                     lock-timeout="240000"/>
                 <replicated-cache 


### PR DESCRIPTION
We want to run client testsuite not only with udp but with tcp stack too
