### PR TITLE
ISPN-4250 PR for ISPN-4190 causes a performance drop in repl mode

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
@@ -319,11 +319,9 @@ public class CommandAwareRpcDispatcher extends RpcDispatcher {
       if (oob || mode != ResponseMode.GET_NONE) msg.setFlag(Message.Flag.DONT_BUNDLE);
       if (rsvp) msg.setFlag(Message.Flag.RSVP);
 
-      // The sequencer is in the protocol stack so we need to bypass the protocol when total order is not enabled
-      // Without total order, we also have to prevent the local node from receiving the message.
+      //In total order protocol, the sequencer is in the protocol stack so we need to bypass the protocol
       if(!totalOrder) {
          msg.setFlag(Message.Flag.NO_TOTAL_ORDER);
-         msg.setTransientFlag(Message.TransientFlag.DONT_LOOPBACK);
       } else {
          msg.clearFlag(Message.Flag.OOB);
       }
@@ -391,9 +389,16 @@ public class CommandAwareRpcDispatcher extends RpcDispatcher {
          buf = marshallCall(marshaller, command);
          RequestOptions opts = new RequestOptions(mode, timeout, false, filter);
 
+         //Only the commands in total order must be received...
+         //For correctness, ispn doesn't need their own message, so add own address to exclusion list
+         opts.setExclusionList(card.getChannel().getAddress());
+
          retval = card.castMessage(dests, constructMessage(buf, null, oob, mode, rsvp, false),opts);
       } else {
          RequestOptions opts = new RequestOptions(mode, timeout);
+
+         //Only the commands in total order must be received...
+         opts.setExclusionList(card.getChannel().getAddress());
 
          if (dests.isEmpty()) return new RspList<Object>();
          buf = marshallCall(marshaller, command);


### PR DESCRIPTION
Revert "ISPN-4190 Use Message.Flag.DONT_LOOPBACK instead of RequestOptions.setExclusionList"

This reverts commit 5117fd30c1a487688bca9c75b9426b0db49bda05.
- This is reverted until JGroups bug can be fixed for DONT_LOOPBACK

https://issues.jboss.org/browse/ISPN-4250
