### PR TITLE
ISPN-4368 StateTransferOverwriteTest random failures

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/rehash/BaseTxStateTransferOverwriteTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/BaseTxStateTransferOverwriteTest.java
@@ -244,6 +244,10 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
 
          cyclicBarrier.await(10, SECONDS);
 
+         // After the barrier  has been hit remove the interceptor, since we can just wake it up through the barrier,
+         // this way the state transfer won't be blocked if the normal put occurs before it.
+         removeAllBlockingInterceptorsFromCache(primaryOwnerCache);
+
          // Block the rebalance confirmation on nonOwnerCache
          CheckPoint checkPoint = new CheckPoint();
          log.trace("Adding proxy to state transfer");


### PR DESCRIPTION
- Removed BlockingInterceptor so it wouldn't block state transfer
  *\* This could happen if first put finishes before ST begins

https://issues.jboss.org/browse/ISPN-4368
