### PR TITLE
ISPN-4446 Use thread local to signal cache removal to components

### DIFF
--- a/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
@@ -28,6 +28,7 @@ import org.infinispan.commands.tx.totalorder.TotalOrderVersionedCommitCommand;
 import org.infinispan.commands.tx.totalorder.TotalOrderVersionedPrepareCommand;
 import org.infinispan.commands.write.*;
 import org.infinispan.commons.CacheException;
+import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.iteration.impl.EntryRequestCommand;
 import org.infinispan.iteration.impl.EntryResponseCommand;
 import org.infinispan.factories.GlobalComponentRegistry;
@@ -36,6 +37,7 @@ import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.jmx.CacheJmxRegistration;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.statetransfer.StateRequestCommand;
@@ -201,8 +203,10 @@ public class RemoteCommandsFactory {
                command = new StateResponseCommand(cacheName);
                break;
             case RemoveCacheCommand.COMMAND_ID:
-               command = new RemoveCacheCommand(cacheName, cacheManager, registry,
-                     registry.getNamedComponentRegistry(cacheName).getComponent(PersistenceManager.class));
+               ComponentRegistry namedCacheRegistry = registry.getNamedComponentRegistry(cacheName);
+               command = new RemoveCacheCommand(cacheName, cacheManager, this.registry,
+                     namedCacheRegistry.getComponent(PersistenceManager.class),
+                     namedCacheRegistry.getComponent(CacheJmxRegistration.class));
                break;
             case TxCompletionNotificationCommand.COMMAND_ID:
                command = new TxCompletionNotificationCommand(cacheName);

--- a/core/src/main/java/org/infinispan/commands/RemoveCacheCommand.java
+++ b/core/src/main/java/org/infinispan/commands/RemoveCacheCommand.java
@@ -25,36 +25,28 @@ public class RemoveCacheCommand extends BaseRpcCommand {
    private EmbeddedCacheManager cacheManager;
    private GlobalComponentRegistry registry;
    private PersistenceManager persistenceManager;
+   private CacheJmxRegistration cacheJmxRegistration;
 
    private RemoveCacheCommand() {
       super(null); // For command id uniqueness test
    }
 
    public RemoveCacheCommand(String cacheName, EmbeddedCacheManager cacheManager,
-         GlobalComponentRegistry registry, PersistenceManager persistenceManager) {
+         GlobalComponentRegistry registry, PersistenceManager persistenceManager,
+         CacheJmxRegistration cacheJmxRegistration) {
       super(cacheName);
       this.cacheManager = cacheManager;
       this.registry = registry;
       this.persistenceManager = persistenceManager;
+      this.cacheJmxRegistration = cacheJmxRegistration;
    }
 
    @Override
    public Object perform(InvocationContext ctx) throws Throwable {
-      // To avoid reliance of a thread local flag, get a reference for the
-      // cache store to be able to clear it after cache has stopped.
+      persistenceManager.setClearOnStop(true);
+      cacheJmxRegistration.setUnregisterCacheMBean(true);
       Cache<Object, Object> cache = cacheManager.getCache(cacheName);
-      CacheJmxRegistration jmx = cache.getAdvancedCache().getComponentRegistry().getComponent(CacheJmxRegistration.class);
       cache.stop();
-
-      // After stopping the cache, clear it
-      if (persistenceManager != null)
-         persistenceManager.clearAllStores(BOTH);
-
-      // And see if we need to remove it from JMX
-      if (jmx != null) {
-         jmx.unregisterCacheMBean();
-      }
-
       registry.removeCache(cacheName);
       return null;
    }

--- a/core/src/main/java/org/infinispan/jmx/CacheJmxRegistration.java
+++ b/core/src/main/java/org/infinispan/jmx/CacheJmxRegistration.java
@@ -42,6 +42,8 @@ public class CacheJmxRegistration extends AbstractJmxRegistration {
    private Set<Component> nonCacheComponents;
    private boolean needToUnregister = false;
 
+   private volatile boolean unregisterCacheMBean;
+
    @Inject
    public void initialize(Cache<?, ?> cache, GlobalConfiguration globalConfig) {
       this.cache = cache.getAdvancedCache();
@@ -87,6 +89,10 @@ public class CacheJmxRegistration extends AbstractJmxRegistration {
          }
       }
 
+      // If removing cache, also remove cache MBean
+      if (unregisterCacheMBean)
+         unregisterCacheMBean();
+
       // make sure we don't set cache to null, in case it needs to be restarted via JMX.
    }
 
@@ -110,6 +116,9 @@ public class CacheJmxRegistration extends AbstractJmxRegistration {
       }
    }
 
+   public void setUnregisterCacheMBean(boolean unregisterCacheMBean) {
+      this.unregisterCacheMBean = unregisterCacheMBean;
+   }
 
    @Override
    protected ComponentsJmxRegistration buildRegistrar(Set<AbstractComponentRegistry.Component> components) {

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -473,7 +473,8 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
       ComponentRegistry cacheComponentRegistry = globalComponentRegistry.getNamedComponentRegistry(cacheName);
       if (cacheComponentRegistry != null) {
          RemoveCacheCommand cmd = new RemoveCacheCommand(cacheName, this, globalComponentRegistry,
-               cacheComponentRegistry.getComponent(PersistenceManager.class));
+               cacheComponentRegistry.getComponent(PersistenceManager.class),
+               cacheComponentRegistry.getComponent(CacheJmxRegistration.class));
          Transport transport = getTransport();
          try {
             if (transport != null) {

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManager.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManager.java
@@ -106,6 +106,9 @@ public interface PersistenceManager extends Lifecycle {
        */
       protected abstract boolean canPerform(StoreConfiguration configuration);
    }
+
+   void setClearOnStop(boolean clearOnStop);
+
 }
 
 

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -91,6 +91,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
    private Executor persistenceExecutor;
    private ByteBufferFactory byteBufferFactory;
    private MarshalledEntryFactory marshalledEntryFactory;
+   private volatile boolean clearOnStop;
 
    @Inject
    public void inject(AdvancedCache<Object, Object> cache, @ComponentName(CACHE_MARSHALLER) StreamingMarshaller marshaller,
@@ -163,6 +164,9 @@ public class PersistenceManagerImpl implements PersistenceManager {
    @Override
    @Stop
    public void stop() {
+      // If needed, clear the persistent store before stopping
+      if (clearOnStop)
+         clearAllStores(AccessMode.BOTH);
 
       Set undelegated = new HashSet();
       for (CacheWriter w : writers) {
@@ -488,6 +492,11 @@ public class PersistenceManagerImpl implements PersistenceManager {
          storesMutex.readLock().unlock();
       }
       return 0;
+   }
+
+   @Override
+   public void setClearOnStop(boolean clearOnStop) {
+      this.clearOnStop = clearOnStop;
    }
 
    public List<CacheLoader> getAllLoaders() {

--- a/core/src/test/java/org/infinispan/persistence/BaseStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/BaseStoreFunctionalTest.java
@@ -186,9 +186,25 @@ public abstract class BaseStoreFunctionalTest extends SingleCacheManagerTest {
       assertArrayEquals(value, found);
    }
 
+   public void testRemoveCache() {
+      ConfigurationBuilder cb = TestCacheManagerFactory.getDefaultCacheConfiguration(false);
+      createCacheStoreConfig(cb.persistence(), true);
+      EmbeddedCacheManager local = TestCacheManagerFactory.createCacheManager(cb);
+      try {
+         final String cacheName = "to-be-removed";
+         Cache<String, Object> cache = local.getCache(cacheName);
+         assertTrue(local.isRunning(cacheName));
+         cache.put("1", wrap("1", "v1"));
+         assertCacheEntry(cache, "1", "v1", -1, -1);
+         local.removeCache(cacheName);
+         assertFalse(local.isRunning(cacheName));
+      } finally {
+         TestingUtil.killCacheManagers(local);
+      }
+   }
+
    private ConfigurationBuilder configureCacheLoader(ConfigurationBuilder base, boolean purge) {
       ConfigurationBuilder cfg = base == null ? new ConfigurationBuilder() : base;
-
       cfg.transaction().transactionMode(TransactionMode.TRANSACTIONAL);
       createCacheStoreConfig(cfg.persistence(), false);
       cfg.persistence().stores().get(0).purgeOnStartup(purge);


### PR DESCRIPTION
- Since stop() takes no parameters, the only way to get correct semantics of cache removal is to use a thread local variable.

I remember that there's a test that verifies that we do not use thread locals, but can't remember the exact reason for that. Regardless, I don't see any simpler solutions to this without having stop() methods in components take parameters, which would require some refactoring.
