### PR TITLE
ISPN-3812 Java Hot Rod client should use version 1.3

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/Version.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/Version.java
@@ -8,7 +8,7 @@ package org.infinispan.client.hotrod;
  */
 public class Version {
 
-   private static final String PROTOCOL_VERSION = "1.2";
+   private static final String PROTOCOL_VERSION = "1.3";
 
    public static String getProtocolVersion() {
       return "HotRod client, protocol version :" + PROTOCOL_VERSION;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
@@ -48,10 +48,11 @@ public class ConfigurationProperties {
    public static final int DEFAULT_HOTROD_PORT = 11222;
    public static final int DEFAULT_SO_TIMEOUT = 60000;
    public static final int DEFAULT_CONNECT_TIMEOUT = 60000;
+   public static final String PROTOCOL_VERSION_13 = "1.3";
    public static final String PROTOCOL_VERSION_12 = "1.2";
    public static final String PROTOCOL_VERSION_11 = "1.1";
    public static final String PROTOCOL_VERSION_10 = "1.0";
-   public static final String DEFAULT_PROTOCOL_VERSION = PROTOCOL_VERSION_12;
+   public static final String DEFAULT_PROTOCOL_VERSION = PROTOCOL_VERSION_13;
 
    private final TypedProperties props;
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec13.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec13.java
@@ -1,0 +1,27 @@
+package org.infinispan.client.hotrod.impl.protocol;
+
+import org.infinispan.client.hotrod.impl.transport.Transport;
+import org.infinispan.client.hotrod.logging.Log;
+import org.infinispan.client.hotrod.logging.LogFactory;
+
+/**
+ * A Hot Rod encoder/decoder for version 1.3 of the protocol.
+ *
+ * @author Adrian Nistor
+ * @since 6.1
+ */
+public class Codec13 extends Codec12 {
+
+   private static final Log log = LogFactory.getLog(Codec13.class, Log.class);
+
+   @Override
+   public HeaderParams writeHeader(Transport transport, HeaderParams params) {
+      return writeHeader(transport, params, HotRodConstants.VERSION_13);
+   }
+
+   @Override
+   public Log getLog() {
+      return log;
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/CodecFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/CodecFactory.java
@@ -17,12 +17,14 @@ public class CodecFactory {
    private static final Codec CODEC_10 = new Codec10();
    private static final Codec CODEC_11 = new Codec11();
    private static final Codec CODEC_12 = new Codec12();
+   private static final Codec CODEC_13 = new Codec13();
 
    static {
       codecMap = new HashMap<String, Codec>();
       codecMap.put(PROTOCOL_VERSION_10, CODEC_10);
       codecMap.put(PROTOCOL_VERSION_11, CODEC_11);
       codecMap.put(PROTOCOL_VERSION_12, CODEC_12);
+      codecMap.put(PROTOCOL_VERSION_13, CODEC_13);
    }
 
    public static Codec getCodec(String version) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HotRodConstants.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HotRodConstants.java
@@ -16,6 +16,7 @@ public interface HotRodConstants {
    static final byte VERSION_10 = 10;
    static final byte VERSION_11 = 11;
    static final byte VERSION_12 = 12;
+   static final byte VERSION_13 = 13;
 
    //requests
    static final byte PUT_REQUEST = 0x01;

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Encoders.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Encoders.scala
@@ -1,17 +1,6 @@
 package org.infinispan.server.hotrod
 
-import logging.{JavaLog, Log}
-import org.jboss.netty.buffer.ChannelBuffer
-import org.infinispan.Cache
-import org.infinispan.remoting.transport.Address
-import org.infinispan.server.core.transport.ExtendedChannelBuffer._
-import collection.JavaConversions._
-import org.infinispan.configuration.cache.Configuration
-import org.infinispan.distribution.ch.ConsistentHash
-import collection.mutable.ArrayBuffer
-import collection.immutable.{TreeMap, SortedMap}
-import collection.mutable
-import org.infinispan.util.logging.LogFactory
+import logging.Log
 
 /**
  * Version specific encoders are included here.
@@ -35,4 +24,9 @@ object Encoders {
     * Encoder for version 1.2 of the Hot Rod protocol.
     */
    object Encoder12 extends AbstractTopologyAwareEncoder1x with Log
+
+   /**
+    * Encoder for version 1.3 of the Hot Rod protocol.
+    */
+   object Encoder13 extends AbstractTopologyAwareEncoder1x with Log
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
@@ -34,11 +34,12 @@ class HotRodEncoder(cacheManager: EmbeddedCacheManager, server: HotRodServer)
          case VERSION_10 => Encoders.Encoder10
          case VERSION_11 => Encoders.Encoder11
          case VERSION_12 => Encoders.Encoder12
-         case 0 => Encoders.Encoder12
+         case VERSION_13 => Encoders.Encoder13
+         case 0 => Encoders.Encoder13
       }
 
       r.version match {
-         case VERSION_10 | VERSION_11 | VERSION_12 => encoder.writeHeader(r, buf, addressCache, server)
+         case VERSION_10 | VERSION_11 | VERSION_12 | VERSION_13 => encoder.writeHeader(r, buf, addressCache, server)
          // if error before reading version, don't send any topology changes
          // cos the encoding might vary from one version to the other
          case 0 => encoder.writeHeader(r, buf, null, null)


### PR DESCRIPTION
- Version 1.3 is really just like version 1.2 + support for query operation
- Add 1.3 version constants and make 1.3 default
- Add encoders for 1.3

Jira: https://issues.jboss.org/browse/ISPN-3812
