### PR TITLE
ISPN-4395 Query tests slow

### DIFF
--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -10,6 +10,7 @@
          max_bundle_size="31k"
          use_send_queues="true"
          enable_diagnostics="false"
+         tcp_nodelay="true"
          bundler_type="sender-sends-with-timer"
 
          thread_naming_pattern="pl"


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4395

This should fix random timeouts in CI in the query module, and also reduce considerably the execution time
Further investigation needed (on the JGroups side) of the root cause of the slowness
