### PR TITLE
ISPN-3921 Soft-Index File Store: (local files)-based cache store

### DIFF
--- a/persistence/soft-index/pom.xml
+++ b/persistence/soft-index/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+   <parent>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-persistence-parent</artifactId>
+      <version>7.0.0-SNAPSHOT</version>
+      <relativePath>../pom.xml</relativePath>
+   </parent>
+
+   <artifactId>infinispan-persistence-soft-index</artifactId>
+   <packaging>bundle</packaging>
+   <name>Infinispan Soft-Index CacheStore</name>
+   <description>Infinispan Soft-Index CacheStore module</description>
+
+   <dependencies>
+      <dependency>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>infinispan-core</artifactId>
+      </dependency>
+   </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <configuration>
+               <instructions>
+                  <Export-Package>
+                     ${project.groupId}.persistence.sfis.*;version=${project.version};-split-package:=error
+                  </Export-Package>
+               </instructions>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+</project>

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/Compactor.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/Compactor.java
@@ -1,0 +1,352 @@
+package org.infinispan.persistence.sifs;
+
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.util.TimeService;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * Component keeping the data about log file usage - as soon as entries from some file are overwritten so that the file
+ * becomes cluttered with old records, the valid records are moved to another file and the old ones are dropped.
+ * Expired records are moved as tombstones without values (records of entry removal).
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+class Compactor extends Thread {
+   private static final Log log = LogFactory.getLog(Compactor.class);
+   private static final boolean trace = log.isTraceEnabled();
+
+   private final ConcurrentMap<Integer, Stats> fileStats = new ConcurrentHashMap<Integer, Stats>();
+   private final BlockingQueue<Integer> scheduledCompaction = new LinkedBlockingQueue<Integer>();
+   private final BlockingQueue<IndexRequest> indexQueue;
+   private final FileProvider fileProvider;
+   private final TemporaryTable temporaryTable;
+   private final Marshaller marshaller;
+   private final TimeService timeService;
+   private final int maxFileSize;
+   private final double compactionThreshold;
+
+   private Index index;
+   // as processing single scheduled compaction takes a lot of time, we don't use the queue to signalize
+   private volatile boolean clearSignal = false;
+   private volatile boolean terminateSignal = false;
+   private volatile CountDownLatch compactorResume;
+   private volatile CountDownLatch compactorStop;
+
+
+   public Compactor(FileProvider fileProvider,
+                    TemporaryTable temporaryTable,
+                    BlockingQueue<IndexRequest> indexQueue,
+                    Marshaller marshaller, TimeService timeService, int maxFileSize, double compactionThreshold) {
+      super("BCS-Compactor");
+      this.fileProvider = fileProvider;
+      this.temporaryTable = temporaryTable;
+      this.indexQueue = indexQueue;
+      this.marshaller = marshaller;
+      this.timeService = timeService;
+      this.maxFileSize = maxFileSize;
+      this.compactionThreshold = compactionThreshold;
+      this.start();
+   }
+
+   public void setIndex(Index index) {
+      this.index = index;
+   }
+
+   public void releaseStats(int file) {
+      fileStats.remove(file);
+   }
+
+   public void free(int file, int size) {
+      // entries expired from compacted file are reported with file = -1
+      if (file < 0) return;
+      recordFreeSpace(getStats(file), file, size);
+   }
+
+   public void completeFile(int file) {
+      Stats stats = getStats(file);
+      stats.setCompleted();
+      if (stats.readyToBeScheduled(compactionThreshold, stats.getFree())) {
+         schedule(file, stats);
+      }
+   }
+
+   private Stats getStats(int file) {
+      Stats stats = fileStats.get(file);
+      if (stats == null) {
+         int fileSize = (int) fileProvider.getFileSize(file);
+         stats = new Stats(fileSize, 0);
+         Stats other = fileStats.putIfAbsent(file, stats);
+         if (other != null) {
+            if (fileSize > other.getTotal()) {
+               other.setTotal(fileSize);
+            }
+            return other;
+         }
+      }
+      if (stats.getTotal() < 0) {
+         int fileSize = (int) fileProvider.getFileSize(file);
+         if (fileSize >= 0) {
+            stats.setTotal(fileSize);
+         }
+      }
+      return stats;
+   }
+
+   private void recordFreeSpace(Stats stats, int file, int size) {
+      if (stats.addFree(size, compactionThreshold)) {
+         schedule(file, stats);
+      }
+   }
+
+   private void schedule(int file, Stats stats) {
+      try {
+         synchronized (stats) {
+            if (!stats.isScheduled()) {
+               log.debug(String.format("Scheduling file %d for compaction: %d/%d free", file, stats.free.get(), stats.total));
+               stats.setScheduled();
+               scheduledCompaction.put(file);
+            }
+         }
+      } catch (InterruptedException e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   @Override
+   public void run() {
+      try {
+         FileProvider.Log logFile = null;
+         int currentOffset = 0;
+         for(;;) {
+            Integer scheduledFile = null;
+            try {
+               scheduledFile = scheduledCompaction.poll(1, TimeUnit.MINUTES);
+            } catch (InterruptedException e) {
+            }
+            if (terminateSignal) {
+               if (logFile != null) {
+                  logFile.close();
+                  completeFile(logFile.fileId);
+               }
+               break;
+            }
+            if (clearSignal) {
+               pauseCompactor(logFile);
+               logFile = null;
+               continue;
+            }
+            if (scheduledFile == null) {
+               if (logFile != null) {
+                  logFile.close();
+                  completeFile(logFile.fileId);
+                  logFile = null;
+               }
+               continue;
+            }
+
+            log.debug("Compacting file " + scheduledFile);
+            int scheduledOffset = 0;
+            FileProvider.Handle handle = fileProvider.getFile(scheduledFile);
+            if (handle == null) {
+               throw new IllegalStateException("Compactor should not get deleted file for compaction!");
+            }
+            try {
+               while (!clearSignal && !terminateSignal) {
+                  EntryHeader header = EntryRecord.readEntryHeader(handle, scheduledOffset);
+                  if (header == null) {
+                     break;
+                  }
+                  byte[] serializedKey = EntryRecord.readKey(handle, header, scheduledOffset);
+                  Object key = marshaller.objectFromByteBuffer(serializedKey);
+
+                  boolean drop = true;
+                  EntryPosition entry = temporaryTable.get(key);
+                  if (entry != null) {
+                     synchronized (entry) {
+                        if (entry.file == scheduledFile && entry.offset == scheduledOffset) {
+                           drop = false;
+                        } else if (trace) {
+                           log.tracef("Key for %d:%d was found in temporary table on %d:%d",
+                                 scheduledFile, scheduledOffset, entry.file, entry.offset);
+                        }
+                     }
+                  } else {
+                     EntryPosition position = index.getPosition(key, serializedKey);
+                     if (position != null && position.file == scheduledFile && position.offset == scheduledOffset) {
+                        drop = false;
+                     } else if (trace) {
+                        if (position != null) {
+                           log.tracef("Key for %d:%d was found in index on %d:%d",
+                                 scheduledFile, scheduledOffset, position.file, position.offset);
+                        } else {
+                           log.tracef("Key for %d:%d was not found in index!", scheduledFile, scheduledOffset);
+                        }
+                     }
+                  }
+                  if (drop) {
+                     if (trace) {
+                        log.tracef("Drop %d:%d (%s)", scheduledFile, scheduledOffset,
+                              header.valueLength() > 0 ? "record" : "tombstone");
+                     }
+                     scheduledOffset += header.totalLength();
+                     continue;
+                  }
+
+                  if (logFile == null || currentOffset + header.totalLength() > maxFileSize) {
+                     if (logFile != null) {
+                        logFile.close();
+                        completeFile(logFile.fileId);
+                     }
+                     currentOffset = 0;
+                     logFile = fileProvider.getFileForLog();
+                     log.debug("Compacting to " + logFile.fileId);
+                  }
+
+                  byte[] serializedValue;
+                  byte[] serializedMetadata;
+                  int entryOffset;
+                  // we have to keep track of expired entries but only as tombstones - do not copy the value nor metadata
+                  if (header.valueLength() > 0 && (header.expiryTime() < 0 || header.expiryTime() > timeService.wallClockTime())) {
+                     serializedMetadata = EntryRecord.readMetadata(handle, header, scheduledOffset);
+                     serializedValue = EntryRecord.readValue(handle, header, scheduledOffset);
+                     entryOffset = currentOffset;
+                  } else {
+                     serializedMetadata = null;
+                     serializedValue = null;
+                     entryOffset = ~currentOffset;
+                  }
+
+                  EntryRecord.writeEntry(logFile.fileChannel, serializedKey, serializedMetadata, serializedValue, header.seqId(), header.expiryTime());
+                  temporaryTable.setConditionally(key, logFile.fileId, entryOffset, scheduledFile, scheduledOffset);
+                  if (trace) {
+                     log.tracef("Update %d:%d -> %d:%d | %d,%d", scheduledFile, scheduledOffset, logFile.fileId, entryOffset, logFile.fileChannel.position(), logFile.fileChannel.size());
+                  }
+                  // entryFile cannot be used as we have to report the file due to free space statistics
+                  indexQueue.put(new IndexRequest(key, serializedKey,
+                        logFile.fileId, entryOffset,
+                        header.totalLength(), scheduledFile, scheduledOffset));
+
+                  currentOffset += header.totalLength();
+                  scheduledOffset += header.totalLength();
+               }
+            } finally {
+               handle.close();
+            }
+            if (terminateSignal) {
+               if (logFile != null) {
+                  logFile.close();
+                  completeFile(logFile.fileId);
+               }
+               return;
+            } else if (clearSignal) {
+               pauseCompactor(logFile);
+               logFile = null;
+            } else {
+               // The deletion must be executed only after the index is fully updated.
+               log.debugf("Finished compacting %d, scheduling delete", scheduledFile);
+               indexQueue.put(IndexRequest.deleteFileRequest(scheduledFile));
+            }
+         }
+      } catch (IOException e) {
+         throw new RuntimeException(e);
+      } catch (ClassNotFoundException e) {
+         throw new RuntimeException(e);
+      } catch (InterruptedException e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   private void pauseCompactor(FileProvider.Log logFile) throws IOException, InterruptedException {
+      if (logFile != null) {
+         logFile.close();
+         completeFile(logFile.fileId);
+      }
+      compactorStop.countDown();
+      compactorResume.await();
+   }
+
+   public void clearAndPause() throws InterruptedException {
+      compactorResume = new CountDownLatch(1);
+      compactorStop = new CountDownLatch(1);
+      clearSignal = true;
+      scheduledCompaction.put(-1);
+      compactorStop.await();
+      scheduledCompaction.clear();
+      fileStats.clear();
+   }
+
+   public void resumeAfterPause() {
+      clearSignal = false;
+      compactorResume.countDown();
+   }
+
+   public void stopOperations() throws InterruptedException {
+      terminateSignal = true;
+      scheduledCompaction.put(-1);
+      this.join();
+   }
+
+   private static class Stats {
+      private final AtomicInteger free;
+      private volatile int total;
+      /* File is not 'completed' when we have not loaded that yet completely.
+         Files created by log appender/compactor are completed as soon as it closes them.
+         File cannot be scheduled for compaction until it's completed.
+         */
+      private volatile boolean completed = false;
+      private volatile boolean scheduled = false;
+
+      private Stats(int total, int free) {
+         this.free = new AtomicInteger(free);
+         this.total = total;
+      }
+
+      public int getTotal() {
+         return total;
+      }
+
+      public void setTotal(int total) {
+         this.total = total;
+      }
+
+      public boolean addFree(int size, double compactionThreshold) {
+         int free = this.free.addAndGet(size);
+         return readyToBeScheduled(compactionThreshold, free);
+      }
+
+      public int getFree() {
+         return free.get();
+      }
+
+      public boolean readyToBeScheduled(double compactionThreshold, int free) {
+         int total = this.total;
+         return completed && !scheduled && total >= 0 && free > total * compactionThreshold;
+      }
+
+      public boolean isScheduled() {
+         return scheduled;
+      }
+
+      public void setScheduled() {
+         scheduled = true;
+      }
+
+      public boolean isCompleted() {
+         return completed;
+      }
+
+      public void setCompleted() {
+         this.completed = true;
+      }
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/EntryHeader.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/EntryHeader.java
@@ -1,0 +1,58 @@
+package org.infinispan.persistence.sifs;
+
+import java.nio.ByteBuffer;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+class EntryHeader {
+   static final int MAGIC = 0xBE11A61C;
+   static final boolean useMagic = false;
+   static final int HEADER_SIZE = 24 + (useMagic ? 4 : 0);
+
+   private final int keyLength;
+   private final int valueLength;
+   private final int metadataLength;
+   private final long seqId;
+   private final long expiration;
+
+   public EntryHeader(ByteBuffer buffer) {
+      if (useMagic) {
+         if (buffer.getInt() != MAGIC) throw new IllegalStateException();
+      }
+      this.keyLength = buffer.getShort();
+      this.metadataLength = buffer.getShort();
+      this.valueLength = buffer.getInt();
+      this.seqId = buffer.getLong();
+      this.expiration = buffer.getLong();
+   }
+
+   public int keyLength() {
+      return keyLength;
+   }
+
+   public int metadataLength() {
+      return metadataLength;
+   }
+
+   public int valueLength() {
+      return valueLength;
+   }
+
+   public long seqId() {
+      return seqId;
+   }
+
+   public long expiryTime() {
+      return expiration;
+   }
+
+   @Override
+   public String toString() {
+      return String.format("[keyLength=%d, valueLength=%d, seqId=%d, expiration=%d]", keyLength, valueLength, seqId, expiration);
+   }
+
+   public int totalLength() {
+      return keyLength + metadataLength + valueLength + HEADER_SIZE;
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/EntryPosition.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/EntryPosition.java
@@ -1,0 +1,45 @@
+package org.infinispan.persistence.sifs;
+
+/**
+ * File-offset pair
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+class EntryPosition {
+   public final int file;
+   public final int offset;
+
+   public EntryPosition(int file, int offset) {
+      this.file = file;
+      this.offset = offset;
+   }
+
+   public boolean equals(long file, int offset) {
+      return this.file == file && this.offset == offset;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || !(o instanceof EntryPosition)) return false;
+
+      EntryPosition entryPosition = (EntryPosition) o;
+
+      if (file != entryPosition.file) return false;
+      if (offset != entryPosition.offset) return false;
+
+      return true;
+   }
+
+   @Override
+   public int hashCode() {
+      int result = file;
+      result = 31 * result + offset;
+      return result;
+   }
+
+   @Override
+   public String toString() {
+      return String.format("[%d:%d]", file, offset);
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/EntryRecord.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/EntryRecord.java
@@ -1,0 +1,151 @@
+package org.infinispan.persistence.sifs;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+/**
+ * Helper for reading/writing entries into file.
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+class EntryRecord {
+
+   private EntryHeader header;
+   private byte[] key;
+   private byte[] metadata;
+   private byte[] value;
+
+   public EntryRecord(EntryHeader header, byte[] key, byte[] metadata, byte[] value) {
+      this.header = header;
+      this.key = key;
+      this.metadata = metadata;
+      this.value = value;
+   }
+
+   public EntryHeader getHeader() {
+      return header;
+   }
+
+   public byte[] getKey() {
+      return key;
+   }
+
+   public byte[] getMetadata() {
+      return metadata;
+   }
+
+   public byte[] getValue() {
+      return value;
+   }
+
+   public EntryRecord loadMetadataAndValue(FileProvider.Handle handle, int offset) throws IOException {
+      int metadataOffset = offset + EntryHeader.HEADER_SIZE + header.keyLength();
+      if (header.metadataLength() > 0) {
+         metadata = new byte[header.metadataLength()];
+         if (read(handle, ByteBuffer.wrap(metadata), metadataOffset, header.metadataLength()) < 0) return null;
+      }
+      value = new byte[header.valueLength()];
+      if (read(handle, ByteBuffer.wrap(value), metadataOffset + header.metadataLength(), header.valueLength()) < 0) return null;
+      return this;
+   }
+
+   public static EntryHeader readEntryHeader(FileProvider.Handle handle, long offset) throws IOException {
+      ByteBuffer header = ByteBuffer.allocate(EntryHeader.HEADER_SIZE);
+      if (read(handle, header, offset, EntryHeader.HEADER_SIZE) < 0) return null;
+      header.flip();
+      try {
+         return new EntryHeader(header);
+      } catch (IllegalStateException e) {
+         throw new IllegalStateException("Error reading from " + handle.getFileId() + ":" + offset);
+      }
+   }
+
+   public static byte[] readKey(FileProvider.Handle handle, EntryHeader header, long offset) throws IOException {
+      byte[] key = new byte[header.keyLength()];
+      if (read(handle, ByteBuffer.wrap(key), offset + EntryHeader.HEADER_SIZE, header.keyLength()) < 0) return null;
+      return key;
+   }
+
+   public static byte[] readMetadata(FileProvider.Handle handle, EntryHeader header, long offset) throws IOException {
+      byte[] metadata = new byte[header.metadataLength()];
+      if (read(handle, ByteBuffer.wrap(metadata), offset + EntryHeader.HEADER_SIZE + header.keyLength(), header.metadataLength()) < 0) return null;
+      return metadata;
+   }
+
+   public static byte[] readValue(FileProvider.Handle handle, EntryHeader header, long offset) throws IOException {
+      byte[] value = new byte[header.valueLength()];
+      if (read(handle, ByteBuffer.wrap(value), offset + EntryHeader.HEADER_SIZE + header.keyLength() + header.metadataLength(), header.valueLength()) < 0) return null;
+      return value;
+   }
+
+   private static int read(FileProvider.Handle handle, ByteBuffer buffer, long position, int length) throws IOException {
+      int read = 0;
+      do {
+         int newRead = handle.read(buffer, position + read);
+         if (newRead < 0) {
+            return -1;
+         }
+         read += newRead;
+      } while (read < length);
+      return read;
+   }
+
+   private static boolean read(FileChannel fileChannel, ByteBuffer buffer, int length) throws IOException {
+      int read = 0;
+      do {
+         int newRead = fileChannel.read(buffer);
+         if (newRead < 0) {
+            return false;
+         }
+         read += newRead;
+      } while (read < length);
+      return true;
+   }
+
+   public static void writeEntry(FileChannel fileChannel, byte[] serializedKey, byte[] serializedMetadata, byte[] serializedValue, long seqId, long expiration) throws IOException {
+      ByteBuffer header = ByteBuffer.allocate(EntryHeader.HEADER_SIZE);
+      if (EntryHeader.useMagic) {
+         header.putInt(EntryHeader.MAGIC);
+      }
+      header.putShort((short) serializedKey.length);
+      header.putShort(serializedMetadata == null ? (short) 0 : (short) serializedMetadata.length);
+      header.putInt(serializedValue == null ? 0 : serializedValue.length);
+      header.putLong(seqId);
+      header.putLong(expiration);
+      header.flip();
+      write(fileChannel, header);
+      write(fileChannel, ByteBuffer.wrap(serializedKey));
+      if (serializedMetadata != null) {
+         write(fileChannel, ByteBuffer.wrap(serializedMetadata));
+      }
+      if (serializedValue != null) {
+         write(fileChannel, ByteBuffer.wrap(serializedValue));
+      }
+   }
+
+   public static void writeEntry(FileChannel fileChannel, org.infinispan.commons.io.ByteBuffer serializedKey, org.infinispan.commons.io.ByteBuffer serializedMetadata, org.infinispan.commons.io.ByteBuffer serializedValue, long seqId, long expiration) throws IOException {
+      ByteBuffer header = ByteBuffer.allocate(EntryHeader.HEADER_SIZE);
+      if (EntryHeader.useMagic) {
+         header.putInt(EntryHeader.MAGIC);
+      }
+      header.putShort((short) serializedKey.getLength());
+      header.putShort(serializedMetadata == null ? (short) 0 : (short) serializedMetadata.getLength());
+      header.putInt(serializedValue == null ? 0 : serializedValue.getLength());
+      header.putLong(seqId);
+      header.putLong(expiration);
+      header.flip();
+      write(fileChannel, header);
+      write(fileChannel, ByteBuffer.wrap(serializedKey.getBuf(), serializedKey.getOffset(), serializedKey.getLength()));
+      if (serializedMetadata != null) {
+         write(fileChannel, ByteBuffer.wrap(serializedMetadata.getBuf(), serializedMetadata.getOffset(), serializedMetadata.getLength()));
+      }
+      if (serializedValue != null) {
+         write(fileChannel, ByteBuffer.wrap(serializedValue.getBuf(), serializedValue.getOffset(), serializedValue.getLength()));
+      }
+   }
+
+   private static void write(FileChannel fileChannel, ByteBuffer buffer) throws IOException {
+      while (buffer.hasRemaining()) fileChannel.write(buffer);
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/FileProvider.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/FileProvider.java
@@ -1,0 +1,381 @@
+package org.infinispan.persistence.sifs;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * Provides resource management for files - only limited amount of files may be opened in one moment, and opened file
+ * should not be deleted. Also allows to generate file indexes.
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+class FileProvider {
+   private static final org.infinispan.util.logging.Log log = LogFactory.getLog(FileProvider.class);
+
+   private final File dataDir;
+   private final int openFileLimit;
+   private final ArrayBlockingQueue<Record> recordQueue;
+   private final ConcurrentMap<Integer, Record> openFiles = new ConcurrentHashMap<Integer, Record>();
+   private final AtomicInteger currentOpenFiles = new AtomicInteger(0);
+   private final ReadWriteLock lock = new ReentrantReadWriteLock();
+   private final Set<Integer> logFiles = new HashSet<Integer>();
+
+   private int nextFileId = 0;
+
+   public FileProvider(String dataDir, int openFileLimit) {
+      this.openFileLimit = openFileLimit;
+      this.recordQueue = new ArrayBlockingQueue<Record>(openFileLimit);
+      this.dataDir = new File(dataDir);
+      this.dataDir.mkdirs();
+   }
+
+   public Handle getFile(int fileId) throws IOException {
+      lock.readLock().lock();
+      try {
+         for (;;) {
+            Record record = openFiles.get(fileId);
+            if (record == null) {
+               for (;;) {
+                  int open = currentOpenFiles.get();
+                  if (open >= openFileLimit) {
+                     // we'll continue only after some other file will be closed
+                     if (tryCloseFile()) break;
+                  } else {
+                     if (currentOpenFiles.compareAndSet(open, open + 1)) {
+                        break;
+                     }
+                  }
+               }
+               // now we have either removed some other opened file or incremented the value below limit
+               for (;;) {
+                  FileChannel fileChannel;
+                  try {
+                     fileChannel = openChannel(fileId);
+                  } catch (FileNotFoundException e) {
+                     currentOpenFiles.decrementAndGet();
+                     log.debug("File " + fileId + " was not found", e);
+                     return null;
+                  }
+                  Record newRecord = new Record(fileChannel, fileId);
+                  Record other = openFiles.putIfAbsent(fileId, newRecord);
+                  if (other != null) {
+                     fileChannel.close();
+                     synchronized (other) {
+                        if (other.isOpen()) {
+                           // we have allocated opening a new file but then we use an old one
+                           currentOpenFiles.decrementAndGet();
+                           return new Handle(other);
+                        }
+                     }
+                  } else {
+                     Handle handle;
+                     synchronized (newRecord) {
+                        // the new file cannot be closed but it can be simultaneously fetched multiple times
+                        if (!newRecord.isOpen()) {
+                           throw new IllegalStateException();
+                        }
+                        handle = new Handle(newRecord);
+                     }
+                     try {
+                        recordQueue.put(newRecord);
+                     } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                     }
+                     return handle;
+                  }
+               }
+            }
+            synchronized (record) {
+               if (record.isOpen()) {
+                  return new Handle(record);
+               }
+            }
+         }
+      } finally {
+         lock.readLock().unlock();
+      }
+   }
+
+   public long getFileSize(int file) {
+      lock.readLock().lock();
+      try {
+         if (logFiles.contains(file)) {
+            return -1;
+         }
+         return new File(dataDir, String.valueOf(file)).length();
+      } finally {
+         lock.readLock().unlock();
+      }
+   }
+
+   private boolean tryCloseFile() throws IOException {
+      Record removed;
+      try {
+         removed = recordQueue.take();
+      } catch (InterruptedException e) {
+         throw new RuntimeException(e);
+      }
+      synchronized (removed) {
+         if (removed.isUsed()) {
+            try {
+               recordQueue.put(removed);
+            } catch (InterruptedException e) {
+               throw new RuntimeException(e);
+            }
+         } else {
+            if (removed.isOpen()) {
+               // if the file was marked deleteOnClose it may have been already closed, but it couldn't be removed from
+               // the queue
+               removed.close();
+               openFiles.remove(removed.getFileId(), removed);
+            }
+            return true;
+         }
+      }
+      return false;
+   }
+
+   protected FileChannel openChannel(int fileId) throws FileNotFoundException {
+      return new RandomAccessFile(new File(dataDir, String.valueOf(fileId)), "r").getChannel();
+   }
+
+   public Log getFileForLog() throws IOException {
+      lock.writeLock().lock();
+      try {
+         for (;;) {
+            File f = new File(dataDir, String.valueOf(nextFileId));
+            if (f.exists()) {
+               if (nextFileId == Integer.MAX_VALUE) {
+                  nextFileId = 0;
+               } else {
+                  nextFileId++;
+               }
+            } else {
+               logFiles.add(nextFileId);
+               return new Log(nextFileId, new FileOutputStream(new File(dataDir, String.valueOf(nextFileId))).getChannel());
+            }
+         }
+      } finally {
+         lock.writeLock().unlock();
+      }
+   }
+
+   public Iterator<Integer> getFileIterator() {
+      Set<Integer> set = new HashSet<Integer>();
+      for (String file : dataDir.list()) {
+         if (file.matches("[0-9]*")) {
+            set.add(Integer.parseInt(file));
+         }
+      }
+      return set.iterator();
+   }
+
+   public void clear() throws IOException {
+      lock.writeLock().lock();
+      log.debug("Dropping all data");
+      while (currentOpenFiles.get() > 0) {
+         if (tryCloseFile()) {
+            if (currentOpenFiles.decrementAndGet() == 0) {
+               break;
+            }
+         }
+      }
+      if (!recordQueue.isEmpty()) throw new IllegalStateException();
+      if (!openFiles.isEmpty()) throw new IllegalStateException();
+      for (File file : dataDir.listFiles()) {
+         if (!file.delete()) {
+            throw new IOException("Cannot delete file " + file);
+         }
+      }
+      lock.writeLock().unlock();
+   }
+
+   public void deleteFile(int fileId) {
+      lock.readLock().lock();
+      try {
+         for (;;) {
+            Record newRecord = new Record(null, fileId);
+            Record record = openFiles.putIfAbsent(fileId, newRecord);
+            if (record == null) {
+               newRecord.delete();
+               openFiles.remove(fileId, newRecord);
+               return;
+            }
+            synchronized (record) {
+               if (openFiles.get(fileId) == record) {
+                  try {
+                     record.deleteOnClose();
+                  } catch (IOException e) {
+                     log.error("Cannot close/delete file " + fileId, e);
+                  }
+                  break;
+               }
+            }
+         }
+      } finally {
+         lock.readLock().unlock();
+      }
+   }
+
+   public void stop() {
+      int open = currentOpenFiles.get();
+      while (open > 0) {
+         try {
+            if (tryCloseFile()) {
+               open = currentOpenFiles.decrementAndGet();
+            } else {
+               // we can't close any further file
+               break;
+            }
+         } catch (IOException e) {
+            log.error("Failed to close file", e);
+         }
+      }
+      if (currentOpenFiles.get() != 0) {
+         for (Map.Entry<Integer, Record> entry : openFiles.entrySet()) {
+            log.warn("File " + entry.getKey() + " open: " + entry.getValue().handleCount + " handles");
+         }
+      }
+   }
+
+   public final class Log implements Closeable {
+      public final int fileId;
+      public final FileChannel fileChannel;
+
+      public Log(int fileId, FileChannel fileChannel) {
+         this.fileId = fileId;
+         this.fileChannel = fileChannel;
+      }
+
+      @Override
+      public void close() throws IOException {
+         fileChannel.close();
+         lock.writeLock().lock();
+         try {
+            logFiles.remove(fileId);
+         } finally {
+            lock.writeLock().unlock();
+         }
+      }
+   }
+
+   public static final class Handle implements Closeable {
+      private boolean usable = true;
+      private Record record;
+
+      private Handle(Record record) {
+         this.record = record;
+         record.increaseHandleCount();
+      }
+
+      public int read(ByteBuffer buffer, long offset) throws IOException {
+         if (!usable) throw new IllegalStateException();
+         return record.getFileChannel().read(buffer, offset);
+      }
+
+      @Override
+      public void close() throws IOException {
+         usable = false;
+         synchronized (record) {
+            record.decreaseHandleCount();
+         }
+      }
+
+      public long getFileSize() throws IOException {
+         return record.fileChannel.size();
+      }
+
+      public int getFileId() {
+         return record.getFileId();
+      }
+   }
+
+   private class Record {
+      private final int fileId;
+      private FileChannel fileChannel;
+      private int handleCount;
+      private boolean deleteOnClose = false;
+
+      private Record(FileChannel fileChannel, int fileId) {
+         this.fileChannel = fileChannel;
+         this.fileId = fileId;
+      }
+
+      FileChannel getFileChannel() {
+         return fileChannel;
+      }
+
+      void increaseHandleCount() {
+         handleCount++;
+      }
+
+      void decreaseHandleCount() throws IOException {
+         handleCount--;
+         if (handleCount == 0 && deleteOnClose) {
+            // we cannot easily remove the record from queue - keep it there until collection,
+            // but physically close and delete the file
+            fileChannel.close();
+            fileChannel = null;
+            openFiles.remove(fileId, this);
+            delete();
+         }
+      }
+
+      boolean isOpen() {
+         return fileChannel != null;
+      }
+
+      boolean isUsed() {
+         return handleCount > 0;
+      }
+
+      public int getFileId() {
+         return fileId;
+      }
+
+      public void close() throws IOException {
+         fileChannel.close();
+         fileChannel = null;
+         if (deleteOnClose) {
+            delete();
+         }
+      }
+
+      public void delete() {
+         log.debug("Deleting file " + fileId);
+         new File(dataDir, String.valueOf(fileId)).delete();
+      }
+
+      public void deleteOnClose() throws IOException {
+         if (handleCount == 0) {
+            if (fileChannel != null) {
+               fileChannel.close();
+               fileChannel = null;
+            }
+            openFiles.remove(fileId, this);
+            delete();
+         } else {
+            log.debug("Marking file " + fileId + " for deletion");
+            deleteOnClose = true;
+         }
+      }
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/Index.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/Index.java
@@ -1,0 +1,361 @@
+package org.infinispan.persistence.sifs;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.infinispan.commons.equivalence.Equivalence;
+import org.infinispan.util.TimeService;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * Keeps the entry positions persisted in a file. It consists of couple of segments, each for one modulo-range
+ * of key's hashcodes (according to DataContainer's key equivalence configuration) - writes to each index segment
+ * are performed by single thread, having multiple segments spreads the load between them.
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+class Index {
+   private static final Log log = LogFactory.getLog(Index.class);
+   private static final boolean trace = log.isTraceEnabled();
+
+   private final String indexDir;
+   private final FileProvider fileProvider;
+   private final Compactor compactor;
+   private final int minNodeSize;
+   private final int maxNodeSize;
+   private final ReadWriteLock lock = new ReentrantReadWriteLock();
+   private final Segment[] segments;
+   private final TimeService timeService;
+   private final Equivalence<Object> keyEquivalence;
+
+   public Index(FileProvider fileProvider, String indexDir, int segments, int minNodeSize, int maxNodeSize,
+                IndexQueue indexQueue, TemporaryTable temporaryTable, Compactor compactor,
+                TimeService timeService, Equivalence<Object> keyEquivalence) throws IOException {
+      this.fileProvider = fileProvider;
+      this.compactor = compactor;
+      this.timeService = timeService;
+      this.keyEquivalence = keyEquivalence;
+      this.indexDir = indexDir;
+      this.minNodeSize = minNodeSize;
+      this.maxNodeSize = maxNodeSize;
+      new File(indexDir).mkdirs();
+
+      this.segments = new Segment[segments];
+      for (int i = 0; i < segments; ++i) {
+         this.segments[i] = new Segment(i, indexQueue.subQueue(i), temporaryTable);
+      }
+   }
+
+   public EntryRecord getRecord(Object key, byte[] serializedKey) throws IOException {
+      int segment = Math.abs(keyEquivalence.hashCode(key)) % segments.length;
+      lock.readLock().lock();
+      try {
+         return IndexNode.applyOnLeaf(segments[segment], serializedKey, segments[segment].rootReadLock(), IndexNode.ReadOperation.GET_RECORD);
+      } finally {
+         lock.readLock().unlock();
+      }
+   }
+
+   public EntryPosition getPosition(Object key, byte[] serializedKey) throws IOException {
+      int segment = Math.abs(keyEquivalence.hashCode(key)) % segments.length;
+      lock.readLock().lock();
+      try {
+         return IndexNode.applyOnLeaf(segments[segment], serializedKey, segments[segment].rootReadLock(), IndexNode.ReadOperation.GET_POSITION);
+      } finally {
+         lock.readLock().unlock();
+      }
+   }
+
+
+   public void clear() throws IOException {
+      lock.writeLock().lock();
+      try {
+         ArrayList<CountDownLatch> pauses = new ArrayList<CountDownLatch>();
+         for (Segment seg : segments) {
+            pauses.add(seg.pauseAndClear());
+         }
+         for (CountDownLatch pause : pauses) {
+            pause.countDown();
+         }
+      } catch (InterruptedException e) {
+         throw new RuntimeException(e);
+      } finally {
+         lock.writeLock().unlock();
+      }
+   }
+
+   public void stopOperations() throws InterruptedException {
+      for (Segment seg : segments) {
+         seg.stopOperations();
+      }
+   }
+
+   public long size() throws InterruptedException {
+      long size = 0;
+      for (Segment seg : segments) {
+         size += seg.size();
+      }
+      return size;
+   }
+
+   class Segment extends Thread {
+      private final BlockingQueue<IndexRequest> indexQueue;
+      private final TemporaryTable temporaryTable;
+      private final TreeMap<Integer, List<IndexSpace>> freeBlocks = new TreeMap<Integer, List<IndexSpace>>();
+      private final ReadWriteLock rootLock = new ReentrantReadWriteLock();
+      private final File indexFileFile;
+      private FileChannel indexFile;
+      private long indexFileSize = 0;
+      private AtomicLong size = new AtomicLong();
+
+      private volatile IndexNode root = IndexNode.emptyWithLeaves(this);
+
+
+      private Segment(int id, BlockingQueue<IndexRequest> indexQueue, TemporaryTable temporaryTable) throws IOException {
+         super("BCS-IndexUpdater-" + id);
+         this.setDaemon(true);
+         this.indexQueue = indexQueue;
+         this.temporaryTable = temporaryTable;
+
+         this.indexFileFile = new File(indexDir, "index." + id);
+         this.indexFile = new RandomAccessFile(indexFileFile, "rw").getChannel();
+         this.indexFile.truncate(0);
+
+         start();
+      }
+
+      @Override
+      public void run() {
+         try {
+            int counter = 0;
+            while (true) {
+               if (++counter % 30000 == 0) {
+                  log.debug("Queue size is " + indexQueue.size());
+               }
+               final IndexRequest request = indexQueue.take();
+               if (trace) log.trace("Indexing " + request);
+               switch (request.getType()) {
+                  case CLEAR:
+                     IndexRequest cleared;
+                     while ((cleared = indexQueue.poll()) != null) {
+                        cleared.setResult(false);
+                     }
+                     CountDownLatch pause = new CountDownLatch(1);
+                     request.setResult(pause);
+                     log.debug("Waiting for cleared " + System.nanoTime());
+                     pause.await();
+                     continue;
+                  case DELETE_FILE:
+                     // the last segment that processes the delete request actually deletes the file
+                     if (request.countDown()) {
+                        fileProvider.deleteFile(request.getFile());
+                        compactor.releaseStats(request.getFile());
+                     }
+                     continue;
+                  case STOP:
+                     return;
+                  case GET_SIZE :
+                     request.setResult(size.get());
+                     continue;
+               }
+
+               IndexNode.OverwriteHook overwriteHook;
+               if (request.isCompareAndSet()) {
+                  overwriteHook = new IndexNode.OverwriteHook() {
+                     @Override
+                     public boolean check(int oldFile, int oldOffset) {
+                        return oldFile == request.getPrevFile() && oldOffset == request.getPrevOffset();
+                     }
+
+                     @Override
+                     public void setOverwritten(boolean overwritten, int prevFile, int prevOffset) {
+                        if (overwritten && request.getOffset() < 0 && request.getPrevOffset() >= 0) {
+                           size.decrementAndGet();
+                        }
+                     }
+                  };
+               } else {
+                  overwriteHook = new IndexNode.OverwriteHook() {
+                     @Override
+                     public void setOverwritten(boolean overwritten, int prevFile, int prevOffset) {
+                        request.setResult(overwritten);
+                        if (request.getOffset() >= 0 && prevOffset < 0) {
+                           size.incrementAndGet();
+                        } else if (request.getOffset() < 0 && prevOffset >= 0) {
+                           size.decrementAndGet();
+                        }
+                     }
+                  };
+               }
+               try {
+                  IndexNode.setPosition(root, request.getSerializedKey(), request.getFile(), request.getOffset(), request.getSize(), overwriteHook);
+               } catch (IllegalStateException e) {
+                  throw new IllegalStateException(request.toString(), e);
+               }
+               request.setResult(false);
+               temporaryTable.removeConditionally(request.getKey(), request.getFile(), request.getOffset());
+            }
+         } catch (IOException e) {
+            throw new RuntimeException(e);
+         } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+         } catch (Exception e) {
+            log.error("Error in indexer thread", e);
+         } finally {
+            try {
+               indexFile.close();
+               indexFileFile.delete();
+            } catch (IOException e) {
+               log.error("Failed to close/delete the index", e);
+            }
+         }
+      }
+
+      public CountDownLatch pauseAndClear() throws InterruptedException, IOException {
+         IndexRequest clear = IndexRequest.clearRequest();
+         indexQueue.put(clear);
+         CountDownLatch pause = (CountDownLatch) clear.getResult();
+         root = IndexNode.emptyWithLeaves(this);
+         indexFile.truncate(0);
+         indexFileSize = 0;
+         freeBlocks.clear();
+         size.set(0);
+         return pause;
+      }
+
+      public long size() throws InterruptedException {
+         IndexRequest sizeRequest = IndexRequest.sizeRequest();
+         indexQueue.put(sizeRequest);
+         return (Long) sizeRequest.getResult();
+      }
+
+      public FileChannel getIndexFile() {
+         return indexFile;
+      }
+
+      public FileProvider getFileProvider() {
+         return fileProvider;
+      }
+
+      public Compactor getCompactor() {
+         return compactor;
+      }
+
+      public IndexNode getRoot() {
+         // this has to be called with rootLock locked!
+         return root;
+      }
+
+      public void setRoot(IndexNode root) {
+         rootLock.writeLock().lock();
+         this.root = root;
+         rootLock.writeLock().unlock();
+      }
+
+      public int getMaxNodeSize() {
+         return maxNodeSize;
+      }
+
+      public int getMinNodeSize() {
+         return minNodeSize;
+      }
+
+      // this should be accessed only from the updater thread
+      IndexSpace allocateIndexSpace(int length) {
+         Map.Entry<Integer, List<IndexSpace>> entry = freeBlocks.ceilingEntry(length);
+         if (entry == null || entry.getValue().isEmpty()) {
+            long oldSize = indexFileSize;
+            indexFileSize += length;
+            return new IndexSpace(oldSize, length);
+         } else {
+            return entry.getValue().remove(entry.getValue().size() - 1);
+         }
+      }
+
+      // this should be accessed only from the updater thread
+      void freeIndexSpace(long offset, int length) {
+         if (length <= 0) throw new IllegalArgumentException("Offset=" + offset + ", length=" + length);
+         // TODO: fragmentation!
+         // TODO: memory bounds!
+         if (offset + length < indexFileSize) {
+            List<IndexSpace> list = freeBlocks.get(length);
+            if (list == null) {
+               freeBlocks.put(length, list = new ArrayList<IndexSpace>());
+            }
+            list.add(new IndexSpace(offset, length));
+         } else {
+            indexFileSize -= length;
+            try {
+               indexFile.truncate(indexFileSize);
+            } catch (IOException e) {
+               log.warn("Cannot truncate index", e);
+            }
+         }
+      }
+
+      public Lock rootReadLock() {
+         return rootLock.readLock();
+      }
+
+      public void stopOperations() throws InterruptedException {
+         indexQueue.put(IndexRequest.stopRequest());
+         this.join();
+      }
+
+      public TimeService getTimeService() {
+         return timeService;
+      }
+   }
+
+   /**
+    * Offset-length pair
+    */
+   static class IndexSpace {
+      protected long offset;
+      protected int length;
+
+      public IndexSpace(long offset, int length) {
+         this.offset = offset;
+         this.length = length;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) return true;
+         if (o == null || !(o instanceof IndexSpace)) return false;
+
+         IndexSpace innerNode = (IndexSpace) o;
+
+         if (length != innerNode.length) return false;
+         if (offset != innerNode.offset) return false;
+
+         return true;
+      }
+
+      @Override
+      public int hashCode() {
+         int result = (int) (offset ^ (offset >>> 32));
+         result = 31 * result + length;
+         return result;
+      }
+
+      @Override
+      public String toString() {
+         return String.format("[%d-%d(%d)]", offset, offset + length, length);
+      }
+   }
+
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/IndexNode.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/IndexNode.java
@@ -1,0 +1,951 @@
+package org.infinispan.persistence.sifs;
+
+import java.io.IOException;
+import java.lang.ref.SoftReference;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Stack;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.infinispan.persistence.spi.PersistenceException;
+import org.infinispan.util.TimeService;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * The recursive index structure. References to children are held in soft references,
+ * which allows JVM-handled caching and reduces the amount of reads required while
+ * evading OOMs if the index gets too big.
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+class IndexNode {
+   private static final Log log = LogFactory.getLog(IndexNode.class);
+   private static final boolean trace = log.isTraceEnabled();
+
+   private static final byte HAS_LEAVES = 1;
+   private static final int INNER_NODE_HEADER_SIZE = 5;
+   private static final int INNER_NODE_REFERENCE_SIZE = 10;
+   private static final int LEAF_NODE_REFERENCE_SIZE = 8;
+
+   public static final int RESERVED_SPACE
+         = INNER_NODE_HEADER_SIZE + 2 * Math.max(INNER_NODE_REFERENCE_SIZE, LEAF_NODE_REFERENCE_SIZE);
+
+   private Index.Segment segment;
+   private byte[] prefix;
+   private byte[][] keyParts;
+   InnerNode[] innerNodes;
+   private LeafNode[] leafNodes;
+   private ReadWriteLock lock = new ReentrantReadWriteLock();
+   private long offset = -1;
+   private int contentLength = -1;
+   private int totalLength = -1;
+   private int occupiedSpace;
+
+   public IndexNode(Index.Segment segment, long offset, int occupiedSpace) throws IOException {
+      this.segment = segment;
+      this.offset = offset;
+      this.occupiedSpace = occupiedSpace;
+
+      ByteBuffer buffer = loadBuffer(segment.getIndexFile(), offset, occupiedSpace);
+
+      prefix = new byte[buffer.getShort()];
+      buffer.get(prefix);
+
+      byte flags = buffer.get();
+      int numKeyParts = buffer.getShort();
+
+      keyParts = new byte[numKeyParts][];
+      for (int i = 0; i < numKeyParts; ++i) {
+         keyParts[i] = new byte[buffer.getShort()];
+         buffer.get(keyParts[i]);
+      }
+
+      if ((flags & HAS_LEAVES) != 0) {
+         leafNodes = new LeafNode[numKeyParts + 1];
+         for (int i = 0; i < numKeyParts + 1; ++i) {
+            leafNodes[i] = new LeafNode(buffer.getInt(), buffer.getInt());
+         }
+      } else {
+         innerNodes = new InnerNode[numKeyParts + 1];
+         for (int i = 0; i < numKeyParts + 1; ++i) {
+            innerNodes[i] = new InnerNode(buffer.getLong(), buffer.getShort());
+         }
+      }
+
+      if (trace) log.tracef("Loaded %08x from %d:%d (length %d)", System.identityHashCode(this), offset, occupiedSpace, length());
+   }
+
+   private static ByteBuffer loadBuffer(FileChannel indexFile, long offset, int occupiedSpace) throws IOException {
+      ByteBuffer buffer = ByteBuffer.allocate(occupiedSpace);
+      int read = 0;
+      do {
+         int nowRead = indexFile.read(buffer, offset + read);
+         if (nowRead < 0) {
+            throw new IOException("Cannot read record [" + offset + ":" + occupiedSpace + "] (already read "
+                  + read + "), file size is " + indexFile.size());
+         }
+         read += nowRead;
+      } while (read < occupiedSpace);
+      buffer.rewind();
+      return buffer;
+   }
+
+   IndexNode(Index.Segment segment, byte[] newPrefix, byte[][] newKeyParts, LeafNode[] newLeafNodes) {
+      this.segment = segment;
+      this.prefix = newPrefix;
+      this.keyParts = newKeyParts;
+      this.leafNodes = newLeafNodes;
+   }
+
+   IndexNode(Index.Segment segment, byte[] newPrefix, byte[][] newKeyParts, InnerNode[] newInnerNodes) {
+      this.segment = segment;
+      this.prefix = newPrefix;
+      this.keyParts = newKeyParts;
+      this.innerNodes = newInnerNodes;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      IndexNode indexNode = (IndexNode) o;
+
+      if (!Arrays.equals(innerNodes, indexNode.innerNodes)) return false;
+      if (!Arrays.equals(leafNodes, indexNode.leafNodes)) return false;
+      if (!Arrays.equals(prefix, indexNode.prefix)) return false;
+      if (!Arrays.deepEquals(keyParts, indexNode.keyParts)) return false;
+
+      return true;
+   }
+
+   /**
+    * Can be called only from single writer thread (therefore the write lock guards only other readers)
+    * @param other
+    */
+   public void replaceContent(IndexNode other) throws IOException {
+      try {
+         lock.writeLock().lock();
+         this.prefix = other.prefix;
+         this.keyParts = other.keyParts;
+         this.innerNodes = other.innerNodes;
+         this.leafNodes = other.leafNodes;
+         this.contentLength = -1;
+         this.totalLength = -1;
+      } finally {
+         lock.writeLock().unlock();
+      }
+
+      // don't have to acquire any lock here
+      // the only node with offset < 0 is the root - we can't lose reference to it
+      if (offset >= 0) {
+         store(new Index.IndexSpace(offset, occupiedSpace));
+      }
+   }
+
+   private void store(Index.IndexSpace indexSpace) throws IOException {
+      this.offset = indexSpace.offset;
+      this.occupiedSpace = indexSpace.length;
+      ByteBuffer buffer = ByteBuffer.allocate(length());
+      buffer.putShort((short) prefix.length);
+      buffer.put(prefix);
+      buffer.put(innerNodes == null ? HAS_LEAVES : 0);
+      buffer.putShort((short) keyParts.length);
+      for (int i = 0; i < keyParts.length; ++i) {
+         buffer.putShort((short) keyParts[i].length);
+         buffer.put(keyParts[i]);
+      }
+      if (innerNodes != null) {
+         for (int i = 0; i < innerNodes.length; ++i) {
+            buffer.putLong(innerNodes[i].offset);
+            buffer.putShort((short) innerNodes[i].length);
+         }
+      } else {
+         for (int i = 0; i < leafNodes.length; ++i) {
+            buffer.putInt(leafNodes[i].file);
+            buffer.putInt(leafNodes[i].offset);
+         }
+      }
+      buffer.flip();
+      segment.getIndexFile().write(buffer, offset);
+
+      if (trace) log.tracef("Persisted %08x (length %d, %d %s) to %d:%d", System.identityHashCode(this), length(),
+            innerNodes != null ? innerNodes.length : leafNodes.length,
+            innerNodes != null ? "children" : "leaves", offset, occupiedSpace);
+   }
+
+   private static class Path {
+      public IndexNode node;
+      public int index;
+
+      private Path(IndexNode node, int index) {
+         this.node = node;
+         this.index = index;
+      }
+   }
+
+   public enum ReadOperation {
+      GET_RECORD {
+         @Override
+         protected EntryRecord apply(LeafNode leafNode, byte[] key, FileProvider fileProvider, TimeService timeService) throws IOException, IndexNodeOutdatedException {
+            return leafNode.loadRecord(fileProvider, key, timeService);
+         }
+      },
+      GET_POSITION {
+         @Override
+         protected EntryPosition apply(LeafNode leafNode, byte[] key, FileProvider fileProvider, TimeService timeService) throws IOException, IndexNodeOutdatedException {
+            EntryRecord hak = leafNode.loadHeaderAndKey(fileProvider, timeService);
+            if (hak != null && hak.getKey() != null && Arrays.equals(hak.getKey(), key)) {
+               return leafNode;
+            }
+            return null;
+         }
+      };
+
+      protected abstract <T> T apply(LeafNode leafNode, byte[] key, FileProvider fileProvider, TimeService timeService) throws IOException, IndexNodeOutdatedException;
+   }
+
+   public static <T> T applyOnLeaf(Index.Segment segment, byte[] key, Lock rootLock, ReadOperation operation) throws IOException {
+      int attempts = 0;
+      ArrayList<IndexNode> path = new ArrayList<IndexNode>();
+      for (;;) {
+         rootLock.lock();
+         IndexNode node = segment.getRoot();
+         Lock parentLock = rootLock, currentLock = null;
+         try {
+            while (node.innerNodes != null) {
+               path.add(node);
+               currentLock = node.lock.readLock();
+               currentLock.lock();
+               if (parentLock != null) {
+                  parentLock.unlock();
+               }
+               parentLock = currentLock;
+               int insertionPoint = node.getInsertionPoint(key);
+               node = node.innerNodes[insertionPoint].getIndexNode(segment);
+               if (node == null) {
+                  return null;
+               }
+            }
+            currentLock = node.lock.readLock();
+            currentLock.lock();
+            if (node.leafNodes.length == 0) {
+               return null;
+            }
+            int insertionPoint = node.getInsertionPoint(key);
+            return operation.apply(node.leafNodes[insertionPoint], key, segment.getFileProvider(), segment.getTimeService());
+         } catch (IndexNodeOutdatedException e) {
+            try {
+               if (attempts > 10) {
+                  throw new PersistenceException("Index looks corrupt", e);
+               }
+               Thread.sleep(1000);
+               attempts++;
+               path.clear();
+            } catch (InterruptedException e1) {
+            }
+            // noop, we'll simply retry
+         } finally {
+            if (parentLock != currentLock && parentLock != null) parentLock.unlock();
+            if (currentLock != null) currentLock.unlock();
+         }
+      }
+   }
+
+   public static void setPosition(IndexNode root, byte[] key, int file, int offset, int size, OverwriteHook overwriteHook) throws IOException {
+      IndexNode node = root;
+      Stack<Path> stack = new Stack<Path>();
+      while (node.innerNodes != null) {
+         int insertionPoint = node.getInsertionPoint(key);
+         stack.push(new Path(node, insertionPoint));
+         if (trace) log.tracef("Pushed %08x (length %d, %d children) to stack (insertion point %d)", System.identityHashCode(node), node.length(), node.innerNodes.length, insertionPoint);
+         node = node.innerNodes[insertionPoint].getIndexNode(root.segment);
+      }
+      IndexNode copy = node.copyWith(key, file, offset, size, overwriteHook);
+      if (copy == node) {
+         // no change was executed
+         return;
+      }
+      if (trace) {
+         log.tracef("Created %08x (length %d) from %08x (length %d), stack size %d",
+               System.identityHashCode(copy), copy.length(), System.identityHashCode(node), node.length(), stack.size());
+      }
+
+      Stack<IndexNode> garbage = new Stack<IndexNode>();
+      try {
+         JoinSplitResult result = manageLength(root.segment, stack, node, copy, garbage);
+         if (result == null) {
+            return;
+         }
+         if (trace)
+            log.tracef("Created (1) %d new nodes, GC %08x", result.newNodes.size(), System.identityHashCode(node));
+         garbage.push(node);
+         for (;;) {
+            if (stack.isEmpty()) {
+               IndexNode newRoot;
+               if (result.newNodes.size() == 1) {
+                  newRoot = result.newNodes.get(0);
+                  if (trace) log.tracef("Setting new root %08x (index has shrunk)", System.identityHashCode(newRoot));
+               } else {
+                  newRoot = IndexNode.emptyWithInnerNodes(root.segment).copyWith(0, 0, result.newNodes);
+                  if (trace) log.tracef("Setting new root %08x (index has grown)", System.identityHashCode(newRoot));
+               }
+               newRoot.segment.setRoot(newRoot);
+               return;
+            }
+            Path path = stack.pop();
+            copy = path.node.copyWith(result.from, result.to, result.newNodes);
+            if (trace) {
+               log.tracef("Created %08x (length %d) from %08x with the %d new nodes (%d - %d)",
+                     System.identityHashCode(copy), copy.length(), System.identityHashCode(path.node), result.newNodes.size(), result.from, result.to);
+            }
+            result = manageLength(path.node.segment, stack, path.node, copy, garbage);
+            if (result == null) {
+               if (trace) log.tracef("No more index updates required");
+               return;
+            }
+            if (trace)
+               log.tracef("Created (2) %d new nodes, GC %08x", result.newNodes.size(), System.identityHashCode(path.node));
+            garbage.push(path.node);
+         }
+      } finally {
+         while (!garbage.isEmpty()) {
+            IndexNode oldNode = garbage.pop();
+            // this will be never unlocked, if the algorithm is correct, this node should be GC'ed soon.
+            oldNode.lock.writeLock().lock();
+            if (oldNode.offset >= 0) {
+               oldNode.segment.freeIndexSpace(oldNode.offset, oldNode.occupiedSpace);
+            }
+         }
+      }
+   }
+
+   private static class JoinSplitResult {
+      public final int from;
+      public final int to;
+      public final List<IndexNode> newNodes;
+
+      private JoinSplitResult(int from, int to, List<IndexNode> newNodes) {
+         this.from = from;
+         this.to = to;
+         this.newNodes = newNodes;
+      }
+   }
+
+   private static JoinSplitResult manageLength(Index.Segment segment, Stack<Path> stack, IndexNode node, IndexNode copy, Stack<IndexNode> garbage) throws IOException {
+      int from, to;
+      if (copy.length() < segment.getMinNodeSize() && !stack.isEmpty()) {
+         Path parent = stack.peek();
+         if (parent.node.innerNodes.length == 1) {
+            // we have no siblings - we can't merge with them even when we're really short
+            if (copy.length() <= node.occupiedSpace) {
+               node.replaceContent(copy);
+               return null;
+            } else {
+               return new JoinSplitResult(parent.index, parent.index, Collections.singletonList(copy));
+            }
+         }
+         int sizeWithLeft = Integer.MAX_VALUE;
+         int sizeWithRight = Integer.MAX_VALUE;
+         if (parent.index > 0) {
+            sizeWithLeft = copy.length() + parent.node.innerNodes[parent.index - 1].length - INNER_NODE_HEADER_SIZE;
+         }
+         if (parent.index < parent.node.innerNodes.length - 1) {
+            sizeWithRight = copy.length() + parent.node.innerNodes[parent.index + 1].length - INNER_NODE_HEADER_SIZE;
+         }
+         int joinWith;
+         // this is just some kind of heuristic, may be changed later
+         if (sizeWithLeft == Integer.MAX_VALUE) {
+            joinWith = parent.index + 1;
+         } else if (sizeWithRight == Integer.MAX_VALUE) {
+            joinWith = parent.index - 1;
+         } else if (sizeWithLeft > segment.getMaxNodeSize() && sizeWithRight > segment.getMaxNodeSize()) {
+            joinWith = sizeWithLeft >= sizeWithRight ? parent.index - 1 : parent.index + 1;
+         } else {
+            joinWith = sizeWithLeft <= sizeWithRight ? parent.index - 1 : parent.index + 1;
+         }
+         if (joinWith < 0 || joinWith >= parent.node.innerNodes.length) {
+            throw new IllegalStateException(String.format("parent %08x, %08x -> %08x: cannot join to %d, with left %d, with right %d, max %d",
+                  System.identityHashCode(parent.node), System.identityHashCode(node), System.identityHashCode(copy),
+                  joinWith, sizeWithLeft, sizeWithRight, segment.getMaxNodeSize()));
+         }
+         IndexNode joiner = parent.node.innerNodes[joinWith].getIndexNode(segment);
+         byte[] middleKey = concat(parent.node.prefix, parent.node.keyParts[joinWith < parent.index ? parent.index - 1 : parent.index]);
+         if (joinWith < parent.index) {
+            copy = join(joiner, middleKey, copy);
+            from = joinWith;
+            to = parent.index;
+         } else {
+            copy = join(copy, middleKey, joiner);
+            from = parent.index;
+            to = joinWith;
+         }
+         garbage.push(joiner);
+      } else if (copy.length() <= node.occupiedSpace) {
+         if (copy.innerNodes != null && copy.innerNodes.length == 1 && stack.isEmpty()) {
+            IndexNode child = copy.innerNodes[0].getIndexNode(copy.segment);
+            return new JoinSplitResult(0, 0, Collections.singletonList(child));
+         } else {
+            // special case where we only overwrite the key
+            node.replaceContent(copy);
+            return null;
+         }
+      } else if (stack.isEmpty()) {
+         from = to = 0;
+      } else {
+         from = to = stack.peek().index;
+      }
+      if (copy.length() <= segment.getMaxNodeSize()) {
+         return new JoinSplitResult(from, to, Collections.singletonList(copy));
+      } else {
+         return new JoinSplitResult(from, to, copy.split());
+      }
+   }
+
+   private static IndexNode join(IndexNode left, byte[] middleKey, IndexNode right) throws IOException {
+      byte[] newPrefix = commonPrefix(left.prefix, right.prefix);
+      byte[][] newKeyParts = new byte[left.keyParts.length + right.keyParts.length + 1][];
+      newPrefix = commonPrefix(newPrefix == null ? left.prefix : newPrefix, middleKey);
+      copyKeyParts(left.keyParts, 0, newKeyParts, 0, left.keyParts.length, left.prefix, newPrefix);
+      byte[] rightmostKey;
+      try {
+         rightmostKey = left.rightmostKey();
+      } catch (IndexNodeOutdatedException e) {
+         throw new IllegalStateException(e);
+      }
+      int commonLength = Math.abs(compare(middleKey, rightmostKey));
+      newKeyParts[left.keyParts.length] = substring(middleKey, newPrefix.length, commonLength);
+      copyKeyParts(right.keyParts, 0, newKeyParts, left.keyParts.length + 1, right.keyParts.length, right.prefix, newPrefix);
+      if (left.innerNodes != null && right.innerNodes != null) {
+         InnerNode[] newInnerNodes = new InnerNode[left.innerNodes.length + right.innerNodes.length];
+         System.arraycopy(left.innerNodes, 0, newInnerNodes, 0, left.innerNodes.length);
+         System.arraycopy(right.innerNodes, 0, newInnerNodes, left.innerNodes.length, right.innerNodes.length);
+         return new IndexNode(left.segment, newPrefix, newKeyParts, newInnerNodes);
+      } else if (left.leafNodes != null && right.leafNodes != null) {
+         LeafNode[] newLeafNodes = new LeafNode[left.leafNodes.length + right.leafNodes.length];
+         System.arraycopy(left.leafNodes, 0, newLeafNodes, 0, left.leafNodes.length);
+         System.arraycopy(right.leafNodes, 0, newLeafNodes, left.leafNodes.length, right.leafNodes.length);
+         return new IndexNode(left.segment, newPrefix, newKeyParts, newLeafNodes);
+      } else {
+         throw new IllegalArgumentException("Cannot join " + left + " and " + right);
+      }
+   }
+
+   public IndexNode copyWith(int oldNodesFrom, int oldNodesTo, List<IndexNode> newNodes) throws IOException {
+      InnerNode[] newInnerNodes = new InnerNode[innerNodes.length + newNodes.size() - 1 - oldNodesTo + oldNodesFrom];
+      System.arraycopy(innerNodes, 0, newInnerNodes, 0, oldNodesFrom);
+      System.arraycopy(innerNodes, oldNodesTo + 1, newInnerNodes, oldNodesFrom + newNodes.size(), innerNodes.length - oldNodesTo - 1);
+      for (int i = 0; i < newNodes.size(); ++i) {
+         IndexNode node = newNodes.get(i);
+         Index.IndexSpace space = segment.allocateIndexSpace(node.length());
+         node.store(space);
+         newInnerNodes[i + oldNodesFrom] = new InnerNode(node);
+      }
+      byte[][] newKeys = new byte[newNodes.size() - 1][];
+      byte[] newPrefix = prefix;
+      for (int i = 0; i < newKeys.length; ++i) {
+         try {
+            // TODO: if all keys within the subtree are null (deleted), the new key will be null
+            // will be fixed with proper index reduction
+            newKeys[i] = newNodes.get(i + 1).leftmostKey();
+            if (newKeys[i] == null) {
+               throw new IllegalStateException();
+            }
+         } catch (IndexNodeOutdatedException e) {
+            throw new IllegalStateException("Index cannot be outdated for segment updater thread", e);
+         }
+         newPrefix = commonPrefix(newPrefix, newKeys[i]);
+      }
+      byte[][] newKeyParts = new byte[keyParts.length + newNodes.size() - 1 - oldNodesTo + oldNodesFrom][];
+      copyKeyParts(keyParts, 0, newKeyParts, 0, oldNodesFrom, prefix, newPrefix);
+      copyKeyParts(keyParts, oldNodesTo, newKeyParts, oldNodesFrom + newKeys.length, keyParts.length - oldNodesTo, prefix, newPrefix);
+      for (int i = 0; i < newKeys.length; ++i) {
+         newKeyParts[i + oldNodesFrom] = substring(newKeys[i], newPrefix.length, newKeys[i].length);
+      }
+      return new IndexNode(segment, newPrefix, newKeyParts, newInnerNodes);
+   }
+
+   private byte[] leftmostKey() throws IOException, IndexNodeOutdatedException {
+      if (innerNodes != null) {
+         for (int i = 0; i < innerNodes.length; ++i) {
+            byte[] key = innerNodes[i].getIndexNode(segment).leftmostKey();
+            if (key != null) return key;
+         }
+      } else {
+         for (int i = 0; i < leafNodes.length; ++i) {
+            EntryRecord hak = leafNodes[i].loadHeaderAndKey(segment.getFileProvider(), segment.getTimeService());
+            if (hak != null && hak.getKey() != null) return hak.getKey();
+         }
+      }
+      return null;
+   }
+
+   private byte[] rightmostKey() throws IOException, IndexNodeOutdatedException {
+      if (innerNodes != null) {
+         for (int i = innerNodes.length - 1; i >= 0; --i) {
+            byte[] key = innerNodes[i].getIndexNode(segment).rightmostKey();
+            if (key != null) return key;
+         }
+      } else {
+         for (int i = leafNodes.length - 1; i >= 0; --i) {
+            EntryRecord hak = leafNodes[i].loadHeaderAndKey(segment.getFileProvider(), segment.getTimeService());
+            if (hak != null && hak.getKey() != null) return hak.getKey();
+         }
+      }
+      return null;
+   }
+
+   /**
+    * Called on the most bottom node
+    * @param key
+    * @param file
+    * @param offset
+    * @return
+    */
+   public IndexNode copyWith(byte[] key, int file, int offset, int size, OverwriteHook overwriteHook) throws IOException {
+      if (leafNodes == null) throw new IllegalArgumentException();
+      byte[] newPrefix;
+      byte[][] newKeyParts;
+      LeafNode[] newLeafNodes;
+      if (leafNodes.length == 0) {
+         overwriteHook.setOverwritten(false, -1, -1);
+         if (overwriteHook.check(-1, -1)) {
+            return new IndexNode(segment, prefix, keyParts, new LeafNode[]{ new LeafNode(file, offset)});
+         } else {
+            segment.getCompactor().free(file, size);
+            return this;
+         }
+      }
+
+      int insertPart = getInsertionPoint(key);
+      EntryRecord hak = null;
+      try {
+         hak = leafNodes[insertPart].loadHeaderAndKey(segment.getFileProvider(), segment.getTimeService());
+      } catch (IndexNodeOutdatedException e) {
+         throw new IllegalStateException("Index cannot be outdated for segment updater thread", e);
+      }
+      int keyComp = Integer.MAX_VALUE;
+      if (hak == null || hak.getKey() == null || (keyComp = compare(hak.getKey(), key)) == 0) {
+         if (offset >= 0) {
+            if (overwriteHook.check(leafNodes[insertPart].file, leafNodes[insertPart].offset)) {
+               newPrefix = prefix;
+               newKeyParts = keyParts;
+               newLeafNodes = new LeafNode[leafNodes.length];
+               System.arraycopy(leafNodes, 0, newLeafNodes, 0, leafNodes.length);
+               if (trace) {
+                  log.trace(String.format("Overwriting %d:%d (%s) with %d:%d",
+                        leafNodes[insertPart].file, leafNodes[insertPart].offset,
+                        hak == null ? "removed" : (hak.getKey() == null ? "expired" : "matching"), file, offset));
+               }
+               newLeafNodes[insertPart] = new LeafNode(file, offset);
+               if (hak != null) {
+                  segment.getCompactor().free(leafNodes[insertPart].file, hak.getHeader().totalLength());
+               }
+               overwriteHook.setOverwritten(true, leafNodes[insertPart].file, leafNodes[insertPart].offset);
+            } else {
+               overwriteHook.setOverwritten(false, -1, -1);
+               segment.getCompactor().free(file, size);
+               return this;
+            }
+         } else {
+            overwriteHook.setOverwritten(keyComp == 0, leafNodes[insertPart].file, leafNodes[insertPart].offset);
+            if (keyParts.length <= 1) {
+               newPrefix = new byte[0];
+               newKeyParts = new byte[0][];
+            } else {
+               newPrefix = prefix;
+               newKeyParts = new byte[keyParts.length - 1][];
+               if (insertPart == keyParts.length) {
+                  System.arraycopy(keyParts, 0, newKeyParts, 0, newKeyParts.length);
+               } else {
+                  System.arraycopy(keyParts, 0, newKeyParts, 0, insertPart);
+                  System.arraycopy(keyParts, insertPart + 1, newKeyParts, insertPart, newKeyParts.length - insertPart);
+               }
+            }
+            if (leafNodes.length > 0) {
+               newLeafNodes = new LeafNode[leafNodes.length - 1];
+               System.arraycopy(leafNodes, 0, newLeafNodes, 0, insertPart);
+               System.arraycopy(leafNodes, insertPart + 1, newLeafNodes, insertPart, newLeafNodes.length - insertPart);
+            } else {
+               newLeafNodes = leafNodes;
+            }
+            if (hak != null) {
+               segment.getCompactor().free(leafNodes[insertPart].file, hak.getHeader().totalLength());
+            }
+         }
+      } else {
+         overwriteHook.setOverwritten(false, -1, -1);
+         if (offset < 0) {
+            // this is a remove request, nothing to do
+            return this;
+         }
+         if (keyParts.length == 0) {
+            // TODO: we may use unnecessarily long keys here and the key is never shortened
+            newPrefix = keyComp > 0 ? key : hak.getKey();
+         } else {
+            newPrefix = commonPrefix(prefix, key);
+         }
+         newKeyParts = new byte[keyParts.length + 1][];
+         newLeafNodes = new LeafNode[leafNodes.length + 1];
+         copyKeyParts(keyParts, 0, newKeyParts, 0, insertPart, prefix, newPrefix);
+         copyKeyParts(keyParts, insertPart, newKeyParts, insertPart + 1, keyParts.length - insertPart, prefix, newPrefix);
+         if (keyComp > 0) {
+            newKeyParts[insertPart] = substring(key, newPrefix.length, keyComp);
+            System.arraycopy(leafNodes, 0, newLeafNodes, 0, insertPart + 1);
+            System.arraycopy(leafNodes, insertPart + 1, newLeafNodes, insertPart + 2, leafNodes.length - insertPart - 1);
+            newLeafNodes[insertPart + 1] = new LeafNode(file, offset);
+         } else {
+            newKeyParts[insertPart] = substring(hak.getKey(), newPrefix.length, -keyComp);
+            System.arraycopy(leafNodes, 0, newLeafNodes, 0, insertPart);
+            System.arraycopy(leafNodes, insertPart, newLeafNodes, insertPart + 1, leafNodes.length - insertPart);
+            newLeafNodes[insertPart] = new LeafNode(file, offset);
+         }
+      }
+      return new IndexNode(segment, newPrefix, newKeyParts, newLeafNodes);
+   }
+
+   private int getInsertionPoint(byte[] key) {
+      int comp = compare(prefix, key, prefix.length);
+      int insertionPoint;
+      if (comp < 0) {
+         insertionPoint = 0;
+      } else if (comp > 0) {
+         insertionPoint = keyParts.length;
+      } else {
+         byte[] keyPostfix = substring(key, prefix.length, key.length);
+         insertionPoint = Arrays.binarySearch(keyParts, keyPostfix, new Comparator<byte[]>() {
+            @Override
+            public int compare(byte[] o1, byte[] o2) {
+               return IndexNode.this.compare(o2, o1);
+            }
+         });
+         if (insertionPoint < 0) {
+            insertionPoint = -insertionPoint - 1;
+         } else {
+            insertionPoint++; // identical elements must go to the right
+         }
+      }
+      return insertionPoint;
+   }
+
+   private List<IndexNode> split() {
+      int headerLength = headerLength();
+      int contentLength = contentLength();
+      int maxLength = segment.getMaxNodeSize();
+      int targetParts = contentLength / Math.max(maxLength - headerLength, 1) + 1;
+      int targetLength = contentLength / targetParts + headerLength;
+      List<IndexNode> list = new ArrayList<IndexNode>();
+      int childLength = innerNodes != null ? INNER_NODE_REFERENCE_SIZE : LEAF_NODE_REFERENCE_SIZE;
+      byte[] prefixExtension = keyParts[0]; // the prefix can be only extended
+      int currentLength = INNER_NODE_HEADER_SIZE + prefix.length + prefixExtension.length + 2 * childLength + 2;
+      int nodeFrom = 0;
+      // TODO: under certain circumstances this algorithm can end up by splitting node into very uneven parts
+      // such as having one part with only 1 child, therefore only 15 bytes long
+      for (int i = 1; i < keyParts.length; ++i) {
+         int newLength;
+         byte[] newPrefixExtension = commonPrefix(prefixExtension, keyParts[i]);
+         if (newPrefixExtension.length != prefixExtension.length) {
+            newLength = currentLength + (prefixExtension.length - newPrefixExtension.length) * (i - nodeFrom - 1);
+         } else {
+            newLength = currentLength;
+         }
+         newLength += keyParts[i].length - newPrefixExtension.length + childLength + 2;
+         if (newLength < targetLength) {
+            currentLength = newLength;
+         } else {
+            IndexNode subNode;
+            if (newLength > maxLength) {
+               subNode = subNode(prefixExtension, nodeFrom, i);
+               ++i;
+            } else {
+               subNode = subNode(newPrefixExtension, nodeFrom, i + 1);
+               i += 2;
+            }
+            list.add(subNode);
+            if (i < keyParts.length) {
+               newPrefixExtension = keyParts[i];
+            }
+            currentLength = INNER_NODE_HEADER_SIZE + prefix.length + newPrefixExtension.length + 2 * childLength + 2;
+            nodeFrom = i;
+         }
+         prefixExtension = newPrefixExtension;
+      }
+      if (nodeFrom <= keyParts.length) {
+         list.add(subNode(prefixExtension, nodeFrom, keyParts.length));
+      }
+      return list;
+   }
+
+   private IndexNode subNode(byte[] newPrefixExtension, int childFrom, int childTo) {
+      // first node takes up to child[to + 1], other do not take the child[from] == child[previousTo + 1]
+      // If the new node has > 1 keyParts, it ignores the first keyPart, otherwise it just sets the first child to be
+      // deleted (empty entry)
+      byte[][] newKeyParts = new byte[childTo - childFrom][];
+      if (newPrefixExtension.length > 0) {
+         for (int i = childFrom; i < childTo; ++i) {
+            newKeyParts[i - childFrom] = substring(keyParts[i], newPrefixExtension.length, keyParts[i].length);
+         }
+      } else {
+         System.arraycopy(keyParts, childFrom, newKeyParts, 0, childTo - childFrom);
+      }
+      byte[] newPrefix = childFrom == childTo ? new byte[0] : concat(prefix, newPrefixExtension);
+      if (innerNodes != null) {
+         InnerNode[] newInnerNodes = new InnerNode[childTo - childFrom + 1];
+         System.arraycopy(innerNodes, childFrom, newInnerNodes, 0, childTo - childFrom + 1);
+         return new IndexNode(segment, newPrefix, newKeyParts, newInnerNodes);
+      } else if (leafNodes != null) {
+         LeafNode[] newLeafNodes = new LeafNode[childTo - childFrom + 1];
+         System.arraycopy(leafNodes, childFrom, newLeafNodes, 0, childTo - childFrom + 1);
+         return new IndexNode(segment, newPrefix, newKeyParts, newLeafNodes);
+      }
+      throw new IllegalStateException();
+   }
+
+   private static byte[] concat(byte[] first, byte[] second) {
+      if (first == null || first.length == 0) return second;
+      if (second == null || second.length == 0) return first;
+      byte[] result = new byte[first.length + second.length];
+      System.arraycopy(first, 0, result, 0, first.length);
+      System.arraycopy(second, 0, result, first.length, second.length);
+      return result;
+   }
+
+   private static void copyKeyParts(byte[][] src, int srcIndex, byte[][] dest, int destIndex, int length, byte[] oldPrefix, byte[] common) {
+      if (oldPrefix.length == common.length) {
+         System.arraycopy(src, srcIndex, dest, destIndex, length);
+      } else {
+         for (int i = 0; i < length; ++i) {
+            dest[destIndex + i] = findNewKeyPart(oldPrefix, src[srcIndex + i], common);
+         }
+      }
+   }
+
+   private static byte[] findNewKeyPart(byte[] oldPrefix, byte[] oldKeyPart, byte[] common) {
+      byte[] newPart = new byte[oldKeyPart.length + oldPrefix.length - common.length];
+      System.arraycopy(oldPrefix, common.length, newPart, 0, oldPrefix.length - common.length);
+      System.arraycopy(oldKeyPart, 0, newPart, oldPrefix.length - common.length, oldKeyPart.length);
+      return newPart;
+   }
+
+   private static byte[] substring(byte[] key, int begin, int end) {
+      if (end <= begin) return new byte[0];
+      byte[] sub = new byte[end - begin];
+      System.arraycopy(key, begin, sub, 0, end - begin);
+      return sub;
+   }
+
+   private static byte[] commonPrefix(byte[] oldPrefix, byte[] newKey) {
+      int i;
+      for (i = 0; i < oldPrefix.length && i < newKey.length; ++i) {
+         if (newKey[i] != oldPrefix[i]) break;
+      }
+      if (i == oldPrefix.length) {
+         return oldPrefix;
+      }
+      if (i == newKey.length) {
+         return newKey;
+      }
+      byte[] prefix = new byte[i];
+      for (--i; i >= 0; --i) {
+         prefix[i] = oldPrefix[i];
+      }
+      return prefix;
+   }
+
+   private static int compare(byte[] first, byte[] second, int length) {
+      for (int i = 0; i < length; ++i) {
+         if (i >= second.length) {
+            return -1;
+         }
+         if (second[i] == first[i]) continue;
+         return second[i] > first[i] ? 1 : -1;
+      }
+      return 0;
+   }
+
+   private static int compare(byte[] first, byte[] second) {
+      for (int i = 0; i < first.length && i < second.length; ++i) {
+         if (second[i] == first[i]) continue;
+         return second[i] > first[i] ? i + 1 : -i - 1;
+      }
+      return second.length > first.length ? first.length + 1 : (second.length < first.length ? -second.length - 1 : 0);
+   }
+
+   private int headerLength() {
+      return INNER_NODE_HEADER_SIZE + prefix.length;
+   }
+
+   private int contentLength() {
+      if (contentLength >= 0) {
+         return contentLength;
+      }
+      int sum = 0;
+      for (byte[] keyPart : keyParts) {
+         sum += 2 + keyPart.length;
+      }
+      if (innerNodes != null) {
+         sum += INNER_NODE_REFERENCE_SIZE * innerNodes.length;
+      } else if (leafNodes != null) {
+         sum += LEAF_NODE_REFERENCE_SIZE * leafNodes.length;
+      } else {
+         throw new IllegalStateException();
+      }
+      return contentLength = sum;
+   }
+
+   public int length() {
+      if (totalLength >= 0) return totalLength;
+      return totalLength = headerLength() + contentLength();
+   }
+
+   public static IndexNode emptyWithLeaves(Index.Segment segment) {
+      return new IndexNode(segment, new byte[0], new byte[0][], new LeafNode[] { new LeafNode(-1, -1) });
+   }
+
+   public static IndexNode emptyWithInnerNodes(Index.Segment segment) {
+      return new IndexNode(segment, new byte[0], new byte[0][], new InnerNode[]{ new InnerNode(-1l, (short) -1) });
+   }
+
+   public static class OverwriteHook {
+      public boolean check(int oldFile, int oldOffset) {
+         return true;
+      }
+      public void setOverwritten(boolean overwritten, int prevFile, int prevOffset) {
+
+      }
+   }
+
+   static class InnerNode extends Index.IndexSpace {
+      private volatile SoftReference<IndexNode> reference;
+
+      public InnerNode(long offset, short length) {
+         super(offset, length);
+      }
+
+      public InnerNode(IndexNode node) {
+         super(node.offset, node.occupiedSpace);
+         reference = new SoftReference<IndexNode>(node);
+      }
+
+      public IndexNode getIndexNode(Index.Segment segment) throws IOException {
+         IndexNode node;
+         if (reference == null || (node = reference.get()) == null) {
+            synchronized (this) {
+               if (reference == null || (node = reference.get()) == null) {
+                  if (offset < 0) return null;
+                  node = new IndexNode(segment, offset, length);
+                  reference = new SoftReference<IndexNode>(node);
+                  if (log.isTraceEnabled()) {
+                     log.trace("Loaded inner node from " + offset + " - " + length);
+                  }
+               }
+            }
+         }
+         return node;
+      }
+   }
+
+   private static class LeafNode extends EntryPosition {
+
+      private volatile SoftReference<EntryRecord> keyReference;
+
+      public LeafNode(int file, int offset) {
+         super(file, offset);
+      }
+
+      public EntryRecord loadHeaderAndKey(FileProvider fileProvider, TimeService timeService) throws IOException, IndexNodeOutdatedException {
+         if (offset < 0) return null;
+         EntryRecord headerAndKey = getHeaderAndKey(fileProvider, null, timeService);
+         return headerAndKey;
+      }
+
+      private EntryRecord getHeaderAndKey(FileProvider fileProvider, FileProvider.Handle handle, TimeService timeService) throws IOException, IndexNodeOutdatedException {
+         EntryRecord headerAndKey;
+         if (keyReference == null || (headerAndKey = keyReference.get()) == null) {
+            synchronized (this) {
+               if (keyReference == null || (headerAndKey = keyReference.get()) == null) {
+                  boolean ownHandle = false;
+                  if (handle == null) {
+                     ownHandle = true;
+                     handle = fileProvider.getFile(file);
+                     if (handle == null) {
+                        throw new IndexNodeOutdatedException(file + ":" + offset);
+                     }
+                  }
+                  try {
+                     EntryHeader header = EntryRecord.readEntryHeader(handle, offset);
+                     if (header == null) {
+                        throw new IllegalStateException("Error reading header from " + file + ":" + offset + " | " + handle.getFileSize());
+                     }
+                     headerAndKey = new EntryRecord(header, EntryRecord.readKey(handle, header, offset), null, null);
+                     keyReference = new SoftReference<EntryRecord>(headerAndKey);
+                  } finally {
+                     if (ownHandle) {
+                        handle.close();
+                     }
+                  }
+               }
+            }
+         }
+         if (headerAndKey.getHeader().expiryTime() > 0 && headerAndKey.getHeader().expiryTime() <= timeService.wallClockTime()) {
+            EntryRecord expired = headerAndKey;
+            headerAndKey = new EntryRecord(headerAndKey.getHeader(), null, null, null);
+            synchronized (this) {
+               if (keyReference.get() == expired) {
+                  keyReference = new SoftReference<EntryRecord>(headerAndKey);
+               }
+            }
+         }
+         return headerAndKey;
+      }
+
+      public EntryRecord loadRecord(FileProvider fileProvider, byte[] key, TimeService timeService) throws IOException, IndexNodeOutdatedException {
+         if (offset < 0) return null;
+         FileProvider.Handle handle = fileProvider.getFile(file);
+         if (handle == null) {
+            throw new IndexNodeOutdatedException(file + ":" + offset);
+         }
+         try {
+            EntryRecord headerAndKey = getHeaderAndKey(fileProvider, handle, timeService);
+            if (!Arrays.equals(key, headerAndKey.getKey())) {
+               return null;
+            }
+            return headerAndKey.loadMetadataAndValue(handle, offset);
+         } finally {
+            handle.close();
+         }
+      }
+   }
+
+   private static class IndexNodeOutdatedException extends Exception {
+      IndexNodeOutdatedException(String message) {
+         super(message);
+      }
+   }
+
+   @Override
+   public String toString() {
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i <= keyParts.length; ++i) {
+         sb.append('\n');
+         if (leafNodes != null) {
+            sb.append(" [").append(leafNodes[i].file).append(':').append(leafNodes[i].offset).append("] ");
+         } else {
+            sb.append(" [").append(innerNodes[i].offset).append(':').append(innerNodes[i].length).append("] ");
+         }
+         if (i < keyParts.length) {
+            sb.append(new String(concat(prefix, keyParts[i])));
+         }
+      }
+      sb.append('\n');
+      return sb.toString();
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/IndexQueue.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/IndexQueue.java
@@ -1,0 +1,106 @@
+package org.infinispan.persistence.sifs;
+
+import java.util.AbstractQueue;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.commons.equivalence.Equivalence;
+
+/**
+ * Splits the requests into several subqueues according to request.key.hashCode(). If the request has no key,
+ * inserts countdown into the request and puts it into all subqueues - the thread that retrieves such element
+ * should call countDown() and upon true handle the request (this preserves the FIFO ordering).
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.coPausem&gt;
+ */
+public class IndexQueue extends AbstractQueue<IndexRequest> implements BlockingQueue<IndexRequest> {
+
+   private final ArrayBlockingQueue[] queues;
+   private final Equivalence<Object> keyEquivalence;
+
+   public IndexQueue(int segments, int capacity, Equivalence<Object> keyEquivalence) {
+      queues = new ArrayBlockingQueue[segments];
+      for (int i = 0; i < segments; ++i) {
+         queues[i] = new ArrayBlockingQueue(capacity);
+      }
+      this.keyEquivalence = keyEquivalence;
+   }
+
+   @Override
+   public Iterator<IndexRequest> iterator() {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public int size() {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public void put(IndexRequest indexRequest) throws InterruptedException {
+      if (indexRequest.getKey() != null) {
+         queues[Math.abs(keyEquivalence.hashCode(indexRequest.getKey())) % queues.length].put(indexRequest);
+      } else {
+         indexRequest.setCountDown(queues.length);
+         for (int i = 0; i < queues.length; ++i) {
+            queues[i].put(indexRequest);
+         }
+      }
+   }
+
+   @Override
+   public boolean offer(IndexRequest indexRequest, long timeout, TimeUnit unit) throws InterruptedException {
+      if (indexRequest.getKey() != null) {
+         return queues[Math.abs(keyEquivalence.hashCode(indexRequest.getKey())) % queues.length].offer(indexRequest, timeout, unit);
+      } else {
+         throw new UnsupportedOperationException();
+      }
+   }
+
+   @Override
+   public IndexRequest take() throws InterruptedException {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public IndexRequest poll(long timeout, TimeUnit unit) throws InterruptedException {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public int remainingCapacity() {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public int drainTo(Collection<? super IndexRequest> c) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public int drainTo(Collection<? super IndexRequest> c, int maxElements) {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public boolean offer(IndexRequest indexRequest) {
+      return queues[Math.abs(keyEquivalence.hashCode(indexRequest.getKey())) % queues.length].offer(indexRequest);
+   }
+
+   @Override
+   public IndexRequest poll() {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public IndexRequest peek() {
+      throw new UnsupportedOperationException();
+   }
+
+   public BlockingQueue<IndexRequest> subQueue(int id) {
+      return queues[id];
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/IndexRequest.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/IndexRequest.java
@@ -1,0 +1,141 @@
+package org.infinispan.persistence.sifs;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Request for some change to be persisted in the Index or operation executed by index updater thread.
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+class IndexRequest {
+
+   public enum Type {
+      UPDATE,
+      CLEAR,
+      DELETE_FILE,
+      STOP,
+      GET_SIZE
+   }
+
+   private Type type = Type.UPDATE;
+   private Object key;
+   // the file and offset are duplicate to those in TemporaryTable because we have to match the CAS requests
+   private int file;
+   private int offset;
+   private int prevFile = -1;
+   private int prevOffset = -1;
+   private byte[] serializedKey;
+   private int size;
+   private volatile Object result;
+   private AtomicInteger countDown;
+
+   public IndexRequest(Object key, byte[] serializedKey, int file, int offset, int size) {
+      this.key = key;
+      this.serializedKey = serializedKey;
+      this.file = file;
+      this.offset = offset;
+      this.size = size;
+   }
+
+   public IndexRequest(Object key, byte[] serializedKey, int file, int offset, int size, int prevFile, int prevOffset) {
+      this.key = key;
+      this.serializedKey = serializedKey;
+      this.file = file;
+      this.offset = offset;
+      this.size = size;
+      this.prevFile = prevFile;
+      this.prevOffset = prevOffset;
+   }
+
+   private IndexRequest(Type type) {
+      this.type = type;
+   }
+
+   public static IndexRequest clearRequest() {
+      return new IndexRequest(Type.CLEAR);
+   }
+
+   public static IndexRequest deleteFileRequest(int deletedFile) {
+      IndexRequest req = new IndexRequest(Type.DELETE_FILE);
+      req.file = deletedFile;
+      return req;
+   }
+
+   public static IndexRequest stopRequest() {
+      return new IndexRequest(Type.STOP);
+   }
+
+   public static IndexRequest sizeRequest() {
+      return new IndexRequest(Type.GET_SIZE);
+   }
+
+   public Type getType() {
+      return type;
+   }
+
+   public boolean isCompareAndSet() {
+      return prevFile != -1;
+   }
+
+   public Object getKey() {
+      return key;
+   }
+
+   public long getPrevFile() {
+      return prevFile;
+   }
+
+   public int getPrevOffset() {
+      return prevOffset;
+   }
+
+   public byte[] getSerializedKey() {
+      return serializedKey;
+   }
+
+   public synchronized void setResult(Object result) {
+      if (this.result == null) {
+         this.result = result;
+      }
+      notifyAll();
+   }
+
+   public synchronized Object getResult() throws InterruptedException {
+      while (result == null) {
+         wait();
+      }
+      return result;
+   }
+
+   public void setCountDown(int countDown) {
+      this.countDown = new AtomicInteger(countDown);
+   }
+
+   public boolean countDown() {
+      return countDown.decrementAndGet() == 0;
+   }
+
+   public int getFile() {
+      return file;
+   }
+
+   public int getOffset() {
+      return offset;
+   }
+
+   public int getSize() {
+      return size;
+   }
+
+   @Override
+   public String toString() {
+      return "IndexRequest{" +
+            "file=" + file +
+            ", offset=" + offset +
+            ", prevFile=" + prevFile +
+            ", prevOffset=" + prevOffset +
+            ", size=" + size +
+            ", type=" + type +
+            '}';
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/LogAppender.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/LogAppender.java
@@ -1,0 +1,138 @@
+package org.infinispan.persistence.sifs;
+
+import java.util.concurrent.BlockingQueue;
+
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * This component has the only thread that polls the queue with requests to write some entry into the cache store.
+ * It writes the records to append-only log files, inserts the entry position into TemporaryTable and queues the position
+ * to be persisted in Index.
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class LogAppender extends Thread {
+   private static final Log log = LogFactory.getLog(LogAppender.class);
+
+   private final SyncProcessingQueue<LogRequest> queue;
+   private final BlockingQueue<IndexRequest> indexQueue;
+   private final boolean syncWrites;
+   private final TemporaryTable temporaryTable;
+   private final int maxFileSize;
+   private final Compactor compactor;
+   private final FileProvider fileProvider;
+   private LogRequest pausedRequest;
+   private long seqId = 0;
+
+   LogAppender(SyncProcessingQueue<LogRequest> inboundQueue,
+               BlockingQueue<IndexRequest> indexQueue,
+               TemporaryTable temporaryTable,
+               Compactor compactor,
+               FileProvider fileProvider, boolean syncWrites, int maxFileSize) {
+      super("BCS-LogAppender");
+      this.setDaemon(true);
+      this.queue = inboundQueue;
+      this.indexQueue = indexQueue;
+      this.temporaryTable = temporaryTable;
+      this.compactor = compactor;
+      this.fileProvider = fileProvider;
+      this.syncWrites = syncWrites;
+      this.maxFileSize = maxFileSize;
+      start();
+   }
+
+   public void setSeqId(long seqId) {
+      this.seqId = seqId;
+   }
+
+   public void pause() throws InterruptedException {
+      LogRequest pause = LogRequest.pauseRequest();
+      queue.pushAndWait(pause);
+      pausedRequest = pause;
+   }
+
+   public void clearAndPause() throws InterruptedException {
+      LogRequest clear = LogRequest.clearRequest();
+      queue.pushAndWait(clear);
+      pausedRequest = clear;
+   }
+
+   public void resumeAfterPause() {
+      pausedRequest.resume();
+      pausedRequest = null;
+   }
+
+   @Override
+   public void run() {
+      try {
+         FileProvider.Log logFile = fileProvider.getFileForLog();
+         int currentOffset = 0;
+         while (true) {
+            LogRequest request = queue.pop();
+            if (request != null) {
+               if (request.isClear()) {
+                  logFile.close();
+                  queue.notifyNoWait();
+                  request.pause();
+                  currentOffset = 0;
+                  logFile = fileProvider.getFileForLog();
+                  log.debug("Appending records to " + logFile.fileId);
+                  continue;
+               } else if (request.isStop()) {
+                  queue.notifyNoWait();
+                  break;
+               } else if (request.isPause()) {
+                  queue.notifyNoWait();
+                  request.pause();
+                  continue;
+               }
+               if (currentOffset + request.length() > maxFileSize) {
+                  // switch to next file
+                  logFile.close();
+                  compactor.completeFile(logFile.fileId);
+                  currentOffset = 0;
+                  logFile = fileProvider.getFileForLog();
+                  log.debug("Appending records to " + logFile.fileId);
+               }
+               EntryRecord.writeEntry(logFile.fileChannel, request.getSerializedKey(), request.getSerializedMetadata(), request.getSerializedValue(), nextSeqId(), request.getExpiration());
+               int offset = request.getSerializedValue() == null ? ~currentOffset : currentOffset;
+               temporaryTable.set(request.getKey(), logFile.fileId, offset);
+               IndexRequest indexRequest = new IndexRequest(request.getKey(), raw(request.getSerializedKey()),
+                     logFile.fileId, offset, request.length());
+               request.setIndexRequest(indexRequest);
+               indexQueue.put(indexRequest);
+               currentOffset += request.length();
+            } else {
+               if (syncWrites) {
+                  logFile.fileChannel.force(false);
+               }
+               queue.notifyAndWait();
+            }
+         }
+      } catch (Exception e) {
+         queue.notifyError();
+         throw new RuntimeException(e);
+      }
+   }
+
+   private byte[] raw(ByteBuffer buffer) {
+      if (buffer.getBuf().length == buffer.getLength()) {
+         return buffer.getBuf();
+      } else {
+         byte[] bytes = new byte[buffer.getLength()];
+         System.arraycopy(buffer.getBuf(), buffer.getOffset(), bytes, 0, buffer.getLength());
+         return bytes;
+      }
+   }
+
+   private final long nextSeqId() {
+      return seqId++;
+   }
+
+   public void stopOperations() throws InterruptedException {
+      queue.pushAndWait(LogRequest.stopRequest());
+      this.join();
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/LogRequest.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/LogRequest.java
@@ -1,0 +1,121 @@
+package org.infinispan.persistence.sifs;
+
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.marshall.core.MarshalledEntry;
+
+import java.io.IOException;
+
+/**
+ * Request to persist entry in log file or request executed by the log appender thread.
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+class LogRequest {
+
+   enum Type {
+      STORE,
+      DELETE,
+      CLEAR_ALL,
+      STOP,
+      PAUSE
+   }
+
+   private final Type type;
+   private final Object key;
+   private final long expirationTime;
+   private final ByteBuffer serializedKey;
+   private final ByteBuffer serializedMetadata;
+   private final ByteBuffer serializedValue;
+   private boolean canContinue = false;
+   private volatile IndexRequest indexRequest;
+
+   private LogRequest(Type type, Object key, long expirationTime, ByteBuffer serializedKey, ByteBuffer serializedMetadata, ByteBuffer serializedValue) {
+      this.key = key;
+      this.expirationTime = expirationTime;
+      this.serializedKey = serializedKey;
+      this.serializedMetadata = serializedMetadata;
+      this.serializedValue = serializedValue;
+      this.type = type;
+   }
+
+   private LogRequest(Type type) {
+      this(type, null, 0, null, null, null);
+   }
+
+   public static LogRequest storeRequest(MarshalledEntry entry) throws IOException, InterruptedException {
+      return new LogRequest(Type.STORE, entry.getKey(),
+            entry.getMetadata() == null ? -1 : entry.getMetadata().expiryTime(),
+            entry.getKeyBytes(), entry.getMetadataBytes(), entry.getValueBytes());
+   }
+
+   public static LogRequest deleteRequest(Object key, ByteBuffer serializedKey) throws IOException, InterruptedException {
+      return new LogRequest(Type.DELETE, key, -1, serializedKey, null, null);
+   }
+
+   public static LogRequest clearRequest() {
+      return new LogRequest(Type.CLEAR_ALL);
+   }
+
+   public static LogRequest stopRequest() {
+      return new LogRequest(Type.STOP);
+   }
+
+   public static LogRequest pauseRequest() {
+      return new LogRequest(Type.PAUSE);
+   }
+
+   public int length() {
+      return EntryHeader.HEADER_SIZE + serializedKey.getLength()
+            + (serializedValue != null ? serializedValue.getLength() : 0)
+            + (serializedMetadata != null ? serializedMetadata.getLength() : 0);
+   }
+
+   public Object getKey() {
+      return key;
+   }
+
+   public ByteBuffer getSerializedKey() {
+      return serializedKey;
+   }
+
+   public ByteBuffer getSerializedMetadata() {
+      return serializedMetadata;
+   }
+
+   public ByteBuffer getSerializedValue() {
+      return serializedValue;
+   }
+
+   public long getExpiration() {
+      return expirationTime;
+   }
+
+   public boolean isClear() {
+      return type == Type.CLEAR_ALL;
+   }
+
+   public boolean isStop() {
+      return type == Type.STOP;
+   }
+
+   public boolean isPause() {
+      return type == Type.PAUSE;
+   }
+
+   public void setIndexRequest(IndexRequest indexRequest) {
+      this.indexRequest = indexRequest;
+   }
+
+   public IndexRequest getIndexRequest() {
+      return indexRequest;
+   }
+
+   public synchronized void pause() throws InterruptedException {
+      while (!canContinue) wait();
+   }
+
+   public synchronized void resume() {
+      canContinue = true;
+      notify();
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/SoftIndexFileStore.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/SoftIndexFileStore.java
@@ -1,0 +1,543 @@
+package org.infinispan.persistence.sifs;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.infinispan.commons.equivalence.Equivalence;
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.io.ByteBufferFactory;
+import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.filter.KeyFilter;
+import org.infinispan.marshall.core.MarshalledEntry;
+import org.infinispan.marshall.core.MarshalledEntryFactory;
+import org.infinispan.metadata.InternalMetadata;
+import org.infinispan.persistence.PersistenceUtil;
+import org.infinispan.persistence.TaskContextImpl;
+import org.infinispan.persistence.sifs.configuration.SoftIndexFileStoreConfiguration;
+import org.infinispan.persistence.spi.AdvancedLoadWriteStore;
+import org.infinispan.persistence.spi.InitializationContext;
+import org.infinispan.persistence.spi.PersistenceException;
+import org.infinispan.util.TimeService;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * Local file-based cache store, optimized for write-through use with strong consistency guarantees
+ * (ability to flush disk operations before returning from the store call).
+ *
+ * * DESIGN:
+ * There are three threads operating in the cache-store:
+ * - LogAppender:  Requests to store entries are passed to the LogAppender thread
+ *                 via queue, then the requestor threads wait until LogAppender notifies
+ *                 them about successful store. LogAppender serializes the writes
+ *                 into append-only file, writes the offset into TemporaryTable
+ *                 and enqueues request to update index into UpdateQueue.
+ *                 The append-only files have limited size, when the file is full,
+ *                 new file is started.
+ * - IndexUpdater: Reads the UpdateQueue, applies the operation into B-tree-like
+ *                 structure Index (exact description below) and then removes
+ *                 the entry from TemporaryTable. When the Index is overwriten,
+ *                 the current entry offset is retrieved and IndexUpdater increases
+ *                 the unused space statistics in FileStats.
+ * - Compactor:    When a limit of unused space in some file is reached (according
+ *                 to FileStats), the Compactor starts reading this file sequentially,
+ *                 querying TemporaryTable or Index for the current entry position
+ *                 and copying the unchanged entries into another file. For the entries
+ *                 that are still valid in the original file, a compare-and-set
+ *                 (file-offset based) request is enqueued into UpdateQueue - therefore
+ *                 this operation cannot interfere with concurrent writes overwriting
+ *                 the entry. Multiple files can be merged into single file during
+ *                 compaction.
+ *
+ * Structures:
+ * - TemporaryTable: keeps the records about current entry location until this is
+ *                   applied to the Index. Each read request goes to the TemporaryTable,
+ *                   if the key is not found here, Index is queried.
+ * - UpdateQueue:    bounded queue (to prevent grow the TemporaryTable too much) of either
+ *                   forced writes (used for regular stores) or compare-and-set writes
+ *                   (used by Compactor).
+ * - FileStats:      simple (Concurrent)HashTable with actual file size and amount of unused
+ *                   space for each file.
+ * - Index:          B+-tree of IndexNodes. The tree is dropped and built a new if the process
+ *                   crashes, it does not need to flush disk operations. On disk it is kept as single random-accessed file, with free blocks list stored in memory.
+ *
+ * As IndexUpdater may easily become a bottleneck under heavy load, the IndexUpdater thread,
+ * UpdateQueue and tree of IndexNodes may be multiplied several times - the Index is divided
+ * into Segments. Each segment owns keys according to the hashCode() of the key.
+ *
+ * Amount of entries in IndexNode is limited by the size it occupies on disk. This size is
+ * limited by configurable nodeSize (4096 bytes by default?), only in case that the node
+ * contains single pivot (too long) it can be longer. A key_prefix common for all keys
+ * in the IndexNode is stored in order to reduce space requirements. For implementation
+ * reasons the keys are limited to 32kB - this requirement may be circumvented later.
+ *
+ * The pivots are not whole keys - it is the shortest part of key that is greater than all
+ * left children (but lesser or equal to all right children) - let us call this key_part.
+ * The key_parts are sorted in the IndexNode, naturally. On disk it has this format:
+ *
+ *  key_prefix_length(2 bytes), key_prefix, num_parts(2 bytes),
+ *     ( key_part_length (2 bytes), key_part, left_child_index_node_offset (8 bytes))+,
+ *     right_child_index_node_offset (8 bytes)
+ *
+ * In memory, for every child a SoftReference<IndexNode> is held. When this reference
+ * is empty (but the offset in file is set), any reader may load the reference using
+ * double-locking pattern (synchronized over the reference itself). The entry is never
+ * loaded by multiple threads in parallel and even may block other threads trying to
+ * read this node.
+ *
+ * For each node in memory a RW-lock is held. When the IndexUpdater thread updates
+ * the Index (modifying some IndexNodes), it prepares a copy of these nodes (already
+ * stored into index file). Then, in locks only the uppermost node for writing, overwrites
+ * the references to new data and unlocks the this node. After that the changed nodes are
+ * traversed from top down, write locked and their record in index file is released.
+ * Reader threads crawl the tree from top down, locking the parent node (for reading),
+ * locking child node and unlocking parent node.
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class SoftIndexFileStore implements AdvancedLoadWriteStore {
+
+   private static final Log log = LogFactory.getLog(SoftIndexFileStore.class);
+   private static final boolean trace = log.isTraceEnabled();
+
+   private SoftIndexFileStoreConfiguration configuration;
+   private TemporaryTable temporaryTable;
+   private IndexQueue indexQueue;
+   private SyncProcessingQueue<LogRequest> storeQueue;
+   private FileProvider fileProvider;
+   private LogAppender logAppender;
+   private Index index;
+   private Compactor compactor;
+   private StreamingMarshaller marshaller;
+   private ByteBufferFactory byteBufferFactory;
+   private MarshalledEntryFactory marshalledEntryFactory;
+   private TimeService timeService;
+   private Equivalence<Object> keyEquivalence;
+   private int maxKeyLength;
+
+   @Override
+   public void init(InitializationContext ctx) {
+      configuration = ctx.getConfiguration();
+      marshaller = ctx.getMarshaller();
+      marshalledEntryFactory = ctx.getMarshalledEntryFactory();
+      byteBufferFactory = ctx.getByteBufferFactory();
+      timeService = ctx.getTimeService();
+      keyEquivalence = ctx.getCache().getAdvancedCache().getCacheConfiguration().dataContainer().keyEquivalence();
+      maxKeyLength = configuration.maxNodeSize() - IndexNode.RESERVED_SPACE;
+   }
+
+   @Override
+   public void start() {
+      log.info("Starting using configuration " + configuration);
+      temporaryTable = new TemporaryTable(configuration.indexQueueLength() * configuration.indexSegments(), keyEquivalence);
+      storeQueue = new SyncProcessingQueue<LogRequest>();
+      indexQueue = new IndexQueue(configuration.indexSegments(), configuration.indexQueueLength(), keyEquivalence);
+      fileProvider = new FileProvider(configuration.dataLocation(), configuration.openFilesLimit());
+      compactor = new Compactor(fileProvider, temporaryTable, indexQueue, marshaller, timeService, configuration.maxFileSize(), configuration.compactionThreshold());
+      logAppender = new LogAppender(storeQueue, indexQueue, temporaryTable, compactor, fileProvider, configuration.syncWrites(), configuration.maxFileSize());
+      try {
+         index = new Index(fileProvider, configuration.indexLocation(), configuration.indexSegments(),
+               configuration.minNodeSize(), configuration.maxNodeSize(),
+               indexQueue, temporaryTable, compactor, timeService, keyEquivalence);
+      } catch (IOException e) {
+         throw new PersistenceException("Cannot open index file in " + configuration.indexLocation(), e);
+      }
+      compactor.setIndex(index);
+      final AtomicLong maxSeqId = new AtomicLong(0);
+      if (configuration.purgeOnStartup()) {
+         log.debug("Not building the index - purge will be executed");
+      } else {
+         log.debug("Building the index");
+         forEachOnDisk(false, false, new EntryFunctor() {
+            @Override
+            public boolean apply(int file, int offset, int size, byte[] serializedKey, byte[] serializedMetadata, byte[] serializedValue, long seqId, long expiration) throws IOException, ClassNotFoundException {
+               long prevSeqId;
+               while (seqId > (prevSeqId = maxSeqId.get()) && !maxSeqId.compareAndSet(prevSeqId, seqId));
+               Object key = marshaller.objectFromByteBuffer(serializedKey);
+               if (trace) log.tracef("Loaded %d:%d (seqId %d, expiration %d)", file, offset, seqId, expiration);
+               try {
+                  // We may check the seqId safely as we are the only thread writing to index
+                  EntryPosition entry = temporaryTable.get(key);
+                  if (entry == null) {
+                     entry = index.getPosition(key, serializedKey);
+                  }
+                  if (entry != null) {
+                     FileProvider.Handle handle = fileProvider.getFile(entry.file);
+                     try {
+                        EntryHeader header = EntryRecord.readEntryHeader(handle, entry.offset);
+                        if (header == null) {
+                           throw new IllegalStateException("Cannot read " + entry.file + ":" + entry.offset);
+                        }
+                        if (seqId < header.seqId()) {
+                           if (trace) log.tracef("Record on %d:%d has seqId %d > %d", entry.file, entry.offset, header.seqId(), seqId);
+                           return true;
+                        }
+                     } finally {
+                        handle.close();
+                     }
+                  }
+                  temporaryTable.set(key, file, offset);
+                  indexQueue.put(new IndexRequest(key, serializedKey, file, offset, size));
+               } catch (InterruptedException e) {
+                  log.error("Interrupted building of index, the index won't be built properly!", e);
+                  return false;
+               }
+               return true;
+            }
+         }, new FileFunctor() {
+            @Override
+            public void afterFile(int file) {
+               compactor.completeFile(file);
+            }
+         });
+      }
+      logAppender.setSeqId(0);
+   }
+
+   @Override
+   public void stop() {
+      try {
+         logAppender.stopOperations();
+         logAppender = null;
+         compactor.stopOperations();
+         compactor = null;
+         index.stopOperations();
+         index = null;
+         fileProvider.stop();
+         fileProvider = null;
+         temporaryTable = null;
+         indexQueue = null;
+         storeQueue = null;
+      } catch (InterruptedException e) {
+         throw new PersistenceException("Cannot stop cache store", e);
+      }
+   }
+
+   @Override
+   public synchronized void clear() throws PersistenceException {
+      try {
+         logAppender.clearAndPause();
+         compactor.clearAndPause();
+      } catch (InterruptedException e) {
+         throw new PersistenceException("Cannot pause cache store to clear it.", e);
+      }
+      try {
+         index.clear();
+      } catch (IOException e) {
+         throw new PersistenceException("Cannot clear/reopen index!", e);
+      }
+      try {
+         fileProvider.clear();
+      } catch (IOException e) {
+         throw new PersistenceException("Cannot clear data directory!", e);
+      }
+      temporaryTable.clear();
+      compactor.resumeAfterPause();
+      logAppender.resumeAfterPause();
+   }
+
+   @Override
+   public synchronized int size() {
+      try {
+         logAppender.pause();
+         return (int) index.size();
+      } catch (InterruptedException e) {
+         log.error("Interrupted", e);
+         Thread.currentThread().interrupt();
+         return -1;
+      } finally {
+         logAppender.resumeAfterPause();
+      }
+   }
+
+   @Override
+   public void purge(Executor threadPool, PurgeListener listener) {
+      log.trace("Purge method not supported, ignoring.");
+      // TODO: in future we may support to force compactor run on all files
+   }
+
+   @Override
+   public void write(MarshalledEntry entry) {
+      int keyLength = entry.getKeyBytes().getLength();
+      if (keyLength > maxKeyLength) {
+         throw new PersistenceException("Configuration 'maxNodeSize' is too low - with maxNodeSize="
+               + configuration.maxNodeSize() + " bytes you can use only keys serialized to " + maxKeyLength
+               + " bytes (key " + entry.getKey() + " is serialized to " + keyLength + " bytes)");
+      } else if (keyLength > Short.MAX_VALUE) {
+         // TODO this limitation could be removed by different key length encoding
+         throw new PersistenceException("SoftIndexFileStore is limited to keys with serialized size <= 32767 bytes");
+      }
+      try {
+         storeQueue.pushAndWait(LogRequest.storeRequest(entry));
+      } catch (Exception e) {
+         throw new PersistenceException(e);
+      }
+   }
+
+   @Override
+   public boolean delete(Object key) {
+      try {
+         LogRequest request = LogRequest.deleteRequest(key, toBuffer(marshaller.objectToByteBuffer(key)));
+         storeQueue.pushAndWait(request);
+         return (Boolean) request.getIndexRequest().getResult();
+      } catch (Exception e) {
+         throw new PersistenceException(e);
+      }
+   }
+
+   @Override
+   public boolean contains(Object key) {
+      try {
+         for (;;) {
+            // TODO: consider storing expiration timestamp in temporary table
+            EntryPosition entry = temporaryTable.get(key);
+            if (entry != null) {
+               if (entry.offset < 0) {
+                  return false;
+               }
+               FileProvider.Handle handle = fileProvider.getFile(entry.file);
+               if (handle != null) {
+                  try {
+                     EntryHeader header = EntryRecord.readEntryHeader(handle, entry.offset);
+                     if (header == null) {
+                        throw new IllegalStateException("Error reading from " + entry.file + ":" + entry.offset + " | " + handle.getFileSize());
+                     }
+                     return header.expiryTime() < 0 || header.expiryTime() > timeService.wallClockTime();
+                  } finally {
+                     handle.close();
+                  }
+               }
+            } else {
+               EntryPosition position = index.getPosition(key, marshaller.objectToByteBuffer(key));
+               return position != null;
+            }
+         }
+      } catch (Exception e) {
+         throw new PersistenceException("Cannot load key from index", e);
+      }
+   }
+
+   @Override
+   public MarshalledEntry load(Object key) {
+      try {
+         byte[] serializedValue;
+         byte[] serializedKey;
+         byte[] serializedMetadata;
+         for (;;) {
+            EntryPosition entry = temporaryTable.get(key);
+            if (entry != null) {
+               if (entry.offset < 0) {
+                  return null;
+               }
+               FileProvider.Handle handle = fileProvider.getFile(entry.file);
+               if (handle != null) {
+                  try {
+                     EntryHeader header = EntryRecord.readEntryHeader(handle, entry.offset);
+                     if (header == null) {
+                        throw new IllegalStateException("Error reading from " + entry.file + ":" + entry.offset + " | " + handle.getFileSize());
+                     }
+                     if (header.expiryTime() > 0 && header.expiryTime() <= timeService.wallClockTime()) {
+                        return null;
+                     }
+                     serializedKey = EntryRecord.readKey(handle, header, entry.offset);
+                     if (header.metadataLength() > 0) {
+                        serializedMetadata = EntryRecord.readMetadata(handle, header, entry.offset);
+                     } else {
+                        serializedMetadata = null;
+                     }
+                     if (header.valueLength() > 0) {
+                        serializedValue = EntryRecord.readValue(handle, header, entry.offset);
+                     } else {
+                        return null;
+                     }
+                     return marshalledEntryFactory.newMarshalledEntry(toBuffer(serializedKey), toBuffer(serializedValue), toBuffer(serializedMetadata));
+                  } finally {
+                     handle.close();
+                  }
+               }
+            } else {
+               EntryRecord record = index.getRecord(key, marshaller.objectToByteBuffer(key));
+               if (record == null) return null;
+               return marshalledEntryFactory.newMarshalledEntry(toBuffer(record.getKey()), toBuffer(record.getValue()), toBuffer(record.getMetadata()));
+            }
+         }
+      } catch (Exception e) {
+         throw new PersistenceException(e);
+      }
+   }
+
+   /**
+    * This method should be called by reflection to get more info about the missing/invalid key (from test tools)
+    * @param key
+    * @return
+    */
+   public String debugInfo(Object key) {
+      EntryPosition entry = temporaryTable.get(key);
+      if (entry != null) {
+         return "temporaryTable: " + entry;
+      } else {
+         try {
+            entry = index.getPosition(key, marshaller.objectToByteBuffer(key));
+            return "index: " + entry;
+         } catch (Exception e) {
+            log.debug("Cannot debug key " + key, e);
+            return "exception: " + e;
+         }
+      }
+   }
+
+   private ByteBuffer toBuffer(byte[] array) {
+      return array == null ? null : byteBufferFactory.newByteBuffer(array, 0, array.length);
+   }
+
+   private interface EntryFunctor {
+      boolean apply(int file, int offset, int size, byte[] serializedKey, byte[] serializedMetadata, byte[] serializedValue, long seqId, long expiration) throws Exception;
+   }
+
+   private interface FileFunctor {
+      void afterFile(int file);
+   }
+
+   private void forEachOnDisk(boolean readMetadata, boolean readValues, EntryFunctor functor, FileFunctor fileFunctor) throws PersistenceException {
+      try {
+         Iterator<Integer> iterator = fileProvider.getFileIterator();
+         while (iterator.hasNext()) {
+            int file = iterator.next();
+            log.debug("Loading entries from file " + file);
+            FileProvider.Handle handle = fileProvider.getFile(file);
+            if (handle == null) {
+               log.debug("File " + file + " was deleted during iteration");
+               fileFunctor.afterFile(file);
+               continue;
+            }
+            try {
+               int offset = 0;
+               for (;;) {
+                  EntryHeader header = EntryRecord.readEntryHeader(handle, offset);
+                  if (header == null) {
+                     break; // end of file;
+                  }
+                  try {
+                     byte[] serializedKey = EntryRecord.readKey(handle, header, offset);
+                     if (serializedKey == null) {
+                        break; // we have read the file concurrently with writing there
+                        //throw new CacheLoaderException("File " + file + " appears corrupt when reading key from " + offset + ": header is " + header);
+                     }
+                     byte[] serializedMetadata = null;
+                     if (readMetadata && header.metadataLength() > 0) {
+                        serializedMetadata = EntryRecord.readMetadata(handle, header, offset);
+                     }
+                     byte[] serializedValue = null;
+                     int offsetOrNegation = offset;
+                     if (header.valueLength() > 0) {
+                        if (header.expiryTime() >= 0 && header.expiryTime() <= timeService.wallClockTime()) {
+                           offsetOrNegation = ~offset;
+                        } else if (readValues) {
+                           serializedValue = EntryRecord.readValue(handle, header, offset);
+                        }
+                     } else {
+                        offsetOrNegation = ~offset;
+                     }
+                     if (!functor.apply(file, offsetOrNegation, header.totalLength(), serializedKey, serializedMetadata, serializedValue, header.seqId(), header.expiryTime())) {
+                        return;
+                     }
+                  } finally {
+                     offset += header.totalLength();
+                  }
+               }
+            } finally {
+               handle.close();
+               fileFunctor.afterFile(file);
+            }
+         }
+      } catch (Exception e) {
+         throw new PersistenceException(e);
+      }
+   }
+
+   @Override
+   public void process(KeyFilter filter, final CacheLoaderTask task, final Executor executor, final boolean fetchValue, final boolean fetchMetadata) {
+      final TaskContext context = new TaskContextImpl();
+      final KeyFilter notNullFilter = PersistenceUtil.notNull(filter);
+      final AtomicLong tasksSubmitted = new AtomicLong();
+      final AtomicLong tasksFinished = new AtomicLong();
+      forEachOnDisk(fetchMetadata, fetchValue, new EntryFunctor() {
+         @Override
+         public boolean apply(int file, int offset, int size,
+                              final byte[] serializedKey, final byte[] serializedMetadata, final byte[] serializedValue,
+                              long seqId, long expiration) throws IOException, ClassNotFoundException {
+            if (context.isStopped()) {
+               return false;
+            }
+            final Object key = marshaller.objectFromByteBuffer(serializedKey);
+            if (!notNullFilter.accept(key)) {
+               return true;
+            }
+            EntryPosition entry = temporaryTable.get(key);
+            if (entry == null) {
+               entry = index.getPosition(key, serializedKey);
+            }
+            if (entry != null) {
+               FileProvider.Handle handle = fileProvider.getFile(entry.file);
+               try {
+                  EntryHeader header = EntryRecord.readEntryHeader(handle, entry.offset);
+                  if (header == null) {
+                     throw new IllegalStateException("Cannot read " + entry.file + ":" + entry.offset);
+                  }
+                  if (seqId < header.seqId()) {
+                     return true;
+                  }
+               } finally {
+                  handle.close();
+               }
+            } else {
+               // entry is not in index = it was deleted
+               return true;
+            }
+            if (serializedValue != null && (expiration < 0 || expiration > timeService.wallClockTime())) {
+               executor.execute(new Runnable() {
+                  @Override
+                  public void run() {
+                     try {
+                        task.processEntry(marshalledEntryFactory.newMarshalledEntry(key,
+                              serializedValue == null ? null : marshaller.objectFromByteBuffer(serializedValue),
+                              serializedMetadata == null ? null : (InternalMetadata) marshaller.objectFromByteBuffer(serializedMetadata)),
+                              context);
+                     } catch (Exception e) {
+                        log.error("Failed to process task for key " + key, e);
+                     } finally {
+                        long finished = tasksFinished.incrementAndGet();
+                        if (finished == tasksSubmitted.longValue()) {
+                           synchronized (context) {
+                              context.notifyAll();
+                           }
+                        }
+                     }
+                  }
+               });
+               tasksSubmitted.incrementAndGet();
+               return !context.isStopped();
+            }
+            return true;
+         }
+      }, new FileFunctor() {
+         @Override
+         public void afterFile(int file) {
+            // noop
+         }
+      });
+      while (tasksSubmitted.longValue() > tasksFinished.longValue()) {
+         synchronized (context) {
+            try {
+               context.wait(100);
+            } catch (InterruptedException e) {
+               log.error("Iteration was interrupted", e);
+               Thread.currentThread().interrupt();
+               return;
+            }
+         }
+      }
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/SyncProcessingQueue.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/SyncProcessingQueue.java
@@ -1,0 +1,119 @@
+package org.infinispan.persistence.sifs;
+
+import java.util.ArrayDeque;
+
+/**
+ * Multiple producer-single consumer queue. The producers are expected to call pushAndWait(),
+ * the consumer should call pop() in a loop and if a null is returned (meaning that the queue is either empty
+ * or the limit of elements processed in a loop has been reached, to call notifyAndWait().
+ *
+ * Example:
+ * while (running) {
+ *    T element = queue.pop();
+ *    if (element != null) {
+ *       process(element);
+ *    } else {
+ *       flush();
+ *       queue.notifyAndWait();
+ *    }
+ * }
+ * // terminate producers and process the rest of the queue
+ * queue.notifyNoWait();
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class SyncProcessingQueue<T> {
+   private final ArrayDeque<T> queue = new ArrayDeque<T>();
+   private final int maxPoppedInRow;
+   private final Object sync = new Object();
+
+   private volatile long popIndex = 0;
+   private long pushIndex = 0;
+
+   private long processorPopIndex = 0;
+   private int poppedInRow = 0;
+   private volatile boolean error;
+
+   public SyncProcessingQueue() {
+      this(Integer.MAX_VALUE);
+   }
+
+   public SyncProcessingQueue(int maxPoppedInRow) {
+      this.maxPoppedInRow = maxPoppedInRow;
+   }
+
+   public void pushAndWait(T element) throws InterruptedException {
+      waitFor(push(element));
+   }
+
+   public long push(T element) {
+      synchronized (queue) {
+         queue.push(element);
+         queue.notify();
+         pushIndex++;
+         return pushIndex;
+      }
+   }
+
+   protected void waitFor(long myIndex) throws InterruptedException {
+      synchronized (sync) {
+         while (myIndex > popIndex) {
+            sync.wait();
+            //Thread.yield();
+         }
+      }
+      if (error) {
+         throw new IllegalStateException("Exception in consumer");
+      }
+   }
+
+   public T pop() {
+      if (poppedInRow >= maxPoppedInRow) {
+         return null;
+      }
+      T element;
+      synchronized (queue) {
+         element = queue.poll();
+      }
+      if (element == null) {
+         return null;
+      } else {
+         processorPopIndex++;
+         poppedInRow++;
+         return element;
+      }
+   }
+
+   public void notifyAndWait() {
+      poppedInRow = 0;
+      popIndex = processorPopIndex;
+      synchronized (sync) {
+         sync.notifyAll();
+      }
+      synchronized (queue) {
+         if (queue.isEmpty()) {
+            try {
+               queue.wait();
+            } catch (InterruptedException e) {
+               return;
+            }
+         }
+      }
+   }
+
+   public void notifyNoWait() {
+      poppedInRow = 0;
+      popIndex = processorPopIndex;
+      synchronized (sync) {
+         sync.notifyAll();
+      }
+   }
+
+   public void notifyError() {
+      error = true;
+      popIndex = Long.MAX_VALUE;
+      synchronized (sync) {
+         sync.notifyAll();
+      }
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/TemporaryTable.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/TemporaryTable.java
@@ -1,0 +1,118 @@
+package org.infinispan.persistence.sifs;
+
+import java.util.concurrent.ConcurrentMap;
+
+import org.infinispan.commons.equivalence.AnyEquivalence;
+import org.infinispan.commons.equivalence.Equivalence;
+import org.infinispan.commons.util.CollectionFactory;
+
+/**
+ * Table holding the entry positions in log before these are persisted to the index.
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class TemporaryTable {
+
+   private ConcurrentMap<Object, Entry> table;
+
+   public TemporaryTable(int capacity, Equivalence<Object> keyEquivalence) {
+      table = CollectionFactory.makeConcurrentMap(capacity, keyEquivalence, AnyEquivalence.getInstance());
+   }
+
+   public void set(Object key, int file, int offset) {
+      for (;;) {
+         Entry entry = table.putIfAbsent(key, new Entry(file, offset));
+         if (entry != null) {
+            synchronized (entry) {
+               if (entry.isRemoved()) {
+                  continue;
+               }
+               entry.update(file, offset);
+               return;
+            }
+         } else {
+            return;
+         }
+      }
+   }
+
+   public void setConditionally(Object key, int file, int offset, int prevFile, int prevOffset) {
+      for (;;) {
+         Entry entry = table.putIfAbsent(key, new Entry(file, offset));
+         if (entry != null) {
+            synchronized (entry) {
+               if (entry.isRemoved()) {
+                  continue;
+               }
+               if (entry.getFile() == prevFile && entry.getOffset() == prevOffset) {
+                  entry.update(file, offset);
+               }
+               return;
+            }
+         } else {
+            return;
+         }
+      }
+   }
+
+   public EntryPosition get(Object key) {
+      Entry entry = table.get(key);
+      if (entry == null) {
+         return null;
+      }
+      int file, offset;
+      synchronized (entry) {
+         file = entry.getFile();
+         offset = entry.getOffset();
+      }
+      return new EntryPosition(file, offset);
+   }
+
+   public void clear() {
+      table.clear();
+   }
+
+   public void removeConditionally(Object key, int file, int offset) {
+      Entry tempEntry = table.get(key);
+      if (tempEntry != null) {
+         synchronized (tempEntry) {
+            if (tempEntry.getFile() == file && tempEntry.getOffset() == offset) {
+               table.remove(key, tempEntry);
+               tempEntry.setRemoved(true);
+            }
+         }
+      }
+   }
+
+   private static class Entry {
+      private int file;
+      private int offset;
+      private boolean removed = false;
+
+      Entry(int file, int offset) {
+         this.file = file;
+         this.offset = offset;
+      }
+
+      public int getFile() {
+         return file;
+      }
+
+      public int getOffset() {
+         return offset;
+      }
+
+      public void update(int currentFile, int currentOffset) {
+         this.file = currentFile;
+         this.offset = currentOffset;
+      }
+
+      public boolean isRemoved() {
+         return removed;
+      }
+
+      public void setRemoved(boolean removed) {
+         this.removed = removed;
+      }
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/Attribute.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/Attribute.java
@@ -1,0 +1,58 @@
+package org.infinispan.persistence.sifs.configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Enumerates the attributes used by the LevelDB cache stores configuration
+ * 
+ * @author <a href="mailto:rtsang@redhat.com">Ray Tsang</a>
+ */
+public enum Attribute {
+   // must be first
+   UNKNOWN(null),
+   COMPACTION_THRESHOLD("compactionThreshold"),
+   DATA_LOCATION("dataLocation"),
+   INDEX_QUEUE_LENGTH("indexQueueLength"),
+   INDEX_LOCATION("indexLocation"),
+   INDEX_SEGMENTS("indexSegments"),
+   MAX_FILE_SIZE("maxFileSize"),
+   MAX_NODE_SIZE("maxNodeSize"),
+   MIN_NODE_SIZE("minNodeSize"),
+   OPEN_FILES_LIMIT("openFilesLimit"),
+   SYNC_WRITES("syncWrites")
+   ;
+
+   private final String name;
+
+   private Attribute(final String name) {
+      this.name = name;
+   }
+
+   /**
+    * Get the local name of this element.
+    * 
+    * @return the local name
+    */
+   public String getLocalName() {
+      return name;
+   }
+
+   private static final Map<String, Attribute> attributes;
+
+   static {
+      final Map<String, Attribute> map = new HashMap<String, Attribute>(64);
+      for (Attribute attribute : values()) {
+         final String name = attribute.getLocalName();
+         if (name != null) {
+            map.put(name, attribute);
+         }
+      }
+      attributes = map;
+   }
+
+   public static Attribute forName(final String localName) {
+      final Attribute attribute = attributes.get(localName);
+      return attribute == null ? UNKNOWN : attribute;
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/Element.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/Element.java
@@ -1,0 +1,47 @@
+package org.infinispan.persistence.sifs.configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public enum Element {
+   UNKNOWN(null),
+   SOFT_INDEX_FILE_STORE("softIndexStore"),
+
+   ;
+
+   private final String name;
+
+   Element(final String name) {
+      this.name = name;
+   }
+
+   /**
+    * Get the local name of this element.
+    *
+    * @return the local name
+    */
+   public String getLocalName() {
+      return name;
+   }
+
+   private static final Map<String, Element> MAP;
+
+   static {
+      final Map<String, Element> map = new HashMap<String, Element>(8);
+      for (Element element : values()) {
+         final String name = element.getLocalName();
+         if (name != null) {
+            map.put(name, element);
+         }
+      }
+      MAP = map;
+   }
+
+   public static Element forName(final String localName) {
+      final Element element = MAP.get(localName);
+      return element == null ? UNKNOWN : element;
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/SoftIndexFileStoreConfiguration.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/SoftIndexFileStoreConfiguration.java
@@ -1,0 +1,92 @@
+package org.infinispan.persistence.sifs.configuration;
+
+import java.util.Properties;
+
+import org.infinispan.commons.configuration.BuiltBy;
+import org.infinispan.commons.configuration.ConfigurationFor;
+import org.infinispan.configuration.cache.AbstractStoreConfiguration;
+import org.infinispan.configuration.cache.AsyncStoreConfiguration;
+import org.infinispan.configuration.cache.SingletonStoreConfiguration;
+import org.infinispan.persistence.sifs.SoftIndexFileStore;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+@BuiltBy(SoftIndexFileStoreConfigurationBuilder.class)
+@ConfigurationFor(SoftIndexFileStore.class)
+public class SoftIndexFileStoreConfiguration extends AbstractStoreConfiguration {
+   private final String dataLocation;
+   private final String indexLocation;
+   private final int indexSegments;
+   private final int maxFileSize;
+   private final int minNodeSize;
+   private final int maxNodeSize;
+   private final int indexQueueLength;
+   private final boolean syncWrites;
+   private final int openFilesLimit;
+   private final double compactionThreshold;
+
+
+   public SoftIndexFileStoreConfiguration(boolean purgeOnStartup, boolean fetchPersistentState,
+                                          boolean ignoreModifications, AsyncStoreConfiguration async,
+                                          SingletonStoreConfiguration singletonStore, boolean preload, boolean shared,
+                                          Properties properties,
+                                          String dataLocation, String indexLocation, int indexSegments,
+                                          int maxFileSize, int minNodeSize, int maxNodeSize, int indexQueueLength,
+                                          boolean syncWrites, int openFilesLimit, double compactionThreshold) {
+      super(purgeOnStartup, fetchPersistentState, ignoreModifications, async, singletonStore, preload, shared, properties);
+      this.dataLocation = dataLocation;
+      this.indexLocation = indexLocation;
+      this.indexSegments = indexSegments;
+      this.minNodeSize = minNodeSize;
+      this.maxFileSize = maxFileSize;
+      this.maxNodeSize = maxNodeSize;
+      this.indexQueueLength = indexQueueLength;
+      this.syncWrites = syncWrites;
+      this.openFilesLimit = openFilesLimit;
+      this.compactionThreshold = compactionThreshold;
+   }
+
+   public String dataLocation() {
+      return dataLocation;
+   }
+
+   public String indexLocation() {
+      return indexLocation;
+   }
+
+   public int indexSegments() {
+      return indexSegments;
+   }
+
+   public int maxFileSize() {
+      return maxFileSize;
+   }
+
+   public int minNodeSize() {
+      return minNodeSize;
+   }
+
+   public int maxNodeSize() {
+      return maxNodeSize;
+   }
+
+   public int indexQueueLength() {
+      return indexQueueLength;
+   }
+
+   public boolean syncWrites() {
+      return syncWrites;
+   }
+
+   public int openFilesLimit() {
+      return openFilesLimit;
+   }
+
+   public double compactionThreshold() {
+      return compactionThreshold;
+   }
+
+
+
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/SoftIndexFileStoreConfigurationBuilder.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/SoftIndexFileStoreConfigurationBuilder.java
@@ -1,0 +1,117 @@
+package org.infinispan.persistence.sifs.configuration;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.cache.AbstractStoreConfigurationBuilder;
+import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class SoftIndexFileStoreConfigurationBuilder extends AbstractStoreConfigurationBuilder<SoftIndexFileStoreConfiguration, SoftIndexFileStoreConfigurationBuilder> {
+
+   private String dataLocation = "Infinispan-SoftIndexFileStore-Data";
+   private String indexLocation = "Infinispan-SoftIndexFileStore-Index";
+   private int indexSegments = 3;
+   private int maxFileSize = 16 * 1024 * 1024;
+   private int minNodeSize = -1;
+   private int maxNodeSize = 4096;
+   private int indexQueueLength = 1000;
+   private boolean syncWrites = false;
+   private int openFilesLimit = 1000;
+   private double compactionThreshold = 0.5;
+
+   public SoftIndexFileStoreConfigurationBuilder(PersistenceConfigurationBuilder builder) {
+      super(builder);
+   }
+
+   public SoftIndexFileStoreConfigurationBuilder dataLocation(String dataLocation) {
+      this.dataLocation = dataLocation;
+      return this;
+   }
+
+   public SoftIndexFileStoreConfigurationBuilder indexLocation(String indexLocation) {
+      this.indexLocation = indexLocation;
+      return this;
+   }
+
+   public SoftIndexFileStoreConfigurationBuilder indexSegments(int indexSegments) {
+      this.indexSegments = indexSegments;
+      return this;
+   }
+
+   public SoftIndexFileStoreConfigurationBuilder maxFileSize(int maxFileSize) {
+      this.maxFileSize = maxFileSize;
+      return this;
+   }
+
+   public SoftIndexFileStoreConfigurationBuilder minNodeSize(int minNodeSize) {
+      this.minNodeSize = minNodeSize;
+      return this;
+   }
+
+   public SoftIndexFileStoreConfigurationBuilder maxNodeSize(int maxNodeSize) {
+      this.maxNodeSize = maxNodeSize;
+      return this;
+   }
+
+   public SoftIndexFileStoreConfigurationBuilder indexQueueLength(int indexQueueLength) {
+      this.indexQueueLength = indexQueueLength;
+      return this;
+   }
+
+   public SoftIndexFileStoreConfigurationBuilder syncWrites(boolean syncWrites) {
+      this.syncWrites = syncWrites;
+      return this;
+   }
+
+   public SoftIndexFileStoreConfigurationBuilder openFilesLimit(int openFilesLimit) {
+      this.openFilesLimit = openFilesLimit;
+      return this;
+   }
+
+   public SoftIndexFileStoreConfigurationBuilder compactionThreshold(double compactionThreshold) {
+      this.compactionThreshold = compactionThreshold;
+      return this;
+   }
+
+   @Override
+   public SoftIndexFileStoreConfiguration create() {
+      return new SoftIndexFileStoreConfiguration(
+            purgeOnStartup, fetchPersistentState, ignoreModifications,
+            async.create(), singletonStore.create(), preload, shared, properties,
+            dataLocation, indexLocation, indexSegments,
+            maxFileSize, minNodeSize < 0 ? maxNodeSize/3 : minNodeSize, maxNodeSize,
+            indexQueueLength, syncWrites, openFilesLimit, compactionThreshold);
+   }
+
+   @Override
+   public Builder<?> read(SoftIndexFileStoreConfiguration template) {
+      dataLocation = template.dataLocation();
+      indexLocation = template.indexLocation();
+      indexSegments = template.indexSegments();
+      maxFileSize = template.maxFileSize();
+      minNodeSize = template.minNodeSize();
+      maxNodeSize = template.maxNodeSize();
+      indexQueueLength = template.indexQueueLength();
+      syncWrites = template.syncWrites();
+      openFilesLimit = template.openFilesLimit();
+      compactionThreshold = template.compactionThreshold();
+
+      // AbstractStore-specific configuration
+      fetchPersistentState = template.fetchPersistentState();
+      ignoreModifications = template.ignoreModifications();
+      properties = template.properties();
+      purgeOnStartup = template.purgeOnStartup();
+      async.read(template.async());
+      singletonStore.read(template.singletonStore());
+      preload = template.preload();
+      shared = template.shared();
+
+      return this;
+   }
+
+   @Override
+   public SoftIndexFileStoreConfigurationBuilder self() {
+      return this;
+   }
+}

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/SoftIndexFileStoreConfigurationParser70.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/SoftIndexFileStoreConfigurationParser70.java
@@ -1,0 +1,94 @@
+package org.infinispan.persistence.sifs.configuration;
+
+import static org.infinispan.commons.util.StringPropertyReplacer.replaceProperties;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
+import org.infinispan.configuration.parsing.ConfigurationParser;
+import org.infinispan.configuration.parsing.Namespace;
+import org.infinispan.configuration.parsing.Namespaces;
+import org.infinispan.configuration.parsing.ParseUtils;
+import org.infinispan.configuration.parsing.Parser70;
+import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
+
+/**
+ *
+ * @author <a href="mailto:rtsang@redhat.com">Ray Tsang</a>
+ *
+ */
+@Namespaces({ @Namespace(uri = "urn:infinispan:config:soft-index:7.0", root = "softIndexStore"), @Namespace(root = "softIndexStore") })
+public class SoftIndexFileStoreConfigurationParser70 implements ConfigurationParser {
+
+   public SoftIndexFileStoreConfigurationParser70() {
+   }
+
+   @Override
+   public void readElement(XMLExtendedStreamReader reader, ConfigurationBuilderHolder holder) throws XMLStreamException {
+      ConfigurationBuilder builder = holder.getCurrentConfigurationBuilder();
+      Element element = Element.forName(reader.getLocalName());
+      switch (element) {
+      case SOFT_INDEX_FILE_STORE: {
+         parseSoftIndexFileStore(reader, builder.persistence().addStore(SoftIndexFileStoreConfigurationBuilder.class));
+         break;
+      }
+      default: {
+         throw ParseUtils.unexpectedElement(reader);
+      }
+      }
+   }
+
+   @Override
+   public Namespace[] getNamespaces() {
+      return ParseUtils.getNamespaceAnnotations(getClass());
+   }
+
+   private void parseSoftIndexFileStore(XMLExtendedStreamReader reader, SoftIndexFileStoreConfigurationBuilder builder) throws XMLStreamException {
+      for (int i = 0; i < reader.getAttributeCount(); i++) {
+         ParseUtils.requireNoNamespaceAttribute(reader, i);
+         String value = replaceProperties(reader.getAttributeValue(i));
+         String attrName = reader.getAttributeLocalName(i);
+         Attribute attribute = Attribute.forName(attrName);
+         switch (attribute) {
+            case DATA_LOCATION:
+               builder.dataLocation(value);
+               break;
+            case INDEX_LOCATION:
+               builder.indexLocation(value);
+               break;
+            case INDEX_SEGMENTS:
+               builder.indexSegments(Integer.parseInt(value));
+               break;
+            case INDEX_QUEUE_LENGTH:
+               builder.indexQueueLength(Integer.parseInt(value));
+               break;
+            case MAX_FILE_SIZE:
+               builder.maxFileSize(Integer.parseInt(value));
+               break;
+            case MIN_NODE_SIZE:
+               builder.minNodeSize(Integer.parseInt(value));
+               break;
+            case MAX_NODE_SIZE:
+               builder.maxNodeSize(Integer.parseInt(value));
+               break;
+            case SYNC_WRITES:
+               builder.syncWrites(Boolean.parseBoolean(value));
+               break;
+            case OPEN_FILES_LIMIT:
+               builder.openFilesLimit(Integer.parseInt(value));
+               break;
+            case COMPACTION_THRESHOLD:
+               builder.compactionThreshold(Double.parseDouble(value));
+               break;
+            default:
+               Parser70.parseStoreAttribute(reader, i, builder);
+               break;
+         }
+      }
+      if (reader.hasNext() && (reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {
+         throw ParseUtils.unexpectedElement(reader);
+      }
+   }
+}

--- a/persistence/soft-index/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
+++ b/persistence/soft-index/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
@@ -1,0 +1,1 @@
+org.infinispan.persistence.sifs.configuration.SoftIndexFileStoreConfigurationParser70

--- a/persistence/soft-index/src/main/resources/schema/infinispan-persistence-soft-index-config-7.0.xsd
+++ b/persistence/soft-index/src/main/resources/schema/infinispan-persistence-soft-index-config-7.0.xsd
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xs:schema attributeFormDefault="unqualified"
+   elementFormDefault="qualified" version="1.0" targetNamespace="urn:infinispan:config:soft-index:7.0"
+   xmlns:tns="urn:infinispan:config:soft-index:7.0" xmlns:config="urn:infinispan:config:7.0"
+   xmlns:xs="http://www.w3.org/2001/XMLSchema">
+   <xs:import namespace="urn:infinispan:config:7.0" schemaLocation="http://www.infinispan.org/schemas/infinispan-config-7.0.xsd" />
+
+   <xs:element name="softIndexStore" type="tns:softIndexStoreType"/>
+   
+   <xs:complexType name="softIndexStoreType">
+      <xs:complexContent>
+         <xs:extension base="config:store">
+            <xs:attribute name="dataLocation" type="xs:string" default="Infinispan-SoftIndexFileStore-Data">
+               <xs:annotation>
+                  <xs:documentation>
+                     A location on disk where the store writes entries (persistent location). Files are written sequentially, reads are random.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="indexLocation" type="xs:string" default="Infinispan-SotfIndexFileStore-Index">
+               <xs:annotation>
+                  <xs:documentation>
+                     A location where the store keeps index - this does not have be persistent across restarts, and SSD storage is recommended (the index is accessed randomly).
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="indexSegments" type="xs:int" default="3">
+               <xs:annotation>
+                  <xs:documentation>
+                     Number of index segment files. Increasing this value improves throughput but requires more threads to be spawned.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="indexQueueLength" type="xs:int" default="1000">
+               <xs:annotation>
+                  <xs:documentation>
+                     Max number of entry writes that are waiting to be written to the index, per index segment.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="maxFileSize" type="xs:int" default="16777216">
+               <xs:annotation>
+                  <xs:documentation>
+                     Max size of single file with entries, in bytes.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="maxNodeSize" type="xs:int" default="4096">
+               <xs:annotation>
+                  <xs:documentation>
+                     Max size of node (continuous block on filesystem used in index implementation), in bytes.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="minNodeSize" type="xs:int" default="4096">
+               <xs:annotation>
+                  <xs:documentation>
+                     If the size of node (continuous block on filesystem used in index implementation) drops below this threshold, the node will try to balance its size with some neighbour node, possibly causing join of multiple nodes.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="syncWrites" type="xs:boolean" default="false">
+               <xs:annotation>
+                  <xs:documentation>
+                     If true, the write is confirmed only after the entry is fsynced on disk.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="openFilesLimit" type="xs:int" default="1000">
+               <xs:annotation>
+                  <xs:documentation>
+                     Max number of data files opened for reading (current log file, compaction output and index segments are not included here).
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="compactionThreshold" type="xs:double" default="0.5">
+               <xs:annotation>
+                  <xs:documentation>
+                     If amount of unused space in some data file gets above this threshold, the file is compacted - entries from that file are copied to a new file and the old file is deleted.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+</xs:schema>

--- a/persistence/soft-index/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreFunctionalTest.java
+++ b/persistence/soft-index/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreFunctionalTest.java
@@ -1,0 +1,37 @@
+package org.infinispan.persistence.sifs;
+
+import java.io.File;
+
+import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+import org.infinispan.persistence.BaseStoreFunctionalTest;
+import org.infinispan.persistence.sifs.configuration.SoftIndexFileStoreConfigurationBuilder;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+@Test(groups = "unit", testName = "persistence.SoftIndexFileStoreFunctionalTest")
+public class SoftIndexFileStoreFunctionalTest extends BaseStoreFunctionalTest {
+   private String tmpDirectory;
+
+   @BeforeClass
+   protected void setUpTempDir() {
+      tmpDirectory = TestingUtil.tmpDirectory(this.getClass());
+   }
+
+   @AfterClass
+   protected void clearTempDir() {
+      TestingUtil.recursiveFileRemove(tmpDirectory);
+      new File(tmpDirectory).mkdirs();
+   }
+
+
+   @Override
+   protected PersistenceConfigurationBuilder createCacheStoreConfig(PersistenceConfigurationBuilder persistence, boolean preload) {
+      persistence.addStore(SoftIndexFileStoreConfigurationBuilder.class).preload(preload).dataLocation(tmpDirectory + "/data").indexLocation(tmpDirectory);
+      return persistence;
+   }
+}

--- a/persistence/soft-index/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreTest.java
+++ b/persistence/soft-index/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreTest.java
@@ -1,0 +1,90 @@
+package org.infinispan.persistence.sifs;
+
+import static org.infinispan.persistence.PersistenceUtil.internalMetadata;
+import static org.infinispan.test.TestingUtil.recursiveFileRemove;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.marshall.core.MarshalledEntryImpl;
+import org.infinispan.persistence.BaseStoreTest;
+import org.infinispan.persistence.sifs.configuration.SoftIndexFileStoreConfigurationBuilder;
+import org.infinispan.persistence.spi.AdvancedLoadWriteStore;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
+import org.testng.AssertJUnit;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Low level single-file cache store tests.
+ *
+ * @author Galder Zamarreño
+ * @since 6.0
+ */
+@Test(groups = "unit", testName = "persistence.SoftIndexFileStoreTest")
+public class SoftIndexFileStoreTest extends BaseStoreTest {
+
+   SoftIndexFileStore store;
+   String tmpDirectory;
+
+   @BeforeClass
+   protected void setUpTempDir() {
+      tmpDirectory = TestingUtil.tmpDirectory(this.getClass());
+   }
+
+   @AfterClass
+   protected void clearTempDir() {
+      recursiveFileRemove(tmpDirectory);
+   }
+
+   @Override
+   protected AdvancedLoadWriteStore createStore() throws Exception {
+      clearTempDir();
+      store = new SoftIndexFileStore();
+      ConfigurationBuilder builder = TestCacheManagerFactory
+            .getDefaultCacheConfiguration(false);
+      builder.persistence()
+               .addStore(SoftIndexFileStoreConfigurationBuilder.class)
+                  .indexLocation(tmpDirectory).dataLocation(tmpDirectory + "/data");
+
+      store.init(createContext(builder.build()));
+      store.start();
+      return store;
+   }
+
+   @Override
+   protected boolean storePurgesAllExpired() {
+      return false;
+   }
+
+   public void testLoadUnload() {
+      int numEntries = 10000;
+      for (int i = 0; i < numEntries; ++i) {
+         InternalCacheEntry ice = TestInternalCacheEntryFactory.create(key(i), "value" + i);
+         store.write(new MarshalledEntryImpl(ice.getKey(), ice.getValue(), internalMetadata(ice), getMarshaller()));
+      }
+      System.out.println("Loaded all entries");
+      for (int i = 0; i < numEntries; ++i) {
+         if (!store.delete(key(i))) {
+            AssertJUnit.fail("Key " + key(i) + " not found");
+         }
+      }
+      store.clear();
+      for (int i = 0; i < numEntries; ++i) {
+         InternalCacheEntry ice = TestInternalCacheEntryFactory.create(key(i), "value" + i);
+         store.write(new MarshalledEntryImpl(ice.getKey(), ice.getValue(), internalMetadata(ice), getMarshaller()));
+      }
+      for (int i = numEntries - 1; i >= 0; --i) {
+         if (!store.delete(key(i))) {
+            AssertJUnit.fail("Key " + key(i) + " not found");
+         }
+      }
+   }
+
+   private String key(int i) {
+      return String.format("key%010d", i);
+   }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
       <module>persistence/cli</module>
       <module>persistence/leveldb</module>
       <module>persistence/rest</module>
+      <module>persistence/soft-index</module>
       <module>server</module>
       <module>server/core</module>
       <module>server/memcached</module>


### PR DESCRIPTION
- see SoftIndexFileStore javadoc for design info

https://issues.jboss.org/browse/ISPN-3921

I will provide performance comparison with LevelDB soon.

Currently the SoftIndexFileStoreFuctionalTest#testStoreAsBinary fails, but this bug in the test (should be fixed in another JIRA). The test does not purge the cache, therefore, when it configures the ByteArrayEquality to be used and store finds String key, it passes it to the Equality and the test fails.
