### PR TITLE
ISPN-3951 Make sure TestingUtil.replaceComponent is only called after

### DIFF
--- a/core/src/test/java/org/infinispan/api/ConditionalOperationPrimaryOwnerFailTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationPrimaryOwnerFailTest.java
@@ -81,6 +81,8 @@ public class ConditionalOperationPrimaryOwnerFailTest extends MultipleCacheManag
                                                any(InternalCacheEntry.class), anyBoolean(),
                                                any(FlagAffectedCommand.class), anyBoolean());
 
+      replaceComponent(futureBackupOwnerCache.getCacheManager(), InboundInvocationHandler.class, spyHandler, true);
+
       fork(new Runnable() {
          @Override
          public void run() {
@@ -112,7 +114,6 @@ public class ConditionalOperationPrimaryOwnerFailTest extends MultipleCacheManag
 
    private InboundInvocationHandler spyInvocationHandler(Cache cache) {
       InboundInvocationHandler spy = Mockito.spy(extractComponent(cache, InboundInvocationHandler.class));
-      replaceComponent(cache.getCacheManager(), InboundInvocationHandler.class, spy, true);
       JGroupsTransport t = (JGroupsTransport) extractComponent(cache, Transport.class);
       CommandAwareRpcDispatcher card = t.getCommandAwareRpcDispatcher();
       replaceField(spy, "inboundInvocationHandler", card, CommandAwareRpcDispatcher.class);

--- a/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
@@ -465,7 +465,6 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
       StateTransferLock stl = TestingUtil.extractComponent(cache, StateTransferLock.class);
       final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(stl);
       StateTransferLock mockLock = mock(StateTransferLock.class, withSettings().defaultAnswer(forwardedAnswer));
-      TestingUtil.replaceComponent(cache, StateTransferLock.class, mockLock, true);
       doAnswer(new Answer() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -477,5 +476,6 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
             return forwardedAnswer.answer(invocation);
          }
       }).when(mockLock).acquireSharedTopologyLock();
+      TestingUtil.replaceComponent(cache, StateTransferLock.class, mockLock, true);
    }
 }

--- a/core/src/test/java/org/infinispan/distribution/DistSyncTxL1FuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncTxL1FuncTest.java
@@ -375,7 +375,7 @@ public class DistSyncTxL1FuncTest extends BaseDistSyncL1Test {
       RpcManager rm2 = TestingUtil.extractComponent(backupOwnerCache, RpcManager.class);
       ControlledRpcManager crm2 = new ControlledRpcManager(rm2);
       // Make our node block and not return the get yet
-      crm.blockBefore(InvalidateL1Command.class);
+      crm2.blockBefore(InvalidateL1Command.class);
       TestingUtil.replaceComponent(backupOwnerCache, RpcManager.class, crm2, true);
 
       try {

--- a/core/src/test/java/org/infinispan/distribution/rehash/BaseTxStateTransferOverwriteTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/BaseTxStateTransferOverwriteTest.java
@@ -503,7 +503,6 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
       ClusterTopologyManager ctm = TestingUtil.extractGlobalComponent(manager, ClusterTopologyManager.class);
       final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(ctm);
       ClusterTopologyManager mockManager = mock(ClusterTopologyManager.class, withSettings().defaultAnswer(forwardedAnswer));
-      TestingUtil.replaceComponent(manager, ClusterTopologyManager.class, mockManager, true);
       doAnswer(new Answer<Object>() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -517,13 +516,13 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
          }
       }).when(mockManager).handleRebalanceCompleted(anyString(), any(Address.class), anyInt(), any(Throwable.class),
                                                    anyInt());
+      TestingUtil.replaceComponent(manager, ClusterTopologyManager.class, mockManager, true);
    }
 
    protected void waitUntilStateBeingTransferred(final Cache<?, ?> cache, final CheckPoint checkPoint) {
       StateConsumer sc = TestingUtil.extractComponent(cache, StateConsumer.class);
       final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(sc);
       StateConsumer mockConsumer = mock(StateConsumer.class, withSettings().defaultAnswer(forwardedAnswer));
-      TestingUtil.replaceComponent(cache, StateConsumer.class, mockConsumer, true);
       doAnswer(new Answer() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -535,5 +534,6 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
             return forwardedAnswer.answer(invocation);
          }
       }).when(mockConsumer).applyState(any(Address.class), anyInt(), anyCollection());
+      TestingUtil.replaceComponent(cache, StateConsumer.class, mockConsumer, true);
    }
 }

