### PR TITLE
ISPN-4137 Transaction executed multiple times due to forwarded CommitCommand

### DIFF
--- a/core/src/main/java/org/infinispan/commands/tx/CommitCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/CommitCommand.java
@@ -28,12 +28,6 @@ public class CommitCommand extends AbstractTransactionBoundaryCommand {
    }
 
    @Override
-   public Object perform(InvocationContext ctx) throws Throwable {
-      txTable.markTransactionCompleted(globalTx);
-      return super.perform(ctx);
-   }
-
-   @Override
    public Object acceptVisitor(InvocationContext ctx, Visitor visitor) throws Throwable {
       return visitor.visitCommitCommand((TxInvocationContext) ctx, this);
    }

--- a/core/src/main/java/org/infinispan/commands/tx/RollbackCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/RollbackCommand.java
@@ -30,6 +30,7 @@ public class RollbackCommand extends AbstractTransactionBoundaryCommand {
 
    @Override
    public Object perform(InvocationContext ctx) throws Throwable {
+      // Need to mark the transaction as completed even if the prepare command was not executed on this node
       txTable.markTransactionCompleted(globalTx);
       return super.perform(ctx);
    }

--- a/core/src/main/java/org/infinispan/context/impl/LocalTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/LocalTxInvocationContext.java
@@ -60,17 +60,6 @@ public class LocalTxInvocationContext extends AbstractTxInvocationContext<LocalT
    }
 
    @Override
-   public final void skipTransactionCompleteCheck(boolean skip) {
-      //no-op
-   }
-
-   @Override
-   public final boolean skipTransactionCompleteCheck() {
-      //no-op. the check is only performed in remote transactions
-      return true;
-   }
-
-   @Override
    public final Transaction getTransaction() {
       return getCacheTransaction().getTransaction();
    }

--- a/core/src/main/java/org/infinispan/context/impl/RemoteTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/RemoteTxInvocationContext.java
@@ -53,14 +53,4 @@ public class RemoteTxInvocationContext extends AbstractTxInvocationContext<Remot
    public final int hashCode() {
       return getCacheTransaction().hashCode();
    }
-
-   @Override
-   public final void skipTransactionCompleteCheck(boolean skip) {
-      getCacheTransaction().skipTransactionCompleteCheck(skip);
-   }
-
-   @Override
-   public final boolean skipTransactionCompleteCheck() {
-      return getCacheTransaction().skipTransactionCompleteCheck();
-   }
 }

--- a/core/src/main/java/org/infinispan/context/impl/TxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/TxInvocationContext.java
@@ -65,8 +65,4 @@ public interface TxInvocationContext<T extends AbstractCacheTransaction> extends
    boolean isImplicitTransaction();
 
    T getCacheTransaction();
-
-   void skipTransactionCompleteCheck(boolean skip);
-
-   boolean skipTransactionCompleteCheck();
 }

