### PR TITLE
ISPN-4296 Restore predefined cache limitation for Hot Rod servers

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientAsymmetricClusterTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientAsymmetricClusterTest.java
@@ -31,6 +31,8 @@ public class ClientAsymmetricClusterTest extends MultiHotRodServersTest {
       manager(0).defineConfiguration(CACHE_NAME, builder.build());
    }
 
+   @Test(expectedExceptions = HotRodClientException.class,
+         expectedExceptionsMessageRegExp = ".*CacheNotFoundException.*")
    public void testAsymmetricCluster() {
       RemoteCacheManager client0 = client(0);
       RemoteCache<Object, Object> cache0 = client0.getCache(CACHE_NAME);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteCacheManagerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteCacheManagerTest.java
@@ -120,7 +120,7 @@ public class RemoteCacheManagerTest extends SingleCacheManagerTest {
       remoteCacheManager = new RemoteCacheManager(p, false);
       assert !remoteCacheManager.isStarted();
       remoteCacheManager.start();
-      assert null != remoteCacheManager.getCache("Undefined1234");
+      assert null == remoteCacheManager.getCache("Undefined1234");
    }
 
    private void assertWorks(RemoteCacheManager remoteCacheManager) {

--- a/server/core/src/test/scala/org/infinispan/server/core/AbstractProtocolServerTest.scala
+++ b/server/core/src/test/scala/org/infinispan/server/core/AbstractProtocolServerTest.scala
@@ -63,13 +63,15 @@ class AbstractProtocolServerTest {
 
       override def startInternal(configuration: MockServerConfiguration, cacheManager: EmbeddedCacheManager) {
          super.startInternal(configuration, cacheManager)
-         this.tcpNoDelay = configuration.tcpNoDelay
       }
 
       override def getEncoder = null
 
       override def getDecoder = null
 
+      override def startTransport {
+         this.tcpNoDelay = configuration.tcpNoDelay
+      }
    }
 
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/OperationStatus.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/OperationStatus.scala
@@ -15,9 +15,9 @@ object OperationStatus extends Enumeration {
 
    val InvalidMagicOrMsgId = Value(0x81)
    val UnknownOperation = Value(0x82)
-   val UnknownVersion = Value(0x83)
-   val ParseError = Value(0x84)
-   val ServerError = Value(0x85)
-   val OperationTimedOut = Value(0x86)
+   val UnknownVersion = Value(0x83) // todo: test
+   val ParseError = Value(0x84) // todo: test
+   val ServerError = Value(0x85) // todo: test
+   val OperationTimedOut = Value(0x86) // todo: test
 
 }

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodAsymmetricClusterTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodAsymmetricClusterTest.scala
@@ -45,7 +45,7 @@ class HotRodAsymmetricClusterTest extends HotRodMultiNodeTest {
 
    def testPutInNonCacheDefinedNode(m: Method) {
       val resp = clients.tail.head.put(k(m) , 0, 0, v(m))
-      assertStatus(resp, Success)
+      assertStatus(resp, ParseError)
    }
 
 }

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodFunctionalTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodFunctionalTest.scala
@@ -50,9 +50,10 @@ class HotRodFunctionalTest extends HotRodSingleNodeTest {
    }
 
    def testPutOnUndefinedCache(m: Method) {
-      val resp = client.execute(0xA0, 0x01, "boomooo", k(m), 0, 0, v(m), 0, 1, 0)
-      assertStatus(resp, Success)
-      assertHotRodEquals(cacheManager, "boomooo", k(m), v(m))
+      val resp = client.execute(0xA0, 0x01, "boomooo", k(m), 0, 0, v(m), 0, 1, 0).asInstanceOf[TestErrorResponse]
+      assertTrue(resp.msg.contains("CacheNotFoundException"))
+      assertEquals(resp.status, ParseError, "Status should have been 'ParseError' but instead was: " + resp.status)
+      client.assertPut(m)
    }
 
    def testPutOnTopologyCache(m: Method) {

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/AbstractRemoteCacheManagerTest.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/AbstractRemoteCacheManagerTest.java
@@ -184,8 +184,13 @@ public abstract class AbstractRemoteCacheManagerTest {
         RemoteCacheManager rcm = new RemoteCacheManager(createRemoteCacheManagerConfigurationBuilder().build());
         RemoteCache rc1 = rcm.getCache("nonExistentCache");
 
-        for (String stat : rc1.stats().getStatsMap().keySet()) {
-            System.out.println(stat + " " + rc1.stats().getStatsMap().get(stat));
+        try {
+            for (String stat : rc1.stats().getStatsMap().keySet()) {
+                System.out.println(stat + " " + rc1.stats().getStatsMap().get(stat));
+            }
+            fail("Should throw CacheNotFoundException");
+        } catch (Exception e) {
+            //ok
         }
     }
 

--- a/server/rest/src/main/scala/org/infinispan/rest/Server.scala
+++ b/server/rest/src/main/scala/org/infinispan/rest/Server.scala
@@ -499,7 +499,12 @@ class Server(@Context request: Request, @Context servletContext: ServletContext,
    private def lastModified[K, V](ice: InternalCacheEntry[K, V]): Date = { new Date(ice.getCreated / 1000 * 1000) }
 
    private def protectCacheNotFound(request: Request, useAsync: Boolean) (op: (Request, Boolean) => Response): Response = {
-      op(request, useAsync)
+      try {
+         op(request, useAsync)
+      } catch {
+         case e: CacheNotFoundException =>
+            Response.status(Status.NOT_FOUND).build
+      }
    }
 
 }
@@ -513,6 +518,8 @@ class ManagerInstance(instance: EmbeddedCacheManager) {
 
    def getCache(name: String): AdvancedCache[String, Array[Byte]] = {
       val isKnownCache = knownCaches.containsKey(name)
+      if (name != BasicCacheContainer.DEFAULT_CACHE_NAME && !isKnownCache && !instance.getCacheNames.contains(name))
+         throw new CacheNotFoundException("Cache with name '" + name + "' not found amongst the configured caches")
 
       if (isKnownCache) {
          knownCaches.get(name)
@@ -565,6 +572,8 @@ class ManagerInstance(instance: EmbeddedCacheManager) {
    }
 
 }
+
+class CacheNotFoundException(msg: String) extends CacheException(msg)
 
 object Escaper {
    def escapeHtml(html: String): String = {

--- a/server/rest/src/test/scala/org/infinispan/rest/IntegrationTest.scala
+++ b/server/rest/src/test/scala/org/infinispan/rest/IntegrationTest.scala
@@ -629,7 +629,7 @@ class IntegrationTest extends RestServerTestBase {
       val put = new PostMethod(fullPathKey)
       put.setRequestEntity(new StringRequestEntity("data", "application/text", "UTF-8"))
       call(put)
-      assertEquals(HttpServletResponse.SC_OK, put.getStatusCode)
+      assertEquals(HttpServletResponse.SC_NOT_FOUND, put.getStatusCode)
    }
 
    def testByteArrayAsSerializedObjects(m: Method) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4296
https://issues.jboss.org/browse/ISPN-833
- Revert "ISPN-833 Remove cache defined limitation for Infinispan servers"
- This reverts commit 2d5acd4bf685f27b45d43dbd0dea53ecea411527.
