### PR TITLE
ISPN-3885 Non-Tx Cross Site optimizations

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/xsite/BaseBackupInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/xsite/BaseBackupInterceptor.java
@@ -1,5 +1,7 @@
 package org.infinispan.interceptors.xsite;
 
+import org.infinispan.commands.FlagAffectedCommand;
+import org.infinispan.context.Flag;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.interceptors.base.CommandInterceptor;
@@ -37,6 +39,10 @@ public class BaseBackupInterceptor extends CommandInterceptor {
       boolean shouldBackupRemotely = ctx.isOriginLocal() && ctx.hasModifications();
       getLog().tracef("Should backup remotely? %s", shouldBackupRemotely);
       return shouldBackupRemotely;
+   }
+
+   protected final boolean skipXSiteBackup(FlagAffectedCommand command) {
+      return command.hasFlag(Flag.SKIP_XSITE_BACKUP);
    }
    
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/xsite/NonTransactionalBackupInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/xsite/NonTransactionalBackupInterceptor.java
@@ -1,54 +1,91 @@
 package org.infinispan.interceptors.xsite;
 
+import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.write.ClearCommand;
+import org.infinispan.commands.write.DataWriteCommand;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commands.write.WriteCommand;
-import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.remoting.transport.BackupResponse;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 
 /**
  * Handles x-site data backups for non-transactional caches.
  *
  * @author Mircea Markus
+ * @author Pedro Ruivo
  * @since 5.2
  */
 public class NonTransactionalBackupInterceptor extends BaseBackupInterceptor {
 
+   private CommandsFactory commandsFactory;
+   private ClusteringDependentLogic clusteringDependentLogic;
+
+   @Inject
+   public void injectDependencies(CommandsFactory commandsFactory, ClusteringDependentLogic clusteringDependentLogic) {
+      this.commandsFactory = commandsFactory;
+      this.clusteringDependentLogic = clusteringDependentLogic;
+   }
+
    @Override
    public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) throws Throwable {
-      return handleWrite(ctx, command);
+      return handleSingleKeyWriteCommand(ctx, command);
    }
 
    @Override
    public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
-      return handleWrite(ctx, command);
+      return handleSingleKeyWriteCommand(ctx, command);
    }
 
    @Override
    public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) throws Throwable {
-      return handleWrite(ctx, command);
+      return handleSingleKeyWriteCommand(ctx, command);
    }
 
    @Override
    public Object visitClearCommand(InvocationContext ctx, ClearCommand command) throws Throwable {
-      return handleWrite(ctx, command);
+      return handleMultipleKeysWriteCommand(ctx, command);
    }
 
    @Override
    public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) throws Throwable {
-      return handleWrite(ctx, command);
+      return handleMultipleKeysWriteCommand(ctx, command);
    }
 
-   private Object handleWrite(InvocationContext ctx, WriteCommand command) throws Throwable {
-      if (!ctx.isOriginLocal() || command.hasFlag(Flag.SKIP_XSITE_BACKUP))
-         return invokeNextInterceptor(ctx, command);
-      BackupResponse backupResponse = backupSender.backupWrite(command);
+   private Object handleSingleKeyWriteCommand(InvocationContext ctx, DataWriteCommand command) throws Throwable {
       Object result = invokeNextInterceptor(ctx, command);
-      backupSender.processResponses(backupResponse, command);
+      if (skipXSiteBackup(command)) {
+         return result;
+      } else if (command.isSuccessful() && clusteringDependentLogic.localNodeIsPrimaryOwner(command.getKey())) {
+         backupSender.processResponses(backupSender.backupWrite(transform(command)), command);
+      }
       return result;
+   }
+
+   private Object handleMultipleKeysWriteCommand(InvocationContext ctx, WriteCommand command) throws Throwable {
+      if (!ctx.isOriginLocal() || skipXSiteBackup(command)) {
+         return invokeNextInterceptor(ctx, command);
+      }
+      Object result = invokeNextInterceptor(ctx, command);
+      backupSender.processResponses(backupSender.backupWrite(command), command);
+      return result;
+   }
+
+   private WriteCommand transform(DataWriteCommand command) {
+      if (command instanceof PutKeyValueCommand) {
+         PutKeyValueCommand putCommand = (PutKeyValueCommand) command;
+         return commandsFactory.buildPutKeyValueCommand(putCommand.getKey(), putCommand.getValue(),
+                                                        command.getMetadata(), command.getFlags());
+      } else if (command instanceof ReplaceCommand) {
+         ReplaceCommand replaceCommand = (ReplaceCommand) command;
+         return commandsFactory.buildPutKeyValueCommand(replaceCommand.getKey(), replaceCommand.getNewValue(),
+                                                        command.getMetadata(), command.getFlags());
+      } else if (command instanceof RemoveCommand) {
+         return commandsFactory.buildRemoveCommand(command.getKey(), null, command.getFlags());
+      }
+      throw new IllegalArgumentException("Command " + command + " is not valid!");
    }
 }

