### PR TITLE
ISPN-3840 Test suite should continue when a test hasn't closed its cache managers

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/ConcurrentStartWithReplTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ConcurrentStartWithReplTest.java
@@ -10,6 +10,7 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.commons.util.concurrent.AbstractInProcessFuture;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -39,7 +40,7 @@ public class ConcurrentStartWithReplTest extends AbstractInfinispanTest {
 
    @Test(timeOut = 60000)
    public void testSequence1() throws ExecutionException, InterruptedException {
-      TestCacheManagerFactory.backgroundTestStarted(this);
+      TestResourceTracker.backgroundTestStarted(this);
       /*
 
       Sequence 1:
@@ -59,7 +60,7 @@ public class ConcurrentStartWithReplTest extends AbstractInfinispanTest {
 
    @Test(timeOut = 60000)
    public void testSequence2() throws ExecutionException, InterruptedException {
-      TestCacheManagerFactory.backgroundTestStarted(this);
+      TestResourceTracker.backgroundTestStarted(this);
       /*
 
       Sequence 2:
@@ -78,7 +79,7 @@ public class ConcurrentStartWithReplTest extends AbstractInfinispanTest {
 
    @Test(timeOut = 60000)
    public void testSequence3() throws ExecutionException, InterruptedException {
-      TestCacheManagerFactory.backgroundTestStarted(this);
+      TestResourceTracker.backgroundTestStarted(this);
       /*
 
       Sequence 3:
@@ -96,7 +97,7 @@ public class ConcurrentStartWithReplTest extends AbstractInfinispanTest {
 
    @Test(timeOut = 60000)
    public void testSequence4() throws ExecutionException, InterruptedException {
-      TestCacheManagerFactory.backgroundTestStarted(this);
+      TestResourceTracker.backgroundTestStarted(this);
       /*
 
       Sequence 4:

--- a/core/src/test/java/org/infinispan/distribution/IllegalMonitorTest.java
+++ b/core/src/test/java/org/infinispan/distribution/IllegalMonitorTest.java
@@ -2,6 +2,7 @@ package org.infinispan.distribution;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.context.Flag;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -37,6 +38,7 @@ public class IllegalMonitorTest extends BaseDistFunctionalTest<Object, String> {
     */
    @Test(threadPoolSize = 7, invocationCount = 21)
    public void testScenario() throws InterruptedException {
+      TestResourceTracker.backgroundTestStarted(this);
       int myId = sequencer.incrementAndGet();
       AdvancedCache cache = this.caches.get(myId % this.INIT_CLUSTER_SIZE).getAdvancedCache();
       for (int i = 0; i < 100; i++) {

--- a/core/src/test/java/org/infinispan/distribution/UnknownCacheStartTest.java
+++ b/core/src/test/java/org/infinispan/distribution/UnknownCacheStartTest.java
@@ -8,7 +8,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
-import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.testng.TestException;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -36,7 +36,7 @@ public class UnknownCacheStartTest extends AbstractInfinispanTest {
 
    @Test (expectedExceptions = {CacheException.class, TestException.class}, timeOut = 60000)
    public void testStartingUnknownCaches() throws Throwable {
-      TestCacheManagerFactory.backgroundTestStarted(this);
+      TestResourceTracker.backgroundTestStarted(this);
 
       cm1 = createCacheManager(configuration);
 

--- a/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverStressTest.java
+++ b/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverStressTest.java
@@ -15,6 +15,7 @@ import org.infinispan.metadata.Metadata;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.test.fwk.TransportFlags;
 import org.testng.annotations.Test;
 
@@ -150,7 +151,7 @@ public class DistributedEntryRetrieverStressTest extends MultipleCacheManagersTe
       futures[futures.length - 1] = fork(new Callable<Void>() {
          @Override
          public Void call() throws Exception {
-            TestCacheManagerFactory.backgroundTestStarted(DistributedEntryRetrieverStressTest.this);
+            TestResourceTracker.backgroundTestStarted(DistributedEntryRetrieverStressTest.this);
             try {
                Cache<?, ?> cacheToKill = cache(CACHE_COUNT - 1);
                while (!complete.get()) {

--- a/core/src/test/java/org/infinispan/persistence/FlushingAsyncStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/FlushingAsyncStoreTest.java
@@ -3,9 +3,9 @@ package org.infinispan.persistence;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.testng.annotations.Test;
 
 /**
@@ -38,7 +38,7 @@ public class FlushingAsyncStoreTest extends SingleCacheManagerTest {
 
    @Test(timeOut = 10000)
    public void writeOnStorage() {
-      TestCacheManagerFactory.backgroundTestStarted(this);
+      TestResourceTracker.backgroundTestStarted(this);
       cache = cacheManager.getCache("AsyncStoreInMemory");
       cache.put("key1", "value");
       cache.stop();

--- a/core/src/test/java/org/infinispan/persistence/support/AsyncStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/support/AsyncStoreTest.java
@@ -31,6 +31,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.testng.annotations.AfterMethod;
@@ -91,7 +92,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
 
    @Test(timeOut=30000)
    public void testPutRemove() throws Exception {
-      TestCacheManagerFactory.backgroundTestStarted(this);
+      TestResourceTracker.backgroundTestStarted(this);
       createStore();
 
       final int number = 1000;
@@ -103,7 +104,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
 
    @Test(timeOut=30000, groups = "unstable")
    public void testPutClearPut() throws Exception {
-      TestCacheManagerFactory.backgroundTestStarted(this);
+      TestResourceTracker.backgroundTestStarted(this);
       createStore();
 
       final int number = 1000;
@@ -118,7 +119,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
 
    @Test(timeOut=30000)
    public void testMultiplePutsOnSameKey() throws Exception {
-      TestCacheManagerFactory.backgroundTestStarted(this);
+      TestResourceTracker.backgroundTestStarted(this);
       createStore();
 
       final int number = 1000;
@@ -130,7 +131,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
 
    @Test(timeOut=30000)
    public void testRestrictionOnAddingToAsyncQueue() throws Exception {
-      TestCacheManagerFactory.backgroundTestStarted(this);
+      TestResourceTracker.backgroundTestStarted(this);
       createStore();
 
       writer.delete("blah");

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferFunctionalTest.java
@@ -7,7 +7,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
-import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.test.fwk.TransportFlags;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.util.logging.Log;
@@ -250,7 +250,7 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
 
    @Test (timeOut = 120000)
    public void testSTWithWritingNonTxThread(Method m) throws Exception {
-      TestCacheManagerFactory.backgroundTestStarted(this);
+      TestResourceTracker.backgroundTestStarted(this);
       testCount++;
       logTestStart(m);
       writingThreadTest(false);
@@ -259,7 +259,7 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
 
    @Test (timeOut = 120000, groups = "unstable")
    public void testSTWithWritingTxThread(Method m) throws Exception {
-      TestCacheManagerFactory.backgroundTestStarted(this);
+      TestResourceTracker.backgroundTestStarted(this);
       testCount++;
       logTestStart(m);
       writingThreadTest(true);

--- a/core/src/test/java/org/infinispan/test/fwk/FailAllSetupTestNGHook.java
+++ b/core/src/test/java/org/infinispan/test/fwk/FailAllSetupTestNGHook.java
@@ -1,0 +1,28 @@
+package org.infinispan.test.fwk;
+
+import org.testng.IConfigurable;
+import org.testng.IConfigureCallBack;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+
+/**
+ * TestNG hook to fail all tests.
+ *
+ * Useful to check that the cache managers are shut down properly for failed tests.
+ *
+ * @author Dan Berindei
+ * @since 7.0
+ */
+public class FailAllSetupTestNGHook implements IConfigurable {
+   @Override
+   public void run(IConfigureCallBack callBack, ITestResult testResult) {
+      ITestNGMethod testMethod = testResult.getMethod();
+      System.out.println("Running " + testMethod.getDescription());
+
+      callBack.runConfigurationMethod(testResult);
+
+      if (testMethod.isBeforeMethodConfiguration() || testMethod.isBeforeClassConfiguration() || testMethod.isBeforeTestConfiguration()) {
+         throw new RuntimeException("Induced failure");
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/test/fwk/FailAllTestNGHook.java
+++ b/core/src/test/java/org/infinispan/test/fwk/FailAllTestNGHook.java
@@ -1,0 +1,22 @@
+package org.infinispan.test.fwk;
+
+import org.testng.IHookCallBack;
+import org.testng.IHookable;
+import org.testng.ITestResult;
+import org.testng.SkipException;
+
+/**
+ * TestNG hook to fail all tests.
+ *
+ * Useful to check that the cache managers are shut down properly for failed tests.
+ *
+ * @author Dan Berindei
+ * @since 7.0
+ */
+public class FailAllTestNGHook implements IHookable {
+   @Override
+   public void run(IHookCallBack iHookCallBack, ITestResult iTestResult) {
+      iHookCallBack.runTestMethod(iTestResult);
+      throw new SkipException("Induced failure");
+   }
+}

--- a/core/src/test/java/org/infinispan/test/fwk/TestResourceTracker.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestResourceTracker.java
@@ -1,0 +1,218 @@
+package org.infinispan.test.fwk;
+
+import org.infinispan.commons.equivalence.AnyEquivalence;
+import org.infinispan.commons.util.concurrent.jdk8backported.EquivalentConcurrentHashMapV8;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.security.Security;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Keeps track of resources created by tests and cleans them up at the end of the test.
+ *
+ * @author Dan Berindei
+ * @since 7.0
+ */
+public class TestResourceTracker {
+   private static final Log log = LogFactory.getLog(TestResourceTracker.class);
+   private static final EquivalentConcurrentHashMapV8<String, TestResources> testResources = new EquivalentConcurrentHashMapV8<>(AnyEquivalence.getInstance(), AnyEquivalence.getInstance());
+   private static final ThreadLocal<String> threadTestName = new ThreadLocal<>();
+
+   public static void addResource(String testName, final Cleaner<?> cleaner) {
+      TestResources resources = getTestResources(testName);
+      resources.addResource(cleaner);
+   }
+
+   /**
+    * Add a resource to the current thread's running test.
+    */
+   public static void addResource(Cleaner<?> cleaner) {
+      String testName = getCurrentTestName();
+      addResource(testName, cleaner);
+   }
+
+   protected static void cleanUpResources(String testName) {
+      TestResources resources = testResources.remove(testName);
+      if (resources != null) {
+         for (Cleaner<?> cleaner : resources.getCleaners()) {
+            try {
+               cleaner.close();
+            } catch (Throwable t) {
+               log.fatalf(t, "Error cleaning resource %s for test %s", cleaner.ref, testName);
+               throw new IllegalStateException("Error cleaning resource " + cleaner.ref + " for test " + testName);
+            }
+         }
+      }
+   }
+
+   public static String getCurrentTestName() {
+      String testName = threadTestName.get();
+      if (testName == null) {
+         // Either we're running from within the IDE or it's a
+         // @Test(timeOut=nnn) test. We rely here on some specific TestNG
+         // thread naming convention which can break, but TestNG offers no
+         // other alternative. It does not offer any callbacks within the
+         // thread that runs the test that can timeout.
+         String threadName = Thread.currentThread().getName();
+         String pattern = "TestNGInvoker-";
+         if (threadName.startsWith(pattern)) {
+            // This is a timeout test, so force the user to call our marking method
+            throw new IllegalStateException("Test name is not set! Please call TestResourceTracker.testStarted(this) in your test method!");
+         } else if (Thread.currentThread().getName().equals("main")) {
+            // Test is being run from an IDE
+            testName = "main";
+         } else {
+            log.warnf("Test name not set in unknown thread %s", Thread.currentThread().getName());
+            testName = "unknown";
+         }
+      }
+      return testName;
+   }
+
+   /**
+    * Called on the "main" test thread, before any configuration method.
+    */
+   public static void testStarted(String testName) {
+      if (testResources.containsKey(testName)) {
+         throw new IllegalStateException("Two tests with the same name running in parallel: " + testName);
+      }
+      setThreadTestName(testName);
+      Thread.currentThread().setName(getNextTestThreadName());
+   }
+
+   /**
+    * Called on the "main" test thread, after any configuration method.
+    */
+   public static void testFinished(String testName) {
+      cleanUpResources(testName);
+      if (!testName.equals(getCurrentTestName())) {
+         cleanUpResources(getCurrentTestName());
+         throw new IllegalArgumentException("Current thread name was not set correctly: " + getCurrentTestName() +
+               ", should have been " + testName);
+      }
+      setThreadTestName(null);
+   }
+
+   /**
+    * Should be called by the user on any "background" test thread that creates resources, e.g. at the beginning of a
+    * test with a {@code @Test(timeout=n)} annotation.
+    */
+   public static void backgroundTestStarted(Object testInstance) {
+      setThreadTestName(testInstance.getClass().getName());
+      Thread.currentThread().setName(getNextTestThreadName());
+   }
+
+   public static void setThreadTestName(String testName) {
+      threadTestName.set(testName);
+   }
+
+   public static String getNextNodeName() {
+      String testName = getCurrentTestName();
+      TestResources resources = getTestResources(testName);
+      String simpleName = resources.getSimpleName();
+      int nextNodeIndex = resources.addNode();
+      return simpleName + "-" + "Node" + getNameForIndex(nextNodeIndex);
+   }
+
+   public static String getNextTestThreadName() {
+      String testName = getCurrentTestName();
+      TestResources resources = getTestResources(testName);
+      String simpleName = resources.getSimpleName();
+      int nextThreadIndex = resources.addThread();
+      return "testng-" + simpleName + (nextThreadIndex != 0 ? "-" + nextThreadIndex : "");
+   }
+
+   private static String getNameForIndex(int i) {
+      final int k = 'Z' - 'A' + 1;
+      String c = String.valueOf((char) ('A' + i % k));
+      int q = i / k;
+      return q == 0 ? c : getNameForIndex(q - 1) + c;
+   }
+
+   private static TestResources getTestResources(final String testName) {
+      return testResources.computeIfAbsent(testName, new EquivalentConcurrentHashMapV8.Fun<String, TestResources>() {
+         @Override
+         public TestResources apply(String key) {
+            return new TestResources(getSimpleName(testName));
+         }
+      });
+   }
+
+   private static String getSimpleName(String fullTestName) {
+      return fullTestName.substring(fullTestName.lastIndexOf(".") + 1);
+   }
+
+   private static class TestResources {
+      private final String simpleName;
+      private final AtomicInteger nodeCount = new AtomicInteger(0);
+      private final AtomicInteger threadCount = new AtomicInteger(0);
+      private final List<Cleaner<?>> resourceCleaners = Collections.synchronizedList(new ArrayList<Cleaner<?>>());
+
+      private TestResources(String simpleName) {
+         this.simpleName = simpleName;
+      }
+
+      public String getSimpleName() {
+         return simpleName;
+      }
+
+      public int addNode() {
+         return nodeCount.getAndIncrement();
+      }
+
+      public int addThread() {
+         return threadCount.getAndIncrement();
+      }
+
+      public void addResource(Cleaner<?> cleaner) {
+         resourceCleaners.add(cleaner);
+      }
+
+      public List<Cleaner<?>> getCleaners() {
+         return resourceCleaners;
+      }
+   }
+
+   public static abstract class Cleaner<T> {
+      protected final T ref;
+
+      protected Cleaner(T ref) {
+         this.ref = ref;
+      }
+
+      public abstract void close();
+   }
+
+   public static class CacheManagerCleaner extends Cleaner<EmbeddedCacheManager> {
+
+      protected CacheManagerCleaner(EmbeddedCacheManager ref) {
+         super(ref);
+      }
+
+      @Override
+      public void close() {
+         PrivilegedAction<Object> action = new PrivilegedAction<Object>() {
+            @Override
+            public Object run() {
+               if (!ref.getStatus().isTerminated()) {
+                  log.debugf("Stopping cache manager %s", ref);
+                  ref.stop();
+               }
+               return null;
+            }
+         };
+         if (System.getSecurityManager() != null) {
+            AccessController.doPrivileged(action);
+         } else {
+            Security.doPrivileged(action);
+         }
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/test/fwk/UnitTestTestNGListener.java
+++ b/core/src/test/java/org/infinispan/test/fwk/UnitTestTestNGListener.java
@@ -4,7 +4,6 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.testng.*;
 
-import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -92,16 +91,15 @@ public class UnitTestTestNGListener implements ITestListener, IInvokedMethodList
       String fullName = arg0.getName();
       String simpleName = fullName.substring(fullName.lastIndexOf('.') + 1);
       Class testClass = arg0.getCurrentXmlTest().getXmlClasses().get(0).getSupportClass();
-      boolean isAbstract = Modifier.isAbstract(testClass.getModifiers());
-      if (!isAbstract && !simpleName.equals(testClass.getSimpleName())) {
+      if (!simpleName.equals(testClass.getSimpleName())) {
          log.warnf("Wrong test name %s for class %s", simpleName, testClass.getSimpleName());
       }
-      TestCacheManagerFactory.testStarted(testClass.getSimpleName(), testClass.getName());
+      TestResourceTracker.testStarted(testClass.getName());
    }
 
    public void onFinish(ITestContext arg0) {
       Class testClass = arg0.getCurrentXmlTest().getXmlClasses().get(0).getSupportClass();
-      TestCacheManagerFactory.testFinished(testClass.getSimpleName());
+      TestResourceTracker.testFinished(testClass.getName());
    }
 
    private String getThreadId() {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -83,6 +83,7 @@
       <defaultTestGroup>functional,unit,arquillian</defaultTestGroup>
       <!-- unstable and stress because we can have them inside a functional class, for example -->
       <defaultExcludedTestGroup>unstable,stress,unstable_xsite</defaultExcludedTestGroup>
+      <forkJvmArgs>-Xmx1024m -XX:MaxPermSize=256m</forkJvmArgs>
       <testNGListener>org.infinispan.test.fwk.UnitTestTestNGListener</testNGListener>
       <infinispan.test.parallel.threads>15</infinispan.test.parallel.threads>
       <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
@@ -1533,6 +1534,8 @@
                   <infinispan.unsafe.allow_jdk8_chm>true</infinispan.unsafe.allow_jdk8_chm>
                   <log4j.configuration>${log4j.configuration}</log4j.configuration>
                   <build.directory>${project.build.directory}</build.directory>
+                 <!-- this is picked up in the log4j xml which prepends it to each module's log file-->
+                 <infinispan.module-name>${project.artifactId}</infinispan.module-name>
                </systemPropertyVariables>
                <trimStackTrace>false</trimStackTrace>
                <properties>
@@ -1542,7 +1545,7 @@
                   </property>
                </properties>
                <!-- -Dsun.nio.ch.bugLevel needed because of http://bugs.sun.com/view_bug.do?bug_id=6427854 -->
-               <argLine>-Xmx1024m -XX:MaxPermSize=256m -Dsun.nio.ch.bugLevel</argLine>
+               <argLine>${forkJvmArgs} -Dsun.nio.ch.bugLevel</argLine>
             </configuration>
          </plugin>
          <!-- Scan module for components and persist these into a data file, for use at runtime -->
@@ -1674,20 +1677,6 @@
             <defaultTestGroup>functional,unit,arquillian</defaultTestGroup>
             <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
          </properties>
-         <build>
-            <plugins>
-               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-surefire-plugin</artifactId>
-                  <configuration>
-                     <systemPropertyVariables>
-                           <!-- this is picked up in the log4j xml which prepends it to each module's log file-->
-                           <infinispan.module-name>${project.artifactId}</infinispan.module-name>
-                     </systemPropertyVariables>
-                  </configuration>
-               </plugin>
-            </plugins>
-         </build>
       </profile>
       <profile>
          <id>test-functional</id>
@@ -1741,13 +1730,39 @@
             <defaultTestGroup>transaction</defaultTestGroup>
          </properties>
       </profile>
-      <profile>
-         <id>debug-tests</id>
-         <properties>
-            <testNGListener>org.infinispan.test.fwk.DebuggingUnitTestNGListener</testNGListener>
-            <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
-         </properties>
-      </profile>
+     <profile>
+       <id>debug-tests</id>
+       <properties>
+         <testNGListener>org.infinispan.test.fwk.DebuggingUnitTestNGListener</testNGListener>
+         <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
+       </properties>
+     </profile>
+     <profile>
+       <id>fail-all-tests</id>
+       <properties>
+         <testNGListener>org.infinispan.test.fwk.UnitTestTestNGListener,org.infinispan.test.fwk.FailAllTestNGHook</testNGListener>
+         <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
+       </properties>
+     </profile>
+     <profile>
+       <id>fail-all-tests-setup</id>
+       <properties>
+         <testNGListener>org.infinispan.test.fwk.UnitTestTestNGListener,org.infinispan.test.fwk.FailAllSetupTestNGHook</testNGListener>
+         <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
+       </properties>
+     </profile>
+     <profile>
+       <id>customForkJvmArgs</id>
+       <activation>
+         <activeByDefault>false</activeByDefault>
+         <property>
+           <name>env.MAVEN_FORK_OPTS</name>
+         </property>
+       </activation>
+       <properties>
+         <forkJvmArgs>${env.MAVEN_FORK_OPTS}</forkJvmArgs>
+       </properties>
+     </profile>
       <profile>
          <id>nonParallel</id>
          <activation>

--- a/tree/src/test/java/org/infinispan/api/tree/TreeStructureHashCodeTest.java
+++ b/tree/src/test/java/org/infinispan/api/tree/TreeStructureHashCodeTest.java
@@ -43,7 +43,6 @@ public class TreeStructureHashCodeTest {
          addToDistribution(container.getLock(structureKey), distribution);
       }
 
-      System.out.println("Distribution: " + distribution);
       assert distribution.size() <= container.size() : "Cannot have more locks than the container size!";
       // assume at least a 2/3rd even distribution
       // but also consider that data snd structure keys would typically provide the same hash code


### PR DESCRIPTION
.https://issues.jboss.org/browse/ISPN-3840

Add fail-all-tests and fail-all-tests-setup profile to fail all the tests
and @Before methods and check that their cache managers are closed properly.

Initially I intended to keep logging the managers not shut down by the tests, but it turns out SingleCacheManagerTest-derived tests too often leak managers because the createCacheManager implementation fails after creating the manager (and without returning it).
