### PR TITLE
ISPN-3976 Protobuf marshalling on Indexed server caches interferes with ...

### DIFF
--- a/server/integration/testsuite/build-testsuite.xml
+++ b/server/integration/testsuite/build-testsuite.xml
@@ -136,6 +136,9 @@
         <transform in="clustered.xml" out="testsuite/clustered-with-indexing.xml"
                    modifyInfinispan="${infinispan.parts}/indexing-clustered.xml"
                    filtering="true"/>
+        <transform in="clustered.xml" out="testsuite/distributed-with-indexing.xml"
+                   modifyInfinispan="${infinispan.parts}/indexing-distributed.xml"
+                   filtering="true"/>
         <transform in="standalone.xml" out="testsuite/standalone-leveldb-local.xml"
                    modifyInfinispan="${infinispan.parts}/leveldb-local.xml"
                    filtering="true"/>

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryBaseTest.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryBaseTest.java
@@ -1,0 +1,90 @@
+package org.infinispan.server.test.query;
+
+import org.infinispan.arquillian.core.RemoteInfinispanServer;
+import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
+import org.infinispan.commons.util.Util;
+import org.infinispan.protostream.sampledomain.User;
+import org.infinispan.protostream.sampledomain.marshallers.MarshallerRegistration;
+import org.infinispan.server.test.util.RemoteCacheManagerFactory;
+import org.junit.After;
+import org.junit.Before;
+
+import javax.management.ObjectName;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.infinispan.server.test.util.TestUtil.invokeOperation;
+
+/**
+ * Base class for tests for remote queries over HotRod.
+ *
+ * @author Adrian Nistor
+ * @author Martin Gencur
+ */
+public abstract class RemoteQueryBaseTest {
+
+   protected final String cacheContainerName;
+   protected final String cacheName;
+
+   protected RemoteCacheManager remoteCacheManager;
+   protected RemoteCache<Integer, User> remoteCache;
+   protected MBeanServerConnectionProvider jmxConnectionProvider;
+   protected RemoteCacheManagerFactory rcmFactory;
+
+   protected RemoteQueryBaseTest(String cacheContainerName, String cacheName) {
+      this.cacheContainerName = cacheContainerName;
+      this.cacheName = cacheName;
+   }
+
+   protected abstract RemoteInfinispanServer getServer();
+
+   @Before
+   public void setUp() throws Exception {
+      jmxConnectionProvider = new MBeanServerConnectionProvider(getServer().getHotrodEndpoint().getInetAddress().getHostName(), 9999);
+      rcmFactory = new RemoteCacheManagerFactory();
+      ConfigurationBuilder clientBuilder = new ConfigurationBuilder();
+      clientBuilder.addServer()
+            .host(getServer().getHotrodEndpoint().getInetAddress().getHostName())
+            .port(getServer().getHotrodEndpoint().getPort())
+            .marshaller(new ProtoStreamMarshaller());
+      remoteCacheManager = rcmFactory.createManager(clientBuilder);
+      remoteCache = remoteCacheManager.getCache(cacheName);
+
+      String mbean = "jboss.infinispan:type=RemoteQuery,name="
+            + ObjectName.quote(cacheContainerName)
+            + ",component=ProtobufMetadataManager";
+
+      //initialize server-side serialization context via JMX
+      byte[] descriptor = readClasspathResource("/sample_bank_account/bank.protobin");
+      invokeOperation(jmxConnectionProvider, mbean, "registerProtofile", new Object[]{descriptor}, new String[]{byte[].class.getName()});
+
+      //initialize client-side serialization context
+      MarshallerRegistration.registerMarshallers(ProtoStreamMarshaller.getSerializationContext(remoteCacheManager));
+   }
+
+   @After
+   public void tearDown() {
+      if (remoteCache != null) {
+         remoteCache.clear();
+      }
+      if (rcmFactory != null) {
+         rcmFactory.stopManagers();
+      }
+      rcmFactory = null;
+   }
+
+   private byte[] readClasspathResource(String resourcePath) throws IOException {
+      InputStream is = getClass().getResourceAsStream(resourcePath);
+      try {
+         return Util.readStream(is);
+      } finally {
+         if (is != null) {
+            is.close();
+         }
+      }
+   }
+}

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryIspnDirTest.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryIspnDirTest.java
@@ -6,9 +6,6 @@ import org.infinispan.arquillian.core.WithRunningServer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 /**
  * Tests for remote queries over HotRod on a replicated cache using Infinispan directory.
  *
@@ -18,15 +15,15 @@ import static org.junit.Assert.assertNotNull;
 @WithRunningServer("remote-query-infinispan-dir")
 public class RemoteQueryIspnDirTest extends RemoteQueryTest {
 
-    @InfinispanResource("remote-query-infinispan-dir")
-    private RemoteInfinispanServer server;
+   @InfinispanResource("remote-query-infinispan-dir")
+   protected RemoteInfinispanServer server;
 
-    public RemoteQueryIspnDirTest() {
-       cacheContainerName = "clustered";
-    }
+   public RemoteQueryIspnDirTest() {
+      super("clustered", "testcache");
+   }
 
-    @Override
-    protected RemoteInfinispanServer getServer() {
-        return server;
-    }
+   @Override
+   protected RemoteInfinispanServer getServer() {
+      return server;
+   }
 }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryKeySetTest.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryKeySetTest.java
@@ -1,0 +1,56 @@
+package org.infinispan.server.test.query;
+
+import org.infinispan.arquillian.core.InfinispanResource;
+import org.infinispan.arquillian.core.RemoteInfinispanServer;
+import org.infinispan.arquillian.core.WithRunningServer;
+import org.infinispan.protostream.sampledomain.User;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for keySet() method on a distributed remote cache that uses protobuf marshalling.
+ *
+ * @author anistor@redhat.com
+ */
+@RunWith(Arquillian.class)
+@WithRunningServer("remote-query-keySet")
+public class RemoteQueryKeySetTest extends RemoteQueryBaseTest {
+
+   @InfinispanResource("remote-query-keySet")
+   protected RemoteInfinispanServer server;
+
+   public RemoteQueryKeySetTest() {
+      super("clustered", "testcache");
+   }
+
+   @Override
+   protected RemoteInfinispanServer getServer() {
+      return server;
+   }
+
+   @Test
+   public void testDistributedKeySet() throws Exception {
+      remoteCache.put(1, createUser(1));
+      remoteCache.put(2, createUser(2));
+
+      Set<Integer> keys = remoteCache.keySet();
+      assertNotNull(keys);
+      assertEquals(2, keys.size());
+      assertTrue(keys.contains(1));
+      assertTrue(keys.contains(2));
+   }
+
+   private User createUser(int id) {
+      User user = new User();
+      user.setId(id);
+      user.setName("John " + id);
+      user.setSurname("Doe");
+      user.setGender(User.Gender.MALE);
+      return user;
+   }
+}

