### PR TITLE
ISPN-4598 Use externalizers for BinaryFilter/BinaryConverter

### DIFF
--- a/server/core/src/main/scala/org/infinispan/server/core/ExternalizerIds.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/ExternalizerIds.scala
@@ -16,5 +16,7 @@ object ExternalizerIds {
    val TOPOLOGY_VIEW = 1103
    val SERVER_ADDRESS = 1104
    val MIME_METADATA = 1105
+   val BINARY_FILTER = 1106
+   val BINARY_CONVERTER = 1107
 
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/LifecycleCallbacks.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/LifecycleCallbacks.scala
@@ -4,6 +4,7 @@ import org.infinispan.lifecycle.AbstractModuleLifecycle
 import org.infinispan.factories.GlobalComponentRegistry
 import org.infinispan.server.core.ExternalizerIds._
 import org.infinispan.configuration.global.GlobalConfiguration
+import org.infinispan.server.hotrod.ClientListenerRegistry.{BinaryConverterExternalizer, BinaryFilterExternalizer}
 
 /**
  * Module lifecycle callbacks implementation that enables module specific
@@ -14,8 +15,11 @@ import org.infinispan.configuration.global.GlobalConfiguration
  */
 class LifecycleCallbacks extends AbstractModuleLifecycle {
 
-   override def cacheManagerStarting(gcr: GlobalComponentRegistry, globalCfg: GlobalConfiguration) =
-      globalCfg.serialization().advancedExternalizers().put(
-            SERVER_ADDRESS, new ServerAddress.Externalizer)
+   override def cacheManagerStarting(gcr: GlobalComponentRegistry, globalCfg: GlobalConfiguration) = {
+      val externalizers = globalCfg.serialization().advancedExternalizers()
+      externalizers.put(SERVER_ADDRESS, new ServerAddress.Externalizer)
+      externalizers.put(BINARY_FILTER, new BinaryFilterExternalizer())
+      externalizers.put(BINARY_CONVERTER, new BinaryConverterExternalizer())
+   }
 
 }


### PR DESCRIPTION
- Externalizers provide better guarantees in terms of initialization and also are better performance wise, though the latter is not so important in this particular case.
