### PR TITLE
Fix generic signature of AdvancedCacheLoader.process(...)

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/PersistenceUtil.java
+++ b/core/src/main/java/org/infinispan/persistence/PersistenceUtil.java
@@ -35,37 +35,37 @@ public class PersistenceUtil {
       return filter == null ? KeyFilter.LOAD_ALL_FILTER : filter;
    }
 
-   public static <K> int count(AdvancedCacheLoader<K, ?> acl, KeyFilter<? super K> filter) {
+   public static <K, V> int count(AdvancedCacheLoader<K, V> acl, KeyFilter<? super K> filter) {
       final AtomicInteger result = new AtomicInteger(0);
-      acl.process(filter, new AdvancedCacheLoader.CacheLoaderTask() {
+      acl.process(filter, new AdvancedCacheLoader.CacheLoaderTask<K, V>() {
          @Override
-         public void processEntry(MarshalledEntry marshalledEntry, AdvancedCacheLoader.TaskContext taskContext) throws InterruptedException {
+         public void processEntry(MarshalledEntry<K, V> marshalledEntry, AdvancedCacheLoader.TaskContext taskContext) throws InterruptedException {
             result.incrementAndGet();
          }
       }, new WithinThreadExecutor(), false, false);
       return result.get();
    }
 
-   public static <K> Set<K> toKeySet(AdvancedCacheLoader<K, ?> acl, KeyFilter<? super K> filter) {
+   public static <K, V> Set<K> toKeySet(AdvancedCacheLoader<K, V> acl, KeyFilter<? super K> filter) {
       if (acl == null)
          return Collections.emptySet();
       final Set<K> set = new HashSet<K>();
-      acl.process(filter, new AdvancedCacheLoader.CacheLoaderTask<K, Object>() {
+      acl.process(filter, new AdvancedCacheLoader.CacheLoaderTask<K, V>() {
          @Override
-         public void processEntry(MarshalledEntry<K, Object> marshalledEntry, AdvancedCacheLoader.TaskContext taskContext) throws InterruptedException {
+         public void processEntry(MarshalledEntry<K, V> marshalledEntry, AdvancedCacheLoader.TaskContext taskContext) throws InterruptedException {
             set.add(marshalledEntry.getKey());
          }
       }, new WithinThreadExecutor(), false, false);
       return set;
    }
 
-   public static <K> Set<InternalCacheEntry> toEntrySet(AdvancedCacheLoader<K, ?> acl, KeyFilter<? super K> filter, final InternalEntryFactory ief) {
+   public static <K, V> Set<InternalCacheEntry> toEntrySet(AdvancedCacheLoader<K, V> acl, KeyFilter<? super K> filter, final InternalEntryFactory ief) {
       if (acl == null)
          return Collections.emptySet();
       final Set<InternalCacheEntry> set = new HashSet<InternalCacheEntry>();
-      acl.process(filter, new AdvancedCacheLoader.CacheLoaderTask() {
+      acl.process(filter, new AdvancedCacheLoader.CacheLoaderTask<K, V>() {
          @Override
-         public void processEntry(MarshalledEntry ce, AdvancedCacheLoader.TaskContext taskContext) throws InterruptedException {
+         public void processEntry(MarshalledEntry<K, V> ce, AdvancedCacheLoader.TaskContext taskContext) throws InterruptedException {
             set.add(ief.create(ce.getKey(), ce.getValue(), ce.getMetadata()));
          }
       }, new WithinThreadExecutor(), true, true);

--- a/core/src/main/java/org/infinispan/persistence/spi/AdvancedCacheLoader.java
+++ b/core/src/main/java/org/infinispan/persistence/spi/AdvancedCacheLoader.java
@@ -37,7 +37,7 @@ public interface AdvancedCacheLoader<K, V> extends CacheLoader<K, V> {
     *                      as well
     * @throws PersistenceException in case of an error, e.g. communicating with the external storage
     */
-   void process(KeyFilter<? super K> filter, CacheLoaderTask<? super K, ? super V> task, Executor executor, boolean fetchValue, boolean fetchMetadata);
+   void process(KeyFilter<? super K> filter, CacheLoaderTask<K, V> task, Executor executor, boolean fetchValue, boolean fetchMetadata);
 
    /**
     * Returns the number of elements in the store.


### PR DESCRIPTION
... so that implementations don't need to resort to type erasure to invoke CacheLoaderTask.processEntry(...).

Otherwise cache loader implementations need to resort to tactics like:
https://github.com/pferraro/wildfly/blob/infinispan/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/persistence/file/FileStore.java#L185
