### PR TITLE
ISPN-3611 Service jboss.infinispan.default failed to start on IBM JDK 6 argument type mismatch

### DIFF
--- a/core/src/main/java/org/infinispan/factories/components/ComponentMetadata.java
+++ b/core/src/main/java/org/infinispan/factories/components/ComponentMetadata.java
@@ -105,25 +105,27 @@ public class ComponentMetadata implements Serializable {
          int j=0;
          for (Method m : injectMethods) {
             
-            List<String> params = new LinkedList<String>();
             InjectMetadata injectMetadata = new InjectMetadata(m.getName());
             
             Class<?>[] parameterTypes = m.getParameterTypes();
+            String[] params = new String[parameterTypes.length];
+            String[] paramNames = new String[parameterTypes.length];
 
             // Add this to our dependencies map
             Annotation[][] annotations = m.getParameterAnnotations();
             for (int i=0; i<parameterTypes.length; i++) {
                String componentName = findComponentName(annotations, i);
                String parameterType = parameterTypes[i].getName();
-               params.add(parameterType);
+               params[i] = parameterType;
                if (componentName == null) {
                   dependencies.put(parameterType, parameterType);
                } else {
-                  injectMetadata.addParameterName(i, componentName);
+                  paramNames[i] = componentName;
                   dependencies.put(componentName, parameterType);
                }
             }
-            injectMetadata.parameters = params.toArray(new String[params.size()]);
+            injectMetadata.parameters = params;
+            injectMetadata.parameterNames = paramNames;
             this.injectMetadata[j++] = injectMetadata;
          }
       }
@@ -241,7 +243,7 @@ public class ComponentMetadata implements Serializable {
       transient Method method;
       String[] parameters;
       transient Class<?>[] parameterClasses;
-      Map<Integer, String> parameterNames; 
+      String[] parameterNames;
 
       private InjectMetadata(String methodName) {
          this.methodName = methodName;
@@ -256,18 +258,14 @@ public class ComponentMetadata implements Serializable {
       }
       
       public String getParameterName(int subscript) {
-         String name = parameterNames == null ? null : parameterNames.get(subscript);
+         String name = parameterNames == null ? null : parameterNames[subscript];
          return name == null ? parameters[subscript] : name;
       }
 
       public boolean isParameterNameSet(int subscript) {
-         return parameterNames != null && parameterNames.containsKey(subscript);
+         return parameterNames != null && parameterNames[subscript] != null;
       }
       
-      void addParameterName(int subscript, String name) {
-         if (parameterNames == null) parameterNames = new HashMap<Integer, String>(1);
-         parameterNames.put(subscript, name);
-      }
 
       public synchronized Method getMethod() {
          return method;


### PR DESCRIPTION
Backport of ISPN-3611 fix for 5.2.X
