### PR TITLE
ISPN-4331 Add searching for TransactionManager in OSGi to GenericTransac...

### DIFF
--- a/core/src/main/java/org/infinispan/transaction/lookup/GenericTransactionManagerLookup.java
+++ b/core/src/main/java/org/infinispan/transaction/lookup/GenericTransactionManagerLookup.java
@@ -58,6 +58,7 @@ public class GenericTransactionManagerLookup implements TransactionManagerLookup
                {"java:pm/TransactionManager", "Borland, Sun"},
                {"javax.transaction.TransactionManager", "BEA WebLogic"},
                {"java:comp/UserTransaction", "Resin, Orion, JOnAS (JOTM)"},
+               {"osgi:service/javax.transaction.TransactionManager", "Karaf"},
          };
 
    /**

--- a/integrationtests/osgi/src/test/resources/test-features.xml
+++ b/integrationtests/osgi/src/test/resources/test-features.xml
@@ -13,12 +13,12 @@
       <bundle>file:///${basedir}/target/infinispan-core-with-tests.jar</bundle>
    </feature>
    <feature name="infinispan-core-deps" version="${project.version}">
+      <feature>transaction</feature>
       <bundle>mvn:org.jboss.logging/jboss-logging/${version.jboss.logging}</bundle>
       <bundle>mvn:org.infinispan/infinispan-commons/${project.version}</bundle>
       <bundle>mvn:commons-pool/commons-pool/${version.commons.pool}</bundle>
       <bundle>mvn:org.jboss.marshalling/jboss-marshalling-osgi/${version.jboss.marshalling}</bundle>
       <bundle>mvn:org.jgroups/jgroups/${version.jgroups}</bundle>
       <bundle>mvn:org.jboss.spec.javax.transaction/jboss-transaction-api_1.1_spec/${version.jta}</bundle>
-      <bundle>wrap:mvn:org.jboss.jbossts.jta/narayana-jta/${version.jbossjta}</bundle>
    </feature>
 </features>


### PR DESCRIPTION
...tionManagerLookup

https://issues.jboss.org/browse/ISPN-4331

You can run respective tests by mvn clean verify -Dtest=TransactionsSpanningReplicatedCachesTest in integrationtests/osgi folder.

Please let me know if you think this test is enough to verify that the Apache Aries transaction manager works correclty with ISPN. I think it could be enough (apart from stress tests that I'm not gonna run in Karaf! :))
