### PR TITLE
ISPN-4569 Inserting into cache with indexing fails for XA transactions

### DIFF
--- a/query/src/test/java/org/infinispan/query/dsl/embedded/ClusteredQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/ClusteredQueryDslConditionsTest.java
@@ -37,12 +37,12 @@ public class ClusteredQueryDslConditionsTest extends QueryDslConditionsTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      ConfigurationBuilder defaultConfiguration = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, transactionsEnabled());
+      ConfigurationBuilder defaultConfiguration = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
       defaultConfiguration.clustering()
             .stateTransfer().fetchInMemoryState(true);
       createClusteredCaches(2, defaultConfiguration);
 
-      ConfigurationBuilder cfg = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, transactionsEnabled());
+      ConfigurationBuilder cfg = initialCacheConfiguration();
       cfg.clustering()
             .stateTransfer().fetchInMemoryState(true)
             .indexing()
@@ -56,8 +56,8 @@ public class ClusteredQueryDslConditionsTest extends QueryDslConditionsTest {
       cache2 = manager(1).getCache(TEST_CACHE_NAME);
    }
 
-   protected boolean transactionsEnabled() {
-      return false;
+   protected ConfigurationBuilder initialCacheConfiguration() {
+      return getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
    }
 
    @Override

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/TxClusteredQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/TxClusteredQueryDslConditionsTest.java
@@ -1,0 +1,27 @@
+package org.infinispan.query.dsl.embedded;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.testng.annotations.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies the functionality of Query DSL in clustered environment for ISPN directory provider.
+ *
+ * @author Dan Berindei
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "query.dsl.embedded.TxClusteredQueryDslConditionsTest")
+public class TxClusteredQueryDslConditionsTest extends ClusteredQueryDslConditionsTest {
+
+   @Override
+   protected ConfigurationBuilder initialCacheConfiguration() {
+      ConfigurationBuilder cfg = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
+      cfg.transaction().useSynchronization(false);
+      return cfg;
+   }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4569
- Use the BatchModeTransactionManager for the cluster registry cache.
- Suspend ongoing transactions during cluster registry cache operations,
  in case another cache also uses the same TM.
