### PR TITLE
Change obj.hashCode() to System.identityHashCode(obj)

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/format/PropertyFormatter.java
+++ b/core/src/main/java/org/infinispan/configuration/format/PropertyFormatter.java
@@ -75,7 +75,7 @@ public class PropertyFormatter {
          if (cls.getMethod("toString") == plainToString) {
             return true;
          }
-         String plainToStringValue = cls.getName() + "@" + Integer.toHexString(obj.hashCode());
+         String plainToStringValue = cls.getName() + "@" + Integer.toHexString(System.identityHashCode(obj));
          return plainToStringValue.equals(obj.toString());
       } catch (Exception e) {
          return false;


### PR DESCRIPTION
... to avoid getting non-default hashCode() value

this was pointed out by Radim in review when I used this method in a component in RadarGun
so fixing here as well ...
