### PR TITLE
ISPN-3947 Make it compile with JDK8

### DIFF
--- a/as-modules/build.xml
+++ b/as-modules/build.xml
@@ -32,10 +32,6 @@
          <maven-resource group="org.infinispan" artifact="infinispan-core" />
       </module-def>
 
-      <module-def name="org.infinispan.cachestore.jdbc" slot="${infinispan.slot}" />
-
-      <module-def name="org.infinispan.cachestore.remote" slot="${infinispan.slot}" />
-      
       <module-def name="org.infinispan.persistence.jdbc" slot="${infinispan.slot}">
          <maven-resource group="org.infinispan" artifact="infinispan-cachestore-jdbc" />
       </module-def>

--- a/as-modules/lib.xml
+++ b/as-modules/lib.xml
@@ -87,7 +87,14 @@
         <attribute name="slot"/>
         <![CDATA[
             name = attributes.get("name");
-            name = name.replace(".", "/");
+            name = name.split(".").join("/");
+            if (name) {
+              self.log("Use JDK8 method to build module names");
+            } else {
+              name = attributes.get("name");
+              name = name.replace(".", "/");
+              self.log("Use JDK7 method to build module names");
+            }
             project.setProperty("source.module.path", name + "/main");
             project.setProperty("current.module.path", name + "/" + attributes.get("slot"));
         ]]>
@@ -98,7 +105,14 @@
         <attribute name="slot"/>
         <![CDATA[
             name = attributes.get("name");
-            name = name.replace(".", "/");
+            name = name.split(".").join("/");
+            if (name) {
+              self.log("Use JDK8 method to build module names");
+            } else {
+              name = attributes.get("name");
+              name = name.replace(".", "/");
+              self.log("Use JDK7 method to build module names");
+            }
             project.setProperty("current.bundle.path", name + "/" + attributes.get("slot"));
         ]]>
     </scriptdef>

--- a/commons/src/main/java/org/infinispan/commons/util/concurrent/jdk8backported/EquivalentConcurrentHashMapV8.java
+++ b/commons/src/main/java/org/infinispan/commons/util/concurrent/jdk8backported/EquivalentConcurrentHashMapV8.java
@@ -4552,7 +4552,7 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
                               (containsAll(c) && c.containsAll(this))));
       }
 
-      public ConcurrentHashMapSpliterator<K> spliterator() {
+      public ConcurrentHashMapSpliterator<K> spliteratorV8() {
          Node<K,V>[] t;
          EquivalentConcurrentHashMapV8<K,V> m = map;
          long n = m.sumCount();
@@ -4610,7 +4610,7 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
          throw new UnsupportedOperationException();
       }
 
-      public ConcurrentHashMapSpliterator<V> spliterator() {
+      public ConcurrentHashMapSpliterator<V> spliteratorV8() {
          Node<K,V>[] t;
          EquivalentConcurrentHashMapV8<K,V> m = map;
          long n = m.sumCount();
@@ -4699,7 +4699,7 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
                               (containsAll(c) && c.containsAll(this))));
       }
 
-      public ConcurrentHashMapSpliterator<Map.Entry<K,V>> spliterator() {
+      public ConcurrentHashMapSpliterator<Map.Entry<K,V>> spliteratorV8() {
          Node<K,V>[] t;
          EquivalentConcurrentHashMapV8<K,V> m = map;
          long n = m.sumCount();

--- a/core/src/test/java/org/infinispan/commons/util/concurrent/jdk8backported/ConcurrentHashMapV8.java
+++ b/core/src/test/java/org/infinispan/commons/util/concurrent/jdk8backported/ConcurrentHashMapV8.java
@@ -4515,7 +4515,7 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
                               (containsAll(c) && c.containsAll(this))));
       }
 
