### PR TITLE
Properly fix the server testsuite by making it use the 7.0 schema

### DIFF
--- a/server/integration/build/src/main/resources-ispn/configuration/examples/subsystems/infinispan.xml
+++ b/server/integration/build/src/main/resources-ispn/configuration/examples/subsystems/infinispan.xml
@@ -2,7 +2,7 @@
 <!-- See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config default-supplement="default">
    <extension-module>org.jboss.as.clustering.infinispan</extension-module>
-   <subsystem xmlns="urn:infinispan:server:core:6.0" default-cache-container="@@default-cache-container@@">
+   <subsystem xmlns="urn:infinispan:server:core:7.0" default-cache-container="@@default-cache-container@@">
       <?CACHE-CONTAINERS?>
    </subsystem>
    <supplement name="ccl-clustered">

--- a/server/integration/build/src/main/resources-ispn/configuration/subsystems/infinispan.xml
+++ b/server/integration/build/src/main/resources-ispn/configuration/subsystems/infinispan.xml
@@ -2,7 +2,7 @@
 <!-- See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config default-supplement="default">
    <extension-module>org.jboss.as.clustering.infinispan</extension-module>
-   <subsystem xmlns="urn:infinispan:server:core:6.0" default-cache-container="@@default-cache-container@@">
+   <subsystem xmlns="urn:infinispan:server:core:7.0" default-cache-container="@@default-cache-container@@">
       <?CACHE-CONTAINERS?>
    </subsystem>
    <supplement name="default">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/asymmetric-1.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/asymmetric-1.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:infinispan:server:core:6.0">
+<subsystem xmlns="urn:infinispan:server:core:7.0">
     <cache-container name="clustered" default-cache="memcachedCache">
         <transport stack="${jboss.default.jgroups.stack:udp}" executor="infinispan-transport" lock-timeout="240000"/>
         <distributed-cache name="memcachedCache" mode="SYNC" segments="20" owners="2" remote-timeout="30000" start="EAGER" />

--- a/server/integration/testsuite/src/test/resources/config/infinispan/asymmetric-2.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/asymmetric-2.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:infinispan:server:core:6.0">
+<subsystem xmlns="urn:infinispan:server:core:7.0">
     <cache-container name="clustered" default-cache="memcachedCache">
         <transport stack="${jboss.default.jgroups.stack:udp}" executor="infinispan-transport" lock-timeout="240000"/>
         <distributed-cache name="memcachedCache" mode="SYNC" segments="20" owners="2" remote-timeout="30000" start="EAGER" />

--- a/server/integration/testsuite/src/test/resources/config/infinispan/cachecontainer.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/cachecontainer.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:infinispan:server:core:6.0">
+<subsystem xmlns="urn:infinispan:server:core:7.0">
     <cache-container name="default" default-cache="default" listener-executor="test-infinispan-listener" eviction-executor="test-infinispan-eviction" replication-queue-executor="test-infinispan-repl-queue">
         <local-cache name="default" batching="false" />
     </cache-container>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/clusteredcache.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/clusteredcache.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:infinispan:server:core:6.0">
+<subsystem xmlns="urn:infinispan:server:core:7.0">
     <cache-container name="clustered" default-cache="queueSizeCache">
         <transport stack="udp" executor="infinispan-transport" lock-timeout="240000"/>
         <replicated-cache name="memcachedCache" start="EAGER" mode="ASYNC" queue-size="1000" queue-flush-interval="3000"/>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/customcs.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/customcs.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:infinispan:server:core:6.0">
+<subsystem xmlns="urn:infinispan:server:core:7.0">
     <cache-container name="local" default-cache="default">
         <local-cache name="default" start="EAGER">
             <store name="customStore" class="org.infinispan.persistence.cluster.MyCustomCacheStore">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/default-dist.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/default-dist.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+        <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container 
                 name="clustered"
                 default-cache="testcache">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/default-local.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/default-local.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+        <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container 
                 name="local"
                 default-cache="testcache">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/default-repl.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/default-repl.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+        <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container 
                 name="clustered"
                 default-cache="testcache">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/eviction.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/eviction.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:infinispan:server:core:6.0">
