### PR TITLE
ISPN-4519 Prepare should be broadcasted to entire cluster in replicated mode

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/base/BaseRpcInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/base/BaseRpcInterceptor.java
@@ -106,11 +106,14 @@ public abstract class BaseRpcInterceptor extends CommandInterceptor {
             && !((LocalTransaction)ctx.getCacheTransaction()).isCommitOrRollbackSent();
    }
 
-   protected final Map<Address, Response> totalOrderAnycastPrepare(Collection<Address> recipients,
-                                                                   PrepareCommand prepareCommand,
-                                                                   TimeoutValidationResponseFilter responseFilter) {
-      Set<Address> realRecipients = new HashSet<Address>(recipients);
-      realRecipients.add(rpcManager.getAddress());
+   protected final Map<Address, Response> totalOrderPrepare(Collection<Address> recipients,
+         PrepareCommand prepareCommand,
+         TimeoutValidationResponseFilter responseFilter) {
+      Set<Address> realRecipients = null;
+      if (recipients != null) {
+         realRecipients = new HashSet<Address>(recipients);
+         realRecipients.add(rpcManager.getAddress());
+      }
       return internalTotalOrderPrepare(realRecipients, prepareCommand, responseFilter);
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -194,7 +194,6 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
          boolean affectsAllNodes = ctx.getCacheTransaction().hasModification(ClearCommand.class);
          Collection<Address> recipients = affectsAllNodes ? dm.getWriteConsistentHash().getMembers() :
                cdl.getOwners(getAffectedKeysFromContext(ctx));
-         recipients = recipients == null ? dm.getWriteConsistentHash().getMembers() : recipients;
          prepareOnAffectedNodes(ctx, command, recipients, defaultSynchronous);
 
          ((LocalTxInvocationContext) ctx).remoteLocksAcquired(recipients == null ? dm.getWriteConsistentHash().getMembers() : recipients);

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderDistributionInterceptor.java
@@ -61,7 +61,7 @@ public class TotalOrderDistributionInterceptor extends TxDistributionInterceptor
       }
 
       try {
-         totalOrderAnycastPrepare(recipients, command, isSyncCommitPhase() ? null : getSelfDeliverFilter());
+         totalOrderPrepare(recipients, command, isSyncCommitPhase() ? null : getSelfDeliverFilter());
       } finally {
          transactionRemotelyPrepared(ctx);
       }

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedDistributionInterceptor.java
@@ -71,7 +71,7 @@ public class TotalOrderVersionedDistributionInterceptor extends VersionedDistrib
          KeysValidateFilter responseFilter = ctx.getCacheTransaction().hasModification(ClearCommand.class) || isSyncCommitPhase() ?
                null : new KeysValidateFilter(rpcManager.getAddress(), ctx.getAffectedKeys());
 
-         totalOrderAnycastPrepare(recipients, command, responseFilter);
+         totalOrderPrepare(recipients, command, responseFilter);
       } finally {
          transactionRemotelyPrepared(ctx);
       }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4519

Command should be sent to null even if not all caches are members