--- a/core/src/test/java/org/infinispan/distribution/rehash/L1StateTransferRemovesValueTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/L1StateTransferRemovesValueTest.java
@@ -195,7 +195,6 @@ public class L1StateTransferRemovesValueTest extends BaseDistFunctionalTest<Stri
       StateConsumer sc = TestingUtil.extractComponent(cache, StateConsumer.class);
       final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(sc);
       StateConsumer mockConsumer = mock(StateConsumer.class, withSettings().defaultAnswer(forwardedAnswer));
-      TestingUtil.replaceComponent(cache, StateConsumer.class, mockConsumer, true);
       doAnswer(new Answer() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -207,13 +206,13 @@ public class L1StateTransferRemovesValueTest extends BaseDistFunctionalTest<Stri
             return forwardedAnswer.answer(invocation);
          }
       }).when(mockConsumer).onTopologyUpdate(any(CacheTopology.class), anyBoolean());
+      TestingUtil.replaceComponent(cache, StateConsumer.class, mockConsumer, true);
    }
 
    protected void waitUntilToplogyInstalled(final Cache<?, ?> cache, final CheckPoint checkPoint) {
       StateTransferLock sc = TestingUtil.extractComponent(cache, StateTransferLock.class);
       final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(sc);
       StateTransferLock mockConsumer = mock(StateTransferLock.class, withSettings().defaultAnswer(forwardedAnswer));
-      TestingUtil.replaceComponent(cache, StateTransferLock.class, mockConsumer, true);
       doAnswer(new Answer() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -225,6 +224,7 @@ public class L1StateTransferRemovesValueTest extends BaseDistFunctionalTest<Stri
             return answer;
          }
       }).when(mockConsumer).notifyTopologyInstalled(anyInt());
+      TestingUtil.replaceComponent(cache, StateTransferLock.class, mockConsumer, true);
    }
 
    public static class ControllableConsistentHashFactory extends SingleSegmentConsistentHashFactory {

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxStateTransferOverwritingValue2Test.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxStateTransferOverwritingValue2Test.java
@@ -190,7 +190,6 @@ public class NonTxStateTransferOverwritingValue2Test extends MultipleCacheManage
    private void blockEntryCommit(final CheckPoint checkPoint, AdvancedCache<Object, Object> cache) {
       ClusteringDependentLogic cdl1 = cache.getComponentRegistry().getComponent(ClusteringDependentLogic.class);
       ClusteringDependentLogic spyCdl1 = spy(cdl1);
-      TestingUtil.replaceComponent(cache, ClusteringDependentLogic.class, spyCdl1, true);
       doAnswer(new Answer() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -207,6 +206,7 @@ public class NonTxStateTransferOverwritingValue2Test extends MultipleCacheManage
          }
       }).when(spyCdl1).commitEntry(any(CacheEntry.class), any(Metadata.class), any(FlagAffectedCommand.class),
             any(InvocationContext.class));
+      TestingUtil.replaceComponent(cache, ClusteringDependentLogic.class, spyCdl1, true);
    }
 
    private ControlledRpcManager blockStateResponseCommand(final Cache cache) throws InterruptedException {
@@ -221,7 +221,6 @@ public class NonTxStateTransferOverwritingValue2Test extends MultipleCacheManage
          throws Exception {
       ClusterTopologyManager ctm = TestingUtil.extractGlobalComponent(manager, ClusterTopologyManager.class);
       ClusterTopologyManager spyManager = spy(ctm);
-      TestingUtil.replaceComponent(manager, ClusterTopologyManager.class, spyManager, true);
       doAnswer(new Answer<Object>() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -234,5 +233,6 @@ public class NonTxStateTransferOverwritingValue2Test extends MultipleCacheManage
          }
       }).when(spyManager).handleRebalanceCompleted(anyString(), any(Address.class), anyInt(), any(Throwable.class),
             anyInt());
+      TestingUtil.replaceComponent(manager, ClusterTopologyManager.class, spyManager, true);
    }
 }

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxStateTransferOverwritingValueTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxStateTransferOverwritingValueTest.java
@@ -191,7 +191,6 @@ public class NonTxStateTransferOverwritingValueTest extends MultipleCacheManager
          throws Exception {
       ClusterTopologyManager ctm = TestingUtil.extractGlobalComponent(manager, ClusterTopologyManager.class);
       ClusterTopologyManager spyManager = spy(ctm);
-      TestingUtil.replaceComponent(manager, ClusterTopologyManager.class, spyManager, true);
       doAnswer(new Answer<Object>() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -204,5 +203,6 @@ public class NonTxStateTransferOverwritingValueTest extends MultipleCacheManager
          }
       }).when(spyManager).handleRebalanceCompleted(anyString(), any(Address.class), anyInt(), any(Throwable.class),
             anyInt());
+      TestingUtil.replaceComponent(manager, ClusterTopologyManager.class, spyManager, true);
    }
 }

