### PR TITLE
ISPN-3948 Custom Cache Store Fix

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser60.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser60.java
@@ -685,18 +685,16 @@ public class Parser60 implements ConfigurationParser {
             ClusterLoaderConfigurationBuilder cscb = builder.persistence().addClusterLoader();
             parseLoaderChildren(reader, cscb);
          } else {
-		    BuiltBy builtByClazz = store.getClass().getAnnotation(
-				BuiltBy.class);
-			if(builtByClazz == null) { 
-			   throw new CacheConfigurationException(
-			      store.getClass()
-				   + " as a custom cache store, should have the annotation @BuiltBy specified for the StoreConfigurationBuilder!");
-			}
-			builderClass = builtByClazz.value();
-			@SuppressWarnings("unchecked")
-			StoreConfigurationBuilder<?, ?> pcb = builder.persistence()
-			   .addStore(builderClass);
-			parseStoreChildren(reader, pcb);
+            BuiltBy builtByClazz = store.getClass().getAnnotation(BuiltBy.class);
+            if (builtByClazz == null) {
+               throw new CacheConfigurationException(
+                     store.getClass()
+                           + " as a custom cache store, should have the annotation @BuiltBy specified for the StoreConfigurationBuilder!");
+            }
+            builderClass = builtByClazz.value();
+            @SuppressWarnings("unchecked")
+            StoreConfigurationBuilder<?, ?> pcb = builder.persistence().addStore(builderClass);
+            parseStoreChildren(reader, pcb);
          }
       }
    }


### PR DESCRIPTION
Add the functionality that a custom cache store can be used by specifying the class in the xml configuration.  The class must utilize the BuiltBy annotation where the value is the class of the StoreConfigurationBuilder.
