### PR TITLE
ISPN-4400 Takes a long time to start up all clusters which has a lot of ...

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -465,8 +465,9 @@ public class StateConsumerImpl implements StateConsumer {
          log.tracef("Before applying the received state the data container of cache %s has %d keys", cacheName, dataContainer.size());
       }
 
+      Set<Integer> mySegments = wCh.getSegmentsForOwner(rpcManager.getAddress());
       for (StateChunk stateChunk : stateChunks) {
-         if (!wCh.getSegmentsForOwner(rpcManager.getAddress()).contains(stateChunk.getSegmentId())) {
+         if (!mySegments.contains(stateChunk.getSegmentId())) {
             log.warnf("Discarding received cache entries for segment %d of cache %s because they do not belong to this node.", stateChunk.getSegmentId(), cacheName);
             continue;
          }


### PR DESCRIPTION
...segments

This is mainly caused by the myriad of internal copies performed by the CopyOnWriteArraySet used in InboundTransferTask for tracking the segments being requested during ST. This collection is updated way too frequently if we have a large number of segments. It seems that using a simple HashMap and doing external synchronization works better both in terms of time and memory.

Jira: https://issues.jboss.org/browse/ISPN-4400
