### PR TITLE
ISPN-4196 Local transaction not removed from transaction table with keyS...

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/TxInterceptor.java
@@ -8,7 +8,10 @@ import javax.transaction.Transaction;
 
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.control.LockControlCommand;
+import org.infinispan.commands.read.EntrySetCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
+import org.infinispan.commands.read.KeySetCommand;
+import org.infinispan.commands.read.ValuesCommand;
 import org.infinispan.commands.tx.AbstractTransactionBoundaryCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
@@ -203,6 +206,21 @@ public class TxInterceptor extends CommandInterceptor {
    @Override
    public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) throws Throwable {
       return enlistWriteAndInvokeNext(ctx, command);
+   }
+
+   @Override
+   public Object visitKeySetCommand(InvocationContext ctx, KeySetCommand command) throws Throwable {
+      return enlistReadAndInvokeNext(ctx, command);
+   }
+
+   @Override
+   public Object visitValuesCommand(InvocationContext ctx, ValuesCommand command) throws Throwable {
+      return enlistReadAndInvokeNext(ctx, command);
+   }
+
+   @Override
+   public Object visitEntrySetCommand(InvocationContext ctx, EntrySetCommand command) throws Throwable {
+      return enlistReadAndInvokeNext(ctx, command);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -831,6 +831,10 @@ public class TestingUtil {
       return gcr.getComponent(ExternalizerTable.class);
    }
 
+   public static TransactionTable extractTxTable(Cache<Object, Object> c) {
+      return (TransactionTable) TestingUtil.extractField(c, "txTable");
+   }
+
    /**
     * Replaces the existing interceptor chain in the cache wih one represented by the interceptor passed in.  This
     * utility updates dependencies on all components that rely on the interceptor chain as well.

--- a/core/src/test/java/org/infinispan/tx/LocalModeTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/LocalModeTxTest.java
@@ -5,10 +5,12 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.impl.TransactionTable;
 import org.testng.annotations.Test;
 
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
+import static org.infinispan.test.TestingUtil.extractTxTable;
 
 @Test(groups = "functional", testName = "tx.LocalModeTxTest")
 public class LocalModeTxTest extends SingleCacheManagerTest {
@@ -102,5 +104,32 @@ public class LocalModeTxTest extends SingleCacheManagerTest {
       tm().rollback();
       assert cache.keySet().size() == 2;
       assert cache.values().size() == 2;
+   }
+
+   public void testTxCleanupWithKeySet() throws Exception {
+      tm().begin();
+      assert cache.keySet().size() == 0;
+      TransactionTable txTable = extractTxTable(cache);
+      assert txTable.getLocalTransactions().size() == 1;
+      tm().commit();
+      assert txTable.getLocalTransactions().size() == 0;
+   }
+
+   public void testTxCleanupWithEntrySet() throws Exception {
+      tm().begin();
+      assert cache.entrySet().size() == 0;
+      TransactionTable txTable = extractTxTable(cache);
+      assert txTable.getLocalTransactions().size() == 1;
+      tm().commit();
+      assert txTable.getLocalTransactions().size() == 0;
+   }
+
+   public void testTxCleanupWithValues() throws Exception {
+      tm().begin();
+      assert cache.values().size() == 0;
+      TransactionTable txTable = extractTxTable(cache);
+      assert txTable.getLocalTransactions().size() == 1;
+      tm().commit();
+      assert txTable.getLocalTransactions().size() == 0;
    }
 }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslIterationTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslIterationTest.java
@@ -28,8 +28,6 @@ import static org.testng.AssertJUnit.assertTrue;
 @Test(groups = "functional", testName = "query.dsl.QueryDslIterationTest")
 public class QueryDslIterationTest extends AbstractQueryDslTest {
 
-   private List<String> entryIds = new ArrayList<String>();
-
    @BeforeMethod
    protected void populateCache() throws Exception {
       User user1 = new User();
@@ -56,20 +54,11 @@ public class QueryDslIterationTest extends AbstractQueryDslTest {
       cache.put("user_" + user2.getId(), user2);
       cache.put("user_" + user3.getId(), user3);
       cache.put("user_" + user4.getId(), user4);
-
-      //track what we stored in the cache (for distributed caches the keySet is not enough)
-      entryIds.add("user_" + user1.getId());
-      entryIds.add("user_" + user2.getId());
-      entryIds.add("user_" + user3.getId());
-      entryIds.add("user_" + user4.getId());
    }
 
    @AfterMethod
    protected void cleanCache() {
-      for (String s : entryIds) {
-         cache.remove(s);
-      }
-      entryIds.clear();
+      cache.clear();
    }
 
    public void testOrderByAsc() throws Exception {


### PR DESCRIPTION
...et, entrySet, values operations

https://issues.jboss.org/browse/ISPN-4196

This happens only if there's not yet a local transaction registered in the transaction table. Se we haven't seen it yet because all tests first store some data with e.g. a put operation which creates the local transaction. However, this was a problem for Query because QueryInterceptor uses another cache and calls keySet on it as its first operation (without preceding put or so).
