### PR TITLE
ISPN-3803 Stale locks during state transfer in non-tx caches

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxBackupOwnerBecomingPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxBackupOwnerBecomingPrimaryOwnerTest.java
@@ -37,10 +37,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertNotNull;
-import static org.testng.AssertJUnit.assertNull;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.*;
 
 /**
  * Tests data loss during state transfer a backup owner of a key becomes the primary owner
@@ -185,6 +182,11 @@ public class NonTxBackupOwnerBecomingPrimaryOwnerTest extends MultipleCacheManag
       assertEquals("v", cache0.get(key));
       assertEquals("v", cache1.get(key));
       assertEquals("v", cache2.get(key));
+
+      // Check that there are no leaked locks
+      assertFalse(cache0.getAdvancedCache().getLockManager().isLocked(key));
+      assertFalse(cache1.getAdvancedCache().getLockManager().isLocked(key));
+      assertFalse(cache2.getAdvancedCache().getLockManager().isLocked(key));
    }
 
    private static class CustomConsistentHashFactory extends SingleSegmentConsistentHashFactory {

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxPutIfAbsentDuringJoinStressTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxPutIfAbsentDuringJoinStressTest.java
@@ -7,6 +7,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.TransactionMode;
+import org.infinispan.util.concurrent.locks.LockManager;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.Callable;
@@ -15,7 +16,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
 /**
@@ -96,6 +97,15 @@ public class NonTxPutIfAbsentDuringJoinStressTest extends MultipleCacheManagersT
                String key = "key_" + j;
                assertEquals(insertedValues.get(key), cache(k).get(key));
             }
+         }
+      }
+
+      for (int i = 0; i < caches().size(); i++) {
+         LockManager lockManager = advancedCache(i).getLockManager();
+         assertEquals(0, lockManager.getNumberOfLocksHeld());
+         for (int j = 0; j < NUM_KEYS; j++) {
+            String key = "key_" + j;
+            assertFalse(lockManager.isLocked(key));
          }
       }
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3803

Clean up SingleKeyNonTxInvocationContext and allow the key to be
locked/unlocked independently of whether the entry was looked-up or not.