--- a/core/src/main/java/org/infinispan/remoting/CacheUnreachableException.java
+++ b/core/src/main/java/org/infinispan/remoting/CacheUnreachableException.java
@@ -1,0 +1,17 @@
+package org.infinispan.remoting;
+
+import org.jgroups.UnreachableException;
+
+/**
+ * Wraps the UnreachableException.
+ *
+ * @author Pedro Ruivo
+ * @since 7.0
+ */
+public class CacheUnreachableException extends RuntimeException {
+
+   public CacheUnreachableException(UnreachableException e) {
+      super(e.toString());
+   }
+
+}

--- a/core/src/test/java/org/infinispan/xsite/backupfailure/NonTxBackupFailureTest.java
+++ b/core/src/test/java/org/infinispan/xsite/backupfailure/NonTxBackupFailureTest.java
@@ -76,7 +76,8 @@ public class NonTxBackupFailureTest extends BaseBackupFailureTest {
 
       assertEquals("v2", cache("LON", 0).get("k"));
       assertEquals("v2", cache("LON", 1).get("k"));
-      assertTrue(failureInterceptor.replaceFailed);
+      //the ReplaceCommand is transformed in a PutKeyValueCommand when it succeeds in the originator site!
+      assertTrue(failureInterceptor.putFailed);
       assertEquals("v", backup("LON").get("k"));
    }
 

--- a/documentation/src/main/asciidoc/user_guide/chapter-65-Cross_site_replication.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-65-Cross_site_replication.adoc
@@ -164,7 +164,7 @@ This is the configuration file for the local (intra-site) infinispan cluster. It
 
 ----
 
-In order to allow inter-site calls, the RELAY2 protocol needs to be added to the protocol stack defined in the jgroups configuration (see attached $$https://gist.github.com/maniksurtani/409fe5ece5fe4bcf679f[jgroups.xml] for an example). 
+In order to allow inter-site calls, the RELAY2 protocol needs to be added to the protocol stack defined in the jgroups configuration (see attached link:https://gist.github.com/maniksurtani/409fe5ece5fe4bcf679f[jgroups.xml] for an example).
 
 ==== RELAY2 configuration file
 
@@ -231,7 +231,11 @@ The taking offline of a site can be configured as follows:
 
 ----
 
-The _takeOfline_ element under the _backup_ configures the taking offline of a site: * _afterFailure_ - the number of failed backup operations after which this site should be taken offline. Defaults to 0 (never). A negative value would mean that the site will be taken offline after _minTimeToWait_ * _minTimeToWait_ - the number of milliseconds in which a site is not marked offline even if it is unreachable for 'afterFailures' number of times. If smaller or equal to 0, then only _afterFailures_ is considered. 
+The _takeOfline_ element under the _backup_ configures the taking offline of a site:
+
+* _afterFailure_ - the number of failed backup operations after which this site should be taken offline. Defaults to 0 (never). A negative value would mean that the site will be taken offline after _minTimeToWait_
+
+* _minTimeToWait_ - the number of milliseconds in which a site is not marked offline even if it is unreachable for 'afterFailures' number of times. If smaller or equal to 0, then only _afterFailures_ is considered.
 
 The equivalent programmatic configuration is:
 


### PR DESCRIPTION
- clear() and putAll() methods remain unchanged
- fixed a link and a list in the x-site documentation
- split the non-tx backup interceptor in two to allow sending the
  rpc for the backup nodes and backup sites concurrently

https://issues.jboss.org/browse/ISPN-3885
