### PR TITLE
Ispn 4061 JPA Cache Store fails on Oracle, Postgres and MsSQL

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -140,6 +140,7 @@
       <version.mockito>1.9.5</version.mockito>
       <version.mysql.driver>5.1.19</version.mysql.driver>
       <version.org.jboss.naming>5.0.6.CR1</version.org.jboss.naming>
+      <version.postgresql.driver>9.3-1101-jdbc41</version.postgresql.driver>
       <version.resteasy>2.3.2.Final</version.resteasy>
       <version.shrinkwrapResolver>2.0.0-alpha-6</version.shrinkwrapResolver>
       <version.slf4j>1.6.4</version.slf4j>
@@ -411,6 +412,11 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${version.mysql.driver}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${version.postgresql.driver}</version>
          </dependency>
          <dependency>
             <groupId>junit</groupId>

--- a/persistence/jpa/pom.xml
+++ b/persistence/jpa/pom.xml
@@ -40,16 +40,6 @@
          <scope>provided</scope>
       </dependency>
       <dependency>
-         <groupId>com.h2database</groupId>
-         <artifactId>h2</artifactId>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>mysql</groupId>
-         <artifactId>mysql-connector-java</artifactId>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-simple</artifactId>
          <scope>test</scope>
@@ -67,6 +57,13 @@
          <activation>
             <activeByDefault>true</activeByDefault>
          </activation>
+         <dependencies>
+            <dependency>
+               <groupId>com.h2database</groupId>
+               <artifactId>h2</artifactId>
+               <scope>test</scope>
+            </dependency>
+         </dependencies>
          <build>
             <plugins>
                <plugin>
@@ -84,6 +81,13 @@
       </profile>
       <profile>
          <id>mysql</id>
+         <dependencies>
+            <dependency>
+               <groupId>mysql</groupId>
+               <artifactId>mysql-connector-java</artifactId>
+               <scope>test</scope>
+            </dependency>
+         </dependencies>
          <build>
             <plugins>
                <plugin>
@@ -93,7 +97,33 @@
                      <systemPropertyVariables>
                         <connection.url>jdbc:mysql://localhost:3306/ispn_jpa_test</connection.url>
                         <driver.class>com.mysql.jdbc.Driver</driver.class>
-                        <db.username>root</db.username>
+                        <db.username>${db.username}</db.username>
+                        <db.password>${db.password}</db.password>
+                     </systemPropertyVariables>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+      <profile>
+         <id>postgres</id>
+         <dependencies>
+            <dependency>
+               <groupId>org.postgresql</groupId>
+               <artifactId>postgresql</artifactId>
+            </dependency>
+         </dependencies>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                     <systemPropertyVariables>
+                        <connection.url>jdbc:postgresql://localhost:5432/ispn_jpa_test</connection.url>
+                        <driver.class>org.postgresql.Driver</driver.class>
+                        <db.username>${db.username}</db.username>
+                        <db.password>${db.password}</db.password>
                      </systemPropertyVariables>
                   </configuration>
                </plugin>

--- a/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/MetadataEntity.java
+++ b/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/MetadataEntity.java
@@ -1,47 +1,87 @@
 package org.infinispan.persistence.jpa;
 
-import org.infinispan.commons.io.ByteBuffer;
-
 import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.Id;
+import javax.persistence.Lob;
 import javax.persistence.Table;
 import javax.persistence.Version;
 
+import org.infinispan.commons.io.ByteBuffer;
+
 /**
  * Entity which should hold serialized metadata
- *
+ * 
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 @Entity
-@Table(name = "__ispn_metadata__")
+@Table(name = "`__ispn_metadata__`")
 class MetadataEntity {
    public static final String EXPIRATION = "expiration";
 
-   @Id
-   // Some DBs require primary columns to have specified length, 767 is max length for InnoDB
-   @Column(columnDefinition = "VARBINARY(767)", length = 767)
-   public byte[] name;
+   @EmbeddedId
+   private MetadataEntityKey key;
+   @Lob
    @Column(length = 65535)
-   public byte[] metadata;
+   private byte[] keyBytes;
+   @Lob
+   @Column(length = 65535)
+   private byte[] metadata;
    @Column(name = EXPIRATION)
-   public long expiration; // to simplify query for expired entries
+   private long expiration; // to simplify query for expired entries
    @Version
-   public int version;
+   private int version;
 
    public MetadataEntity() {
    }
 
    public MetadataEntity(ByteBuffer key, ByteBuffer metadata, long expiration) {
-      this.name = key.getBuf();
+      this.key = new MetadataEntityKey(key.getBuf());
+      this.keyBytes = key.getBuf();
       if (metadata != null) {
          this.metadata = metadata.getBuf();
       }
       this.expiration = expiration < 0 ? Long.MAX_VALUE : expiration;
    }
 
+   public MetadataEntityKey getKey() {
+      return key;
+   }
+
+   public void setKey(MetadataEntityKey key) {
+      this.key = key;
+   }
+   
+   public byte[] getKeyBytes() {
+      return keyBytes;
+   }
+
+   public void setKeyBytes(byte[] keyBytes) {
+      this.keyBytes = keyBytes;
+   }
+
    public byte[] getMetadata() {
       return metadata;
+   }
+
+   public void setMetadata(byte[] metadata) {
+      this.metadata = metadata;
+   }
+
+   public long getExpiration() {
+      return expiration;
+   }
+
+   public void setExpiration(long expiration) {
+      this.expiration = expiration;
+   }
+
+   public int getVersion() {
+      return version;
+   }
+
+   public void setVersion(int version) {
+      this.version = version;
    }
 
    public boolean hasBytes() {

--- a/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/MetadataEntityKey.java
+++ b/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/MetadataEntityKey.java
@@ -1,0 +1,64 @@
+package org.infinispan.persistence.jpa;
+
+import java.io.Serializable;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import javax.persistence.Embeddable;
+
+import org.infinispan.commons.util.Base64;
+
+/**
+ * 
+ * Embedded entity which serves as primary key for metadata. Bytes representing the key are hashed
+ * via SHA-256.
+ * 
+ * @author vjuranek
+ */
+@Embeddable
+public class MetadataEntityKey implements Serializable {
+
+   private static final long serialVersionUID = 73757405630621L;
+   private static final String DIGEST_ALG = "SHA-256";
+
+   private String keySha;
+
+   public MetadataEntityKey() {
+   }
+
+   public MetadataEntityKey(byte[] keyBytes) {
+      keySha = getKeyBytesSha(keyBytes);
+   }
+   
+   public String getKeySha() {
+      return keySha;
+   }
+
+   public void setKeySha(String keySha) {
+      this.keySha = keySha;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (o == null || !(o instanceof MetadataEntityKey))
+         return false;
+      return keySha.equals(((MetadataEntityKey) o).getKeySha());
+   }
+
+   @Override
+   public int hashCode() {
+      return keySha.hashCode();
+   }
+   
+   public static String getKeyBytesSha(byte[] keyBytes) {
+      String keyBytesSha;
+      try {
+         MessageDigest digest = MessageDigest.getInstance(DIGEST_ALG);
+         byte[] sha = digest.digest(keyBytes);
+         keyBytesSha = Base64.encodeBytes(sha);
+      } catch(NoSuchAlgorithmException e) {
+         throw new JpaStoreException("Failed to create SHA hash of metadata key", e);
+      }
+      return keyBytesSha;
+   }
+}

