### PR TITLE
ISPN-4618 Map/Reduce jobs should not timeout by default

### DIFF
--- a/core/src/main/java/org/infinispan/distexec/mapreduce/MapReduceTask.java
+++ b/core/src/main/java/org/infinispan/distexec/mapreduce/MapReduceTask.java
@@ -231,6 +231,9 @@ public class MapReduceTask<KIn, VIn, KOut, VOut> {
       this.clusteringDependentLogic = componentRegistry.getComponent(ClusteringDependentLogic.class);
       this.isLocalOnly = SecurityActions.getCacheRpcManager(cache) == null;
       this.rpcOptionsBuilder = isLocalOnly ? null : new RpcOptionsBuilder(SecurityActions.getCacheRpcManager(cache).getDefaultRpcOptions(true));
+      if (!isLocalOnly) {
+         this.rpcOptionsBuilder.timeout(0, TimeUnit.MILLISECONDS);
+      }
    }
 
    /**
@@ -307,6 +310,7 @@ public class MapReduceTask<KIn, VIn, KOut, VOut> {
     * See {@link #timeout(TimeUnit)}.
     *
     * Note: the timeout value will be converted to milliseconds and a value less or equal than zero means wait forever.
+    * The default timeout for this task is 0. The task will wait indefinitely for its completion.
     *
     * @param timeout
     * @param unit
@@ -318,8 +322,8 @@ public class MapReduceTask<KIn, VIn, KOut, VOut> {
    }
 
    /**
-    * @return the timeout value in {@link TimeUnit} to wait for the remote map/reduce task to finish. The default value
-    *         given by {@link org.infinispan.configuration.cache.SyncConfiguration#replTimeout()}
+    * @return the timeout value in {@link TimeUnit} to wait for the remote map/reduce task to finish. The default
+    * timeout is 0, the task will wait indefinitely for its completion.
     */
    public final long timeout(TimeUnit outputTimeUnit) {
       return rpcOptionsBuilder.timeout(outputTimeUnit);

--- a/core/src/test/java/org/infinispan/distexec/mapreduce/SimpleMapReduceTaskTimeoutTest.java
+++ b/core/src/test/java/org/infinispan/distexec/mapreduce/SimpleMapReduceTaskTimeoutTest.java
@@ -28,6 +28,7 @@ import static org.testng.AssertJUnit.fail;
 public class SimpleMapReduceTaskTimeoutTest extends MultipleCacheManagersTest {
 
    private static final int REPLICATION_TIMEOUT = 5000;
+   private static final int DEFAULT_TIMEOUT = 0;
 
    public SimpleMapReduceTaskTimeoutTest() {
       this.cleanup = CleanupPhase.AFTER_METHOD;
@@ -43,7 +44,7 @@ public class SimpleMapReduceTaskTimeoutTest extends MultipleCacheManagersTest {
       final String sleepOnKey = init();
 
       MapReduceTask<String, String, String, Integer> task = createMapReduceTask(this.<String, String>cache(0));
-      assertEquals("Wrong task timeout.", REPLICATION_TIMEOUT, task.timeout(MILLISECONDS));
+      assertEquals("Wrong task timeout.", DEFAULT_TIMEOUT, task.timeout(MILLISECONDS));
       assertEquals("Wrong replication timeout.", REPLICATION_TIMEOUT,
                    cache(0).getCacheConfiguration().clustering().sync().replTimeout());
       task.timeout(taskTimeout, MILLISECONDS);
@@ -81,7 +82,7 @@ public class SimpleMapReduceTaskTimeoutTest extends MultipleCacheManagersTest {
       final String sleepOnKey = init();
 
       MapReduceTask<String, String, String, Integer> task = createMapReduceTask(this.<String, String> cache(0));
-      assertEquals("Wrong task timeout.", REPLICATION_TIMEOUT, task.timeout(MILLISECONDS));
+      assertEquals("Wrong task timeout.", DEFAULT_TIMEOUT, task.timeout(MILLISECONDS));
       assertEquals("Wrong replication timeout.", REPLICATION_TIMEOUT, cache(0).getCacheConfiguration().clustering()
             .sync().replTimeout());
       task.timeout(taskTimeout, MILLISECONDS);
@@ -120,7 +121,7 @@ public class SimpleMapReduceTaskTimeoutTest extends MultipleCacheManagersTest {
       final String sleepOnKey = init();
 
       MapReduceTask<String, String, String, Integer> task = createMapReduceTask(this.<String, String>cache(0));
-      assertEquals("Wrong task timeout.", REPLICATION_TIMEOUT, task.timeout(MILLISECONDS));
+      assertEquals("Wrong task timeout.", DEFAULT_TIMEOUT, task.timeout(MILLISECONDS));
       assertEquals("Wrong replication timeout.", REPLICATION_TIMEOUT,
                    cache(0).getCacheConfiguration().clustering().sync().replTimeout());
       task.timeout(taskTimeout, MILLISECONDS);
@@ -145,7 +146,7 @@ public class SimpleMapReduceTaskTimeoutTest extends MultipleCacheManagersTest {
       final String sleepOnKey = init();
 
       MapReduceTask<String, String, String, Integer> task = createMapReduceTask(this.<String, String>cache(0));
-      assertEquals("Wrong task timeout.", REPLICATION_TIMEOUT, task.timeout(MILLISECONDS));
+      assertEquals("Wrong task timeout.", DEFAULT_TIMEOUT, task.timeout(MILLISECONDS));
       assertEquals("Wrong replication timeout.", REPLICATION_TIMEOUT,
                    cache(0).getCacheConfiguration().clustering().sync().replTimeout());
       task.timeout(taskTimeout, MILLISECONDS);


### PR DESCRIPTION
Master only. See https://issues.jboss.org/browse/ISPN-4618 for more details. 
