### PR TITLE
ISPN-4370 CacheNotifierImplInitialTransferDistTest random failures

### DIFF
--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplInitialTransferDistTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplInitialTransferDistTest.java
@@ -518,7 +518,7 @@ public class CacheNotifierImplInitialTransferDistTest extends MultipleCacheManag
             CacheEntryEvent event = null;
             boolean foundEarlierCreate = false;
             // We iterate backwards so we only have to do it once
-            for (int i = listener.events.size() - 1; i > 0; --i) {
+            for (int i = listener.events.size() - 1; i >= 0; --i) {
                CacheEntryEvent currentEvent = listener.events.get(i);
                if (currentEvent.getKey().equals(keyToChange) && operation.getType() == currentEvent.getType()) {
                   if (event == null) {


### PR DESCRIPTION
- Fixed issue where if first event was the created event for our key

https://issues.jboss.org/browse/ISPN-4370
