### PR TITLE
ISPN-4194 VersionedDistStateTransferTest.testStateTransfer random failures

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ReplicationRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ReplicationRetryTest.java
@@ -11,6 +11,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.test.TestingUtil;
 import org.testng.annotations.Test;
 
 /**
@@ -131,7 +132,7 @@ public class ReplicationRetryTest extends AbstractRetryTest {
       for (Iterator<EmbeddedCacheManager> ecmIt = cacheManagers.iterator(); ecmIt.hasNext();) {
          if (ecmIt.next().getAddress().equals(expectedServer)) ecmIt.remove();
       }
-      waitForClusterToForm();
+      TestingUtil.waitForRehashToComplete(caches());
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/container/versioning/VersionedDistStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/VersionedDistStateTransferTest.java
@@ -9,6 +9,7 @@ import org.infinispan.distribution.MagicKey;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.LockingMode;
@@ -93,7 +94,7 @@ public class VersionedDistStateTransferTest extends MultipleCacheManagersTest {
       manager(3).stop();
       // Eliminate the dead cache from the caches collection, cache4 now becomes cache(3)
       cacheManagers.remove(3);
-      waitForClusterToForm();
+      TestingUtil.waitForRehashToComplete(caches());
 
       log.debugf("Leaver stopped, checking transferred data");
       checkStateTransfer(keys, values);

--- a/core/src/test/java/org/infinispan/container/versioning/VersionedReplStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/VersionedReplStateTransferTest.java
@@ -5,6 +5,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.VersioningScheme;
 import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.LockingMode;
@@ -70,7 +71,7 @@ public class VersionedReplStateTransferTest extends MultipleCacheManagersTest {
 
       cacheManagers.get(0).stop();
       cacheManagers.remove(0);
-      waitForClusterToForm();
+      TestingUtil.waitForRehashToComplete(caches());
 
       // Cause a write skew
       cache2.put("hello", "new world");

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxPutIfAbsentDuringLeaveStressTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxPutIfAbsentDuringLeaveStressTest.java
@@ -10,6 +10,7 @@ import org.infinispan.remoting.RemoteException;
 import org.infinispan.remoting.transport.jgroups.SuspectException;
 import org.infinispan.statetransfer.OutdatedTopologyException;
 import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.TransactionMode;
 import org.testng.annotations.Test;
@@ -104,10 +105,10 @@ public class NonTxPutIfAbsentDuringLeaveStressTest extends MultipleCacheManagers
       }
 
       killMember(4);
-      waitForClusterToForm();
+      TestingUtil.waitForRehashToComplete(caches());
 
       killMember(3);
-      waitForClusterToForm();
+      TestingUtil.waitForRehashToComplete(caches());
 
       stop = true;
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4194

Use waitForRehashToComplete() instead of waitForClusterToForm().
