### PR TITLE
ISPN-3367 ClusterTopologyManagerTest.testClusterRecoveryWithRebalance fa...

### DIFF
--- a/core/src/test/java/org/infinispan/statetransfer/ClusterTopologyManagerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ClusterTopologyManagerTest.java
@@ -153,7 +153,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
 
       // wait for the merged cluster to form
       long startTime = System.currentTimeMillis();
-      TestingUtil.blockUntilViewsReceived(30000, c1, c2, c3);
+      TestingUtil.blockUntilViewsReceived(60000, c1, c2, c3);
       TestingUtil.waitForRehashToComplete(c1, c2, c3);
 
       long endTime = System.currentTimeMillis();
@@ -247,7 +247,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
             int viewId = (Integer) invocation.getArguments()[2];
             checkpoint.trigger("rebalance_" + viewId);
             log.debugf("Blocking the REBALANCE_START command on the merge coordinator");
-            checkpoint.awaitStrict("merge", 10, TimeUnit.SECONDS);
+            checkpoint.awaitStrict("merge", 30, TimeUnit.SECONDS);
             return invocation.callRealMethod();
          }
       }).when(spyLocalTopologyManager).handleRebalance(eq(CACHE_NAME), any(CacheTopology.class), anyInt());

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -46,7 +46,7 @@
    <!--mcast_port="${jgroups.mping.mcast_port:43366}"-->
    <!--ip_ttl="2" num_initial_members="3"/>-->
 
-   <MERGE2 max_interval="10000"
+   <MERGE2 max_interval="5000"
            min_interval="3000"/>
 
    <FD_SOCK/>

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -36,7 +36,7 @@
 
    <org.infinispan.test.fwk.TEST_PING ergonomics="false" testName=""/>
    <!--<PING timeout="3000" num_initial_members="3"/>-->
-   <MERGE2 max_interval="10000" min_interval="3000"/>
+   <MERGE2 max_interval="5000" min_interval="3000"/>
 
    <FD_SOCK/>
    <FD_ALL interval="1000" timeout="3000" timeout_check_interval="1000"/>


### PR DESCRIPTION
...ils randomly

https://issues.jboss.org/browse/ISPN-3367

Lower MERGE2.max_interval to speed up merging.
