### PR TITLE
ISPN-4606 Startup scripts out of date

### DIFF
--- a/server/integration/build/src/main/resources/bin/add-user.bat
+++ b/server/integration/build/src/main/resources/bin/add-user.bat
@@ -3,7 +3,7 @@ rem -------------------------------------------------------------------------
 rem Add User script for Windows
 rem -------------------------------------------------------------------------
 rem
-rem A simple utility for adding new users to the properties file used 
+rem A simple utility for adding new users to the properties file used
 rem for domain management authentication out of the box.
 
 rem $Id$
@@ -17,28 +17,24 @@ if "%OS%" == "Windows_NT" (
   set DIRNAME=.\
 )
 
-pushd %DIRNAME%..
+pushd "%DIRNAME%.."
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
 if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%" 
+  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
 )
 
 pushd "%JBOSS_HOME%"
 set "SANITIZED_JBOSS_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
-)
-
-set DIRNAME=
-
-if "%OS%" == "Windows_NT" (
-  set "PROGNAME=%~nx0%"
-) else (
-  set "PROGNAME=jdr.bat"
+if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
+   echo.
+   echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+   echo.
+   echo       JBOSS_HOME: "%JBOSS_HOME%"
+   echo.
 )
 
 rem Setup JBoss specific properties
@@ -51,26 +47,25 @@ if "x%JAVA_HOME%" == "x" (
 )
 
 rem Find jboss-modules.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
-) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+set "JBOSS_RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if not exist "%JBOSS_RUNJAR%" (
+  echo Could not locate "%JBOSS_RUNJAR%".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
 
-rem Setup JBoss specific properties
-
-rem Setup the java endorsed dirs
-set JBOSS_ENDORSED_DIRS=%JBOSS_HOME%\lib\endorsed
-
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
 )
 
-"%JAVA%" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+rem Uncomment to override standalone and domain user location
+rem set "JAVA_OPTS=%JAVA_OPTS% -Djboss.server.config.user.dir=..\standalone\configuration -Djboss.domain.config.user.dir=..\domain\configuration"
+
+set "JAVA_OPTS=%JAVA_OPTS%"
+
+"%JAVA%" %JAVA_OPTS% ^
+    -jar "%JBOSS_RUNJAR%" ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.domain-add-user ^
      %*

--- a/server/integration/build/src/main/resources/bin/add-user.properties
+++ b/server/integration/build/src/main/resources/bin/add-user.properties
@@ -1,0 +1,58 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2010, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+#
+# Password restriction
+#
+
+# Valid values: RELAX, WARN or REJECT
+# RELAX : Don't perform any strength checks on the password in both interactive and non-interactive mode
+# WARN : Display a message about the strength of the password. Ask confirmation if the password is weak in interactive mode
+# REJECT : Display a message about the strength of the password (if the password is weak, the user is not created).
+# Ask confirmation if the password is weak in interactive mode
+password.restriction=WARN
+
+# Password minimum length
+password.restriction.minLength=8
+
+# Password must contains at least one alpha
+password.restriction.minAlpha=1
+
+# Password must contains at least one digit
+password.restriction.minDigit=1
+
+# Password must contains at least one symbol
+password.restriction.minSymbol=1
+
+# Password must not match the username. Valid values: TRUE or FALSE.
+password.restriction.mustNotMatchUsername=TRUE
+
+# Comma separated list of forbidden passwords (easily guessable)
+password.restriction.forbiddenValue=root,admin,administrator
+
+# Password strength. Valid values: VERY_WEAK, WEAK, MODERATE, MEDIUM, STRONG, VERY_STRONG or EXCEPTIONAL.
+# If not present, it defaults to "MODERATE"
+password.restriction.strength=MEDIUM
+
+# Class of password strength checker.
+# If not present, utility will revert to default implementation
+password.restriction.checker=org.jboss.as.domain.management.security.password.simple.SimplePasswordStrengthChecker

--- a/server/integration/build/src/main/resources/bin/add-user.sh
+++ b/server/integration/build/src/main/resources/bin/add-user.sh
@@ -55,16 +55,18 @@ fi
 if $cygwin; then
     JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
-    JBOSS_CLASSPATH=`cygpath --path --windows "$JBOSS_CLASSPATH"`
-    JBOSS_ENDORSED_DIRS=`cygpath --path --windows "$JBOSS_ENDORSED_DIRS"`
     JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
 
 # Sample JPDA settings for remote socket debugging
-#JAVA_OPTS="$JAVA_OPTS -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y"
+#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y"
+# Uncomment to override standalone and domain user location
+#JAVA_OPTS="$JAVA_OPTS -Djboss.server.config.user.dir=../standalone/configuration -Djboss.domain.config.user.dir=../domain/configuration"
+
+JAVA_OPTS="$JAVA_OPTS"
 
 eval \"$JAVA\" $JAVA_OPTS \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \
          org.jboss.as.domain-add-user \
-         "$@"
+         '"$@"'

--- a/server/integration/build/src/main/resources/bin/clustered.bat
+++ b/server/integration/build/src/main/resources/bin/clustered.bat
@@ -3,15 +3,79 @@ rem -------------------------------------------------------------------------
 rem JBoss Bootstrap Script for Windows
 rem -------------------------------------------------------------------------
 
-rem $Id$
+rem Use --debug to activate debug mode with an optional argument to specify the port
+rem Usage : clustered.bat --debug
+rem         clustered.bat --debug 9797
 
 @if not "%ECHO%" == ""  echo %ECHO%
 @if "%OS%" == "Windows_NT" setlocal
+
+rem By default debug mode is disable.
+set DEBUG_MODE=false
+set DEBUG_PORT=8787
+rem Set to all parameters by default
+set "SERVER_OPTS=%*"
+
+rem Get the program name before using shift as the command modify the variable ~nx0
+if "%OS%" == "Windows_NT" (
+  set "PROGNAME=%~nx0%"
+) else (
+  set "PROGNAME=clustered.bat"
+)
 
 if "%OS%" == "Windows_NT" (
   set "DIRNAME=%~dp0%"
 ) else (
   set DIRNAME=.\
+)
+
+rem Read command-line args.
+:READ-ARGS
+if "%1" == "" (
+   goto MAIN
+) else if "%1" == "--debug" (
+   goto READ-DEBUG-PORT
+) else (
+   rem This doesn't work as Windows splits on = and spaces by default
+   rem set SERVER_OPTS=%SERVER_OPTS% %1
+   shift
+   goto READ-ARGS
+)
+
+:READ-DEBUG-PORT
+set "DEBUG_MODE=true"
+set DEBUG_ARG="%2"
+if not "x%DEBUG_ARG" == "x" (
+   if x%DEBUG_ARG:-=%==x%DEBUG_ARG% (
+      shift
+      set DEBUG_PORT=%DEBUG_ARG%
+   )
+   shift
+   goto READ-ARGS
+)
+
+:MAIN
+rem $Id$
+)
+
+pushd "%DIRNAME%.."
+set "RESOLVED_JBOSS_HOME=%CD%"
+popd
+
+if "x%JBOSS_HOME%" == "x" (
+  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+)
+
+pushd "%JBOSS_HOME%"
+set "SANITIZED_JBOSS_HOME=%CD%"
+popd
+
+if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
+   echo.
+   echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+   echo.
+   echo       JBOSS_HOME: "%JBOSS_HOME%"
+   echo.
 )
 
 rem Read an optional configuration file.
@@ -25,83 +89,50 @@ if exist "%STANDALONE_CONF%" (
    echo Config file not found "%STANDALONE_CONF%"
 )
 
-pushd %DIRNAME%..
-set "RESOLVED_JBOSS_HOME=%CD%"
-popd
 
