### PR TITLE
ISPN-3990 AtomicMapAPITest.testConcurrentTx fails randomly

### DIFF
--- a/core/src/test/java/org/infinispan/atomic/AtomicMapAPITest.java
+++ b/core/src/test/java/org/infinispan/atomic/AtomicMapAPITest.java
@@ -28,10 +28,4 @@ public class AtomicMapAPITest extends BaseAtomicHashMapAPITest {
    protected <CK, K, V> Map<K, V> createAtomicMap(Cache<CK, Object> cache, CK key, boolean createIfAbsent) {
       return getAtomicMap(cache, key, createIfAbsent);
    }
-
-   @Test(groups = "unstable", description = "See ISPN-3990")
-   @Override
-   public void testConcurrentTx() throws Exception {
-      super.testConcurrentTx();
-   }
 }

--- a/core/src/test/java/org/infinispan/atomic/DistAtomicMapAPITest.java
+++ b/core/src/test/java/org/infinispan/atomic/DistAtomicMapAPITest.java
@@ -22,7 +22,7 @@ public class DistAtomicMapAPITest extends AtomicMapAPITest {
             .transactionMode(TransactionMode.TRANSACTIONAL)
             .syncCommitPhase(true)
             .lockingMode(LockingMode.PESSIMISTIC)
-            .locking().lockAcquisitionTimeout(100l);
+            .locking().lockAcquisitionTimeout(2000l);
       configurationBuilder.clustering().hash().numOwners(1);
       createClusteredCaches(2, "atomic", configurationBuilder);
    }

--- a/core/src/test/java/org/infinispan/atomic/DistFineGrainedAtomicMapAPITest.java
+++ b/core/src/test/java/org/infinispan/atomic/DistFineGrainedAtomicMapAPITest.java
@@ -22,7 +22,7 @@ public class DistFineGrainedAtomicMapAPITest extends FineGrainedAtomicMapAPITest
             .transactionMode(TransactionMode.TRANSACTIONAL)
             .syncCommitPhase(true)
             .lockingMode(LockingMode.PESSIMISTIC)
-            .locking().lockAcquisitionTimeout(100l);
+            .locking().lockAcquisitionTimeout(2000l);
       configurationBuilder.clustering().hash().numOwners(1);
       createClusteredCaches(2, "atomic", configurationBuilder);
    }

--- a/core/src/test/java/org/infinispan/atomic/DistRepeatableReadAtomicMapAPITest.java
+++ b/core/src/test/java/org/infinispan/atomic/DistRepeatableReadAtomicMapAPITest.java
@@ -24,7 +24,7 @@ public class DistRepeatableReadAtomicMapAPITest extends RepeatableReadAtomicMapA
             .syncCommitPhase(true)
             .lockingMode(LockingMode.PESSIMISTIC)
             .locking().isolationLevel(IsolationLevel.REPEATABLE_READ)
-            .locking().lockAcquisitionTimeout(100l);
+            .locking().lockAcquisitionTimeout(2000l);
       c.clustering().hash().numOwners(1);
       createClusteredCaches(2, "atomic", c);
    }

--- a/core/src/test/java/org/infinispan/atomic/DistRepeatableReadFineGrainedAtomicMapAPITest.java
+++ b/core/src/test/java/org/infinispan/atomic/DistRepeatableReadFineGrainedAtomicMapAPITest.java
@@ -24,7 +24,7 @@ public class DistRepeatableReadFineGrainedAtomicMapAPITest extends RepeatableRea
             .syncCommitPhase(true)
             .lockingMode(LockingMode.PESSIMISTIC)
             .locking().isolationLevel(IsolationLevel.REPEATABLE_READ)
-            .locking().lockAcquisitionTimeout(100l);
+            .locking().lockAcquisitionTimeout(2000l);
       c.clustering().hash().numOwners(1);
       createClusteredCaches(2, "atomic", c);
    }

--- a/core/src/test/java/org/infinispan/atomic/RepeatableReadAtomicMapAPITest.java
+++ b/core/src/test/java/org/infinispan/atomic/RepeatableReadAtomicMapAPITest.java
@@ -21,13 +21,7 @@ public class RepeatableReadAtomicMapAPITest extends AtomicMapAPITest {
             .transactionMode(TransactionMode.TRANSACTIONAL)
             .lockingMode(LockingMode.PESSIMISTIC)
             .locking().isolationLevel(IsolationLevel.REPEATABLE_READ)
-            .locking().lockAcquisitionTimeout(100l);
+            .locking().lockAcquisitionTimeout(2000l);
       createClusteredCaches(2, "atomic", c);
-   }
-
-   @Test(groups = "unstable", description = "See ISPN-3990")
-   @Override
-   public void testConcurrentTx() throws Exception {
-      super.testConcurrentTx();
    }
 }

--- a/core/src/test/java/org/infinispan/atomic/RepeatableReadFineGrainedAtomicMapAPITest.java
+++ b/core/src/test/java/org/infinispan/atomic/RepeatableReadFineGrainedAtomicMapAPITest.java
@@ -21,7 +21,7 @@ public class RepeatableReadFineGrainedAtomicMapAPITest extends FineGrainedAtomic
             .transactionMode(TransactionMode.TRANSACTIONAL)
             .lockingMode(LockingMode.PESSIMISTIC)
             .locking().isolationLevel(IsolationLevel.REPEATABLE_READ)
-            .locking().lockAcquisitionTimeout(100l);
+            .locking().lockAcquisitionTimeout(2000l);
       createClusteredCaches(2, "atomic", c);
    }
 }


### PR DESCRIPTION
- Increased lock timeout to 2 seconds.

https://issues.jboss.org/browse/ISPN-3990