+<subsystem xmlns="urn:infinispan:server:core:7.0">
      <cache-container name="local" default-cache="none">
          <local-cache name="none" start="EAGER">
              <eviction strategy="NONE" />

--- a/server/integration/testsuite/src/test/resources/config/infinispan/expiration.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/expiration.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:infinispan:server:core:6.0">
+<subsystem xmlns="urn:infinispan:server:core:7.0">
     <cache-container name="clustered" default-cache="default">
         <transport stack="udp" executor="infinispan-transport" lock-timeout="240000"/>
         <replicated-cache name="hotrodExpiration" start="EAGER" mode="SYNC" batching="false" remote-timeout="30000">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/filecachestore.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/filecachestore.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:infinispan:server:core:6.0">
+<subsystem xmlns="urn:infinispan:server:core:7.0">
     <cache-container name="local" default-cache="default">
         <local-cache name="default" start="EAGER">
             <file-store name="myFileStore" passivation="false" purge="false" max-entries="2" />

--- a/server/integration/testsuite/src/test/resources/config/infinispan/indexing-clustered.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/indexing-clustered.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+        <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container 
                 name="clustered"
                 default-cache="testcache">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/indexing-distributed.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/indexing-distributed.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+        <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container 
                 name="clustered"
                 default-cache="testcache">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/indexing.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/indexing.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+        <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container 
                 name="local"
                 default-cache="testcache">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-binary-no-passivation.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-binary-no-passivation.xml
@@ -1,4 +1,4 @@
-       <subsystem xmlns="urn:infinispan:server:core:6.0" >
+       <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container name="local" default-cache="defaultx/xx" start="EAGER">
                 <local-cache 
                     name="defaultx/xx"

--- a/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-binary-with-passivation.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-binary-with-passivation.xml
@@ -1,4 +1,4 @@
-       <subsystem xmlns="urn:infinispan:server:core:6.0" >
+       <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container name="local" default-cache="default" start="EAGER">
                 <local-cache 
                     name="default"

--- a/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-mixed-no-passivation.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-mixed-no-passivation.xml
@@ -1,4 +1,4 @@
-       <subsystem xmlns="urn:infinispan:server:core:6.0" >
+       <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container name="local" default-cache="memcachedCache" start="EAGER">
                 <local-cache 
                     name="memcachedCache"

--- a/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-mixed-with-passivation.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-mixed-with-passivation.xml
@@ -1,4 +1,4 @@
-       <subsystem xmlns="urn:infinispan:server:core:6.0" >
+       <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container name="local" default-cache="memcachedCache" start="EAGER">
                 <local-cache 
                     name="memcachedCache"

--- a/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-string-async.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-string-async.xml
@@ -1,4 +1,4 @@
-       <subsystem xmlns="urn:infinispan:server:core:6.0" >
+       <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container name="local" default-cache="memcachedCache" start="EAGER">
                 <local-cache 
                     name="memcachedCache"

--- a/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-string-invalidation.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-string-invalidation.xml
@@ -1,4 +1,4 @@
-       <subsystem xmlns="urn:infinispan:server:core:6.0" >
+       <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container name="clustered" default-cache="memcachedCache">
                 <transport
                         stack="${jboss.default.jgroups.stack:udp}"

--- a/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-string-multinode-fetch-state.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-string-multinode-fetch-state.xml
@@ -1,4 +1,4 @@
-       <subsystem xmlns="urn:infinispan:server:core:6.0" >
+       <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container name="clustered" default-cache="memcachedCache" start="EAGER">
                 <transport
                         stack="${jboss.default.jgroups.stack:udp}"

--- a/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-string-multinode-singleton.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-string-multinode-singleton.xml
@@ -1,4 +1,4 @@
-       <subsystem xmlns="urn:infinispan:server:core:6.0" >
+       <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container name="clustered" default-cache="memcachedCache" start="EAGER">
                 <transport
                         stack="${jboss.default.jgroups.stack:udp}"

--- a/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-string-no-passivation.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-string-no-passivation.xml
@@ -1,4 +1,4 @@
-       <subsystem xmlns="urn:infinispan:server:core:6.0" >
+       <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container name="local" default-cache="default" start="EAGER">
                 <local-cache
                     name="memcachedCache"