-if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
-)
-
-pushd "%JBOSS_HOME%"
-set "SANITIZED_JBOSS_HOME=%CD%"
-popd
-
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+rem Set debug settings if not already set
+if "%DEBUG_MODE%" == "true" (
+   echo "%JAVA_OPTS%" | findstr /I "\-agentlib:jdwp" > nul
+  if errorlevel == 1 (
+     set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=%DEBUG_PORT%,server=y,suspend=n"
+  ) else (
+     echo Debug already enabled in JAVA_OPTS, ignoring --debug argument
+  )
 )
 
 set DIRNAME=
 
-if "%OS%" == "Windows_NT" (
-  set "PROGNAME=%~nx0%"
-) else (
-  set "PROGNAME=clustered.bat"
-)
-
-rem Setup JBoss specific properties
-set JAVA_OPTS=-Dprogram.name=%PROGNAME% %JAVA_OPTS%
-
-if "x%JAVA_HOME%" == "x" (
-  set  JAVA=java
-  echo JAVA_HOME is not set. Unexpected results may occur.
-  echo Set JAVA_HOME to the directory of your local JDK to avoid this message.
-) else (
-  set "JAVA=%JAVA_HOME%\bin\java"
-)
-
-if not "%PRESERVE_JAVA_OPTS%" == "true" (
-  rem Add -client to the JVM options, if supported (32 bit VM), and not overriden
-  echo "%JAVA_OPTS%" | findstr /I \-server > nul
-  if errorlevel == 1 (
-    "%JAVA%" -client -version 2>&1 | findstr /I /C:"Client VM" > nul
-    if not errorlevel == 1 (
-      set "JAVA_OPTS=-client %JAVA_OPTS%"
-    )
-  )
-
-  rem Add compressed oops, if supported (64 bit VM), and not overriden
-  echo "%JAVA_OPTS%" | findstr /I "\-XX:\-UseCompressedOops \-client" > nul
-  if errorlevel == 1 (
-    "%JAVA%" -XX:+UseCompressedOops -version > nul 2>&1
-    if not errorlevel == 1 (
-      set "JAVA_OPTS=-XX:+UseCompressedOops %JAVA_OPTS%"
-    )
-  )
-
-  rem Add tiered compilation, if supported (64 bit VM), and not overriden
-  echo "%JAVA_OPTS%" | findstr /I "\-XX:\-TieredCompilation \-client" > nul
-  if errorlevel == 1 (
-    "%JAVA%" -XX:+TieredCompilation -version > nul 2>&1
-    if not errorlevel == 1 (
-      set "JAVA_OPTS=-XX:+TieredCompilation %JAVA_OPTS%"
-    )
-  )
-)
-
-rem Find jboss-modules.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
-) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
-  echo Please check that you are in the bin directory when running this script.
-  goto END
-)
-
 rem Setup JBoss specific properties
 