--- a/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/JpaStoreFunctionalTest.java
+++ b/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/JpaStoreFunctionalTest.java
@@ -31,7 +31,7 @@ public class JpaStoreFunctionalTest extends BaseStoreFunctionalTest {
 
    @Override
    public String unwrap(Object wrapper) {
-      return ((KeyValueEntity) wrapper).value;
+      return ((KeyValueEntity) wrapper).getValue();
    }
 
    @Test(enabled = false)

--- a/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/JpaStoreTest.java
+++ b/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/JpaStoreTest.java
@@ -55,7 +55,7 @@ public class JpaStoreTest extends BaseStoreTest {
 
    @Override
    public String unwrap(Object wrapper) {
-      return ((KeyValueEntity) wrapper).value;
+      return ((KeyValueEntity) wrapper).getValue();
    }
 
    @Test(enabled = false)

--- a/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/entity/KeyValueEntity.java
+++ b/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/entity/KeyValueEntity.java
@@ -6,21 +6,37 @@ import javax.persistence.Id;
 import java.io.Serializable;
 
 /**
-* @author Radim Vansa &lt;rvansa@redhat.com&gt;
-*/
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
 @Entity
 public class KeyValueEntity implements Serializable {
    @Id
-   public String k; // key is reserved word in SQL
+   private String k; // key is reserved word in SQL
 
    @Basic
-   public String value;
+   private String value;
 
    public KeyValueEntity() {
    }
 
    public KeyValueEntity(String key, String value) {
       this.k = key;
+      this.value = value;
+   }
+
+   public String getK() {
+      return k;
+   }
+
+   public void setK(String k) {
+      this.k = k;
+   }
+
+   public String getValue() {
+      return value;
+   }
+
+   public void setValue(String value) {
       this.value = value;
    }
 

--- a/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/entity/User.java
+++ b/persistence/jpa/src/test/java/org/infinispan/persistence/jpa/entity/User.java
@@ -1,9 +1,11 @@
 package org.infinispan.persistence.jpa.entity;
 
+import java.io.Serializable;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import java.io.Serializable;
+import javax.persistence.Table;
 
 /**
  * 
@@ -11,6 +13,7 @@ import java.io.Serializable;
  *
  */
 @Entity
+@Table(name="Users")
 public class User implements Serializable {
 	/**
 	 * 

--- a/persistence/jpa/src/test/resources/META-INF/persistence.xml
+++ b/persistence/jpa/src/test/resources/META-INF/persistence.xml
@@ -20,7 +20,8 @@
        <property name="hibernate.jdbc.batch_size" value="20" />
        <property name="hibernate.jdbc.fetch_size" value="20" />
        <property name="hibernate.hbm2ddl.auto" value="update"/> <!--  use create-drop for testing -->
-       <property name="hibernate.show_sql" value="false" /> <!-- set to true if you'd like to see what's going on -->  
+       <property name="hibernate.show_sql" value="false" /> <!-- set to true if you'd like to see what's going on -->
+       <property name="hibernate.connection.autocommit" value="false" />  
      </properties>
    </persistence-unit>
    
@@ -42,6 +43,7 @@
        <property name="hibernate.jdbc.fetch_size" value="20" />
        <property name="hibernate.hbm2ddl.auto" value="update"/> <!--  use create-drop for testing -->
        <property name="hibernate.show_sql" value="true" />
+       <property name="hibernate.connection.autocommit" value="false" />
      </properties>
    </persistence-unit>
 </persistence>


### PR DESCRIPTION
- MetadataEntity shouldn't use byte[] field as a primary key - as primary key is used SHA-256 hash of the key
- MetadataEntity table name needs to be quoted (tables starting with underscore are not allowed on Oracle, unless quoted)
- Table name 'User' is reserved table on MsSQL - switched to table name 'Users'
- Added Postgres profile
- Switch to private filed in test entities