-      public ConcurrentHashMapSpliterator<K> spliterator() {
+      public ConcurrentHashMapSpliterator<K> spliteratorV8() {
          Node<K,V>[] t;
          ConcurrentHashMapV8<K,V> m = map;
          long n = m.sumCount();
@@ -4573,7 +4573,7 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
          throw new UnsupportedOperationException();
       }
 
-      public ConcurrentHashMapSpliterator<V> spliterator() {
+      public ConcurrentHashMapSpliterator<V> spliteratorV8() {
          Node<K,V>[] t;
          ConcurrentHashMapV8<K,V> m = map;
          long n = m.sumCount();
@@ -4661,7 +4661,7 @@ public class ConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
                               (containsAll(c) && c.containsAll(this))));
       }
 
-      public ConcurrentHashMapSpliterator<Map.Entry<K,V>> spliterator() {
+      public ConcurrentHashMapSpliterator<Map.Entry<K,V>> spliteratorV8() {
          Node<K,V>[] t;
          ConcurrentHashMapV8<K,V> m = map;
          long n = m.sumCount();

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -150,7 +150,7 @@
       <version.webdav.servlet>2.0.1</version.webdav.servlet>
       <version.weld>1.1.13.Final</version.weld>
       <version.wildfly>8.0.0.Beta1</version.wildfly>
-      <version.javassist>3.15.0-GA</version.javassist>
+      <version.javassist>3.18.0-GA</version.javassist>
       <version.maven.animal.sniffer>1.9</version.maven.animal.sniffer>
       <version.maven.buildhelper>1.8</version.maven.buildhelper>
       <version.maven.bundle>2.4.0</version.maven.bundle>
@@ -1150,30 +1150,6 @@
             </executions>
          </plugin>
          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>animal-sniffer-maven-plugin</artifactId>
-            <version>${version.maven.animal.sniffer}</version>
-            <configuration>
-               <signature>
-                  <groupId>org.codehaus.mojo.signature</groupId>
-                  <artifactId>java16</artifactId>
-                  <version>1.0</version>
-               </signature>
-               <ignores>
-                  <ignore>sun.misc.Unsafe</ignore>
-                  <ignore>org.apache.lucene.store.IOContext</ignore>
-               </ignores>
-            </configuration>
-            <executions>
-              <execution>
-                <phase>process-classes</phase>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-         </plugin>
-         <plugin>
             <artifactId>maven-remote-resources-plugin</artifactId>
             <version>1.1</version>
             <executions>
@@ -1901,6 +1877,38 @@
             </plugins>
          </build>
       </profile>
-
+      <profile>
+         <activation>
+            <jdk>1.7</jdk>
+         </activation>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.codehaus.mojo</groupId>
+                  <artifactId>animal-sniffer-maven-plugin</artifactId>
+                  <version>${version.maven.animal.sniffer}</version>
+                  <configuration>
+                     <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <artifactId>java16</artifactId>
+                        <version>1.0</version>
+                     </signature>
+                     <ignores>
+                        <ignore>sun.misc.Unsafe</ignore>
+                        <ignore>org.apache.lucene.store.IOContext</ignore>
+                     </ignores>
+                  </configuration>
+                  <executions>
+                     <execution>
+                        <phase>process-classes</phase>
+                        <goals>
+                        <goal>check</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
    </profiles>
 </project>

--- a/server/integration/build/lib.xml
+++ b/server/integration/build/lib.xml
@@ -111,7 +111,14 @@
         <attribute name="slot"/>
         <![CDATA[
             name = attributes.get("name");
-            name = name.replace(".", "/");
+            name = name.split(".").join("/");
+            if (name) {
+              self.log("Use JDK8 method to build module names");
+            } else {
+              name = attributes.get("name");
+              name = name.replace(".", "/");
+              self.log("Use JDK7 method to build module names");
+            }
             project.setProperty("current.module.path", name + "/" + attributes.get("slot"));
         ]]>
     </scriptdef>
@@ -121,7 +128,14 @@
         <attribute name="slot"/>
         <![CDATA[
             name = attributes.get("name");
-            name = name.replace(".", "/");
+            name = name.split(".").join("/");
+            if (name) {
+              self.log("Use JDK8 method to build module names");
+            } else {
+              name = attributes.get("name");
+              name = name.replace(".", "/");
+              self.log("Use JDK7 method to build module names");
+            }
             project.setProperty("current.bundle.path", name + "/" + attributes.get("slot"));
         ]]>
     </scriptdef>

--- a/server/integration/versions/pom.xml
+++ b/server/integration/versions/pom.xml
@@ -457,30 +457,6 @@
             </executions>
          </plugin>
          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>animal-sniffer-maven-plugin</artifactId>
-            <version>1.9</version>
-            <configuration>
-               <signature>
-                  <groupId>org.codehaus.mojo.signature</groupId>
-                  <artifactId>java16</artifactId>
-                  <version>1.0</version>
-               </signature>
-               <ignores>
-                  <ignore>sun.misc.Unsafe</ignore>
-                  <ignore>org.apache.lucene.store.IOContext</ignore>
-               </ignores>
-            </configuration>
-            <executions>
-               <execution>
-                  <phase>process-classes</phase>
-                  <goals>
-                     <goal>check</goal>
-                  </goals>
-               </execution>
-            </executions>
-         </plugin>
-         <plugin>
             <groupId>org.apache.servicemix.tooling</groupId>
             <artifactId>depends-maven-plugin</artifactId>
             <version>1.2</version>
@@ -497,6 +473,39 @@
          <properties>
             <maven.test.skip.exec>true</maven.test.skip.exec>
          </properties>
+      </profile>
+      <profile>
+         <activation>
+            <jdk>1.7</jdk>
+         </activation>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.codehaus.mojo</groupId>
+                  <artifactId>animal-sniffer-maven-plugin</artifactId>
+                  <version>1.9</version>
+                  <configuration>
+                     <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <artifactId>java16</artifactId>
+                        <version>1.0</version>
+                     </signature>
+                     <ignores>
+                        <ignore>sun.misc.Unsafe</ignore>
+                        <ignore>org.apache.lucene.store.IOContext</ignore>
+                     </ignores>
+                  </configuration>
+                  <executions>
+                     <execution>
+                        <phase>process-classes</phase>
+                        <goals>
+                           <goal>check</goal>
+                        </goals>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
       </profile>
    </profiles>
 

--- a/tools/src/main/java/org/infinispan/tools/doclet/jmx/JmxDoclet.java
+++ b/tools/src/main/java/org/infinispan/tools/doclet/jmx/JmxDoclet.java
@@ -16,6 +16,8 @@ import org.infinispan.tools.doclet.html.HtmlGenerator;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -64,7 +66,7 @@ public class JmxDoclet {
    }
 
    public static int optionLength(String option) {
-      return (ConfigurationImpl.getInstance()).optionLength(option);
+      return (createConfigurationImpl()).optionLength(option);
    }
 
    public static boolean validOptions(String options[][], DocErrorReporter reporter) {
@@ -77,7 +79,23 @@ public class JmxDoclet {
          else if (option[0].equals("-header")) header = option[1];
          else if (option[0].equals("-doctitle")) title = option[1];
       }
-      return (ConfigurationImpl.getInstance()).validOptions(options, reporter);
+      return (createConfigurationImpl()).validOptions(options, reporter);
+   }
+
+   private static ConfigurationImpl createConfigurationImpl() {
+      try {
+         // Deal with JDK7/JDK8 differences
+         Method getInstanceMethod = ConfigurationImpl.class.getMethod("getInstance");
+         return (ConfigurationImpl) getInstanceMethod.invoke(null);
+      } catch (NoSuchMethodException e) {
+         try {
+            return ConfigurationImpl.class.newInstance();
+         } catch (Exception e1) {
+            throw new RuntimeException(e1);
+         }
+      } catch (Exception e1) {
+         throw new RuntimeException(e1);
+      }
    }
 
    private static MBeanComponent toJmxComponent(ClassDoc cd) {


### PR DESCRIPTION
- Module name calculation in javascript driven Server/AS/Wildfly now works with both JDK7 and JDK8 by trying a split/join and if it does not work, use a replace.
- `spliterator()` method name clashes with a new spliterator() method introduced in java.util.Collection for JDK8, so name it differently.
- Disable animal sniffer plugin since it does not yet work with JDK8. Even latest version 1.10 still fails.