-rem Setup the java endorsed dirs
-set JBOSS_ENDORSED_DIRS=%JBOSS_HOME%\lib\endorsed
+rem Setup directories, note directories with spaces do not work
+set "CONSOLIDATED_OPTS=%JAVA_OPTS% %SERVER_OPTS%"
+:DIRLOOP
+echo(%CONSOLIDATED_OPTS% | findstr /r /c:"^-Djboss.server.base.dir" > nul && (
+  for /f "tokens=1,2* delims==" %%a IN ("%CONSOLIDATED_OPTS%") DO (
+    for /f %%i IN ("%%b") DO set "JBOSS_BASE_DIR=%%~fi"
+  )
+)
+echo(%CONSOLIDATED_OPTS% | findstr /r /c:"^-Djboss.server.config.dir" > nul && (
+  for /f "tokens=1,2* delims==" %%a IN ("%CONSOLIDATED_OPTS%") DO (
+    for /f %%i IN ("%%b") DO set "JBOSS_CONFIG_DIR=%%~fi"
+  )
+)
+echo(%CONSOLIDATED_OPTS% | findstr /r /c:"^-Djboss.server.log.dir" > nul && (
+  for /f "tokens=1,2* delims==" %%a IN ("%CONSOLIDATED_OPTS%") DO (
+    for /f %%i IN ("%%b") DO set "JBOSS_LOG_DIR=%%~fi"
+  )
+)
+
+for /f "tokens=1* delims= " %%i IN ("%CONSOLIDATED_OPTS%") DO (
+  if %%i == "" (
+    goto ENDDIRLOOP
+  ) else (
+    set CONSOLIDATED_OPTS=%%j
+    GOTO DIRLOOP
+  )
+)
+
+:ENDDIRLOOP
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
@@ -118,32 +149,106 @@ if "x%JBOSS_LOG_DIR%" == "x" (
 )
 rem Set the standalone configuration dir
 if "x%JBOSS_CONFIG_DIR%" == "x" (
-  set  "JBOSS_CONFIG_DIR=%JBOSS_BASE_DIR%/configuration"
+  set  "JBOSS_CONFIG_DIR=%JBOSS_BASE_DIR%\configuration"
 )
+
+rem Setup JBoss specific properties
+set "JAVA_OPTS=-Dprogram.name=%PROGNAME% %JAVA_OPTS%"
+
+if "x%JAVA_HOME%" == "x" (
+  set  JAVA=java
+  echo JAVA_HOME is not set. Unexpected results may occur.
+  echo Set JAVA_HOME to the directory of your local JDK to avoid this message.
+) else (
+  if not exist "%JAVA_HOME%" (
+    echo JAVA_HOME "%JAVA_HOME%" path doesn't exist
+    goto END
+  ) else (
+    echo Setting JAVA property to "%JAVA_HOME%\bin\java"
+    set "JAVA=%JAVA_HOME%\bin\java"
+  )
+)
+
+if not "%PRESERVE_JAVA_OPTS%" == "true" (
+  rem Add -client to the JVM options, if supported (32 bit VM), and not overriden
+  echo "%JAVA_OPTS%" | findstr /I \-server > nul
+  if errorlevel == 1 (
+    "%JAVA%" -client -version 2>&1 | findstr /I /C:"Client VM" > nul
+    if not errorlevel == 1 (
+      set "JAVA_OPTS=-client %JAVA_OPTS%"
+    )
+  )
+)
+
+rem EAP6-121 feature disabled
+rem if not "%PRESERVE_JAVA_OPTS%" == "true" (
+  rem Add rotating GC logs, if supported, and not already defined
+  rem echo "%JAVA_OPTS%" | findstr /I "\-verbose:gc" > nul
+  rem if errorlevel == 1 (
+    rem Back up any prior logs
+    rem move /y "%JBOSS_LOG_DIR%\gc.log.0" "%JBOSS_LOG_DIR%\backupgc.log.0" > nul 2>&1
+    rem move /y "%JBOSS_LOG_DIR%\gc.log.1" "%JBOSS_LOG_DIR%\backupgc.log.1" > nul 2>&1
+    rem move /y "%JBOSS_LOG_DIR%\gc.log.2" "%JBOSS_LOG_DIR%\backupgc.log.2" > nul 2>&1
+    rem move /y "%JBOSS_LOG_DIR%\gc.log.3" "%JBOSS_LOG_DIR%\backupgc.log.3" > nul 2>&1
+    rem move /y "%JBOSS_LOG_DIR%\gc.log.4" "%JBOSS_LOG_DIR%\backupgc.log.4" > nul 2>&1
+    rem move /y "%JBOSS_LOG_DIR%\gc.log.*.current" "%JBOSS_LOG_DIR%\backupgc.log.current" > nul 2>&1
+    rem "%JAVA%" -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -Xloggc:%XLOGGC% -XX:-TraceClassUnloading -version > nul 2>&1
+    rem if not errorlevel == 1 (
+      rem if not exist "%JBOSS_LOG_DIR" > nul 2>&1 (
+        rem mkdir "%JBOSS_LOG_DIR%"
+      rem )
+     rem set XLOGGC="%JBOSS_LOG_DIR%\gc.log"
+     rem set "JAVA_OPTS=-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -XX:-TraceClassUnloading %JAVA_OPTS%"
+    rem )
+  rem )
+rem )
+
+rem Find jboss-modules.jar, or we can't continue
+if exist "%JBOSS_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+) else (
+  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Please check that you are in the bin directory when running this script.
+  goto END
+)
+
+
 
 echo ===============================================================================
 echo.
 echo   JBoss Bootstrap Environment
 echo.
-echo   JBOSS_HOME: %JBOSS_HOME%
+echo   JBOSS_HOME: "%JBOSS_HOME%"
 echo.
-echo   JAVA: %JAVA%
+echo   JAVA: "%JAVA%"
 echo.
-echo   JAVA_OPTS: %JAVA_OPTS%
+echo   JAVA_OPTS: "%JAVA_OPTS%"
 echo.
 echo ===============================================================================
 echo.
 
 :RESTART
-"%JAVA%" %JAVA_OPTS% ^
- "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\boot.log" ^
- "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
-    -mp "%JBOSS_MODULEPATH%" ^
-    -jaxpmodule "javax.xml.jaxp-provider" ^
-     org.jboss.as.standalone ^
-    -Djboss.home.dir="%JBOSS_HOME%" ^
-     %*
+rem if x%XLOGGC% == x (
+  "%JAVA%" %JAVA_OPTS% ^
+   "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\server.log" ^
+   "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
+      -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+      -mp "%JBOSS_MODULEPATH%" ^
+      -jaxpmodule "javax.xml.jaxp-provider" ^
+       org.jboss.as.standalone ^
+      "-Djboss.home.dir=%JBOSS_HOME%" ^
+       %SERVER_OPTS%
+rem ) else (
+  rem "%JAVA%" -Xloggc:%XLOGGC% %JAVA_OPTS% ^
+   rem "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\server.log" ^
+   rem "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
+      rem -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+      rem -mp "%JBOSS_MODULEPATH%" ^
+      rem -jaxpmodule "javax.xml.jaxp-provider" ^
+      rem org.jboss.as.standalone ^
+      rem "-Djboss.home.dir=%JBOSS_HOME%" ^
+      rem %SERVER_OPTS%
+rem )
 
 if ERRORLEVEL 10 goto RESTART
 

--- a/server/integration/build/src/main/resources/bin/clustered.conf
+++ b/server/integration/build/src/main/resources/bin/clustered.conf
@@ -47,7 +47,7 @@ fi
 # Specify options to pass to the Java VM.
 #
 if [ "x$JAVA_OPTS" = "x" ]; then
-   JAVA_OPTS="-Xms1303m -Xmx1303m -XX:MaxPermSize=256m -Djava.net.preferIPv4Stack=true -Dorg.jboss.resolver.warning=true -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000"
+   JAVA_OPTS="-Xms1303m -Xmx1303m -XX:MaxPermSize=256m -Djava.net.preferIPv4Stack=true"
    JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS -Djava.awt.headless=true"
    JAVA_OPTS="$JAVA_OPTS -Djboss.server.default.config=clustered.xml"
    JAVA_OPTS="$JAVA_OPTS -Dsun.nio.ch.bugLevel=''"
@@ -56,10 +56,10 @@ else
 fi
 
 # Sample JPDA settings for remote socket debugging
-#JAVA_OPTS="$JAVA_OPTS -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"
+#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 # Sample JPDA settings for shared memory debugging
-#JAVA_OPTS="$JAVA_OPTS -Xrunjdwp:transport=dt_shmem,server=y,suspend=n,address=jboss"
+#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=jboss"
 
 # Uncomment to not use JBoss Modules lockless mode
 #JAVA_OPTS="$JAVA_OPTS -Djboss.modules.lockless=false"
@@ -67,3 +67,6 @@ fi
 # Uncomment to gather JBoss Modules metrics
 #JAVA_OPTS="$JAVA_OPTS -Djboss.modules.metrics=true"
 
+# Uncomment this in order to be able to run WildFly on FreeBSD
+# when you get "epoll_create function not implemented" message in dmesg output
+#JAVA_OPTS="$JAVA_OPTS -Djava.nio.channels.spi.SelectorProvider=sun.nio.ch.PollSelectorProvider"

--- a/server/integration/build/src/main/resources/bin/clustered.conf.bat
+++ b/server/integration/build/src/main/resources/bin/clustered.conf.bat
@@ -48,11 +48,8 @@ rem #
 rem # JVM memory allocation pool parameters - modify as appropriate.
 set "JAVA_OPTS=-Xms64M -Xmx512M -XX:MaxPermSize=256M"
 
-rem # Reduce the RMI GCs to once per hour for Sun JVMs.
-set "JAVA_OPTS=%JAVA_OPTS% -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000 -Djava.net.preferIPv4Stack=true"
-
-rem # Warn when resolving remote XML DTDs or schemas.
-set "JAVA_OPTS=%JAVA_OPTS% -Dorg.jboss.resolver.warning=true"
+rem # Prefer IPv4
+set "JAVA_OPTS=%JAVA_OPTS% -Djava.net.preferIPv4Stack=true"
 
 rem # Make Byteman classes visible in all module loaders
 rem # This is necessary to inject Byteman rules into AS7 deployments
@@ -62,10 +59,10 @@ rem # Set the default configuration file to use if -c or --server-config are not
 set "JAVA_OPTS=%JAVA_OPTS% -Djboss.server.default.config=clustered.xml"
 
 rem # Sample JPDA settings for remote socket debugging
-rem set "JAVA_OPTS=%JAVA_OPTS% -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"
+rem set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 rem # Sample JPDA settings for shared memory debugging
-rem set "JAVA_OPTS=%JAVA_OPTS% -Xrunjdwp:transport=dt_shmem,address=jboss,server=y,suspend=n"
+rem set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_shmem,address=jboss,server=y,suspend=n"
 
 rem # Use JBoss Modules lockless mode
 rem set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.lockless=true"

--- a/server/integration/build/src/main/resources/bin/clustered.sh
+++ b/server/integration/build/src/main/resources/bin/clustered.sh
@@ -1,5 +1,33 @@
 #!/bin/sh
 
+# Use --debug to activate debug mode with an optional argument to specify the port.
+# Usage : clustered.sh --debug
+#         clustered.sh --debug 9797
+
+# By default debug mode is disable.
+DEBUG_MODE=false
+DEBUG_PORT="8787"
+SERVER_OPTS=""
+while [ "$#" -gt 0 ]
+do
+    case "$1" in
+      --debug)
+          DEBUG_MODE=true
+          shift
+          if [ -n "$1" ] && [ "${1#*-}" = "$1" ]; then
+              DEBUG_PORT=$1
+          fi
+          ;;
+      --)
+          shift
+          break;;
+      *)
+          SERVER_OPTS="$SERVER_OPTS \"$1\""
+          ;;
+    esac
+    shift
+done
+
 DIRNAME=`dirname "$0"`
 PROGNAME=`basename "$0"`
 GREP="grep"
@@ -11,6 +39,9 @@ MAX_FD="maximum"
 cygwin=false;
 darwin=false;
 linux=false;
+solaris=false;
+freebsd=false;
+
 case "`uname`" in
     CYGWIN*)
         cygwin=true
@@ -19,19 +50,16 @@ case "`uname`" in
     Darwin*)
         darwin=true
         ;;
-
+    FreeBSD)
+        freebsd=true
+        ;;
     Linux)
         linux=true
         ;;
+    SunOS*)
+        solaris=true
+        ;;
 esac
-
-# Read an optional running configuration file
-if [ "x$RUN_CONF" = "x" ]; then
-    RUN_CONF="$DIRNAME/clustered.conf"
-fi
-if [ -r "$RUN_CONF" ]; then
-    . "$RUN_CONF"
-fi
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
@@ -51,11 +79,34 @@ if [ "x$JBOSS_HOME" = "x" ]; then
 else
  SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
  if [ "$RESOLVED_JBOSS_HOME" != "$SANITIZED_JBOSS_HOME" ]; then
