### PR TITLE
ISPN-4638 Add ability to remove filter/converter factories

### DIFF
--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ClientListenerRegistry.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ClientListenerRegistry.scala
@@ -41,8 +41,16 @@ class ClientListenerRegistry(configuration: HotRodServerConfiguration) extends L
       keyValueFilterFactories.put(name, factory)
    }
 
+   def removeKeyValueFilterFactory(name: String): Unit = {
+      keyValueFilterFactories.remove(name)
+   }
+
    def addConverterFactory(name: String, factory: ConverterFactory): Unit = {
       converterFactories.put(name, factory)
+   }
+
+   def removeConverterFactory(name: String): Unit = {
+      converterFactories.remove(name)
    }
 
    def addClientListener(ch: Channel, h: HotRodHeader, listenerId: Bytes, cache: Cache,
@@ -104,6 +112,12 @@ class ClientListenerRegistry(configuration: HotRodServerConfiguration) extends L
          cache.removeListener(sender)
          true
       } else false
+   }
+
+   def stop(): Unit = {
+      eventSenders.clear()
+      keyValueFilterFactories.clear()
+      converterFactories.clear()
    }
 
    @Listener(clustered = true, includeCurrentState = true)

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
@@ -230,10 +230,22 @@ class HotRodServer extends AbstractProtocolServer("HotRod") with Log {
       clientListenerRegistry.addKeyValueFilterFactory(name, factory)
    }
 
+   def removeKeyValueFilterFactory(name: String): Unit = {
+      clientListenerRegistry.removeKeyValueFilterFactory(name)
+   }
+
    def addConverterFactory(name: String, factory: ConverterFactory): Unit = {
       clientListenerRegistry.addConverterFactory(name, factory)
    }
 
+   def removeConverterFactory(name: String): Unit = {
+      clientListenerRegistry.removeConverterFactory(name)
+   }
+
+   override def stop: Unit = {
+      if (clientListenerRegistry != null) clientListenerRegistry.stop()
+      super.stop
+   }
 }
 
 object HotRodServer {

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/AbstractServerExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/AbstractServerExtensionProcessor.java
@@ -47,6 +47,7 @@ public abstract class AbstractServerExtensionProcessor<T> implements DeploymentU
 
     @Override
     public void undeploy(DeploymentUnit context) {
-        // No-op
+        // Deploy only adds services, so no need to do anything here
+        // since these services are automatically removed.
     }
 }

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/ConverterFactoryExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/ConverterFactoryExtensionProcessor.java
@@ -37,6 +37,7 @@ public final class ConverterFactoryExtensionProcessor extends AbstractNamedFacto
         @Override
         public void stop(StopContext context) {
             ROOT_LOGGER.debugf("Stopped converter service with name = %s", name);
+            extensionManager.getValue().removeConverterFactory(name);
         }
 
         @Override

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/FilterFactoryExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/FilterFactoryExtensionProcessor.java
@@ -42,6 +42,7 @@ public final class FilterFactoryExtensionProcessor extends AbstractNamedFactoryE
         @Override
         public void stop(StopContext context) {
             ROOT_LOGGER.debugf("Stopped key-value filter service with name = %s", name);
+            extensionManager.getValue().removeKeyValueFilterFactory(name);
         }
 
         @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4638
- Extension manager service should allow for filter/converter factories to be removed when their undeployed (via their service stop() method).
- Extension manager service should allow for Hot Rod servers to be removed when their removed (via their service stop() method).
