### PR TITLE
ISPN-4325 RHQ JMX does not support multiple cache managers properly

### DIFF
--- a/rhq-plugin/src/main/java/org/infinispan/rhq/CacheDiscovery.java
+++ b/rhq-plugin/src/main/java/org/infinispan/rhq/CacheDiscovery.java
@@ -13,6 +13,8 @@ import javax.management.ObjectName;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Discovery class for individual cache instances
@@ -28,7 +30,7 @@ public class CacheDiscovery extends MBeanResourceDiscoveryComponent<CacheManager
    public Set<DiscoveredResourceDetails> discoverResources(ResourceDiscoveryContext<CacheManagerComponent> ctx) {
       boolean trace = log.isTraceEnabled();
       if (trace) log.trace("Discover resources with context");
-      Set<DiscoveredResourceDetails> discoveredResources = new HashSet<DiscoveredResourceDetails>();
+      Set<DiscoveredResourceDetails> discoveredResources = new HashSet<>();
 
       EmsConnection conn = ctx.getParentResourceComponent().getEmsConnection();
       if (trace) log.trace("Connection to ems server established");
@@ -69,11 +71,13 @@ public class CacheDiscovery extends MBeanResourceDiscoveryComponent<CacheManager
       return discoveredResources;
    }
 
-   private String getAllCachesPattern(String cacheManagerName) {
+   protected static String getAllCachesPattern(String cacheManagerName) {
       return cacheComponentPattern(cacheManagerName, "Cache") + ",*";
    }
 
    protected static String cacheComponentPattern(String cacheManagerName, String componentName) {
-      return "*:type=Cache,component=" + componentName + ",manager=" + ObjectName.quote(cacheManagerName);
+      // The CacheManager registers like <domain>:name=<name> so add those to request
+      return cacheManagerName.substring(0, cacheManagerName.indexOf(":")) + ":manager=" +
+            cacheManagerName.substring(cacheManagerName.indexOf("=") + 1)  + ",type=Cache,component=" + componentName;
    }
 }

--- a/rhq-plugin/src/main/java/org/infinispan/rhq/CacheManagerDiscovery.java
+++ b/rhq-plugin/src/main/java/org/infinispan/rhq/CacheManagerDiscovery.java
@@ -17,6 +17,8 @@ import org.rhq.plugins.jmx.JMXComponent;
 import org.rhq.plugins.jmx.MBeanResourceDiscoveryComponent;
 import org.rhq.plugins.jmx.util.ObjectNameQueryUtility;
 
+import javax.management.ObjectName;
+
 /**
  * Discovery class for Infinispan engines
  *
@@ -60,14 +62,15 @@ public class CacheManagerDiscovery extends MBeanResourceDiscoveryComponent<JMXCo
             // Filter out spurious beans
             if (CacheManagerComponent.isCacheManagerComponent(bean)) {
                String managerName = bean.getBeanName().getCanonicalName();
+               String domain = managerName.substring(0, managerName.indexOf(":"));
                String resourceName = bean.getAttribute("Name").getValue().toString();
                String version = bean.getAttribute("Version").getValue().toString();
                /* A discovered resource must have a unique key, that must stay the same when the resource is discovered the next time */
                if (trace) log.trace("Add resource with version '"+version+"' and type " + ctx.getResourceType());
                DiscoveredResourceDetails detail = new DiscoveredResourceDetails(
                      ctx.getResourceType(), // Resource type
-                     resourceName, // Resource key
-                     resourceName, // Resource name
+                     domain + ":name=" + ObjectName.quote(resourceName), // Resource key
+                     (beans.size() > 1 ? domain + ":" : "") + resourceName, // Resource name
                      version, // Resource version
                      "A cache manager within Infinispan", // Description
                      pluginConfiguration, // Plugin config


### PR DESCRIPTION
- Added support for multiple cache managers
- Existing single cache manager will still have same name
- Also improved performance a bit more by not doing queries as often
- Also fixed NPE with Cache values

https://issues.jboss.org/browse/ISPN-4235