-   echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
+   echo "   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+   echo ""
+   echo "             JBOSS_HOME: $JBOSS_HOME"
+   echo ""
+   sleep 2s
  fi
 fi
 export JBOSS_HOME
+
+# Read an optional running configuration file
+if [ "x$RUN_CONF" = "x" ]; then
+    RUN_CONF="$DIRNAME/clustered.conf"
+fi
+if [ -r "$RUN_CONF" ]; then
+    . "$RUN_CONF"
+fi
+
+# Set debug settings if not already set
+if [ "$DEBUG_MODE" = "true" ]; then
+    DEBUG_OPT=`echo $JAVA_OPTS | $GREP "\-agentlib:jdwp"`
+    if [ "x$DEBUG_OPT" = "x" ]; then
+        JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=$DEBUG_PORT,server=y,suspend=n"
+    else
+        echo "Debug already enabled in JAVA_OPTS, ignoring --debug argument"
+    fi
+    SERVER_OPTS="$SERVER_OPTS --debug ${DEBUG_PORT}"
+fi
 
 # Setup the JVM
 if [ "x$JAVA" = "x" ]; then
@@ -64,6 +115,74 @@ if [ "x$JAVA" = "x" ]; then
     else
         JAVA="java"
     fi
+fi
+
+if $linux || $solaris; then
+    # consolidate the server and command line opts
+    CONSOLIDATED_OPTS="$JAVA_OPTS $SERVER_OPTS"
+    # process the standalone options
+    for var in $CONSOLIDATED_OPTS
+    do
+       # Remove quotes
+       p=`echo $var | tr -d '"'`
+       case $p in
+         -Djboss.server.base.dir=*)
+              JBOSS_BASE_DIR=`readlink -m ${p#*=}`
+              ;;
+         -Djboss.server.log.dir=*)
+              JBOSS_LOG_DIR=`readlink -m ${p#*=}`
+              ;;
+         -Djboss.server.config.dir=*)
+              JBOSS_CONFIG_DIR=`readlink -m ${p#*=}`
+              ;;
+       esac
+    done
+fi
+
+# No readlink -m on BSD
+if $darwin || $freebsd; then
+    # consolidate the server and command line opts
+    CONSOLIDATED_OPTS="$JAVA_OPTS $SERVER_OPTS"
+    # process the standalone options
+    for var in $CONSOLIDATED_OPTS
+    do
+       # Remove quotes
+       p=`echo $var | tr -d '"'`
+       case $p in
+         -Djboss.server.base.dir=*)
+              JBOSS_BASE_DIR=`cd ${p#*=} ; pwd -P`
+              ;;
+         -Djboss.server.log.dir=*)
+              JBOSS_LOG_DIR=`cd ${p#*=} ; pwd -P`
+              ;;
+         -Djboss.server.config.dir=*)
+              JBOSS_CONFIG_DIR=`cd ${p#*=} ; pwd -P`
+              ;;
+       esac
+    done
+fi
+
+# determine the default base dir, if not set
+if [ "x$JBOSS_BASE_DIR" = "x" ]; then
+   JBOSS_BASE_DIR="$JBOSS_HOME/standalone"
+fi
+# determine the default log dir, if not set
+if [ "x$JBOSS_LOG_DIR" = "x" ]; then
+   JBOSS_LOG_DIR="$JBOSS_BASE_DIR/log"
+fi
+# determine the default configuration dir, if not set
+if [ "x$JBOSS_CONFIG_DIR" = "x" ]; then
+   JBOSS_CONFIG_DIR="$JBOSS_BASE_DIR/configuration"
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
+    JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
+    JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
+    JBOSS_BASE_DIR=`cygpath --path --windows "$JBOSS_BASE_DIR"`
+    JBOSS_LOG_DIR=`cygpath --path --windows "$JBOSS_LOG_DIR"`
+    JBOSS_CONFIG_DIR=`cygpath --path --windows "$JBOSS_CONFIG_DIR"`
 fi
 
 if [ "$PRESERVE_JAVA_OPTS" != "true" ]; then
@@ -97,17 +216,19 @@ if [ "$PRESERVE_JAVA_OPTS" != "true" ]; then
         fi
     fi
 
-    if [ $CLIENT_VM = false ]; then
-        NO_COMPRESSED_OOPS=`echo $JAVA_OPTS | $GREP "\-XX:\-UseCompressedOops"`
-        if [ "x$NO_COMPRESSED_OOPS" = "x" ]; then
-            "$JAVA" $JVM_OPTVERSION -server -XX:+UseCompressedOops -version >/dev/null 2>&1 && PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -XX:+UseCompressedOops"
-        fi
-
-        NO_TIERED_COMPILATION=`echo $JAVA_OPTS | $GREP "\-XX:\-TieredCompilation"`
-        if [ "x$NO_TIERED_COMPILATION" = "x" ]; then
-            "$JAVA" $JVM_OPTVERSION -server -XX:+TieredCompilation -version >/dev/null 2>&1 && PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -XX:+TieredCompilation"
-        fi
-    fi
+    # EAP6-121 feature disabled
+    # Enable rotating GC logs if the JVM supports it and GC logs are not already enabled
+    #NO_GC_LOG_ROTATE=`echo $JAVA_OPTS | $GREP "\-verbose:gc"`
+    #if [ "x$NO_GC_LOG_ROTATE" = "x" ]; then
+        # backup prior gc logs
+        #mv "$JBOSS_LOG_DIR/gc.log.0" "$JBOSS_LOG_DIR/backupgc.log.0" >/dev/null 2>&1
+        #mv "$JBOSS_LOG_DIR/gc.log.1" "$JBOSS_LOG_DIR/backupgc.log.1" >/dev/null 2>&1
+        #mv "$JBOSS_LOG_DIR/gc.log.2" "$JBOSS_LOG_DIR/backupgc.log.2" >/dev/null 2>&1
+        #mv "$JBOSS_LOG_DIR/gc.log.3" "$JBOSS_LOG_DIR/backupgc.log.3" >/dev/null 2>&1
+        #mv "$JBOSS_LOG_DIR/gc.log.4" "$JBOSS_LOG_DIR/backupgc.log.4" >/dev/null 2>&1
+        #mv "$JBOSS_LOG_DIR/gc.log.*.current" "$JBOSS_LOG_DIR/backupgc.log.current" >/dev/null 2>&1
+        #"$JAVA" $JVM_OPTVERSION -verbose:gc -Xloggc:"$JBOSS_LOG_DIR/gc.log" -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -XX:-TraceClassUnloading -version >/dev/null 2>&1 && mkdir -p $JBOSS_LOG_DIR && PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -verbose:gc -Xloggc:\"$JBOSS_LOG_DIR/gc.log\" -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -XX:-TraceClassUnloading" 
+    #fi
 
     JAVA_OPTS="$PREPEND_JAVA_OPTS $JAVA_OPTS"
 fi
@@ -116,46 +237,6 @@ if [ "x$JBOSS_MODULEPATH" = "x" ]; then
     JBOSS_MODULEPATH="$JBOSS_HOME/modules"
 fi
 
