### PR TITLE
ISPN-3666 Fix CI failures regarding L1 issues

### DIFF
--- a/core/src/main/java/org/infinispan/distribution/L1Manager.java
+++ b/core/src/main/java/org/infinispan/distribution/L1Manager.java
@@ -24,9 +24,6 @@ public interface L1Manager {
 	 */
 	void addRequestor(Object key, Address requestor);
 
-   Future<Object> flushCacheWithSimpleFuture(Collection<Object> keys, Object retval, Address origin,
-                                             boolean assumeOriginKeptEntryInL1);
-
    Future<Object> flushCache(Collection<Object> key, Address origin, boolean assumeOriginKeptEntryInL1);
 
    /**

--- a/core/src/main/java/org/infinispan/distribution/L1ManagerImpl.java
+++ b/core/src/main/java/org/infinispan/distribution/L1ManagerImpl.java
@@ -60,7 +60,6 @@ public class L1ManagerImpl implements L1Manager, RemoteValueRetrievedListener {
    private ScheduledFuture<?> scheduledRequestorsCleanupTask;
    private TimeService timeService;
 
-   private RpcOptions syncRpcOptions;
    private RpcOptions syncIgnoreLeaversRpcOptions;
 
    public L1ManagerImpl() {
@@ -96,7 +95,8 @@ public class L1ManagerImpl implements L1Manager, RemoteValueRetrievedListener {
       } else {
          log.warnL1NotHavingReaperThread();
       }
-      syncRpcOptions = rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS, false).build();
+      // L1 invalidations can ignore a member leaving while sending invalidation, since their value is no longer
+      // cached any longer
       syncIgnoreLeaversRpcOptions = rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS, false)
             .build();
    }
@@ -143,11 +143,6 @@ public class L1ManagerImpl implements L1Manager, RemoteValueRetrievedListener {
    }
 
    @Override
-   public Future<Object> flushCacheWithSimpleFuture(Collection<Object> keys, Object retval, Address origin, boolean assumeOriginKeptEntryInL1) {
-      return flushCache(keys, retval, origin, assumeOriginKeptEntryInL1, false);
-   }
-
-   @Override
    public Future<Object> flushCache(Collection<Object> keys, Address origin, boolean assumeOriginKeptEntryInL1) {
       final Collection<Address> invalidationAddresses = buildInvalidationAddressList(keys, origin, assumeOriginKeptEntryInL1);
 
@@ -166,14 +161,14 @@ public class L1ManagerImpl implements L1Manager, RemoteValueRetrievedListener {
             toExecute = new Runnable() {
                @Override
                public void run() {
-                  rpcManager.invokeRemotely(null, rpcCommand, rpcManager.getDefaultRpcOptions(true));
+                  rpcManager.invokeRemotely(null, rpcCommand, syncIgnoreLeaversRpcOptions);
                }
             };
          } else {
             toExecute = new Runnable() {
                @Override
                public void run() {
-                  rpcManager.invokeRemotely(invalidationAddresses, rpcCommand, syncRpcOptions);
+                  rpcManager.invokeRemotely(invalidationAddresses, rpcCommand, syncIgnoreLeaversRpcOptions);
                }
             };
          }
@@ -181,63 +176,6 @@ public class L1ManagerImpl implements L1Manager, RemoteValueRetrievedListener {
       } else {
          if (trace) log.tracef("No L1 caches to invalidate for keys %s", keys);
          return null;
-      }
-   }
-
-   private Future<Object> flushCache(Collection<Object> keys, final Object retval, Address origin, boolean assumeOriginKeptEntryInL1, boolean useNotifyingFuture) {
-      if (trace) log.tracef("Invalidating L1 caches for keys %s", keys);
-
-      final Collection<Address> invalidationAddresses = buildInvalidationAddressList(keys, origin, assumeOriginKeptEntryInL1);
-
-      int nodes = invalidationAddresses.size();
-
-      if (nodes > 0) {
-         // No need to invalidate at all if there is no one to invalidate!
-         boolean multicast = isUseMulticast(nodes);
-
-         if (trace)
-            log.tracef("There are %s nodes involved in invalidation. Threshold is: %s; using multicast: %s", nodes, threshold, multicast);
-
-         if (multicast) {
-            if (trace) log.tracef("Invalidating keys %s via multicast", keys);
-            final InvalidateCommand ic = commandsFactory.buildInvalidateFromL1Command(
-                  origin, false, InfinispanCollections.<Flag>emptySet(), keys);
-            if (useNotifyingFuture) {
-               NotifyingNotifiableFuture<Object> future = new AggregatingNotifyingFutureImpl(retval, 2);
-               rpcManager.invokeRemotelyInFuture(null, ic, rpcManager.getDefaultRpcOptions(true), future);
-               return future;
-            } else {
-               return asyncTransportExecutor.submit(new Callable<Object>() {
-                  @Override
-                  public Object call() throws Exception {
-                     rpcManager.invokeRemotely(null, ic, rpcManager.getDefaultRpcOptions(true));
-                     return retval;
-                  }
-               });
-            }
-         } else {
-            final CacheRpcCommand rpc = commandsFactory.buildSingleRpcCommand(
-                  commandsFactory.buildInvalidateFromL1Command(origin, false,
-                        InfinispanCollections.<Flag>emptySet(), keys));
-            // Ask the caches who have requested from us to remove
-            if (trace) log.tracef("Keys %s needs invalidation on %s", keys, invalidationAddresses);
-            if (useNotifyingFuture) {
-               NotifyingNotifiableFuture<Object> future = new AggregatingNotifyingFutureImpl(retval, 2);
-               rpcManager.invokeRemotelyInFuture(invalidationAddresses, rpc, syncIgnoreLeaversRpcOptions, future);
-               return future;
-            } else {
-               return asyncTransportExecutor.submit(new Callable<Object>() {
-                  @Override
-                  public Object call() throws Exception {
-                     rpcManager.invokeRemotely(invalidationAddresses, rpc, syncRpcOptions);
-                     return retval;
-                  }
-               });
-            }
-         }
-      } else {
-         if (trace) log.trace("No L1 caches to invalidate");
-         return useNotifyingFuture ? new NotifyingFutureImpl(retval) : new NoOpFuture<Object>(retval);
       }
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1TxInterceptor.java
@@ -72,7 +72,7 @@ public class L1TxInterceptor extends L1NonTxInterceptor {
    }
 
    private Future<?> flushL1Caches(TxInvocationContext ctx) {
-      return l1Manager.flushCacheWithSimpleFuture(ctx.getAffectedKeys(), null, ctx.getOrigin(), true);
+      return l1Manager.flushCache(ctx.getAffectedKeys(), ctx.getOrigin(), true);
    }
 
    private void blockOnL1FutureIfNeeded(Future<?> f) {


### PR DESCRIPTION
- Changed L1 invalidation to ignore leavers
- Also removed extra redundant invalidation method from L1Manager

https://issues.jboss.org/browse/ISPN-3666
