### PR TITLE
ISPN-3778 ClusteredCacheWithAsyncDirTest throws lots of "org.h2.jdbc.Jdb...

### DIFF
--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithAsyncDirTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithAsyncDirTest.java
@@ -1,7 +1,16 @@
 package org.infinispan.query.blackbox;
 
+import org.infinispan.commons.util.FileLookupFactory;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.StoreConfigurationBuilder;
+import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
+import org.infinispan.configuration.parsing.ParserRegistry;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.persistence.jdbc.configuration.AbstractJdbcStoreConfigurationBuilder;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
+
+import java.io.InputStream;
 
 /**
  * Testing the ISPN Directory configuration with Async. JDBC CacheStore. The tests are performed for Clustered cache.
@@ -13,12 +22,34 @@ public class ClusteredCacheWithAsyncDirTest extends ClusteredCacheTest {
 
    @Override
    protected void createCacheManagers() throws Exception {
-      cacheManagers.add(TestCacheManagerFactory.fromXml("async-store-config.xml"));
-      cacheManagers.add(TestCacheManagerFactory.fromXml("async-store-config.xml"));
+      cacheManagers.add(createCacheManager(1));
+      cacheManagers.add(createCacheManager(2));
       waitForClusterToForm();
 
       cache1 = cacheManagers.get(0).getCache("JDBCBased_LocalIndex");
       cache2 = cacheManagers.get(1).getCache("JDBCBased_LocalIndex");
+   }
+
+   private EmbeddedCacheManager createCacheManager(int nodeIndex) throws Exception {
+      InputStream is = FileLookupFactory.newInstance().lookupFileStrict("async-store-config.xml",
+                                                                        Thread.currentThread().getContextClassLoader());
+      ParserRegistry parserRegistry = new ParserRegistry(Thread.currentThread().getContextClassLoader());
+
+      ConfigurationBuilderHolder holder = parserRegistry.parse(is);
+      is.close();
+
+      for (ConfigurationBuilder builder : holder.getNamedConfigurationBuilders().values()) {
+         for (StoreConfigurationBuilder storeBuilder : builder.persistence().stores()) {
+            if (storeBuilder instanceof AbstractJdbcStoreConfigurationBuilder) {
+               AbstractJdbcStoreConfigurationBuilder jdbcStoreBuilder = (AbstractJdbcStoreConfigurationBuilder) storeBuilder;
+               jdbcStoreBuilder.connectionPool()
+                     .driverClass("org.h2.Driver")
+                     .connectionUrl("jdbc:h2:mem:infinispan_string_based_" + nodeIndex + ";DB_CLOSE_DELAY=-1")
+                     .username("sa");
+            }
+         }
+      }
+      return TestCacheManagerFactory.createClusteredCacheManager(holder);
    }
 
    protected boolean transactionsEnabled() {

--- a/query/src/test/resources/async-store-config.xml
+++ b/query/src/test/resources/async-store-config.xml
@@ -108,13 +108,11 @@
     <namedCache name="LuceneIndexesMetadata_custom1">
         <transaction transactionMode="TRANSACTIONAL" />
 
-        <clustering mode="REPL">
-        </clustering>
+        <clustering mode="REPL"/>
         <indexing enabled="false" />
 
         <persistence>
             <stringKeyedJdbcStore xmlns="urn:infinispan:config:jdbc:6.0" key2StringMapper="org.infinispan.lucene.LuceneKey2StringMapper" fetchPersistentState="false" ignoreModifications="false" purgeOnStartup="false">
-                <connectionPool connectionUrl="jdbc:h2:mem:infinispan_string_based;DB_CLOSE_DELAY=-1" username="sa" driverClass="org.h2.Driver"/>
                 <stringKeyedTable dropOnExit="true" createOnStart="true" prefix="ISPN_STRING_TABLE">
                     <idColumn name="ID_COLUMN" type="VARCHAR(255)" />
                     <dataColumn name="DATA_COLUMN" type="BINARY" />
@@ -131,13 +129,11 @@
     <namedCache name="LuceneIndexesData_custom1">
         <transaction transactionMode="TRANSACTIONAL" />
 
-        <clustering mode="REPL">
-        </clustering>
+        <clustering mode="REPL"/>
         <indexing enabled="false" />
 
         <persistence>
             <stringKeyedJdbcStore xmlns="urn:infinispan:config:jdbc:6.0" key2StringMapper="org.infinispan.lucene.LuceneKey2StringMapper" fetchPersistentState="false" ignoreModifications="false" purgeOnStartup="false">
-                <connectionPool connectionUrl="jdbc:h2:mem:infinispan_string_based;DB_CLOSE_DELAY=-1" username="sa" driverClass="org.h2.Driver"/>
                 <stringKeyedTable dropOnExit="true" createOnStart="true" prefix="ISPN_STRING_TABLE">
                     <idColumn name="ID_COLUMN" type="VARCHAR(255)" />
                     <dataColumn name="DATA_COLUMN" type="BINARY" />
@@ -160,7 +156,6 @@
 
         <persistence>
             <stringKeyedJdbcStore xmlns="urn:infinispan:config:jdbc:6.0" key2StringMapper="org.infinispan.lucene.LuceneKey2StringMapper" fetchPersistentState="false" ignoreModifications="false" purgeOnStartup="false">
-                <connectionPool connectionUrl="jdbc:h2:mem:infinispan_string_based;DB_CLOSE_DELAY=-1" username="sa" driverClass="org.h2.Driver"/>
                 <stringKeyedTable dropOnExit="true" createOnStart="true" prefix="ISPN_STRING_TABLE">
                     <idColumn name="ID_COLUMN" type="VARCHAR(255)" />
                     <dataColumn name="DATA_COLUMN" type="BINARY" />


### PR DESCRIPTION
...cSQLException: Unique index or primary key violation"

The jdbc cache stores of two nodes collide using the same in-memory H2 database instance. The config file should not specify hardcoded jdbc connection pool settings; these should rather be set in code ensuring a unique database name for each node.

Jira: https://issues.jboss.org/browse/ISPN-3778
