### PR TITLE
ISPN-3937 Investigate the memory usage of JDBC cache stores when process...

### DIFF
--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/TableManipulation.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/TableManipulation.java
@@ -370,7 +370,7 @@ public class TableManipulation implements Cloneable {
     * if not specified will be defaulted to {@link #DEFAULT_FETCH_SIZE}.
     */
    public int getFetchSize() {
-      return config.fetchSize();
+      return getDialect() == Dialect.MYSQL ? Integer.MIN_VALUE : config.fetchSize();
    }
 
    /**

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/binary/JdbcBinaryStore.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/binary/JdbcBinaryStore.java
@@ -185,10 +185,10 @@ public class JdbcBinaryStore implements AdvancedLoadWriteStore {
             log.tracef("Running sql %s", sql);
          }
          conn = connectionFactory.getConnection();
-         ps = conn.prepareStatement(sql);
+         ps = conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
          ps.setLong(1, ctx.getTimeService().wallClockTime());
+         ps.setFetchSize(tableManipulation.getFetchSize());
          rs = ps.executeQuery();
-         rs.setFetchSize(tableManipulation.getFetchSize());
          ExecutorAllCompletionService ecs = new ExecutorAllCompletionService(executor);
          final TaskContextImpl taskContext = new TaskContextImpl();
          //we can do better here: ATM we load the entries in the caller's thread and process them in parallel

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
@@ -321,10 +321,10 @@ public class JdbcStringBasedStore implements AdvancedLoadWriteStore {
                   log.tracef("Running sql %s", sql);
                }
                conn = connectionFactory.getConnection();
-               ps = conn.prepareStatement(sql);
+               ps = conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
                ps.setLong(1, ctx.getTimeService().wallClockTime());
+               ps.setFetchSize(tableManipulation.getFetchSize());
                rs = ps.executeQuery();
-               rs.setFetchSize(tableManipulation.getFetchSize());
 
                TaskContext taskContext = new TaskContextImpl();
                while (rs.next()) {


### PR DESCRIPTION
...ing a large result set
- Set the result type to TYPE_FORWARD_ONLY and the concurrency to CONCUR_READ_ONLY
- For the particular case of MySQL, setting the fetchSite to MIN_VALUE will fetch
  a single row at the time

https://issues.jboss.org/browse/ISPN-3937