-if $linux; then
-    # consolidate the server and command line opts
-    SERVER_OPTS="$JAVA_OPTS $@"
-    # process the standalone options
-    for var in $SERVER_OPTS
-    do
-       case $var in
-         -Djboss.server.base.dir=*)
-              JBOSS_BASE_DIR=`readlink -m ${var#*=}`
-              ;;
-         -Djboss.server.log.dir=*)
-              JBOSS_LOG_DIR=`readlink -m ${var#*=}`
-              ;;
-         -Djboss.server.config.dir=*)
-              JBOSS_CONFIG_DIR=`readlink -m ${var#*=}`
-              ;;
-       esac
-    done
-fi
-# determine the default base dir, if not set
-if [ "x$JBOSS_BASE_DIR" = "x" ]; then
-   JBOSS_BASE_DIR="$JBOSS_HOME/standalone"
-fi
-# determine the default log dir, if not set
-if [ "x$JBOSS_LOG_DIR" = "x" ]; then
-   JBOSS_LOG_DIR="$JBOSS_BASE_DIR/log"
-fi
-# determine the default configuration dir, if not set
-if [ "x$JBOSS_CONFIG_DIR" = "x" ]; then
-   JBOSS_CONFIG_DIR="$JBOSS_BASE_DIR/configuration"
-fi
-
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin; then
-    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
-    JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
-    JBOSS_CLASSPATH=`cygpath --path --windows "$JBOSS_CLASSPATH"`
-    JBOSS_ENDORSED_DIRS=`cygpath --path --windows "$JBOSS_ENDORSED_DIRS"`
-    JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
-fi
 
 # Display our environment
 echo "========================================================================="
@@ -175,26 +256,26 @@ while true; do
    if [ "x$LAUNCH_JBOSS_IN_BACKGROUND" = "x" ]; then
       # Execute the JVM in the foreground
       eval \"$JAVA\" -D\"[Standalone]\" $JAVA_OPTS \
-         \"-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/boot.log\" \
+         \"-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/server.log\" \
          \"-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties\" \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \
-         -jaxpmodule "javax.xml.jaxp-provider" \
          org.jboss.as.standalone \
          -Djboss.home.dir=\"$JBOSS_HOME\" \
-         "$@"
+         -Djboss.server.base.dir=\"$JBOSS_BASE_DIR\" \
+         "$SERVER_OPTS"
       JBOSS_STATUS=$?
    else
       # Execute the JVM in the background
       eval \"$JAVA\" -D\"[Standalone]\" $JAVA_OPTS \
-         \"-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/boot.log\" \
+         \"-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/server.log\" \
          \"-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties\" \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \
-         -jaxpmodule "javax.xml.jaxp-provider" \
          org.jboss.as.standalone \
          -Djboss.home.dir=\"$JBOSS_HOME\" \
-         "$@" "&"
+         -Djboss.server.base.dir=\"$JBOSS_BASE_DIR\" \
+         "$SERVER_OPTS" "&"
       JBOSS_PID=$!
       # Trap common signals and relay them to the jboss process
       trap "kill -HUP  $JBOSS_PID" HUP

--- a/server/integration/build/src/main/resources/bin/jconsole.bat
+++ b/server/integration/build/src/main/resources/bin/jconsole.bat
@@ -16,7 +16,7 @@ if "%OS%" == "Windows_NT" (
   set DIRNAME=.\
 )
 
-pushd %DIRNAME%..
+pushd "%DIRNAME%.."
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
@@ -28,16 +28,12 @@ pushd "%JBOSS_HOME%"
 set "SANITIZED_JBOSS_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
-)
-
-set DIRNAME=
-
-if "%OS%" == "Windows_NT" (
-  set "PROGNAME=%~nx0%"
-) else (
-  set "PROGNAME=jdr.bat"
+if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
+   echo.
+   echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+   echo.
+   echo       JBOSS_HOME: "%JBOSS_HOME%"
+   echo.
 )
 
 rem Setup JBoss specific properties
@@ -46,62 +42,31 @@ if "x%JAVA_HOME%" == "x" (
   goto END
 )
 
-rem Find jboss-modules.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
-) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
-  echo Please check that you are in the bin directory when running this script.
-  goto END
-)
-
-rem Set default module root paths
-if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
-)
-
 rem Setup The Classpath
 
-set CLASSPATH=%JAVA_HOME%\lib\jconsole.jar
-set CLASSPATH=%CLASSPATH%;%JAVA_HOME%\lib\tools.jar
-
-call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\remoting-jmx\main"
-call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\remoting3\main"
-call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\logging\main"
-call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\xnio\main"
-call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\xnio\nio\main"
-call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\sasl\main"
-call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\marshalling\main"
-call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\as\cli\main"
-call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\staxmapper\main"
-call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\as\protocol\main"
-call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\dmr\main"
-call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\as\controller-client\main"
-call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\threads\main"
+set "CLASSPATH=%JAVA_HOME%\lib\jconsole.jar"
+set "CLASSPATH=%CLASSPATH%;%JAVA_HOME%\lib\tools.jar"
+set "CLASSPATH=%CLASSPATH%;%JBOSS_HOME%\bin\client\jboss-cli-client.jar"
 
 rem echo %CLASSPATH%
 
-"%JAVA_HOME%\bin\jconsole.exe" -J"-Djava.class.path=%CLASSPATH%"
+if "%*" == "" (
+    "%JAVA_HOME%\bin\jconsole.exe" "-J-Djava.class.path=%CLASSPATH%"
+) else (
+    "%JAVA_HOME%\bin\jconsole.exe" "-J-Djava.class.path=%CLASSPATH%" %*
+)
 
 :END
 goto :EOF
 
 :SearchForJars
-set NEXT_MODULE_DIR=%1
-call :DeQuote NEXT_MODULE_DIR
-pushd %NEXT_MODULE_DIR%
-for %%j in (*.jar) do call :ClasspathAdd "%NEXT_MODULE_DIR%\%%j"
+pushd %1
+for %%j in (*.jar) do call :ClasspathAdd %%j
 popd
 goto :EOF
 
 :ClasspathAdd
-set NEXT_JAR=%1
-call :DeQuote NEXT_JAR
-set CLASSPATH=%CLASSPATH%;%NEXT_JAR%
-goto :EOF
-
-:DeQuote
-for /f "delims=" %%A in ('echo %%%1%%') do set %1=%%~A
+set "CLASSPATH=%CLASSPATH%;%CD%\%1"
 goto :EOF
 
 :EOF

--- a/server/integration/build/src/main/resources/bin/jdr.bat
+++ b/server/integration/build/src/main/resources/bin/jdr.bat
@@ -19,28 +19,24 @@ if "%OS%" == "Windows_NT" (
   set DIRNAME=.\
 )
 
-pushd %DIRNAME%..
+pushd "%DIRNAME%.."
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
 if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%" 
+  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
 )
 
 pushd "%JBOSS_HOME%"
 set "SANITIZED_JBOSS_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
-)
-
-set DIRNAME=
-
-if "%OS%" == "Windows_NT" (
-  set "PROGNAME=%~nx0%"
-) else (
-  set "PROGNAME=jdr.bat"
+if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
+   echo.
+   echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+   echo.
+   echo       JBOSS_HOME: "%JBOSS_HOME%"
+   echo.
 )
 
 rem Setup JBoss specific properties
@@ -53,27 +49,22 @@ if "x%JAVA_HOME%" == "x" (
 )
 
 rem Find jboss-modules.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
-) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+set "JBOSS_RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if not exist "%JBOSS_RUNJAR%" (
+  echo Could not locate "%JBOSS_RUNJAR%".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
 
-rem Setup JBoss specific properties
-
-rem Setup the java endorsed dirs
-set JBOSS_ENDORSED_DIRS=%JBOSS_HOME%\lib\endorsed
-
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
 )
 
-"%JAVA%" ^
-    -Djboss.home.dir="%JBOSS_HOME%" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+"%JAVA%" %JAVA_OPTS% ^
+    -jar "%JBOSS_RUNJAR%" ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.jdr ^
      %*
+
+:END

--- a/server/integration/build/src/main/resources/bin/jdr.sh
+++ b/server/integration/build/src/main/resources/bin/jdr.sh
@@ -13,7 +13,7 @@ DIRNAME=`dirname "$0"`
 # OS specific support (must be 'true' or 'false').
 cygwin=false;
 if  [ `uname|grep -i CYGWIN` ]; then
