### PR TITLE
ISPN-3799 Update base CHMv8 to rev 1.120

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/concurrent/jdk8backported/EquivalentConcurrentHashMapV8.java
+++ b/commons/src/main/java/org/infinispan/commons/util/concurrent/jdk8backported/EquivalentConcurrentHashMapV8.java
@@ -1,4 +1,4 @@
-// Revision 1.112
+// Revision 1.120
 
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
@@ -279,6 +279,7 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
    /** Interface describing a function mapping two ints to an int */
    public interface IntByIntToInt { int apply(int a, int b); }
 
+
     /*
      * Overview:
      *
@@ -384,14 +385,15 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
      * The table is resized when occupancy exceeds a percentage
      * threshold (nominally, 0.75, but see below).  Any thread
      * noticing an overfull bin may assist in resizing after the
-     * initiating thread allocates and sets up the replacement
-     * array. However, rather than stalling, these other threads may
-     * proceed with insertions etc.  The use of TreeBins shields us
-     * from the worst case effects of overfilling while resizes are in
+     * initiating thread allocates and sets up the replacement array.
+     * However, rather than stalling, these other threads may proceed
+     * with insertions etc.  The use of TreeBins shields us from the
+     * worst case effects of overfilling while resizes are in
      * progress.  Resizing proceeds by transferring bins, one by one,
-     * from the table to the next table. To enable concurrency, the
-     * next table must be (incrementally) prefilled with place-holders
-     * serving as reverse forwarders to the old table.  Because we are
+     * from the table to the next table. However, threads claim small
+     * blocks of indices to transfer (via field transferIndex) before
+     * doing so, reducing contention.  A generation stamp in field
+     * sizeCtl ensures that resizings do not overlap. Because we are
      * using power-of-two expansion, the elements from each bin must
      * either stay at same index, or move with a power of two
      * offset. We eliminate unnecessary node creation by catching
@@ -412,13 +414,19 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
      * locks, average aggregate waits become shorter as resizing
      * progresses.  The transfer operation must also ensure that all
      * accessible bins in both the old and new table are usable by any
-     * traversal.  This is arranged by proceeding from the last bin
-     * (table.length - 1) up towards the first.  Upon seeing a
-     * forwarding node, traversals (see class Traverser) arrange to
-     * move to the new table without revisiting nodes.  However, to
-     * ensure that no intervening nodes are skipped, bin splitting can
-     * only begin after the associated reverse-forwarders are in
-     * place.
+     * traversal.  This is arranged in part by proceeding from the
+     * last bin (table.length - 1) up towards the first.  Upon seeing
+     * a forwarding node, traversals (see class Traverser) arrange to
+     * move to the new table without revisiting nodes.  To ensure that
+     * no intervening nodes are skipped even when moved out of order,
+     * a stack (see class TableStack) is created on first encounter of
+     * a forwarding node during a traversal, to maintain its place if
+     * later processing the current table. The need for these
+     * save/restore mechanics is relatively rare, but when one
+     * forwarding node is encountered, typically many more will be.
+     * So Traversers use a simple caching scheme to avoid creating so
+     * many new TableStack nodes. (Thanks to Peter Levart for
+     * suggesting use of a stack here.)
      *
      * The traversal scheme also applies to partial traversals of
      * ranges of bins (via an alternate Traverser constructor)
@@ -574,6 +582,23 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     * DEFAULT_CAPACITY.
     */
    private static final int MIN_TRANSFER_STRIDE = 16;
+
+   /**
+    * The number of bits used for generation stamp in sizeCtl.
+    * Must be at least 6 for 32bit arrays.
+    */
+   private static int RESIZE_STAMP_BITS = 16;
+
+   /**
+    * The maximum number of threads that can help resize.
+    * Must fit in 32 - RESIZE_STAMP_BITS bits.
+    */
+   private static final int MAX_RESIZERS = (1 << (32 - RESIZE_STAMP_BITS)) - 1;
+
+   /**
+    * The bit shift for recording size stamp in sizeCtl.
+    */
+   private static final int RESIZE_STAMP_SHIFT = 32 - RESIZE_STAMP_BITS;
 
    /*
      * Encodings for Node hash fields. See above for explanation.
@@ -744,7 +769,7 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
      * errors by users, these checks must operate on local variables,
      * which accounts for some odd-looking inline assignments below.
      * Note that calls to setTabAt always occur within locked regions,
-     * and so in principle require only release ordering, not need
+     * and so in principle require only release ordering, not
      * full volatile semantics, but are currently coded as volatile
      * writes to be conservative.
      */
@@ -797,11 +822,6 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     * The next table index (plus one) to split while resizing.
     */
    private transient volatile int transferIndex;
