### PR TITLE
ISPN-2956 Hot Rod conditional operations and transactional caches

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ServerFailureRetrySingleOwnerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ServerFailureRetrySingleOwnerTest.java
@@ -1,0 +1,162 @@
+package org.infinispan.client.hotrod.retry;
+
+import org.infinispan.client.hotrod.TestHelper;
+import org.infinispan.client.hotrod.VersionedValue;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
+import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
+import org.infinispan.remoting.transport.jgroups.SuspectException;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.util.ControlledConsistentHashFactory;
+import org.testng.annotations.Test;
+
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.testng.AssertJUnit.*;
+
+/**
+ * Tests that force operations to be directed to a server that applies the
+ * change locally but fails to send it to other nodes. The failover mechanism
+ * in the Hot Rod client will determine a different server and retry.
+ */
+@Test(groups = "functional", testName = "client.hotrod.retry.ServerFailureRetryTest")
+public class ServerFailureRetrySingleOwnerTest extends AbstractRetryTest {
+
+   @Override
+   protected ConfigurationBuilder getCacheConfig() {
+      ConfigurationBuilder builder = hotRodCacheConfiguration(
+            getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
+      builder.clustering().hash().numOwners(1).numSegments(1)
+            .consistentHashFactory(new ControlledConsistentHashFactory(0))
+            .transaction().transactionMode(TransactionMode.TRANSACTIONAL);
+      return builder;
+   }
+
+   public void testRetryReplaceWithVersion() {
+      ErrorInducingListener listener = new ErrorInducingListener();
+      byte[] key = TestHelper.getKeyForServer(hotRodServer1);
+      try {
+         assertNull(remoteCache.putIfAbsent(key, 1));
+         VersionedValue versioned = remoteCache.getVersioned(key);
+         assertEquals(1, versioned.getValue());
+         hotRodServer1.getCacheManager().getCache().addListener(listener);
+         assertFalse(listener.errorInduced);
+         assertEquals(true, remoteCache.replaceWithVersion(key, 2, versioned.getVersion()));
+         assertTrue(listener.errorInduced);
+         assertEquals(2, remoteCache.get(key));
+      } finally {
+         hotRodServer1.getCacheManager().removeListener(listener);
+      }
+   }
+
+   public void testRetryRemoveWithVersion() {
+      ErrorInducingListener listener = new ErrorInducingListener();
+      byte[] key = TestHelper.getKeyForServer(hotRodServer1);
+      try {
+         assertNull(remoteCache.putIfAbsent(key, 1));
+         VersionedValue versioned = remoteCache.getVersioned(key);
+         assertEquals(1, versioned.getValue());
+         hotRodServer1.getCacheManager().getCache().addListener(listener);
+         assertFalse(listener.errorInduced);
+         assertEquals(true, remoteCache.removeWithVersion(key, versioned.getVersion()));
+         assertTrue(listener.errorInduced);
+         assertNull(remoteCache.get(key));
+      } finally {
+         hotRodServer1.getCacheManager().removeListener(listener);
+      }
+   }
+
+   public void testRetryRemove() {
+      ErrorInducingListener listener = new ErrorInducingListener();
+      byte[] key = TestHelper.getKeyForServer(hotRodServer1);
+      try {
+         assertNull(remoteCache.putIfAbsent(key, 1));
+         hotRodServer1.getCacheManager().getCache().addListener(listener);
+         assertFalse(listener.errorInduced);
+         assertEquals(1, remoteCache.remove(key));
+         assertTrue(listener.errorInduced);
+         assertNull(remoteCache.get(key));
+      } finally {
+         hotRodServer1.getCacheManager().removeListener(listener);
+      }
+   }
+
+   public void testRetryReplace() {
+      ErrorInducingListener listener = new ErrorInducingListener();
+      byte[] key = TestHelper.getKeyForServer(hotRodServer1);
+      try {
+         assertNull(remoteCache.putIfAbsent(key, 1));
+         hotRodServer1.getCacheManager().getCache().addListener(listener);
+         assertFalse(listener.errorInduced);
+         assertEquals(1, remoteCache.replace(key, 2));
+         assertTrue(listener.errorInduced);
+         assertEquals(2, remoteCache.get(key));
+      } finally {
+         hotRodServer1.getCacheManager().removeListener(listener);
+      }
+   }
+
+   public void testRetryPutIfAbsent() {
+      ErrorInducingListener listener = new ErrorInducingListener();
+      byte[] key = TestHelper.getKeyForServer(hotRodServer1);
+      hotRodServer1.getCacheManager().getCache().addListener(listener);
+      try {
+         assertFalse(listener.errorInduced);
+         assertNull(remoteCache.putIfAbsent(key, 1));
+         assertTrue(listener.errorInduced);
+         assertEquals(1, remoteCache.get(key));
+      } finally {
+         hotRodServer1.getCacheManager().removeListener(listener);
+      }
+   }
+
+   public void testRetryPutOnNonEmpty() {
+      ErrorInducingListener listener = new ErrorInducingListener();
+      byte[] key = TestHelper.getKeyForServer(hotRodServer1);
+      try {
+         assertNull(remoteCache.put(key, 1));
+         hotRodServer1.getCacheManager().getCache().addListener(listener);
+         assertFalse(listener.errorInduced);
+         assertEquals(1, remoteCache.put(key, 2));
+         assertTrue(listener.errorInduced);
+         assertEquals(2, remoteCache.get(key));
+      } finally {
+         hotRodServer1.getCacheManager().removeListener(listener);
+      }
+   }
+
+   public void testRetryPutOnEmpty() {
+      ErrorInducingListener listener = new ErrorInducingListener();
+      byte[] key = TestHelper.getKeyForServer(hotRodServer1);
+      hotRodServer1.getCacheManager().getCache().addListener(listener);
+      try {
+         assertFalse(listener.errorInduced);
+         assertNull(remoteCache.put(key, 1));
+         assertTrue(listener.errorInduced);
+         assertEquals(1, remoteCache.get(key));
+      } finally {
+         hotRodServer1.getCacheManager().removeListener(listener);
+      }
+   }
+
+   @Listener
+   public static class ErrorInducingListener {
+      boolean errorInduced;
+
+      @CacheEntryCreated
+      @CacheEntryModified
+      @CacheEntryRemoved
+      @SuppressWarnings("unused")
+      public void handleEvent(CacheEntryEvent event) throws Exception {
+         if (!event.isPre() && event.isOriginLocal()) {
+            errorInduced = true;
+            throw new SuspectException("Simulated suspicion");
+         }
+      }
+   }
+
+
+}

--- a/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
@@ -597,6 +597,32 @@ It is highly recommended to read the following Javadocs (this is pretty much all
 
 [[sid-68355052]]
 
+==== Failover capabilities
+
+Hot Rod clients' capabilities to keep up with topology changes helps with request
+balancing and more importantly, with the ability to failover operations
+if one or several of the servers fail.
+
+Some of the conditional operations mentioned above, including `putIfAbsent`,
+`replace` with and without version, and conditional `remove` have strict method
+return guarantees, as well as those operations where returning the previous
+value is forced.
+
+In spite of failures, these methods return values need to be guaranteed, and
+in order to do so, it's necessary that these methods are not applied partially
+in the cluster in the event of failure. For example, imagine a `replace()`
+operation called in a server for key=k1 with `Flag.FORCE_RETURN_VALUE`, whose
+current value is `A` and the replace wants to set it to `B`. If the replace
+fails, it could happen that some servers contain `B` and others contain `A`,
+and during the failover, the original `replace()` could end up returning `B`,
+if the replace failovers to a node where `B` is set, or could end up returning
+`A`.
+
+To avoid this kind of situations, whenever Java Hot Rod client users want to
+use conditional operations, or operations whose previous value is required,
+it's important that the cache is configured to be transactional in order to
+avoid incorrect conditional operations or return values.
+
 ====  Consistent Concurrent Updates With Hot Rod Versioned Operations
 Data structures, such as Infinispan link:$$http://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/Cache.html$$[Cache] , that are accessed and modified concurrently can suffer from data consistency issues unless there're mechanisms to guarantee data correctness. Infinispan Cache, since it implements link:$$http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ConcurrentMap.html$$[ConcurrentMap] , provides operations such as link:$$http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ConcurrentMap.html#replace(K, V, V)$$[conditional replace] , link:$$http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ConcurrentMap.html#putIfAbsent(K, V)$$[putIfAbsent] , and link:$$http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ConcurrentMap.html#remove(java.lang.Object, java.lang.Object)$$[conditional remove] to its clients in order to guarantee data correctness. It even allows clients to operate against cache instances within JTA transactions, hence providing the necessary data consistency guarantees.
 

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
@@ -389,6 +389,13 @@ object Decoder2x extends AbstractVersionedDecoder with ServerConstants with Log 
 
    override def getOptimizedCache(h: HotRodHeader, c: Cache): Cache = {
       var optCache = c
+      h.op match {
+         case PutIfAbsentRequest | ReplaceRequest | ReplaceIfUnmodifiedRequest
+              | RemoveIfUnmodifiedRequest if !isCacheTransactional(optCache) =>
+            warnConditionalOperationNonTransactional(h.op.toString)
+         case _ => // no-op
+      }
+
       if (hasFlag(h, SkipCacheLoader)) {
          h.op match {
             case PutRequest
@@ -410,9 +417,15 @@ object Decoder2x extends AbstractVersionedDecoder with ServerConstants with Log 
                optCache = optCache.withFlags(IGNORE_RETURN_VALUES)
             case _ =>
          }
+      } else {
+         if (!isCacheTransactional(optCache))
+            warnForceReturnPreviousNonTransactional(h.op.toString)
       }
       optCache
    }
+
+   private def isCacheTransactional(c: Cache): Boolean =
+      SecurityActions.getCacheConfiguration(c).transaction().transactionMode().isTransactional
 
    def normalizeAuthorizationId(id: String): String = {
       val realm = id.indexOf('@')

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/logging/JavaLog.java
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/logging/JavaLog.java
@@ -55,4 +55,12 @@ public interface JavaLog extends org.infinispan.util.logging.Log {
    @Message(value = "Event not handled by current Hot Rod event implementation: '%s'", id = 6009)
    IllegalStateException unexpectedEvent(Event e);
 
+   @LogMessage(level = WARN)
+   @Message(value = "Conditional operation '%s' should be used with transactional caches, otherwise data inconsistency issues could arise under failure situations", id = 6010)
+   void warnConditionalOperationNonTransactional(String op);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Operation '%s' forced to return previous value should be used on transactional caches, otherwise data inconsistency issues could arise under failure situations", id = 6011)
+   void warnForceReturnPreviousNonTransactional(String op);
+
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/logging/Log.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/logging/Log.scala
@@ -22,4 +22,7 @@ trait Log extends org.infinispan.server.core.logging.Log {
 
    def unexpectedEvent(e: Event[Bytes, Bytes]) = log.unexpectedEvent(e)
 
+   def warnConditionalOperationNonTransactional(op: String) = log.warnConditionalOperationNonTransactional(op)
+
+   def warnForceReturnPreviousNonTransactional(op: String) = log.warnForceReturnPreviousNonTransactional(op)
 }


### PR DESCRIPTION
- Transactional caches are required in order to be able to guarantee correct retry logic for Hot Rod operations relying on conditional operations, or operations where the previous value is returned.
- WARN messages have been added for when conditional or operations needing previous value are executed against non-transactional caches.
