### PR TITLE
ISPN-4291 Poor REPL state transfer performance with cache stores

### DIFF
--- a/core/src/test/java/org/infinispan/statetransfer/TxReadAfterLosingOwnershipTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/TxReadAfterLosingOwnershipTest.java
@@ -67,9 +67,9 @@ public class TxReadAfterLosingOwnershipTest extends MultipleCacheManagersTest {
       cache(0).put("key", "value0");
       assertCachesKeyValue("key", "value0");
 
-      StateConsumerImpl stateConsumer = (StateConsumerImpl) TestingUtil.extractComponent(cache(1), StateConsumer.class);
+      StateConsumerImpl stateConsumer1 = (StateConsumerImpl) TestingUtil.extractComponent(cache(1), StateConsumer.class);
       Listener listener = new Listener();
-      stateConsumer.setKeyInvalidationListener(listener);
+      stateConsumer1.setKeyInvalidationListener(listener);
 
       log.debug("Add a 3rd node");
       addClusterEnabledCacheManager(createConfigurationBuilder());
@@ -82,21 +82,22 @@ public class TxReadAfterLosingOwnershipTest extends MultipleCacheManagersTest {
          }
       });
 
+      log.debug("Waiting for the 3rd node to join");
+
+      join.get();
+
       log.debug("Waiting for command to block");
       listener.notifier.await();
 
       log.debug("Set a new value");
       //we change the value in the old owner
-      operation.update(cache(1));
+      operation.update(cache(0));
 
       //we check the value in the primary owner and old owner (cache(2) has not started yet)
       assertCachesKeyValue("key", operation.finalValue(), cache(0), cache(1));
 
 
       listener.wait.countDown();
-
-      log.debug("Waiting for the 3rd node to join");
-      join.get();
 
       assertCachesKeyValue("key", operation.finalValue());
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4400
- Skip the cache store iteration if the local node didn't lose any segments
- Move the invalidation after receiving the transaction data, so that write
  commands can be performed in parallel.
