### PR TITLE
Allow subclassing DefaultExecutorService.DistributedTaskPart.

### DIFF
--- a/core/src/main/java/org/infinispan/distexec/DefaultExecutorService.java
+++ b/core/src/main/java/org/infinispan/distexec/DefaultExecutorService.java
@@ -788,7 +788,7 @@ public class DefaultExecutorService extends AbstractExecutorService implements D
     * @author Mircea Markus
     * @author Vladimir Blagojevic
     */
-   private class DistributedTaskPart<V> implements NotifyingNotifiableFuture<V>, RunnableFuture<V>{
+   protected class DistributedTaskPart<V> implements NotifyingNotifiableFuture<V>, RunnableFuture<V>{
 
       private final DistributedExecuteCommand<V> distCommand;
       private volatile Future<V> f;


### PR DESCRIPTION
There are 2 protected methods called createDistributedTaskPart that make it look like this was the original intent. It would be nice if this made it into 6.0.x as well.
