### PR TITLE
ISPN-3530 ISPN-1855 Keep per-cache CH to route requests correctly

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AbstractKeyOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AbstractKeyOperation.java
@@ -37,9 +37,9 @@ public abstract class AbstractKeyOperation<T> extends RetryOnFailureOperation<T>
    @Override
    protected Transport getTransport(int retryCount, Set<SocketAddress> failedServers) {
       if (retryCount == 0) {
-         return transportFactory.getTransport(key, failedServers);
+         return transportFactory.getTransport(key, failedServers, cacheName);
       } else {
-         return transportFactory.getTransport(failedServers);
+         return transportFactory.getTransport(failedServers, cacheName);
       }
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AddClientListenerOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AddClientListenerOperation.java
@@ -63,7 +63,7 @@ public class AddClientListenerOperation extends RetryOnFailureOperation<Short> {
 
    @Override
    protected Transport getTransport(int retryCount, Set<SocketAddress> failedServers) {
-      this.dedicatedTransport = transportFactory.getTransport(failedServers);
+      this.dedicatedTransport = transportFactory.getTransport(failedServers, cacheName);
       return dedicatedTransport;
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/BulkGetKeysOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/BulkGetKeysOperation.java
@@ -27,7 +27,7 @@ public class BulkGetKeysOperation extends RetryOnFailureOperation<Set<byte[]>> {
    
    @Override
    protected Transport getTransport(int retryCount, Set<SocketAddress> failedServers) {
-      return transportFactory.getTransport(failedServers);
+      return transportFactory.getTransport(failedServers, cacheName);
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/BulkGetOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/BulkGetOperation.java
@@ -29,7 +29,7 @@ public class BulkGetOperation extends RetryOnFailureOperation<Map<byte[], byte[]
    
    @Override
    protected Transport getTransport(int retryCount, Set<SocketAddress> failedServers) {
-      return transportFactory.getTransport(failedServers);
+      return transportFactory.getTransport(failedServers, cacheName);
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ClearOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ClearOperation.java
@@ -27,7 +27,7 @@ public class ClearOperation extends RetryOnFailureOperation<Void> {
 
    @Override
    protected Transport getTransport(int retryCount, Set<SocketAddress> failedServers) {
-      return transportFactory.getTransport(failedServers);
+      return transportFactory.getTransport(failedServers, cacheName);
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/FaultTolerantPingOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/FaultTolerantPingOperation.java
@@ -24,7 +24,7 @@ public class FaultTolerantPingOperation extends RetryOnFailureOperation<PingOper
 
    @Override
    protected Transport getTransport(int retryCount, Set<SocketAddress> failedServers) {
-      return transportFactory.getTransport(failedServers);
+      return transportFactory.getTransport(failedServers, cacheName);
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
@@ -49,8 +49,7 @@ public class OperationsFactory implements HotRodConstants {
                             AtomicInteger topologyId, boolean forceReturnValue, Codec codec,
                             ClientListenerNotifier listenerNotifier) {
       this.transportFactory = transportFactory;
-      this.cacheNameBytes = cacheName.equals(RemoteCacheManager.DEFAULT_CACHE_NAME) ?
-            DEFAULT_CACHE_NAME_BYTES : cacheName.getBytes(HOTROD_STRING_CHARSET);
+      this.cacheNameBytes = RemoteCacheManager.cacheNameBytes(cacheName);
       this.topologyId = topologyId;
       this.forceReturnValue = forceReturnValue;
       this.codec = codec;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/QueryOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/QueryOperation.java
@@ -33,7 +33,7 @@ public class QueryOperation extends RetryOnFailureOperation<QueryResponse> {
 
    @Override
    protected Transport getTransport(int retryCount, Set<SocketAddress> failedServers) {
-      return transportFactory.getTransport(failedServers);
+      return transportFactory.getTransport(failedServers, cacheName);
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/StatsOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/StatsOperation.java
@@ -29,7 +29,7 @@ public class StatsOperation extends RetryOnFailureOperation<Map<String, String>>
 
    @Override
    protected Transport getTransport(int retryCount, Set<SocketAddress> failedServers) {
-      return transportFactory.getTransport(failedServers);
+      return transportFactory.getTransport(failedServers, cacheName);
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
@@ -178,10 +178,10 @@ public class Codec10 implements Codec {
    protected void readNewTopologyIfPresent(Transport transport, HeaderParams params) {
       short topologyChangeByte = transport.readByte();
       if (topologyChangeByte == 1)
-         readNewTopologyAndHash(transport, params.topologyId);
+         readNewTopologyAndHash(transport, params.topologyId, params.cacheName);
    }
 
-   protected void readNewTopologyAndHash(Transport transport, AtomicInteger topologyId) {
+   protected void readNewTopologyAndHash(Transport transport, AtomicInteger topologyId, byte[] cacheName) {
       final Log localLog = getLog();
       int newTopologyId = transport.readVInt();
       topologyId.set(newTopologyId);
@@ -199,12 +199,12 @@ public class Codec10 implements Codec {
          localLog.newTopology(transport.getRemoteSocketAddress(), newTopologyId,
                socketAddresses.size(), socketAddresses);
       }
-      transport.getTransportFactory().updateServers(socketAddresses);
+      transport.getTransportFactory().updateServers(socketAddresses, cacheName);
       if (hashFunctionVersion == 0) {
          localLog.trace("Not using a consistent hash function (hash function version == 0).");
       } else {
          transport.getTransportFactory().updateHashFunction(
-               servers2Hash, numKeyOwners, hashFunctionVersion, hashSpace);
+               servers2Hash, numKeyOwners, hashFunctionVersion, hashSpace, cacheName);
       }
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
@@ -307,10 +307,10 @@ public class Codec20 implements Codec, HotRodConstants {
    protected void readNewTopologyIfPresent(Transport transport, HeaderParams params) {
       short topologyChangeByte = transport.readByte();
       if (topologyChangeByte == 1)
-         readNewTopologyAndHash(transport, params.topologyId);
+         readNewTopologyAndHash(transport, params.topologyId, params.cacheName);
    }
 
-   protected void readNewTopologyAndHash(Transport transport, AtomicInteger topologyId) {
+   protected void readNewTopologyAndHash(Transport transport, AtomicInteger topologyId, byte[] cacheName) {
       final Log localLog = getLog();
       int newTopologyId = transport.readVInt();
       topologyId.set(newTopologyId);
@@ -340,12 +340,12 @@ public class Codec20 implements Codec, HotRodConstants {
          localLog.newTopology(transport.getRemoteSocketAddress(), newTopologyId,
                addresses.length, new HashSet<SocketAddress>(addressList));
       }
-      transport.getTransportFactory().updateServers(addressList);
+      transport.getTransportFactory().updateServers(addressList, cacheName);
       if (hashFunctionVersion == 0) {
          if (trace)
             localLog.trace("Not using a consistent hash function (hash function version == 0).");
       } else {
-         transport.getTransportFactory().updateHashFunction(segmentOwners, numSegments, hashFunctionVersion);
+         transport.getTransportFactory().updateHashFunction(segmentOwners, numSegments, hashFunctionVersion, cacheName);
       }
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
@@ -20,7 +20,7 @@ import org.infinispan.client.hotrod.impl.protocol.Codec;
  */
 public interface TransportFactory {
 
-   Transport getTransport(Set<SocketAddress> failedServers);
+   Transport getTransport(Set<SocketAddress> failedServers, byte[] cacheName);
 
    Transport getAddressTransport(SocketAddress server);
 
@@ -28,18 +28,21 @@ public interface TransportFactory {
 
    void start(Codec codec, Configuration configuration, AtomicInteger topologyId, ClientListenerNotifier listenerNotifier);
 
-   void updateServers(Collection<SocketAddress> newServers);
+   void updateServers(Collection<SocketAddress> newServers, byte[] cacheName);
 
    void destroy();
 
+   /**
+    * @deprecated Only called for Hot Rod 1.x protocol.
+    */
    @Deprecated
-   void updateHashFunction(Map<SocketAddress, Set<Integer>> servers2Hash, int numKeyOwners, short hashFunctionVersion, int hashSpace);
+   void updateHashFunction(Map<SocketAddress, Set<Integer>> servers2Hash, int numKeyOwners, short hashFunctionVersion, int hashSpace, byte[] cacheName);
 
-   void updateHashFunction(SocketAddress[][] segmentOwners, int numSegments, short hashFunctionVersion);
+   void updateHashFunction(SocketAddress[][] segmentOwners, int numSegments, short hashFunctionVersion, byte[] cacheName);
 
    ConsistentHashFactory getConsistentHashFactory();
 
-   Transport getTransport(byte[] key, Set<SocketAddress> failedServers);
+   Transport getTransport(byte[] key, Set<SocketAddress> failedServers, byte[] cacheName);
 
    boolean isTcpNoDelay();
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/SaslTransportObjectFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/SaslTransportObjectFactory.java
@@ -35,9 +35,9 @@ public class SaslTransportObjectFactory extends TransportObjectFactory {
    private static final String AUTO_CONF = "auth-conf";
    private final AuthenticationConfiguration configuration;
 
-   public SaslTransportObjectFactory(Codec codec, TcpTransportFactory tcpTransportFactory, AtomicInteger topologyId,
-         boolean pingOnStartup, AuthenticationConfiguration configuration) {
-      super(codec, tcpTransportFactory, topologyId, pingOnStartup);
+   public SaslTransportObjectFactory(Codec codec, TcpTransportFactory tcpTransportFactory,
+         AtomicInteger defaultCacheTopologyId, boolean pingOnStartup, AuthenticationConfiguration configuration) {
+      super(codec, tcpTransportFactory, defaultCacheTopologyId, pingOnStartup);
       this.configuration = configuration;
    }
 
@@ -48,7 +48,7 @@ public class SaslTransportObjectFactory extends TransportObjectFactory {
          log.tracef("Created tcp transport: %s", tcpTransport);
       }
 
-      List<String> serverMechs = mechList(tcpTransport, topologyId);
+      List<String> serverMechs = mechList(tcpTransport, defaultCacheTopologyId);
       if (!serverMechs.contains(configuration.saslMechanism())) {
          throw log.unsupportedMech(configuration.saslMechanism(), serverMechs);
       }
@@ -76,13 +76,13 @@ public class SaslTransportObjectFactory extends TransportObjectFactory {
       }
       byte response[] = saslClient.hasInitialResponse() ? evaluateChallenge(saslClient, EMPTY_BYTES) : EMPTY_BYTES;
 
-      byte challenge[] = auth(tcpTransport, topologyId, configuration.saslMechanism(), response);
+      byte challenge[] = auth(tcpTransport, defaultCacheTopologyId, configuration.saslMechanism(), response);
       while (!saslClient.isComplete() && challenge != null) {
          response = evaluateChallenge(saslClient, challenge);
          if (response == null) {
             break;
          }
-         challenge = auth(tcpTransport, topologyId, "", response);
+         challenge = auth(tcpTransport, defaultCacheTopologyId, "", response);
       }
 
       /*String qop = (String) saslClient.getNegotiatedProperty(Sasl.QOP);
@@ -97,7 +97,7 @@ public class SaslTransportObjectFactory extends TransportObjectFactory {
 
          // Don't ignore exceptions from ping() command, since
          // they indicate that the transport instance is invalid.
-         ping(tcpTransport, topologyId);
+         ping(tcpTransport, defaultCacheTopologyId);
       }
       return tcpTransport;
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/TcpTransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/TcpTransportFactory.java
@@ -16,6 +16,7 @@ import net.jcip.annotations.ThreadSafe;
 
 import org.apache.commons.pool.KeyedObjectPool;
 import org.apache.commons.pool.impl.GenericKeyedObjectPool;
+import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.configuration.ServerConfiguration;
 import org.infinispan.client.hotrod.configuration.SslConfiguration;
@@ -29,6 +30,9 @@ import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
+import org.infinispan.commons.equivalence.AnyEquivalence;
+import org.infinispan.commons.equivalence.ByteArrayEquivalence;
+import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.commons.util.SslContextFactory;
 import org.infinispan.commons.util.Util;
 
@@ -42,15 +46,18 @@ public class TcpTransportFactory implements TransportFactory {
    private static final Log log = LogFactory.getLog(TcpTransportFactory.class, Log.class);
 
    /**
-    * We need synchronization as the thread that calls {@link org.infinispan.client.hotrod.impl.transport.TransportFactory#start(org.infinispan.client.hotrod.impl.protocol.Codec, org.infinispan.client.hotrod.configuration.Configuration, java.util.concurrent.atomic.AtomicInteger, org.infinispan.client.hotrod.event.ClientListenerNotifier)}
-    * might(and likely will) be different from the thread(s) that calls {@link org.infinispan.client.hotrod.impl.transport.TransportFactory#getTransport(java.util.Set)} or other methods
+    * We need synchronization as the thread that calls {@link TransportFactory#start(org.infinispan.client.hotrod.impl.protocol.Codec, org.infinispan.client.hotrod.configuration.Configuration, java.util.concurrent.atomic.AtomicInteger, org.infinispan.client.hotrod.event.ClientListenerNotifier)}
+    * might(and likely will) be different from the thread(s) that calls {@link TransportFactory#getTransport(byte[], java.util.Set, byte[])} or other methods
     */
    private final Object lock = new Object();
    // The connection pool implementation is assumed to be thread-safe, so we need to synchronize just the access to this field and not the method calls
    private GenericKeyedObjectPool<SocketAddress, TcpTransport> connectionPool;
-   private FailoverRequestBalancingStrategy balancer;
+   // Per cache request balancing strategy
+   private Map<byte[], FailoverRequestBalancingStrategy> balancers;
+   // Per cache consistent hash
+   private Map<byte[], ConsistentHash> consistentHashes;
+   private Configuration configuration;
    private Collection<SocketAddress> servers;
-   private ConsistentHash consistentHash;
    private final ConsistentHashFactory hashFactory = new ConsistentHashFactory();
 
    // the primitive fields are often accessed separately from the rest so it makes sense not to require synchronization for them
@@ -64,9 +71,10 @@ public class TcpTransportFactory implements TransportFactory {
    private volatile AtomicInteger topologyId;
 
    @Override
-   public void start(Codec codec, Configuration configuration, AtomicInteger topologyId, ClientListenerNotifier listenerNotifier) {
+   public void start(Codec codec, Configuration configuration, AtomicInteger defaultCacheTopologyId, ClientListenerNotifier listenerNotifier) {
       synchronized (lock) {
          this.listenerNotifier = listenerNotifier;
+         this.configuration = configuration;
          hashFactory.init(configuration);
          boolean pingOnStartup = configuration.pingOnStartup();
          servers = new ArrayList<SocketAddress>();
@@ -74,8 +82,6 @@ public class TcpTransportFactory implements TransportFactory {
             servers.add(new InetSocketAddress(server.host(), server.port()));
          }
          servers = Collections.unmodifiableCollection(servers);
-         balancer = createBalancer(configuration);
-
          tcpNoDelay = configuration.tcpNoDelay();
          tcpKeepAlive = configuration.tcpKeepAlive();
          soTimeout = configuration.socketTimeout();
@@ -94,34 +100,40 @@ public class TcpTransportFactory implements TransportFactory {
 
          if (log.isDebugEnabled()) {
             log.debugf("Statically configured servers: %s", servers);
-            log.debugf("Load balancer class: %s", balancer.getClass().getName());
+            log.debugf("Load balancer class: %s", configuration.balancingStrategy().getName());
             log.debugf("Tcp no delay = %b; client socket timeout = %d ms; connect timeout = %d ms",
                        tcpNoDelay, soTimeout, connectTimeout);
          }
          TransportObjectFactory connectionFactory;
          if (configuration.security().authentication().enabled()) {
-            connectionFactory = new SaslTransportObjectFactory(codec, this, topologyId, pingOnStartup, configuration.security().authentication());
+            connectionFactory = new SaslTransportObjectFactory(codec, this, defaultCacheTopologyId, pingOnStartup, configuration.security().authentication());
          } else {
-            connectionFactory = new TransportObjectFactory(codec, this, topologyId, pingOnStartup);
+            connectionFactory = new TransportObjectFactory(codec, this, defaultCacheTopologyId, pingOnStartup);
          }
          PropsKeyedObjectPoolFactory<SocketAddress, TcpTransport> poolFactory =
                new PropsKeyedObjectPoolFactory<SocketAddress, TcpTransport>(
                      connectionFactory,
                      configuration.connectionPool());
          createAndPreparePool(poolFactory);
-         balancer.setServers(servers);
+         balancers = CollectionFactory.makeMap(ByteArrayEquivalence.INSTANCE, AnyEquivalence.getInstance());
+         consistentHashes = CollectionFactory.makeMap(ByteArrayEquivalence.INSTANCE, AnyEquivalence.getInstance());
+         addBalancer(RemoteCacheManager.cacheNameBytes());
       }
 
       if (configuration.pingOnStartup())
          pingServers();
    }
 
-   private FailoverRequestBalancingStrategy createBalancer(Configuration configuration) {
-      RequestBalancingStrategy balancingStrategy = Util.getInstance(configuration.balancingStrategy());
-      if (balancingStrategy instanceof FailoverRequestBalancingStrategy)
-         return (FailoverRequestBalancingStrategy) balancingStrategy;
-      else
-         return new FailoverToRequestBalancingStrategyDelegate(balancingStrategy);
+   private FailoverRequestBalancingStrategy addBalancer(byte[] cacheName) {
+      RequestBalancingStrategy cfgBalancer = Util.getInstance(configuration.balancingStrategy());
+      FailoverRequestBalancingStrategy balancer =
+         (cfgBalancer instanceof FailoverRequestBalancingStrategy)
+            ? (FailoverRequestBalancingStrategy) cfgBalancer
+            : new FailoverToRequestBalancingStrategyDelegate(cfgBalancer);
+
+      balancers.put(cacheName, balancer);
+      balancer.setServers(servers);
+      return balancer;
    }
 
    private void pingServers() {
@@ -167,7 +179,7 @@ public class TcpTransportFactory implements TransportFactory {
    }
 
    @Override
-   public void updateHashFunction(Map<SocketAddress, Set<Integer>> servers2Hash, int numKeyOwners, short hashFunctionVersion, int hashSpace) {
+   public void updateHashFunction(Map<SocketAddress, Set<Integer>> servers2Hash, int numKeyOwners, short hashFunctionVersion, int hashSpace, byte[] cacheName) {
        synchronized (lock) {
          ConsistentHash hash = hashFactory.newConsistentHash(hashFunctionVersion);
          if (hash == null) {
@@ -175,12 +187,12 @@ public class TcpTransportFactory implements TransportFactory {
          } else {
             hash.init(servers2Hash, numKeyOwners, hashSpace);
          }
-         consistentHash = hash;
+         consistentHashes.put(cacheName, hash);
       }
    }
 
    @Override
-   public void updateHashFunction(SocketAddress[][] segmentOwners, int numSegments, short hashFunctionVersion) {
+   public void updateHashFunction(SocketAddress[][] segmentOwners, int numSegments, short hashFunctionVersion, byte[] cacheName) {
       synchronized (lock) {
          SegmentConsistentHash hash = hashFactory.newConsistentHash(hashFunctionVersion);
          if (hash == null) {
@@ -188,17 +200,35 @@ public class TcpTransportFactory implements TransportFactory {
          } else {
             hash.init(segmentOwners, numSegments);
          }
-         consistentHash = hash;
+         consistentHashes.put(cacheName, hash);
       }
    }
 
    @Override
-   public Transport getTransport(Set<SocketAddress> failedServers) {
+   public Transport getTransport(Set<SocketAddress> failedServers, byte[] cacheName) {
       SocketAddress server;
       synchronized (lock) {
-         server = nextServer(failedServers);
+         server = getNextServer(failedServers, cacheName);
       }
       return borrowTransportFromPool(server);
+   }
+
+   // To be called from within `lock` synchronized block
+   private SocketAddress getNextServer(Set<SocketAddress> failedServers, byte[] cacheName) {
+      FailoverRequestBalancingStrategy balancer = getOrCreateIfAbsentBalancer(cacheName);
+
+      SocketAddress server = balancer.nextServer(failedServers);
+      if (log.isTraceEnabled())
+         log.tracef("Using the balancer for determining the server: %s", server);
+
+      return server;
+   }
+
+   private FailoverRequestBalancingStrategy getOrCreateIfAbsentBalancer(byte[] cacheName) {
+      FailoverRequestBalancingStrategy balancer = balancers.get(cacheName);
+      if (balancer == null)
+         balancer = addBalancer(cacheName);
+      return balancer;
    }
 
    @Override
@@ -206,28 +236,20 @@ public class TcpTransportFactory implements TransportFactory {
       return borrowTransportFromPool(server);
    }
 
-   @Override
-   public Transport getTransport(byte[] key, Set<SocketAddress> failedServers) {
+   public Transport getTransport(byte[] key, Set<SocketAddress> failedServers, byte[] cacheName) {
       SocketAddress server;
       synchronized (lock) {
+         ConsistentHash consistentHash = consistentHashes.get(cacheName);
          if (consistentHash != null) {
             server = consistentHash.getServer(key);
             if (log.isTraceEnabled()) {
                log.tracef("Using consistent hash for determining the server: " + server);
             }
          } else {
-            server = nextServer(failedServers);
-
-            if (log.isTraceEnabled()) {
-               log.tracef("Using the balancer for determining the server: %s", server);
-            }
+            server = getNextServer(failedServers, cacheName);
          }
       }
       return borrowTransportFromPool(server);
-   }
-
-   private SocketAddress nextServer(Set<SocketAddress> failedServers) {
-      return balancer.nextServer(failedServers);
    }
 
    @Override
@@ -268,7 +290,7 @@ public class TcpTransportFactory implements TransportFactory {
    }
 
    @Override
-   public void updateServers(Collection<SocketAddress> newServers) {
+   public void updateServers(Collection<SocketAddress> newServers, byte[] cacheName) {
       synchronized (lock) {
          Set<SocketAddress> addedServers = new HashSet<SocketAddress>(newServers);
          addedServers.removeAll(servers);
@@ -296,13 +318,7 @@ public class TcpTransportFactory implements TransportFactory {
             }
          }
 
-         //2. now set the server list to the active list of servers. All the active servers (potentially together with some
-         // failed servers) are in the pool now. But after this, the pool won't be asked for connections to failed servers,
-         // as the balancer will only know about the active servers
-         balancer.setServers(newServers);
-
-
-         //3. Now just remove failed servers
+         //2. Remove failed servers
          for (SocketAddress server : failedServers) {
             log.removingServer(server);
             connectionPool.clear(server);
@@ -313,6 +329,9 @@ public class TcpTransportFactory implements TransportFactory {
          if (!failedServers.isEmpty()) {
             listenerNotifier.failoverClientListeners(failedServers);
          }
+
+         FailoverRequestBalancingStrategy balancer = getOrCreateIfAbsentBalancer(cacheName);
+         balancer.setServers(servers);
       }
    }
 
@@ -347,9 +366,9 @@ public class TcpTransportFactory implements TransportFactory {
    /**
     * Note that the returned <code>ConsistentHash</code> may not be thread-safe.
     */
-   public ConsistentHash getConsistentHash() {
+   public ConsistentHash getConsistentHash(byte[] cacheName) {
       synchronized (lock) {
-         return consistentHash;
+         return consistentHashes.get(cacheName);
       }
    }
 
@@ -394,9 +413,9 @@ public class TcpTransportFactory implements TransportFactory {
    /**
     * Note that the returned <code>RequestBalancingStrategy</code> may not be thread-safe.
     */
-   public RequestBalancingStrategy getBalancer() {
+   public RequestBalancingStrategy getBalancer(byte[] cacheName) {
       synchronized (lock) {
-         return balancer;
+         return balancers.get(cacheName);
       }
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/TransportObjectFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/TransportObjectFactory.java
@@ -18,14 +18,15 @@ public class TransportObjectFactory
 
    private static final Log log = LogFactory.getLog(TransportObjectFactory.class);
    protected final TcpTransportFactory tcpTransportFactory;
-   protected final AtomicInteger topologyId;
+   protected final AtomicInteger defaultCacheTopologyId;
    protected final boolean pingOnStartup;
    protected volatile boolean firstPingExecuted = false;
    protected final Codec codec;
 
-   public TransportObjectFactory(Codec codec, TcpTransportFactory tcpTransportFactory, AtomicInteger topologyId, boolean pingOnStartup) {
+   public TransportObjectFactory(Codec codec, TcpTransportFactory tcpTransportFactory,
+         AtomicInteger defaultCacheTopologyId, boolean pingOnStartup) {
       this.tcpTransportFactory = tcpTransportFactory;
-      this.topologyId = topologyId;
+      this.defaultCacheTopologyId = defaultCacheTopologyId;
       this.pingOnStartup = pingOnStartup;
       this.codec = codec;
    }
@@ -42,7 +43,7 @@ public class TransportObjectFactory
 
          // Don't ignore exceptions from ping() command, since
          // they indicate that the transport instance is invalid.
-         ping(tcpTransport, topologyId);
+         ping(tcpTransport, defaultCacheTopologyId);
       }
       return tcpTransport;
    }
@@ -58,7 +59,7 @@ public class TransportObjectFactory
    @Override
    public boolean validateObject(SocketAddress address, TcpTransport transport) {
       try {
-         boolean valid = ping(transport, topologyId) == PingOperation.PingResult.SUCCESS;
+         boolean valid = ping(transport, defaultCacheTopologyId) == PingOperation.PingResult.SUCCESS;
          log.tracef("Is connection %s valid? %s", transport, valid);
          return valid;
       } catch (Throwable e) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AsymmetricRoutingDefaultLocalCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AsymmetricRoutingDefaultLocalCacheTest.java
@@ -1,0 +1,17 @@
+package org.infinispan.client.hotrod;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.testng.annotations.Test;
+
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+
+@Test(groups = "functional", testName = "client.hotrod.AsymmetricRoutingDefaultLocalCacheTest")
+public class AsymmetricRoutingDefaultLocalCacheTest extends AsymmetricRoutingTest {
+
+   @Override
+   protected ConfigurationBuilder defaultCacheConfigurationBuilder() {
+      return hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.LOCAL));
+   }
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AsymmetricRoutingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AsymmetricRoutingTest.java
@@ -1,0 +1,138 @@
+package org.infinispan.client.hotrod;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.util.ControlledConsistentHashFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Random;
+import java.util.Set;
+
+import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
+import static org.infinispan.distribution.DistributionTestHelper.isFirstOwner;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.test.TestingUtil.blockUntilCacheStatusAchieved;
+import static org.infinispan.test.TestingUtil.blockUntilViewReceived;
+import static org.testng.AssertJUnit.assertEquals;
+
+@Test(groups = "functional", testName = "client.hotrod.AsymmetricRoutingTest")
+public class AsymmetricRoutingTest extends HitsAwareCacheManagersTest {
+
+   private static final String DIST_ONE_CACHE_NAME = "dist-one-cache";
+   private static final String DIST_TWO_CACHE_NAME = "dist-two-cache";
+
+   HotRodServer server1;
+   HotRodServer server2;
+
+   ConfigurationBuilder defaultBuilder;
+   ConfigurationBuilder distOneBuilder;
+   ConfigurationBuilder distTwoBuilder;
+
+   RemoteCacheManager rcm;
+
+   protected ConfigurationBuilder defaultCacheConfigurationBuilder() {
+      return hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC));
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      defaultBuilder = defaultCacheConfigurationBuilder();
+      distOneBuilder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC));
+      distOneBuilder.clustering().hash().numOwners(1).numSegments(1)
+            .consistentHashFactory(new ControlledConsistentHashFactory(0));
+      distTwoBuilder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC));
+      distTwoBuilder.clustering().hash().numOwners(1).numSegments(1)
+            .consistentHashFactory(new ControlledConsistentHashFactory(1));
+
+      server1 = addHotRodServer();
+      server2 = addHotRodServer();
+
+      blockUntilViewReceived(manager(0).getCache(), 2);
+      blockUntilCacheStatusAchieved(manager(0).getCache(), ComponentStatus.RUNNING, 10000);
+      blockUntilCacheStatusAchieved(manager(1).getCache(), ComponentStatus.RUNNING, 10000);
+
+      org.infinispan.client.hotrod.configuration.ConfigurationBuilder clientBuilder =
+            new org.infinispan.client.hotrod.configuration.ConfigurationBuilder();
+      clientBuilder.addServer().host(server1.getHost()).port(server1.getPort())
+            .addServer().host(server2.getHost()).port(server2.getPort());
+      rcm = new RemoteCacheManager(clientBuilder.build());
+   }
+
+   @AfterClass
+   @Override
+   protected void destroy() {
+      killServers(server1, server2);
+      super.destroy();
+   }
+
+   private HotRodServer addHotRodServer() {
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager(defaultBuilder);
+      cm.defineConfiguration(DIST_ONE_CACHE_NAME, distOneBuilder.build());
+      cm.defineConfiguration(DIST_TWO_CACHE_NAME, distTwoBuilder.build());
+      HotRodServer server = TestHelper.startHotRodServer(cm);
+      hrServ2CacheManager.put(new InetSocketAddress(server.getHost(), server.getPort()), cm);
+      return server;
+   }
+
+   public void testRequestRouting() {
+      addInterceptors(DIST_ONE_CACHE_NAME);
+      addInterceptors(DIST_TWO_CACHE_NAME);
+      byte[] keyDistOne = getKeyForServer(server1, DIST_ONE_CACHE_NAME);
+      byte[] keyDistTwo = getKeyForServer(server2, DIST_TWO_CACHE_NAME);
+      assertSegments(DIST_ONE_CACHE_NAME, server1, server1.getCacheManager().getAddress());
+      assertSegments(DIST_ONE_CACHE_NAME, server2, server1.getCacheManager().getAddress());
+      assertSegments(DIST_TWO_CACHE_NAME, server1, server2.getCacheManager().getAddress());
+      assertSegments(DIST_TWO_CACHE_NAME, server2, server2.getCacheManager().getAddress());
+      assertRequestRouting(keyDistOne, DIST_ONE_CACHE_NAME, server1);
+      assertRequestRouting(keyDistTwo, DIST_TWO_CACHE_NAME, server2);
+   }
+
+   private void assertSegments(String cacheName, HotRodServer server, Address owner) {
+      AdvancedCache<Object, Object> cache = server.getCacheManager().getCache(cacheName).getAdvancedCache();
+      ConsistentHash ch = cache.getDistributionManager().getReadConsistentHash();
+      assertEquals(1, ch.getNumSegments());
+      Set<Integer> segments = ch.getSegmentsForOwner(owner);
+      assertEquals(1, segments.size());
+      assertEquals(0, segments.iterator().next().intValue());
+   }
+
+   private void assertRequestRouting(byte[] key, String cacheName, HotRodServer server) {
+      RemoteCache<Object, Object> rcOne = rcm.getCache(cacheName);
+      InetSocketAddress serverAddress = new InetSocketAddress(server.getHost(), server.getPort());
+      for (int i = 0; i < 2; i++) {
+         log.infof("Routing put test for key %s", Util.printArray(key, false));
+         rcOne.put(key, "value");
+         assertServerHit(serverAddress, cacheName, i + 1);
+      }
+   }
+
+   byte[] getKeyForServer(HotRodServer primaryOwner, String cacheName) {
+      Cache<?, ?> cache = primaryOwner.getCacheManager().getCache(cacheName);
+      Random r = new Random();
+      byte[] dummy = new byte[8];
+      int attemptsLeft = 1000;
+      do {
+         r.nextBytes(dummy);
+      } while (!isFirstOwner(cache, dummy) && attemptsLeft >= 0);
+
+      if (attemptsLeft < 0)
+         throw new IllegalStateException("Could not find any key owned by " + primaryOwner);
+
+      log.infof("Binary key %s hashes to [cluster=%s,hotrod=%s]",
+            Util.printArray(dummy, false), primaryOwner.getCacheManager().getAddress(),
+            primaryOwner.getAddress());
+
+      return dummy;
+   }
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
@@ -108,7 +108,7 @@ public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
          Thread.sleep(1000);
       }
       assertEquals(3, tcpConnectionFactory.getServers().size());
-      assertNotNull(tcpConnectionFactory.getConsistentHash());
+      assertNotNull(tcpConnectionFactory.getConsistentHash(RemoteCacheManager.cacheNameBytes()));
    }
 
    @Test(dependsOnMethods = "testHashInfoRetrieved")
@@ -121,7 +121,7 @@ public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
    public void testHashFunctionReturnsSameValues() {
       for (int i = 0; i < 1000; i++) {
          byte[] key = generateKey(i);
-         TcpTransport transport = (TcpTransport) tcpConnectionFactory.getTransport(key, null);
+         TcpTransport transport = (TcpTransport) tcpConnectionFactory.getTransport(key, null, RemoteCacheManager.cacheNameBytes());
          SocketAddress serverAddress = transport.getServerAddress();
          CacheContainer cacheContainer = hrServ2CacheManager.get(serverAddress);
          assertNotNull("For server address " + serverAddress + " found " + cacheContainer + ". Map is: " + hrServ2CacheManager, cacheContainer);
@@ -147,7 +147,7 @@ public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
          keys.add(key);
          String keyStr = new String(key);
          remoteCache.put(keyStr, "value");
-         TcpTransport transport = (TcpTransport) tcpConnectionFactory.getTransport(marshall(keyStr), null);
+         TcpTransport transport = (TcpTransport) tcpConnectionFactory.getTransport(marshall(keyStr), null, RemoteCacheManager.cacheNameBytes());
          assertHotRodEquals(hrServ2CacheManager.get(transport.getServerAddress()), keyStr, "value");
          tcpConnectionFactory.releaseTransport(transport);
       }
@@ -158,7 +158,7 @@ public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
          resetStats();
          String keyStr = new String(key);
          assert remoteCache.get(keyStr).equals("value");
-         TcpTransport transport = (TcpTransport) tcpConnectionFactory.getTransport(marshall(keyStr), null);
+         TcpTransport transport = (TcpTransport) tcpConnectionFactory.getTransport(marshall(keyStr), null, RemoteCacheManager.cacheNameBytes());
          assertOnlyServerHit(transport.getServerAddress());
          tcpConnectionFactory.releaseTransport(transport);
       }
@@ -170,4 +170,5 @@ public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
       r.nextBytes(result);
       return result;
    }
+
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV1IntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV1IntegrationTest.java
@@ -132,7 +132,7 @@ public class ConsistentHashV1IntegrationTest extends MultipleCacheManagersTest {
    }
 
    public void testCorrectBalancingOfKeysAfterNodeKill() {
-      final AtomicInteger clientTopologyId = (AtomicInteger) TestingUtil.extractField(remoteCacheManager, "topologyId");
+      final AtomicInteger clientTopologyId = TestingUtil.extractField(remoteCacheManager, "defaultCacheTopologyId");
 
       final int topologyIdBeforeJoin = clientTopologyId.get();
       log.tracef("Starting test with client topology id %d", topologyIdBeforeJoin);
@@ -179,12 +179,7 @@ public class ConsistentHashV1IntegrationTest extends MultipleCacheManagersTest {
       runTest(3);
    }
 
-   private org.infinispan.client.hotrod.impl.consistenthash.ConsistentHash extractClientConsistentHash() {
-      TcpTransportFactory transport = (TcpTransportFactory) TestingUtil.extractField(remoteCacheManager, "transport");
-      return transport.getConsistentHash();
-   }
-
-   private void resetHitInterceptors() {
+  private void resetHitInterceptors() {
       for (int i = 0; i < 4; i++) {
          HitsAwareCacheManagersTest.HitCountInterceptor interceptor = hitCountInterceptor(i);
          interceptor.reset();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RoundRobinBalancingIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RoundRobinBalancingIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod;
 
 import org.infinispan.Cache;
+import org.infinispan.client.hotrod.impl.transport.tcp.RequestBalancingStrategy;
 import org.infinispan.client.hotrod.impl.transport.tcp.RoundRobinBalancingStrategy;
 import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory;
 import org.infinispan.server.hotrod.HotRodServer;
@@ -16,6 +17,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
@@ -218,8 +220,9 @@ public class RoundRobinBalancingIntegrationTest extends MultipleCacheManagersTes
    }
 
    private RoundRobinBalancingStrategy getBalancer() {
-      TcpTransportFactory transportFactory = (TcpTransportFactory) TestingUtil.extractField(remoteCache.getRemoteCacheManager(), "transportFactory");
-      return (RoundRobinBalancingStrategy) TestingUtil.extractField(transportFactory, "balancer");
+      TcpTransportFactory transportFactory = TestingUtil.extractField(remoteCache.getRemoteCacheManager(), "transportFactory");
+      Map<byte[], RoundRobinBalancingStrategy> balancers = TestingUtil.extractField(transportFactory, "balancers");
+      return balancers.get(RemoteCacheManager.cacheNameBytes());
    }
 
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/AbstractRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/AbstractRetryTest.java
@@ -70,8 +70,8 @@ public abstract class AbstractRetryTest extends HitsAwareCacheManagersTest {
 
       remoteCacheManager = new RemoteCacheManager(clientConfig);
       remoteCache = (RemoteCacheImpl) remoteCacheManager.getCache();
-      tcpConnectionFactory = (TcpTransportFactory) TestingUtil.extractField(remoteCacheManager, "transportFactory");
-      strategy = (RoundRobinBalancingStrategy) tcpConnectionFactory.getBalancer();
+      tcpConnectionFactory = TestingUtil.extractField(remoteCacheManager, "transportFactory");
+      strategy = (RoundRobinBalancingStrategy) tcpConnectionFactory.getBalancer(RemoteCacheManager.cacheNameBytes());
       addInterceptors();
 
       assert super.cacheManagers.size() == 3;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/DistributionRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/DistributionRetryTest.java
@@ -4,12 +4,13 @@ import org.infinispan.Cache;
 import org.infinispan.affinity.KeyAffinityService;
 import org.infinispan.affinity.KeyAffinityServiceFactory;
 import org.infinispan.affinity.KeyGenerator;
+import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.VersionedValue;
 import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransport;
 import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.marshall.core.JBossMarshaller;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.TestingUtil;
@@ -113,10 +114,10 @@ public class DistributionRetryTest extends AbstractRetryTest {
 
       remoteCache.put(key, "v");
       assertOnlyServerHit(getAddress(hotRodServer2));
-      TcpTransportFactory tcpTp = (TcpTransportFactory) TestingUtil.extractField(remoteCacheManager, "transportFactory");
+      TcpTransportFactory tcpTp = TestingUtil.extractField(remoteCacheManager, "transportFactory");
 
       Marshaller sm = new JBossMarshaller();
-      TcpTransport transport = (TcpTransport) tcpTp.getTransport(sm.objectToByteBuffer(key, 64), null);
+      TcpTransport transport = (TcpTransport) tcpTp.getTransport(sm.objectToByteBuffer(key, 64), null, RemoteCacheManager.cacheNameBytes());
       try {
       assertEquals(transport.getServerAddress(), new InetSocketAddress("localhost", hotRodServer2.getPort()));
       } finally {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/ClientConsistentHashPerfTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/ClientConsistentHashPerfTest.java
@@ -37,8 +37,8 @@ public class ClientConsistentHashPerfTest extends MultiHotRodServersTest {
       // This will initialize the consistent hash
       cache.put("k", "v");
 
-      TcpTransportFactory transportFactory = (TcpTransportFactory) TestingUtil.extractField(rcm, "transportFactory");
-      ConsistentHash ch = transportFactory.getConsistentHash();
+      TcpTransportFactory transportFactory = TestingUtil.extractField(rcm, "transportFactory");
+      ConsistentHash ch = transportFactory.getConsistentHash(RemoteCacheManager.cacheNameBytes());
       byte[][] keys = new byte[NUM_KEYS][];
 
       for (int i = 0; i < NUM_KEYS; i++) {

--- a/core/src/main/java/org/infinispan/commands/write/PutKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/PutKeyValueCommand.java
@@ -164,7 +164,7 @@ public class PutKeyValueCommand extends AbstractDataWriteCommand implements Meta
       return new StringBuilder()
             .append("PutKeyValueCommand{key=")
             .append(toStr(key))
-            .append(", value=").append(value)
+            .append(", value=").append(toStr(value))
             .append(", flags=").append(flags)
             .append(", putIfAbsent=").append(putIfAbsent)
             .append(", valueMatcher=").append(valueMatcher)

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -137,8 +137,8 @@ public class TestingUtil {
     *
     * @return field value
     */
-   public static Object extractField(Object target, String fieldName) {
-      return extractField(target.getClass(), target, fieldName);
+   public static <T> T extractField(Object target, String fieldName) {
+      return (T) extractField(target.getClass(), target, fieldName);
    }
 
    public static void replaceField(Object newValue, String fieldName, Object owner, Class baseType) {

--- a/core/src/test/java/org/infinispan/util/ControlledConsistentHashFactory.java
+++ b/core/src/test/java/org/infinispan/util/ControlledConsistentHashFactory.java
@@ -44,7 +44,7 @@ public class ControlledConsistentHashFactory extends BaseControlledConsistentHas
 
    private int[] concatOwners(int primaryOwnerIndex, int[] backupOwnerIndexes) {
       int[] firstSegmentOwners;
-      if (backupOwnerIndexes == null) {
+      if (backupOwnerIndexes == null || backupOwnerIndexes.length == 0) {
          firstSegmentOwners = new int[]{primaryOwnerIndex};
       } else {
          firstSegmentOwners = new int[backupOwnerIndexes.length + 1];

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/AbstractRemoteCacheManagerIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/AbstractRemoteCacheManagerIT.java
@@ -239,17 +239,17 @@ public abstract class AbstractRemoteCacheManagerIT {
         TcpTransportFactory ttf = (TcpTransportFactory) getTransportFactoryField(of);
 
         // perform first simulated operation
-        tt = (TcpTransport) ttf.getTransport(null);
+        tt = (TcpTransport) ttf.getTransport(null, null);
         sock_addr = (InetSocketAddress) tt.getServerAddress();
         ttf.releaseTransport(tt);
         serverAddrSequence.append(sock_addr.getAddress().getHostAddress() + ":" + sock_addr.getPort()).append(" ");
 
-        tt = (TcpTransport) ttf.getTransport(null);
+        tt = (TcpTransport) ttf.getTransport(null, null);
         sock_addr = (InetSocketAddress) tt.getServerAddress();
         ttf.releaseTransport(tt);
         serverAddrSequence.append(sock_addr.getAddress().getHostAddress() + ":" + sock_addr.getPort()).append(" ");
 
-        tt = (TcpTransport) ttf.getTransport(null);
+        tt = (TcpTransport) ttf.getTransport(null, null);
         sock_addr = (InetSocketAddress) tt.getServerAddress();
         ttf.releaseTransport(tt);
         serverAddrSequence.append(sock_addr.getAddress().getHostAddress() + ":" + sock_addr.getPort());
@@ -307,13 +307,13 @@ public abstract class AbstractRemoteCacheManagerIT {
         OperationsFactory of = getOperationsFactoryField(rci);
         TcpTransportFactory ttf = (TcpTransportFactory) getTransportFactoryField(of);
         // perform first simulated operation
-        tt = (TcpTransport) ttf.getTransport(null);
+        tt = (TcpTransport) ttf.getTransport(null, null);
         sock_addr = (InetSocketAddress) tt.getServerAddress();
         ttf.releaseTransport(tt);
         assertEquals("load balancing first request: server address expected " + hostport0 + ", actual server address "
                 + sock_addr, sock_addr, hostport0);
 
-        tt = (TcpTransport) ttf.getTransport(null);
+        tt = (TcpTransport) ttf.getTransport(null, null);
         sock_addr = (InetSocketAddress) tt.getServerAddress();
         ttf.releaseTransport(tt);
         assertEquals("load balancing second request: server address expected " + hostport0 + ", actual server address"
@@ -388,11 +388,10 @@ public abstract class AbstractRemoteCacheManagerIT {
     }
 
     private String getRequestBalancingStrategyProperty(RemoteCache rc) throws Exception {
-
         RemoteCacheImpl rci = (RemoteCacheImpl) rc;
         OperationsFactory of = getOperationsFactoryField(rci);
         TcpTransportFactory ttf = (TcpTransportFactory) getTransportFactoryField(of);
-        RequestBalancingStrategy rbs = ttf.getBalancer();
+        RequestBalancingStrategy rbs = ttf.getBalancer(RemoteCacheManager.cacheNameBytes());
         return rbs.getClass().getName();
     }
 
@@ -480,7 +479,7 @@ public abstract class AbstractRemoteCacheManagerIT {
         RemoteCacheImpl rci = (RemoteCacheImpl) rc;
         OperationsFactory of = getOperationsFactoryField(rci);
         TcpTransportFactory ttf = (TcpTransportFactory) getTransportFactoryField(of);
-        ConsistentHash ch = ttf.getConsistentHash();
+        ConsistentHash ch = ttf.getConsistentHash(null);
         return ch.getClass().getName();
     }
 

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodTestInterceptingTransportFactory.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodTestInterceptingTransportFactory.java
@@ -23,8 +23,8 @@ public class HotRodTestInterceptingTransportFactory extends TcpTransportFactory 
      * Version of getTransport() which keeps track of InetSocketAddress values
      */
     @Override
-    public Transport getTransport(Set<SocketAddress> failedServers) {
-        Transport transport = super.getTransport(failedServers);
+    public Transport getTransport(Set<SocketAddress> failedServers, byte[] cacheName) {
+        Transport transport = super.getTransport(failedServers, cacheName);
         System.out.println("InterceptingTransport called");
         sock_addr = (InetSocketAddress) ((TcpTransport) transport).getServerAddress();
         return transport;

--- a/spring/src/test/java/org/infinispan/spring/mock/MockTransportFactory.java
+++ b/spring/src/test/java/org/infinispan/spring/mock/MockTransportFactory.java
@@ -17,7 +17,7 @@ import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 public final class MockTransportFactory implements TransportFactory {
 
    @Override
-   public Transport getTransport(Set<SocketAddress> failedServers) {
+   public Transport getTransport(Set<SocketAddress> failedServers, byte[] cacheName) {
       return null;
    }
 
@@ -30,7 +30,7 @@ public final class MockTransportFactory implements TransportFactory {
    }
 
    @Override
-   public void updateServers(final Collection<SocketAddress> newServers) {
+   public void updateServers(final Collection<SocketAddress> newServers, byte[] cacheName) {
    }
 
    @Override
@@ -38,15 +38,15 @@ public final class MockTransportFactory implements TransportFactory {
    }
 
    @Override
-   public void updateHashFunction(final Map<SocketAddress, Set<Integer>> servers2Hash,
-            final int numKeyOwners, final short hashFunctionVersion, final int hashSpace) {
-   }
-
-   public void updateHashFunction(SocketAddress[][] segmentOwners, int numSegments, short hashFunctionVersion) {
+   public void updateHashFunction(Map<SocketAddress, Set<Integer>> servers2Hash, int numKeyOwners, short hashFunctionVersion, int hashSpace, byte[] cacheName) {
    }
 
    @Override
-   public Transport getTransport(final byte[] key, Set<SocketAddress> failedServers) {
+   public void updateHashFunction(SocketAddress[][] segmentOwners, int numSegments, short hashFunctionVersion, byte[] cacheName) {
+   }
+
+   @Override
+   public Transport getTransport(final byte[] key, Set<SocketAddress> failedServers, byte[] cacheName) {
       return null;
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3530
https://issues.jboss.org/browse/ISPN-1855
- It fixes an issue where accessing non-distributed caches can break topology updates.
- Add asymmetric routing test that forces each server to hash only to itself to replicate situations where different distributed caches have different CH.
