### PR TITLE
ISPN-3829 Null value read with RR can be replaced by cache loader value

### DIFF
--- a/core/src/main/java/org/infinispan/container/EntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/EntryFactoryImpl.java
@@ -171,7 +171,7 @@ public class EntryFactoryImpl implements EntryFactory {
                                                      "but it is " + cacheEntry.getClass().getCanonicalName());
             }
             //if the icEntry is not null, then this is a remote get. We need to update the value and the metadata.
-            if (!mvccEntry.isRemoved() && !mvccEntry.skipRemoteGet() && icEntry != null) {
+            if (!mvccEntry.isRemoved() && !mvccEntry.skipLookup() && icEntry != null) {
                mvccEntry.setValue(icEntry.getValue());
                updateVersion(mvccEntry, icEntry.getMetadata());
             }

--- a/core/src/main/java/org/infinispan/container/entries/AbstractInternalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/AbstractInternalCacheEntry.java
@@ -61,7 +61,7 @@ public abstract class AbstractInternalCacheEntry implements InternalCacheEntry {
    }
 
    @Override
-   public void setSkipRemoteGet(boolean skipRemoteGet) {
+   public void setSkipLookup(boolean skipLookup) {
       //no-op
    }
 
@@ -101,7 +101,7 @@ public abstract class AbstractInternalCacheEntry implements InternalCacheEntry {
    }
 
    @Override
-   public boolean skipRemoteGet() {
+   public boolean skipLookup() {
       return false;
    }
 

--- a/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
@@ -80,9 +80,9 @@ public interface CacheEntry extends Map.Entry<Object, Object>, MetadataAware {
    long getMaxIdle();
 
    /**
-    * @return {@code true} if the value must not be fetch from a remote node.
+    * @return {@code true} if the value must not be fetch from an external source
     */
-   boolean skipRemoteGet();
+   boolean skipLookup();
 
    /**
     * Sets the value of the entry, returning the previous value
@@ -118,10 +118,10 @@ public interface CacheEntry extends Map.Entry<Object, Object>, MetadataAware {
    void setLoaded(boolean loaded);
 
    /**
-    * See {@link #skipRemoteGet()}.
-    * @param skipRemoteGet
+    * See {@link #skipLookup()}.
+    * @param skipLookup
     */
-   void setSkipRemoteGet(boolean skipRemoteGet);
+   void setSkipLookup(boolean skipLookup);
 
    /**
     * If the entry is marked as removed and doUndelete==true then the "valid" flag is set to true and "removed"

--- a/core/src/main/java/org/infinispan/container/entries/DeltaAwareCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/DeltaAwareCacheEntry.java
@@ -76,7 +76,7 @@ public class DeltaAwareCacheEntry implements CacheEntry, StateChangingEntry {
       VALID(1 << 3),
       EVICTED(1 << 4),
       LOADED(1 << 5),
-      SKIP_REMOTE_GET(1 << 6);
+      SKIP_LOOKUP(1 << 6);
 
       final byte mask;
 
@@ -127,8 +127,8 @@ public class DeltaAwareCacheEntry implements CacheEntry, StateChangingEntry {
    }
 
    @Override
-   public boolean skipRemoteGet() {
-      return isFlagSet(SKIP_REMOTE_GET);
+   public boolean skipLookup() {
+      return isFlagSet(SKIP_LOOKUP);
    }
 
    @Override
@@ -267,8 +267,8 @@ public class DeltaAwareCacheEntry implements CacheEntry, StateChangingEntry {
    }
 
    @Override
-   public void setSkipRemoteGet(boolean skipRemoteGet) {
-      setFlag(skipRemoteGet, SKIP_REMOTE_GET);
+   public void setSkipLookup(boolean skipLookup) {
+      setFlag(skipLookup, SKIP_LOOKUP);
    }
 
    private void setFlag(boolean enable, Flags flag) {

--- a/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
@@ -52,7 +52,7 @@ public class ReadCommittedEntry implements MVCCEntry {
       VALID(1 << 3),
       EVICTED(1 << 4),
       LOADED(1 << 5),
-      SKIP_REMOTE_GET(1 << 6),
+      SKIP_LOOKUP(1 << 6),
       COPIED(1 << 7);
 
       final byte mask;
@@ -192,12 +192,12 @@ public class ReadCommittedEntry implements MVCCEntry {
    }
 
    @Override
-   public void setSkipRemoteGet(boolean skipRemoteGet) {
+   public void setSkipLookup(boolean skipLookup) {
       //no-op
    }
 
    @Override
-   public boolean skipRemoteGet() {
+   public boolean skipLookup() {
       //in read committed, it can read from the data container / remote source multiple times.
       return false;
    }
@@ -279,7 +279,7 @@ public class ReadCommittedEntry implements MVCCEntry {
             ", isChanged=" + isChanged() +
             ", isRemoved=" + isRemoved() +
             ", isValid=" + isValid() +
-            ", skipRemoteGet=" + skipRemoteGet() +
+            ", skipRemoteGet=" + skipLookup() +
             ", metadata=" + metadata +
             '}';
    }

--- a/core/src/main/java/org/infinispan/container/entries/RepeatableReadEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/RepeatableReadEntry.java
@@ -7,7 +7,7 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 import static org.infinispan.container.entries.ReadCommittedEntry.Flags.COPIED;
-import static org.infinispan.container.entries.ReadCommittedEntry.Flags.SKIP_REMOTE_GET;
+import static org.infinispan.container.entries.ReadCommittedEntry.Flags.SKIP_LOOKUP;
 
 /**
  * An extension of {@link ReadCommittedEntry} that provides Repeatable Read semantics
@@ -62,12 +62,12 @@ public class RepeatableReadEntry extends ReadCommittedEntry {
    }
 
    @Override
-   public void setSkipRemoteGet(boolean skipRemoteGet) {
-      setFlag(skipRemoteGet, SKIP_REMOTE_GET);
+   public void setSkipLookup(boolean skipLookup) {
+      setFlag(skipLookup, SKIP_LOOKUP);
    }
 
    @Override
-   public boolean skipRemoteGet() {
-      return isFlagSet(SKIP_REMOTE_GET);
+   public boolean skipLookup() {
+      return isFlagSet(SKIP_LOOKUP);
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/ActivationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/ActivationInterceptor.java
@@ -67,7 +67,7 @@ public class ActivationInterceptor extends CacheLoaderInterceptor {
    @Override
    protected Boolean loadIfNeeded(InvocationContext ctx, Object key, boolean isRetrieval, FlagAffectedCommand cmd) throws Throwable {
       CacheEntry entry = ctx.lookupEntry(key);
-      if (entry != null && !entry.isNull() && entry.getValue() != null) {
+      if (!shouldAttemptLookup(entry)) {
          //the entry is already in the context. Avoid look in the cache loader.
          return null;
       }

--- a/core/src/main/java/org/infinispan/interceptors/CacheLoaderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheLoaderInterceptor.java
@@ -259,7 +259,7 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
 
       // first check if the container contains the key we need.  Try and load this into the context.
       CacheEntry e = ctx.lookupEntry(key);
-      if (e == null || e.isNull() || e.getValue() == null) {
+      if (shouldAttemptLookup(e)) {
          MarshalledEntry loaded = persistenceManager.loadFromAllStores(key, ctx);
          if(loaded == null)
             return Boolean.FALSE;
@@ -280,6 +280,14 @@ public class CacheLoaderInterceptor extends JmxStatsCommandInterceptor {
       } else {
          return null;
       }
+   }
+
+   /**
+    * Only perform if context doesn't have a value found (Read Committed) or if we can do a remote
+    * get only if the value is null (Repeatable Read)
+    */
+   protected boolean shouldAttemptLookup(CacheEntry e) {
+      return e == null || (e.isNull() || e.getValue() == null) && !e.skipLookup();
    }
 
    /**

--- a/core/src/main/java/org/infinispan/interceptors/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/EntryWrappingInterceptor.java
@@ -121,7 +121,7 @@ public class EntryWrappingInterceptor extends CommandInterceptor {
          else {
             CacheEntry entry = ctx.lookupEntry(command.getKey());
             if (entry != null) {
-               entry.setSkipRemoteGet(true);
+               entry.setSkipLookup(true);
             }
          }
       }
@@ -363,7 +363,7 @@ public class EntryWrappingInterceptor extends CommandInterceptor {
       if (txScope) {
          for (CacheEntry entry : context.getLookedUpEntries().values()) {
             if (entry != null) {
-               entry.setSkipRemoteGet(true);
+               entry.setSkipLookup(true);
             }
          }
       }
@@ -371,7 +371,7 @@ public class EntryWrappingInterceptor extends CommandInterceptor {
       if (txScope) {
          for (CacheEntry entry : context.getLookedUpEntries().values()) {
             if (entry != null) {
-               entry.setSkipRemoteGet(true);
+               entry.setSkipLookup(true);
             }
          }
       }
@@ -387,7 +387,7 @@ public class EntryWrappingInterceptor extends CommandInterceptor {
          for (Object key : command.getAffectedKeys()) {
             CacheEntry entry = context.lookupEntry(key);
             if (entry != null) {
-               entry.setSkipRemoteGet(true);
+               entry.setSkipLookup(true);
             }
          }
       }
@@ -403,7 +403,7 @@ public class EntryWrappingInterceptor extends CommandInterceptor {
       if (context.isInTxScope()) {
          CacheEntry entry = context.lookupEntry(command.getKey());
          if (entry != null) {
-            entry.setSkipRemoteGet(true);
+            entry.setSkipLookup(true);
          }
       }
       return retVal;

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -131,7 +131,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
 
          //if the cache entry has the value lock flag set, skip the remote get.
          CacheEntry entry = ctx.lookupEntry(command.getKey());
-         boolean skipRemoteGet = entry != null && entry.skipRemoteGet();
+         boolean skipRemoteGet = entry != null && entry.skipLookup();
 
          // need to check in the context as well since a null retval is not necessarily an indication of the entry not being
          // available.  It could just have been removed in the same tx beforehand.  Also don't bother with a remote get if
@@ -302,7 +302,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
             shouldFetchRemoteValuesForWriteSkewCheck(ctx, command)) {
          for (Object k : keygen.getKeys()) {
             CacheEntry entry = ctx.lookupEntry(k);
-            boolean skipRemoteGet =  entry != null && entry.skipRemoteGet();
+            boolean skipRemoteGet =  entry != null && entry.skipLookup();
             if (skipRemoteGet) {
                continue;
             }

--- a/core/src/main/java/org/infinispan/util/CoreImmutables.java
+++ b/core/src/main/java/org/infinispan/util/CoreImmutables.java
@@ -156,7 +156,7 @@ public class CoreImmutables extends Immutables {
       }
 
       @Override
-      public boolean skipRemoteGet() {
+      public boolean skipLookup() {
          return false;
       }
 
@@ -231,7 +231,7 @@ public class CoreImmutables extends Immutables {
       }
 
       @Override
-      public void setSkipRemoteGet(boolean skipRemoteGet) {
+      public void setSkipLookup(boolean skipLookup) {
          throw new UnsupportedOperationException();
       }
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/L1StateTransferRemovesValueTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/L1StateTransferRemovesValueTest.java
@@ -245,7 +245,6 @@ public class L1StateTransferRemovesValueTest extends BaseDistFunctionalTest<Stri
                owners.add(members.get(i));
             }
          }
-         System.out.println("Owners used are: " + owners);
          return owners;
       }
    }

--- a/core/src/test/java/org/infinispan/persistence/CacheLoaderRepeatableReadFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/CacheLoaderRepeatableReadFunctionalTest.java
@@ -1,0 +1,19 @@
+package org.infinispan.persistence;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.util.concurrent.IsolationLevel;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the cache loader when used in a repeatable read isolation level
+ *
+ * @author William Burns
+ * @since 6.0
+ */
+@Test(groups = "functional", testName = "persistence.CacheLoaderRepeatableReadFunctionalTest")
+public class CacheLoaderRepeatableReadFunctionalTest extends CacheLoaderFunctionalTest {
+   @Override
+   protected void configure(ConfigurationBuilder cb) {
+      cb.locking().isolationLevel(IsolationLevel.REPEATABLE_READ);
+   }
+}


### PR DESCRIPTION
- Fixed issue where RR if found null woud still query cache loader

https://issues.jboss.org/browse/ISPN-3829
