### PR TITLE
ISPN-4424 Synchronize updating cache entry and making a copy

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplaceWithVersionConcurrencyTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ReplaceWithVersionConcurrencyTest.java
@@ -1,0 +1,123 @@
+package org.infinispan.client.hotrod;
+
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.commons.equivalence.ByteArrayEquivalence;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.fail;
+
+@Test(groups = "functional", testName = "client.hotrod.ReplaceWithVersionConcurrencyTest")
+public class ReplaceWithVersionConcurrencyTest extends MultiHotRodServersTest {
+
+   static final AtomicInteger globalCounter = new AtomicInteger();
+   static final String KEY = "A";
+   static final int NUM_THREADS = 20;
+   static final int OPS_PER_THREAD = 200;
+   static final int TIMEOUT_MINUTES = 5;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = hotRodCacheConfiguration(
+            getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false));
+//            .transaction()
+//            .lockingMode(LockingMode.PESSIMISTIC)
+//            .transactionMode(TransactionMode.TRANSACTIONAL)
+      ;
+      createHotRodServers(2, builder);
+   }
+
+   public void testKeepingCounterWithReplaceWithVersion() throws Exception {
+      RemoteCache<String, Integer> cache = client(0).getCache();
+      assertNull(cache.get(KEY));
+      long timeSpent = System.currentTimeMillis();
+      List<Future<Integer>> results = new ArrayList<Future<Integer>>(NUM_THREADS);
+      ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
+      for (int i = 0; i < NUM_THREADS; i++) {
+         CounterUpdater app = new CounterUpdater(cache, KEY, OPS_PER_THREAD);
+         Future<Integer> result = executor.submit(app);
+         results.add(result);
+      }
+      executor.shutdown();
+      executor.awaitTermination(TIMEOUT_MINUTES, TimeUnit.MINUTES);
+      timeSpent = System.currentTimeMillis() - timeSpent;
+
+      int actual = cache.get(KEY); // server-side value
+      int expected = 0; // client-side value
+      for (Future<Integer> f : results)
+         expected += f.get();
+
+      log.info("Time spent: " + timeSpent / 1000.0 + " secs.");
+      assertEquals(expected, actual);
+   }
+
+   static class CounterUpdater implements Callable<Integer> {
+      static final Log log = LogFactory.getLog(CounterUpdater.class);
+      final RemoteCache<String, Integer> cache;
+      final String key;
+      final int limit;
+
+      CounterUpdater(RemoteCache<String, Integer> cache, String key, int limit) {
+         this.cache = cache;
+         this.key = key;
+         this.limit = limit;
+      }
+
+      @Override
+      public Integer call() throws Exception {
+         int counter = 0;
+         log.info("Start to count.");
+         int i = 0;
+         while (i < limit) {
+            incrementCounter();
+            counter++;
+            i++;
+         }
+         log.info("Counted " + counter);
+         return counter;
+      }
+
+      private void incrementCounter() {
+         while (true) {
+            VersionedValue<Integer> versioned = cache.getVersioned(key);
+            if (versioned == null) {
+               if (cache.withFlags(Flag.FORCE_RETURN_VALUE).putIfAbsent(key, 1) == null) {
+                  log.info("count=" + globalCounter.getAndIncrement() + ",prev=0,new=1 (first-put)");
+                  return;
+               }
+            } else {
+               int val = versioned.getValue() + 1;
+               long version = versioned.getVersion();
+               if (cache.replaceWithVersion(key, val, version)) {
+                  int count = globalCounter.getAndIncrement();
+                  log.info("count=" + count +",prev=" + versioned.getValue() + ",new=" + val + ",prev-version=" + version);
+                  // Optimistically updated, no more retries.
+                  return;
+               }
+            }
+         }
+      }
+
+
+   }
+
+}

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -234,7 +234,8 @@ public class CommandsFactoryImpl implements CommandsFactory {
 
    @Override
    public GetKeyValueCommand buildGetKeyValueCommand(Object key, Set<Flag> flags, boolean returnEntry) {
-      return new GetKeyValueCommand(key, flags, returnEntry);
+      // TODO: This could be optimised, with a separate class for GetCacheEntryCommand that takes entryFactory, avoiding normal gets getting extra instance variable
+      return new GetKeyValueCommand(key, flags, returnEntry, entryFactory);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/container/InternalEntryFactory.java
+++ b/core/src/main/java/org/infinispan/container/InternalEntryFactory.java
@@ -118,4 +118,12 @@ public interface InternalEntryFactory {
     * @return an {@link InternalCacheValue}
     */
    InternalCacheValue createValue(CacheEntry cacheEntry);
+
+   /**
+    * TODO..
+    *
+    * @param cacheEntry
+    * @return
+    */
+   CacheEntry copy(CacheEntry cacheEntry);
 }

--- a/core/src/main/java/org/infinispan/util/CoreImmutables.java
+++ b/core/src/main/java/org/infinispan/util/CoreImmutables.java
@@ -4,6 +4,7 @@ import static org.infinispan.commons.util.Util.toStr;
 
 import org.infinispan.commons.util.Immutables;
 import org.infinispan.container.DataContainer;
+import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.InternalCacheValue;
 import org.infinispan.metadata.Metadata;
@@ -26,6 +27,22 @@ public class CoreImmutables extends Immutables {
     */
    public static <K, V> InternalCacheEntry<K, V> immutableInternalCacheEntry(InternalCacheEntry<K, V> entry) {
       return new ImmutableInternalCacheEntry<K, V>(entry);
+   }
+
+   /**
+    * TODO...
+    *
+    * Creates an immutable version of cache entry whose attributes are set on
+    * construction. This is a true shallow copy because referencing the
+    * {@link CacheEntry} could lead to changes in the attributes over time,
+    * due to its mutability.
+    *
+    * @param entry the cache entry to provide immutability view for
+    * @return an immutable {@link CacheEntry}} wrapper contains the values of
+    * the wrapped cache entry at construction time.
+    */
+   public static <K, V> CacheEntry<K, V> cacheEntryCopy(CacheEntry<K, V> entry) {
+      return new CacheEntryCopy<>(entry);
    }
 
    /**
@@ -308,4 +325,226 @@ public class CoreImmutables extends Immutables {
          return entry.getMetadata();
       }
    }
+
+   /**
+    * Copy of {@link org.infinispan.container.entries.CacheEntry}.
+    */
+   private static class CacheEntryCopy<K, V> implements CacheEntry<K, V>, Immutable {
+      final int hash;
+      final V value;
+      final K key;
+      final long lifespan;
+      final long maxIdle;
+      final boolean isChanged;
+      final boolean isCreated;
+      final boolean isNull;
+      final boolean isRemoved;
+      final boolean isEvicted;
+      final boolean isValid;
+      final boolean isLoaded;
+      final Metadata metadata;
+
+      CacheEntryCopy(CacheEntry<K, V> entry) {
+         metadata = entry.getMetadata();
+         key = entry.getKey();
+         value = entry.getValue();
+         hash = entry.hashCode();
+         lifespan = entry.getLifespan();
+         maxIdle = entry.getMaxIdle();
+         isChanged = entry.isChanged();
+         isCreated = entry.isCreated();
+         isNull = entry.isNull();
+         isRemoved = entry.isRemoved();
+         isEvicted = entry.isEvicted();
+         isValid = entry.isValid();
+         isLoaded = entry.isLoaded();
+      }
+
+      @Override
+      public K getKey() {
+         return key;
+      }
+
+      @Override
+      public V getValue() {
+         return value;
+      }
+
+      @Override
+      public V setValue(V value) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void commit(DataContainer container, Metadata metadata) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) return true;
+         if (o == null || getClass() != o.getClass()) return false;
+
+         CacheEntry that = (CacheEntry) o;
+
+         if (hash != that.hashCode()) return false;
+         if (isChanged != that.isChanged()) return false;
+         if (isCreated != that.isCreated()) return false;
+         if (isEvicted != that.isEvicted()) return false;
+         if (isLoaded != that.isLoaded()) return false;
+         if (isNull != that.isNull()) return false;
+         if (isRemoved != that.isRemoved()) return false;
+         if (isValid != that.isValid()) return false;
+         if (lifespan != that.getLifespan()) return false;
+         if (maxIdle != that.getMaxIdle()) return false;
+         if (!key.equals(that.getKey())) return false;
+         if (!metadata.equals(that.getMetadata())) return false;
+         if (!value.equals(that.getValue())) return false;
+
+         return true;
+      }
+
+      @Override
+      public int hashCode() {
+         int result = hash;
+         result = 31 * result + value.hashCode();
+         result = 31 * result + key.hashCode();
+         result = 31 * result + (int) (lifespan ^ (lifespan >>> 32));
+         result = 31 * result + (int) (maxIdle ^ (maxIdle >>> 32));
+         result = 31 * result + (isChanged ? 1 : 0);
+         result = 31 * result + (isCreated ? 1 : 0);
+         result = 31 * result + (isNull ? 1 : 0);
+         result = 31 * result + (isRemoved ? 1 : 0);
+         result = 31 * result + (isEvicted ? 1 : 0);
+         result = 31 * result + (isValid ? 1 : 0);
+         result = 31 * result + (isLoaded ? 1 : 0);
+         result = 31 * result + metadata.hashCode();
+         return result;
+      }
+
+      @Override
+      public boolean undelete(boolean doUndelete) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void setMetadata(Metadata metadata) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public long getLifespan() {
+         return lifespan;
+      }
+
+      @Override
+      public long getMaxIdle() {
+         return maxIdle;
+      }
+
+      @Override
+      public boolean skipLookup() {
+         return false;
+      }
+
+      @Override
+      public boolean isChanged() {
+         return isChanged;
+      }
+
+      @Override
+      public boolean isCreated() {
+         return isCreated;
+      }
+
+      @Override
+      public boolean isNull() {
+         return isNull;
+      }
+
+      @Override
+      public boolean isRemoved() {
+         return isRemoved;
+      }
+
+      @Override
+      public boolean isEvicted() {
+         return isEvicted;
+      }
+
+      @Override
+      public boolean isValid() {
+         return isValid;
+      }
+
+      @Override
+      public boolean isLoaded() {
+         return isLoaded;
+      }
+
+      @Override
+      public void rollback() {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void setCreated(boolean created) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void setRemoved(boolean removed) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void setChanged(boolean changed) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void setEvicted(boolean evicted) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void setValid(boolean valid) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void setLoaded(boolean loaded) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void setSkipLookup(boolean skipLookup) {
+         throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Metadata getMetadata() {
+         return metadata;
+      }
+
+      @Override
+      public String toString() {
+         return "CacheEntryCopy{" +
+               "hash=" + hash +
+               ", value=" + toStr(value) +
+               ", key=" + toStr(key) +
+               ", lifespan=" + lifespan +
+               ", maxIdle=" + maxIdle +
+               ", isChanged=" + isChanged +
+               ", isCreated=" + isCreated +
+               ", isNull=" + isNull +
+               ", isRemoved=" + isRemoved +
+               ", isEvicted=" + isEvicted +
+               ", isValid=" + isValid +
+               ", isLoaded=" + isLoaded +
+               ", metadata=" + metadata +
+               '}';
+      }
+   }
+
 }

--- a/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
@@ -2,6 +2,7 @@ package org.infinispan.marshall;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.util.Util;
+import org.infinispan.container.InternalEntryFactoryImpl;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.atomic.impl.AtomicHashMap;
 import org.infinispan.commands.ReplicableCommand;
@@ -216,7 +217,7 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
 
       // SizeCommand does not have an empty constructor, so doesn't look to be one that is marshallable.
 
-      GetKeyValueCommand c4 = new GetKeyValueCommand("key", Collections.<Flag>emptySet(), false);
+      GetKeyValueCommand c4 = new GetKeyValueCommand("key", Collections.<Flag>emptySet(), false, new InternalEntryFactoryImpl());
       byte[] bytes = marshaller.objectToByteBuffer(c4);
       GetKeyValueCommand rc4 = (GetKeyValueCommand) marshaller.objectFromByteBuffer(bytes);
       assert rc4.getCommandId() == c4.getCommandId() : "Writen[" + c4.getCommandId() + "] and read[" + rc4.getCommandId() + "] objects should be the same";

--- a/core/src/test/java/org/infinispan/remoting/AsynchronousInvocationTest.java
+++ b/core/src/test/java/org/infinispan/remoting/AsynchronousInvocationTest.java
@@ -13,6 +13,7 @@ import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.util.InfinispanCollections;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.InternalEntryFactoryImpl;
 import org.infinispan.context.Flag;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.metadata.EmbeddedMetadata;
@@ -95,7 +96,7 @@ public class AsynchronousInvocationTest extends AbstractInfinispanTest {
                                InboundInvocationHandlerImpl.class);
 
       GetKeyValueCommand getKeyValueCommand =
-            new GetKeyValueCommand("key", InfinispanCollections.<Flag>emptySet(), false);
+            new GetKeyValueCommand("key", InfinispanCollections.<Flag>emptySet(), false, new InternalEntryFactoryImpl());
       PutKeyValueCommand putKeyValueCommand =
             new PutKeyValueCommand("key", "value", false, null,
                                    new EmbeddedMetadata.Builder().build(), InfinispanCollections.<Flag>emptySet(), AnyEquivalence.getInstance());
@@ -105,7 +106,7 @@ public class AsynchronousInvocationTest extends AbstractInfinispanTest {
       nonBlockingCacheRpcCommand = new ClusteredGetCommand(cacheName);
       blockingNonCacheRpcCommand = new CacheTopologyControlCommand();
       //the GetKeyValueCommand is not replicated, but I only need a command that returns false in canBlock()
-      nonBlockingNonCacheRpcCommand = new GetKeyValueCommand("key", InfinispanCollections.<Flag>emptySet(), false);
+      nonBlockingNonCacheRpcCommand = new GetKeyValueCommand("key", InfinispanCollections.<Flag>emptySet(), false, new InternalEntryFactoryImpl());
       blockingSingleRpcCommand = new SingleRpcCommand(cacheName, putKeyValueCommand);
       nonBlockingSingleRpcCommand = new SingleRpcCommand(cacheName, getKeyValueCommand);
       blockingMultipleRpcCommand = new MultipleRpcCommand(Arrays.<ReplicableCommand>asList(putKeyValueCommand, putKeyValueCommand), cacheName);


### PR DESCRIPTION
Exploratory PR. Local tests and tests in Takayoshi's environment have been successful with this patch (the patch in `t_4424` failed in Takayoshi's environment).

The patch could be further improved by potentially separating GetCacheEntryCommand out of GetKeyValueCommand, in order to avoid the extra cost of 2 instance variables in GetCacheEntryCommand, and have better encapsulation of responsibilities.
