### PR TITLE
ISPN-3956 L1WriteSynchronizer can cause locking with concurrent gets

### DIFF
--- a/core/src/main/java/org/infinispan/distribution/L1ManagerImpl.java
+++ b/core/src/main/java/org/infinispan/distribution/L1ManagerImpl.java
@@ -228,4 +228,13 @@ public class L1ManagerImpl implements L1Manager, RemoteValueRetrievedListener {
          synchronizer.runL1UpdateIfPossible(ice);
       }
    }
+
+   @Override
+   public void remoteValueNotFound(Object key) {
+      L1WriteSynchronizer synchronizer = synchronizers.get(key);
+      if (synchronizer != null) {
+         // we assume synchronizer supports null value properly
+         synchronizer.runL1UpdateIfPossible(null);
+      }
+   }
 }

--- a/core/src/main/java/org/infinispan/distribution/RemoteValueRetrievedListener.java
+++ b/core/src/main/java/org/infinispan/distribution/RemoteValueRetrievedListener.java
@@ -17,4 +17,10 @@ public interface RemoteValueRetrievedListener {
     * @param ice The cache entry that was found
     */
    public void remoteValueFound(InternalCacheEntry ice);
+
+   /**
+    * Invoked when a remote value is not found from the remote source for the given key
+    * @param key The key for which there was no value found
+    */
+   public void remoteValueNotFound(Object key);
 }

--- a/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
@@ -149,6 +149,9 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
             }
          }
       }
+      if (rvrl != null) {
+         rvrl.remoteValueNotFound(key);
+      }
       return null;
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1WriteSynchronizer.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1WriteSynchronizer.java
@@ -158,7 +158,9 @@ public class L1WriteSynchronizer {
 
    /**
     * Attempts to the L1 update and set the value.  If the L1 update was marked as being skipped this will instead
-    * just set the value to release blockers
+    * just set the value to release blockers.
+    * A null value can be provided which will not run the L1 update but will just alert other waiters that a null
+    * was given.
     */
    public void runL1UpdateIfPossible(InternalCacheEntry ice) {
       Object value = null;

--- a/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
@@ -6,6 +6,7 @@ import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.write.InvalidateL1Command;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.interceptors.base.CommandInterceptor;
+import org.infinispan.interceptors.distribution.L1WriteSynchronizer;
 import org.infinispan.statetransfer.StateTransferLock;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CheckPoint;
@@ -13,6 +14,7 @@ import org.infinispan.transaction.TransactionMode;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.junit.Assert;
 import org.mockito.AdditionalAnswers;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.annotations.Test;
@@ -393,31 +395,72 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
       assertIsNotInL1(nonOwnerCache, key);
 
       CheckPoint checkPoint = new CheckPoint();
-      waitUntilAboutToAcquireLock(nonOwnerCache, checkPoint);
-
-      log.warn("Doing get here - ignore all previous");
-
-      Future<String> getFuture = nonOwnerCache.getAsync(key);
-
-      // Wait until we are about to write value into data container on non owner
-      checkPoint.awaitStrict("pre_acquire_shared_topology_lock_invoked", 10, TimeUnit.SECONDS);
-
-      Future<String> getFuture2 = nonOwnerCache.getAsync(key);
+      StateTransferLock lock = waitUntilAboutToAcquireLock(nonOwnerCache, checkPoint);
 
       try {
-         getFuture2.get(1, TimeUnit.SECONDS);
-         fail("Should have thrown a TimeoutException");
-      } catch (TimeoutException e) {
+         log.warn("Doing get here - ignore all previous");
+
+         Future<String> getFuture = nonOwnerCache.getAsync(key);
+
+         // Wait until we are about to write value into data container on non owner
+         checkPoint.awaitStrict("pre_acquire_shared_topology_lock_invoked", 10, TimeUnit.SECONDS);
+
+         Future<String> getFuture2 = nonOwnerCache.getAsync(key);
+
+         try {
+            getFuture2.get(1, TimeUnit.SECONDS);
+            fail("Should have thrown a TimeoutException");
+         } catch (TimeoutException e) {
+         }
+
+         // Let the get complete finally
+         checkPoint.triggerForever("pre_acquire_shared_topology_lock_released");
+
+         Assert.assertEquals(firstValue, getFuture.get(10, TimeUnit.SECONDS));
+
+         Assert.assertEquals(firstValue, getFuture2.get(10, TimeUnit.SECONDS));
+
+         assertIsInL1(nonOwnerCache, key);
+      } finally {
+         TestingUtil.replaceComponent(nonOwnerCache, StateTransferLock.class, lock, true);
       }
+   }
 
-      // Let the get complete finally
-      checkPoint.triggerForever("pre_acquire_shared_topology_lock_released");
+   @Test
+   public void testGetBlockingAnotherGetWithMiss() throws Throwable {
+      final Cache<Object, String> nonOwnerCache = getFirstNonOwner(key);
+      final Cache<Object, String> ownerCache = getFirstOwner(key);
 
-      Assert.assertEquals(firstValue, getFuture.get(10, TimeUnit.SECONDS));
+      assertIsNotInL1(nonOwnerCache, key);
 
-      Assert.assertEquals(firstValue, getFuture2.get(10, TimeUnit.SECONDS));
+      CheckPoint checkPoint = new CheckPoint();
+      L1Manager l1Manager = waitUntilL1Registration(nonOwnerCache, checkPoint);
 
-      assertIsInL1(nonOwnerCache, key);
+      try {
+         log.warn("Doing get here - ignore all previous");
+
+         Future<String> getFuture = nonOwnerCache.getAsync(key);
+
+         // Wait until we are about to write value into data container on non owner
+         checkPoint.awaitStrict("pre_acquire_shared_topology_lock_invoked", 10, TimeUnit.SECONDS);
+
+         Future<String> getFuture2 = nonOwnerCache.getAsync(key);
+
+         try {
+            getFuture2.get(1, TimeUnit.SECONDS);
+            fail("Should have thrown a TimeoutException");
+         } catch (TimeoutException e) {
+         }
+
+         // Let the get complete finally
+         checkPoint.triggerForever("pre_acquire_shared_topology_lock_released");
+
+         Assert.assertNull(getFuture.get(10, TimeUnit.SECONDS));
+
+         Assert.assertNull(getFuture2.get(10, TimeUnit.SECONDS));
+      } finally {
+         TestingUtil.replaceComponent(nonOwnerCache, L1Manager.class, l1Manager, true);
+      }
    }
 
    @Test
@@ -461,11 +504,17 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
       }
    }
 