--- a/core/src/test/java/org/infinispan/lock/singlelock/OriginatorBecomesOwnerLockTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/OriginatorBecomesOwnerLockTest.java
@@ -10,6 +10,7 @@ import javax.transaction.RollbackException;
 import javax.transaction.SystemException;
 
 import org.infinispan.Cache;
+import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.configuration.cache.CacheMode;
@@ -81,8 +82,7 @@ public class OriginatorBecomesOwnerLockTest extends MultipleCacheManagersTest {
    }
 
    private void testLockMigrationDuringPrepare(final Object key) throws Exception {
-      ControlledRpcManager controlledRpcManager = installControlledRpcManager();
-      controlledRpcManager.blockBefore(PrepareCommand.class);
+      ControlledRpcManager controlledRpcManager = installControlledRpcManager(PrepareCommand.class);
       final DummyTransactionManager tm = dummyTm(ORIGINATOR_INDEX);
 
       Future<DummyTransaction> f = fork(new Callable<DummyTransaction>() {
@@ -169,8 +169,7 @@ public class OriginatorBecomesOwnerLockTest extends MultipleCacheManagersTest {
    }
 
    private void testLockMigrationDuringCommit(final Object key) throws Exception {
-      ControlledRpcManager controlledRpcManager = installControlledRpcManager();
-      controlledRpcManager.blockBefore(CommitCommand.class);
+      ControlledRpcManager controlledRpcManager = installControlledRpcManager(CommitCommand.class);
       final DummyTransactionManager tm = dummyTm(ORIGINATOR_INDEX);
 
       Future<DummyTransaction> f = fork(new Callable<DummyTransaction>() {
@@ -221,9 +220,10 @@ public class OriginatorBecomesOwnerLockTest extends MultipleCacheManagersTest {
       });
    }
 
-   private ControlledRpcManager installControlledRpcManager() {
+   private ControlledRpcManager installControlledRpcManager(Class<? extends VisitableCommand> commandClass) {
       ControlledRpcManager controlledRpcManager = new ControlledRpcManager(
             originatorCache.getAdvancedCache().getRpcManager());
+      controlledRpcManager.blockBefore(commandClass);
       TestingUtil.replaceComponent(originatorCache, RpcManager.class, controlledRpcManager, true);
       return controlledRpcManager;
    }

--- a/core/src/test/java/org/infinispan/statetransfer/ClusterTopologyManagerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ClusterTopologyManagerTest.java
@@ -241,7 +241,6 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
             LocalTopologyManager.class);
       final CheckPoint checkpoint = new CheckPoint();
       LocalTopologyManager spyLocalTopologyManager = spy(localTopologyManager);
-      TestingUtil.replaceComponent(mergeCoordManager, LocalTopologyManager.class, spyLocalTopologyManager, true);
       doAnswer(new Answer<Object>() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -252,6 +251,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
             return invocation.callRealMethod();
          }
       }).when(spyLocalTopologyManager).handleRebalance(eq(CACHE_NAME), any(CacheTopology.class), anyInt());
+      TestingUtil.replaceComponent(mergeCoordManager, LocalTopologyManager.class, spyLocalTopologyManager, true);
 
       final EmbeddedCacheManager cm4 = addClusterEnabledCacheManager(defaultConfig,
             new TransportFlags().withFD(true).withMerge(true));
@@ -302,7 +302,6 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
             LocalTopologyManager.class);
       final CheckPoint checkpoint = new CheckPoint();
       LocalTopologyManager spyLocalTopologyManager = spy(localTopologyManager);
-      TestingUtil.replaceComponent(manager(1), LocalTopologyManager.class, spyLocalTopologyManager, true);
       doAnswer(new Answer<Object>() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -313,6 +312,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
             return invocation.callRealMethod();
          }
       }).when(spyLocalTopologyManager).handleStatusRequest(anyInt());
+      TestingUtil.replaceComponent(manager(1), LocalTopologyManager.class, spyLocalTopologyManager, true);
 
       // Node 1 (the coordinator) dies. Node 2 becomes coordinator and tries to call GET_STATUS
       log.debugf("Killing coordinator");
@@ -335,7 +335,6 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
       final CheckPoint checkpoint = new CheckPoint();
       StateProvider stateProvider = TestingUtil.extractComponent(c2, StateProvider.class);
       StateProvider spyStateProvider = spy(stateProvider);
-      TestingUtil.replaceComponent(c2, StateProvider.class, spyStateProvider, true);
       doAnswer(new Answer<Object>() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -346,6 +345,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
             return invocation.callRealMethod();
          }
       }).when(spyStateProvider).getTransactionsForSegments(any(Address.class), anyInt(), anySet());
