### PR TITLE
ISPN-3998 Let infinispan-parent inherit from infinispan-bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -56,6 +56,7 @@
       <version.protostream>1.0.0.CR1</version.protostream>
       <version.aesh>0.33.7</version.aesh>
       <version.antlr>3.4</version.antlr>
+      <version.commons.pool>1.6</version.commons.pool>
       <version.gnu.getopt>1.0.13</version.gnu.getopt>
       <version.hibernate.search>4.5.0.Final</version.hibernate.search>
       <version.jboss.marshalling>1.4.2.Final</version.jboss.marshalling>
@@ -327,6 +328,11 @@
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
             <version>${version.xstream}</version>
+         </dependency>
+         <dependency>
+            <groupId>commons-pool</groupId>
+            <artifactId>commons-pool</artifactId>
+            <version>${version.commons.pool}</version>
          </dependency>
       </dependencies>
    </dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,9 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <modelVersion>4.0.0</modelVersion>
-   <groupId>org.infinispan</groupId>
-   <artifactId>infinispan-parent</artifactId>
+   <parent>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-bom</artifactId>
       <version>7.0.0-SNAPSHOT</version>
+      <relativePath>../bom/pom.xml</relativePath>
+   </parent>
+   <artifactId>infinispan-parent</artifactId>
    <packaging>pom</packaging>
    <name>Infinispan Common Parent</name>
    <description>Infinispan common parent POM module</description>
@@ -100,7 +104,6 @@
       <version.commons.codec>1.4</version.commons.codec>
       <version.commons.collections>3.2.1</version.commons.collections>
       <version.commons.dbcp>1.4</version.commons.dbcp>
-      <version.commons.pool>1.6</version.commons.pool>
       <version.commons.httpclient>3.1</version.commons.httpclient>
       <version.commons.io>1.3.2</version.commons.io>
       <version.commons.logging>1.1</version.commons.logging>
@@ -165,13 +168,6 @@
    
    <dependencyManagement>
       <dependencies>
-         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>infinispan-bom</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-         </dependency>
          <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>infinispan-cachestore-jdbc</artifactId>
@@ -358,11 +354,6 @@
             <artifactId>commons-logging</artifactId>
             <version>${version.commons.logging}</version>
             <scope>runtime</scope>
-         </dependency>
-         <dependency>
-            <groupId>commons-pool</groupId>
-            <artifactId>commons-pool</artifactId>
-            <version>${version.commons.pool}</version>
          </dependency>
          <dependency>
             <groupId>org.javassist</groupId>


### PR DESCRIPTION
- With infinispan-bom as a parent, the properties are visible to child modules (this is required when doing filtering e.g. with maven-resources-plugin)
- Moved commons-pool to infinispan-bom as it's a runtime dependency of hotrod-client, not just a build time dependency