--- a/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-string-with-passivation.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/jdbc-string-with-passivation.xml
@@ -1,4 +1,4 @@
-       <subsystem xmlns="urn:infinispan:server:core:6.0" >
+       <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container name="local" default-cache="memcachedCache" start="EAGER">
                 <local-cache 
                     name="memcachedCache"

--- a/server/integration/testsuite/src/test/resources/config/infinispan/jmx.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/jmx.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:infinispan:server:core:6.0" >
+<subsystem xmlns="urn:infinispan:server:core:7.0" >
     <cache-container name="clustered" default-cache="default">
         <transport stack="${jboss.default.jgroups.stack:udp}" executor="infinispan-transport" lock-timeout="240000"/>
         <distributed-cache

--- a/server/integration/testsuite/src/test/resources/config/infinispan/l1.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/l1.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+        <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container 
                 name="clustered"
                 default-cache="memcachedCache">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/leveldb-dist.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/leveldb-dist.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+        <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container 
                 name="clustered"
                 default-cache="testcache">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/leveldb-local.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/leveldb-local.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+        <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container 
                 name="local"
                 default-cache="testcache">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/leveldb-repl.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/leveldb-repl.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+        <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container 
                 name="clustered"
                 default-cache="testcache">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/rcs-local.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/rcs-local.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+        <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container 
                 name="local"
                 default-cache="memcachedCache">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/rcs-remote.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/rcs-remote.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+        <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container 
                 name="local"
                 default-cache="default">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/rest-security.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/rest-security.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:6.0" >
+        <subsystem xmlns="urn:infinispan:server:core:7.0" >
             <cache-container 
                 name="security"
                 default-cache="default">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/suppress-state-transfer.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/suppress-state-transfer.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:infinispan:server:core:6.0" >
+<subsystem xmlns="urn:infinispan:server:core:7.0" >
     <cache-container name="clustered" default-cache="default">
         <transport stack="${jboss.default.jgroups.stack:udp}" executor="infinispan-transport" lock-timeout="240000"/>
         <distributed-cache

--- a/server/integration/testsuite/src/test/resources/config/infinispan/xsite-server2.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/xsite-server2.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:infinispan:server:core:6.0" >
+<subsystem xmlns="urn:infinispan:server:core:7.0" >
     <cache-container name="clustered" default-cache="default">
         <transport executor="infinispan-transport" lock-timeout="60000" cluster="LON" stack="${jboss.default.jgroups.stack:udp}"/>
         <distributed-cache name="default" mode="SYNC" segments="20" owners="2" remote-timeout="30000" start="EAGER">

--- a/server/integration/testsuite/src/test/resources/config/infinispan/xsite-server3.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/xsite-server3.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:infinispan:server:core:6.0" >
+<subsystem xmlns="urn:infinispan:server:core:7.0" >
     <cache-container name="clustered" default-cache="default">
         <transport executor="infinispan-transport" lock-timeout="60000" cluster="NYC" stack="${jboss.default.jgroups.stack:udp}"/>
         <distributed-cache name="default" mode="SYNC" segments="20" owners="2" remote-timeout="30000" start="EAGER">

--- a/server/integration/testsuite/src/test/resources/config/xslt/config-modifier.xsl
+++ b/server/integration/testsuite/src/test/resources/config/xslt/config-modifier.xsl
@@ -3,7 +3,7 @@
                 xmlns:logging="urn:jboss:domain:logging:1.2"
                 xmlns:p="urn:jboss:domain:1.4"
                 xmlns:jgroups="urn:jboss:domain:jgroups:1.2"
-                xmlns:core="urn:infinispan:server:core:6.0"
+                xmlns:core="urn:infinispan:server:core:7.0"
                 xmlns:threads="urn:jboss:domain:threads:1.1"
                 xmlns:datasources="urn:jboss:domain:datasources:1.1"
                 xmlns:endpoint="urn:infinispan:server:endpoint:6.0">


### PR DESCRIPTION
Properly fix the server testsuite by making it use the 7.0 schema (instead of downgrading the distributed configuration schema)
