### PR TITLE
ISPN-3731 Multicast messages can be replayed to new node

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/InboundInvocationHandlerImpl.java
@@ -107,7 +107,7 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
    }
 
    private void handleWithWaitForBlocks(final CacheRpcCommand cmd, final ComponentRegistry cr, final org.jgroups.blocks.Response response, boolean preserveOrder) throws Throwable {
-      StateTransferManager stm = cr.getStateTransferManager();
+      final StateTransferManager stm = cr.getStateTransferManager();
       // We must have completed the join before handling commands
       // (even if we didn't complete the initial state transfer)
       if (cmd instanceof TotalOrderPrepareCommand && !stm.ownsData()) {
@@ -167,6 +167,11 @@ public class InboundInvocationHandlerImpl implements InboundInvocationHandler {
 
                @Override
                public void run() {
+                  if (0 < commandTopologyId && commandTopologyId < stm.getFirstTopologyAsMember()) {
+                     if (trace) log.tracef("Ignoring command sent before the local node was a member " +
+                           "(command topology id is %d)", commandTopologyId);
+                     reply(response, null);
+                  }
                   Response resp;
                   try {
                      resp = handleInternal(cmd, cr);

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManager.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManager.java
@@ -59,4 +59,10 @@ public interface StateTransferManager {
     * @return  true if this node has already received the first rebalance start
     */
    boolean ownsData();
+
+   /**
+    * @return The id of the first cache topology in which the local node was a member
+    *    (even if it didn't own any data).
+    */
+   int getFirstTopologyAsMember();
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3731

Keep track of the first cache topology was a member, and ignore commands
with a lower topology id.

No test, I'm not sure how to make JGroups retransmit the messages after the join.
