### PR TITLE
ISPN-4104 Generic store cache child creation fails

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/configuration/BuiltBy.java
+++ b/commons/src/main/java/org/infinispan/commons/configuration/BuiltBy.java
@@ -1,7 +1,9 @@
 package org.infinispan.commons.configuration;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * BuiltBy. An annotation for configuration beans to specify what builder builds them.
@@ -12,6 +14,7 @@ import java.lang.annotation.RetentionPolicy;
  * @since 5.2
  */
 @Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
 public @interface BuiltBy {
    @SuppressWarnings("rawtypes")
    Class<? extends Builder> value();

--- a/commons/src/main/java/org/infinispan/commons/configuration/ConfiguredBy.java
+++ b/commons/src/main/java/org/infinispan/commons/configuration/ConfiguredBy.java
@@ -1,0 +1,18 @@
+package org.infinispan.commons.configuration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines the configuration used to configure the given class instances
+ *
+ * @author wburns
+ * @since 7.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ConfiguredBy {
+   Class<?> value();
+}

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractStoreConfigurationBuilder.java
@@ -1,5 +1,6 @@
 package org.infinispan.configuration.cache;
 
+import org.infinispan.commons.configuration.Builder;
 import org.infinispan.configuration.parsing.XmlConfigHelper;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -125,4 +126,17 @@ public abstract class AbstractStoreConfigurationBuilder<T extends StoreConfigura
          log.localIndexingWithSharedCacheLoaderRequiresPreload();
    }
 