-   protected void waitUntilAboutToAcquireLock(final Cache<?, ?> cache, final CheckPoint checkPoint) {
+   /**
+    * Replaces StateTransferLock in cache with a proxy one that will block on
+    * {#link StateTransferLock#acquireSharedTopologyLock} until the checkpoint is triggered
+    * @param cache The cache to replace the StateTransferLock on
+    * @param checkPoint The checkpoint to use to trigger blocking
+    * @return The original real StateTransferLock
+    */
+   protected StateTransferLock waitUntilAboutToAcquireLock(final Cache<?, ?> cache, final CheckPoint checkPoint) {
       StateTransferLock stl = TestingUtil.extractComponent(cache, StateTransferLock.class);
       final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(stl);
       StateTransferLock mockLock = mock(StateTransferLock.class, withSettings().defaultAnswer(forwardedAnswer));
-      TestingUtil.replaceComponent(cache, StateTransferLock.class, mockLock, true);
       doAnswer(new Answer() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -477,5 +526,33 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
             return forwardedAnswer.answer(invocation);
          }
       }).when(mockLock).acquireSharedTopologyLock();
+      TestingUtil.replaceComponent(cache, StateTransferLock.class, mockLock, true);
+      return stl;
+   }
+
+   /**
+    * Replaces L1Manager in cache with a proxy one that will block on
+    * {#link L1Manager#registerL1WriteSynchronizer} until the checkpoint is triggered
+    * @param cache The cache to replace the L1Manager on
+    * @param checkPoint The checkpoint to use to trigger blocking
+    * @return The original real L1Manager
+    */
+   protected L1Manager waitUntilL1Registration(final Cache<?, ?> cache, final CheckPoint checkPoint) {
+      L1Manager l1Manager = TestingUtil.extractComponent(cache, L1Manager.class);
+      final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(l1Manager);
+      L1Manager mockL1 = mock(L1Manager.class, withSettings().defaultAnswer(forwardedAnswer));
+      doAnswer(new Answer() {
+         @Override
+         public Object answer(InvocationOnMock invocation) throws Throwable {
+            // Wait for main thread to sync up
+            checkPoint.trigger("pre_acquire_shared_topology_lock_invoked");
+            // Now wait until main thread lets us through
+            checkPoint.awaitStrict("pre_acquire_shared_topology_lock_released", 10, TimeUnit.SECONDS);
+
+            return forwardedAnswer.answer(invocation);
+         }
+      }).when(mockL1).registerL1WriteSynchronizer(Mockito.anyObject(), Mockito.any(L1WriteSynchronizer.class));
+      TestingUtil.replaceComponent(cache, L1Manager.class, mockL1, true);
+      return l1Manager;
    }
 }


### PR DESCRIPTION
when value is not present
- Added synchronizer update on get miss to properly release waiters

https://issues.jboss.org/browse/ISPN-3956
