### PR TITLE
ISPN-4602 Verify EntryIterator works with MarshalledValues

### DIFF
--- a/core/src/main/java/org/infinispan/iteration/impl/LocalEntryRetriever.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/LocalEntryRetriever.java
@@ -21,6 +21,7 @@ import org.infinispan.filter.KeyFilter;
 import org.infinispan.filter.KeyValueFilter;
 import org.infinispan.filter.KeyValueFilterAsKeyFilter;
 import org.infinispan.marshall.core.MarshalledEntry;
+import org.infinispan.marshall.core.MarshalledValue;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated;
 import org.infinispan.notifications.cachelistener.event.CacheEntryActivatedEvent;
@@ -197,14 +198,17 @@ public class LocalEntryRetriever<K, V> implements EntryRetriever<K, V> {
                try {
                   int interruptCheck = 0;
                   for (InternalCacheEntry<K, V> entry : dataContainer) {
-                     K key = entry.getKey();
+                     InternalCacheEntry<K, V> clone = entryFactory.create(unwrapMarshalledvalue(entry.getKey()),
+                                                                          unwrapMarshalledvalue(entry.getValue()),
+                                                                          entry);
+                     K key = clone.getKey();
                      if (filter != null) {
-                        if (!filter.accept(key, entry.getValue(), entry.getMetadata())) {
+                        if (!filter.accept(key, clone.getValue(), clone.getMetadata())) {
                            continue;
                         }
                      }
 
-                     action.apply(key, entry);
+                     action.apply(key, clone);
                      if (interruptCheck++ % batchSize == 0) {
                         if (Thread.interrupted()) {
                            throw new CacheException("Entry Iterator was interrupted!");
@@ -431,5 +435,12 @@ public class LocalEntryRetriever<K, V> implements EntryRetriever<K, V> {
             nextLock.unlock();
          }
       }
+   }
+
+   protected static <T> T unwrapMarshalledvalue(T value) {
+      if (value instanceof MarshalledValue) {
+         return (T) ((MarshalledValue) value).get();
+      }
+      return value;
    }
 }

--- a/core/src/main/java/org/infinispan/marshall/core/MarshalledValue.java
+++ b/core/src/main/java/org/infinispan/marshall/core/MarshalledValue.java
@@ -59,6 +59,15 @@ public final class MarshalledValue implements Externalizable {
       // For JDK serialization
    }
 
+   /**
+    * Construct a Marshalledvalue from the already serialized bytes.  The hashCode provided should be
+    * the hashCode of the object when it is deserialized.  Great <b>CARE</b> should be taken to guarantee
+    * the hashCode is correct, or else the hashCode contract will be broken and things like
+    * {@link java.util.Map#containsKey(Object)} will not work properly.
+    * @param bytes The serialized form of the object
+    * @param hashCode The hashCode of the object when it was deserialized
+    * @param marshaller The marshaller to use to deserialize the object
+    */
    public MarshalledValue(byte[] bytes, int hashCode, StreamingMarshaller marshaller) {
       this.marshaller = marshaller;
       this.raw = new ImmutableMarshalledValueByteStream(bytes);
@@ -66,15 +75,11 @@ public final class MarshalledValue implements Externalizable {
       this.serialisedSize = bytes.length;
    }
 
-   public MarshalledValue(byte[] bytes, StreamingMarshaller marshaller) {
-      this(bytes, Arrays.hashCode(bytes), marshaller);
-   }
-
    public MarshalledValue(Object instance, StreamingMarshaller marshaller) {
       this.marshaller = marshaller;
       this.raw = serialize(instance);
       this.serialisedSize = raw.size();
-      this.cachedHashCode = Util.hashCode(raw.getRaw(), raw.size());
+      this.cachedHashCode = instance.hashCode();
    }
 
    /**

--- a/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverWithLoaderTest.java
+++ b/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverWithLoaderTest.java
@@ -1,1 +1,127 @@
-package org.infinispan.iteration;import org.infinispan.Cache;import org.infinispan.configuration.cache.CacheMode;import org.infinispan.configuration.cache.ConfigurationBuilder;import org.infinispan.container.entries.CacheEntry;import org.infinispan.context.Flag;import org.infinispan.distribution.MagicKey;import org.infinispan.iteration.impl.EntryRetriever;import org.infinispan.marshall.TestObjectStreamMarshaller;import org.infinispan.marshall.core.MarshalledEntryImpl;import org.infinispan.persistence.dummy.DummyInMemoryStore;import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;import org.infinispan.persistence.manager.PersistenceManager;import org.infinispan.test.MultipleCacheManagersTest;import org.infinispan.test.TestingUtil;import org.infinispan.transaction.TransactionMode;import org.testng.annotations.Test;import java.util.EnumSet;import java.util.HashMap;import java.util.Iterator;import java.util.Map;import java.util.concurrent.ExecutionException;import java.util.concurrent.TimeoutException;import static org.testng.Assert.assertEquals;/** * Test to verify distributed entry behavior when a loader is present * * @author wburns * @since 7.0 */@Test(groups = "functional", testName = "distexec.DistributedEntryRetrieverWithLoaderTest")public class DistributedEntryRetrieverWithLoaderTest extends MultipleCacheManagersTest {   protected final static String CACHE_NAME = "DistributedEntryRetrieverWithLoaderTest";   protected ConfigurationBuilder builderUsed;   protected final boolean tx = false;   protected final CacheMode cacheMode = CacheMode.DIST_SYNC;   @Override   protected void createCacheManagers() throws Throwable {      builderUsed = new ConfigurationBuilder();      builderUsed.clustering().cacheMode(cacheMode);      builderUsed.clustering().hash().numOwners(1);      builderUsed.persistence().passivation(false).addStore(DummyInMemoryStoreConfigurationBuilder.class).storeName(CACHE_NAME);      if (tx) {         builderUsed.transaction().transactionMode(TransactionMode.TRANSACTIONAL);      }      createClusteredCaches(3, CACHE_NAME, builderUsed);   }   private Map<MagicKey, String> insertDefaultValues(boolean includeLoaderEntry) {      Cache<MagicKey, String> cache0 = cache(0, CACHE_NAME);      Cache<MagicKey, String> cache1 = cache(1, CACHE_NAME);      Cache<MagicKey, String> cache2 = cache(2, CACHE_NAME);      Map<MagicKey, String> originalValues = new HashMap<MagicKey, String>();      originalValues.put(new MagicKey(cache0), "cache0");      originalValues.put(new MagicKey(cache1), "cache1");      originalValues.put(new MagicKey(cache2), "cache2");      cache0.putAll(originalValues);      PersistenceManager persistenceManager = TestingUtil.extractComponent(cache0, PersistenceManager.class);      DummyInMemoryStore store = persistenceManager.getStores(DummyInMemoryStore.class).iterator().next();      TestObjectStreamMarshaller sm = new TestObjectStreamMarshaller();      PersistenceManager pm = null;      try {         MagicKey loaderKey = new MagicKey(cache2);         String loaderValue = "loader-value";         store.write(new MarshalledEntryImpl(loaderKey, loaderValue, null, sm));         if (includeLoaderEntry) {            originalValues.put(loaderKey, loaderValue);         }      } finally {         sm.stop();      }      return originalValues;   }   @Test   public void testCacheLoader() throws InterruptedException, ExecutionException, TimeoutException {      Map<MagicKey, String> originalValues = insertDefaultValues(true);      EntryRetriever<MagicKey, String> retriever = cache(1, CACHE_NAME).getAdvancedCache().getComponentRegistry().getComponent(            EntryRetriever.class);      Iterator<CacheEntry<MagicKey, String>> iterator = retriever.retrieveEntries(null, null, null, null);      // we need this count since the map will replace same key'd value      int count = 0;      Map<MagicKey, String> results = new HashMap<MagicKey, String>();      while (iterator.hasNext()) {         Map.Entry<MagicKey, String> entry = iterator.next();         results.put(entry.getKey(), entry.getValue());         count++;      }      assertEquals(count, 4);      assertEquals(originalValues, results);   }   @Test   public void testCacheLoaderIgnored() throws InterruptedException, ExecutionException, TimeoutException {      Map<MagicKey, String> originalValues = insertDefaultValues(false);      EntryRetriever<MagicKey, String> retriever = cache(1, CACHE_NAME).getAdvancedCache().getComponentRegistry().getComponent(            EntryRetriever.class);      Iterator<CacheEntry<MagicKey, String>> iterator = retriever.retrieveEntries(null, null,                                                                                  EnumSet.of(Flag.SKIP_CACHE_LOAD), null);      // we need this count since the map will replace same key'd value      int count = 0;      Map<MagicKey, String> results = new HashMap<MagicKey, String>();      while (iterator.hasNext()) {         Map.Entry<MagicKey, String> entry = iterator.next();         results.put(entry.getKey(), entry.getValue());         count++;      }      assertEquals(count, 3);      assertEquals(originalValues, results);   }}
+package org.infinispan.iteration;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.context.Flag;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.iteration.impl.EntryRetriever;
+import org.infinispan.marshall.TestObjectStreamMarshaller;
+import org.infinispan.marshall.core.MarshalledEntryImpl;
+import org.infinispan.persistence.dummy.DummyInMemoryStore;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.persistence.manager.PersistenceManager;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.transaction.TransactionMode;
+import org.testng.annotations.Test;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test to verify distributed entry behavior when a loader is present
+ *
+ * @author wburns
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "distexec.DistributedEntryRetrieverWithLoaderTest")
+public class DistributedEntryRetrieverWithLoaderTest extends MultipleCacheManagersTest {
+   protected final static String CACHE_NAME = "DistributedEntryRetrieverWithLoaderTest";
+   protected ConfigurationBuilder builderUsed;
+   protected final boolean tx = false;
+   protected final CacheMode cacheMode = CacheMode.DIST_SYNC;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      builderUsed = new ConfigurationBuilder();
+      builderUsed.clustering().cacheMode(cacheMode);
+      builderUsed.clustering().hash().numOwners(1);
+      builderUsed.persistence().passivation(false).addStore(DummyInMemoryStoreConfigurationBuilder.class).storeName(CACHE_NAME);
+      if (tx) {
+         builderUsed.transaction().transactionMode(TransactionMode.TRANSACTIONAL);
+      }
+      createClusteredCaches(3, CACHE_NAME, builderUsed);
+   }
+
+   private Map<MagicKey, String> insertDefaultValues(boolean includeLoaderEntry) {
+      Cache<MagicKey, String> cache0 = cache(0, CACHE_NAME);
+      Cache<MagicKey, String> cache1 = cache(1, CACHE_NAME);
+      Cache<MagicKey, String> cache2 = cache(2, CACHE_NAME);
+
+      Map<MagicKey, String> originalValues = new HashMap<MagicKey, String>();
+      originalValues.put(new MagicKey(cache0), "cache0");
+      originalValues.put(new MagicKey(cache1), "cache1");
+      originalValues.put(new MagicKey(cache2), "cache2");
+
+      cache0.putAll(originalValues);
+
+      PersistenceManager persistenceManager = TestingUtil.extractComponent(cache0, PersistenceManager.class);
+      DummyInMemoryStore store = persistenceManager.getStores(DummyInMemoryStore.class).iterator().next();
+
+      TestObjectStreamMarshaller sm = new TestObjectStreamMarshaller();
+      PersistenceManager pm = null;
+      try {
+         MagicKey loaderKey = new MagicKey(cache2);
+         String loaderValue = "loader-value";
+         store.write(new MarshalledEntryImpl(loaderKey, loaderValue, null, sm));
+         if (includeLoaderEntry) {
+            originalValues.put(loaderKey, loaderValue);
+         }
+      } finally {
+         sm.stop();
+      }
+      return originalValues;
+   }
+
+   @Test
+   public void testCacheLoader() throws InterruptedException, ExecutionException, TimeoutException {
+      Map<MagicKey, String> originalValues = insertDefaultValues(true);
+
+      EntryRetriever<MagicKey, String> retriever = cache(1, CACHE_NAME).getAdvancedCache().getComponentRegistry().getComponent(
+            EntryRetriever.class);
+
+      Iterator<CacheEntry<MagicKey, String>> iterator = retriever.retrieveEntries(null, null, null, null);
+
+      // we need this count since the map will replace same key'd value
+      int count = 0;
+      Map<MagicKey, String> results = new HashMap<MagicKey, String>();
+      while (iterator.hasNext()) {
+         Map.Entry<MagicKey, String> entry = iterator.next();
+         results.put(entry.getKey(), entry.getValue());
+         count++;
+      }
+      assertEquals(count, 4);
+      assertEquals(originalValues, results);
+   }
+
+   @Test
+   public void testCacheLoaderIgnored() throws InterruptedException, ExecutionException, TimeoutException {
+      Map<MagicKey, String> originalValues = insertDefaultValues(false);
+
+      EntryRetriever<MagicKey, String> retriever = cache(1, CACHE_NAME).getAdvancedCache().getComponentRegistry().getComponent(
+            EntryRetriever.class);
+
+      Iterator<CacheEntry<MagicKey, String>> iterator = retriever.retrieveEntries(null, null,
+                                                                                  EnumSet.of(Flag.SKIP_CACHE_LOAD), null);
+
+      // we need this count since the map will replace same key'd value
+      int count = 0;
+      Map<MagicKey, String> results = new HashMap<MagicKey, String>();
+      while (iterator.hasNext()) {
+         Map.Entry<MagicKey, String> entry = iterator.next();
+         results.put(entry.getKey(), entry.getValue());
+         count++;
+      }
+      assertEquals(count, 3);
+      assertEquals(originalValues, results);
+   }
+}
+

--- a/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverWithPassivationTest.java
+++ b/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverWithPassivationTest.java
@@ -1,1 +1,231 @@
-package org.infinispan.iteration;import org.infinispan.Cache;import org.infinispan.configuration.cache.CacheMode;import org.infinispan.configuration.cache.ConfigurationBuilder;import org.infinispan.container.entries.CacheEntry;import org.infinispan.container.entries.ImmortalCacheEntry;import org.infinispan.distribution.MagicKey;import org.infinispan.eviction.PassivationManager;import org.infinispan.filter.KeyFilter;import org.infinispan.iteration.impl.EntryRetriever;import org.infinispan.marshall.TestObjectStreamMarshaller;import org.infinispan.marshall.core.MarshalledEntryImpl;import org.infinispan.persistence.dummy.DummyInMemoryStore;import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;import org.infinispan.persistence.manager.PersistenceManager;import org.infinispan.persistence.spi.AdvancedCacheLoader;import org.infinispan.test.MultipleCacheManagersTest;import org.infinispan.test.TestingUtil;import org.infinispan.test.fwk.CheckPoint;import org.infinispan.transaction.TransactionMode;import org.mockito.AdditionalAnswers;import org.mockito.invocation.InvocationOnMock;import org.mockito.stubbing.Answer;import org.testng.annotations.Test;import java.util.HashMap;import java.util.Iterator;import java.util.Map;import java.util.concurrent.Callable;import java.util.concurrent.ExecutionException;import java.util.concurrent.Executor;import java.util.concurrent.Future;import java.util.concurrent.TimeUnit;import java.util.concurrent.TimeoutException;import static org.mockito.Matchers.any;import static org.mockito.Matchers.anyBoolean;import static org.mockito.Mockito.doAnswer;import static org.mockito.Mockito.withSettings;import static org.testng.Assert.assertEquals;import static org.mockito.Mockito.mock;/** * Test to verify distributed entry behavior when a loader with passivation is present * * @author wburns * @since 7.0 */@Test(groups = "functional", testName = "distexec.DistributedEntryRetrieverWithPassivationTest")public class DistributedEntryRetrieverWithPassivationTest extends MultipleCacheManagersTest {   protected final static String CACHE_NAME = "DistributedEntryRetrieverWithPassivationTest";   protected ConfigurationBuilder builderUsed;   protected final boolean tx = false;   protected final CacheMode cacheMode = CacheMode.DIST_SYNC;   @Override   protected void createCacheManagers() throws Throwable {      builderUsed = new ConfigurationBuilder();      builderUsed.clustering().cacheMode(cacheMode);      builderUsed.clustering().hash().numOwners(1);      builderUsed.persistence().passivation(true).addStore(DummyInMemoryStoreConfigurationBuilder.class).storeName(CACHE_NAME);      if (tx) {         builderUsed.transaction().transactionMode(TransactionMode.TRANSACTIONAL);      }      createClusteredCaches(3, CACHE_NAME, builderUsed);   }   @Test   public void testConcurrentActivation() throws InterruptedException, ExecutionException, TimeoutException {      final Cache<MagicKey, String> cache0 = cache(0, CACHE_NAME);      Cache<MagicKey, String> cache1 = cache(1, CACHE_NAME);      Cache<MagicKey, String> cache2 = cache(2, CACHE_NAME);      Map<MagicKey, String> originalValues = new HashMap<MagicKey, String>();      originalValues.put(new MagicKey(cache0), "cache0");      originalValues.put(new MagicKey(cache1), "cache1");      originalValues.put(new MagicKey(cache2), "cache2");      final MagicKey loaderKey = new MagicKey(cache0);      final String loaderValue = "loader0";      cache0.putAll(originalValues);      // Put this in after the cache has been updated      originalValues.put(loaderKey, loaderValue);      PersistenceManager persistenceManager = TestingUtil.extractComponent(cache0, PersistenceManager.class);      DummyInMemoryStore store = persistenceManager.getStores(DummyInMemoryStore.class).iterator().next();      TestObjectStreamMarshaller sm = new TestObjectStreamMarshaller();      PersistenceManager pm = null;      try {         store.write(new MarshalledEntryImpl(loaderKey, loaderValue, null, sm));         final CheckPoint checkPoint = new CheckPoint();         pm = waitUntilAboutToProcessStoreTask(cache0, checkPoint);         Future<Void> future = fork(new Callable<Void>() {            @Override            public Void call() throws Exception {               // Wait until loader is invoked               checkPoint.awaitStrict("pre_process_on_all_stores_invoked", 1000, TimeUnit.SECONDS);               // Now force the entry to be moved to the in memory               assertEquals(loaderValue, cache0.get(loaderKey));               checkPoint.triggerForever("pre_process_on_all_stores_released");               return null;            }         });         EntryRetriever<MagicKey, String> retriever = cache1.getAdvancedCache().getComponentRegistry().getComponent(               EntryRetriever.class);         Iterator<CacheEntry<MagicKey, String>> iterator = retriever.retrieveEntries(null, null, null, null);         // we need this count since the map will replace same key'd value         int count = 0;         Map<MagicKey, String> results = new HashMap<MagicKey, String>();         while (iterator.hasNext()) {            Map.Entry<MagicKey, String> entry = iterator.next();            results.put(entry.getKey(), entry.getValue());            count++;         }         assertEquals(count, 4);         assertEquals(originalValues, results);         future.get(10, TimeUnit.SECONDS);      } finally {         if (pm != null) {            TestingUtil.replaceComponent(cache0, PersistenceManager.class, pm, true);         }         sm.stop();      }   }   protected PersistenceManager waitUntilAboutToProcessStoreTask(final Cache<?, ?> cache, final CheckPoint checkPoint) {      PersistenceManager pm = TestingUtil.extractComponent(cache, PersistenceManager.class);      final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(pm);      PersistenceManager mockManager = mock(PersistenceManager.class, withSettings().defaultAnswer(forwardedAnswer));      doAnswer(new Answer() {         @Override         public Object answer(InvocationOnMock invocation) throws Throwable {            // Wait for main thread to sync up            checkPoint.trigger("pre_process_on_all_stores_invoked");            // Now wait until main thread lets us through            checkPoint.awaitStrict("pre_process_on_all_stores_released", 10, TimeUnit.SECONDS);            return forwardedAnswer.answer(invocation);         }      }).when(mockManager).processOnAllStores(any(Executor.class),      any(KeyFilter.class), any(AdvancedCacheLoader.CacheLoaderTask.class),                                                  anyBoolean(), anyBoolean());      TestingUtil.replaceComponent(cache, PersistenceManager.class, mockManager, true);      return pm;   }   /**    * This test is to verify that if a concurrent passivation occurs while switching between data container and loader(s)    * that we don't return the same key/value twice    * @throws InterruptedException    * @throws ExecutionException    * @throws TimeoutException    */   @Test   public void testConcurrentPassivation() throws InterruptedException, ExecutionException, TimeoutException {      final Cache<MagicKey, String> cache0 = cache(0, CACHE_NAME);      Cache<MagicKey, String> cache1 = cache(1, CACHE_NAME);      Cache<MagicKey, String> cache2 = cache(2, CACHE_NAME);      Map<MagicKey, String> originalValues = new HashMap<MagicKey, String>();      originalValues.put(new MagicKey(cache0), "cache0");      originalValues.put(new MagicKey(cache1), "cache1");      originalValues.put(new MagicKey(cache2), "cache2");      final MagicKey loaderKey = new MagicKey(cache0);      final String loaderValue = "loader0";      // Make sure this is in the cache to begin with      originalValues.put(loaderKey, loaderValue);      cache0.putAll(originalValues);      PersistenceManager pm = null;      try {         final CheckPoint checkPoint = new CheckPoint();         pm = waitUntilAboutToProcessStoreTask(cache0, checkPoint);         Future<Void> future = fork(new Callable<Void>() {            @Override            public Void call() throws Exception {               // Wait until loader is invoked               checkPoint.awaitStrict("pre_process_on_all_stores_invoked", 1000, TimeUnit.SECONDS);               // Now force the entry to be moved to loader               TestingUtil.extractComponent(cache0, PassivationManager.class).passivate(new ImmortalCacheEntry(loaderKey, loaderValue));               checkPoint.triggerForever("pre_process_on_all_stores_released");               return null;            }         });         EntryRetriever<MagicKey, String> retriever = cache1.getAdvancedCache().getComponentRegistry().getComponent(               EntryRetriever.class);         Iterator<CacheEntry<MagicKey, String>> iterator = retriever.retrieveEntries(null, null, null, null);         // we need this count since the map will replace same key'd value         int count = 0;         Map<MagicKey, String> results = new HashMap<MagicKey, String>();         while (iterator.hasNext()) {            Map.Entry<MagicKey, String> entry = iterator.next();            results.put(entry.getKey(), entry.getValue());            count++;         }         assertEquals(4, count);         assertEquals(originalValues, results);         future.get(10, TimeUnit.SECONDS);      } finally {         if (pm != null) {            TestingUtil.replaceComponent(cache0, PersistenceManager.class, pm, true);         }      }   }}
+package org.infinispan.iteration;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.container.entries.ImmortalCacheEntry;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.eviction.PassivationManager;
+import org.infinispan.filter.KeyFilter;
+import org.infinispan.iteration.impl.EntryRetriever;
+import org.infinispan.marshall.TestObjectStreamMarshaller;
+import org.infinispan.marshall.core.MarshalledEntryImpl;
+import org.infinispan.persistence.dummy.DummyInMemoryStore;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.persistence.manager.PersistenceManager;
+import org.infinispan.persistence.spi.AdvancedCacheLoader;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CheckPoint;
+import org.infinispan.transaction.TransactionMode;
+import org.mockito.AdditionalAnswers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.withSettings;
+import static org.testng.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test to verify distributed entry behavior when a loader with passivation is present
+ *
+ * @author wburns
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "distexec.DistributedEntryRetrieverWithPassivationTest")
+public class DistributedEntryRetrieverWithPassivationTest extends MultipleCacheManagersTest {
+   protected final static String CACHE_NAME = "DistributedEntryRetrieverWithPassivationTest";
+   protected ConfigurationBuilder builderUsed;
+   protected final boolean tx = false;
+   protected final CacheMode cacheMode = CacheMode.DIST_SYNC;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      builderUsed = new ConfigurationBuilder();
+      builderUsed.clustering().cacheMode(cacheMode);
+      builderUsed.clustering().hash().numOwners(1);
+      builderUsed.persistence().passivation(true).addStore(DummyInMemoryStoreConfigurationBuilder.class).storeName(CACHE_NAME);
+      if (tx) {
+         builderUsed.transaction().transactionMode(TransactionMode.TRANSACTIONAL);
+      }
+      createClusteredCaches(3, CACHE_NAME, builderUsed);
+   }
+
+   @Test
+   public void testConcurrentActivation() throws InterruptedException, ExecutionException, TimeoutException {
+      final Cache<MagicKey, String> cache0 = cache(0, CACHE_NAME);
+      Cache<MagicKey, String> cache1 = cache(1, CACHE_NAME);
+      Cache<MagicKey, String> cache2 = cache(2, CACHE_NAME);
+
+      Map<MagicKey, String> originalValues = new HashMap<MagicKey, String>();
+      originalValues.put(new MagicKey(cache0), "cache0");
+      originalValues.put(new MagicKey(cache1), "cache1");
+      originalValues.put(new MagicKey(cache2), "cache2");
+
+      final MagicKey loaderKey = new MagicKey(cache0);
+      final String loaderValue = "loader0";
+
+      cache0.putAll(originalValues);
+
+      // Put this in after the cache has been updated
+      originalValues.put(loaderKey, loaderValue);
+
+      PersistenceManager persistenceManager = TestingUtil.extractComponent(cache0, PersistenceManager.class);
+      DummyInMemoryStore store = persistenceManager.getStores(DummyInMemoryStore.class).iterator().next();
+
+      TestObjectStreamMarshaller sm = new TestObjectStreamMarshaller();
+      PersistenceManager pm = null;
+      try {
+         store.write(new MarshalledEntryImpl(loaderKey, loaderValue, null, sm));
+
+         final CheckPoint checkPoint = new CheckPoint();
+         pm = waitUntilAboutToProcessStoreTask(cache0, checkPoint);
+
+         Future<Void> future = fork(new Callable<Void>() {
+
+            @Override
+            public Void call() throws Exception {
+               // Wait until loader is invoked
+               checkPoint.awaitStrict("pre_process_on_all_stores_invoked", 1000, TimeUnit.SECONDS);
+
+               // Now force the entry to be moved to the in memory
+               assertEquals(loaderValue, cache0.get(loaderKey));
+
+               checkPoint.triggerForever("pre_process_on_all_stores_released");
+               return null;
+            }
+         });
+
+         EntryRetriever<MagicKey, String> retriever = cache1.getAdvancedCache().getComponentRegistry().getComponent(
+               EntryRetriever.class);
+
+         Iterator<CacheEntry<MagicKey, String>> iterator = retriever.retrieveEntries(null, null, null, null);
+
+         // we need this count since the map will replace same key'd value
+         int count = 0;
+         Map<MagicKey, String> results = new HashMap<MagicKey, String>();
+         while (iterator.hasNext()) {
+            Map.Entry<MagicKey, String> entry = iterator.next();
+            results.put(entry.getKey(), entry.getValue());
+            count++;
+         }
+         assertEquals(count, 4);
+         assertEquals(originalValues, results);
+
+         future.get(10, TimeUnit.SECONDS);
+      } finally {
+         if (pm != null) {
+            TestingUtil.replaceComponent(cache0, PersistenceManager.class, pm, true);
+         }
+         sm.stop();
+      }
+   }
+
+
+   protected PersistenceManager waitUntilAboutToProcessStoreTask(final Cache<?, ?> cache, final CheckPoint checkPoint) {
+      PersistenceManager pm = TestingUtil.extractComponent(cache, PersistenceManager.class);
+      final Answer<Object> forwardedAnswer = AdditionalAnswers.delegatesTo(pm);
+      PersistenceManager mockManager = mock(PersistenceManager.class, withSettings().defaultAnswer(forwardedAnswer));
+      doAnswer(new Answer() {
+         @Override
+         public Object answer(InvocationOnMock invocation) throws Throwable {
+            // Wait for main thread to sync up
+            checkPoint.trigger("pre_process_on_all_stores_invoked");
+            // Now wait until main thread lets us through
+            checkPoint.awaitStrict("pre_process_on_all_stores_released", 10, TimeUnit.SECONDS);
+
+            return forwardedAnswer.answer(invocation);
+         }
+      }).when(mockManager).processOnAllStores(any(Executor.class),      any(KeyFilter.class), any(AdvancedCacheLoader.CacheLoaderTask.class),
+                                                  anyBoolean(), anyBoolean());
+      TestingUtil.replaceComponent(cache, PersistenceManager.class, mockManager, true);
+      return pm;
+   }
+
+   /**
+    * This test is to verify that if a concurrent passivation occurs while switching between data container and loader(s)
+    * that we don't return the same key/value twice
+    * @throws InterruptedException
+    * @throws ExecutionException
+    * @throws TimeoutException
+    */
+   @Test
+   public void testConcurrentPassivation() throws InterruptedException, ExecutionException, TimeoutException {
+      final Cache<MagicKey, String> cache0 = cache(0, CACHE_NAME);
+      Cache<MagicKey, String> cache1 = cache(1, CACHE_NAME);
+      Cache<MagicKey, String> cache2 = cache(2, CACHE_NAME);
+
+      Map<MagicKey, String> originalValues = new HashMap<MagicKey, String>();
+      originalValues.put(new MagicKey(cache0), "cache0");
+      originalValues.put(new MagicKey(cache1), "cache1");
+      originalValues.put(new MagicKey(cache2), "cache2");
+
+      final MagicKey loaderKey = new MagicKey(cache0);
+      final String loaderValue = "loader0";
+
+      // Make sure this is in the cache to begin with
+      originalValues.put(loaderKey, loaderValue);
+
+      cache0.putAll(originalValues);
+
+      PersistenceManager pm = null;
+
+      try {
+         final CheckPoint checkPoint = new CheckPoint();
+         pm = waitUntilAboutToProcessStoreTask(cache0, checkPoint);
+
+         Future<Void> future = fork(new Callable<Void>() {
+
+            @Override
+            public Void call() throws Exception {
+               // Wait until loader is invoked
+               checkPoint.awaitStrict("pre_process_on_all_stores_invoked", 1000, TimeUnit.SECONDS);
+
+               // Now force the entry to be moved to loader
+               TestingUtil.extractComponent(cache0, PassivationManager.class).passivate(new ImmortalCacheEntry(loaderKey, loaderValue));
+
+               checkPoint.triggerForever("pre_process_on_all_stores_released");
+               return null;
+            }
+         });
+
+         EntryRetriever<MagicKey, String> retriever = cache1.getAdvancedCache().getComponentRegistry().getComponent(
+               EntryRetriever.class);
+
+         Iterator<CacheEntry<MagicKey, String>> iterator = retriever.retrieveEntries(null, null, null, null);
+
+         // we need this count since the map will replace same key'd value
+         int count = 0;
+         Map<MagicKey, String> results = new HashMap<MagicKey, String>();
+         while (iterator.hasNext()) {
+            Map.Entry<MagicKey, String> entry = iterator.next();
+            results.put(entry.getKey(), entry.getValue());
+            count++;
+         }
+         assertEquals(4, count);
+         assertEquals(originalValues, results);
+
+         future.get(10, TimeUnit.SECONDS);
+      } finally {
+         if (pm != null) {
+            TestingUtil.replaceComponent(cache0, PersistenceManager.class, pm, true);
+         }
+      }
+   }
+}
+

--- a/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverWithStoreAsBinaryTest.java
+++ b/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverWithStoreAsBinaryTest.java
@@ -1,0 +1,126 @@
+package org.infinispan.iteration;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.filter.KeyValueFilter;
+import org.infinispan.iteration.impl.EntryRetriever;
+import org.infinispan.metadata.Metadata;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.transaction.TransactionMode;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+
+/**
+ * Test to verify distributed entry behavior when store as binary is used
+ *
+ * @author wburns
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "distexec.DistributedEntryRetrieverWithStoreAsBinaryTest")
+public class DistributedEntryRetrieverWithStoreAsBinaryTest extends MultipleCacheManagersTest {
+   protected final static String CACHE_NAME = "DistributedEntryRetrieverWithStoreAsBinaryTest";
+   protected ConfigurationBuilder builderUsed;
+   protected final boolean tx = false;
+   protected final CacheMode cacheMode = CacheMode.DIST_SYNC;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      builderUsed = new ConfigurationBuilder();
+      builderUsed.clustering().cacheMode(cacheMode);
+      builderUsed.clustering().hash().numOwners(1);
+      builderUsed.dataContainer().storeAsBinary().enabled(true).storeKeysAsBinary(true).storeValuesAsBinary(true);
+      if (tx) {
+         builderUsed.transaction().transactionMode(TransactionMode.TRANSACTIONAL);
+      }
+      createClusteredCaches(3, CACHE_NAME, builderUsed);
+   }
+
+   @Test
+   public void testFilterWithStoreAsBinary() throws InterruptedException, ExecutionException, TimeoutException {
+      Cache<MagicKey, String> cache0 = cache(0, CACHE_NAME);
+      Cache<MagicKey, String> cache1 = cache(1, CACHE_NAME);
+      Cache<MagicKey, String> cache2 = cache(2, CACHE_NAME);
+
+      Map<MagicKey, String> originalValues = new HashMap<>();
+      originalValues.put(new MagicKey(cache0), "cache0");
+      originalValues.put(new MagicKey(cache1), "cache1");
+      originalValues.put(new MagicKey(cache2), "cache2");
+
+      cache0.putAll(originalValues);
+
+      EntryRetriever<MagicKey, String> retriever = cache1.getAdvancedCache().getComponentRegistry().getComponent(
+            EntryRetriever.class);
+
+      // Try filter for all values
+      Iterator<CacheEntry<MagicKey, String>> iterator = retriever.retrieveEntries(
+            new MagicKeyStringFilter(originalValues), null, null, null);
+
+      // we need this count since the map will replace same key'd value
+      int count = 0;
+      Map<MagicKey, String> results = new HashMap<MagicKey, String>();
+      while (iterator.hasNext()) {
+         Map.Entry<MagicKey, String> entry = iterator.next();
+         results.put(entry.getKey(), entry.getValue());
+         count++;
+      }
+      assertEquals(count, 3);
+      assertEquals(originalValues, results);
+   }
+
+   @Test
+   public void testFilterWithStoreAsBinaryPartialKeys() throws InterruptedException, ExecutionException, TimeoutException {
+      Cache<MagicKey, String> cache0 = cache(0, CACHE_NAME);
+      Cache<MagicKey, String> cache1 = cache(1, CACHE_NAME);
+      Cache<MagicKey, String> cache2 = cache(2, CACHE_NAME);
+
+      MagicKey findKey = new MagicKey(cache1);
+      Map<MagicKey, String> originalValues = new HashMap<>();
+      originalValues.put(new MagicKey(cache0), "cache0");
+      originalValues.put(findKey, "cache1");
+      originalValues.put(new MagicKey(cache2), "cache2");
+
+      cache0.putAll(originalValues);
+
+      EntryRetriever<MagicKey, String> retriever = cache2.getAdvancedCache().getComponentRegistry().getComponent(
+            EntryRetriever.class);
+
+      // Try filter for all values
+      Iterator<CacheEntry<MagicKey, String>> iterator = retriever.retrieveEntries(
+            new MagicKeyStringFilter(Collections.singletonMap(findKey, "cache1")), null, null, null);
+
+      CacheEntry<MagicKey, String> entry = iterator.next();
+      AssertJUnit.assertEquals(findKey, entry.getKey());
+      AssertJUnit.assertEquals("cache1", entry.getValue());
+      assertFalse(iterator.hasNext());
+   }
+
+   private static class MagicKeyStringFilter implements KeyValueFilter<MagicKey, String>, Serializable {
+      private final Map<MagicKey, String> allowedEntries;
+
+      public MagicKeyStringFilter(Map<MagicKey, String> allowedEntries) {
+         this.allowedEntries = allowedEntries;
+      }
+
+      @Override
+      public boolean accept(MagicKey key, String value, Metadata metadata) {
+         String allowedValue = allowedEntries.get(key);
+         return allowedValue != null && allowedValue.equals(value);
+      }
+   }
+}
+

--- a/core/src/test/java/org/infinispan/iteration/LocalEntryRetrieverWithStoreAsBinaryTest.java
+++ b/core/src/test/java/org/infinispan/iteration/LocalEntryRetrieverWithStoreAsBinaryTest.java
@@ -1,0 +1,113 @@
+package org.infinispan.iteration;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.filter.KeyValueFilter;
+import org.infinispan.iteration.impl.EntryRetriever;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.metadata.Metadata;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.TransactionMode;
+import org.testng.annotations.Test;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+
+/**
+ * Test to verify local entry behavior when store as binary is used
+ *
+ * @author wburns
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "distexec.LocalEntryRetrieverWithStoreAsBinaryTest")
+public class LocalEntryRetrieverWithStoreAsBinaryTest extends SingleCacheManagerTest {
+   protected final static String CACHE_NAME = "LocalEntryRetrieverWithStoreAsBinaryTest";
+   protected ConfigurationBuilder builderUsed;
+   protected final boolean tx = false;
+   protected final CacheMode cacheMode = CacheMode.DIST_SYNC;
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      builderUsed = new ConfigurationBuilder();
+      builderUsed.dataContainer().storeAsBinary().enabled(true).storeKeysAsBinary(true).storeValuesAsBinary(true);
+      if (tx) {
+         builderUsed.transaction().transactionMode(TransactionMode.TRANSACTIONAL);
+      }
+      return TestCacheManagerFactory.createCacheManager(builderUsed);
+   }
+
+   @Test
+   public void testFilterWithStoreAsBinary() throws InterruptedException, ExecutionException, TimeoutException {
+      Map<String, String> originalValues = new HashMap<>();
+      originalValues.put("value0", "cache0");
+      originalValues.put("value1", "cache1");
+      originalValues.put("value2", "cache2");
+
+      cache.putAll(originalValues);
+
+      EntryRetriever<String, String> retriever = cache.getAdvancedCache().getComponentRegistry().getComponent(
+            EntryRetriever.class);
+
+      // Try filter for all values
+      Iterator<CacheEntry<String, String>> iterator = retriever.retrieveEntries(
+            new StringStringFilter(originalValues), null, null, null);
+
+      // we need this count since the map will replace same key'd value
+      int count = 0;
+      Map<String, String> results = new HashMap<>();
+      while (iterator.hasNext()) {
+         Map.Entry<String, String> entry = iterator.next();
+         results.put(entry.getKey(), entry.getValue());
+         count++;
+      }
+      assertEquals(3, count);
+      assertEquals(originalValues, results);
+   }
+
+   @Test
+   public void testFilterWithStoreAsBinaryPartialKeys() throws InterruptedException, ExecutionException, TimeoutException {
+      Map<String, String> originalValues = new HashMap<>();
+      originalValues.put("value0", "cache0");
+      originalValues.put("value1", "cache1");
+      originalValues.put("value2", "cache2");
+
+      cache.putAll(originalValues);
+
+      EntryRetriever<String, String> retriever = cache.getAdvancedCache().getComponentRegistry().getComponent(
+            EntryRetriever.class);
+
+      // Try filter for all values
+      Iterator<CacheEntry<String, String>> iterator = retriever.retrieveEntries(
+            new StringStringFilter(Collections.singletonMap("value1", "cache1")), null, null, null);
+
+      CacheEntry<String, String> entry = iterator.next();
+      assertEquals("value1", entry.getKey());
+      assertEquals("cache1", entry.getValue());
+      assertFalse(iterator.hasNext());
+   }
+
+   private static class StringStringFilter implements KeyValueFilter<String, String>, Serializable {
+      private final Map<String, String> allowedEntries;
+
+      public StringStringFilter(Map<String, String> allowedEntries) {
+         this.allowedEntries = allowedEntries;
+      }
+
+      @Override
+      public boolean accept(String key, String value, Metadata metadata) {
+         String allowedValue = allowedEntries.get(key);
+         return allowedValue != null && allowedValue.equals(value);
+      }
+   }
+}
+


### PR DESCRIPTION
- Added unwrapping of MarshalledValues
- Changed MarshalledValue to use inner object hash code

https://issues.jboss.org/browse/ISPN-4602

The 2 with bad newlines were unchanged btw.  Only the 2 new classes have changes.
