### PR TITLE
ISPN-4076 fix RHQ stats bytesRead and Write, remove for REST endpoint

### DIFF
--- a/server/integration/management/server-rhq-plugin/src/main/java/org/infinispan/server/rhq/MetricsRemappingComponent.java
+++ b/server/integration/management/server-rhq-plugin/src/main/java/org/infinispan/server/rhq/MetricsRemappingComponent.java
@@ -46,8 +46,6 @@ public abstract class MetricsRemappingComponent<T extends MetricsRemappingCompon
 
    static {
       server2plugin = new HashMap<String, String>();
-      server2plugin.put("bytes-read", "bytesRead");
-      server2plugin.put("bytes-written", "bytesWritten");
       server2plugin.put("cache-manager-status", "cacheManagerStatus");
       server2plugin.put("cluster-name", "clusterName");
       server2plugin.put("coordinator-address", "coordinatorAddress");
@@ -81,6 +79,10 @@ public abstract class MetricsRemappingComponent<T extends MetricsRemappingCompon
       server2plugin.put("activations", "activations");
       server2plugin.put("cache-loader-loads", "cacheLoaderLoads");
       server2plugin.put("cache-loader-misses", "cacheLoaderMisses");
+
+      // we will put these 2 here as well, just to be aware of them
+      server2plugin.put("bytesRead", "bytesRead");
+      server2plugin.put("bytesWritten", "bytesWritten");
 
       plugin2server = new HashMap<String, String>(server2plugin.size());
       for (Entry<String, String> entry : server2plugin.entrySet()) {

--- a/server/integration/management/server-rhq-plugin/src/main/resources/META-INF/rhq-plugin.xml
+++ b/server/integration/management/server-rhq-plugin/src/main/resources/META-INF/rhq-plugin.xml
@@ -137,8 +137,6 @@
             <operation name="remove" displayName="Remove Endpoint"
                        description="Removes the given endpoint from the server"/>
 
-            &commonConnectorMetrics;
-
             <resource-configuration>
                 &addConnectorCommandParameters;
                 <c:simple-property name="auth-method" required="false"


### PR DESCRIPTION
REST endpoint does not provide bytesRead and bytesWritten statistics. We remove it from plugin. 
- we fixed the right mapping of name for those 2 statistics to be understand properly by plugin.

Note: we possibly can remove them from the map completely but I prefer to let it there as we can better map what we are working with and what we are monitoring (for the future).
