### PR TITLE
ISPN-3329 DatabaseStoredIndexTest.indexWasStored random failures

### DIFF
--- a/lucene/lucene-directory/src/main/java/org/infinispan/lucene/impl/FileListCacheValue.java
+++ b/lucene/lucene-directory/src/main/java/org/infinispan/lucene/impl/FileListCacheValue.java
@@ -26,7 +26,7 @@ import org.infinispan.lucene.ExternalizerIds;
  * @since 7.0
  */
 @ThreadSafe
-public class FileListCacheValue {
+public final class FileListCacheValue {
 
    private final HashSet<String> filenames = new HashSet<>();
    private final Lock writeLock;
@@ -112,6 +112,53 @@ public class FileListCacheValue {
       }
    }
 
+   @Override
+   public int hashCode() {
+      readLock.lock();
+      try {
+         return filenames.hashCode();
+      }
+      finally {
+         readLock.unlock();
+      }
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (FileListCacheValue.class != obj.getClass())
+         return false;
+      final FileListCacheValue other = (FileListCacheValue) obj;
+      final HashSet<String> copyFromOther;
+      other.readLock.lock();
+      try {
+         copyFromOther = new HashSet<>(other.filenames);
+      }
+      finally {
+         other.readLock.unlock();
+      }
+      readLock.lock();
+      try {
+         return (filenames.equals(copyFromOther));
+      }
+      finally {
+         readLock.unlock();
+      }
+   }
+
+   @Override
+   public String toString() {
+      readLock.lock();
+      try {
+         return "FileListCacheValue [filenames=" + filenames + "]";
+      }
+      finally {
+         readLock.unlock();
+      }
+   }
 
    public static final class Externalizer extends AbstractExternalizer<FileListCacheValue> {
 

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/DatabaseStoredIndexTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/DatabaseStoredIndexTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  * @since 4.1
  */
 @SuppressWarnings("unchecked")
-@Test(groups = "unstable", testName = "lucene.DatabaseStoredIndexTest", description = "original group: functional")
+@Test(groups = "functional", testName = "lucene.DatabaseStoredIndexTest")
 public class DatabaseStoredIndexTest extends SingleCacheManagerTest {
 
    private static final String DB_URL = "jdbc:h2:mem:infinispan;DB_CLOSE_DELAY=0";


### PR DESCRIPTION
- https://issues.jboss.org/browse/ISPN-3329

I believe the issue was fixed by @gustavonalle in 74db418

I just had to add an equals implementation to the recently created FileListCacheValue (this should have been done when I introduced the new type but didn't notice as this test was disabled)
