### PR TITLE
Add missing generic types to return values for getDataContainer() and getCacheEntry(K).

### DIFF
--- a/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingAdvancedCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingAdvancedCache.java
@@ -127,7 +127,7 @@ public class AbstractDelegatingAdvancedCache<K, V> extends AbstractDelegatingCac
    }
 
    @Override
-   public DataContainer getDataContainer() {
+   public DataContainer<K, V> getDataContainer() {
       return cache.getDataContainer();
    }
 
@@ -182,7 +182,7 @@ public class AbstractDelegatingAdvancedCache<K, V> extends AbstractDelegatingCac
    }
 
    @Override
-   public CacheEntry getCacheEntry(K key) {
+   public CacheEntry<K, V> getCacheEntry(K key) {
       return cache.getCacheEntry(key);
    }
 


### PR DESCRIPTION
This fixes compiler warnings for classes that extend AbstractDelegatingAdvancedCache.
