### PR TITLE
ISPN-4055 Upgrade to JGroups 3.5.0.Alpha1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -62,7 +62,7 @@
       <version.hibernate.search>4.5.0.Final</version.hibernate.search>
       <version.jboss.marshalling>1.4.2.Final</version.jboss.marshalling>
       <version.jboss.logging>3.1.2.GA</version.jboss.logging>
-      <version.jgroups>3.4.1.Final</version.jgroups>
+      <version.jgroups>3.5.0.Alpha1</version.jgroups>
       <version.json>20090211</version.json>
       <version.jta>1.0.1.Final</version.jta>
       <version.netty>4.0.15.Final</version.netty>

--- a/core/src/main/resources/jgroups-ec2.xml
+++ b/core/src/main/resources/jgroups-ec2.xml
@@ -13,7 +13,7 @@
         sock_conn_timeout="300"
         enable_diagnostics="false"
         
-        bundler_type="old"
+        bundler_type="sender-sends-with-timer"
 
         thread_pool.enabled="true"
         thread_pool.min_threads="2"

--- a/core/src/main/resources/jgroups-tcp.xml
+++ b/core/src/main/resources/jgroups-tcp.xml
@@ -11,7 +11,7 @@
         max_bundle_size="31k"
         use_send_queues="true"
         enable_diagnostics="false"
-        bundler_type="old"
+        bundler_type="sender-sends-with-timer"
 
         thread_naming_pattern="pl"
 

--- a/core/src/main/resources/jgroups-udp.xml
+++ b/core/src/main/resources/jgroups-udp.xml
@@ -13,7 +13,7 @@
          max_bundle_size="31k"
          ip_ttl="${jgroups.udp.ip_ttl:2}"
          enable_diagnostics="false"
-         bundler_type="old"
+         bundler_type="sender-sends-with-timer"
 
          thread_naming_pattern="pl"
 

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -10,7 +10,7 @@
          use_send_queues="true"
          sock_conn_timeout="300"
          enable_diagnostics="false"
-         bundler_type="old"
+         bundler_type="sender-sends-with-timer"
          send_queue_size="0"
 
          thread_pool.enabled="true"

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -11,7 +11,7 @@
          max_bundle_size="31k"
          use_send_queues="true"
          enable_diagnostics="false"
-         bundler_type="old"
+         bundler_type="sender-sends-with-timer"
 
          thread_naming_pattern="pl"
 

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -9,7 +9,7 @@
         max_bundle_size="64k"
         use_send_queues="false"
         sock_conn_timeout="300"
-        bundler_type="old"
+        bundler_type="sender-sends-with-timer"
 
         thread_pool.enabled="true"
         thread_pool.min_threads="1"

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -9,7 +9,7 @@
         max_bundle_size="64000"
         use_send_queues="false"
         sock_conn_timeout="300"
-        bundler_type="old"
+        bundler_type="sender-sends-with-timer"
 
         thread_pool.enabled="true"
         thread_pool.min_threads="1"

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -13,7 +13,7 @@
          max_bundle_size="31k"
          ip_ttl="${jgroups.udp.ip_ttl:2}"
          enable_diagnostics="false"
-         bundler_type="old"
+         bundler_type="sender-sends-with-timer"
 
          thread_naming_pattern="pl"
 

--- a/demos/gui/src/main/release/etc/config-samples/jgroups-relay1.xml
+++ b/demos/gui/src/main/release/etc/config-samples/jgroups-relay1.xml
@@ -20,7 +20,7 @@
          mcast_send_buf_size="640000"
          loopback="true"
          max_bundle_size="64k"
-         bundler_type="old"
+         bundler_type="sender-sends-with-timer"
          ip_ttl="${jgroups.udp.ip_ttl:0}"
          enable_diagnostics="true"
          thread_naming_pattern="cl"

--- a/demos/gui/src/main/release/etc/config-samples/jgroups-relay2.xml
+++ b/demos/gui/src/main/release/etc/config-samples/jgroups-relay2.xml
@@ -20,7 +20,7 @@
          mcast_send_buf_size="640000"
          loopback="true"
          max_bundle_size="64000"
-         bundler_type="old"
+         bundler_type="sender-sends-with-timer"
          ip_ttl="${jgroups.udp.ip_ttl:0}"
          enable_diagnostics="true"
          thread_naming_pattern="cl"

--- a/demos/gui/src/main/release/etc/config-samples/jgroups-tcp.xml
+++ b/demos/gui/src/main/release/etc/config-samples/jgroups-tcp.xml
@@ -16,7 +16,7 @@
          send_buf_size="640000"
          loopback="false"
          max_bundle_size="64k"
-         bundler_type="old"
+         bundler_type="sender-sends-with-timer"
          enable_diagnostics="true"
          thread_naming_pattern="cl"
 


### PR DESCRIPTION
- bundler updated to sender-sends-with-timer

https://issues.jboss.org/browse/ISPN-4055