-    cygwin=true;
+    cygwin = true;
 fi
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
@@ -56,9 +56,6 @@ fi
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
     JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
-    JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
-    JBOSS_CLASSPATH=`cygpath --path --windows "$JBOSS_CLASSPATH"`
-    JBOSS_ENDORSED_DIRS=`cygpath --path --windows "$JBOSS_ENDORSED_DIRS"`
     JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
 

--- a/server/integration/build/src/main/resources/bin/standalone.bat
+++ b/server/integration/build/src/main/resources/bin/standalone.bat
@@ -7,11 +7,14 @@ rem Use --debug to activate debug mode with an optional argument to specify the 
 rem Usage : standalone.bat --debug
 rem         standalone.bat --debug 9797
 
+@if not "%ECHO%" == ""  echo %ECHO%
+@if "%OS%" == "Windows_NT" setlocal
+
 rem By default debug mode is disable.
 set DEBUG_MODE=false
 set DEBUG_PORT=8787
 rem Set to all parameters by default
-set SERVER_OPTS=%*
+set "SERVER_OPTS=%*"
 
 rem Get the program name before using shift as the command modify the variable ~nx0
 if "%OS%" == "Windows_NT" (
@@ -19,9 +22,6 @@ if "%OS%" == "Windows_NT" (
 ) else (
   set "PROGNAME=standalone.bat"
 )
-
-@if not "%ECHO%" == ""  echo %ECHO%
-@if "%OS%" == "Windows_NT" setlocal
 
 if "%OS%" == "Windows_NT" (
   set "DIRNAME=%~dp0%"
@@ -31,7 +31,7 @@ if "%OS%" == "Windows_NT" (
 
 rem Read command-line args.
 :READ-ARGS
-if "%1" == "" ( 
+if "%1" == "" (
    goto MAIN
 ) else if "%1" == "--debug" (
    goto READ-DEBUG-PORT
@@ -58,7 +58,7 @@ if not "x%DEBUG_ARG" == "x" (
 rem $Id$
 )
 
-pushd %DIRNAME%..
+pushd "%DIRNAME%.."
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
@@ -74,10 +74,8 @@ if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
    echo.
    echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
    echo.
-   echo             JBOSS_HOME: %JBOSS_HOME%
+   echo       JBOSS_HOME: "%JBOSS_HOME%"
    echo.
-   rem 2 seconds pause
-   ping 127.0.0.1 -n 3 > nul
 )
 
 rem Read an optional configuration file.
@@ -96,71 +94,45 @@ rem Set debug settings if not already set
 if "%DEBUG_MODE%" == "true" (
    echo "%JAVA_OPTS%" | findstr /I "\-agentlib:jdwp" > nul
   if errorlevel == 1 (
-     echo Debug already enabled in JAVA_OPTS, ignoring --debug argument
-  ) else (
      set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=%DEBUG_PORT%,server=y,suspend=n"
+  ) else (
+     echo Debug already enabled in JAVA_OPTS, ignoring --debug argument
   )
 )
 
 set DIRNAME=
 
 rem Setup JBoss specific properties
-set JAVA_OPTS=-Dprogram.name=%PROGNAME% %JAVA_OPTS%
 
-if "x%JAVA_HOME%" == "x" (
-  set  JAVA=java
-  echo JAVA_HOME is not set. Unexpected results may occur.
-  echo Set JAVA_HOME to the directory of your local JDK to avoid this message.
-) else (
-  set "JAVA=%JAVA_HOME%\bin\java"
+rem Setup directories, note directories with spaces do not work
+set "CONSOLIDATED_OPTS=%JAVA_OPTS% %SERVER_OPTS%"
+:DIRLOOP
+echo(%CONSOLIDATED_OPTS% | findstr /r /c:"^-Djboss.server.base.dir" > nul && (
+  for /f "tokens=1,2* delims==" %%a IN ("%CONSOLIDATED_OPTS%") DO (
+    for /f %%i IN ("%%b") DO set "JBOSS_BASE_DIR=%%~fi"
+  )
 )
-
-if not "%PRESERVE_JAVA_OPTS%" == "true" (
-  rem Add -client to the JVM options, if supported (32 bit VM), and not overriden
-  echo "%JAVA_OPTS%" | findstr /I \-server > nul
-  if errorlevel == 1 (
-    "%JAVA%" -client -version 2>&1 | findstr /I /C:"Client VM" > nul
-    if not errorlevel == 1 (
-      set "JAVA_OPTS=-client %JAVA_OPTS%"
-    )
+echo(%CONSOLIDATED_OPTS% | findstr /r /c:"^-Djboss.server.config.dir" > nul && (
+  for /f "tokens=1,2* delims==" %%a IN ("%CONSOLIDATED_OPTS%") DO (
+    for /f %%i IN ("%%b") DO set "JBOSS_CONFIG_DIR=%%~fi"
+  )
+)
+echo(%CONSOLIDATED_OPTS% | findstr /r /c:"^-Djboss.server.log.dir" > nul && (
+  for /f "tokens=1,2* delims==" %%a IN ("%CONSOLIDATED_OPTS%") DO (
+    for /f %%i IN ("%%b") DO set "JBOSS_LOG_DIR=%%~fi"
   )
 )
 
-if not "%PRESERVE_JAVA_OPTS%" == "true" (
-  rem Add compressed oops, if supported (64 bit VM), and not overriden
-  echo "%JAVA_OPTS%" | findstr /I "\-XX:\-UseCompressedOops \-client" > nul
-  if errorlevel == 1 (
-    "%JAVA%" -XX:+UseCompressedOops -version > nul 2>&1
-    if not errorlevel == 1 (
-      set "JAVA_OPTS=-XX:+UseCompressedOops %JAVA_OPTS%"
-    )
+for /f "tokens=1* delims= " %%i IN ("%CONSOLIDATED_OPTS%") DO (
+  if %%i == "" (
+    goto ENDDIRLOOP
+  ) else (
+    set CONSOLIDATED_OPTS=%%j
+    GOTO DIRLOOP
   )
 )
 
-if not "%PRESERVE_JAVA_OPTS%" == "true" (
-  rem Add tiered compilation, if supported (64 bit VM), and not overriden
-  echo "%JAVA_OPTS%" | findstr /I "\-XX:\-TieredCompilation \-client" > nul
-  if errorlevel == 1 (
-    "%JAVA%" -XX:+TieredCompilation -version > nul 2>&1
-    if not errorlevel == 1 (
-      set "JAVA_OPTS=-XX:+TieredCompilation %JAVA_OPTS%"
-    )
-  )
-)
-
-rem Find jboss-modules.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
-) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
-  echo Please check that you are in the bin directory when running this script.
-  goto END
-)
-
-rem Setup JBoss specific properties
-
-rem Setup the java endorsed dirs
-set JBOSS_ENDORSED_DIRS=%JBOSS_HOME%\lib\endorsed
+:ENDDIRLOOP
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
@@ -177,32 +149,106 @@ if "x%JBOSS_LOG_DIR%" == "x" (
 )
 rem Set the standalone configuration dir
 if "x%JBOSS_CONFIG_DIR%" == "x" (
-  set  "JBOSS_CONFIG_DIR=%JBOSS_BASE_DIR%/configuration"
+  set  "JBOSS_CONFIG_DIR=%JBOSS_BASE_DIR%\configuration"
 )
+
+rem Setup JBoss specific properties
+set "JAVA_OPTS=-Dprogram.name=%PROGNAME% %JAVA_OPTS%"
+
+if "x%JAVA_HOME%" == "x" (
+  set  JAVA=java
+  echo JAVA_HOME is not set. Unexpected results may occur.
+  echo Set JAVA_HOME to the directory of your local JDK to avoid this message.
+) else (
+  if not exist "%JAVA_HOME%" (
+    echo JAVA_HOME "%JAVA_HOME%" path doesn't exist
+    goto END
+  ) else (
+    echo Setting JAVA property to "%JAVA_HOME%\bin\java"
+    set "JAVA=%JAVA_HOME%\bin\java"
+  )
+)
+
+if not "%PRESERVE_JAVA_OPTS%" == "true" (
+  rem Add -client to the JVM options, if supported (32 bit VM), and not overriden
+  echo "%JAVA_OPTS%" | findstr /I \-server > nul
+  if errorlevel == 1 (
+    "%JAVA%" -client -version 2>&1 | findstr /I /C:"Client VM" > nul
+    if not errorlevel == 1 (
+      set "JAVA_OPTS=-client %JAVA_OPTS%"
+    )
+  )
+)
+
+rem EAP6-121 feature disabled
+rem if not "%PRESERVE_JAVA_OPTS%" == "true" (
+  rem Add rotating GC logs, if supported, and not already defined
+  rem echo "%JAVA_OPTS%" | findstr /I "\-verbose:gc" > nul
+  rem if errorlevel == 1 (
+    rem Back up any prior logs
+    rem move /y "%JBOSS_LOG_DIR%\gc.log.0" "%JBOSS_LOG_DIR%\backupgc.log.0" > nul 2>&1
+    rem move /y "%JBOSS_LOG_DIR%\gc.log.1" "%JBOSS_LOG_DIR%\backupgc.log.1" > nul 2>&1
+    rem move /y "%JBOSS_LOG_DIR%\gc.log.2" "%JBOSS_LOG_DIR%\backupgc.log.2" > nul 2>&1
+    rem move /y "%JBOSS_LOG_DIR%\gc.log.3" "%JBOSS_LOG_DIR%\backupgc.log.3" > nul 2>&1
+    rem move /y "%JBOSS_LOG_DIR%\gc.log.4" "%JBOSS_LOG_DIR%\backupgc.log.4" > nul 2>&1
+    rem move /y "%JBOSS_LOG_DIR%\gc.log.*.current" "%JBOSS_LOG_DIR%\backupgc.log.current" > nul 2>&1
+    rem "%JAVA%" -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -Xloggc:%XLOGGC% -XX:-TraceClassUnloading -version > nul 2>&1
+    rem if not errorlevel == 1 (
+      rem if not exist "%JBOSS_LOG_DIR" > nul 2>&1 (
+        rem mkdir "%JBOSS_LOG_DIR%"
+      rem )
+     rem set XLOGGC="%JBOSS_LOG_DIR%\gc.log"
+     rem set "JAVA_OPTS=-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -XX:-TraceClassUnloading %JAVA_OPTS%"
+    rem )
+  rem )
+rem )
+
+rem Find jboss-modules.jar, or we can't continue
+if exist "%JBOSS_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+) else (
+  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Please check that you are in the bin directory when running this script.
+  goto END
+)
+
+
 
 echo ===============================================================================
 echo.
 echo   JBoss Bootstrap Environment
 echo.
-echo   JBOSS_HOME: %JBOSS_HOME%
+echo   JBOSS_HOME: "%JBOSS_HOME%"
 echo.
-echo   JAVA: %JAVA%
+echo   JAVA: "%JAVA%"
 echo.
-echo   JAVA_OPTS: %JAVA_OPTS%
+echo   JAVA_OPTS: "%JAVA_OPTS%"
 echo.
 echo ===============================================================================
 echo.
 
 :RESTART
-"%JAVA%" %JAVA_OPTS% ^
- "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\server.log" ^
- "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
-    -mp "%JBOSS_MODULEPATH%" ^
-    -jaxpmodule "javax.xml.jaxp-provider" ^
-     org.jboss.as.standalone ^
-    -Djboss.home.dir="%JBOSS_HOME%" ^
-     %SERVER_OPTS%
+rem if x%XLOGGC% == x (
+  "%JAVA%" %JAVA_OPTS% ^
+   "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\server.log" ^
+   "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
+      -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+      -mp "%JBOSS_MODULEPATH%" ^
+      -jaxpmodule "javax.xml.jaxp-provider" ^
+       org.jboss.as.standalone ^
+      "-Djboss.home.dir=%JBOSS_HOME%" ^
+       %SERVER_OPTS%
+rem ) else (
+  rem "%JAVA%" -Xloggc:%XLOGGC% %JAVA_OPTS% ^
+   rem "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\server.log" ^
+   rem "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
+      rem -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+      rem -mp "%JBOSS_MODULEPATH%" ^
+      rem -jaxpmodule "javax.xml.jaxp-provider" ^
+      rem org.jboss.as.standalone ^
+      rem "-Djboss.home.dir=%JBOSS_HOME%" ^
+      rem %SERVER_OPTS%
+rem )
 
 if ERRORLEVEL 10 goto RESTART
 

--- a/server/integration/build/src/main/resources/bin/standalone.conf
+++ b/server/integration/build/src/main/resources/bin/standalone.conf
@@ -65,3 +65,6 @@ fi
 # Uncomment to gather JBoss Modules metrics
 #JAVA_OPTS="$JAVA_OPTS -Djboss.modules.metrics=true"
 
+# Uncomment this in order to be able to run WildFly on FreeBSD
+# when you get "epoll_create function not implemented" message in dmesg output
+#JAVA_OPTS="$JAVA_OPTS -Djava.nio.channels.spi.SelectorProvider=sun.nio.ch.PollSelectorProvider"

--- a/server/integration/build/src/main/resources/bin/standalone.sh
+++ b/server/integration/build/src/main/resources/bin/standalone.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # Use --debug to activate debug mode with an optional argument to specify the port.
-# Usage : standalone.bat --debug
-#         standalone.bat --debug 9797
+# Usage : standalone.sh --debug
+#         standalone.sh --debug 9797
 
 # By default debug mode is disable.
 DEBUG_MODE=false
@@ -16,12 +16,10 @@ do
           shift
           if [ -n "$1" ] && [ "${1#*-}" = "$1" ]; then
               DEBUG_PORT=$1
-          else
-              SERVER_OPTS="$SERVER_OPTS $1"
           fi
           ;;
       --)
-          shift 
+          shift
           break;;
       *)
           SERVER_OPTS="$SERVER_OPTS \"$1\""
@@ -41,6 +39,9 @@ MAX_FD="maximum"
 cygwin=false;
 darwin=false;
 linux=false;
+solaris=false;
+freebsd=false;
+
 case "`uname`" in
     CYGWIN*)
         cygwin=true
@@ -49,9 +50,14 @@ case "`uname`" in
     Darwin*)
         darwin=true
         ;;
-
+    FreeBSD)
+        freebsd=true
+        ;;
     Linux)
         linux=true
+        ;;
+    SunOS*)
+        solaris=true
         ;;
 esac
 
@@ -99,6 +105,7 @@ if [ "$DEBUG_MODE" = "true" ]; then
     else
         echo "Debug already enabled in JAVA_OPTS, ignoring --debug argument"
     fi
+    SERVER_OPTS="$SERVER_OPTS --debug ${DEBUG_PORT}"
 fi
 
 # Setup the JVM
@@ -108,6 +115,74 @@ if [ "x$JAVA" = "x" ]; then
     else
         JAVA="java"
     fi
+fi
+
+if $linux || $solaris; then
+    # consolidate the server and command line opts
+    CONSOLIDATED_OPTS="$JAVA_OPTS $SERVER_OPTS"
+    # process the standalone options
+    for var in $CONSOLIDATED_OPTS
+    do
+       # Remove quotes
+       p=`echo $var | tr -d '"'`
+       case $p in
+         -Djboss.server.base.dir=*)
+              JBOSS_BASE_DIR=`readlink -m ${p#*=}`
+              ;;
+         -Djboss.server.log.dir=*)
+              JBOSS_LOG_DIR=`readlink -m ${p#*=}`
+              ;;
+         -Djboss.server.config.dir=*)
+              JBOSS_CONFIG_DIR=`readlink -m ${p#*=}`
+              ;;
+       esac
+    done
+fi
+
+# No readlink -m on BSD
+if $darwin || $freebsd; then
+    # consolidate the server and command line opts
+    CONSOLIDATED_OPTS="$JAVA_OPTS $SERVER_OPTS"
+    # process the standalone options
+    for var in $CONSOLIDATED_OPTS
+    do
+       # Remove quotes
+       p=`echo $var | tr -d '"'`
+       case $p in
+         -Djboss.server.base.dir=*)
+              JBOSS_BASE_DIR=`cd ${p#*=} ; pwd -P`
+              ;;
+         -Djboss.server.log.dir=*)
+              JBOSS_LOG_DIR=`cd ${p#*=} ; pwd -P`
+              ;;
+         -Djboss.server.config.dir=*)
+              JBOSS_CONFIG_DIR=`cd ${p#*=} ; pwd -P`
+              ;;
+       esac
+    done
+fi
+
+# determine the default base dir, if not set
+if [ "x$JBOSS_BASE_DIR" = "x" ]; then
+   JBOSS_BASE_DIR="$JBOSS_HOME/standalone"
+fi
+# determine the default log dir, if not set
+if [ "x$JBOSS_LOG_DIR" = "x" ]; then
+   JBOSS_LOG_DIR="$JBOSS_BASE_DIR/log"
+fi
+# determine the default configuration dir, if not set
+if [ "x$JBOSS_CONFIG_DIR" = "x" ]; then
+   JBOSS_CONFIG_DIR="$JBOSS_BASE_DIR/configuration"
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
+    JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
+    JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
+    JBOSS_BASE_DIR=`cygpath --path --windows "$JBOSS_BASE_DIR"`
+    JBOSS_LOG_DIR=`cygpath --path --windows "$JBOSS_LOG_DIR"`
+    JBOSS_CONFIG_DIR=`cygpath --path --windows "$JBOSS_CONFIG_DIR"`
 fi
 
 if [ "$PRESERVE_JAVA_OPTS" != "true" ]; then
