### PR TITLE
ISPN-3842 Inconsistent L1 in non-tx distributed cache in certain

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
@@ -226,6 +226,12 @@ public class L1NonTxInterceptor extends BaseRpcInterceptor {
    public Object visitInvalidateL1Command(InvocationContext ctx, InvalidateL1Command invalidateL1Command) throws Throwable {
       for (Object key : invalidateL1Command.getKeys()) {
          abortL1UpdateOrWait(key);
+         // If our invalidation was sent when the value wasn't yet cached but is still being requested the context
+         // may not have the value - if so we need to add it then now that we know we waited for the get response
+         // to complete
+         if (ctx.lookupEntry(key) == null) {
+            entryFactory.wrapEntryForRemove(ctx, key, true, true, false);
+         }
       }
       return super.visitInvalidateL1Command(ctx, invalidateL1Command);
    }


### PR DESCRIPTION
circumstances
- Added entry to context when invalidation was blocked by get

https://issues.jboss.org/browse/ISPN-3842
