### PR TITLE
ISPN-3761 Tests from org.infinispan.query.dsl.embedded package fail on a...

### DIFF
--- a/query/src/test/java/org/infinispan/query/dsl/embedded/FilesystemQueryDslIterationTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/FilesystemQueryDslIterationTest.java
@@ -5,6 +5,8 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -32,22 +34,14 @@ public class FilesystemQueryDslIterationTest extends QueryDslIterationTest {
       return TestCacheManagerFactory.createCacheManager(cfg);
    }
 
-   @Override
-   protected void setup() throws Exception {
+   @BeforeClass(alwaysRun = true)
+   protected void setUp() throws Exception {
       TestingUtil.recursiveFileRemove(indexDirectory);
-      boolean created = new File(indexDirectory).mkdirs();
-      assertTrue(created);
-      super.setup();
+      new File(indexDirectory).mkdirs();
    }
 
-   @Override
-   protected void teardown() {
-      try {
-         //first stop cache managers, then clear the index
-         super.teardown();
-      } finally {
-         //delete the index otherwise it will mess up the index for next tests
-         TestingUtil.recursiveFileRemove(indexDirectory);
-      }
+   @AfterClass(alwaysRun = true)
+   protected void tearDown() {
+      TestingUtil.recursiveFileRemove(indexDirectory);
    }
 }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslIterationTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslIterationTest.java
@@ -8,9 +8,11 @@ import org.infinispan.query.dsl.QueryBuilder;
 import org.infinispan.query.dsl.QueryFactory;
 import org.infinispan.query.dsl.SortOrder;
 import org.infinispan.query.dsl.embedded.sample_domain_model.User;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.testng.AssertJUnit.assertEquals;
@@ -25,6 +27,8 @@ import static org.testng.AssertJUnit.assertTrue;
  */
 @Test(groups = "functional", testName = "query.dsl.QueryDslIterationTest")
 public class QueryDslIterationTest extends AbstractQueryDslTest {
+
+   private List<String> entryIds = new ArrayList<String>();
 
    @BeforeMethod
    protected void populateCache() throws Exception {
@@ -52,6 +56,20 @@ public class QueryDslIterationTest extends AbstractQueryDslTest {
       cache.put("user_" + user2.getId(), user2);
       cache.put("user_" + user3.getId(), user3);
       cache.put("user_" + user4.getId(), user4);
+
+      //track what we stored in the cache (for distributed caches the keySet is not enough)
+      entryIds.add("user_" + user1.getId());
+      entryIds.add("user_" + user2.getId());
+      entryIds.add("user_" + user3.getId());
+      entryIds.add("user_" + user4.getId());
+   }
+
+   @AfterMethod
+   protected void cleanCache() {
+      for (String s : entryIds) {
+         cache.remove(s);
+      }
+      entryIds.clear();
    }
 
    public void testOrderByAsc() throws Exception {


### PR DESCRIPTION
...ll environmets

https://issues.jboss.org/browse/ISPN-3761

I made the tests more robust. Instead of manually removing (cleaning) the index from the file system after each method, I only do it BeforeClass and AfterClass, and remove cache entries after each test method (which results in removing them from the index as well, i.e. cleaning the index for next test method). 

Also, I did not use cache.clear() because it takes too long (a few seconds) to execute it together with TestingUtil.killCacheManagers. Removing individual entries is much faster.

Tested on Win 2012 - passed.