--- a/server/integration/testsuite/src/test/resources/arquillian.xml
+++ b/server/integration/testsuite/src/test/resources/arquillian.xml
@@ -313,6 +313,16 @@
                 <property name="waitForPorts">11222 8080</property>
             </configuration>
         </container>
+        <container qualifier="remote-query-keySet" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="serverConfig">testsuite/distributed-with-indexing.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0</property>
+                <property name="managementPort">9999</property>
+                <property name="waitForPorts">11222 8080</property>
+            </configuration>
+        </container>
         <container qualifier="leveldb" mode="manual">
             <configuration>
                 <property name="javaHome">${server.jvm}</property>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/indexing-distributed.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/indexing-distributed.xml
@@ -1,0 +1,23 @@
+        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+            <cache-container 
+                name="clustered"
+                default-cache="testcache">
+                <transport
+                    stack="${jboss.default.jgroups.stack:udp}"
+                    executor="infinispan-transport"
+                    lock-timeout="240000"/>
+                <distributed-cache
+                    name="testcache"
+                    mode="SYNC"
+                    start="EAGER"
+                    batching="false"
+                    module="org.infinispan.remote-query.server">
+                    <transaction mode="NONE" />
+                    <indexing index="ALL">
+                        <property name="default.directory_provider">ram</property>
+                        <property name="lucene_version">LUCENE_36</property>
+                    </indexing>
+                </distributed-cache>
+            </cache-container>
+            <cache-container name="security"/>
+        </subsystem>


### PR DESCRIPTION
...keySet and bulk marshalling

This happens only in clustered caches because that's when map-reduce is used to collect the keys and
fails due to ClassCastException. The map-reduce task used to assume the values are byte[] which is no
longer true whith remote query.

Jira: https://issues.jboss.org/browse/ISPN-3976
