### PR TITLE
ISPN-3867 L1 cache of ISPN server cannot be enabled

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/L1ConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/L1ConfigurationBuilder.java
@@ -19,7 +19,7 @@ public class L1ConfigurationBuilder extends AbstractClusteringConfigurationChild
    private boolean enabled = false;
    private int invalidationThreshold = 0;
    private long lifespan = TimeUnit.MINUTES.toMillis(10);
-   private Boolean onRehash = null;
+   private boolean onRehash = false;
    private long cleanupTaskFrequency = TimeUnit.MINUTES.toMillis(10);
 
    L1ConfigurationBuilder(ClusteringConfigurationBuilder builder) {
@@ -114,13 +114,11 @@ public class L1ConfigurationBuilder extends AbstractClusteringConfigurationChild
 
    public L1ConfigurationBuilder disable() {
       this.enabled = false;
-      this.onRehash = null;
       return this;
    }
 
    public L1ConfigurationBuilder enabled(boolean enabled) {
       this.enabled = enabled;
-      this.onRehash = enabled ? this.onRehash : null;
       return this;
    }
 
@@ -136,24 +134,14 @@ public class L1ConfigurationBuilder extends AbstractClusteringConfigurationChild
       }
       else {
          // If L1 is disabled, L1ForRehash should also be disabled
-         if (onRehash != null && onRehash)
+         if (onRehash)
             throw new CacheConfigurationException("Can only move entries to L1 on rehash when L1 is enabled");
       }
    }
 
    @Override
    public L1Configuration create() {
-      boolean finalOnRehash;
-      if (onRehash != null) {
-         finalOnRehash = onRehash;
-      } else {
-         finalOnRehash = false;
-         if (enabled) {
-            log.debug("L1 is enabled and L1OnRehash was not defined, enabling it");
-            finalOnRehash = true;
-         }
-      }
-      return new L1Configuration(enabled, invalidationThreshold, lifespan, finalOnRehash, cleanupTaskFrequency);
+      return new L1Configuration(enabled, invalidationThreshold, lifespan, onRehash, cleanupTaskFrequency);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/configuration/cache/L1ConfigurationBuilderTest.java
+++ b/core/src/test/java/org/infinispan/configuration/cache/L1ConfigurationBuilderTest.java
@@ -1,0 +1,30 @@
+package org.infinispan.configuration.cache;
+
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
+
+/**
+ * Tests to ensure the L1 Configuration builder operates properly
+ *
+ * @author William Burns
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "configuration.cache.L1ConfigurationBuilderTest")
+public class L1ConfigurationBuilderTest {
+   public void testDefaultsWhenEnabledOnly() {
+      Configuration config = new ConfigurationBuilder().clustering().cacheMode(CacheMode.DIST_SYNC).l1().enable().build();
+
+      L1Configuration l1Config = config.clustering().l1();
+
+      assertTrue(l1Config.enabled());
+      assertFalse(l1Config.onRehash());
+      assertEquals(l1Config.cleanupTaskFrequency(), TimeUnit.MINUTES.toMillis(10));
+      assertEquals(l1Config.invalidationThreshold(), 0);
+      assertEquals(l1Config.lifespan(), TimeUnit.MINUTES.toMillis(10));
+   }
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheAdd.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheAdd.java
@@ -98,7 +98,8 @@ public class DistributedCacheAdd extends SharedStateCacheAdd {
             .capacityFactor(capacityFactor)
         ;
         if (lifespan > 0) {
-            builder.clustering().l1().lifespan(lifespan);
+            // is disabled by default in L1ConfigurationBuilder
+            builder.clustering().l1().enable().lifespan(lifespan);
         } else {
             builder.clustering().l1().disable();
         }

--- a/server/integration/testsuite/build-testsuite.xml
+++ b/server/integration/testsuite/build-testsuite.xml
@@ -159,6 +159,8 @@
                    filtering="true"/>
         <transform in="clustered.xml" out="testsuite/clustered-transport-stack.xml"
                    modifyStack="${other.parts}/jgroups-stack.xml"/>
+        <transform in="clustered.xml" out="testsuite/clustered-with-l1.xml"
+                   modifyInfinispan="${infinispan.parts}/l1.xml"/>
         <transform in="standalone.xml" out="testsuite/rest-sec-basic-wr.xml"
                    modifyInfinispan="${infinispan.parts}/rest-security.xml"
                    filtering="true">

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/l1/L1CachingTestCase.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/l1/L1CachingTestCase.java
@@ -1,0 +1,127 @@
+package org.infinispan.server.test.l1;
+
+import org.infinispan.arquillian.core.InfinispanResource;
+import org.infinispan.arquillian.core.RemoteInfinispanServer;
+import org.infinispan.arquillian.core.WithRunningServer;
+import org.infinispan.server.test.client.memcached.MemcachedClient;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for L1 caching.
+ *
+ * @author <a href="mailto:tsykora@redhat.com">Tomas Sykora</a>
+ * @author <a href="mailto:wburns@redhat.com">William Burns</a>
+ */
+@RunWith(Arquillian.class)
+@WithRunningServer({"l1-1", "l1-2"})
+public class L1CachingTestCase {
+   final String CONTAINER1 = "l1-1";
+   final String CONTAINER2 = "l1-2";
+
+   @InfinispanResource(CONTAINER1)
+   RemoteInfinispanServer server1;
+
+   @InfinispanResource(CONTAINER2)
+   RemoteInfinispanServer server2;
+
+   static final String ENCODING = "UTF-8";
+
+   private MemcachedClient mc1;
+   private MemcachedClient mc2;
+
+   @Before
+   public void setUp() throws Exception {
+      mc1 = new MemcachedClient(ENCODING, server1.getMemcachedEndpoint().getInetAddress().getHostName(), server1
+            .getMemcachedEndpoint().getPort(), 10000);
+      mc2 = new MemcachedClient(ENCODING, server2.getMemcachedEndpoint().getInetAddress().getHostName(), server2
+            .getMemcachedEndpoint().getPort(), 10000);
+      mc1.delete("KeyA");
+      mc2.delete("KeyA");
+      mc1.delete("KeyB");
+      mc2.delete("KeyB");
+      mc2.delete("KeyBB");
+      mc2.delete("KeyBB");
+      mc1.delete("KeyC");
+      mc2.delete("KeyC");
+   }
+
+   @After
+   public void tearDown() throws Exception {
+      if (mc1 != null) {
+         mc1.close();
+      }
+      if (mc2 != null) {
+         mc2.close();
+      }
+   }
+
+
+   /*
+   * Entries in L1 cache are stored directly into "main" cache. They are fetched from remote (distribution) node.
+   * In TRACE we can see: "Doing a remote get for key KeyA" and "Caching remotely retrieved entry for key KeyA in L1"
+   *
+   * Number of hits is increased for cache on which is issued get. Hits on real-owner are still 0.
+   * For caching L1 entries there is NO increase for number of stores. (Only for number of entries)
+   */
+   @Test
+   public void testL1CachingEnabled() throws Exception {
+
+      // NOTE
+      // after https://issues.jboss.org/browse/ISPN-2120 (= 6.0.1 ER1)
+      // I put to server1, then I issue get on server2 -> number of hits on server1 should be still 0
+      // but number of hits on server2 should increase (entry was fetched from server1 to server2 for this get)
+      mc1.set("KeyA", "A");
+      mc1.set("KeyB", "B");
+      mc1.set("KeyC", "C");
+
+      assertTrue("Distribution of entries is wrong (at least unexpected).",
+                 server1.getCacheManager("clustered").getCache("memcachedCache").getNumberOfEntries() > 0);
+      assertTrue("Distribution of entries is wrong (at least unexpected).",
+                 server2.getCacheManager("clustered").getCache("memcachedCache").getNumberOfEntries() > 0);
+
+      assertEquals("More entries in caches than expected.", 3, server1.getCacheManager("clustered").getCache("memcachedCache").getNumberOfEntries() +
+            server2.getCacheManager("clustered").getCache("memcachedCache").getNumberOfEntries());
+
+      assertTrue("A".equals(mc2.get("KeyA")));
+      assertTrue("B".equals(mc2.get("KeyB")));
+      assertTrue("C".equals(mc2.get("KeyC")));
+
+      assertEquals("Number of hits on server 1 is wrong.", 0, server1.getCacheManager("clustered").getCache("memcachedCache").getHits());
+      assertEquals("Number of hits on server 2 is wrong.", 3, server2.getCacheManager("clustered").getCache("memcachedCache").getHits());
+
+      assertEquals("Number of stores on server 1 is wrong.", 3, server1.getCacheManager("clustered").getCache("memcachedCache").getStores());
+      assertEquals("Number of stores on server 2 is wrong.", 0, server2.getCacheManager("clustered").getCache("memcachedCache").getStores());
+
+      // main condition (some entries are in the L1 cache - its copy is there)
+      assertTrue("The are no entries in L1 cache! L1 seems to be disabled! Check TRACE [org.infinispan.factories.ComponentRegistry] output.",
+                 server1.getCacheManager("clustered").getCache("memcachedCache").getNumberOfEntries() +
+                       server2.getCacheManager("clustered").getCache("memcachedCache").getNumberOfEntries() > 3);
+
+      // *****************************
+      // do the same round for server1
+      assertTrue("A".equals(mc1.get("KeyA")));
+      assertTrue("B".equals(mc1.get("KeyB")));
+      assertTrue("C".equals(mc1.get("KeyC")));
+
+      assertEquals("Number of hits on server 1 is wrong.", 3, server1.getCacheManager("clustered").getCache("memcachedCache").getHits());
+      assertEquals("Number of hits on server 2 is wrong.", 3, server2.getCacheManager("clustered").getCache("memcachedCache").getHits());
+
+      // should be still the same as on the start
+      assertEquals("Number of stores on server 1 is wrong.", 3, server1.getCacheManager("clustered").getCache("memcachedCache").getStores());
+      assertEquals("Number of stores on server 2 is wrong.", 0, server2.getCacheManager("clustered").getCache("memcachedCache").getStores());
+
+      // main condition (there should be server1 - 1 entry + 2 in L1, server2 - 2 entries + 1 in L1 = 3x2 = 6 num of entries JMX stat.
+      assertEquals("The are no entries in L1 cache! L1 seems to be disabled! Check TRACE [org.infinispan.factories.ComponentRegistry] output.",
+                   6, server1.getCacheManager("clustered").getCache("memcachedCache").getNumberOfEntries() +
+            server2.getCacheManager("clustered").getCache("memcachedCache").getNumberOfEntries());
+   }
+}

--- a/server/integration/testsuite/src/test/resources/arquillian.xml
+++ b/server/integration/testsuite/src/test/resources/arquillian.xml
@@ -497,6 +497,29 @@
                 <property name="waitForPorts">11311 11322 8180</property>
             </configuration>
         </container>
+        <container qualifier="l1-1" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="serverConfig">testsuite/clustered-with-l1.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                </property>
+                <property name="managementPort">9999</property>
+                <property name="waitForPorts">11211 11222 8080</property>
+            </configuration>
+        </container>
+        <container qualifier="l1-2" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server2.dist}</property>
+                <property name="serverConfig">testsuite/clustered-with-l1.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.socket.binding.port-offset=100
+                </property>
+                <property name="managementPort">10099</property>
+                <property name="waitForPorts">11311 11322 8180</property>
+            </configuration>
+        </container>
     </group>
     <group qualifier="suite-client-local">
         <container qualifier="container1" mode="suite">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/l1.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/l1.xml
@@ -1,0 +1,15 @@
+        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+            <cache-container 
+                name="clustered"
+                default-cache="memcachedCache">
+                <transport stack="${jboss.default.jgroups.stack:udp}"
+                    executor="infinispan-transport" lock-timeout="240000"/>
+                <distributed-cache
+                    name="memcachedCache"
+                    start="EAGER"
+                    mode="SYNC" 
+                    owners="1"
+                    l1-lifespan="2000">
+                </distributed-cache>
+            </cache-container>
+        </subsystem>


### PR DESCRIPTION
- Made sure L1 is enabled properly in server when lifespan is configured
- Also changed l1OnRehash to not be enabled by default

https://issues.jboss.org/browse/ISPN-3867
