### PR TITLE
ISPN-4079 Enhance Cache addListener method to match types for filter and

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/equivalence/AnyEquivalence.java
+++ b/commons/src/main/java/org/infinispan/commons/equivalence/AnyEquivalence.java
@@ -10,21 +10,21 @@ public final class AnyEquivalence<T> implements Equivalence<T> {
 
    private static AnyEquivalence<Object> OBJECT = new AnyEquivalence<Object>();
 
-   public static AnyEquivalence<String> STRING = new AnyEquivalence<String>();
+   public static AnyEquivalence<String> STRING = getInstance(String.class);
 
-   public static AnyEquivalence<Byte> BYTE = new AnyEquivalence<Byte>();
+   public static AnyEquivalence<Byte> BYTE = getInstance(Byte.class);
 
-   public static AnyEquivalence<Short> SHORT = new AnyEquivalence<Short>();
+   public static AnyEquivalence<Short> SHORT = getInstance(Short.class);
 
-   public static AnyEquivalence<Integer> INT = new AnyEquivalence<Integer>();
+   public static AnyEquivalence<Integer> INT = getInstance(Integer.class);
 
-   public static AnyEquivalence<Long> LONG = new AnyEquivalence<Long>();
+   public static AnyEquivalence<Long> LONG = getInstance(Long.class);
 
-   public static AnyEquivalence<Double> DOUBLE  = new AnyEquivalence<Double>();
+   public static AnyEquivalence<Double> DOUBLE  = getInstance(Double.class);
 
-   public static AnyEquivalence<Float> FLOAT = new AnyEquivalence<Float>();
+   public static AnyEquivalence<Float> FLOAT = getInstance(Float.class);
 
-   public static AnyEquivalence<Boolean> BOOLEAN = new AnyEquivalence<Boolean>();
+   public static AnyEquivalence<Boolean> BOOLEAN = getInstance(Boolean.class);
 
    // To avoid instantiation
    private AnyEquivalence() {
@@ -61,4 +61,8 @@ public final class AnyEquivalence<T> implements Equivalence<T> {
       return (AnyEquivalence<T>) OBJECT;
    }
 
+   @SuppressWarnings("unchecked")
+   public static <T> AnyEquivalence<T> getInstance(Class<T> classType) {
+      return (AnyEquivalence<T>) OBJECT;
+   }
 }

--- a/commons/src/main/java/org/infinispan/commons/equivalence/EquivalentHashMap.java
+++ b/commons/src/main/java/org/infinispan/commons/equivalence/EquivalentHashMap.java
@@ -46,26 +46,26 @@ public class EquivalentHashMap<K, V> extends AbstractMap<K, V> {
 
    int modCount;
 
-   private final Equivalence<K> keyEq;
+   private final Equivalence<? super K> keyEq;
 
-   private final Equivalence<V> valueEq;
+   private final Equivalence<? super V> valueEq;
 
    @SuppressWarnings("unchecked")
    public EquivalentHashMap(
-         Equivalence<K> keyEq, Equivalence<V> valueEq) {
+         Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       this(DEFAULT_INITIAL_CAPACITY, keyEq, valueEq);
    }
 
    @SuppressWarnings("unchecked")
    public EquivalentHashMap(
-         int initialCapacity, Equivalence<K> keyEq, Equivalence<V> valueEq) {
+         int initialCapacity, Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       this(initialCapacity, DEFAULT_LOAD_FACTOR, keyEq, valueEq);
    }
 
    @SuppressWarnings("unchecked")
    public EquivalentHashMap(
          int initialCapacity, float loadFactor,
-         Equivalence<K> keyEq, Equivalence<V> valueEq) {
+         Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       int capacity = 1;
       while (capacity < initialCapacity)
          capacity <<= 1;
@@ -79,7 +79,7 @@ public class EquivalentHashMap<K, V> extends AbstractMap<K, V> {
 
    @SuppressWarnings("unchecked")
    public EquivalentHashMap(
-         Map<? extends K, ? extends V> map, Equivalence<K> keyEq, Equivalence<V> valueEq) {
+         Map<? extends K, ? extends V> map, Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       if (map instanceof EquivalentHashMap) {
          EquivalentHashMap<? extends K, ? extends V> equivalentMap =
                (EquivalentHashMap<? extends K, ? extends V>) map;
@@ -329,11 +329,11 @@ public class EquivalentHashMap<K, V> extends AbstractMap<K, V> {
       return true;
    }
 
-   public Equivalence<K> getKeyEquivalence() {
+   public Equivalence<? super K> getKeyEquivalence() {
       return keyEq;
    }
 
-   public Equivalence<V> getValueEquivalence() {
+   public Equivalence<? super V> getValueEquivalence() {
       return valueEq;
    }
 

--- a/commons/src/main/java/org/infinispan/commons/equivalence/EquivalentHashSet.java
+++ b/commons/src/main/java/org/infinispan/commons/equivalence/EquivalentHashSet.java
@@ -22,7 +22,7 @@ public class EquivalentHashSet<E> extends AbstractSet<E> {
     * functionality to check equality, calculate hash codes...etc of the
     * stored entries.
     */
-   private final Equivalence<E> entryEq;
+   private final Equivalence<? super E> entryEq;
 
    /**
     * The underlying map. Uses Boolean.TRUE as value for each element.
@@ -35,7 +35,7 @@ public class EquivalentHashSet<E> extends AbstractSet<E> {
     * @param entryEq the Equivalence function to be used to compare entries
     *                in this set.
     */
-   public EquivalentHashSet(Equivalence<E> entryEq) {
+   public EquivalentHashSet(Equivalence<? super E> entryEq) {
       this.entryEq = entryEq;
       m = new EquivalentHashMap<E, Boolean>(entryEq, AnyEquivalence.BOOLEAN);
    }
@@ -48,7 +48,7 @@ public class EquivalentHashSet<E> extends AbstractSet<E> {
     * @param entryEq the Equivalence function to be used to compare entries
     *                in this set.
     */
-   public EquivalentHashSet(int initialCapacity, Equivalence<E> entryEq) {
+   public EquivalentHashSet(int initialCapacity, Equivalence<? super E> entryEq) {
       this.entryEq = entryEq;
       m = new EquivalentHashMap<E, Boolean>(
             initialCapacity, entryEq, AnyEquivalence.BOOLEAN);

--- a/commons/src/main/java/org/infinispan/commons/equivalence/EquivalentLinkedHashMap.java
+++ b/commons/src/main/java/org/infinispan/commons/equivalence/EquivalentLinkedHashMap.java
@@ -28,7 +28,7 @@ public class EquivalentLinkedHashMap<K, V> extends EquivalentHashMap<K, V> {
 
    public EquivalentLinkedHashMap(int initialCapacity, float loadFactor,
          IterationOrder iterationOrder,
-         Equivalence<K> keyEq, Equivalence<V> valueEq) {
+         Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       super(initialCapacity, loadFactor, keyEq, valueEq);
       this.iterationOrder = iterationOrder;
       addFirstEntry();

--- a/commons/src/main/java/org/infinispan/commons/util/CollectionFactory.java
+++ b/commons/src/main/java/org/infinispan/commons/util/CollectionFactory.java
@@ -62,8 +62,8 @@ public class CollectionFactory {
       public <K, V> ConcurrentMap<K, V> createConcurrentParallelMap(int initialCapacity, int concurrencyLevel) {
          // by the time we baseline on JDK8 this code will be either dropped or adjusted, 
          //for now we need to use ConcurrentParallelHashMapV8
-         return new ConcurrentParallelHashMapV8<K, V>(initialCapacity, AnyEquivalence.<K> getInstance(),
-               AnyEquivalence.<V> getInstance());
+         return new ConcurrentParallelHashMapV8<K, V>(initialCapacity, AnyEquivalence.getInstance(),
+               AnyEquivalence.getInstance());
       }
    }
 
@@ -72,31 +72,31 @@ public class CollectionFactory {
       @Override
       public <K, V> ConcurrentMap<K, V> createConcurrentMap() {
          return new EquivalentConcurrentHashMapV8<K, V>(
-               AnyEquivalence.<K>getInstance(), AnyEquivalence.<V>getInstance());
+               AnyEquivalence.getInstance(), AnyEquivalence.getInstance());
       }
 
       @Override
       public <K, V> ConcurrentMap<K, V> createConcurrentMap(int initialCapacity) {
          return new EquivalentConcurrentHashMapV8<K, V>(initialCapacity,
-               AnyEquivalence.<K>getInstance(), AnyEquivalence.<V>getInstance());
+               AnyEquivalence.getInstance(), AnyEquivalence.getInstance());
       }
 
       @Override
       public <K, V> ConcurrentMap<K, V> createConcurrentMap(int initialCapacity, int concurrencyLevel) {
          return new EquivalentConcurrentHashMapV8<K, V>(initialCapacity, 0.75f,
-               concurrencyLevel, AnyEquivalence.<K>getInstance(), AnyEquivalence.<V>getInstance());
+               concurrencyLevel, AnyEquivalence.getInstance(), AnyEquivalence.getInstance());
       }
 
       @Override
       public <K, V> ConcurrentMap<K, V> createConcurrentMap(int initialCapacity, float loadFactor, int concurrencyLevel) {
          return new EquivalentConcurrentHashMapV8<K, V>(initialCapacity, loadFactor,
-               concurrencyLevel, AnyEquivalence.<K>getInstance(), AnyEquivalence.<V>getInstance());
+               concurrencyLevel, AnyEquivalence.getInstance(), AnyEquivalence.getInstance());
       }
 
       @Override
       public <K, V> ConcurrentMap<K, V> createConcurrentParallelMap(int initialCapacity, int concurrencyLevel) {
          return new ConcurrentParallelHashMapV8<K, V>(initialCapacity, 0.75f,
-               concurrencyLevel, AnyEquivalence.<K>getInstance(), AnyEquivalence.<V>getInstance());
+               concurrencyLevel, AnyEquivalence.getInstance(), AnyEquivalence.getInstance());
       }
    }
    
@@ -146,7 +146,7 @@ public class CollectionFactory {
    }
 
    public static <K, V> ConcurrentMap<K, V> makeConcurrentMap(
-         Equivalence<K> keyEq, Equivalence<V> valueEq) {
+         Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       if (requiresEquivalent(keyEq, valueEq))
          return new EquivalentConcurrentHashMapV8<K, V>(keyEq, valueEq);
       else
@@ -154,7 +154,7 @@ public class CollectionFactory {
    }
 
    public static <K, V> ConcurrentMap<K, V> makeConcurrentMap(
-         int initCapacity, Equivalence<K> keyEq, Equivalence<V> valueEq) {
+         int initCapacity, Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       if (requiresEquivalent(keyEq, valueEq))
          return new EquivalentConcurrentHashMapV8<K, V>(initCapacity, keyEq, valueEq);
       else
@@ -162,7 +162,7 @@ public class CollectionFactory {
    }
 
    public static <K, V> ConcurrentMap<K, V> makeConcurrentMap(
-         int initCapacity, int concurrencyLevel, Equivalence<K> keyEq, Equivalence<V> valueEq) {
+         int initCapacity, int concurrencyLevel, Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       if (requiresEquivalent(keyEq, valueEq))
          return new EquivalentConcurrentHashMapV8<K, V>(
                initCapacity, concurrencyLevel, keyEq, valueEq);
@@ -171,7 +171,7 @@ public class CollectionFactory {
    }
    
    public static <K, V> ConcurrentMap<K, V> makeConcurrentParallelMap(
-         int initCapacity, int concurrencyLevel, Equivalence<K> keyEq, Equivalence<V> valueEq) {
+         int initCapacity, int concurrencyLevel, Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       if (requiresEquivalent(keyEq, valueEq))
          return new ConcurrentParallelHashMapV8<K, V>(
                initCapacity, concurrencyLevel, keyEq, valueEq);
@@ -181,7 +181,7 @@ public class CollectionFactory {
 
    public static <K, V> ConcurrentMap<K, V> makeConcurrentMap(
          int initCapacity, float loadFactor, int concurrencyLevel,
-         Equivalence<K> keyEq, Equivalence<V> valueEq) {
+         Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       if (requiresEquivalent(keyEq, valueEq))
          return new EquivalentConcurrentHashMapV8<K, V>(
                initCapacity, loadFactor, concurrencyLevel, keyEq, valueEq);
@@ -190,7 +190,7 @@ public class CollectionFactory {
    }
 
    public static <K, V> Map<K, V> makeMap(
-         Equivalence<K> keyEq, Equivalence<V> valueEq) {
+         Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       if (requiresEquivalent(keyEq, valueEq))
          return new EquivalentHashMap<K, V>(keyEq, valueEq);
       else
@@ -198,7 +198,7 @@ public class CollectionFactory {
    }
 
    public static <K, V> Map<K, V> makeMap(
-         int initialCapacity, Equivalence<K> keyEq, Equivalence<V> valueEq) {
+         int initialCapacity, Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       if (requiresEquivalent(keyEq, valueEq))
          return new EquivalentHashMap<K, V>(initialCapacity, keyEq, valueEq);
       else
@@ -206,7 +206,7 @@ public class CollectionFactory {
    }
 
    public static <K, V> Map<K, V> makeMap(
-         Map<? extends K, ? extends V> entries, Equivalence<K> keyEq, Equivalence<V> valueEq) {
+         Map<? extends K, ? extends V> entries, Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       if (requiresEquivalent(keyEq, valueEq))
          return new EquivalentHashMap<K, V>(entries, keyEq, valueEq);
       else
@@ -215,21 +215,21 @@ public class CollectionFactory {
 
    public static <K, V> Map<K, V> makeLinkedMap(int initialCapacity,
          float loadFactor, EquivalentLinkedHashMap.IterationOrder iterationOrder,
-         Equivalence<K> keyEq, Equivalence<V> valueEq) {
+         Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       if (requiresEquivalent(keyEq, valueEq))
          return new EquivalentLinkedHashMap<K, V>(initialCapacity, loadFactor, iterationOrder, keyEq, valueEq);
       else
          return new LinkedHashMap<K, V>(initialCapacity, loadFactor, iterationOrder.toJdkAccessOrder());
    }
 
-   public static <T> Set<T> makeSet(Equivalence<T> entryEq) {
+   public static <T> Set<T> makeSet(Equivalence<? super T> entryEq) {
       if (requiresEquivalent(entryEq))
          return new EquivalentHashSet<T>(entryEq);
       else
          return new HashSet<T>();
    }
 
-   public static <T> Set<T> makeSet(int initialCapacity, Equivalence<T> entryEq) {
+   public static <T> Set<T> makeSet(int initialCapacity, Equivalence<? super T> entryEq) {
       if (requiresEquivalent(entryEq))
          return new EquivalentHashSet<T>(initialCapacity, entryEq);
       else

--- a/commons/src/main/java/org/infinispan/commons/util/InfinispanCollections.java
+++ b/commons/src/main/java/org/infinispan/commons/util/InfinispanCollections.java
@@ -228,7 +228,7 @@ public class InfinispanCollections {
     * @param <E> input collection's entry type
     * @return a Map with keys and values generated from the input collection
     */
-   public static <K, V, E> Map<K, V> transformCollectionToMap(Collection<E> input, MapMakerFunction<K, V, E> f) {
+   public static <K, V, E> Map<K, V> transformCollectionToMap(Collection<? extends E> input, MapMakerFunction<K, V, ? super E> f) {
       // This screams for a map function! Gimme functional programming pleasee...
       if (input.isEmpty()) return InfinispanCollections.emptyMap();
       if (input.size() == 1) {
@@ -254,7 +254,7 @@ public class InfinispanCollections {
     * @param <E> type of objects in Set
     * @return the elements in s1 that are not in s2
     */
-   public static <E> Set<E> difference(Set<E> s1, Set<E> s2) {
+   public static <E> Set<E> difference(Set<? extends E> s1, Set<? extends E> s2) {
       Set<E> copy1 = new HashSet<E>(s1);
       copy1.removeAll(new HashSet<E>(s2));
       return copy1;

--- a/commons/src/main/java/org/infinispan/commons/util/concurrent/jdk8backported/ConcurrentParallelHashMapV8.java
+++ b/commons/src/main/java/org/infinispan/commons/util/concurrent/jdk8backported/ConcurrentParallelHashMapV8.java
@@ -15,27 +15,27 @@ public class ConcurrentParallelHashMapV8<K, V> extends EquivalentConcurrentHashM
     */
    private static final long serialVersionUID = 7306507951179792494L;
 
-   public ConcurrentParallelHashMapV8(Equivalence<K> keyEquivalence, Equivalence<V> valueEquivalence) {
+   public ConcurrentParallelHashMapV8(Equivalence<? super K> keyEquivalence, Equivalence<? super V> valueEquivalence) {
       super(keyEquivalence, valueEquivalence);
    }
 
-   public ConcurrentParallelHashMapV8(int initialCapacity, Equivalence<K> keyEquivalence,
-         Equivalence<V> valueEquivalence) {
+   public ConcurrentParallelHashMapV8(int initialCapacity, Equivalence<? super K> keyEquivalence,
+         Equivalence<? super V> valueEquivalence) {
       super(initialCapacity, keyEquivalence, valueEquivalence);
    }
 
-   public ConcurrentParallelHashMapV8(int initialCapacity, float loadFactor, Equivalence<K> keyEquivalence,
-         Equivalence<V> valueEquivalence) {
+   public ConcurrentParallelHashMapV8(int initialCapacity, float loadFactor, Equivalence<? super K> keyEquivalence,
+         Equivalence<? super V> valueEquivalence) {
       super(initialCapacity, loadFactor, keyEquivalence, valueEquivalence);
    }
 
    public ConcurrentParallelHashMapV8(int initialCapacity, float loadFactor, int concurrencyLevel,
-         Equivalence<K> keyEquivalence, Equivalence<V> valueEquivalence) {
+         Equivalence<? super K> keyEquivalence, Equivalence<? super V> valueEquivalence) {
       super(initialCapacity, loadFactor, concurrencyLevel, keyEquivalence, valueEquivalence);
    }
 
-   public ConcurrentParallelHashMapV8(Map<? extends K, ? extends V> m, Equivalence<K> keyEquivalence,
-         Equivalence<V> valueEquivalence) {
+   public ConcurrentParallelHashMapV8(Map<? extends K, ? extends V> m, Equivalence<? super K> keyEquivalence,
+         Equivalence<? super V> valueEquivalence) {
       super(m, keyEquivalence, valueEquivalence);
    }
 

--- a/commons/src/main/java/org/infinispan/commons/util/concurrent/jdk8backported/EquivalentConcurrentHashMapV8.java
+++ b/commons/src/main/java/org/infinispan/commons/util/concurrent/jdk8backported/EquivalentConcurrentHashMapV8.java
@@ -621,10 +621,10 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     /* ---------------- Nodes -------------- */
 
    static class NodeEquivalence<K,V> {
-      final Equivalence<K> keyEq;
-      final Equivalence<V> valueEq;
+      final Equivalence<? super K> keyEq;
+      final Equivalence<? super V> valueEq;
 
-      NodeEquivalence(Equivalence<K> keyEq, Equivalence<V> valueEq) {
+      NodeEquivalence(Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
          this.keyEq = keyEq;
          this.valueEq = valueEq;
       }
@@ -838,8 +838,8 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
    private transient ValuesView<K,V> values;
    private transient EntrySetView<K,V> entrySet;
 
-   Equivalence<K> keyEq;
-   Equivalence<V> valueEq;
+   Equivalence<? super K> keyEq;
+   Equivalence<? super V> valueEq;
    transient NodeEquivalence<K, V> nodeEq;
 
     /* ---------------- Public operations -------------- */
@@ -848,7 +848,7 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     * Creates a new, empty map with the default initial table size (16).
     */
    public EquivalentConcurrentHashMapV8(
-         Equivalence<K> keyEquivalence, Equivalence<V> valueEquivalence) {
+         Equivalence<? super K> keyEquivalence, Equivalence<? super V> valueEquivalence) {
       this.keyEq = keyEquivalence; // EQUIVALENCE_MOD
       this.valueEq = valueEquivalence; // EQUIVALENCE_MOD
       this.nodeEq = new NodeEquivalence<K, V>(this.keyEq, this.valueEq); // EQUIVALENCE_MOD
@@ -865,7 +865,7 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     * elements is negative
     */
    public EquivalentConcurrentHashMapV8(int initialCapacity,
-         Equivalence<K> keyEquivalence, Equivalence<V> valueEquivalence) {
+         Equivalence<? super K> keyEquivalence, Equivalence<? super V> valueEquivalence) {
       this(keyEquivalence, valueEquivalence); // EQUIVALENCE_MOD
       if (initialCapacity < 0)
          throw new IllegalArgumentException();
@@ -881,7 +881,7 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     * @param m the map
     */
    public EquivalentConcurrentHashMapV8(Map<? extends K, ? extends V> m,
-         Equivalence<K> keyEquivalence, Equivalence<V> valueEquivalence) {
+         Equivalence<? super K> keyEquivalence, Equivalence<? super V> valueEquivalence) {
       this(keyEquivalence, valueEquivalence); // EQUIVALENCE_MOD
       this.sizeCtl = DEFAULT_CAPACITY;
       putAll(m);
@@ -903,7 +903,7 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     * @since 1.6
     */
    public EquivalentConcurrentHashMapV8(int initialCapacity, float loadFactor,
-         Equivalence<K> keyEquivalence, Equivalence<V> valueEquivalence) {
+         Equivalence<? super K> keyEquivalence, Equivalence<? super V> valueEquivalence) {
       this(initialCapacity, loadFactor, 1, keyEquivalence, valueEquivalence); // EQUIVALENCE_MOD
    }
 
@@ -927,7 +927,7 @@ public class EquivalentConcurrentHashMapV8<K,V> extends AbstractMap<K,V>
     */
    public EquivalentConcurrentHashMapV8(int initialCapacity,
          float loadFactor, int concurrencyLevel,
-         Equivalence<K> keyEquivalence, Equivalence<V> valueEquivalence) {
+         Equivalence<? super K> keyEquivalence, Equivalence<? super V> valueEquivalence) {
       this(keyEquivalence, valueEquivalence); // EQUIVALENCE_MOD
       if (!(loadFactor > 0.0f) || initialCapacity < 0 || concurrencyLevel <= 0)
          throw new IllegalArgumentException();

--- a/core/src/main/java/org/infinispan/AbstractDelegatingCache.java
+++ b/core/src/main/java/org/infinispan/AbstractDelegatingCache.java
@@ -324,12 +324,13 @@ public abstract class AbstractDelegatingCache<K, V> implements Cache<K, V> {
    }
 
    @Override
-   public void addListener(Object listener, KeyFilter filter) {
+   public void addListener(Object listener, KeyFilter<? super K> filter) {
       cache.addListener(listener, filter);
    }
 
    @Override
-   public <K, V, C> void addListener(Object listener, KeyValueFilter<K, V> filter, Converter<K, V, C> converter) {
+   public <C> void addListener(Object listener, KeyValueFilter<? super K, ? super V> filter,
+                               Converter<? super K, ? super V, C> converter) {
       cache.addListener(listener, filter, converter);
    }
 

--- a/core/src/main/java/org/infinispan/AdvancedCache.java
+++ b/core/src/main/java/org/infinispan/AdvancedCache.java
@@ -210,7 +210,7 @@ public interface AdvancedCache<K, V> extends Cache<K, V> {
     *
     * @return the data container associated with this cache instance
     */
-   DataContainer getDataContainer();
+   DataContainer<K, V> getDataContainer();
 
    /**
     * Returns the transaction manager configured for this cache. If no
@@ -380,5 +380,5 @@ public interface AdvancedCache<K, V> extends Cache<K, V> {
     *
     * @since 5.3
     */
-   CacheEntry getCacheEntry(K key);
+   CacheEntry<K, V> getCacheEntry(K key);
 }

--- a/core/src/main/java/org/infinispan/Cache.java
+++ b/core/src/main/java/org/infinispan/Cache.java
@@ -84,7 +84,7 @@ import java.util.concurrent.ConcurrentMap;
  * @see <a href="http://www.jboss.org/community/wiki/5minutetutorialonInfinispan">5 Minute Usage Tutorial</a>
  * @since 4.0
  */
-public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringListenable {
+public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringListenable<K, V> {
    /**
     * Under special operating behavior, associates the value with the specified key. <ul> <li> Only goes through if the
     * key specified does not exist; no-op otherwise (similar to {@link ConcurrentMap#putIfAbsent(Object, Object)})</i>

--- a/core/src/main/java/org/infinispan/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/CacheImpl.java
@@ -548,12 +548,13 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    }
 
    @Override
-   public void addListener(Object listener, KeyFilter filter) {
+   public void addListener(Object listener, KeyFilter<? super K> filter) {
       notifier.addListener(listener, filter);
    }
 
    @Override
-   public <K, V, C> void addListener(Object listener, KeyValueFilter<K, V> filter, Converter<K, V, C> converter) {
+   public <C> void addListener(Object listener, KeyValueFilter<? super K, ? super V> filter,
+                               Converter<? super K, ? super V, C> converter) {
       notifier.addListener(listener, filter, converter);
    }
 

--- a/core/src/main/java/org/infinispan/commands/read/ValuesCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/ValuesCommand.java
@@ -57,15 +57,13 @@ public class ValuesCommand extends AbstractLocalCommand implements VisitableComm
    }
 
    private static class FilteredValues extends AbstractCollection<Object> {
-      final DataContainer container;
-      final Collection<Object> values;
+      final DataContainer<Object, Object> container;
       final Set<InternalCacheEntry> entrySet;
       final Map<Object, CacheEntry> lookedUpEntries;
       final TimeService timeService;
 
       FilteredValues(DataContainer container, Map<Object, CacheEntry> lookedUpEntries, TimeService timeService) {
          this.container = container;
-         values = container.values();
          entrySet = container.entrySet();
          this.lookedUpEntries = lookedUpEntries;
          this.timeService = timeService;

--- a/core/src/main/java/org/infinispan/container/DataContainer.java
+++ b/core/src/main/java/org/infinispan/container/DataContainer.java
@@ -20,7 +20,7 @@ import org.infinispan.factories.scopes.Scopes;
  * @since 4.0
  */
 @Scope(Scopes.NAMED_CACHE)
-public interface DataContainer extends Iterable<InternalCacheEntry> {
+public interface DataContainer<K, V> extends Iterable<InternalCacheEntry<K, V>> {
 
    /**
     * Retrieves a cached entry
@@ -28,8 +28,8 @@ public interface DataContainer extends Iterable<InternalCacheEntry> {
     * @param k key under which entry is stored
     * @return entry, if it exists and has not expired, or null if not
     */
-   InternalCacheEntry get(Object k);
-
+   InternalCacheEntry<K, V> get(Object k);
+   
    /**
     * Retrieves a cache entry in the same way as {@link #get(Object)}} except that it does not update or reorder any of
     * the internal constructs. I.e., expiration does not happen, and in the case of the LRU container, the entry is not
@@ -41,7 +41,7 @@ public interface DataContainer extends Iterable<InternalCacheEntry> {
     * @param k key under which entry is stored
     * @return entry, if it exists, or null if not
     */
-   InternalCacheEntry peek(Object k);
+   InternalCacheEntry<K, V> peek(Object k);
 
    /**
     * Puts an entry in the cache along with metadata adding information such lifespan of entry, max idle time, version
@@ -50,11 +50,11 @@ public interface DataContainer extends Iterable<InternalCacheEntry> {
     * If the {@code key} does not exists previously, it must be activate by invoking {@link
     * org.infinispan.eviction.ActivationManager#activate(Object)}.
     *
-    * @param k        key under which to store entry
-    * @param v        value to store
+    * @param k key under which to store entry
+    * @param v value to store
     * @param metadata metadata of the entry
     */
-   void put(Object k, Object v, Metadata metadata);
+   void put(K k, V v, Metadata metadata);
 
    /**
     * Tests whether an entry exists in the container
@@ -70,9 +70,10 @@ public interface DataContainer extends Iterable<InternalCacheEntry> {
     * @param k key to remove
     * @return entry removed, or null if it didn't exist or had expired
     */
-   InternalCacheEntry remove(Object k);
+   InternalCacheEntry<K, V> remove(Object k);
 
    /**
+    *
     * @return count of the number of entries in the container
     */
    int size();
@@ -90,12 +91,12 @@ public interface DataContainer extends Iterable<InternalCacheEntry> {
     *
     * @return a set of keys
     */
-   Set<Object> keySet();
+   Set<K> keySet();
 
    /**
     * @return a set of values contained in the container
     */
-   Collection<Object> values();
+   Collection<V> values();
 
    /**
     * Returns a mutable set of immutable cache entries exposed as immutable Map.Entry instances. Clients of this method
@@ -107,7 +108,7 @@ public interface DataContainer extends Iterable<InternalCacheEntry> {
     *
     * @return a set of immutable cache entries
     */
-   Set<InternalCacheEntry> entrySet();
+   Set<InternalCacheEntry<K, V>> entrySet();
 
    /**
     * Purges entries that have passed their expiry time
@@ -121,7 +122,7 @@ public interface DataContainer extends Iterable<InternalCacheEntry> {
     *
     * @param key The key to evict.
     */
-   void evict(Object key);
+   void evict(K key);
 
    /**
     * Computes the new value for the key.
@@ -134,7 +135,7 @@ public interface DataContainer extends Iterable<InternalCacheEntry> {
     * @param key    The key.
     * @param action The action that will compute the new value.
     */
-   void compute(Object key, ComputeAction action);
+   void compute(K key, ComputeAction<K, V> action);
 
    /**
     * Executes task specified by the given action on the container key/values filtered using the specified key filter.
@@ -143,10 +144,10 @@ public interface DataContainer extends Iterable<InternalCacheEntry> {
     * @param action the specified action to execute on filtered key/values
     * @throws InterruptedException
     */
-   public <K> void executeTask(AdvancedCacheLoader.KeyFilter<K> filter,
-                               ParallelIterableMap.KeyValueAction<Object, InternalCacheEntry> action) throws InterruptedException;
+   public void executeTask(AdvancedCacheLoader.KeyFilter<? super K> filter,
+         ParallelIterableMap.KeyValueAction<? super K, InternalCacheEntry<? super K, ? super V>> action) throws InterruptedException;
 
-   public static interface ComputeAction {
+   public static interface ComputeAction<K, V> {
 
       /**
        * Computes the new value for the key.
@@ -154,7 +155,7 @@ public interface DataContainer extends Iterable<InternalCacheEntry> {
        * @return The new {@code InternalCacheEntry} for the key, {@code null} if the entry is to be removed or {@code
        * oldEntry} is the entry is not to be changed (i.e. not entries are added, removed or touched).
        */
-      InternalCacheEntry compute(Object key, InternalCacheEntry oldEntry, InternalEntryFactory factory);
+      InternalCacheEntry<K, V> compute(K key, InternalCacheEntry<K, V> oldEntry, InternalEntryFactory factory);
 
    }
 }

--- a/core/src/main/java/org/infinispan/container/DefaultDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/DefaultDataContainer.java
@@ -1,11 +1,10 @@
 package org.infinispan.container;
 
 import net.jcip.annotations.ThreadSafe;
-
+import org.infinispan.commons.equivalence.AnyEquivalence;
+import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.logging.Log;
 import org.infinispan.commons.logging.LogFactory;
-import org.infinispan.metadata.Metadata;
-import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.commons.util.concurrent.ParallelIterableMap;
 import org.infinispan.commons.util.concurrent.jdk8backported.EquivalentConcurrentHashMapV8;
@@ -16,6 +15,7 @@ import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.eviction.EvictionThreadPolicy;
 import org.infinispan.eviction.PassivationManager;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.metadata.Metadata;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.persistence.spi.AdvancedCacheLoader;
 import org.infinispan.util.CoreImmutables;
@@ -45,14 +45,14 @@ import java.util.concurrent.ConcurrentMap;
  * @since 4.0
  */
 @ThreadSafe
-public class DefaultDataContainer implements DataContainer {
+public class DefaultDataContainer<K, V> implements DataContainer<K, V> {
 
    private static final Log log = LogFactory.getLog(DefaultDataContainer.class);
    private static final boolean trace = log.isTraceEnabled();
 
-   private final ConcurrentMap<Object, InternalCacheEntry> entries;
+   private final ConcurrentMap<K, InternalCacheEntry<K, V>> entries;
    private final DefaultEvictionListener evictionListener;
-   private final ExtendedMap extendedMap;
+   private final ExtendedMap<K, V> extendedMap;
    protected InternalEntryFactory entryFactory;
    private EvictionManager evictionManager;
    private PassivationManager passivator;
@@ -64,13 +64,13 @@ public class DefaultDataContainer implements DataContainer {
       // If no comparing implementations passed, could fallback on JDK CHM
       entries = CollectionFactory.makeConcurrentParallelMap(128, concurrencyLevel);
       evictionListener = null;
-      extendedMap = new ExtendedMap() {
+      extendedMap = new ExtendedMap<K, V>() {
          @Override
-         public void evict(Object key) {
-            ((EquivalentConcurrentHashMapV8<Object, InternalCacheEntry>) entries)
-                  .computeIfPresent(key, new EquivalentConcurrentHashMapV8.BiFun<Object, InternalCacheEntry, InternalCacheEntry>() {
+         public void evict(K key) {
+            ((EquivalentConcurrentHashMapV8<K, InternalCacheEntry<K, V>>) entries)
+                  .computeIfPresent(key, new EquivalentConcurrentHashMapV8.BiFun<K, InternalCacheEntry<K, V>, InternalCacheEntry<K, V>>() {
                      @Override
-                     public InternalCacheEntry apply(Object o, InternalCacheEntry entry) {
+                     public InternalCacheEntry<K, V> apply(K o, InternalCacheEntry<K, V> entry) {
                         passivator.passivate(entry);
                         return null;
                      }
@@ -78,12 +78,12 @@ public class DefaultDataContainer implements DataContainer {
          }
 
          @Override
-         public void compute(Object key, final ComputeAction action) {
-            ((EquivalentConcurrentHashMapV8<Object, InternalCacheEntry>) entries)
-                  .compute(key, new EquivalentConcurrentHashMapV8.BiFun<Object, InternalCacheEntry, InternalCacheEntry>() {
+         public void compute(K key, final ComputeAction<K, V> action) {
+            ((EquivalentConcurrentHashMapV8<K, InternalCacheEntry<K, V>>) entries)
+                  .compute(key, new EquivalentConcurrentHashMapV8.BiFun<K, InternalCacheEntry<K, V>, InternalCacheEntry<K, V>>() {
                      @Override
-                     public InternalCacheEntry apply(Object key, InternalCacheEntry oldEntry) {
-                        InternalCacheEntry newEntry = action.compute(key, oldEntry, entryFactory);
+                     public InternalCacheEntry<K, V> apply(K key, InternalCacheEntry<K, V> oldEntry) {
+                        InternalCacheEntry<K, V> newEntry = action.compute(key, oldEntry, entryFactory);
                         if (newEntry == oldEntry) {
                            return oldEntry;
                         } else if (newEntry == null) {
@@ -101,11 +101,11 @@ public class DefaultDataContainer implements DataContainer {
          }
 
          @Override
-         public void putAndActivate(final InternalCacheEntry newEntry) {
-            ((EquivalentConcurrentHashMapV8<Object, InternalCacheEntry>) entries)
-                  .compute(newEntry.getKey(), new EquivalentConcurrentHashMapV8.BiFun<Object, InternalCacheEntry, InternalCacheEntry>() {
+         public void putAndActivate(final InternalCacheEntry<K, V> newEntry) {
+            ((EquivalentConcurrentHashMapV8<K, InternalCacheEntry<K, V>>) entries)
+                  .compute(newEntry.getKey(), new EquivalentConcurrentHashMapV8.BiFun<Object, InternalCacheEntry<K, V>, InternalCacheEntry<K, V>>() {
                      @Override
-                     public InternalCacheEntry apply(Object key, InternalCacheEntry entry) {
+                     public InternalCacheEntry apply(Object key, InternalCacheEntry<K, V> entry) {
                         if (entry == null) {
                            //entry does not exists before. we need to activate it.
                            activator.activate(key);
@@ -118,17 +118,18 @@ public class DefaultDataContainer implements DataContainer {
       };
    }
 
-   public DefaultDataContainer(int concurrencyLevel, Equivalence<Object> keyEq, Equivalence<InternalCacheEntry> valueEq) {
+   public DefaultDataContainer(int concurrencyLevel,
+         Equivalence<? super K> keyEq) {
       // If at least one comparing implementation give, use ComparingCHMv8
-      entries = CollectionFactory.makeConcurrentParallelMap(128, concurrencyLevel, keyEq, valueEq);
+      entries = CollectionFactory.makeConcurrentParallelMap(128, concurrencyLevel, keyEq, AnyEquivalence.getInstance());
       evictionListener = null;
-      extendedMap = new ExtendedMap() {
+      extendedMap = new ExtendedMap<K, V>() {
          @Override
-         public void evict(Object key) {
-            ((EquivalentConcurrentHashMapV8<Object, InternalCacheEntry>) entries)
-                  .computeIfPresent(key, new EquivalentConcurrentHashMapV8.BiFun<Object, InternalCacheEntry, InternalCacheEntry>() {
+         public void evict(K key) {
+            ((EquivalentConcurrentHashMapV8<K, InternalCacheEntry<K, V>>) entries)
+                  .computeIfPresent(key, new EquivalentConcurrentHashMapV8.BiFun<K, InternalCacheEntry<K, V>, InternalCacheEntry<K, V>>() {
                      @Override
-                     public InternalCacheEntry apply(Object o, InternalCacheEntry entry) {
+                     public InternalCacheEntry<K, V> apply(K o, InternalCacheEntry<K, V> entry) {
                         passivator.passivate(entry);
                         return null;
                      }
@@ -136,12 +137,12 @@ public class DefaultDataContainer implements DataContainer {
          }
 
          @Override
-         public void compute(Object key, final ComputeAction action) {
-            ((EquivalentConcurrentHashMapV8<Object, InternalCacheEntry>) entries)
-                  .compute(key, new EquivalentConcurrentHashMapV8.BiFun<Object, InternalCacheEntry, InternalCacheEntry>() {
+         public void compute(K key, final ComputeAction<K, V> action) {
+            ((EquivalentConcurrentHashMapV8<K, InternalCacheEntry<K, V>>) entries)
+                  .compute(key, new EquivalentConcurrentHashMapV8.BiFun<K, InternalCacheEntry<K, V>, InternalCacheEntry<K, V>>() {
                      @Override
-                     public InternalCacheEntry apply(Object key, InternalCacheEntry oldEntry) {
-                        InternalCacheEntry newEntry = action.compute(key, oldEntry, entryFactory);
+                     public InternalCacheEntry<K, V> apply(K key, InternalCacheEntry<K, V> oldEntry) {
+                        InternalCacheEntry<K, V> newEntry = action.compute(key, oldEntry, entryFactory);
                         if (newEntry == oldEntry) {
                            return oldEntry;
                         } else if (newEntry == null) {
@@ -159,11 +160,11 @@ public class DefaultDataContainer implements DataContainer {
          }
 
          @Override
-         public void putAndActivate(final InternalCacheEntry newEntry) {
-            ((EquivalentConcurrentHashMapV8<Object, InternalCacheEntry>) entries)
-                  .compute(newEntry.getKey(), new EquivalentConcurrentHashMapV8.BiFun<Object, InternalCacheEntry, InternalCacheEntry>() {
+         public void putAndActivate(final InternalCacheEntry<K, V> newEntry) {
+            ((EquivalentConcurrentHashMapV8<K, InternalCacheEntry<K, V>>) entries)
+                  .compute(newEntry.getKey(), new EquivalentConcurrentHashMapV8.BiFun<K, InternalCacheEntry<K, V>, InternalCacheEntry<K, V>>() {
                      @Override
-                     public InternalCacheEntry apply(Object key, InternalCacheEntry entry) {
+                     public InternalCacheEntry<K, V> apply(K key, InternalCacheEntry<K, V> entry) {
                         if (entry == null) {
                            //entry does not exists before. we need to activate it.
                            activator.activate(key);
@@ -177,8 +178,8 @@ public class DefaultDataContainer implements DataContainer {
    }
 
    protected DefaultDataContainer(int concurrencyLevel, int maxEntries,
-                                  EvictionStrategy strategy, EvictionThreadPolicy policy,
-                                  Equivalence<Object> keyEquivalence, Equivalence<InternalCacheEntry> valueEquivalence) {
+         EvictionStrategy strategy, EvictionThreadPolicy policy,
+         Equivalence<? super K> keyEquivalence) {
       // translate eviction policy and strategy
       switch (policy) {
          case PIGGYBACK:
@@ -203,22 +204,22 @@ public class DefaultDataContainer implements DataContainer {
             throw new IllegalArgumentException("No such eviction strategy " + strategy);
       }
 
-      final BoundedConcurrentHashMap<Object, InternalCacheEntry> boundedMap =
-            new BoundedConcurrentHashMap<Object, InternalCacheEntry>(maxEntries, concurrencyLevel, eviction, evictionListener,
-                                                                     keyEquivalence, valueEquivalence);
+      final BoundedConcurrentHashMap<K, InternalCacheEntry<K, V>> boundedMap =
+            new BoundedConcurrentHashMap<K, InternalCacheEntry<K, V>>(maxEntries, concurrencyLevel, eviction, evictionListener,
+                                                                     keyEquivalence, AnyEquivalence.getInstance());
       entries = boundedMap;
-      extendedMap = new ExtendedMap() {
+      extendedMap = new ExtendedMap<K, V>() {
          @Override
-         public void evict(Object key) {
+         public void evict(K key) {
             boundedMap.evict(key);
          }
 
          @Override
-         public void compute(Object key, final ComputeAction action) {
+         public void compute(K key, final ComputeAction<K, V> action) {
             boundedMap.lock(key);
             try {
-               InternalCacheEntry oldEntry = boundedMap.get(key);
-               InternalCacheEntry newEntry = action.compute(key, oldEntry, entryFactory);
+               InternalCacheEntry<K, V> oldEntry = boundedMap.get(key);
+               InternalCacheEntry<K, V> newEntry = action.compute(key, oldEntry, entryFactory);
                if (oldEntry == newEntry) {
                   return;
                } else if (newEntry == null) {
@@ -235,7 +236,7 @@ public class DefaultDataContainer implements DataContainer {
          }
 
          @Override
-         public void putAndActivate(InternalCacheEntry newEntry) {
+         public void putAndActivate(InternalCacheEntry<K, V> newEntry) {
             //put already activate the entry if it is new.
             boundedMap.put(newEntry.getKey(), newEntry);
          }
@@ -253,16 +254,16 @@ public class DefaultDataContainer implements DataContainer {
       this.timeService = timeService;
    }
 
-   public static DataContainer boundedDataContainer(int concurrencyLevel, int maxEntries,
-                                                    EvictionStrategy strategy, EvictionThreadPolicy policy,
-                                                    Equivalence<Object> keyEquivalence, Equivalence<InternalCacheEntry> valueEquivalence) {
+   public static <K, V> DataContainer<K, V> boundedDataContainer(int concurrencyLevel, int maxEntries,
+            EvictionStrategy strategy, EvictionThreadPolicy policy,
+            Equivalence<? super K> keyEquivalence) {
       return new DefaultDataContainer(concurrencyLevel, maxEntries, strategy,
-                                      policy, keyEquivalence, valueEquivalence);
+            policy, keyEquivalence);
    }
 
-   public static DataContainer unBoundedDataContainer(int concurrencyLevel,
-                                                      Equivalence<Object> keyEquivalence, Equivalence<InternalCacheEntry> valueEquivalence) {
-      return new DefaultDataContainer(concurrencyLevel, keyEquivalence, valueEquivalence);
+   public static <K, V> DataContainer<K, V> unBoundedDataContainer(int concurrencyLevel,
+         Equivalence<? super K> keyEquivalence) {
+      return new DefaultDataContainer(concurrencyLevel, keyEquivalence);
    }
 
    public static DataContainer unBoundedDataContainer(int concurrencyLevel) {
@@ -270,13 +271,13 @@ public class DefaultDataContainer implements DataContainer {
    }
 
    @Override
-   public InternalCacheEntry peek(Object key) {
+   public InternalCacheEntry<K, V> peek(Object key) {
       return entries.get(key);
    }
 
    @Override
-   public InternalCacheEntry get(Object k) {
-      InternalCacheEntry e = peek(k);
+   public InternalCacheEntry<K, V> get(Object k) {
+      InternalCacheEntry<K, V> e = peek(k);
       if (e != null && e.canExpire()) {
          long currentTimeMillis = timeService.wallClockTime();
          if (e.isExpired(currentTimeMillis)) {
@@ -290,8 +291,8 @@ public class DefaultDataContainer implements DataContainer {
    }
 
    @Override
-   public void put(Object k, Object v, Metadata metadata) {
-      InternalCacheEntry e = entries.get(k);
+   public void put(K k, V v, Metadata metadata) {
+      InternalCacheEntry<K, V> e = entries.get(k);
 
       if (trace) {
          log.tracef("Creating new ICE for writing. Existing=%s, metadata=%s, new value=%s", e, metadata, v);
@@ -311,7 +312,7 @@ public class DefaultDataContainer implements DataContainer {
 
    @Override
    public boolean containsKey(Object k) {
-      InternalCacheEntry ice = peek(k);
+      InternalCacheEntry<K, V> ice = peek(k);
       if (ice != null && ice.canExpire() && ice.isExpired(timeService.wallClockTime())) {
          entries.remove(k);
          ice = null;
@@ -320,8 +321,8 @@ public class DefaultDataContainer implements DataContainer {
    }
 
    @Override
-   public InternalCacheEntry remove(Object k) {
-      InternalCacheEntry e = entries.remove(k);
+   public InternalCacheEntry<K, V> remove(Object k) {
+      InternalCacheEntry<K, V> e = entries.remove(k);
       return e == null || (e.canExpire() && e.isExpired(timeService.wallClockTime())) ? null : e;
    }
 
@@ -336,24 +337,24 @@ public class DefaultDataContainer implements DataContainer {
    }
 
    @Override
-   public Set<Object> keySet() {
+   public Set<K> keySet() {
       return Collections.unmodifiableSet(entries.keySet());
    }
 
    @Override
-   public Collection<Object> values() {
+   public Collection<V> values() {
       return new Values();
    }
 
    @Override
-   public Set<InternalCacheEntry> entrySet() {
+   public Set<InternalCacheEntry<K, V>> entrySet() {
       return new EntrySet();
    }
 
    @Override
    public void purgeExpired() {
       long currentTimeMillis = timeService.wallClockTime();
-      for (Iterator<InternalCacheEntry> purgeCandidates = entries.values().iterator(); purgeCandidates.hasNext();) {
+      for (Iterator<InternalCacheEntry<K, V>> purgeCandidates = entries.values().iterator(); purgeCandidates.hasNext();) {
          InternalCacheEntry e = purgeCandidates.next();
          if (e.isExpired(currentTimeMillis)) {
             purgeCandidates.remove();
@@ -362,24 +363,24 @@ public class DefaultDataContainer implements DataContainer {
    }
 
    @Override
-   public void evict(Object key) {
+   public void evict(K key) {
       extendedMap.evict(key);
    }
 
    @Override
-   public void compute(Object key, ComputeAction action) {
+   public void compute(K key, ComputeAction<K, V> action) {
       extendedMap.compute(key, action);
    }
 
    @Override
-   public Iterator<InternalCacheEntry> iterator() {
+   public Iterator<InternalCacheEntry<K, V>> iterator() {
       return new EntryIterator(entries.values().iterator());
    }
 
-   private final class DefaultEvictionListener implements EvictionListener<Object, InternalCacheEntry> {
+   private final class DefaultEvictionListener implements EvictionListener<K, InternalCacheEntry<K, V>> {
 
       @Override
-      public void onEntryEviction(Map<Object, InternalCacheEntry> evicted) {
+      public void onEntryEviction(Map<K, InternalCacheEntry<K, V>> evicted) {
          evictionManager.onEntryEviction(evicted);
       }
 
@@ -400,25 +401,25 @@ public class DefaultDataContainer implements DataContainer {
       }
    }
 
-   private static class ImmutableEntryIterator extends EntryIterator {
-      ImmutableEntryIterator(Iterator<InternalCacheEntry> it){
+   private static class ImmutableEntryIterator<K, V> extends EntryIterator<K, V> {
+      ImmutableEntryIterator(Iterator<InternalCacheEntry<K, V>> it){
          super(it);
       }
 
       @Override
-      public InternalCacheEntry next() {
+      public InternalCacheEntry<K, V> next() {
          return CoreImmutables.immutableInternalCacheEntry(super.next());
       }
    }
 
-   public static class EntryIterator implements Iterator<InternalCacheEntry> {
+   public static class EntryIterator<K, V> implements Iterator<InternalCacheEntry<K, V>> {
 
-      private final Iterator<InternalCacheEntry> it;
+      private final Iterator<InternalCacheEntry<K, V>> it;
 
-      EntryIterator(Iterator<InternalCacheEntry> it){this.it=it;}
+      EntryIterator(Iterator<InternalCacheEntry<K, V>> it){this.it=it;}
 
       @Override
-      public InternalCacheEntry next() {
+      public InternalCacheEntry<K, V> next() {
          return it.next();
       }
 
@@ -437,7 +438,7 @@ public class DefaultDataContainer implements DataContainer {
     * Minimal implementation needed for unmodifiable Set
     *
     */
-   private class EntrySet extends AbstractSet<InternalCacheEntry> {
+   private class EntrySet extends AbstractSet<InternalCacheEntry<K, V>> {
 
       @Override
       public boolean contains(Object o) {
@@ -455,7 +456,7 @@ public class DefaultDataContainer implements DataContainer {
       }
 
       @Override
-      public Iterator<InternalCacheEntry> iterator() {
+      public Iterator<InternalCacheEntry<K, V>> iterator() {
          return new ImmutableEntryIterator(entries.values().iterator());
       }
 
@@ -474,9 +475,9 @@ public class DefaultDataContainer implements DataContainer {
     * Minimal implementation needed for unmodifiable Collection
     *
     */
-   private class Values extends AbstractCollection<Object> {
+   private class Values extends AbstractCollection<V> {
       @Override
-      public Iterator<Object> iterator() {
+      public Iterator<V> iterator() {
          return new ValueIterator(entries.values().iterator());
       }
 
@@ -486,10 +487,10 @@ public class DefaultDataContainer implements DataContainer {
       }
    }
 
-   private static class ValueIterator implements Iterator<Object> {
-      Iterator<InternalCacheEntry> currentIterator;
+   private static class ValueIterator<K, V> implements Iterator<V> {
+      Iterator<InternalCacheEntry<K, V>> currentIterator;
 
-      private ValueIterator(Iterator<InternalCacheEntry> it) {
+      private ValueIterator(Iterator<InternalCacheEntry<K, V>> it) {
          currentIterator = it;
       }
 
@@ -504,24 +505,25 @@ public class DefaultDataContainer implements DataContainer {
       }
 
       @Override
-      public Object next() {
+      public V next() {
          return currentIterator.next().getValue();
       }
    }
 
    @Override
-   public <K> void executeTask(final AdvancedCacheLoader.KeyFilter<K> filter, final ParallelIterableMap.KeyValueAction<Object, InternalCacheEntry> action) throws InterruptedException{
+   public void executeTask(final AdvancedCacheLoader.KeyFilter<? super K> filter,
+                               final ParallelIterableMap.KeyValueAction<? super K, InternalCacheEntry<? super K, ? super V>> action) throws InterruptedException{
       if (filter == null)
          throw new IllegalArgumentException("No filter specified");
       if (action == null)
          throw new IllegalArgumentException("No action specified");
 
-      ParallelIterableMap<Object, InternalCacheEntry> map = (ParallelIterableMap<Object, InternalCacheEntry>) entries;
-      map.forEach(512, new ParallelIterableMap.KeyValueAction<Object, InternalCacheEntry>() {
+      ParallelIterableMap<K, InternalCacheEntry<K, V>> map = (ParallelIterableMap<K, InternalCacheEntry<K, V>>) entries;
+      map.forEach(512, new ParallelIterableMap.KeyValueAction<K, InternalCacheEntry<K, V>>() {
          @Override
-         public void apply(Object key, InternalCacheEntry value) {
-            if (filter.shouldLoadKey((K)key)) {
-               action.apply((K)key, value);
+         public void apply(K key, InternalCacheEntry<K, V> value) {
+            if (filter.shouldLoadKey(key)) {
+               action.apply(key, value);
             }
          }
       });
@@ -534,12 +536,12 @@ public class DefaultDataContainer implements DataContainer {
    /**
     * Atomic logic to activate/passivate entries. This is dependent of the {@code ConcurrentMap} implementation.
     */
-   private static interface ExtendedMap {
-      void evict(Object key);
+   private static interface ExtendedMap<K, V> {
+      void evict(K key);
 
-      void compute(Object key, ComputeAction action);
+      void compute(K key, ComputeAction<K, V> action);
 
-      void putAndActivate(InternalCacheEntry newEntry);
+      void putAndActivate(InternalCacheEntry<K, V> newEntry);
    }
 
 

--- a/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
@@ -13,7 +13,7 @@ import java.util.Map;
  * @author Galder Zamarreño
  * @since 4.0
  */
-public interface CacheEntry extends Map.Entry<Object, Object>, MetadataAware {
+public interface CacheEntry<K, V> extends Map.Entry<K, V>, MetadataAware {
 
    /**
     * Tests whether the entry represents a null value, typically used for repeatable read.
@@ -59,7 +59,7 @@ public interface CacheEntry extends Map.Entry<Object, Object>, MetadataAware {
     * @return a key
     */
    @Override
-   Object getKey();
+   K getKey();
 
    /**
     * Retrieves the value of this entry
@@ -67,7 +67,7 @@ public interface CacheEntry extends Map.Entry<Object, Object>, MetadataAware {
     * @return the value of the entry
     */
    @Override
-   Object getValue();
+   V getValue();
 
    /**
     * @return retrieves the lifespan of this entry.  -1 means an unlimited lifespan.
@@ -91,7 +91,7 @@ public interface CacheEntry extends Map.Entry<Object, Object>, MetadataAware {
     * @return previous value
     */
    @Override
-   Object setValue(Object value);
+   V setValue(V value);
 
    /**
     * Commits changes

--- a/core/src/main/java/org/infinispan/container/entries/InternalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/InternalCacheEntry.java
@@ -7,7 +7,7 @@ package org.infinispan.container.entries;
  * @author Sanne Grinovero
  * @since 4.0
  */
-public interface InternalCacheEntry extends CacheEntry, Cloneable {
+public interface InternalCacheEntry<K, V> extends CacheEntry<K, V>, Cloneable {
 
    /**
     * @param now the current time as defined by {@link System#currentTimeMillis()} or {@link
@@ -88,7 +88,7 @@ public interface InternalCacheEntry extends CacheEntry, Cloneable {
     *
     * @return a new InternalCacheValue encapsulating this InternalCacheEntry's value and expiration information.
     */
-   InternalCacheValue toInternalCacheValue();
+   InternalCacheValue<V> toInternalCacheValue();
 
-   InternalCacheEntry clone();
+   InternalCacheEntry<K, V> clone();
 }

--- a/core/src/main/java/org/infinispan/container/entries/InternalCacheValue.java
+++ b/core/src/main/java/org/infinispan/container/entries/InternalCacheValue.java
@@ -19,14 +19,14 @@ import org.infinispan.metadata.Metadata;
  * @author Manik Surtani
  * @since 4.0
  */
-public interface InternalCacheValue {
+public interface InternalCacheValue<V> {
 
    /**
     * @return the value represented by this internal wrapper
     */
-   Object getValue();
+   V getValue();
 
-   InternalCacheEntry toInternalCacheEntry(Object key);
+   <K> InternalCacheEntry<K, V> toInternalCacheEntry(K key);
 
    /**
     * @param now the current time as expressed by {@link System#currentTimeMillis()}

--- a/core/src/main/java/org/infinispan/container/entries/MVCCEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/MVCCEntry.java
@@ -8,14 +8,14 @@ import org.infinispan.container.DataContainer;
  * @author Manik Surtani
  * @since 4.0
  */
-public interface MVCCEntry extends CacheEntry, StateChangingEntry {
+public interface MVCCEntry<K, V> extends CacheEntry<K, V>, StateChangingEntry {
 
    /**
     * Makes internal copies of the entry for updates
     *
     * @param container      data container
     */
-   void copyForUpdate(DataContainer container);
+   void copyForUpdate(DataContainer<? super K, ? super V> container);
 
    void setChanged(boolean isChanged);
 }

--- a/core/src/main/java/org/infinispan/eviction/EvictionManager.java
+++ b/core/src/main/java/org/infinispan/eviction/EvictionManager.java
@@ -24,7 +24,7 @@ import org.infinispan.factories.scopes.Scopes;
  */
 @ThreadSafe
 @Scope(Scopes.NAMED_CACHE)
-public interface EvictionManager {
+public interface EvictionManager<K, V> {
 
    /**
     * Processes the eviction event queue.
@@ -36,5 +36,5 @@ public interface EvictionManager {
     */
    boolean isEnabled();
 
-   void onEntryEviction(Map<Object, InternalCacheEntry> evicted);
+   void onEntryEviction(Map<? extends K, InternalCacheEntry<? extends K, ? extends V>> evicted);
 }

--- a/core/src/main/java/org/infinispan/eviction/EvictionManagerImpl.java
+++ b/core/src/main/java/org/infinispan/eviction/EvictionManagerImpl.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 @ThreadSafe
-public class EvictionManagerImpl implements EvictionManager {
+public class EvictionManagerImpl<K, V> implements EvictionManager<K, V> {
    private static final Log log = LogFactory.getLog(EvictionManagerImpl.class);
    private static final boolean trace = log.isTraceEnabled();
    ScheduledFuture <?> evictionTask;
@@ -35,7 +35,7 @@ public class EvictionManagerImpl implements EvictionManager {
    private Configuration configuration;
    private PersistenceManager persistenceManager;
    private DataContainer dataContainer;
-   private CacheNotifier cacheNotifier;
+   private CacheNotifier<K, V> cacheNotifier;
    private TimeService timeService;
    private boolean enabled;
    private String cacheName;
@@ -43,14 +43,14 @@ public class EvictionManagerImpl implements EvictionManager {
    @Inject
    public void initialize(@ComponentName(KnownComponentNames.EVICTION_SCHEDULED_EXECUTOR)
          ScheduledExecutorService executor, Cache cache, Configuration cfg, DataContainer dataContainer,
-         PersistenceManager persistenceManager, CacheNotifier cacheNotifier, TimeService timeService) {
+         PersistenceManager persistenceManager, CacheNotifier<K, V> cacheNotifier, TimeService timeService) {
       initialize(executor, cache.getName(), cfg, dataContainer,
                  persistenceManager, cacheNotifier, timeService);
    }
 
    void initialize(ScheduledExecutorService executor,
             String cacheName, Configuration cfg, DataContainer dataContainer,
-            PersistenceManager persistenceManager, CacheNotifier cacheNotifier, TimeService timeService) {
+            PersistenceManager persistenceManager, CacheNotifier<K, V> cacheNotifier, TimeService timeService) {
       this.executor = executor;
       this.configuration = cfg;
       this.cacheName = cacheName;
@@ -127,7 +127,7 @@ public class EvictionManagerImpl implements EvictionManager {
    }
 
    @Override
-   public void onEntryEviction(Map<Object, InternalCacheEntry> evicted) {
+   public void onEntryEviction(Map<? extends K, InternalCacheEntry<? extends K, ? extends V>> evicted) {
       // don't reuse the threadlocal context as we don't want to include eviction
       // operations in any ongoing transaction, nor be affected by flags
       // especially see ISPN-1154: it's illegal to acquire locks in a committing transaction

--- a/core/src/main/java/org/infinispan/eviction/PassivationManagerImpl.java
+++ b/core/src/main/java/org/infinispan/eviction/PassivationManagerImpl.java
@@ -33,7 +33,7 @@ public class PassivationManagerImpl implements PassivationManager {
    boolean enabled = false;
    private static final Log log = LogFactory.getLog(PassivationManagerImpl.class);
    private final AtomicLong passivations = new AtomicLong(0);
-   private DataContainer container;
+   private DataContainer<Object, Object> container;
    private TimeService timeService;
    private static final boolean trace = log.isTraceEnabled();
    private MarshalledEntryFactory marshalledEntryFactory;

--- a/core/src/main/java/org/infinispan/factories/DataContainerFactory.java
+++ b/core/src/main/java/org/infinispan/factories/DataContainerFactory.java
@@ -29,12 +29,11 @@ public class DataContainerFactory extends AbstractNamedCacheComponentFactory imp
          EvictionStrategy st = configuration.eviction().strategy();
          int level = configuration.locking().concurrencyLevel();
          Equivalence keyEquivalence = configuration.dataContainer().keyEquivalence();
-         Equivalence valueEquivalence = configuration.dataContainer().valueEquivalence();
 
          switch (st) {
             case NONE:
                return (T) DefaultDataContainer.unBoundedDataContainer(
-                     level, keyEquivalence, valueEquivalence);
+                     level, keyEquivalence);
             case UNORDERED:
             case LRU:
             case FIFO:
@@ -43,13 +42,13 @@ public class DataContainerFactory extends AbstractNamedCacheComponentFactory imp
                //handle case when < 0 value signifies unbounded container 
                if(maxEntries < 0) {
                    return (T) DefaultDataContainer.unBoundedDataContainer(
-                         level, keyEquivalence, valueEquivalence);
+                         level, keyEquivalence);
                }
 
                EvictionThreadPolicy policy = configuration.eviction().threadPolicy();
 
                return (T) DefaultDataContainer.boundedDataContainer(
-                  level, maxEntries, st, policy, keyEquivalence, valueEquivalence);
+                  level, maxEntries, st, policy, keyEquivalence);
             default:
                throw new CacheConfigurationException("Unknown eviction strategy "
                         + configuration.eviction().strategy());

--- a/core/src/main/java/org/infinispan/interceptors/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/EntryWrappingInterceptor.java
@@ -55,7 +55,7 @@ import static org.infinispan.commons.util.Util.toStr;
 public class EntryWrappingInterceptor extends CommandInterceptor {
 
    private EntryFactory entryFactory;
-   protected DataContainer dataContainer;
+   protected DataContainer<Object, Object> dataContainer;
    protected ClusteringDependentLogic cdl;
    protected final EntryWrappingVisitor entryWrappingVisitor = new EntryWrappingVisitor();
    private CommandsFactory commandFactory;

--- a/core/src/main/java/org/infinispan/interceptors/locking/AbstractLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/AbstractLockingInterceptor.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 public abstract class AbstractLockingInterceptor extends CommandInterceptor {
 
    protected LockManager lockManager;
-   protected DataContainer dataContainer;
+   protected DataContainer<Object, Object> dataContainer;
    protected EntryFactory entryFactory;
    protected ClusteringDependentLogic cdl;
 

--- a/core/src/main/java/org/infinispan/notifications/ClassLoaderAwareFilteringListenable.java
+++ b/core/src/main/java/org/infinispan/notifications/ClassLoaderAwareFilteringListenable.java
@@ -10,7 +10,7 @@ package org.infinispan.notifications;
  * @see ClassLoaderAwareListenable
  * @see FilteringListenable
  */
-public interface ClassLoaderAwareFilteringListenable extends FilteringListenable {
+public interface ClassLoaderAwareFilteringListenable<K, V> extends FilteringListenable<K, V> {
    /**
     * Adds a listener to the component.  Typically, listeners would need to be annotated with {@link org.infinispan.notifications.Listener} and
     * further to that, contain methods annotated appropriately, otherwise the listener will not be registered.
@@ -21,5 +21,20 @@ public interface ClassLoaderAwareFilteringListenable extends FilteringListenable
     * @param listener must not be null.
     * @param classLoader class loader
     */
-   void addListener(Object listener, KeyFilter filter, ClassLoader classLoader);
+   void addListener(Object listener, KeyFilter<? super K> filter, ClassLoader classLoader);
+
+   /**
+    * Adds a listener with the provided filter and converter and using a given classloader when invoked.  See
+    * {@link org.infinispan.notifications.FilteringListenable#addListener(Object, KeyValueFilter, Converter)}
+    * for more details.
+    * <p/>
+    * @param listener must not be null.  The listener to callback on when an event is raised
+    * @param filter The filter to apply for the entry to see if the event should be raised
+    * @param converter The converter to convert the filtered entry to a new value
+    * @param classLoader The class loader to use when the event is fired
+    * @param <C> The type that the converter returns.  The listener must handle this type in any methods that handle
+    *            events being returned
+    */
+   <C> void addListener(Object listener, KeyValueFilter<? super K, ? super V> filter,
+                    Converter<? super K, ? super V, C> converter, ClassLoader classLoader);
 }

--- a/core/src/main/java/org/infinispan/notifications/FilteringListenable.java
+++ b/core/src/main/java/org/infinispan/notifications/FilteringListenable.java
@@ -6,7 +6,7 @@ package org.infinispan.notifications;
  * @author Manik Surtani
  * @since 6.0
  */
-public interface FilteringListenable extends Listenable {
+public interface FilteringListenable<K, V> extends Listenable {
    /**
     * Adds a listener to the component.  Typically, listeners would need to be annotated with {@link org.infinispan.notifications.Listener} and
     * further to that, contain methods annotated appropriately, otherwise the listener will not be registered.
@@ -16,7 +16,7 @@ public interface FilteringListenable extends Listenable {
     *
     * @param listener must not be null.
     */
-   void addListener(Object listener, KeyFilter filter);
+   void addListener(Object listener, KeyFilter<? super K> filter);
 
    /**
     * Registers a listener that will be notified on events that pass the filter condition.  The value presented in the
@@ -24,10 +24,8 @@ public interface FilteringListenable extends Listenable {
     * @param listener The listener to callback upon event notifications.  Must not be null.
     * @param filter The filter to see if the notification should be sent to the listener.  Can be null.
     * @param converter The converter to apply to the entry before being sent to the listener.  Can be null.
-    * @param <K> The type of the key
-    * @param <V> The type of the Value
     * @param <C> The type of the resultant value after being converted
     * @throws NullPointerException if the specified listener is null
     */
-   <K,V,C> void addListener(Object listener, KeyValueFilter<K, V> filter, Converter<K, V, C> converter);
+   <C> void addListener(Object listener, KeyValueFilter<? super K, ? super V> filter, Converter<? super K, ? super V, C> converter);
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifier.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifier.java
@@ -20,37 +20,37 @@ import java.util.Collection;
  * @since 4.0
  */
 @Scope(Scopes.NAMED_CACHE)
-public interface CacheNotifier extends ClassLoaderAwareFilteringListenable, ClassLoaderAwareListenable {
+public interface CacheNotifier<K, V> extends ClassLoaderAwareFilteringListenable<K, V>, ClassLoaderAwareListenable {
 
    /**
     * Notifies all registered listeners of a CacheEntryCreated event.
     */
-   void notifyCacheEntryCreated(Object key, Object value, boolean pre,
+   void notifyCacheEntryCreated(K key, V value, boolean pre,
          InvocationContext ctx, FlagAffectedCommand command);
 
    /**
     * Notifies all registered listeners of a CacheEntryModified event.
     */
-   void notifyCacheEntryModified(Object key, Object value,
+   void notifyCacheEntryModified(K key, V value,
          boolean created, boolean pre, InvocationContext ctx,
          FlagAffectedCommand command);
 
    /**
     * Notifies all registered listeners of a CacheEntryRemoved event.
     */
-   void notifyCacheEntryRemoved(Object key, Object value, Object oldValue,
+   void notifyCacheEntryRemoved(K key, V value, V oldValue,
          boolean pre, InvocationContext ctx, FlagAffectedCommand command);
 
    /**
     * Notifies all registered listeners of a CacheEntryVisited event.
     */
-   void notifyCacheEntryVisited(Object key, Object value, boolean pre,
+   void notifyCacheEntryVisited(K key, V value, boolean pre,
          InvocationContext ctx, FlagAffectedCommand command);
 
    /**
     * Notifies all registered listeners of a CacheEntriesEvicted event.
     */
-   void notifyCacheEntriesEvicted(Collection<InternalCacheEntry> entries,
+   void notifyCacheEntriesEvicted(Collection<InternalCacheEntry<? extends K, ? extends V>> entries,
          InvocationContext ctx, FlagAffectedCommand command);
 
    /**
@@ -59,31 +59,31 @@ public interface CacheNotifier extends ClassLoaderAwareFilteringListenable, Clas
     * @param value value evicted
     * @param ctx context
     */
-   void notifyCacheEntryEvicted(Object key, Object value,
+   void notifyCacheEntryEvicted(K key, V value,
          InvocationContext ctx, FlagAffectedCommand command);
 
    /**
     * Notifies all registered listeners of a CacheEntryInvalidated event.
     */
-   void notifyCacheEntryInvalidated(Object key, Object value, boolean pre,
+   void notifyCacheEntryInvalidated(K key, V value, boolean pre,
          InvocationContext ctx, FlagAffectedCommand command);
 
    /**
     * Notifies all registered listeners of a CacheEntryLoaded event.
     */
-   void notifyCacheEntryLoaded(Object key, Object value, boolean pre,
+   void notifyCacheEntryLoaded(K key, V value, boolean pre,
          InvocationContext ctx, FlagAffectedCommand command);
 
    /**
     * Notifies all registered listeners of a CacheEntryActivated event.
     */
-   void notifyCacheEntryActivated(Object key, Object value, boolean pre,
+   void notifyCacheEntryActivated(K key, V value, boolean pre,
          InvocationContext ctx, FlagAffectedCommand command);
 
    /**
     * Notifies all registered listeners of a CacheEntryPassivated event.
     */
-   void notifyCacheEntryPassivated(Object key, Object value, boolean pre,
+   void notifyCacheEntryPassivated(K key, V value, boolean pre,
          InvocationContext ctx, FlagAffectedCommand command);
 
    /**

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterCacheNotifier.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterCacheNotifier.java
@@ -15,7 +15,7 @@ import java.util.UUID;
  * @author wburns
  * @since 7.0
  */
-public interface ClusterCacheNotifier extends CacheNotifier {
+public interface ClusterCacheNotifier<K, V> extends CacheNotifier<K, V> {
    /**
     * Method that is invoked on the node that has the given cluster listener that when registered generated the given
     * listenerId.  Note this will notify only cluster listeners and regular listeners are not notified of the events.
@@ -23,7 +23,7 @@ public interface ClusterCacheNotifier extends CacheNotifier {
     * @param events
     * @param listenerId
     */
-   void notifyClusterListeners(Collection<? extends Event> events, UUID listenerId);
+   void notifyClusterListeners(Collection<? extends Event<? extends K, ? extends V>> events, UUID listenerId);
 
    /**
     * This method is invoked so that this node can send the details required for a new node to be bootstrapped with

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterEventCallable.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterEventCallable.java
@@ -33,13 +33,13 @@ public class ClusterEventCallable<K, V> implements DistributedCallable<K, V, Voi
    private transient ClusterCacheNotifier clusterCacheNotifier;
 
    private final UUID identifier;
-   private final Collection<? extends ClusterEvent> events;
+   private final Collection<? extends ClusterEvent<K, V>> events;
 
-   public ClusterEventCallable(UUID identifier, ClusterEvent event) {
+   public ClusterEventCallable(UUID identifier, ClusterEvent<K, V> event) {
       this(identifier, Collections.singleton(event));
    }
 
-   public ClusterEventCallable(UUID identifier, Collection<? extends ClusterEvent> events) {
+   public ClusterEventCallable(UUID identifier, Collection<? extends ClusterEvent<K, V>> events) {
       this.identifier = identifier;
       this.events = events;
    }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/event/EventImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/event/EventImpl.java
@@ -36,7 +36,7 @@ public class EventImpl<K, V> implements CacheEntryActivatedEvent, CacheEntryCrea
    private V oldValue;
    private ConsistentHash consistentHashAtStart, consistentHashAtEnd;
    private int newTopologyId;
-   private Map<Object, Object> entries;
+   private Map<? extends K, ? extends V> entries;
    private boolean created;
    private boolean commandRetried;
 
@@ -161,7 +161,7 @@ public class EventImpl<K, V> implements CacheEntryActivatedEvent, CacheEntryCrea
       this.value = value;
    }
 
-   public void setEntries(Map<Object, Object> entries) {
+   public void setEntries(Map<? extends K, ? extends V> entries) {
       this.entries = entries;
    }
 
@@ -268,7 +268,7 @@ public class EventImpl<K, V> implements CacheEntryActivatedEvent, CacheEntryCrea
 
    @Override
    @SuppressWarnings("unchecked")
-   public Map<K, V> getEntries() {
-      return (Map<K, V>) entries;
+   public Map<? extends K, ? extends V> getEntries() {
+      return entries;
    }
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/filter/KeyFilterAsKeyValueFilter.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/filter/KeyFilterAsKeyValueFilter.java
@@ -20,9 +20,9 @@ import java.util.Set;
  * @since 7.0
  */
 public class KeyFilterAsKeyValueFilter<K, V> implements KeyValueFilter<K, V> {
-   private final KeyFilter filter;
+   private final KeyFilter<? super K> filter;
 
-   public KeyFilterAsKeyValueFilter(KeyFilter<K> filter) {
+   public KeyFilterAsKeyValueFilter(KeyFilter<? super K> filter) {
       if (filter == null) {
          throw new NullPointerException();
       }

--- a/core/src/main/java/org/infinispan/persistence/spi/AdvancedCacheLoader.java
+++ b/core/src/main/java/org/infinispan/persistence/spi/AdvancedCacheLoader.java
@@ -36,7 +36,7 @@ public interface AdvancedCacheLoader<K, V> extends CacheLoader<K, V> {
     *                      as well
     * @throws PersistenceException in case of an error, e.g. communicating with the external storage
     */
-   void process(KeyFilter<K> filter, CacheLoaderTask<K, V> task, Executor executor, boolean fetchValue, boolean fetchMetadata);
+   void process(KeyFilter<? super K> filter, CacheLoaderTask<? super K, ? super V> task, Executor executor, boolean fetchValue, boolean fetchMetadata);
 
    /**
     * Returns the number of elements in the store.

--- a/core/src/main/java/org/infinispan/persistence/spi/AdvancedCacheWriter.java
+++ b/core/src/main/java/org/infinispan/persistence/spi/AdvancedCacheWriter.java
@@ -26,7 +26,7 @@ public interface AdvancedCacheWriter<K, V> extends CacheWriter<K, V> {
     *
     * @throws PersistenceException in case of an error, e.g. communicating with the external storage
     */
-   void purge(Executor threadPool, PurgeListener listener);
+   void purge(Executor threadPool, PurgeListener<? super K> listener);
 
    /**
     * Callback to be notified when an entry is removed by the {@link #purge(java.util.concurrent.Executor,

--- a/core/src/main/java/org/infinispan/persistence/spi/CacheLoader.java
+++ b/core/src/main/java/org/infinispan/persistence/spi/CacheLoader.java
@@ -30,12 +30,12 @@ public interface CacheLoader<K, V> extends Lifecycle {
     * @return the entry, or null if the entry does not exist
     * @throws PersistenceException in case of an error, e.g. communicating with the external storage
     */
-   MarshalledEntry<K, V> load(K key);
+   MarshalledEntry<K, V> load(Object key);
 
    /**
     * Returns true if the storage contains an entry associated with the given key.
     *
     * @throws PersistenceException in case of an error, e.g. communicating with the external storage
     */
-   boolean contains(K key);
+   boolean contains(Object key);
 }

--- a/core/src/main/java/org/infinispan/persistence/spi/CacheWriter.java
+++ b/core/src/main/java/org/infinispan/persistence/spi/CacheWriter.java
@@ -27,11 +27,11 @@ public interface CacheWriter<K, V> extends Lifecycle {
     * @throws PersistenceException in case of an error, e.g. communicating with the external storage
     * @see MarshalledEntry
     */
-   void write(MarshalledEntry<K, V> entry);
+   void write(MarshalledEntry<? extends K, ? extends V> entry);
 
    /**
     * @return true if the entry existed in the persistent store and it was deleted.
     * @throws PersistenceException in case of an error, e.g. communicating with the external storage
     */
-   boolean delete(K key);
+   boolean delete(Object key);
 }

--- a/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
+++ b/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
@@ -58,13 +58,14 @@ public final class SecureCacheImpl<K, V> implements SecureCache<K, V> {
    }
 
    @Override
-   public <K, V, C> void addListener(Object listener, KeyValueFilter<K, V> filter, Converter<K, V, C> converter) {
+   public <C> void addListener(Object listener, KeyValueFilter<? super K, ? super V> filter,
+                               Converter<? super K, ? super V, C> converter) {
       authzManager.checkPermission(AuthorizationPermission.LISTEN);
       delegate.addListener(listener, filter, converter);
    }
 
    @Override
-   public void addListener(Object listener, KeyFilter filter) {
+   public void addListener(Object listener, KeyFilter<? super K> filter) {
       authzManager.checkPermission(AuthorizationPermission.LISTEN);
       delegate.addListener(listener, filter);
    }

--- a/core/src/main/java/org/infinispan/statetransfer/OutboundTransferTask.java
+++ b/core/src/main/java/org/infinispan/statetransfer/OutboundTransferTask.java
@@ -54,7 +54,7 @@ public class OutboundTransferTask implements Runnable {
 
    private final ConsistentHash readCh;
 
-   private final DataContainer dataContainer;
+   private final DataContainer<Object, Object> dataContainer;
 
    private final PersistenceManager persistenceManager;
 

--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -78,7 +78,7 @@ public class StateConsumerImpl implements StateConsumer {
    private TransactionManager transactionManager;   // optional
    private CommandsFactory commandsFactory;
    private TransactionTable transactionTable;       // optional
-   private DataContainer dataContainer;
+   private DataContainer<Object, Object> dataContainer;
    private PersistenceManager persistenceManager;
    private InterceptorChain interceptorChain;
    private InvocationContextFactory icf;

--- a/core/src/main/java/org/infinispan/util/CoreImmutables.java
+++ b/core/src/main/java/org/infinispan/util/CoreImmutables.java
@@ -24,34 +24,34 @@ public class CoreImmutables extends Immutables {
     * @param entry the internal cache entry to wrap.
     * @return an immutable {@link InternalCacheEntry}} wrapper that delegates to the original entry.
     */
-   public static InternalCacheEntry immutableInternalCacheEntry(InternalCacheEntry entry) {
-      return new ImmutableInternalCacheEntry(entry);
+   public static <K, V> InternalCacheEntry<K, V> immutableInternalCacheEntry(InternalCacheEntry<K, V> entry) {
+      return new ImmutableInternalCacheEntry<K, V>(entry);
    }
 
    /**
     * Immutable version of InternalCacheEntry for traversing data containers.
     */
-   private static class ImmutableInternalCacheEntry implements InternalCacheEntry, Immutable {
-      private final InternalCacheEntry entry;
+   private static class ImmutableInternalCacheEntry<K, V> implements InternalCacheEntry<K, V>, Immutable {
+      private final InternalCacheEntry<K, V> entry;
       private final int hash;
 
-      ImmutableInternalCacheEntry(InternalCacheEntry entry) {
+      ImmutableInternalCacheEntry(InternalCacheEntry<K, V> entry) {
          this.entry = entry;
          this.hash = entry.hashCode();
       }
 
       @Override
-      public Object getKey() {
+      public K getKey() {
          return entry.getKey();
       }
 
       @Override
-      public Object getValue() {
+      public V getValue() {
          return entry.getValue();
       }
 
       @Override
-      public Object setValue(Object value) {
+      public V setValue(V value) {
          throw new UnsupportedOperationException();
       }
 
@@ -111,7 +111,7 @@ public class CoreImmutables extends Immutables {
       }
 
       @Override
-      public InternalCacheValue toInternalCacheValue() {
+      public InternalCacheValue<V> toInternalCacheValue() {
          return new CoreImmutables.ImmutableInternalCacheValue(this);
       }
 
@@ -246,10 +246,10 @@ public class CoreImmutables extends Immutables {
       }
    }
 
-   private static class ImmutableInternalCacheValue implements InternalCacheValue, Immutable {
-      private final ImmutableInternalCacheEntry entry;
+   private static class ImmutableInternalCacheValue<V> implements InternalCacheValue<V>, Immutable {
+      private final ImmutableInternalCacheEntry<?, V> entry;
 
-      ImmutableInternalCacheValue(ImmutableInternalCacheEntry entry) {
+      ImmutableInternalCacheValue(ImmutableInternalCacheEntry<?, V> entry) {
          this.entry = entry;
       }
 
@@ -279,7 +279,7 @@ public class CoreImmutables extends Immutables {
       }
 
       @Override
-      public Object getValue() {
+      public V getValue() {
          return entry.getValue();
       }
 
@@ -294,8 +294,8 @@ public class CoreImmutables extends Immutables {
       }
 
       @Override
-      public InternalCacheEntry toInternalCacheEntry(Object key) {
-         return entry;
+      public <K> InternalCacheEntry<K, V> toInternalCacheEntry(K key) {
+         return (InternalCacheEntry<K, V>)entry;
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/util/concurrent/BoundedConcurrentHashMap.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/BoundedConcurrentHashMap.java
@@ -175,9 +175,9 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
    transient Set<Map.Entry<K,V>> entrySet;
    transient Collection<V> values;
 
-   private transient final Equivalence<K> keyEquivalence;
-   private transient final Equivalence<V> valueEquivalence;
-   private transient final EvictionListener<K, V> evictionListener;
+   private transient final Equivalence<? super K> keyEquivalence;
+   private transient final Equivalence<? super V> valueEquivalence;
+   private transient final EvictionListener<? super K, ? super V> evictionListener;
    private final int evictCap;
    
    private final ExecutorService executor;
@@ -1710,8 +1710,8 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
     *             nonpositive.
     */
    public BoundedConcurrentHashMap(int capacity, int concurrencyLevel,
-         Eviction evictionStrategy, EvictionListener<K, V> evictionListener,
-         Equivalence<K> keyEquivalence, Equivalence<V> valueEquivalence) {
+         Eviction evictionStrategy, EvictionListener<? super K, ? super V> evictionListener,
+         Equivalence<? super K> keyEquivalence, Equivalence<? super V> valueEquivalence) {
       this.keyEquivalence = keyEquivalence;
       this.valueEquivalence = valueEquivalence;
 
@@ -1782,7 +1782,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
     *             nonpositive.
     */
    public BoundedConcurrentHashMap(int capacity, int concurrencyLevel,
-         Equivalence<K> keyEquivalence, Equivalence<V> valueEquivalence) {
+         Equivalence<? super K> keyEquivalence, Equivalence<? super V> valueEquivalence) {
       this(capacity, concurrencyLevel, Eviction.LRU, keyEquivalence, valueEquivalence);
    }
 
@@ -1805,7 +1805,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
     *             nonpositive.
     */
    public BoundedConcurrentHashMap(int capacity, int concurrencyLevel,
-         Eviction evictionStrategy, Equivalence<K> keyEquivalence, Equivalence<V> valueEquivalence) {
+         Eviction evictionStrategy, Equivalence<? super K> keyEquivalence, Equivalence<? super V> valueEquivalence) {
       this(capacity, concurrencyLevel, evictionStrategy, new NullEvictionListener<K, V>(), keyEquivalence, valueEquivalence);
    }
 
@@ -1822,14 +1822,14 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
     *
     * @since 1.6
     */
-   public BoundedConcurrentHashMap(int capacity, Equivalence<K> keyEquivalence, Equivalence<V> valueEquivalence) {
+   public BoundedConcurrentHashMap(int capacity, Equivalence<? super K> keyEquivalence, Equivalence<? super V> valueEquivalence) {
       this(capacity, DEFAULT_CONCURRENCY_LEVEL, keyEquivalence, valueEquivalence);
    }
 
    /**
     * Creates a new, empty map with the default maximum capacity
     */
-   public BoundedConcurrentHashMap(Equivalence<K> keyEquivalence, Equivalence<V> valueEquivalence) {
+   public BoundedConcurrentHashMap(Equivalence<? super K> keyEquivalence, Equivalence<? super V> valueEquivalence) {
       this(DEFAULT_MAXIMUM_CAPACITY, DEFAULT_CONCURRENCY_LEVEL, keyEquivalence, valueEquivalence);
    }
 

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/containers/AbstractPerEntryLockContainer.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/containers/AbstractPerEntryLockContainer.java
@@ -24,7 +24,7 @@ public abstract class AbstractPerEntryLockContainer<L extends RefCountingLock> e
 
    protected AbstractPerEntryLockContainer(int concurrencyLevel) {
       locks = new EquivalentConcurrentHashMapV8<Object, L>(
-            16, concurrencyLevel, AnyEquivalence.getInstance(), AnyEquivalence.<L>getInstance());
+            16, concurrencyLevel, AnyEquivalence.getInstance(), AnyEquivalence.getInstance());
    }
 
    protected abstract L newLock();

--- a/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateProviderImpl.java
+++ b/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateProviderImpl.java
@@ -57,7 +57,7 @@ public class XSiteStateProviderImpl implements XSiteStateProvider {
 
    private final ConcurrentMap<String, StateProviderRunnable> runningStateTransfer;
 
-   private DataContainer dataContainer;
+   private DataContainer<Object, Object> dataContainer;
    private PersistenceManager persistenceManager;
    private ClusteringDependentLogic clusteringDependentLogic;
    private CommandsFactory commandsFactory;

--- a/core/src/test/java/org/infinispan/commons/EquivalentLinkedHashMapTest.java
+++ b/core/src/test/java/org/infinispan/commons/EquivalentLinkedHashMapTest.java
@@ -22,7 +22,7 @@ import static org.testng.AssertJUnit.assertEquals;
 public class EquivalentLinkedHashMapTest {
 
    public void testIterationAndSize() {
-      EquivalentLinkedHashMap map = new EquivalentLinkedHashMap(16, 0.75f,
+      EquivalentLinkedHashMap<String, String> map = new EquivalentLinkedHashMap<String, String>(16, 0.75f,
                                                                 EquivalentLinkedHashMap.IterationOrder.ACCESS_ORDER,
                                                                 AnyEquivalence.getInstance(), AnyEquivalence.getInstance());
 

--- a/core/src/test/java/org/infinispan/configuration/QueryableDataContainer.java
+++ b/core/src/test/java/org/infinispan/configuration/QueryableDataContainer.java
@@ -14,11 +14,12 @@ import java.util.Set;
 
 import static java.util.Collections.synchronizedCollection;
 
-public class QueryableDataContainer implements DataContainer {
+public class QueryableDataContainer implements DataContainer<Object, Object> {
 
-   private static DataContainer delegate;
+   // Since this static field is here, we can't use generic types properly
+   private static DataContainer<Object, Object> delegate;
 
-   public static void setDelegate(DataContainer delegate) {
+   public static void setDelegate(DataContainer<Object, Object> delegate) {
       QueryableDataContainer.delegate = delegate;
    }
 
@@ -33,19 +34,19 @@ public class QueryableDataContainer implements DataContainer {
    }
 
    @Override
-   public Iterator<InternalCacheEntry> iterator() {
+   public Iterator<InternalCacheEntry<Object, Object>> iterator() {
       loggedOperations.add("iterator()");
       return delegate.iterator();
    }
 
    @Override
-   public InternalCacheEntry get(Object k) {
+   public InternalCacheEntry<Object, Object> get(Object k) {
       loggedOperations.add("get(" + k + ")" );
       return delegate.get(k);
    }
 
    @Override
-   public InternalCacheEntry peek(Object k) {
+   public InternalCacheEntry<Object, Object> peek(Object k) {
       loggedOperations.add("peek(" + k + ")" );
       return delegate.peek(k);
    }
@@ -63,7 +64,7 @@ public class QueryableDataContainer implements DataContainer {
    }
 
    @Override
-   public InternalCacheEntry remove(Object k) {
+   public InternalCacheEntry<Object, Object> remove(Object k) {
       loggedOperations.add("remove(" + k + ")" );
       return delegate.remove(k);
    }
@@ -93,7 +94,7 @@ public class QueryableDataContainer implements DataContainer {
    }
 
    @Override
-   public Set<InternalCacheEntry> entrySet() {
+   public Set<InternalCacheEntry<Object, Object>> entrySet() {
       loggedOperations.add("entrySet()" );
       return delegate.entrySet();
    }
@@ -121,7 +122,7 @@ public class QueryableDataContainer implements DataContainer {
    }
 
    @Override
-   public <K> void executeTask(KeyFilter<K> filter, ParallelIterableMap.KeyValueAction <Object, InternalCacheEntry> action)
+   public void executeTask(KeyFilter<? super Object> filter, ParallelIterableMap.KeyValueAction <? super Object, InternalCacheEntry<? super Object, ? super Object>> action)
          throws InterruptedException {
       throw new NotImplementedException();
    }

--- a/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
+++ b/core/src/test/java/org/infinispan/container/SimpleDataContainerTest.java
@@ -26,7 +26,7 @@ import static org.testng.AssertJUnit.assertEquals;
 
 @Test(groups = "unit", testName = "container.SimpleDataContainerTest")
 public class SimpleDataContainerTest extends AbstractInfinispanTest {
-   DataContainer dc;
+   DataContainer<Object, String> dc;
 
    @BeforeMethod
    public void setUp() {
@@ -39,7 +39,7 @@ public class SimpleDataContainerTest extends AbstractInfinispanTest {
    }
 
    protected DataContainer createContainer() {
-      DefaultDataContainer dc = new DefaultDataContainer(16, AnyEquivalence.getInstance(), AnyEquivalence.<InternalCacheEntry>getInstance());
+      DefaultDataContainer dc = new DefaultDataContainer<Object, String>(16, AnyEquivalence.getInstance());
       InternalEntryFactoryImpl internalEntryFactory = new InternalEntryFactoryImpl();
       internalEntryFactory.injectTimeService(TIME_SERVICE);
       ActivationManager activationManager = mock(ActivationManager.class);

--- a/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
@@ -80,7 +80,7 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
 
    protected abstract Class<? extends CommandInterceptor> getL1InterceptorClass();
 
-   protected void assertL1StateOnLocalWrite(Cache<?,?> cache, Cache<?, ?> updatingCache, Object key, Object valueWrite) {
+   protected <K> void assertL1StateOnLocalWrite(Cache<? super K,?> cache, Cache<?, ?> updatingCache, K key, Object valueWrite) {
       // Default just assumes it invalidated the cache
       assertIsNotInL1(cache, key);
    }

--- a/core/src/test/java/org/infinispan/distribution/DistSyncTxL1FuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncTxL1FuncTest.java
@@ -66,7 +66,7 @@ public class DistSyncTxL1FuncTest extends BaseDistSyncL1Test {
    }
 
    @Override
-   protected void assertL1StateOnLocalWrite(Cache<?, ?> cache, Cache<?, ?> updatingCache, Object key, Object valueWrite) {
+   protected <K> void assertL1StateOnLocalWrite(Cache<? super K, ?> cache, Cache<?, ?> updatingCache, K key, Object valueWrite) {
       if (cache != updatingCache) {
          super.assertL1StateOnLocalWrite(cache, updatingCache, key, valueWrite);
       }

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareStateTransferTest.java
@@ -135,13 +135,13 @@ public class TopologyAwareStateTransferTest extends MultipleCacheManagersTest {
    }
 
 
-   private void assertExistence(final Object key) {
+   private <K> void assertExistence(final K key) {
       org.infinispan.distribution.ch.ConsistentHash hash = cache(addresses[0]).getAdvancedCache().getDistributionManager().getConsistentHash();
       final List<Address> addresses = hash.locateOwners(key);
       log.debug(key + " should be present on = " + addresses);
 
       int count = 0;
-      for (Cache<?, ?> c : caches()) {
+      for (Cache<? super K, ?> c : caches()) {
          if (c.getAdvancedCache().getDataContainer().containsKey(key)) {
             log.debug("It is here = " + address(c));
             count++;
@@ -150,7 +150,7 @@ public class TopologyAwareStateTransferTest extends MultipleCacheManagersTest {
       log.debug("count = " + count);
       assert count == 2;
 
-      for (Cache<?, ?> c : caches()) {
+      for (Cache<? super K, ?> c : caches()) {
          if (addresses.contains(address(c))) {
             assert c.getAdvancedCache().getDataContainer().containsKey(key);
          } else {

--- a/core/src/test/java/org/infinispan/eviction/ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/eviction/ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTest.java
@@ -12,6 +12,7 @@ import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.interceptors.CacheLoaderInterceptor;
 import org.infinispan.interceptors.CacheWriterInterceptor;
+import org.infinispan.interceptors.DistCacheWriterInterceptor;
 import org.infinispan.interceptors.InterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -415,7 +416,7 @@ public class ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTes
       }
    }
 
-   private class ControlledDataContainer implements DataContainer {
+   private class ControlledDataContainer<K, V> implements DataContainer<K, V> {
 
       private final DataContainer delegate;
       private volatile Runnable beforeEvict;
@@ -425,17 +426,17 @@ public class ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTes
       }
 
       @Override
-      public InternalCacheEntry get(Object k) {
+      public InternalCacheEntry<K, V> get(Object k) {
          return delegate.get(k);
       }
 
       @Override
-      public InternalCacheEntry peek(Object k) {
+      public InternalCacheEntry<K, V> peek(Object k) {
          return delegate.peek(k);
       }
 
       @Override
-      public void put(Object k, Object v, Metadata metadata) {
+      public void put(K k, V v, Metadata metadata) {
          delegate.put(k, v, metadata);
       }
 
@@ -445,7 +446,7 @@ public class ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTes
       }
 
       @Override
-      public InternalCacheEntry remove(Object k) {
+      public InternalCacheEntry<K, V> remove(Object k) {
          return delegate.remove(k);
       }
 
@@ -461,17 +462,17 @@ public class ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTes
       }
 
       @Override
-      public Set<Object> keySet() {
+      public Set<K> keySet() {
          return delegate.keySet();
       }
 
       @Override
-      public Collection<Object> values() {
+      public Collection<V> values() {
          return delegate.values();
       }
 
       @Override
-      public Set<InternalCacheEntry> entrySet() {
+      public Set<InternalCacheEntry<K, V>> entrySet() {
          return delegate.entrySet();
       }
 
@@ -492,7 +493,7 @@ public class ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTes
       }
 
       @Override
-      public Iterator<InternalCacheEntry> iterator() {
+      public Iterator<InternalCacheEntry<K, V>> iterator() {
          return delegate.iterator();
       }
 
@@ -504,7 +505,7 @@ public class ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTes
       }
 
       @Override
-      public <K> void executeTask(KeyFilter<K> filter, KeyValueAction<Object, InternalCacheEntry> action)
+      public void executeTask(KeyFilter<? super K> filter, KeyValueAction<? super K, InternalCacheEntry<? super K, ? super V>> action)
             throws InterruptedException {
          throw new NotImplementedException();
       }

--- a/core/src/test/java/org/infinispan/marshall/MarshalledValuesFineGrainedTest.java
+++ b/core/src/test/java/org/infinispan/marshall/MarshalledValuesFineGrainedTest.java
@@ -36,7 +36,7 @@ public class MarshalledValuesFineGrainedTest extends AbstractInfinispanTest {
       ecm = TestCacheManagerFactory.createCacheManager(c);
       ecm.getCache().put(key, value);
 
-      DataContainer dc = ecm.getCache().getAdvancedCache().getDataContainer();
+      DataContainer<?, ?> dc = ecm.getCache().getAdvancedCache().getDataContainer();
 
       InternalCacheEntry entry = dc.iterator().next();
       Object key = entry.getKey();
@@ -55,7 +55,7 @@ public class MarshalledValuesFineGrainedTest extends AbstractInfinispanTest {
       ecm = TestCacheManagerFactory.createCacheManager(c);
       ecm.getCache().put(key, value);
 
-      DataContainer dc = ecm.getCache().getAdvancedCache().getDataContainer();
+      DataContainer<?, ?> dc = ecm.getCache().getAdvancedCache().getDataContainer();
 
       InternalCacheEntry entry = dc.iterator().next();
       Object key = entry.getKey();
@@ -73,7 +73,7 @@ public class MarshalledValuesFineGrainedTest extends AbstractInfinispanTest {
       ecm = TestCacheManagerFactory.createCacheManager(c);
       ecm.getCache().put(key, value);
 
-      DataContainer dc = ecm.getCache().getAdvancedCache().getDataContainer();
+      DataContainer<?, ?> dc = ecm.getCache().getAdvancedCache().getDataContainer();
 
       InternalCacheEntry entry = dc.iterator().next();
       Object key = entry.getKey();

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerTest.java
@@ -314,7 +314,8 @@ public abstract class AbstractClusterListenerTest extends MultipleCacheManagersT
       verifySimpleInsertion(cache0, key, FIRST_VALUE, null, clusterListener, FIRST_VALUE.substring(0, 2));
    }
 
-   protected void testConverter(Object key, String value, Object resultingValue, Long lifespan, Converter<?, ? super String, ?> converter) {
+   protected <C> void testConverter(Object key, String value, Object resultingValue, Long lifespan,
+                                    Converter<Object, ? super String, C> converter) {
       Cache<Object, String> cache0 = cache(0, CACHE_NAME);
 
       ClusterListener clusterListener = new ClusterListener();

--- a/core/src/test/java/org/infinispan/persistence/CacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/CacheLoaderFunctionalTest.java
@@ -58,8 +58,8 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
    private static final Log log = LogFactory.getLog(CacheLoaderFunctionalTest.class);
 
    Cache<String, String> cache;
-   AdvancedLoadWriteStore store;
-   AdvancedCacheWriter writer;
+   AdvancedLoadWriteStore<String, String> store;
+   AdvancedCacheWriter<String, String> writer;
    TransactionManager tm;
    ConfigurationBuilder cfg;
    EmbeddedCacheManager cm;
@@ -77,8 +77,8 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
       configure(cfg);
       cm = TestCacheManagerFactory.createCacheManager(cfg);
       cache = cm.getCache();
-      store = (AdvancedLoadWriteStore) TestingUtil.getFirstLoader(cache);
-      writer = (AdvancedCacheWriter) TestingUtil.getFirstLoader(cache);
+      store = (AdvancedLoadWriteStore<String, String>) TestingUtil.getFirstLoader(cache);
+      writer = (AdvancedCacheWriter<String, String>) TestingUtil.getFirstLoader(cache);
       tm = TestingUtil.getTransactionManager(cache);
       sm = cache.getAdvancedCache().getComponentRegistry().getCacheMarshaller();
    }
@@ -96,20 +96,20 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
       store = null;
    }
 
-   private void assertInCacheAndStore(Object key, Object value) throws PersistenceException {
+   private void assertInCacheAndStore(String key, Object value) throws PersistenceException {
       assertInCacheAndStore(key, value, -1);
    }
 
-   private void assertInCacheAndStore(Object key, Object value, long lifespanMillis) throws PersistenceException {
+   private void assertInCacheAndStore(String key, Object value, long lifespanMillis) throws PersistenceException {
       assertInCacheAndStore(cache, store, key, value, lifespanMillis);
    }
 
 
-   private void assertInCacheAndStore(Cache<?, ?> cache, CacheLoader store, Object key, Object value) throws PersistenceException {
+   private <K> void assertInCacheAndStore(Cache<? super K, ?> cache, CacheLoader store, K key, Object value) throws PersistenceException {
       assertInCacheAndStore(cache, store, key, value, -1);
    }
 
-   private void assertInCacheAndStore(Cache<?, ?> cache, CacheLoader loader, Object key, Object value, long lifespanMillis) throws PersistenceException {
+   private <K> void assertInCacheAndStore(Cache<? super K, ?> cache, CacheLoader loader, K key, Object value, long lifespanMillis) throws PersistenceException {
       InternalCacheEntry se = cache.getAdvancedCache().getDataContainer().get(key);
       testStoredEntry(se.getValue(), value, se.getLifespan(), lifespanMillis, "Cache", key);
       MarshalledEntry load = loader.load(key);
@@ -122,34 +122,34 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
       assert lifespan == expectedLifespan : src + " expected lifespan for key " + key + " to be " + expectedLifespan + " but was " + value;
    }
 
-   private void assertNotInCacheAndStore(Cache<?, ?> cache, CacheLoader store, Object... keys) throws PersistenceException {
-      for (Object key : keys) {
+   private static <K> void assertNotInCacheAndStore(Cache<? super K, ?> cache, CacheLoader<? super K, ?> store, K... keys) throws PersistenceException {
+      for (K key : keys) {
          assert !cache.getAdvancedCache().getDataContainer().containsKey(key) : "Cache should not contain key " + key;
          assert !store.contains(key) : "Store should not contain key " + key;
       }
    }
 
-   private void assertNotInCacheAndStore(Object... keys) throws PersistenceException {
+   private void assertNotInCacheAndStore(String... keys) throws PersistenceException {
       assertNotInCacheAndStore(cache, store, keys);
    }
 
-   private void assertInStoreNotInCache(Object... keys) throws PersistenceException {
+   private void assertInStoreNotInCache(String... keys) throws PersistenceException {
       assertInStoreNotInCache(cache, store, keys);
    }
 
-   private void assertInStoreNotInCache(Cache<?, ?> cache, CacheLoader store, Object... keys) throws PersistenceException {
-      for (Object key : keys) {
+   private static <K> void assertInStoreNotInCache(Cache<? super K, ?> cache, CacheLoader<? super K, ?> store, K... keys) throws PersistenceException {
+      for (K key : keys) {
          assert !cache.getAdvancedCache().getDataContainer().containsKey(key) : "Cache should not contain key " + key;
          assert store.contains(key) : "Store should contain key " + key;
       }
    }
 
-   private void assertInCacheAndNotInStore(Object... keys) throws PersistenceException {
+   private void assertInCacheAndNotInStore(String... keys) throws PersistenceException {
       assertInCacheAndNotInStore(cache, store, keys);
    }
 
-   private void assertInCacheAndNotInStore(Cache<?, ?> cache, CacheLoader store, Object... keys) throws PersistenceException {
-      for (Object key : keys) {
+   private static <K> void assertInCacheAndNotInStore(Cache<? super K, ?> cache, CacheLoader<? super K, ?> store, K... keys) throws PersistenceException {
+      for (K key : keys) {
          assert cache.getAdvancedCache().getDataContainer().containsKey(key) : "Cache should not contain key " + key;
          assert !store.contains(key) : "Store should contain key " + key;
       }
@@ -584,7 +584,7 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
       assertEquals("Wrong number of entries in data container", expectedEntriesInContainer, c.size());
 
       for (int i = 1; i < 5; i++) {
-         final Object key = "k" + i;
+         final String key = "k" + i;
          final Object value = "v" + i;
          final long lifespan = i % 2 == 1 ? -1 : this.lifespan;
          boolean found = false;
@@ -615,7 +615,7 @@ public class CacheLoaderFunctionalTest extends AbstractInfinispanTest {
       assertEquals("Wrong number of entries in data container", expectedEntriesInContainer, c.size());
 
       for (int i = 1; i < 5; i++) {
-         final Object key = "k" + i;
+         final String key = "k" + i;
          final Object value = "v" + i;
          final long lifespan = i % 2 == 1 ? -1 : this.lifespan;
          boolean found = false;

--- a/core/src/test/java/org/infinispan/persistence/SharedStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/SharedStoreTest.java
@@ -43,7 +43,7 @@ public class SharedStoreTest extends MultipleCacheManagersTest {
       for (Cache<Object, Object> c: caches())
          assert "value".equals(c.get("key"));
 
-      List<CacheLoader> cacheStores = TestingUtil.cachestores(caches());
+      List<CacheLoader<Object, Object>> cacheStores = TestingUtil.cachestores(caches());
       for (CacheLoader cs: cacheStores) {
          assert cs.contains("key");
          DummyInMemoryStore dimcs = (DummyInMemoryStore) cs;
@@ -67,7 +67,7 @@ public class SharedStoreTest extends MultipleCacheManagersTest {
       cache(0).getAdvancedCache().withFlags(Flag.SKIP_SHARED_CACHE_STORE).put("key", "value");
       assert cache(0).get("key").equals("value");
 
-      List<CacheLoader> cachestores = TestingUtil.cachestores(caches());
+      List<CacheLoader<Object, Object>> cachestores = TestingUtil.cachestores(caches());
       for (CacheLoader cs : cachestores) {
          assert !cs.contains("key");
          DummyInMemoryStore dimcs = (DummyInMemoryStore) cs;

--- a/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStore.java
+++ b/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStore.java
@@ -3,6 +3,7 @@ package org.infinispan.persistence.dummy;
 import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.configuration.ConfiguredBy;
+import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.commons.util.InfinispanCollections;
@@ -174,7 +175,7 @@ public class DummyInMemoryStore implements AdvancedLoadWriteStore {
          return;
 
       Equivalence<Object> keyEq = cache.getCacheConfiguration().dataContainer().keyEquivalence();
-      Equivalence<byte[]> valueEq = cache.getCacheConfiguration().dataContainer().valueEquivalence();
+      Equivalence<byte[]> valueEq = ByteArrayEquivalence.INSTANCE;
       store = new EquivalentConcurrentHashMapV8<Object, byte[]>(keyEq, valueEq);
       stats = newStatsMap();
 

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -683,9 +683,9 @@ public class TestingUtil {
       persistenceManager.clearAllStores(false);
    }
 
-   public static <K, V> List<CacheLoader> cachestores(List<Cache<K, V>> caches) {
-      List<CacheLoader> l = new LinkedList<CacheLoader>();
-      for (Cache<?, ?> c: caches)
+   public static <K, V> List<CacheLoader<K, V>> cachestores(List<Cache<K, V>> caches) {
+      List<CacheLoader<K, V>> l = new LinkedList<CacheLoader<K, V>>();
+      for (Cache<K, V> c: caches)
          l.add(TestingUtil.getFirstLoader(c));
       return l;
    }
@@ -1027,19 +1027,19 @@ public class TestingUtil {
       return builder.toString();
    }
 
-   public static Set getInternalKeys(Cache cache) {
-      DataContainer dataContainer = TestingUtil.extractComponent(cache, DataContainer.class);
-      Set keys = new HashSet();
-      for (CacheEntry entry : dataContainer) {
+   public static <K> Set<K> getInternalKeys(Cache<K, ?> cache) {
+      DataContainer<K, ?> dataContainer = TestingUtil.extractComponent(cache, DataContainer.class);
+      Set<K> keys = new HashSet<K>();
+      for (CacheEntry<K, ?> entry : dataContainer) {
          keys.add(entry.getKey());
       }
       return keys;
    }
 
-   public static Collection getInternalValues(Cache cache) {
-      DataContainer dataContainer = TestingUtil.extractComponent(cache, DataContainer.class);
-      Collection values = new ArrayList();
-      for (CacheEntry entry : dataContainer) {
+   public static <V> Collection<V> getInternalValues(Cache<?, V> cache) {
+      DataContainer<?, V> dataContainer = TestingUtil.extractComponent(cache, DataContainer.class);
+      Collection<V> values = new ArrayList<V>();
+      for (CacheEntry<?, V> entry : dataContainer) {
          values.add(entry.getValue());
       }
       return values;
@@ -1297,13 +1297,13 @@ public class TestingUtil {
    }
 
 
-   public static CacheLoader getFirstLoader(Cache cache) {
+   public static <K, V> CacheLoader<K, V> getFirstLoader(Cache<K, V> cache) {
       PersistenceManagerImpl persistenceManager = (PersistenceManagerImpl) extractComponent(cache, PersistenceManager.class);
       return persistenceManager.getAllLoaders().get(0);
    }
 
    @SuppressWarnings("unchecked")
-   public static <T extends CacheWriter> T getFirstWriter(Cache cache) {
+   public static <T extends CacheWriter<K, V>, K, V> T getFirstWriter(Cache<K, V> cache) {
       PersistenceManagerImpl persistenceManager = (PersistenceManagerImpl) extractComponent(cache, PersistenceManager.class);
       return (T) persistenceManager.getAllWriters().get(0);
    }

--- a/persistence/cli/src/main/java/org/infinispan/persistence/cli/CLInterfaceLoader.java
+++ b/persistence/cli/src/main/java/org/infinispan/persistence/cli/CLInterfaceLoader.java
@@ -49,7 +49,7 @@ public class CLInterfaceLoader<K, V> implements CacheLoader<K, V> {
    }
 
    @Override
-   public MarshalledEntry<K, V> load(K key) {
+   public MarshalledEntry<K, V> load(Object key) {
       // TODO: a CLI command to retrieve value + metadata is needed
       ProcessedCommand parsed = new ProcessedCommand("get " + key.toString() + ";");
 
@@ -91,7 +91,7 @@ public class CLInterfaceLoader<K, V> implements CacheLoader<K, V> {
    }
 
    @Override
-   public boolean contains(K key) {
+   public boolean contains(Object key) {
       return load(key) != null;
    }
 

--- a/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolDecoder.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/AbstractProtocolDecoder.scala
@@ -315,9 +315,9 @@ abstract class AbstractProtocolDecoder[K, V](transport: NettyTransport)
 
    protected def createNotExistResponse: AnyRef
 
-   protected def createGetResponse(k: K, entry: CacheEntry): AnyRef
+   protected def createGetResponse(k: K, entry: CacheEntry[K, V]): AnyRef
 
-   protected def createMultiGetResponse(pairs: Map[K, CacheEntry]): AnyRef
+   protected def createMultiGetResponse(pairs: Map[K, CacheEntry[K, V]]): AnyRef
 
    protected def createErrorResponse(t: Throwable): AnyRef
 

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/AbstractVersionedDecoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/AbstractVersionedDecoder.scala
@@ -47,7 +47,7 @@ abstract class AbstractVersionedDecoder {
    /**
     * Create a response for get a request.
     */
-   def createGetResponse(header: HotRodHeader, entry: CacheEntry): AnyRef
+   def createGetResponse(header: HotRodHeader, entry: CacheEntry[Array[Byte], Array[Byte]]): AnyRef
 
    /**
     * Handle a protocol specific header reading.

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder10.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder10.scala
@@ -134,7 +134,7 @@ object Decoder10 extends AbstractVersionedDecoder with ServerConstants with Log 
          new Response(h.version, h.messageId, h.cacheName, h.clientIntel, op, st, h.topologyId)
    }
 
-   override def createGetResponse(h: HotRodHeader, entry: CacheEntry): AnyRef = {
+   override def createGetResponse(h: HotRodHeader, entry: CacheEntry[Array[Byte], Array[Byte]]): AnyRef = {
       val op = h.op
       if (entry != null && op == GetRequest)
          new GetResponse(h.version, h.messageId, h.cacheName, h.clientIntel,
@@ -227,7 +227,7 @@ object Decoder10 extends AbstractVersionedDecoder with ServerConstants with Log 
    def getKeyMetadata(h: HotRodHeader, k: Array[Byte], cache: Cache): GetWithMetadataResponse = {
       val ce = cache.getAdvancedCache.getCacheEntry(k)
       if (ce != null) {
-         val ice = ce.asInstanceOf[InternalCacheEntry]
+         val ice = ce.asInstanceOf[InternalCacheEntry[Array[Byte], Array[Byte]]]
          val entryVersion = ice.getMetadata.version().asInstanceOf[NumericVersion]
          val v = ce.getValue.asInstanceOf[Array[Byte]]
          val lifespan = if (ice.getLifespan < 0) -1 else (ice.getLifespan / 1000).toInt

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
@@ -132,7 +132,7 @@ object Decoder2x extends AbstractVersionedDecoder with ServerConstants with Log 
          new Response(h.version, h.messageId, h.cacheName, h.clientIntel, op, st, h.topologyId)
    }
 
-   override def createGetResponse(h: HotRodHeader, entry: CacheEntry): AnyRef = {
+   override def createGetResponse(h: HotRodHeader, entry: CacheEntry[Array[Byte], Array[Byte]]): AnyRef = {
       val op = h.op
       if (entry != null && op == GetRequest)
          new GetResponse(h.version, h.messageId, h.cacheName, h.clientIntel,
@@ -225,7 +225,7 @@ object Decoder2x extends AbstractVersionedDecoder with ServerConstants with Log 
    def getKeyMetadata(h: HotRodHeader, k: Array[Byte], cache: Cache): GetWithMetadataResponse = {
       val ce = cache.getCacheEntry(k)
       if (ce != null) {
-         val ice = ce.asInstanceOf[InternalCacheEntry]
+         val ice = ce.asInstanceOf[InternalCacheEntry[Array[Byte], Array[Byte]]]
          val entryVersion = ice.getMetadata.version().asInstanceOf[NumericVersion]
          val v = ce.getValue.asInstanceOf[Array[Byte]]
          val lifespan = if (ice.getLifespan < 0) -1 else (ice.getLifespan / 1000).toInt

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
@@ -112,10 +112,10 @@ class HotRodDecoder(cacheManager: EmbeddedCacheManager, transport: NettyTranspor
    override def createNotExistResponse: AnyRef =
       header.decoder.createNotExistResponse(header)
 
-   override def createGetResponse(k: Array[Byte], entry: CacheEntry): AnyRef =
+   override def createGetResponse(k: Array[Byte], entry: CacheEntry[Array[Byte], Array[Byte]]): AnyRef =
       header.decoder.createGetResponse(header, entry)
 
-   override def createMultiGetResponse(pairs: Map[Array[Byte], CacheEntry]): AnyRef =
+   override def createMultiGetResponse(pairs: Map[Array[Byte], CacheEntry[Array[Byte], Array[Byte]]]): AnyRef =
       null // Unsupported
 
    override protected def customDecodeHeader(ch: Channel, buffer: ByteBuf): AnyRef =

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodTestingUtil.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodTestingUtil.scala
@@ -329,26 +329,26 @@ object HotRodTestingUtil extends Log {
    }
 
    def assertHotRodEquals(cm: EmbeddedCacheManager,
-           key: Array[Byte], expectedValue: Array[Byte]): InternalCacheEntry =
+           key: Array[Byte], expectedValue: Array[Byte]): InternalCacheEntry[Array[Byte], Array[Byte]] =
       assertHotRodEquals(cm, cm.getCache[Array[Byte], Array[Byte]](), key, expectedValue)
 
    def assertHotRodEquals(cm: EmbeddedCacheManager, cacheName: String,
-           key: Array[Byte], expectedValue: Array[Byte]): InternalCacheEntry =
+           key: Array[Byte], expectedValue: Array[Byte]): InternalCacheEntry[Array[Byte], Array[Byte]] =
       assertHotRodEquals(cm, cm.getCache[Array[Byte], Array[Byte]](cacheName), key, expectedValue)
 
    def assertHotRodEquals(cm: EmbeddedCacheManager,
-           key: String, expectedValue: String): InternalCacheEntry =
+           key: String, expectedValue: String): InternalCacheEntry[Array[Byte], Array[Byte]] =
       assertHotRodEquals(cm, cm.getCache[Array[Byte], Array[Byte]](),
          marshall(key), marshall(expectedValue))
 
    def assertHotRodEquals(cm: EmbeddedCacheManager,
-           cacheName: String, key: String, expectedValue: String): InternalCacheEntry =
+           cacheName: String, key: String, expectedValue: String): InternalCacheEntry[Array[Byte], Array[Byte]] =
       assertHotRodEquals(cm, cm.getCache[Array[Byte], Array[Byte]](cacheName),
          marshall(key), marshall(expectedValue))
 
    private def assertHotRodEquals(cm: EmbeddedCacheManager,
            cache: Cache[Array[Byte], Array[Byte]],
-           key: Array[Byte], expectedValue: Array[Byte]): InternalCacheEntry = {
+           key: Array[Byte], expectedValue: Array[Byte]): InternalCacheEntry[Array[Byte], Array[Byte]] = {
       val entry = cache.getAdvancedCache.getDataContainer.get(key)
       // Assert based on passed parameters
       if (expectedValue == null) {


### PR DESCRIPTION
converter
- Revamped quite a bit of the typing to have generics
- Removed value equivalence for DataContainer as it wasn't used

https://issues.jboss.org/browse/ISPN-4079

I know this grew in scope quite a bit, but to properly type these a lot of the inner workings needed types without doing casting everywhere.  Overall I think it was beneficial as it helped find that the types we were providing for the DataContainer Value Equivalence weren't even used properly and actually could have cause a ClassCastException (DataContainer is `<K, InternalCacheEntry<V>>` however our Value Equivalence was for V only.  Also I took the moment to make a lot more of our classes more flexible by taking in super types when appropriate.
