### PR TITLE
ISPN-4184 Expose the Unsafe API from JDK to make Netty more efficient with native buffers

### DIFF
--- a/server/integration/build/src/main/resources-ispn/modules/system/layers/base/io/netty/main/module.xml
+++ b/server/integration/build/src/main/resources-ispn/modules/system/layers/base/io/netty/main/module.xml
@@ -29,5 +29,6 @@
 
     <dependencies>
         <module name="javax.api"/>
+        <module name="sun.jdk"/>
     </dependencies>
 </module>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4184
