### PR TITLE
ISPN-4485 Remote non-indexed query fails if compat mode enabled

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/query/RemoteQuery.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/query/RemoteQuery.java
@@ -83,11 +83,10 @@ public final class RemoteQuery implements Query {
          }
       } else {
          results = new ArrayList<Object>(response.getResults().size());
-         SerializationContext serCtx = getSerializationContext();
          for (WrappedMessage r : response.getResults()) {
             try {
                byte[] bytes = (byte[]) r.getValue();
-               Object o = ProtobufUtil.fromWrappedByteArray(serCtx, bytes);
+               Object o = ProtobufUtil.fromWrappedByteArray(serializationContext, bytes);
                results.add(o);
             } catch (IOException e) {
                throw new HotRodClientException(e);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
@@ -162,6 +162,27 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
       assertAccount(list.get(0));
    }
 
+   public void testRemoteQueryWithProjectionsForEmbeddedEntry() throws Exception {
+      EmbeddedAccount account = new EmbeddedAccount();
+      account.setId(1);
+      account.setDescription("test description");
+      account.setCreationDate(new Date(42));
+      cache.put(1, account);
+
+      // get account back from remote cache via query and check its attributes
+      QueryFactory qf = Search.getQueryFactory(remoteCache);
+      Query query = qf.from(Account.class)
+            .setProjection("description", "id")
+            .having("description").like("%test%").toBuilder()
+            .build();
+      List<Object[]> list = query.list();
+
+      assertNotNull(list);
+      assertEquals(1, list.size());
+      assertEquals("test description", list.get(0)[0]);
+      assertEquals(1, list.get(0)[1]);
+   }
+
    public void testEmbeddedQuery() throws Exception {
       Account account = createAccount();
       remoteCache.put(1, account);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/NonIndexedEmbeddedCompatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/NonIndexedEmbeddedCompatTest.java
@@ -29,16 +29,4 @@ public class NonIndexedEmbeddedCompatTest extends EmbeddedCompatTest {
    public void testEmbeddedQuery() throws Exception {
       // this would only make sense for Lucene based query
    }
-
-   @Test(enabled = false, description = "See https://issues.jboss.org/browse/ISPN-4485")
-   @Override
-   public void testRemoteQuery() throws Exception {
-      super.testRemoteQuery();
-   }
-
-   @Test(enabled = false, description = "See https://issues.jboss.org/browse/ISPN-4485")
-   @Override
-   public void testRemoteQueryForEmbeddedEntry() throws Exception {
-      super.testRemoteQueryForEmbeddedEntry();
-   }
 }

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/ProtobufMatcher.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/ProtobufMatcher.java
@@ -1,6 +1,7 @@
 package org.infinispan.objectfilter.impl;
 
 import org.infinispan.objectfilter.impl.hql.FilterProcessingChain;
+import org.infinispan.objectfilter.impl.hql.ProtobufEntityNamesResolver;
 import org.infinispan.objectfilter.impl.hql.ProtobufPropertyHelper;
 import org.infinispan.objectfilter.impl.predicateindex.MatcherEvalContext;
 import org.infinispan.objectfilter.impl.predicateindex.ProtobufMatcherEvalContext;
@@ -19,15 +20,21 @@ import java.util.Set;
  * @author anistor@redhat.com
  * @since 7.0
  */
-public final class ProtobufMatcher extends BaseMatcher<Descriptor, Integer> {
+public class ProtobufMatcher extends BaseMatcher<Descriptor, Integer> {
 
    private final SerializationContext serializationContext;
+
+   private final ProtobufEntityNamesResolver entityNamesResolver;
+
+   private final ProtobufPropertyHelper propertyHelper;
 
    private final Descriptor wrappedMessageDescriptor;
 
    public ProtobufMatcher(SerializationContext serializationContext) {
       this.serializationContext = serializationContext;
       wrappedMessageDescriptor = serializationContext.getMessageDescriptor(WrappedMessage.PROTOBUF_TYPE_NAME);
+      entityNamesResolver = new ProtobufEntityNamesResolver(serializationContext);
+      propertyHelper = new ProtobufPropertyHelper(entityNamesResolver, serializationContext);
    }
 
    @Override
@@ -39,7 +46,7 @@ public final class ProtobufMatcher extends BaseMatcher<Descriptor, Integer> {
 
    @Override
    protected FilterProcessingChain<Descriptor> createFilterProcessingChain(Map<String, Object> namedParameters) {
-      return FilterProcessingChain.build(new ProtobufPropertyHelper(serializationContext), namedParameters);
+      return FilterProcessingChain.build(entityNamesResolver, propertyHelper, namedParameters);
    }
 
    @Override

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/ReflectionMatcher.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/ReflectionMatcher.java
@@ -1,6 +1,8 @@
 package org.infinispan.objectfilter.impl;
 
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
 import org.infinispan.objectfilter.impl.hql.FilterProcessingChain;
+import org.infinispan.objectfilter.impl.hql.ReflectionEntityNamesResolver;
 import org.infinispan.objectfilter.impl.hql.ReflectionPropertyHelper;
 import org.infinispan.objectfilter.impl.predicateindex.MatcherEvalContext;
 import org.infinispan.objectfilter.impl.predicateindex.ReflectionMatcherEvalContext;
@@ -14,12 +16,22 @@ import java.util.Set;
  * @author anistor@redhat.com
  * @since 7.0
  */
-public final class ReflectionMatcher extends BaseMatcher<Class<?>, String> {
+public class ReflectionMatcher extends BaseMatcher<Class<?>, String> {
 
-   private final ClassLoader classLoader;
+   private final EntityNamesResolver entityNamesResolver;
+
+   private final ReflectionPropertyHelper propertyHelper;
 
    public ReflectionMatcher(ClassLoader classLoader) {
-      this.classLoader = classLoader;
+      this(new ReflectionEntityNamesResolver(classLoader));
+   }
+
+   protected ReflectionMatcher(EntityNamesResolver entityNamesResolver) {
+      if (entityNamesResolver == null) {
+         throw new IllegalArgumentException("The EntityNamesResolver argument cannot be null");
+      }
+      this.entityNamesResolver = entityNamesResolver;
+      propertyHelper = new ReflectionPropertyHelper(entityNamesResolver);
    }
 
    @Override
@@ -34,7 +46,7 @@ public final class ReflectionMatcher extends BaseMatcher<Class<?>, String> {
 
    @Override
    protected FilterProcessingChain<Class<?>> createFilterProcessingChain(Map<String, Object> namedParameters) {
-      return FilterProcessingChain.build(new ReflectionPropertyHelper(classLoader), namedParameters);
+      return FilterProcessingChain.build(entityNamesResolver, propertyHelper, namedParameters);
    }
 
    @Override

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/FilterProcessingChain.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/FilterProcessingChain.java
@@ -2,6 +2,7 @@ package org.infinispan.objectfilter.impl.hql;
 
 import org.hibernate.hql.ast.spi.AstProcessingChain;
 import org.hibernate.hql.ast.spi.AstProcessor;
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
 import org.hibernate.hql.ast.spi.QueryRendererProcessor;
 import org.hibernate.hql.ast.spi.QueryResolverProcessor;
 import org.hibernate.hql.ast.spi.SingleEntityQueryBuilder;
@@ -38,12 +39,12 @@ public final class FilterProcessingChain<TypeMetadata> implements AstProcessingC
       return rendererDelegate.getResult();
    }
 
-   public static <TypeMetadata> FilterProcessingChain<TypeMetadata> build(ObjectPropertyHelper<TypeMetadata> propertyHelper, Map<String, Object> namedParameters) {
-      QueryResolverProcessor resolverProcessor = new QueryResolverProcessor(new FilterQueryResolverDelegate(propertyHelper));
+   public static <TypeMetadata> FilterProcessingChain<TypeMetadata> build(EntityNamesResolver entityNamesResolver, ObjectPropertyHelper<TypeMetadata> propertyHelper, Map<String, Object> namedParameters) {
+      QueryResolverProcessor resolverProcessor = new QueryResolverProcessor(new FilterQueryResolverDelegate(entityNamesResolver, propertyHelper));
 
-      SingleEntityQueryBuilder<BooleanExpr> queryBuilder = SingleEntityQueryBuilder.getInstance(new FilterPredicateFactory(propertyHelper.getEntityNamesResolver()), propertyHelper);
+      SingleEntityQueryBuilder<BooleanExpr> queryBuilder = SingleEntityQueryBuilder.getInstance(new FilterPredicateFactory(entityNamesResolver), propertyHelper);
 
-      FilterRendererDelegate<TypeMetadata> rendererDelegate = new FilterRendererDelegate<TypeMetadata>(propertyHelper, queryBuilder, namedParameters);
+      FilterRendererDelegate<TypeMetadata> rendererDelegate = new FilterRendererDelegate<TypeMetadata>(entityNamesResolver, propertyHelper, queryBuilder, namedParameters);
 
       QueryRendererProcessor rendererProcessor = new QueryRendererProcessor(rendererDelegate);
 

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/FilterQueryResolverDelegate.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/FilterQueryResolverDelegate.java
@@ -5,6 +5,7 @@ import org.hibernate.hql.ast.common.JoinType;
 import org.hibernate.hql.ast.origin.hql.resolve.path.PathedPropertyReference;
 import org.hibernate.hql.ast.origin.hql.resolve.path.PathedPropertyReferenceSource;
 import org.hibernate.hql.ast.origin.hql.resolve.path.PropertyPath;
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
 import org.hibernate.hql.ast.spi.QueryResolverDelegate;
 import org.infinispan.objectfilter.impl.logging.Log;
 import org.jboss.logging.Logger;
@@ -27,11 +28,14 @@ public final class FilterQueryResolverDelegate implements QueryResolverDelegate 
 
    private final ObjectPropertyHelper propertyHelper;
 
+   private final EntityNamesResolver entityNamesResolver;
+
    private String targetType;
 
    private boolean definingSelect = false;
 
-   public FilterQueryResolverDelegate(ObjectPropertyHelper propertyHelper) {
+   public FilterQueryResolverDelegate(EntityNamesResolver entityNamesResolver, ObjectPropertyHelper propertyHelper) {
+      this.entityNamesResolver = entityNamesResolver;
       this.propertyHelper = propertyHelper;
    }
 
@@ -43,7 +47,7 @@ public final class FilterQueryResolverDelegate implements QueryResolverDelegate 
       if (prevAlias != null && !prevAlias.equalsIgnoreCase(entityName)) {
          throw new UnsupportedOperationException("Alias reuse currently not supported: aliasTree " + alias + " already assigned to type " + prevAlias);
       }
-      if (propertyHelper.getEntityNamesResolver().getClassFromName(entityName) == null) {
+      if (entityNamesResolver.getClassFromName(entityName) == null) {
          throw new IllegalStateException("Unknown entity name " + entityName);
       }
       if (targetType != null) {
@@ -84,7 +88,7 @@ public final class FilterQueryResolverDelegate implements QueryResolverDelegate 
          throw log.getUnknownAliasException(root.getText());
       }
 
-      if (propertyHelper.getEntityNamesResolver().getClassFromName(entityNameForAlias) == null) {
+      if (entityNamesResolver.getClassFromName(entityNameForAlias) == null) {
          throw new IllegalStateException("Unknown entity name " + entityNameForAlias);
       }
 

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/FilterRendererDelegate.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/FilterRendererDelegate.java
@@ -2,6 +2,7 @@ package org.infinispan.objectfilter.impl.hql;
 
 import org.antlr.runtime.tree.Tree;
 import org.hibernate.hql.ast.origin.hql.resolve.path.PropertyPath;
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
 import org.hibernate.hql.ast.spi.SingleEntityQueryBuilder;
 import org.hibernate.hql.ast.spi.SingleEntityQueryRendererDelegate;
 import org.infinispan.objectfilter.SortField;
@@ -23,8 +24,9 @@ public final class FilterRendererDelegate<TypeMetadata> extends SingleEntityQuer
 
    private List<SortField> sortFields;
 
-   public FilterRendererDelegate(ObjectPropertyHelper<TypeMetadata> propertyHelper, SingleEntityQueryBuilder<BooleanExpr> builder, Map<String, Object> namedParameters) {
-      super(propertyHelper.getEntityNamesResolver(), builder, namedParameters);
+   public FilterRendererDelegate(EntityNamesResolver entityNamesResolver, ObjectPropertyHelper<TypeMetadata> propertyHelper,
+                                 SingleEntityQueryBuilder<BooleanExpr> builder, Map<String, Object> namedParameters) {
+      super(entityNamesResolver, builder, namedParameters);
       this.propertyHelper = propertyHelper;
    }
 

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/ObjectPropertyHelper.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/ObjectPropertyHelper.java
@@ -21,12 +21,20 @@ public abstract class ObjectPropertyHelper<TypeMetadata> implements PropertyHelp
 
    private static final Log log = Logger.getMessageLogger(Log.class, ObjectPropertyHelper.class.getName());
 
+   private static final String DATE_FORMAT = "yyyyMMddHHmmssSSS";   //todo [anistor] is there a standard jpa time format?
+
    private static final TimeZone GMT_TZ = TimeZone.getTimeZone("GMT");
 
-   private final DateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmmssSSS");   //todo [anistor] is there a standard jpa time format?
+   protected final EntityNamesResolver entityNamesResolver;
 
-   protected ObjectPropertyHelper() {
+   protected ObjectPropertyHelper(EntityNamesResolver entityNamesResolver) {
+      this.entityNamesResolver = entityNamesResolver;
+   }
+
+   protected DateFormat getDateFormat() {
+      SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
       dateFormat.setTimeZone(GMT_TZ);
+      return dateFormat;
    }
 
    /**
@@ -48,7 +56,7 @@ public abstract class ObjectPropertyHelper<TypeMetadata> implements PropertyHelp
 
       if (Date.class.isAssignableFrom(propertyType)) {
          try {
-            return dateFormat.parse(value);
+            return getDateFormat().parse(value);
          } catch (ParseException e) {
             throw log.getInvalidDateLiteralException(value);
          }
@@ -118,8 +126,6 @@ public abstract class ObjectPropertyHelper<TypeMetadata> implements PropertyHelp
    public abstract boolean hasProperty(String entityType, List<String> propertyPath);
 
    public abstract boolean hasEmbeddedProperty(String entityType, List<String> propertyPath);
-
-   public abstract EntityNamesResolver getEntityNamesResolver();
 
    public abstract TypeMetadata getEntityMetadata(String targetTypeName);
 }

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/ProtobufEntityNamesResolver.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/ProtobufEntityNamesResolver.java
@@ -1,0 +1,24 @@
+package org.infinispan.objectfilter.impl.hql;
+
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
+import org.infinispan.protostream.SerializationContext;
+
+/**
+ * @author anistor@redhat.com
+ * @since 7.0
+ */
+public final class ProtobufEntityNamesResolver implements EntityNamesResolver {
+
+   private final SerializationContext serializationContext;
+
+   public ProtobufEntityNamesResolver(SerializationContext serializationContext) {
+      this.serializationContext = serializationContext;
+   }
+
+   @Override
+   public Class<?> getClassFromName(String entityName) {
+      // The EntityNamesResolver of the HQL parser is not nicely designed to handle non-Class type metadata.
+      // Here we return a 'fake' class. It does not matter what we return as long as it is non-null.
+      return serializationContext.canMarshall(entityName) ? Object.class : null;
+   }
+}

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/ProtobufPropertyHelper.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/ProtobufPropertyHelper.java
@@ -23,22 +23,9 @@ public final class ProtobufPropertyHelper extends ObjectPropertyHelper<Descripto
 
    private final SerializationContext serializationContext;
 
-   // the EntityNamesResolver of the hql parser is not nicely designed to handle non-Class type metadata
-   private final EntityNamesResolver entityNamesResolver = new EntityNamesResolver() {
-      @Override
-      public Class<?> getClassFromName(String entityName) {
-         // Here we return a 'fake' class. It does not matter what we return as long as it is non-null
-         return serializationContext.canMarshall(entityName) ? Object.class : null;
-      }
-   };
-
-   public ProtobufPropertyHelper(SerializationContext serializationContext) {
+   public ProtobufPropertyHelper(EntityNamesResolver entityNamesResolver, SerializationContext serializationContext) {
+      super(entityNamesResolver);
       this.serializationContext = serializationContext;
-   }
-
-   @Override
-   public EntityNamesResolver getEntityNamesResolver() {
-      return entityNamesResolver;
    }
 
    @Override

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/ReflectionEntityNamesResolver.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/ReflectionEntityNamesResolver.java
@@ -1,0 +1,33 @@
+package org.infinispan.objectfilter.impl.hql;
+
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
+
+/**
+ * @author anistor@redhat.com
+ * @since 7.0
+ */
+public final class ReflectionEntityNamesResolver implements EntityNamesResolver {
+
+   private final ClassLoader classLoader;
+
+   public ReflectionEntityNamesResolver(ClassLoader classLoader) {
+      this.classLoader = classLoader;
+   }
+
+   @Override
+   public Class<?> getClassFromName(String entityName) {
+      if (classLoader != null) {
+         try {
+            return classLoader.loadClass(entityName);
+         } catch (ClassNotFoundException e) {
+            return null;
+         }
+      }
+
+      try {
+         return Class.forName(entityName);
+      } catch (ClassNotFoundException e) {
+         return null;
+      }
+   }
+}

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/ReflectionPropertyHelper.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/hql/ReflectionPropertyHelper.java
@@ -41,34 +41,8 @@ public final class ReflectionPropertyHelper extends ObjectPropertyHelper<Class<?
       primitives.add(boolean.class);
    }
 
-   private final ClassLoader classLoader;
-
-   private final EntityNamesResolver entityNamesResolver = new EntityNamesResolver() {
-      @Override
-      public Class<?> getClassFromName(String entityName) {
-         if (classLoader != null) {
-            try {
-               return classLoader.loadClass(entityName);
-            } catch (ClassNotFoundException e) {
-               return null;
-            }
-         }
-
-         try {
-            return Class.forName(entityName);
-         } catch (ClassNotFoundException e) {
-            return null;
-         }
-      }
-   };
-
-   public ReflectionPropertyHelper(ClassLoader classLoader) {
-      this.classLoader = classLoader;
-   }
-
-   @Override
-   public EntityNamesResolver getEntityNamesResolver() {
-      return entityNamesResolver;
+   public ReflectionPropertyHelper(EntityNamesResolver entityNamesResolver) {
+      super(entityNamesResolver);
    }
 
    @Override

--- a/object-filter/src/test/java/org/infinispan/objectfilter/impl/hql/ProtobufParsingTest.java
+++ b/object-filter/src/test/java/org/infinispan/objectfilter/impl/hql/ProtobufParsingTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.objectfilter.impl.hql;
 
 import com.google.protobuf.Descriptors;
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
 import org.infinispan.objectfilter.test.model.MarshallerRegistration;
 import org.infinispan.protostream.ConfigurationBuilder;
 import org.infinispan.protostream.ProtobufUtil;
@@ -23,7 +24,9 @@ public class ProtobufParsingTest extends AbstractParsingTest {
    protected FilterProcessingChain<Descriptor> createFilterProcessingChain() throws IOException, Descriptors.DescriptorValidationException {
       SerializationContext serCtx = ProtobufUtil.newSerializationContext(new ConfigurationBuilder().build());
       MarshallerRegistration.registerMarshallers(serCtx);
-      return FilterProcessingChain.build(new ProtobufPropertyHelper(serCtx), null);
+      EntityNamesResolver entityNamesResolver = new ProtobufEntityNamesResolver(serCtx);
+      ProtobufPropertyHelper protobufPropertyHelper = new ProtobufPropertyHelper(entityNamesResolver, serCtx);
+      return FilterProcessingChain.build(entityNamesResolver, protobufPropertyHelper, null);
    }
 
    @Test

--- a/object-filter/src/test/java/org/infinispan/objectfilter/impl/hql/ReflectionParsingTest.java
+++ b/object-filter/src/test/java/org/infinispan/objectfilter/impl/hql/ReflectionParsingTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.objectfilter.impl.hql;
 
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -13,7 +14,9 @@ public class ReflectionParsingTest extends AbstractParsingTest {
 
    @Override
    protected FilterProcessingChain<Class<?>> createFilterProcessingChain() throws Exception {
-      return FilterProcessingChain.build(new ReflectionPropertyHelper(null), null);
+      EntityNamesResolver entityNamesResolver = new ReflectionEntityNamesResolver(null);
+      ReflectionPropertyHelper reflectionPropertyHelper = new ReflectionPropertyHelper(entityNamesResolver);
+      return FilterProcessingChain.build(entityNamesResolver, reflectionPropertyHelper, null);
    }
 
    @Test

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/CompatibilityReflectionMatcher.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/CompatibilityReflectionMatcher.java
@@ -1,0 +1,30 @@
+package org.infinispan.query.remote;
+
+import org.hibernate.hql.ast.spi.EntityNamesResolver;
+import org.infinispan.objectfilter.impl.ReflectionMatcher;
+import org.infinispan.protostream.MessageMarshaller;
+import org.infinispan.protostream.SerializationContext;
+
+/**
+ * A sub-class of ReflectionMatcher that is able to lookup classes by their protobuf type name and can work when
+ * compatibility mode is used.
+ *
+ * @author anistor@redhat.com
+ * @since 7.0
+ */
+public final class CompatibilityReflectionMatcher extends ReflectionMatcher {
+
+   public CompatibilityReflectionMatcher(final SerializationContext serializationContext) {
+      super(new EntityNamesResolver() {
+         @Override
+         public Class<?> getClassFromName(String entityName) {
+            try {
+               MessageMarshaller messageMarshaller = (MessageMarshaller) serializationContext.getMarshaller(entityName);
+               return messageMarshaller.getJavaClass();
+            } catch (Exception e) {
+               return null;
+            }
+         }
+      });
+   }
+}

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/LifecycleManager.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/LifecycleManager.java
@@ -114,6 +114,10 @@ public class LifecycleManager extends AbstractModuleLifecycle {
       SerializationContext serializationContext = ProtobufMetadataManager.getSerializationContext(cacheManager);
       cr.registerComponent(new ProtobufMatcher(serializationContext), ProtobufMatcher.class);
 
+      if (cfg.compatibility().enabled()) {
+         cr.registerComponent(new CompatibilityReflectionMatcher(serializationContext), CompatibilityReflectionMatcher.class);
+      }
+
       if (cfg.indexing().index().isEnabled() && !cfg.compatibility().enabled()) {
          log.infof("Registering RemoteValueWrapperInterceptor for cache %s", cacheName);
          createRemoteIndexingInterceptor(cr, cfg);


### PR DESCRIPTION
Introduce CompatibilityReflectionMatcher, a special ReflectionMatcher that is able to resolve types
by their protobuf name instead of using the java class name. A number of refactorings around the usage
of EntityNamesResolver were required for this.

jira: https://issues.jboss.org/browse/ISPN-4485
