### PR TITLE
General solution to the ibm xslt transformation issues

### DIFF
--- a/server/integration/testsuite/pom.xml
+++ b/server/integration/testsuite/pom.xml
@@ -272,6 +272,14 @@
                                 <ant antfile="build-testsuite.xml" inheritRefs="true">
                                     <target name="create-all-distros"/>
                                 </ant>
+                                <!-- It happens when you do not specify namespaces in the XSLT templates for the newly added nodes
+                                     then the IBM jdk transformation is adding empty namespace there - not possible to influence this
+                                     behaviour by any environmental property - this is a bit workaround for it -->
+                                <echo message="Removing empty xmlns attributes (xmlns='') which IBM JDK could produce" />
+                                <replace dir="target" value="">
+                                    <include name="server/node*/standalone/configuration/**/*.xml"/>
+                                    <replacetoken><![CDATA[xmlns=""]]></replacetoken>
+                                </replace>
                             </target>
                         </configuration>
                     </execution>

--- a/server/integration/testsuite/src/test/resources/config/parts/xsite-multicast-address-server3.xml
+++ b/server/integration/testsuite/src/test/resources/config/parts/xsite-multicast-address-server3.xml
@@ -1,1 +1,1 @@
-<socket-binding xmlns="urn:jboss:domain:1.4" name="jgroups-udp" port="55200" multicast-address="234.99.54.15" multicast-port="45688"/>
+<socket-binding name="jgroups-udp" port="55200" multicast-address="234.99.54.15" multicast-port="45688"/>

--- a/server/integration/testsuite/src/test/resources/config/parts/xsite-relay-server3.xml
+++ b/server/integration/testsuite/src/test/resources/config/parts/xsite-relay-server3.xml
@@ -1,4 +1,4 @@
-<relay xmlns="urn:jboss:domain:jgroups:1.2" site="NYC">
+<relay site="NYC">
    <remote-site name="LON" stack="tcp" cluster="global"/>
    <remote-site name="SFO" stack="tcp" cluster="global"/>
 </relay>


### PR DESCRIPTION
I saw this solution in some eap testsuite. The issue is that when doing xslt transformations on ibm java, if the added node has no namespace, ibm will insert empty xmlns="" which crashes the server during configuration parsing. Now instead of specifying the namespaces in every config snippet, we remove the xmlns="" from all .xml files in test servers.