@@ -141,12 +216,19 @@ if [ "$PRESERVE_JAVA_OPTS" != "true" ]; then
         fi
     fi
 
-    if [ $CLIENT_VM = false ]; then
-        NO_COMPRESSED_OOPS=`echo $JAVA_OPTS | $GREP "\-XX:\-UseCompressedOops"`
-        if [ "x$NO_COMPRESSED_OOPS" = "x" ]; then
-            "$JAVA" $JVM_OPTVERSION -server -XX:+UseCompressedOops -version >/dev/null 2>&1 && PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -XX:+UseCompressedOops"
-        fi
-    fi
+    # EAP6-121 feature disabled
+    # Enable rotating GC logs if the JVM supports it and GC logs are not already enabled
+    #NO_GC_LOG_ROTATE=`echo $JAVA_OPTS | $GREP "\-verbose:gc"`
+    #if [ "x$NO_GC_LOG_ROTATE" = "x" ]; then
+        # backup prior gc logs
+        #mv "$JBOSS_LOG_DIR/gc.log.0" "$JBOSS_LOG_DIR/backupgc.log.0" >/dev/null 2>&1
+        #mv "$JBOSS_LOG_DIR/gc.log.1" "$JBOSS_LOG_DIR/backupgc.log.1" >/dev/null 2>&1
+        #mv "$JBOSS_LOG_DIR/gc.log.2" "$JBOSS_LOG_DIR/backupgc.log.2" >/dev/null 2>&1
+        #mv "$JBOSS_LOG_DIR/gc.log.3" "$JBOSS_LOG_DIR/backupgc.log.3" >/dev/null 2>&1
+        #mv "$JBOSS_LOG_DIR/gc.log.4" "$JBOSS_LOG_DIR/backupgc.log.4" >/dev/null 2>&1
+        #mv "$JBOSS_LOG_DIR/gc.log.*.current" "$JBOSS_LOG_DIR/backupgc.log.current" >/dev/null 2>&1
+        #"$JAVA" $JVM_OPTVERSION -verbose:gc -Xloggc:"$JBOSS_LOG_DIR/gc.log" -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -XX:-TraceClassUnloading -version >/dev/null 2>&1 && mkdir -p $JBOSS_LOG_DIR && PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -verbose:gc -Xloggc:\"$JBOSS_LOG_DIR/gc.log\" -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -XX:-TraceClassUnloading" 
+    #fi
 
     JAVA_OPTS="$PREPEND_JAVA_OPTS $JAVA_OPTS"
 fi
