### PR TITLE
ISPN-3996 LocalCachePerformantConfTest is reusing the same file path for...

### DIFF
--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCachePerformantConfTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCachePerformantConfTest.java
@@ -17,11 +17,12 @@ import static org.junit.Assert.assertTrue;
 @Test(groups = "functional", testName = "query.blackbox.LocalCachePerformantConfTest")
 public class LocalCachePerformantConfTest extends LocalCacheTest {
 
-   private final String indexDirectory = System.getProperty("java.io.tmpdir") + File.separator + "tunedConfDir";
+   /** the file constant needs to match what's defined in the configuration file **/
+   private final String indexDirectory = System.getProperty("java.io.tmpdir") + File.separator + "LocalCachePerformantConfTest";
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
-      cacheManager = TestCacheManagerFactory.fromXml("nrt-performance-writer.xml");
+      cacheManager = TestCacheManagerFactory.fromXml("testconfig-LocalCachePerformantConfTest.xml");
       cache = cacheManager.getCache("Indexed");
 
       return cacheManager;

--- a/query/src/test/resources/testconfig-LocalCachePerformantConfTest.xml
+++ b/query/src/test/resources/testconfig-LocalCachePerformantConfTest.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:infinispan:config:6.0 http://www.infinispan.org/schemas/infinispan-config-6.0.xsd"
+    xmlns="urn:infinispan:config:6.0">
+
+    <!-- *************************** -->
+    <!-- System-wide global settings -->
+    <!-- *************************** -->
+
+    <global>
+        <globalJmxStatistics
+            enabled="false"
+            cacheManagerName="QueryEnabledGrid-Local-NRTIndexing"
+            allowDuplicateDomains="true"
+            />
+    </global>
+
+    <!-- *************************************** -->
+    <!--  Default Cache                          -->
+    <!-- *************************************** -->
+    <default>
+
+        <jmxStatistics
+            enabled="false" />
+
+        <indexing
+            enabled="false" />
+
+        <eviction
+            maxEntries="-1"
+            strategy="NONE" />
+
+        <expiration
+            maxIdle="-1"
+            reaperEnabled="false" />
+
+    </default>
+
+    <!-- *************************************** -->
+    <!--  Tested Cache: indexing enabled         -->
+    <!-- *************************************** -->
+    <namedCache
+        name="Indexed">
+
+        <indexing enabled="true" indexLocalOnly="false">
+            <properties>
+
+                <!-- Enabled fastest writer: NRT backend -->
+                <property name="default.indexmanager" value="near-real-time" />
+                <property name="default.indexBase" value="${java.io.tmpdir}/LocalCachePerformantConfTest" />
+
+                <!-- Default is to write on FSDirectory; to write in a dedicated cache uncomment: -->
+                <!-- Write indexes in Infinispan
+                <property name="default.directory_provider" value="infinispan" />
+                <property name="default.chunk_size" value="32000" />
+                <property name="default.metadata_cachename" value="LuceneIndexesMetadataOWR" />
+                <property name="default.data_cachename" value="LuceneIndexesDataOWR" /> -->
+
+                <!-- This index is dedicated to the current node -->
+                <property name="default.exclusive_index_use" value="true" />
+
+                <!-- The default is 10, but we don't want to waste many cycles in merging
+                 (tune for writes at cost of reader fragmentation) -->
+                <property name="default.indexwriter.merge_factor" value="30" />
+
+                <!-- Never create segments larger than 4GB -->
+                <property name="default.indexwriter.merge_max_size" value="4096" />
+
+                <!-- IndexWriter flush buffer size in MB -->
+                <property name="default.indexwriter.ram_buffer_size" value="220" />
+
+                <!-- Make sure to use native locking -->
+                <property name="default.locking_strategy" value="native" />
+
+                <!-- Enable sharding on writers -->
+                <property name="default.sharding_strategy.nbr_of_shards" value="6" />
+
+                <!-- No need to be backwards compatible regarding Lucene version -->
+                <property name="lucene_version" value="LUCENE_36" />
+
+            </properties>
+        </indexing>
+
+        <!--  For our test we don't want to keep all data in memory: throw some away -->
+        <eviction
+            maxEntries="200"
+            strategy="LIRS" />
+
+    </namedCache>
+
+    <!-- *************************************** -->
+    <!--  Cache to store Lucene's file metadata  -->
+    <!-- *************************************** -->
+    <namedCache
+        name="LuceneIndexesMetadataOWR" />
+
+    <!-- **************************** -->
+    <!--  Cache to store Lucene data  -->
+    <!-- **************************** -->
+    <namedCache
+        name="LuceneIndexesDataOWR" />
+
+</infinispan>


### PR DESCRIPTION
... multiple tests

On IRC we said this should use TestingUtil.tmpDirectory(), but it actually turns out that:
- each of the ten tests are using the same configuration
- the purpose of the test is to verify behaviour in context of an XML parsed configuration

So I just separated the configuration file to use a different hard-coded path compared to the (single) other test using this configuration.
