### PR TITLE
ISPN-3943 Fix L1WriteSynchronizerTest failures

### DIFF
--- a/core/src/test/java/org/infinispan/interceptors/distribution/L1WriteSynchronizerTest.java
+++ b/core/src/test/java/org/infinispan/interceptors/distribution/L1WriteSynchronizerTest.java
@@ -177,7 +177,7 @@ public class L1WriteSynchronizerTest extends AbstractInfinispanTest {
 
          @Override
          public Object call() throws Exception {
-            return sync.get(500, TimeUnit.MILLISECONDS);
+            return sync.get(5, TimeUnit.SECONDS);
          }
       });
 


### PR DESCRIPTION
- Increased timeout to make sure test doesn't fail incorrectly

https://issues.jboss.org/browse/ISPN-3943
