### PR TITLE
ISPN-4467 Bulk get keys should use a compatibility collator

### DIFF
--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/DistEmbeddedHotRodBulkTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/DistEmbeddedHotRodBulkTest.java
@@ -1,0 +1,64 @@
+package org.infinispan.it.compatibility;
+
+import org.infinispan.Cache;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.commons.api.BasicCache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * Test compatibility between embedded caches and Hot Rod endpoints for
+ * operations that retrieve data in bulk, i.e. keySet.
+ *
+ * @author Martin Gencur
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "it.compatibility.DistEmbeddedHotRodBulkTest")
+public class DistEmbeddedHotRodBulkTest extends AbstractInfinispanTest {
+
+    private final int numOwners = 1;
+
+    private CompatibilityCacheFactory<String, Integer> cacheFactory1;
+    private CompatibilityCacheFactory<String, Integer> cacheFactory2;
+
+    @BeforeClass
+    protected void setup() throws Exception {
+        cacheFactory1 = new CompatibilityCacheFactory<String, Integer>(CacheMode.DIST_SYNC, numOwners).setup();
+        cacheFactory2 = new CompatibilityCacheFactory<String, Integer>(CacheMode.DIST_SYNC, numOwners)
+                .setup(cacheFactory1.getHotRodPort(), 100);
+    }
+
+    @AfterClass
+    protected void teardown() {
+        CompatibilityCacheFactory.killCacheFactories(cacheFactory1, cacheFactory2);
+    }
+
+    private void populateCacheManager(BasicCache cache) {
+        for (int i = 0; i < 100; i++) {
+            cache.put("key" + i, i);
+        }
+    }
+
+    public void testEmbeddedPutHotRodKeySet() {
+        Cache<String, Integer> embedded = cacheFactory1.getEmbeddedCache();
+        RemoteCache<String, Integer> remote = cacheFactory2.getHotRodCache();
+
+        populateCacheManager(embedded);
+
+        Set<String> keySet = remote.keySet();
+        assertEquals(100, keySet.size());
+
+        for(int i = 0; i < 100; i++) {
+            assertTrue(keySet.contains("key" + i));
+        }
+    }
+}

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Encoder2x.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Encoder2x.scala
@@ -1,7 +1,6 @@
 package org.infinispan.server.hotrod
 
 import io.netty.buffer.ByteBuf
-import org.infinispan.distribution.ch.impl.DefaultConsistentHash
 import org.infinispan.manager.EmbeddedCacheManager
 import org.infinispan.remoting.transport.Address
 import org.infinispan.server.core.transport.ExtendedByteBuf._
@@ -9,10 +8,8 @@ import org.infinispan.server.hotrod.HotRodServer._
 import org.infinispan.server.hotrod.OperationStatus._
 import org.infinispan.server.hotrod.logging.Log
 import org.infinispan.server.hotrod.util.BulkUtil
-import scala.Some
 import scala.collection.JavaConversions._
 import scala.collection.mutable
-import scala.collection.mutable.{ListBuffer, ArrayBuffer}
 import org.infinispan.server.hotrod.Events.{CustomEvent, KeyEvent, Event, KeyWithVersionEvent}
 
 /**


### PR DESCRIPTION
Use a different collator when compatibility is enabled which makes the necessary transformations from POJO to byte arrays.