+      TestingUtil.replaceComponent(c2, StateProvider.class, spyStateProvider, true);
 
       long startTime = System.currentTimeMillis();
       manager(2).stop();

--- a/core/src/test/java/org/infinispan/statetransfer/ManyTxsDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ManyTxsDuringStateTransferTest.java
@@ -68,7 +68,6 @@ public class ManyTxsDuringStateTransferTest extends MultipleCacheManagersTest {
       // Block state request commands on cache 0
       StateProvider stateProvider = TestingUtil.extractComponent(cache0, StateProvider.class);
       StateProvider spyProvider = spy(stateProvider);
-      TestingUtil.replaceComponent(cache0, StateProvider.class, spyProvider, true);
       doAnswer(new Answer<Object>() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -81,6 +80,7 @@ public class ManyTxsDuringStateTransferTest extends MultipleCacheManagersTest {
             return result;
          }
       }).when(spyProvider).getTransactionsForSegments(any(Address.class), anyInt(), anySetOf(Integer.class));
+      TestingUtil.replaceComponent(cache0, StateProvider.class, spyProvider, true);
 
       // Start cache 1, but the tx data request will be blocked on cache 0
       StateTransferManager stm0 = TestingUtil.extractComponent(cache0, StateTransferManager.class);

--- a/core/src/test/java/org/infinispan/statetransfer/NonTxStateTransferInvalidationTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/NonTxStateTransferInvalidationTest.java
@@ -120,7 +120,6 @@ public class NonTxStateTransferInvalidationTest extends MultipleCacheManagersTes
       ClusterTopologyManager ctm = TestingUtil.extractGlobalComponent(manager, ClusterTopologyManager.class);
       final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(ctm);
       ClusterTopologyManager mockManager = mock(ClusterTopologyManager.class, withSettings().defaultAnswer(forwardedAnswer));
-      TestingUtil.replaceComponent(manager, ClusterTopologyManager.class, mockManager, true);
       doAnswer(new Answer<Object>() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -130,6 +129,7 @@ public class NonTxStateTransferInvalidationTest extends MultipleCacheManagersTes
             return answer;
          }
       }).when(mockManager).handleJoin(anyString(), any(Address.class), any(CacheJoinInfo.class), anyInt());
+      TestingUtil.replaceComponent(manager, ClusterTopologyManager.class, mockManager, true);
    }
 
 }

--- a/core/src/test/java/org/infinispan/statetransfer/StaleLocksWithLockOnlyTxDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StaleLocksWithLockOnlyTxDuringStateTransferTest.java
@@ -67,7 +67,6 @@ public class StaleLocksWithLockOnlyTxDuringStateTransferTest extends MultipleCac
       // Block state request commands on cache 0
       StateProvider stateProvider = TestingUtil.extractComponent(cache0, StateProvider.class);
       StateProvider spyProvider = spy(stateProvider);
-      TestingUtil.replaceComponent(cache0, StateProvider.class, spyProvider, true);
       doAnswer(new Answer<Object>() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -89,6 +88,7 @@ public class StaleLocksWithLockOnlyTxDuringStateTransferTest extends MultipleCac
             return invocation.callRealMethod();
          }
       }).when(spyProvider).onTopologyUpdate(any(CacheTopology.class), eq(false));
+      TestingUtil.replaceComponent(cache0, StateProvider.class, spyProvider, true);
 
       // Block prepare commands on cache 0
       CyclicBarrier prepareBarrier = new CyclicBarrier(2);

--- a/core/src/test/java/org/infinispan/statetransfer/StaleTxWithCommitDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StaleTxWithCommitDuringStateTransferTest.java
@@ -81,7 +81,6 @@ public class StaleTxWithCommitDuringStateTransferTest extends MultipleCacheManag
       // Block state request commands on cache 0
       StateProvider stateProvider = TestingUtil.extractComponent(cache0, StateProvider.class);
       StateProvider spyProvider = spy(stateProvider);
-      TestingUtil.replaceComponent(cache0, StateProvider.class, spyProvider, true);
       doAnswer(new Answer<Object>() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -94,6 +93,7 @@ public class StaleTxWithCommitDuringStateTransferTest extends MultipleCacheManag
             return result;
          }
       }).when(spyProvider).getTransactionsForSegments(any(Address.class), anyInt(), anySetOf(Integer.class));
+      TestingUtil.replaceComponent(cache0, StateProvider.class, spyProvider, true);
 
       // Start a transaction on cache 0, which will block on cache 1
       MagicKey key = new MagicKey("testkey", cache0);


### PR DESCRIPTION
mock is fully configured
- Changed tests to make sure the replaced component is configured first

https://issues.jboss.org/browse/ISPN-3951
