### PR TITLE
ISPN-4508 Cluster Listener waits forever for listeners to complete with

### DIFF
--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/RemoteClusterListener.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/RemoteClusterListener.java
@@ -104,8 +104,7 @@ public class RemoteClusterListener {
             if (log.isTraceEnabled()) {
                log.tracef("Submitting Event %s to cluster listener to %s", event, origin);
             }
-            distExecService.submit(origin,
-                                   new ClusterEventCallable(id, ClusterEvent.fromEvent(event))).get();
+            distExecService.submit(origin, new ClusterEventCallable(id, ClusterEvent.fromEvent(event))).get();
          }
       }
    }
@@ -122,10 +121,7 @@ public class RemoteClusterListener {
                log.tracef("Submitting Event(s) %s to cluster listener to %s", eventsToSend, origin);
             }
             // Force the execution to wait until completed
-            distExecService.submit(origin,
-                                   distExecService.createDistributedTaskBuilder(
-                                         new ClusterEventCallable(id, eventsToSend)).timeout(Long.MAX_VALUE, TimeUnit.DAYS)
-                                         .build()).get();
+            distExecService.submit(origin, new ClusterEventCallable(id, eventsToSend)).get();
          }
       }
    }


### PR DESCRIPTION
tx completion
- Changed to allow timeout similar to how we do for nontx

https://issues.jboss.org/browse/ISPN-4508
