### PR TITLE
ISPN-3659 Cache stop should clear thread-local ExtendedRiverMarshaller o...

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/concurrent/ConcurrentWeakKeyHashMap.java
+++ b/commons/src/main/java/org/infinispan/commons/util/concurrent/ConcurrentWeakKeyHashMap.java
@@ -3,7 +3,7 @@
  * Expert Group and released to the public domain, as explained at
  * http://creativecommons.org/licenses/publicdomain
  */
-package org.infinispan.util.concurrent;
+package org.infinispan.commons.util.concurrent;
 
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;


### PR DESCRIPTION
...r their instance caches

Added utility method to remove the thread local from all live threads.

https://issues.jboss.org/browse/ISPN-3659
