### PR TITLE
ISPN-3873 Race condition on clustered cache start

### DIFF
--- a/core/src/main/java/org/infinispan/context/AbstractInvocationContextFactory.java
+++ b/core/src/main/java/org/infinispan/context/AbstractInvocationContextFactory.java
@@ -33,6 +33,10 @@ public abstract class AbstractInvocationContextFactory implements InvocationCont
    @Override
    public InvocationContext createRemoteInvocationContextForCommand(
          VisitableCommand cacheCommand, Address origin) {
-      return createRemoteInvocationContext(origin);
+	   if (keyEq != null) {
+		   return createRemoteInvocationContext(origin);
+	   } else {
+		   throw new IllegalStateException(getClass().getName() + " has not started yet, so it cannot create a command");
+	   }
    }
 }


### PR DESCRIPTION
If an InvocationContext is created for a command before this factory instance has been started, it gets a null Equivalence for the key which later causes a NullPointerException in EquivalentHashMap.

This causes a key to be left locked, causing timeouts later.

In this commit we throw an IllegalStateException to prevent the caller from attempting the command, thus not acquiring the lock, thus avoiding the issue.

https://issues.jboss.org/browse/ISPN-3873 