-
-   /**
-    * The least available table index to split while resizing.
-    */
-   private transient volatile int transferOrigin;
 
    /**
     * Spinlock (locked via CAS) used when resizing and/or creating CounterCells.
@@ -1396,6 +1416,7 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     * Saves the state of the {@code EquivalentConcurrentHashMapV8} instance to a
     * stream (i.e., serializes it).
     * @param s the stream
+    * @throws java.io.IOException if an I/O error occurs
     * @serialData
     * the key (Object) and value (Object)
     * for each key-value mapping, followed by a null pair.
@@ -1441,6 +1462,9 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
    /**
     * Reconstitutes the instance from a stream (that is, deserializes it).
     * @param s the stream
+    * @throws ClassNotFoundException if the class of a serialized object
+    *         could not be found
+    * @throws java.io.IOException if an I/O error occurs
     */
    @SuppressWarnings("unchecked")
    private void readObject(java.io.ObjectInputStream s)
@@ -1479,8 +1503,8 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
             int sz = (int)size;
             n = tableSizeFor(sz + (sz >>> 1) + 1);
          }
-         @SuppressWarnings({"rawtypes","unchecked"})
-         Node<K,V>[] tab = (Node<K,V>[])new Node[n];
+         @SuppressWarnings("unchecked")
+         Node<K,V>[] tab = (Node<K,V>[])new Node<?,?>[n];
          int mask = n - 1;
          long added = 0L;
          while (p != null) {
@@ -2229,6 +2253,14 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     /* ---------------- Table Initialization and Resizing -------------- */
 
    /**
+    * Returns the stamp bits for resizing a table of size n.
+    * Must be negative when shifted left by RESIZE_STAMP_SHIFT.
+    */
+   static final int resizeStamp(int n) {
+      return Integer.numberOfLeadingZeros(n) | (1 << (RESIZE_STAMP_BITS - 1));
+   }
+
+   /**
     * Initializes table, using the size recorded in sizeCtl.
     */
    private final Node<K,V>[] initTable() {
@@ -2240,8 +2272,8 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
             try {
                if ((tab = table) == null || tab.length == 0) {
                   int n = (sc > 0) ? sc : DEFAULT_CAPACITY;
-                  @SuppressWarnings({"rawtypes","unchecked"})
-                  Node<K,V>[] nt = (Node<K,V>[])new Node[n];
+                  @SuppressWarnings("unchecked")
+                  Node<K,V>[] nt = (Node<K,V>[])new Node<?,?>[n];
                   table = tab = nt;
                   sc = n - (n >>> 2);
                }
@@ -2283,17 +2315,20 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
          s = sumCount();
       }
       if (check >= 0) {
-         Node<K,V>[] tab, nt; int sc;
+         Node<K,V>[] tab, nt; int n, sc;
          while (s >= (long)(sc = sizeCtl) && (tab = table) != null &&
-               tab.length < MAXIMUM_CAPACITY) {
+               (n = tab.length) < MAXIMUM_CAPACITY) {
+            int rs = resizeStamp(n);
             if (sc < 0) {
-               if (sc == -1 || transferIndex <= transferOrigin ||
-                     (nt = nextTable) == null)
+               if ((sc >>> RESIZE_STAMP_SHIFT) != rs || sc == rs + 1 ||
+                     sc == rs + MAX_RESIZERS || (nt = nextTable) == null ||
+                     transferIndex <= 0)
                   break;
-               if (U.compareAndSwapInt(this, SIZECTL, sc, sc - 1))
+               if (U.compareAndSwapInt(this, SIZECTL, sc, sc + 1))
                   transfer(tab, nt);
             }
-            else if (U.compareAndSwapInt(this, SIZECTL, sc, -2))
+            else if (U.compareAndSwapInt(this, SIZECTL, sc,
+                  (rs << RESIZE_STAMP_SHIFT) + 2))
                transfer(tab, null);
             s = sumCount();
          }
@@ -2305,12 +2340,19 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     */
    final Node<K,V>[] helpTransfer(Node<K,V>[] tab, Node<K,V> f) {
       Node<K,V>[] nextTab; int sc;
-      if ((f instanceof ForwardingNode) &&
+      if (tab != null && (f instanceof ForwardingNode) &&
             (nextTab = ((ForwardingNode<K,V>)f).nextTable) != null) {
-         if (nextTab == nextTable && tab == table &&
-               transferIndex > transferOrigin && (sc = sizeCtl) < -1 &&
-               U.compareAndSwapInt(this, SIZECTL, sc, sc - 1))
-            transfer(tab, nextTab);
+         int rs = resizeStamp(tab.length);
+         while (nextTab == nextTable && table == tab &&
+               (sc = sizeCtl) < 0) {
+            if ((sc >>> RESIZE_STAMP_SHIFT) != rs || sc == rs + 1 ||
+                  sc == rs + MAX_RESIZERS || transferIndex <= 0)
+               break;
+            if (U.compareAndSwapInt(this, SIZECTL, sc, sc + 1)) {
+               transfer(tab, nextTab);
+               break;
+            }
+         }
          return nextTab;
       }
       return table;
@@ -2332,8 +2374,8 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
             if (U.compareAndSwapInt(this, SIZECTL, sc, -1)) {
                try {
                   if (table == tab) {
-                     @SuppressWarnings({"rawtypes","unchecked"})
-                     Node<K,V>[] nt = (Node<K,V>[])new Node[n];
+                     @SuppressWarnings("unchecked")
+                     Node<K,V>[] nt = (Node<K,V>[])new Node<?,?>[n];
                      table = nt;
                      sc = n - (n >>> 2);
                   }
@@ -2344,9 +2386,21 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
          }
          else if (c <= sc || n >= MAXIMUM_CAPACITY)
             break;
-         else if (tab == table &&
-               U.compareAndSwapInt(this, SIZECTL, sc, -2))
-            transfer(tab, null);
+         else if (tab == table) {
+            int rs = resizeStamp(n);
+            if (sc < 0) {
+               Node<K,V>[] nt;
+               if ((sc >>> RESIZE_STAMP_SHIFT) != rs || sc == rs + 1 ||
+                     sc == rs + MAX_RESIZERS || (nt = nextTable) == null ||
+                     transferIndex <= 0)
+                  break;
+               if (U.compareAndSwapInt(this, SIZECTL, sc, sc + 1))
+                  transfer(tab, nt);
+            }
+            else if (U.compareAndSwapInt(this, SIZECTL, sc,
+                  (rs << RESIZE_STAMP_SHIFT) + 2))
+               transfer(tab, null);
+         }
       }
    }
 
@@ -2360,36 +2414,27 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
          stride = MIN_TRANSFER_STRIDE; // subdivide range
       if (nextTab == null) {            // initiating
          try {
-            @SuppressWarnings({"rawtypes","unchecked"})
-            Node<K,V>[] nt = (Node<K,V>[])new Node[n << 1];
+            @SuppressWarnings("unchecked")
+            Node<K,V>[] nt = (Node<K,V>[])new Node<?,?>[n << 1];
             nextTab = nt;
          } catch (Throwable ex) {      // try to cope with OOME
             sizeCtl = Integer.MAX_VALUE;
             return;
          }
          nextTable = nextTab;
-         transferOrigin = n;
          transferIndex = n;
-         ForwardingNode<K,V> rev = new ForwardingNode<K,V>(tab, nodeEq);
-         for (int k = n; k > 0;) {    // progressively reveal ready slots
-            int nextk = (k > stride) ? k - stride : 0;
-            for (int m = nextk; m < k; ++m)
-               nextTab[m] = rev;
-            for (int m = n + nextk; m < n + k; ++m)
-               nextTab[m] = rev;
-            U.putOrderedInt(this, TRANSFERORIGIN, k = nextk);
-         }
       }
       int nextn = nextTab.length;
       ForwardingNode<K,V> fwd = new ForwardingNode<K,V>(nextTab, nodeEq); // EQUIVALENCE_MOD
       boolean advance = true;
       boolean finishing = false; // to ensure sweep before committing nextTab
       for (int i = 0, bound = 0;;) {
-         int nextIndex, nextBound, fh; Node<K,V> f;
+         Node<K,V> f; int fh;
          while (advance) {
+            int nextIndex, nextBound;
             if (--i >= bound || finishing)
                advance = false;
-            else if ((nextIndex = transferIndex) <= transferOrigin) {
+            else if ((nextIndex = transferIndex) <= 0) {
                i = -1;
                advance = false;
             }
@@ -2403,29 +2448,22 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
             }
          }
          if (i < 0 || i >= n || i + n >= nextn) {
+            int sc;
             if (finishing) {
                nextTable = null;
                table = nextTab;
                sizeCtl = (n << 1) - (n >>> 1);
                return;
             }
-            for (int sc;;) {
-               if (U.compareAndSwapInt(this, SIZECTL, sc = sizeCtl, ++sc)) {
-                  if (sc != -1)
-                     return;
-                  finishing = advance = true;
-                  i = n; // recheck before commit
-                  break;
-               }
+            if (U.compareAndSwapInt(this, SIZECTL, sc = sizeCtl, sc - 1)) {
+               if ((sc - 2) != resizeStamp(n) << RESIZE_STAMP_SHIFT)
+                  return;
+               finishing = advance = true;
+               i = n; // recheck before commit
             }
          }
-         else if ((f = tabAt(tab, i)) == null) {
-            if (casTabAt(tab, i, null, fwd)) {
-               setTabAt(nextTab, i, null);
-               setTabAt(nextTab, i + n, null);
-               advance = true;
-            }
-         }
+         else if ((f = tabAt(tab, i)) == null)
+            advance = casTabAt(tab, i, null, fwd);
          else if ((fh = f.hash) == MOVED)
             advance = true; // already processed
          else {
@@ -2512,11 +2550,8 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
    private final void treeifyBin(Node<K,V>[] tab, int index) {
       Node<K,V> b; int n, sc;
       if (tab != null) {
-         if ((n = tab.length) < MIN_TREEIFY_CAPACITY) {
-            if (tab == table && (sc = sizeCtl) >= 0 &&
-                  U.compareAndSwapInt(this, SIZECTL, sc, -2))
-               transfer(tab, null);
-         }
+         if ((n = tab.length) < MIN_TREEIFY_CAPACITY)
+            tryPresize(n << 1);
          else if ((b = tabAt(tab, index)) != null && b.hash >= 0) {
             synchronized (b) {
                if (tabAt(tab, index) == b) {
@@ -2717,7 +2752,7 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
       private final void contendedLock() {
          boolean waiting = false;
          for (int s;;) {
-            if (((s = lockState) & WRITER) == 0) {
+            if (((s = lockState) & ~WAITER) == 0) {
                if (U.compareAndSwapInt(this, LOCKSTATE, s, WRITER)) {
                   if (waiting)
                      waiter = null;
@@ -2742,12 +2777,13 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
        */
       final Node<K,V> find(int h, Object k) {
          if (k != null) {
-            for (Node<K,V> e = first; e != null; e = e.next) {
+            for (Node<K,V> e = first; e != null; ) {
                int s; K ek;
                if (((s = lockState) & (WAITER|WRITER)) != 0) {
                   if (e.hash == h &&
                         ((ek = e.key) == k || (ek != null && nodeEq.keyEq.equals(ek, k)))) // EQUIVALENCE_MOD
                      return e;
+                  e = e.next;
                }
                else if (U.compareAndSwapInt(this, LOCKSTATE, s,
                      s + READER)) {
@@ -3166,6 +3202,18 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     /* ----------------Table Traversal -------------- */
 
    /**
+    * Records the table, its length, and current traversal index for a
+    * traverser that must process a region of a forwarded table before
+    * proceeding with current table.
+    */
+   static final class TableStack<K,V> {
+      int length;
+      int index;
+      Node<K,V>[] tab;
+      TableStack<K,V> next;
+   }
+
+   /**
     * Encapsulates traversal for methods such as containsValue; also
     * serves as a base class for other iterators and spliterators.
     *
@@ -3189,6 +3237,7 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
    static class Traverser<K,V> {
       Node<K,V>[] tab;        // current table; updated if resized
       Node<K,V> next;         // the next entry to use
+      TableStack<K,V> stack, spare; // to save/restore on ForwardingNodes
       int index;              // index of bin to use next
       int baseIndex;          // current index of initial table
       int baseLimit;          // index bound for initial table
@@ -3210,16 +3259,17 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
          if ((e = next) != null)
             e = e.next;
          for (;;) {
-            Node<K,V>[] t; int i, n; K ek;  // must use locals in checks
+            Node<K,V>[] t; int i, n;  // must use locals in checks
             if (e != null)
                return next = e;
             if (baseIndex >= baseLimit || (t = tab) == null ||
                   (n = t.length) <= (i = index) || i < 0)
                return next = null;
-            if ((e = tabAt(t, index)) != null && e.hash < 0) {
+            if ((e = tabAt(t, i)) != null && e.hash < 0) {
                if (e instanceof ForwardingNode) {
                   tab = ((ForwardingNode<K,V>)e).nextTable;
                   e = null;
+                  pushState(t, i, n);
                   continue;
                }
                else if (e instanceof TreeBin)
@@ -3227,9 +3277,48 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
                else
                   e = null;
             }
-            if ((index += baseSize) >= n)
-               index = ++baseIndex;    // visit upper slots if present
+            if (stack != null)
+               recoverState(n);
+            else if ((index = i + baseSize) >= n)
+               index = ++baseIndex; // visit upper slots if present
          }
+      }
+
+      /**
+       * Saves traversal state upon encountering a forwarding node.
+       */
+      private void pushState(Node<K,V>[] t, int i, int n) {
+         TableStack<K,V> s = spare;  // reuse if possible
+         if (s != null)
+            spare = s.next;
+         else
+            s = new TableStack<K,V>();
+         s.tab = t;
+         s.length = n;
+         s.index = i;
+         s.next = stack;
+         stack = s;
+      }
+
+      /**
+       * Possibly pops traversal state.
+       *
+       * @param n length of current table
+       */
+      private void recoverState(int n) {
+         TableStack<K,V> s; int len;
+         while ((s = stack) != null && (index += (len = s.length)) >= n) {
+            n = len;
+            index = s.index;
+            tab = s.tab;
+            s.tab = null;
+            TableStack<K,V> next = s.next;
+            s.next = spare; // save for reuse
+            stack = next;
+            spare = s;
+         }
+         if (s == null && (index += baseSize) >= n)
+            index = ++baseIndex;
       }
    }
 
@@ -6198,7 +6287,6 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
    private static final sun.misc.Unsafe U;
    private static final long SIZECTL;
    private static final long TRANSFERINDEX;
-   private static final long TRANSFERORIGIN;
    private static final long BASECOUNT;
    private static final long CELLSBUSY;
    private static final long CELLVALUE;
@@ -6213,8 +6301,6 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
                (k.getDeclaredField("sizeCtl"));
          TRANSFERINDEX = U.objectFieldOffset
                (k.getDeclaredField("transferIndex"));
-         TRANSFERORIGIN = U.objectFieldOffset
-               (k.getDeclaredField("transferOrigin"));
          BASECOUNT = U.objectFieldOffset
                (k.getDeclaredField("baseCount"));
          CELLSBUSY = U.objectFieldOffset

--- a/core/src/test/java/org/infinispan/commons/util/concurrent/jdk8backported/ConcurrentHashMapV8.java
+++ b/core/src/test/java/org/infinispan/commons/util/concurrent/jdk8backported/ConcurrentHashMapV8.java
@@ -3,7 +3,7 @@
 // the original CHMv8 implementation, or whether it's a problem with the
 // customizations added in the equivalent version.
 
-// Revision 1.112
+// Revision 1.120
 
 /*
  * Written by Doug Lea with assistance from members of JCP JSR-166
@@ -281,6 +281,7 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
    /** Interface describing a function mapping two ints to an int */
    public interface IntByIntToInt { int apply(int a, int b); }
 
+
     /*
      * Overview:
      *
@@ -386,14 +387,15 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
      * The table is resized when occupancy exceeds a percentage
      * threshold (nominally, 0.75, but see below).  Any thread
      * noticing an overfull bin may assist in resizing after the
-     * initiating thread allocates and sets up the replacement
-     * array. However, rather than stalling, these other threads may
-     * proceed with insertions etc.  The use of TreeBins shields us
-     * from the worst case effects of overfilling while resizes are in
+     * initiating thread allocates and sets up the replacement array.
+     * However, rather than stalling, these other threads may proceed
+     * with insertions etc.  The use of TreeBins shields us from the
+     * worst case effects of overfilling while resizes are in
      * progress.  Resizing proceeds by transferring bins, one by one,
-     * from the table to the next table. To enable concurrency, the
-     * next table must be (incrementally) prefilled with place-holders
-     * serving as reverse forwarders to the old table.  Because we are
+     * from the table to the next table. However, threads claim small
+     * blocks of indices to transfer (via field transferIndex) before
+     * doing so, reducing contention.  A generation stamp in field
+     * sizeCtl ensures that resizings do not overlap. Because we are
      * using power-of-two expansion, the elements from each bin must
      * either stay at same index, or move with a power of two
      * offset. We eliminate unnecessary node creation by catching
@@ -414,13 +416,19 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
      * locks, average aggregate waits become shorter as resizing
      * progresses.  The transfer operation must also ensure that all
      * accessible bins in both the old and new table are usable by any
-     * traversal.  This is arranged by proceeding from the last bin
-     * (table.length - 1) up towards the first.  Upon seeing a
-     * forwarding node, traversals (see class Traverser) arrange to
-     * move to the new table without revisiting nodes.  However, to
-     * ensure that no intervening nodes are skipped, bin splitting can
-     * only begin after the associated reverse-forwarders are in
-     * place.
+     * traversal.  This is arranged in part by proceeding from the
+     * last bin (table.length - 1) up towards the first.  Upon seeing
+     * a forwarding node, traversals (see class Traverser) arrange to
+     * move to the new table without revisiting nodes.  To ensure that
+     * no intervening nodes are skipped even when moved out of order,
+     * a stack (see class TableStack) is created on first encounter of
+     * a forwarding node during a traversal, to maintain its place if
+     * later processing the current table. The need for these
+     * save/restore mechanics is relatively rare, but when one
+     * forwarding node is encountered, typically many more will be.
+     * So Traversers use a simple caching scheme to avoid creating so
+     * many new TableStack nodes. (Thanks to Peter Levart for
+     * suggesting use of a stack here.)
      *
      * The traversal scheme also applies to partial traversals of
      * ranges of bins (via an alternate Traverser constructor)
@@ -576,6 +584,23 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     * DEFAULT_CAPACITY.
     */
    private static final int MIN_TRANSFER_STRIDE = 16;
+
+   /**
+    * The number of bits used for generation stamp in sizeCtl.
+    * Must be at least 6 for 32bit arrays.
+    */
+   private static int RESIZE_STAMP_BITS = 16;
+
+   /**
+    * The maximum number of threads that can help resize.
+    * Must fit in 32 - RESIZE_STAMP_BITS bits.
+    */
+   private static final int MAX_RESIZERS = (1 << (32 - RESIZE_STAMP_BITS)) - 1;
+
+   /**
+    * The bit shift for recording size stamp in sizeCtl.
+    */
+   private static final int RESIZE_STAMP_SHIFT = 32 - RESIZE_STAMP_BITS;
 
    /*
      * Encodings for Node hash fields. See above for explanation.
@@ -734,7 +759,7 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
      * errors by users, these checks must operate on local variables,
      * which accounts for some odd-looking inline assignments below.
      * Note that calls to setTabAt always occur within locked regions,
-     * and so in principle require only release ordering, not need
+     * and so in principle require only release ordering, not
      * full volatile semantics, but are currently coded as volatile
      * writes to be conservative.
      */
@@ -787,11 +812,6 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     * The next table index (plus one) to split while resizing.
     */
    private transient volatile int transferIndex;
-
-   /**
-    * The least available table index to split while resizing.
-    */
-   private transient volatile int transferOrigin;
 
    /**
     * Spinlock (locked via CAS) used when resizing and/or creating CounterCells.
@@ -1371,6 +1391,7 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     * Saves the state of the {@code ConcurrentHashMapV8} instance to a
     * stream (i.e., serializes it).
     * @param s the stream
+    * @throws java.io.IOException if an I/O error occurs
     * @serialData
     * the key (Object) and value (Object)
     * for each key-value mapping, followed by a null pair.
@@ -1413,6 +1434,9 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
    /**
     * Reconstitutes the instance from a stream (that is, deserializes it).
     * @param s the stream
+    * @throws ClassNotFoundException if the class of a serialized object
+    *         could not be found
+    * @throws java.io.IOException if an I/O error occurs
     */
    private void readObject(java.io.ObjectInputStream s)
          throws java.io.IOException, ClassNotFoundException {
@@ -1447,8 +1471,8 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
             int sz = (int)size;
             n = tableSizeFor(sz + (sz >>> 1) + 1);
          }
-         @SuppressWarnings({"rawtypes","unchecked"})
-         Node<K,V>[] tab = (Node<K,V>[])new Node[n];
+         @SuppressWarnings("unchecked")
+         Node<K,V>[] tab = (Node<K,V>[])new Node<?,?>[n];
          int mask = n - 1;
          long added = 0L;
          while (p != null) {
@@ -2195,6 +2219,14 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     /* ---------------- Table Initialization and Resizing -------------- */
 
    /**
+    * Returns the stamp bits for resizing a table of size n.
+    * Must be negative when shifted left by RESIZE_STAMP_SHIFT.
+    */
+   static final int resizeStamp(int n) {
+      return Integer.numberOfLeadingZeros(n) | (1 << (RESIZE_STAMP_BITS - 1));
+   }
+
+   /**
     * Initializes table, using the size recorded in sizeCtl.
     */
    private final Node<K,V>[] initTable() {
@@ -2206,8 +2238,8 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
             try {
                if ((tab = table) == null || tab.length == 0) {
                   int n = (sc > 0) ? sc : DEFAULT_CAPACITY;
-                  @SuppressWarnings({"rawtypes","unchecked"})
-                  Node<K,V>[] nt = (Node<K,V>[])new Node[n];
+                  @SuppressWarnings("unchecked")
+                  Node<K,V>[] nt = (Node<K,V>[])new Node<?,?>[n];
                   table = tab = nt;
                   sc = n - (n >>> 2);
                }
@@ -2249,17 +2281,20 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
          s = sumCount();
       }
       if (check >= 0) {
-         Node<K,V>[] tab, nt; int sc;
+         Node<K,V>[] tab, nt; int n, sc;
          while (s >= (long)(sc = sizeCtl) && (tab = table) != null &&
-               tab.length < MAXIMUM_CAPACITY) {
+               (n = tab.length) < MAXIMUM_CAPACITY) {
+            int rs = resizeStamp(n);
             if (sc < 0) {
-               if (sc == -1 || transferIndex <= transferOrigin ||
-                     (nt = nextTable) == null)
+               if ((sc >>> RESIZE_STAMP_SHIFT) != rs || sc == rs + 1 ||
+                     sc == rs + MAX_RESIZERS || (nt = nextTable) == null ||
+                     transferIndex <= 0)
                   break;
-               if (U.compareAndSwapInt(this, SIZECTL, sc, sc - 1))
+               if (U.compareAndSwapInt(this, SIZECTL, sc, sc + 1))
                   transfer(tab, nt);
             }
-            else if (U.compareAndSwapInt(this, SIZECTL, sc, -2))
+            else if (U.compareAndSwapInt(this, SIZECTL, sc,
+                  (rs << RESIZE_STAMP_SHIFT) + 2))
                transfer(tab, null);
             s = sumCount();
          }
@@ -2271,12 +2306,19 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     */
    final Node<K,V>[] helpTransfer(Node<K,V>[] tab, Node<K,V> f) {
       Node<K,V>[] nextTab; int sc;
-      if ((f instanceof ForwardingNode) &&
+      if (tab != null && (f instanceof ForwardingNode) &&
             (nextTab = ((ForwardingNode<K,V>)f).nextTable) != null) {
-         if (nextTab == nextTable && tab == table &&
-               transferIndex > transferOrigin && (sc = sizeCtl) < -1 &&
-               U.compareAndSwapInt(this, SIZECTL, sc, sc - 1))
-            transfer(tab, nextTab);
+         int rs = resizeStamp(tab.length);
+         while (nextTab == nextTable && table == tab &&
+               (sc = sizeCtl) < 0) {
+            if ((sc >>> RESIZE_STAMP_SHIFT) != rs || sc == rs + 1 ||
+                  sc == rs + MAX_RESIZERS || transferIndex <= 0)
+               break;
+            if (U.compareAndSwapInt(this, SIZECTL, sc, sc + 1)) {
+               transfer(tab, nextTab);
+               break;
+            }
+         }
          return nextTab;
       }
       return table;
@@ -2298,8 +2340,8 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
             if (U.compareAndSwapInt(this, SIZECTL, sc, -1)) {
                try {
                   if (table == tab) {
-                     @SuppressWarnings({"rawtypes","unchecked"})
-                     Node<K,V>[] nt = (Node<K,V>[])new Node[n];
+                     @SuppressWarnings("unchecked")
+                     Node<K,V>[] nt = (Node<K,V>[])new Node<?,?>[n];
                      table = nt;
                      sc = n - (n >>> 2);
                   }
@@ -2310,9 +2352,21 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
          }
          else if (c <= sc || n >= MAXIMUM_CAPACITY)
             break;
-         else if (tab == table &&
-               U.compareAndSwapInt(this, SIZECTL, sc, -2))
-            transfer(tab, null);
+         else if (tab == table) {
+            int rs = resizeStamp(n);
+            if (sc < 0) {
+               Node<K,V>[] nt;
+               if ((sc >>> RESIZE_STAMP_SHIFT) != rs || sc == rs + 1 ||
+                     sc == rs + MAX_RESIZERS || (nt = nextTable) == null ||
+                     transferIndex <= 0)
+                  break;
+               if (U.compareAndSwapInt(this, SIZECTL, sc, sc + 1))
+                  transfer(tab, nt);
+            }
+            else if (U.compareAndSwapInt(this, SIZECTL, sc,
+                  (rs << RESIZE_STAMP_SHIFT) + 2))
+               transfer(tab, null);
+         }
       }
    }
 
@@ -2326,36 +2380,27 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
          stride = MIN_TRANSFER_STRIDE; // subdivide range
       if (nextTab == null) {            // initiating
          try {
-            @SuppressWarnings({"rawtypes","unchecked"})
-            Node<K,V>[] nt = (Node<K,V>[])new Node[n << 1];
+            @SuppressWarnings("unchecked")
+            Node<K,V>[] nt = (Node<K,V>[])new Node<?,?>[n << 1];
             nextTab = nt;
          } catch (Throwable ex) {      // try to cope with OOME
             sizeCtl = Integer.MAX_VALUE;
             return;
          }
          nextTable = nextTab;
-         transferOrigin = n;
          transferIndex = n;
-         ForwardingNode<K,V> rev = new ForwardingNode<K,V>(tab);
-         for (int k = n; k > 0;) {    // progressively reveal ready slots
-            int nextk = (k > stride) ? k - stride : 0;
-            for (int m = nextk; m < k; ++m)
-               nextTab[m] = rev;
-            for (int m = n + nextk; m < n + k; ++m)
-               nextTab[m] = rev;
-            U.putOrderedInt(this, TRANSFERORIGIN, k = nextk);
-         }
       }
       int nextn = nextTab.length;
       ForwardingNode<K,V> fwd = new ForwardingNode<K,V>(nextTab);
       boolean advance = true;
       boolean finishing = false; // to ensure sweep before committing nextTab
       for (int i = 0, bound = 0;;) {
-         int nextIndex, nextBound, fh; Node<K,V> f;
+         Node<K,V> f; int fh;
          while (advance) {
+            int nextIndex, nextBound;
             if (--i >= bound || finishing)
                advance = false;
-            else if ((nextIndex = transferIndex) <= transferOrigin) {
+            else if ((nextIndex = transferIndex) <= 0) {
                i = -1;
                advance = false;
             }
@@ -2369,29 +2414,22 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
             }
          }
          if (i < 0 || i >= n || i + n >= nextn) {
+            int sc;
             if (finishing) {
                nextTable = null;
                table = nextTab;
                sizeCtl = (n << 1) - (n >>> 1);
                return;
             }
-            for (int sc;;) {
-               if (U.compareAndSwapInt(this, SIZECTL, sc = sizeCtl, ++sc)) {
-                  if (sc != -1)
-                     return;
-                  finishing = advance = true;
-                  i = n; // recheck before commit
-                  break;
-               }
+            if (U.compareAndSwapInt(this, SIZECTL, sc = sizeCtl, sc - 1)) {
+               if ((sc - 2) != resizeStamp(n) << RESIZE_STAMP_SHIFT)
+                  return;
+               finishing = advance = true;
+               i = n; // recheck before commit
             }
          }
-         else if ((f = tabAt(tab, i)) == null) {
-            if (casTabAt(tab, i, null, fwd)) {
-               setTabAt(nextTab, i, null);
-               setTabAt(nextTab, i + n, null);
-               advance = true;
-            }
-         }
+         else if ((f = tabAt(tab, i)) == null)
+            advance = casTabAt(tab, i, null, fwd);
          else if ((fh = f.hash) == MOVED)
             advance = true; // already processed
          else {
@@ -2478,11 +2516,8 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
    private final void treeifyBin(Node<K,V>[] tab, int index) {
       Node<K,V> b; int n, sc;
       if (tab != null) {
-         if ((n = tab.length) < MIN_TREEIFY_CAPACITY) {
-            if (tab == table && (sc = sizeCtl) >= 0 &&
-                  U.compareAndSwapInt(this, SIZECTL, sc, -2))
-               transfer(tab, null);
-         }
+         if ((n = tab.length) < MIN_TREEIFY_CAPACITY)
+            tryPresize(n << 1);
          else if ((b = tabAt(tab, index)) != null && b.hash >= 0) {
             synchronized (b) {
                if (tabAt(tab, index) == b) {
@@ -2680,7 +2715,7 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
       private final void contendedLock() {
          boolean waiting = false;
          for (int s;;) {
-            if (((s = lockState) & WRITER) == 0) {
+            if (((s = lockState) & ~WAITER) == 0) {
                if (U.compareAndSwapInt(this, LOCKSTATE, s, WRITER)) {
                   if (waiting)
                      waiter = null;
@@ -2705,12 +2740,13 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
        */
       final Node<K,V> find(int h, Object k) {
          if (k != null) {
-            for (Node<K,V> e = first; e != null; e = e.next) {
+            for (Node<K,V> e = first; e != null; ) {
                int s; K ek;
                if (((s = lockState) & (WAITER|WRITER)) != 0) {
                   if (e.hash == h &&
                         ((ek = e.key) == k || (ek != null && k.equals(ek))))
                      return e;
+                  e = e.next;
                }
                else if (U.compareAndSwapInt(this, LOCKSTATE, s,
                      s + READER)) {
@@ -3129,6 +3165,18 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     /* ----------------Table Traversal -------------- */
 
    /**
+    * Records the table, its length, and current traversal index for a
+    * traverser that must process a region of a forwarded table before
+    * proceeding with current table.
+    */
+   static final class TableStack<K,V> {
+      int length;
+      int index;
+      Node<K,V>[] tab;
+      TableStack<K,V> next;
+   }
+
+   /**
     * Encapsulates traversal for methods such as containsValue; also
     * serves as a base class for other iterators and spliterators.
     *
@@ -3152,6 +3200,7 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
    static class Traverser<K,V> {
       Node<K,V>[] tab;        // current table; updated if resized
       Node<K,V> next;         // the next entry to use
+      TableStack<K,V> stack, spare; // to save/restore on ForwardingNodes
       int index;              // index of bin to use next
       int baseIndex;          // current index of initial table
       int baseLimit;          // index bound for initial table
@@ -3173,16 +3222,17 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
          if ((e = next) != null)
             e = e.next;
          for (;;) {
-            Node<K,V>[] t; int i, n; K ek;  // must use locals in checks
+            Node<K,V>[] t; int i, n;  // must use locals in checks
             if (e != null)
                return next = e;
             if (baseIndex >= baseLimit || (t = tab) == null ||
                   (n = t.length) <= (i = index) || i < 0)
                return next = null;
-            if ((e = tabAt(t, index)) != null && e.hash < 0) {
+            if ((e = tabAt(t, i)) != null && e.hash < 0) {
                if (e instanceof ForwardingNode) {
                   tab = ((ForwardingNode<K,V>)e).nextTable;
                   e = null;
+                  pushState(t, i, n);
                   continue;
                }
                else if (e instanceof TreeBin)
@@ -3190,9 +3240,48 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
                else
                   e = null;
             }
-            if ((index += baseSize) >= n)
-               index = ++baseIndex;    // visit upper slots if present
+            if (stack != null)
+               recoverState(n);
+            else if ((index = i + baseSize) >= n)
+               index = ++baseIndex; // visit upper slots if present
          }
+      }
+
+      /**
+       * Saves traversal state upon encountering a forwarding node.
+       */
+      private void pushState(Node<K,V>[] t, int i, int n) {
+         TableStack<K,V> s = spare;  // reuse if possible
+         if (s != null)
+            spare = s.next;
+         else
+            s = new TableStack<K,V>();
+         s.tab = t;
+         s.length = n;
+         s.index = i;
+         s.next = stack;
+         stack = s;
+      }
+
+      /**
+       * Possibly pops traversal state.
+       *
+       * @param n length of current table
+       */
+      private void recoverState(int n) {
+         TableStack<K,V> s; int len;
+         while ((s = stack) != null && (index += (len = s.length)) >= n) {
+            n = len;
+            index = s.index;
+            tab = s.tab;
+            s.tab = null;
+            TableStack<K,V> next = s.next;
+            s.next = spare; // save for reuse
+            stack = next;
+            spare = s;
+         }
+         if (s == null && (index += baseSize) >= n)
+            index = ++baseIndex;
       }
    }
 
@@ -6160,7 +6249,6 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
    private static final sun.misc.Unsafe U;
    private static final long SIZECTL;
    private static final long TRANSFERINDEX;
-   private static final long TRANSFERORIGIN;
    private static final long BASECOUNT;
    private static final long CELLSBUSY;
    private static final long CELLVALUE;
@@ -6175,8 +6263,6 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
                (k.getDeclaredField("sizeCtl"));
          TRANSFERINDEX = U.objectFieldOffset
                (k.getDeclaredField("transferIndex"));
-         TRANSFERORIGIN = U.objectFieldOffset
-               (k.getDeclaredField("transferOrigin"));
          BASECOUNT = U.objectFieldOffset
                (k.getDeclaredField("baseCount"));
          CELLSBUSY = U.objectFieldOffset


### PR DESCRIPTION
- It primarily fixes and edge case where CHM.get will sometimes fail to find a key present in the map.
