### PR TITLE
ISPN-4347 Remove Geronimo from parent pom as global dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -85,6 +85,18 @@
          <scope>test</scope>
       </dependency>
 
+      <dependency>
+         <groupId>org.apache.geronimo.components</groupId>
+         <artifactId>geronimo-transaction</artifactId>
+         <scope>test</scope>
+      </dependency>
+      
+      <dependency>
+         <groupId>org.objectweb.howl</groupId>
+         <artifactId>howl</artifactId>
+         <scope>test</scope>
+      </dependency>
+      
    </dependencies>
 
    <build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -890,10 +890,22 @@
             <version>${version.pax.exam}</version>
             <scope>test</scope>
          </dependency>
-          <dependency>
+         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
             <version>${version.snappy}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.apache.geronimo.components</groupId>
+            <artifactId>geronimo-transaction</artifactId>
+            <version>${version.geronimo.tm}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.objectweb.howl</groupId>
+            <artifactId>howl</artifactId>
+            <version>${version.howl}</version>
+            <scope>test</scope>
          </dependency>
       </dependencies>
    </dependencyManagement>
@@ -936,18 +948,6 @@
          <artifactId>jboss-logging-processor</artifactId>
          <version>${version.jboss.logging.processor}</version>
          <scope>provided</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.geronimo.components</groupId>
-         <artifactId>geronimo-transaction</artifactId>
-         <version>${version.geronimo.tm}</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.objectweb.howl</groupId>
-         <artifactId>howl</artifactId>
-         <version>${version.howl}</version>
-         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.slf4j</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4347

Adding this dependency only to the core module as TX tests are mostly there. This should fix the problem for other modules that must not have both JBossTM and Geronimo on classpath.
