### PR TITLE
ISPN-4391 Test Security features in a cluster

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/global/TransportConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/TransportConfigurationBuilder.java
@@ -219,7 +219,7 @@ public class TransportConfigurationBuilder extends AbstractGlobalConfigurationBu
       this.properties = template.properties();
       this.rackId = template.rackId();
       this.siteId = template.siteId();
-      this.transport = template.transport();
+      this.transport = Util.getInstance(template.transport().getClass().getName(), template.transport().getClass().getClassLoader());
       this.transportThreadPool.read(template.transportThreadPool());
       this.remoteCommandThreadPool.read(template.remoteCommandThreadPool());
       this.totalOrderThreadPool.read(template.totalOrderThreadPool());

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -296,4 +296,10 @@ public class StateTransferManagerImpl implements StateTransferManager {
    public int getFirstTopologyAsMember() {
       return firstTopologyAsMember;
    }
+
+   @Override
+
+   public String toString() {
+      return "StateTransferManagerImpl [" + cacheName + "@" + rpcManager.getAddress() + "]";
+   }
 }

--- a/core/src/test/java/org/infinispan/security/ClusteredSecureCacheTest.java
+++ b/core/src/test/java/org/infinispan/security/ClusteredSecureCacheTest.java
@@ -1,0 +1,85 @@
+package org.infinispan.security;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.security.PrivilegedAction;
+import java.security.PrivilegedExceptionAction;
+
+import javax.security.auth.Subject;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.security.impl.IdentityRoleMapper;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "security.ClusteredSecureCacheTest")
+public class ClusteredSecureCacheTest extends MultipleCacheManagersTest {
+   final static Subject ADMIN = TestingUtil.makeSubject("admin");
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      final GlobalConfigurationBuilder global = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      final ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC);
+      global.security().authorization().enable()
+            .principalRoleMapper(new IdentityRoleMapper()).role("admin").permission(AuthorizationPermission.ALL);
+      builder.security().authorization().enable().role("admin");
+      Subject.doAs(ADMIN, new PrivilegedExceptionAction<Void>() {
+         @Override
+         public Void run() throws Exception {
+            createCluster(global, builder, 2);
+            waitForClusterToForm();
+            return null;
+         }
+      });
+   }
+
+   @Override
+   @AfterClass(alwaysRun = true)
+   protected void destroy() {
+      Subject.doAs(ADMIN, new PrivilegedAction<Void>() {
+         @Override
+         public Void run() {
+            ClusteredSecureCacheTest.super.destroy();
+            return null;
+         }
+      });
+   }
+
+   @Override
+   @AfterMethod(alwaysRun = true)
+   protected void clearContent() throws Throwable {
+      Subject.doAs(ADMIN, new PrivilegedExceptionAction<Void>() {
+         @Override
+         public Void run() throws Exception {
+            try {
+               ClusteredSecureCacheTest.super.clearContent();
+            } catch (Throwable e) {
+               throw new Exception(e);
+            }
+            return null;
+         }
+      });
+   }
+
+   public void testClusteredSecureCache() {
+      Subject.doAs(ADMIN, new PrivilegedAction<Void>() {
+
+         @Override
+         public Void run() {
+            Cache<String, String> cache1 = cache(0);
+            Cache<String, String> cache2 = cache(1);
+            cache1.put("a", "a");
+            cache2.put("b", "b");
+            assertEquals("a", cache2.get("a"));
+            assertEquals("b", cache1.get("b"));
+            return null;
+         }
+      });
+   }
+}

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.security.Principal;
@@ -1386,7 +1387,7 @@ public class TestingUtil {
       return new Subject(true, set, InfinispanCollections.emptySet(), InfinispanCollections.emptySet());
    }
 
-   public static class TestPrincipal implements Principal {
+   public static class TestPrincipal implements Principal, Serializable {
       String name;
 
       public TestPrincipal(String name) {


### PR DESCRIPTION
- Do not reuse a transport when read()ing a new global configuration
- Add StateTransferManagerImpl.toString() to ease debugging
- Make the TestPrincipal serializable

https://issues.jboss.org/browse/ISPN-4391
