### PR TITLE
ISPN-3963 Disable CacheManagetTest.testCacheManagerRestartReusingConfigu...

### DIFF
--- a/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
@@ -316,6 +316,7 @@ public class CacheManagerTest extends AbstractInfinispanTest {
       }
    }
 
+   @Test(enabled = false, description = "Not stable - https://issues.jboss.org/browse/ISPN-3963")
    public void testCacheManagerRestartReusingConfigurations() {
       withCacheManagers(new MultiCacheManagerCallable(
             TestCacheManagerFactory.createCacheManager(CacheMode.REPL_SYNC, false),


### PR DESCRIPTION
This failing test in http://ci.infinispan.org/viewLog.html?buildId=5904&tab=buildResultsDiv&buildTypeId=bt8 is the first test that fails. The rest of tests failing after this could be rooted in this one. Let's disable and have another run to see what else comes up.
