### PR TITLE
Increase server initial state transfer timeout to 4 minutes

### DIFF
--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StateTransferResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StateTransferResource.java
@@ -78,7 +78,7 @@ public class StateTransferResource extends SimpleResourceDefinition {
                     .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setDefaultValue(new ModelNode().set(60000))
+                    .setDefaultValue(new ModelNode().set(240000))
                     .build();
 
     static final AttributeDefinition[] STATE_TRANSFER_ATTRIBUTES = {AWAIT_INITIAL_TRANSFER, ENABLED, TIMEOUT, CHUNK_SIZE};


### PR DESCRIPTION
The default for distributed-cache is to await initial state transfer and to timeout after 60s. This is quite short and fails in my cluster. This pull request increases the default timeout to 240s to match the default timeout in Infinispan library. I think this is a more expected default?

I found it quite hard to find documentation on how to set the state transfer for the server. I am investigating and will submit some other pull requests to try to help.