--- a/core/src/main/java/org/infinispan/interceptors/TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/TxInterceptor.java
@@ -107,7 +107,7 @@ public class TxInterceptor extends CommandInterceptor {
       try {
          return invokeNextInterceptor(ctx, command);
       } finally {
-         if (!ctx.isOriginLocal() && !ctx.skipTransactionCompleteCheck()) {
+         if (!ctx.isOriginLocal()) {
             //It is possible to receive a prepare or lock control command from a node that crashed. If that's the case rollback
             //the transaction forcefully in order to cleanup resources.
             boolean originatorMissing = !rpcManager.getTransport().getMembers().contains(command.getOrigin());
@@ -138,10 +138,18 @@ public class TxInterceptor extends CommandInterceptor {
 
    @Override
    public Object visitCommitCommand(TxInvocationContext ctx, CommitCommand command) throws Throwable {
+      GlobalTransaction gtx = ctx.getGlobalTransaction();
+      // TODO The local origin check is needed for CommitFailsTest, but it doesn't appear correct to roll back an in-doubt tx
+      if (!ctx.isOriginLocal() && txTable.isTransactionCompleted(gtx)) {
+         log.tracef("Transaction %s already completed, skipping commit", gtx);
+         return null;
+      }
+
       if (this.statisticsEnabled) commits.incrementAndGet();
+      txTable.markTransactionCompleted(gtx);
       Object result = invokeNextInterceptor(ctx, command);
       if (!ctx.isOriginLocal() || isTotalOrder) {
-         txTable.remoteTransactionCommitted(ctx.getGlobalTransaction(), false);
+         txTable.remoteTransactionCommitted(gtx, false);
       }
       return result;
    }
@@ -149,6 +157,7 @@ public class TxInterceptor extends CommandInterceptor {
    @Override
    public Object visitRollbackCommand(TxInvocationContext ctx, RollbackCommand command) throws Throwable {
       if (this.statisticsEnabled) rollbacks.incrementAndGet();
+      // The transaction was marked as completed in RollbackCommand.prepare()
       if (!ctx.isOriginLocal() || isTotalOrder) {
          txTable.remoteTransactionRollback(command.getGlobalTransaction());
       }

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
@@ -108,7 +108,6 @@ public class StateTransferInterceptor extends CommandInterceptor {
                        command.getTopologyId());
          }
          if (remoteTx.lookedUpEntriesTopology() < command.getTopologyId()) {
-            ctx.skipTransactionCompleteCheck(true);
             remoteTx.setLookedUpEntriesTopology(command.getTopologyId());
 
             PrepareCommand prepareCommand;

--- a/core/src/main/java/org/infinispan/transaction/RemoteTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/RemoteTransaction.java
@@ -37,11 +37,6 @@ public class RemoteTransaction extends AbstractCacheTransaction implements Clone
    // Default value of MAX_VALUE basically means it hasn't yet received what topology id this is for the entries
    private volatile int lookedUpEntriesTopology = Integer.MAX_VALUE;
 
-   /**
-    * If true, the check transaction completed in TxInterceptor is skipped for this transaction.
-    */
-   private volatile boolean skipTransactionCompletedCheck;
-
    private volatile TotalOrderRemoteTransactionState transactionState;
    private final Object transactionStateLock = new Object();
 
@@ -131,14 +126,6 @@ public class RemoteTransaction extends AbstractCacheTransaction implements Clone
 
    public int lookedUpEntriesTopology() {
       return lookedUpEntriesTopology;
-   }
-
-   public void skipTransactionCompleteCheck(boolean skip) {
-      skipTransactionCompletedCheck = skip;
-   }
-
-   public boolean skipTransactionCompleteCheck() {
-      return skipTransactionCompletedCheck;
    }
 
    private void checkIfRolledBack() {

--- a/core/src/main/java/org/infinispan/transaction/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/TransactionTable.java
@@ -520,6 +520,7 @@ public class TransactionTable {
       if (totalOrder) {
          return;
       }
+      log.tracef("Marking transaction %s as completed", globalTx);
       completedTransactions.put(globalTx, timeService.time());
    }
 

--- a/core/src/test/java/org/infinispan/lock/LockContainerHashingTest.java
+++ b/core/src/test/java/org/infinispan/lock/LockContainerHashingTest.java
@@ -37,8 +37,6 @@ public class LockContainerHashingTest extends AbstractInfinispanTest {
          }
       }
 
-      System.out.println(distribution);
-
       // cannot be larger than the number of locks
       log.trace("dist size: " + distribution.size());
       log.trace("num shared locks: " + stripedLock.size());

--- a/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
@@ -65,7 +65,7 @@ public class TransactionXaAdapterTmIntegrationTest {
       CommandsFactory commandsFactory = mock(CommandsFactory.class);
       InterceptorChain invoker = mock(InterceptorChain.class);
       txCoordinator = new TransactionCoordinator();
-      txCoordinator.init(commandsFactory, icf, invoker, txTable, configuration);
+      txCoordinator.init(commandsFactory, icf, invoker, txTable, null, configuration);
       xaAdapter = new TransactionXaAdapter(localTx, txTable, null, txCoordinator, null, null,
                                            new ClusteringDependentLogic.InvalidationLogic(), configuration, "");
 
@@ -114,13 +114,13 @@ public class TransactionXaAdapterTmIntegrationTest {
 
    public void testOnePhaseCommitConfigured() throws XAException {
       Configuration configuration = new ConfigurationBuilder().clustering().cacheMode(CacheMode.INVALIDATION_ASYNC).build();
-      txCoordinator.init(null, null, null, null, configuration);
+      txCoordinator.init(null, null, null, null, null, configuration);
       assert XAResource.XA_OK == xaAdapter.prepare(xid);
    }
 
    public void test1PcAndNonExistentXid() {
       Configuration configuration = new ConfigurationBuilder().clustering().cacheMode(CacheMode.INVALIDATION_ASYNC).build();
-      txCoordinator.init(null, null, null, null, configuration);
+      txCoordinator.init(null, null, null, null, null, configuration);
       try {
          DummyXid doesNotExists = new DummyXid(uuid);
          xaAdapter.commit(doesNotExists, false);
@@ -132,7 +132,7 @@ public class TransactionXaAdapterTmIntegrationTest {
 
    public void test1PcAndNonExistentXid2() {
       Configuration configuration = new ConfigurationBuilder().clustering().cacheMode(CacheMode.DIST_SYNC).build();
-      txCoordinator.init(null, null, null, null, configuration);
+      txCoordinator.init(null, null, null, null, null, configuration);
       try {
          DummyXid doesNotExists = new DummyXid(uuid);
          xaAdapter.commit(doesNotExists, true);

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/AbstractRecoveryTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/AbstractRecoveryTest.java
@@ -37,6 +37,7 @@ public abstract class AbstractRecoveryTest extends MultipleCacheManagersTest {
    }
 
    protected int countInDoubtTx(String inDoubt) {
+      log.tracef("Retrieved in-doubt transactions: %s", inDoubt);
       int lastIndex = 0;
       int count = 0;
       while ((lastIndex = inDoubt.indexOf("internalId", lastIndex + 1)) >= 0) {

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/CommitFailsTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/CommitFailsTest.java
@@ -105,7 +105,7 @@ public class CommitFailsTest extends AbstractRecoveryTest {
 
    protected void runTest(int where) {
       List<Long> internalIds = getInternalIds(recoveryOps(where).showInDoubtTransactions());
-      log.info("About to force commit!");
+      log.debugf("About to force commit on node %s", address(where));
       recoveryOps(where).forceCommit(internalIds.get(0));
       assertCleanup(0);
       assertCleanup(1);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4137

I don't have a test that triggers a topology update and re-runs the commit command (yet). But I've removed the skipTransactionCompletedCheck flag, so a commit for a command that has been already committed should now be ignored.
- Remove the "skipTransactionCompletedCheck" transaction flag.
- Only mark the transaction as completed after running the prepare from
  state transfer (if needed).
- Do not try to roll back if commit fails and recovery is enabled.