@@ -155,47 +237,6 @@ if [ "x$JBOSS_MODULEPATH" = "x" ]; then
     JBOSS_MODULEPATH="$JBOSS_HOME/modules"
 fi
 
-if $linux; then
-    # consolidate the server and command line opts
-    CONSOLIDATED_OPTS="$JAVA_OPTS $SERVER_OPTS"
-    # process the standalone options
-    for var in $CONSOLIDATED_OPTS
-    do
-       case $var in
-         -Djboss.server.base.dir=*)
-              JBOSS_BASE_DIR=`readlink -m ${var#*=}`
-              ;;
-         -Djboss.server.log.dir=*)
-              JBOSS_LOG_DIR=`readlink -m ${var#*=}`
-              ;;
-         -Djboss.server.config.dir=*)
-              JBOSS_CONFIG_DIR=`readlink -m ${var#*=}`
-              ;;
-       esac
-    done
-fi
-# determine the default base dir, if not set
-if [ "x$JBOSS_BASE_DIR" = "x" ]; then
-   JBOSS_BASE_DIR="$JBOSS_HOME/standalone"
-fi
-# determine the default log dir, if not set
-if [ "x$JBOSS_LOG_DIR" = "x" ]; then
-   JBOSS_LOG_DIR="$JBOSS_BASE_DIR/log"
-fi
-# determine the default configuration dir, if not set
-if [ "x$JBOSS_CONFIG_DIR" = "x" ]; then
-   JBOSS_CONFIG_DIR="$JBOSS_BASE_DIR/configuration"
-fi
-
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin; then
-    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
-    JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
-    JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
-    JBOSS_BASE_DIR=`cygpath --path --windows "$JBOSS_BASE_DIR"`
-    JBOSS_LOG_DIR=`cygpath --path --windows "$JBOSS_LOG_DIR"`
-    JBOSS_CONFIG_DIR=`cygpath --path --windows "$JBOSS_CONFIG_DIR"`
-fi
 
 # Display our environment
 echo "========================================================================="
@@ -219,7 +260,6 @@ while true; do
          \"-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties\" \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \
-         -jaxpmodule "javax.xml.jaxp-provider" \
          org.jboss.as.standalone \
          -Djboss.home.dir=\"$JBOSS_HOME\" \
          -Djboss.server.base.dir=\"$JBOSS_BASE_DIR\" \
@@ -232,7 +272,6 @@ while true; do
          \"-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties\" \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \
-         -jaxpmodule "javax.xml.jaxp-provider" \
          org.jboss.as.standalone \
          -Djboss.home.dir=\"$JBOSS_HOME\" \
          -Djboss.server.base.dir=\"$JBOSS_BASE_DIR\" \


### PR DESCRIPTION
Sync script updates with WildFly 8.1.0.Final.

Verified no refs to "standalone.*" in clustered.*:

  grep 'standalone\.' clustered.*

Vefiried all diffs are reasonable between standalone and clustered:

  diff -u standalone.sh clustered.sh
  diff -u standalone.conf clustered.conf
  diff -u standalone.bat clustered.bat
  diff -u standalone.conf.bat clustered.conf.bat

Verified add-user, jconsole and jdr worked after build.
