### PR TITLE
ISPN-4224 Kerberos auth IT fails on JDK8

### DIFF
--- a/integrationtests/security-it/src/test/java/org/infinispan/test/integration/security/embedded/KrbLdapAuthenticationIT.java
+++ b/integrationtests/security-it/src/test/java/org/infinispan/test/integration/security/embedded/KrbLdapAuthenticationIT.java
@@ -35,6 +35,7 @@ public class KrbLdapAuthenticationIT extends AbstractAuthentication {
    
    @BeforeClass
    public static void ldapSetup() throws Exception {
+      System.setProperty("java.security.krb5.conf", KrbLdapAuthenticationIT.class.getResource("/krb5.conf").getPath());
       krbLdapServer = new ApacheDsKrbLdap("localhost");
       krbLdapServer.start();
    }


### PR DESCRIPTION
Not tested on Linux. It works on Mac for Oracle JDK 1.7 and 1.8