+   @Override
+   public Builder<?> read(T template) {
+      async.read(template.async());
+      singletonStore.read(template.singletonStore());
+      fetchPersistentState = template.fetchPersistentState();
+      ignoreModifications = template.ignoreModifications();
+      purgeOnStartup = template.purgeOnStartup();
+      shared = template.shared();
+      preload = template.preload();
+      properties = template.properties();
+
+      return this;
+   }
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/BaseStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/BaseStoreConfigurationBuilder.java
@@ -1,0 +1,26 @@
+package org.infinispan.configuration.cache;
+
+import org.infinispan.commons.configuration.Builder;
+
+/**
+ * StoreConfigurationBuilder used for stores/loaders that don't have a configuration builder
+ *
+ * @author wburns
+ * @since 7.0
+ */
+public class BaseStoreConfigurationBuilder extends AbstractStoreConfigurationBuilder<AbstractStoreConfiguration, BaseStoreConfigurationBuilder> {
+   public BaseStoreConfigurationBuilder(PersistenceConfigurationBuilder builder) {
+      super(builder);
+   }
+
+   @Override
+   public AbstractStoreConfiguration create() {
+      return new AbstractStoreConfiguration(purgeOnStartup, fetchPersistentState, ignoreModifications, async.create(),
+                                            singletonStore.create(), preload, shared, properties);
+   }
+
+   @Override
+   public BaseStoreConfigurationBuilder self() {
+      return this;
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/cache/ClusterLoaderConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ClusterLoaderConfigurationBuilder.java
@@ -46,6 +46,7 @@ public class ClusterLoaderConfigurationBuilder extends AbstractStoreConfiguratio
 
    @Override
    public ClusterLoaderConfigurationBuilder read(ClusterLoaderConfiguration template) {
+      super.read(template);
       this.remoteCallTimeout = template.remoteCallTimeout();
       this.properties = template.properties();
       return this;

--- a/core/src/main/java/org/infinispan/configuration/cache/SingleFileStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/SingleFileStoreConfigurationBuilder.java
@@ -62,19 +62,11 @@ public class SingleFileStoreConfigurationBuilder
 
    @Override
    public Builder<?> read(SingleFileStoreConfiguration template) {
+      super.read(template);
+
       // SingleFileStore-specific configuration
       location = template.location();
       maxEntries = template.maxEntries();
-
-      // AbstractStore-specific configuration
-      fetchPersistentState = template.fetchPersistentState();
-      ignoreModifications = template.ignoreModifications();
-      properties = template.properties();
-      purgeOnStartup = template.purgeOnStartup();
-      async.read(template.async());
-      singletonStore.read(template.singletonStore());
-      preload = template.preload();
-      shared = template.shared();
 
       return this;
    }

--- a/core/src/main/java/org/infinispan/persistence/cluster/ClusterLoader.java
+++ b/core/src/main/java/org/infinispan/persistence/cluster/ClusterLoader.java
@@ -2,6 +2,7 @@ package org.infinispan.persistence.cluster;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.commands.remote.ClusteredGetCommand;
+import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.util.InfinispanCollections;
 import org.infinispan.configuration.cache.ClusterLoaderConfiguration;
 import org.infinispan.container.entries.InternalCacheValue;
@@ -34,6 +35,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Mircea.Markus@jboss.com
  */
+@ConfiguredBy(ClusterLoaderConfiguration.class)
 public class ClusterLoader implements CacheLoader, LocalOnlyCacheLoader {
    private static final Log log = LogFactory.getLog(ClusterLoader.class);
 

--- a/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
+++ b/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
@@ -1,5 +1,6 @@
 package org.infinispan.persistence.file;
 
+import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.equivalence.EquivalentLinkedHashMap;
@@ -65,6 +66,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * @author Mircea Markus
  * @since 6.0
  */
+@ConfiguredBy(SingleFileStoreConfiguration.class)
 public class SingleFileStore implements AdvancedLoadWriteStore {
    private static final Log log = LogFactory.getLog(SingleFileStore.class);
    private static final boolean trace = log.isTraceEnabled();

--- a/core/src/test/java/org/infinispan/persistence/UnnecessaryLoadingTest.java
+++ b/core/src/test/java/org/infinispan/persistence/UnnecessaryLoadingTest.java
@@ -262,18 +262,6 @@ public class UnnecessaryLoadingTest extends SingleCacheManagerTest {
       }
 
       @Override
-      public Builder<?> read(CountingStoreConfiguration template) {
-         // AbstractStore-specific configuration
-         fetchPersistentState = template.fetchPersistentState();
-         ignoreModifications = template.ignoreModifications();
-         properties = template.properties();
-         purgeOnStartup = template.purgeOnStartup();
-         async.read(template.async());
-         singletonStore.read(template.singletonStore());
-         return this;
-      }
-
-      @Override
       public CountingStoreConfigurationBuilder self() {
          return this;
       }

--- a/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStore.java
+++ b/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStore.java
@@ -2,6 +2,7 @@ package org.infinispan.persistence.dummy;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.commons.util.InfinispanCollections;
@@ -32,6 +33,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@ConfiguredBy(DummyInMemoryStoreConfiguration.class)
 public class DummyInMemoryStore implements AdvancedLoadWriteStore {
    private static final Log log = LogFactory.getLog(DummyInMemoryStore.class);
    private static final boolean trace = log.isTraceEnabled();

--- a/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStoreConfigurationBuilder.java
+++ b/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStoreConfigurationBuilder.java
@@ -49,21 +49,13 @@ public class DummyInMemoryStoreConfigurationBuilder extends
 
    @Override
    public DummyInMemoryStoreConfigurationBuilder read(DummyInMemoryStoreConfiguration template) {
+      super.read(template);
+
       debug = template.debug();
       slow = template.slow();
       storeName = template.storeName();
       failKey = template.failKey();
       shared =template.shared();
-
-      // AbstractStore-specific configuration
-      fetchPersistentState = template.fetchPersistentState();
-      ignoreModifications = template.ignoreModifications();
-      properties = template.properties();
-      purgeOnStartup = template.purgeOnStartup();
-      async.read(template.async());
-      singletonStore.read(template.singletonStore());
-
-      this.preload = template.preload();
 
       return this;
    }

--- a/demos/nearcache-client/src/main/java/org/infinispan/nearcache/jms/RemoteEventStoreConfigurationBuilder.java
+++ b/demos/nearcache-client/src/main/java/org/infinispan/nearcache/jms/RemoteEventStoreConfigurationBuilder.java
@@ -18,20 +18,6 @@ public class RemoteEventStoreConfigurationBuilder extends AbstractStoreConfigura
    }
 
    @Override
-   public Builder<?> read(RemoteEventStoreConfiguration template) {
-      // AbstractStore-specific configuration
-      fetchPersistentState = template.fetchPersistentState();
-      ignoreModifications = template.ignoreModifications();
-      properties = template.properties();
-      purgeOnStartup = template.purgeOnStartup();
-      async.read(template.async());
-      singletonStore.read(template.singletonStore());
-      shared = template.shared();
-      preload = template.preload();
-      return this;
-   }
-
-   @Override
    public RemoteEventStoreConfigurationBuilder self() {
       return this;
    }

--- a/jcache/src/main/java/org/infinispan/jcache/JCacheWriterAdapterConfigurationBuilder.java
+++ b/jcache/src/main/java/org/infinispan/jcache/JCacheWriterAdapterConfigurationBuilder.java
@@ -17,11 +17,6 @@ public class JCacheWriterAdapterConfigurationBuilder extends AbstractStoreConfig
    }
 
    @Override
-   public Builder<?> read(JCacheWriterAdapterConfiguration template) {
-      return this;
-   }
-
-   @Override
    public JCacheWriterAdapterConfigurationBuilder self() {
       return this;
    }

--- a/jcache/src/main/java/org/infinispan/jcache/JStoreAdapterConfigurationBuilder.java
+++ b/jcache/src/main/java/org/infinispan/jcache/JStoreAdapterConfigurationBuilder.java
@@ -22,11 +22,6 @@ public class JStoreAdapterConfigurationBuilder extends AbstractStoreConfiguratio
    }
 
    @Override
-   public Builder<?> read(JStoreAdapterConfiguration template) {
-      return this;
-   }
-
-   @Override
    public JStoreAdapterConfigurationBuilder self() {
       return this;
    }

--- a/lucene/lucene-v3/src/main/java/org/infinispan/lucene/cacheloader/LuceneCacheLoader.java
+++ b/lucene/lucene-v3/src/main/java/org/infinispan/lucene/cacheloader/LuceneCacheLoader.java
@@ -1,6 +1,7 @@
 package org.infinispan.lucene.cacheloader;
 
 import org.apache.lucene.store.FSDirectory;
+import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.executors.ExecutorAllCompletionService;
 import org.infinispan.lucene.IndexScopedKey;
 import org.infinispan.lucene.cacheloader.configuration.LuceneLoaderConfiguration;
@@ -33,6 +34,7 @@ import java.util.concurrent.Executor;
  * @author Sanne Grinovero
  * @since 5.2
  */
+@ConfiguredBy(LuceneLoaderConfiguration.class)
 public class LuceneCacheLoader implements AdvancedCacheLoader {
 
    private static final Log log = LogFactory.getLog(LuceneCacheLoader.class, Log.class);

--- a/lucene/lucene-v3/src/main/java/org/infinispan/lucene/cacheloader/configuration/LuceneLoaderConfigurationBuilder.java
+++ b/lucene/lucene-v3/src/main/java/org/infinispan/lucene/cacheloader/configuration/LuceneLoaderConfigurationBuilder.java
@@ -63,17 +63,10 @@ public class LuceneLoaderConfigurationBuilder extends
 
    @Override
    public Builder<?> read(LuceneLoaderConfiguration template) {
+      super.read(template);
+
       this.autoChunkSize = template.autoChunkSize();
       this.location = template.location();
-
-      // AbstractStore-specific configuration
-      this.fetchPersistentState = template.fetchPersistentState();
-      this.ignoreModifications = template.ignoreModifications();
-      this.properties = template.properties();
-      this.purgeOnStartup = template.purgeOnStartup();
-      this.async.read(template.async());
-      this.singletonStore.read(template.singletonStore());
-      this.preload = template.preload();
 
       return this;
    }

--- a/persistence/cli/src/main/java/org/infinispan/persistence/cli/CLInterfaceLoader.java
+++ b/persistence/cli/src/main/java/org/infinispan/persistence/cli/CLInterfaceLoader.java
@@ -11,6 +11,7 @@ import org.infinispan.cli.impl.CommandBufferImpl;
 import org.infinispan.cli.impl.ContextImpl;
 import org.infinispan.cli.io.IOAdapter;
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.marshall.core.MarshalledEntry;
 import org.infinispan.persistence.cli.configuration.CLInterfaceLoaderConfiguration;
@@ -31,6 +32,7 @@ import java.util.concurrent.ConcurrentMap;
  * @author Galder Zamarreño
  * @since 6.0
  */
+@ConfiguredBy(CLInterfaceLoaderConfiguration.class)
 public class CLInterfaceLoader<K, V> implements CacheLoader<K, V> {
 
    private InitializationContext ctx;

--- a/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/CLInterfaceLoaderConfigurationBuilder.java
+++ b/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/CLInterfaceLoaderConfigurationBuilder.java
@@ -34,6 +34,7 @@ public class CLInterfaceLoaderConfigurationBuilder
 
    @Override
    public Builder<?> read(CLInterfaceLoaderConfiguration template) {
+      super.read(template);
       this.connectionString = template.connectionString();
       return this;
    }

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/binary/JdbcBinaryStore.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/binary/JdbcBinaryStore.java
@@ -1,5 +1,6 @@
 package org.infinispan.persistence.jdbc.binary;
 
+import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.io.ByteBuffer;
 import org.infinispan.commons.marshall.StreamingMarshaller;
@@ -53,6 +54,7 @@ import java.util.concurrent.Executor;
  * @see org.infinispan.persistence.jdbc.configuration.JdbcBinaryStoreConfiguration
  * @see org.infinispan.persistence.jdbc.stringbased.JdbcStringBasedStore
  */
+@ConfiguredBy(JdbcBinaryStoreConfiguration.class)
 public class JdbcBinaryStore implements AdvancedLoadWriteStore {
 
    private static final Log log = LogFactory.getLog(JdbcBinaryStore.class, Log.class);

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/AbstractJdbcStoreConfigurationBuilder.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/AbstractJdbcStoreConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.persistence.jdbc.configuration;
 
 import java.lang.reflect.Constructor;
 
+import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.ConfigurationUtils;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.commons.CacheConfigurationException;
@@ -79,27 +80,13 @@ public abstract class AbstractJdbcStoreConfigurationBuilder<T extends AbstractJd
       }
    }
 
-   /*
-    * TODO: we should really be using inheritance here, but because of a javac bug it won't let me
-    * invoke super.read() from subclasses complaining that abstract methods cannot be invoked. Will
-    * open a bug and add the ID here
-    */
-   protected S readInternal(AbstractJdbcStoreConfiguration template) {
+   @Override
+   public Builder<?> read(T template) {
       Class<? extends ConnectionFactoryConfigurationBuilder<?>> cfb = (Class<? extends ConnectionFactoryConfigurationBuilder<?>>) ConfigurationUtils.builderFor(template.connectionFactory());
       connectionFactory(cfb);
       connectionFactory.read(template.connectionFactory());
       manageConnectionFactory = template.manageConnectionFactory();
 
-      // AbstractStore-specific configuration
-      fetchPersistentState = template.fetchPersistentState();
-      ignoreModifications = template.ignoreModifications();
-      properties = template.properties();
-      purgeOnStartup = template.purgeOnStartup();
-      this.async.read(template.async());
-      this.singletonStore.read(template.singletonStore());
-      this.preload = template.preload();
-      this.shared = template.shared();
-
-      return self();
+      return super.read(template);
    }
 }

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/JdbcBinaryStoreConfigurationBuilder.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/JdbcBinaryStoreConfigurationBuilder.java
@@ -57,7 +57,8 @@ public class JdbcBinaryStoreConfigurationBuilder extends
 
    @Override
    public JdbcBinaryStoreConfigurationBuilder read(JdbcBinaryStoreConfiguration template) {
-      super.readInternal(template);
+      super.read(template);
+
       this.table.read(template.table());
       this.lockAcquisitionTimeout = template.lockAcquisitionTimeout();
       this.concurrencyLevel = template.lockConcurrencyLevel();

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/JdbcMixedStoreConfigurationBuilder.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/JdbcMixedStoreConfigurationBuilder.java
@@ -138,7 +138,8 @@ public class JdbcMixedStoreConfigurationBuilder extends AbstractJdbcStoreConfigu
 
    @Override
    public JdbcMixedStoreConfigurationBuilder read(JdbcMixedStoreConfiguration template) {
-      super.readInternal(template);
+      super.read(template);
+
       this.binaryTable.read(template.binaryTable());
       this.stringTable.read(template.stringTable());
       this.key2StringMapper = template.key2StringMapper();

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/JdbcStringBasedStoreConfigurationBuilder.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/JdbcStringBasedStoreConfigurationBuilder.java
@@ -64,7 +64,8 @@ public class JdbcStringBasedStoreConfigurationBuilder extends AbstractJdbcStoreC
 
    @Override
    public Builder<?> read(JdbcStringBasedStoreConfiguration template) {
-      super.readInternal(template);
+      super.read(template);
+
       this.key2StringMapper = template.key2StringMapper();
       this.table.read(template.table());
       return this;

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/mixed/JdbcMixedStore.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/mixed/JdbcMixedStore.java
@@ -1,5 +1,6 @@
 package org.infinispan.persistence.jdbc.mixed;
 
+import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.persistence.jdbc.binary.JdbcBinaryStore;
@@ -43,6 +44,7 @@ import java.util.concurrent.Executor;
  * @see org.infinispan.persistence.jdbc.binary.JdbcBinaryStore
  * @see org.infinispan.persistence.jdbc.stringbased.JdbcStringBasedStore
  */
+@ConfiguredBy(JdbcMixedStoreConfiguration.class)
 public class JdbcMixedStore implements AdvancedLoadWriteStore {
 
    private static final Log log = LogFactory.getLog(JdbcMixedStore.class);

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
@@ -1,5 +1,6 @@
 package org.infinispan.persistence.jdbc.stringbased;
 
+import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.io.ByteBuffer;
 import org.infinispan.marshall.core.MarshalledEntry;
 import org.infinispan.persistence.spi.PersistenceException;
@@ -66,6 +67,7 @@ import static org.infinispan.persistence.PersistenceUtil.getExpiryTime;
  * @see org.infinispan.persistence.keymappers.Key2StringMapper
  * @see org.infinispan.persistence.keymappers.DefaultTwoWayKey2StringMapper
  */
+@ConfiguredBy(JdbcStringBasedStoreConfiguration.class)
 public class JdbcStringBasedStore implements AdvancedLoadWriteStore {
 
    private static final Log log = LogFactory.getLog(JdbcStringBasedStore.class, Log.class);

--- a/persistence/leveldb/src/main/java/org/infinispan/persistence/leveldb/LevelDBStore.java
+++ b/persistence/leveldb/src/main/java/org/infinispan/persistence/leveldb/LevelDBStore.java
@@ -1,6 +1,7 @@
 package org.infinispan.persistence.leveldb;
 
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.util.Util;
 import org.infinispan.executors.ExecutorAllCompletionService;
 import org.infinispan.marshall.core.MarshalledEntry;
@@ -33,6 +34,7 @@ import java.util.concurrent.CompletionService;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 
+@ConfiguredBy(LevelDBStoreConfiguration.class)
 public class LevelDBStore implements AdvancedLoadWriteStore {
    private static final Log log = LogFactory.getLog(LevelDBStore.class, Log.class);
 

--- a/persistence/leveldb/src/main/java/org/infinispan/persistence/leveldb/configuration/LevelDBStoreConfigurationBuilder.java
+++ b/persistence/leveldb/src/main/java/org/infinispan/persistence/leveldb/configuration/LevelDBStoreConfigurationBuilder.java
@@ -81,6 +81,8 @@ public class LevelDBStoreConfigurationBuilder extends AbstractStoreConfiguration
 
    @Override
    public Builder<?> read(LevelDBStoreConfiguration template) {
+      super.read(template);
+
       location = template.location();
       expiredLocation = template.expiredLocation();
       implementationType = template.implementationType();
@@ -93,15 +95,6 @@ public class LevelDBStoreConfigurationBuilder extends AbstractStoreConfiguration
 
       expiryQueueSize = template.expiryQueueSize();
       clearThreshold = template.clearThreshold();
-
-
-      // AbstractStore-specific configuration
-      fetchPersistentState = template.fetchPersistentState();
-      ignoreModifications = template.ignoreModifications();
-      properties = template.properties();
-      purgeOnStartup = template.purgeOnStartup();
-      this.async.read(template.async());
-      this.singletonStore.read(template.singletonStore());
 
       return self();
    }

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/RemoteStore.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/RemoteStore.java
@@ -10,6 +10,7 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.ExhaustedAction;
 import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 import org.infinispan.commons.api.BasicCacheContainer;
+import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.jboss.GenericJBossMarshaller;
 import org.infinispan.commons.util.Util;
@@ -50,6 +51,7 @@ import java.util.concurrent.TimeUnit;
  * @since 4.1
  */
 @ThreadSafe
+@ConfiguredBy(RemoteStoreConfiguration.class)
 public class RemoteStore implements AdvancedLoadWriteStore {
 
    private static final Log log = LogFactory.getLog(RemoteStore.class, Log.class);

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfigurationBuilder.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfigurationBuilder.java
@@ -183,6 +183,8 @@ public class RemoteStoreConfigurationBuilder extends
 
    @Override
    public RemoteStoreConfigurationBuilder read(RemoteStoreConfiguration template) {
+      super.read(template);
+
       this.asyncExecutorFactory.read(template.asyncExecutorFactory());
       this.balancingStrategy = template.balancingStrategy();
       this.connectionPool.read(template.connectionPool());
@@ -203,13 +205,6 @@ public class RemoteStoreConfigurationBuilder extends
          this.addServer().host(server.host()).port(server.port());
       }
 
-      // AbstractStore-specific configuration
-      fetchPersistentState = template.fetchPersistentState();
-      ignoreModifications = template.ignoreModifications();
-      properties = template.properties();
-      purgeOnStartup = template.purgeOnStartup();
-      async.read(template.async());
-      singletonStore.read(template.singletonStore());
       return this;
    }
 

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/RestStore.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/RestStore.java
@@ -21,6 +21,7 @@ import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.CoreConnectionPNames;
 import org.apache.http.params.HttpParams;
 import org.apache.http.util.EntityUtils;
+import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.util.Util;
 import org.infinispan.container.InternalEntryFactory;
 import org.infinispan.executors.ExecutorAllCompletionService;
@@ -59,6 +60,7 @@ import java.util.concurrent.TimeUnit;
  * @since 6.0
  */
 @ThreadSafe
+@ConfiguredBy(RestStoreConfiguration.class)
 public class RestStore implements AdvancedLoadWriteStore {
    private static final String MAX_IDLE_TIME_SECONDS = "maxIdleTimeSeconds";
    private static final String TIME_TO_LIVE_SECONDS = "timeToLiveSeconds";

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/RestStoreConfigurationBuilder.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/RestStoreConfigurationBuilder.java
@@ -99,6 +99,8 @@ public class RestStoreConfigurationBuilder extends AbstractStoreConfigurationBui
 
    @Override
    public RestStoreConfigurationBuilder read(RestStoreConfiguration template) {
+      super.read(template);
+
       this.connectionPool.read(template.connectionPool());
       this.host = template.host();
       this.port = template.port();
@@ -107,15 +109,6 @@ public class RestStoreConfigurationBuilder extends AbstractStoreConfigurationBui
       this.key2StringMapper = template.key2StringMapper();
       this.metadataHelper = template.metadataHelper();
 
-      // AbstractStore-specific configuration
-      fetchPersistentState = template.fetchPersistentState();
-      ignoreModifications = template.ignoreModifications();
-      properties = template.properties();
-      purgeOnStartup = template.purgeOnStartup();
-      shared = template.shared();
-      preload = template.preload();
-      async.read(template.async());
-      singletonStore.read(template.singletonStore());
       return this;
    }
 

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/CustomCacheLoaderConfigurationBuilder.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/CustomCacheLoaderConfigurationBuilder.java
@@ -24,22 +24,6 @@ public class CustomCacheLoaderConfigurationBuilder extends AbstractStoreConfigur
    }
 
    @Override
-   public Builder<?> read(CustomCacheLoaderConfiguration template) {
-      // AbstractStore-specific configuration
-      fetchPersistentState = template.fetchPersistentState();
-      ignoreModifications = template.ignoreModifications();
-      properties = template.properties();
-      purgeOnStartup = template.purgeOnStartup();
-      async.read(template.async());
-      singletonStore.read(template.singletonStore());
-      preload = template.preload();
-      shared = template.shared();
-
-      return this;
-
-   }
-
-   @Override
    public CustomCacheLoaderConfigurationBuilder self() {
       return this;
    }

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/CustomCacheWriterConfigurationBuilder.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/CustomCacheWriterConfigurationBuilder.java
@@ -25,22 +25,6 @@ public class CustomCacheWriterConfigurationBuilder extends AbstractStoreConfigur
    }
 
    @Override
-   public Builder<?> read(CustomCacheWriterConfiguration template) {
-      // AbstractStore-specific configuration
-      fetchPersistentState = template.fetchPersistentState();
-      ignoreModifications = template.ignoreModifications();
-      properties = template.properties();
-      purgeOnStartup = template.purgeOnStartup();
-      async.read(template.async());
-      singletonStore.read(template.singletonStore());
-      preload = template.preload();
-      shared = template.shared();
-
-      return this;
-
-   }
-
-   @Override
    public CustomCacheWriterConfigurationBuilder self() {
       return this;
    }

--- a/server/integration/testsuite/src/test/java/org/infinispan/persistence/cluster/MyCustomCacheStoreConfigurationBuilder.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/persistence/cluster/MyCustomCacheStoreConfigurationBuilder.java
@@ -42,8 +42,8 @@ public class MyCustomCacheStoreConfigurationBuilder extends AbstractStoreConfigu
 
     @Override
     public MyCustomCacheStoreConfigurationBuilder read(MyCustomCacheStoreConfiguration template) {
+        super.read(template);
         this.customProperty = template.customProperty();
-        this.properties = template.properties();
         return this;
     }
 }


### PR DESCRIPTION
- Added ConfiguredBy annotation
  *\* This allows a Cachestore to tell what Configuration to use
- Updated existing cache stores and loaders to define this
- Added parsing support for embedded and server configuration
- Added tests to verify generic loader definitions
- Refactored base configuration builder to reduce code copy for read

https://issues.jboss.org/browse/ISPN-4104
https://issues.jboss.org/browse/ISPN-4103
