### PR TITLE
ISPN-4639 IndexingConfigurationBuilder query module validation is wrong

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractStoreConfigurationBuilder.java
@@ -1,6 +1,7 @@
 package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.parsing.XmlConfigHelper;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -125,6 +126,10 @@ public abstract class AbstractStoreConfigurationBuilder<T extends StoreConfigura
       if (shared && !preload && builder.indexing().enabled()
             && builder.indexing().indexLocalOnly())
          log.localIndexingWithSharedCacheLoaderRequiresPreload();
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/AsyncConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AsyncConfigurationBuilder.java
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.remoting.ReplicationQueue;
 import org.infinispan.remoting.ReplicationQueueImpl;
 
@@ -109,6 +110,10 @@ public class AsyncConfigurationBuilder extends AbstractClusteringConfigurationCh
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public
    AsyncConfiguration create() {
       return new AsyncConfiguration(asyncMarshalling, replicationQueue, replicationQueueInterval, replicationQueueMaxElements, useReplicationQueue);
@@ -135,5 +140,4 @@ public class AsyncConfigurationBuilder extends AbstractClusteringConfigurationCh
             ", useReplicationQueue=" + useReplicationQueue +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/AsyncStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AsyncStoreConfigurationBuilder.java
@@ -3,6 +3,7 @@ package org.infinispan.configuration.cache;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * Configuration for the async cache store. If enabled, this provides you with asynchronous writes
@@ -102,6 +103,10 @@ public class AsyncStoreConfigurationBuilder<S> extends AbstractStoreConfiguratio
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public AsyncStoreConfiguration create() {
       return new AsyncStoreConfiguration(enabled, flushLockTimeout, modificationQueueSize, shutdownTimeout, threadPoolSize);
    }
@@ -127,5 +132,4 @@ public class AsyncStoreConfigurationBuilder<S> extends AbstractStoreConfiguratio
             ", threadPoolSize=" + threadPoolSize +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/AuthorizationConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AuthorizationConfigurationBuilder.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * AuthorizationConfigurationBuilder.
@@ -45,6 +46,10 @@ public class AuthorizationConfigurationBuilder extends AbstractSecurityConfigura
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public AuthorizationConfiguration create() {
       return new AuthorizationConfiguration(enabled, roles);
    }
@@ -57,5 +62,4 @@ public class AuthorizationConfigurationBuilder extends AbstractSecurityConfigura
 
       return this;
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/BackupConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/BackupConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * @author Mircea.Markus@jboss.com
@@ -147,6 +148,12 @@ public class BackupConfigurationBuilder extends AbstractConfigurationChildBuilde
          throw new CacheConfigurationException("It is required to specify a 'failurePolicyClass' when using a " +
                                                 "custom backup failure policy!");
       }
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
+      takeOfflineBuilder.validate(globalConfig);
+      stateTransferBuilder.validate(globalConfig);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/BackupForBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/BackupForBuilder.java
@@ -3,6 +3,7 @@ package org.infinispan.configuration.cache;
 import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * @author Mircea Markus
@@ -52,6 +53,10 @@ public class BackupForBuilder extends AbstractConfigurationChildBuilder implemen
       if (remoteSite == null || remoteCache == null) {
          throw new CacheConfigurationException("Both 'remoteCache' and 'remoteSite' must be specified for a backup'!");
       }
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/ClusteringConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ClusteringConfigurationBuilder.java
@@ -1,6 +1,10 @@
 package org.infinispan.configuration.cache;
 
+import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
+
+import java.util.Arrays;
 
 /**
  * Defines clustered characteristics of the cache.
@@ -94,12 +98,25 @@ public class ClusteringConfigurationBuilder extends AbstractConfigurationChildBu
    @Override
    public
    void validate() {
-      asyncConfigurationBuilder.validate();
-      hashConfigurationBuilder.validate();
-      l1ConfigurationBuilder.validate();
-      syncConfigurationBuilder.validate();
-      stateTransferConfigurationBuilder.validate();
-      partitionHandlingConfigurationBuilder.validate();
+      for (Builder<?> validatable:
+            Arrays.asList(asyncConfigurationBuilder, hashConfigurationBuilder, l1ConfigurationBuilder,
+                          syncConfigurationBuilder, stateTransferConfigurationBuilder, partitionHandlingConfigurationBuilder)) {
+         validatable.validate();
+      }
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
+      if (cacheMode().isClustered() && globalConfig.transport().transport() == null) {
+         throw new CacheConfigurationException("Must have a transport set in the global configuration in " +
+               "order to define a clustered cache");
+      }
+
+      for (ConfigurationChildBuilder validatable:
+         Arrays.asList(asyncConfigurationBuilder, hashConfigurationBuilder, l1ConfigurationBuilder,
+                       syncConfigurationBuilder, stateTransferConfigurationBuilder, partitionHandlingConfigurationBuilder)) {
+         validatable.validate(globalConfig);
+      }
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/CompatibilityModeConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/CompatibilityModeConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * Compatibility mode configuration builder
@@ -60,6 +61,10 @@ public class CompatibilityModeConfigurationBuilder
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public CompatibilityModeConfiguration create() {
       return new CompatibilityModeConfiguration(enabled, marshaller);
    }
@@ -70,5 +75,4 @@ public class CompatibilityModeConfigurationBuilder
       this.marshaller = template.marshaller();
       return this;
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/ConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ConfigurationBuilder.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.ConfigurationUtils;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 public class ConfigurationBuilder implements ConfigurationChildBuilder {
 
@@ -175,12 +176,26 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder {
       for (Builder<?> m : modules) {
          m.validate();
       }
+   }
 
-      // TODO validate that a transport is set if a singleton store is set
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
+      for (ConfigurationChildBuilder validatable:
+            asList(clustering, customInterceptors, dataContainer, deadlockDetection, eviction, expiration, indexing,
+                   invocationBatching, jmxStatistics, persistence, locking, storeAsBinary, transaction,
+                   versioning, unsafe, sites, compatibility)) {
+         validatable.validate(globalConfig);
+      }
+      // Modules cannot be checked with GlobalConfiguration
    }
 
    @Override
    public Configuration build() {
+      return build(true);
+   }
+
+   public Configuration build(GlobalConfiguration globalConfiguration) {
+      validate(globalConfiguration);
       return build(true);
    }
 

--- a/core/src/main/java/org/infinispan/configuration/cache/ConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ConfigurationChildBuilder.java
@@ -1,5 +1,7 @@
 package org.infinispan.configuration.cache;
 
+import org.infinispan.configuration.global.GlobalConfiguration;
+
 public interface ConfigurationChildBuilder {
 
    ClusteringConfigurationBuilder clustering();
@@ -37,6 +39,8 @@ public interface ConfigurationChildBuilder {
    SitesConfigurationBuilder sites();
 
    CompatibilityModeConfigurationBuilder compatibility();
+
+   void validate(GlobalConfiguration globalConfig);
 
    Configuration build();
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/CustomInterceptorsConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/CustomInterceptorsConfigurationBuilder.java
@@ -5,6 +5,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * Configures custom interceptors to be added to the cache.
@@ -35,6 +36,11 @@ public class CustomInterceptorsConfigurationBuilder extends AbstractConfiguratio
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+      for (InterceptorConfigurationBuilder builder : interceptorBuilders) builder.validate(globalConfig);
+   }
+
+   @Override
    public CustomInterceptorsConfiguration create() {
       if (interceptorBuilders.isEmpty()) {
          return new CustomInterceptorsConfiguration();
@@ -60,5 +66,4 @@ public class CustomInterceptorsConfigurationBuilder extends AbstractConfiguratio
             "interceptors=" + interceptorBuilders +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/DataContainerConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/DataContainerConfigurationBuilder.java
@@ -6,6 +6,7 @@ import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.util.TypedProperties;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.container.DataContainer;
 
 /**
@@ -95,6 +96,10 @@ public class DataContainerConfigurationBuilder extends AbstractConfigurationChil
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public DataContainerConfiguration create() {
       return new DataContainerConfiguration(dataContainer,
             TypedProperties.toTypedProperties(properties), keyEquivalence,
@@ -120,5 +125,4 @@ public class DataContainerConfigurationBuilder extends AbstractConfigurationChil
             ", valueEquivalence=" + valueEquivalence +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/DeadlockDetectionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/DeadlockDetectionConfigurationBuilder.java
@@ -3,6 +3,7 @@ package org.infinispan.configuration.cache;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * Configures deadlock detection.
@@ -63,6 +64,10 @@ public class DeadlockDetectionConfigurationBuilder extends AbstractConfiguration
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public
    DeadlockDetectionConfiguration create() {
       return new DeadlockDetectionConfiguration(enabled, spinDuration);
@@ -83,5 +88,4 @@ public class DeadlockDetectionConfigurationBuilder extends AbstractConfiguration
             ", spinDuration=" + spinDuration +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/EvictionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/EvictionConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.eviction.EvictionThreadPolicy;
 import org.infinispan.util.logging.Log;
@@ -75,6 +76,10 @@ public class EvictionConfigurationBuilder extends AbstractConfigurationChildBuil
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public EvictionConfiguration create() {
       return new EvictionConfiguration(maxEntries, strategy, threadPolicy);
    }
@@ -96,5 +101,4 @@ public class EvictionConfigurationBuilder extends AbstractConfigurationChildBuil
             ", threadPolicy=" + threadPolicy +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/ExpirationConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ExpirationConfigurationBuilder.java
@@ -3,6 +3,7 @@ package org.infinispan.configuration.cache;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * Controls the default expiration settings for entries in the cache.
@@ -114,6 +115,10 @@ public class ExpirationConfigurationBuilder extends AbstractConfigurationChildBu
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public ExpirationConfiguration create() {
       return new ExpirationConfiguration(lifespan, maxIdle, reaperEnabled, wakeUpInterval);
    }
@@ -137,5 +142,4 @@ public class ExpirationConfigurationBuilder extends AbstractConfigurationChildBu
             ", wakeUpInterval=" + wakeUpInterval +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/GroupsConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/GroupsConfigurationBuilder.java
@@ -1,6 +1,7 @@
 package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.distribution.group.Group;
 import org.infinispan.distribution.group.Grouper;
 
@@ -78,6 +79,10 @@ public class GroupsConfigurationBuilder extends AbstractClusteringConfigurationC
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public GroupsConfiguration create() {
       return new GroupsConfiguration(enabled, groupers);
    }
@@ -97,5 +102,4 @@ public class GroupsConfigurationBuilder extends AbstractClusteringConfigurationC
             ", groupers=" + groupers +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/HashConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/HashConfigurationBuilder.java
@@ -3,6 +3,7 @@ package org.infinispan.configuration.cache;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.hash.Hash;
 import org.infinispan.commons.hash.MurmurHash3;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.distribution.ch.ConsistentHashFactory;
 import org.infinispan.util.logging.Log;
@@ -172,6 +173,11 @@ public class HashConfigurationBuilder extends AbstractClusteringConfigurationChi
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+      groupsConfigurationBuilder.validate(globalConfig);
+   }
+
+   @Override
    public HashConfiguration create() {
       // TODO stateTransfer().create() will create a duplicate StateTransferConfiguration instance. That's ok as long as none of the stateTransfer settings are modifiable at runtime.
       return new HashConfiguration(consistentHashFactory, hash, numOwners, numSegments, capacityFactor,
@@ -199,5 +205,4 @@ public class HashConfigurationBuilder extends AbstractClusteringConfigurationChi
             ", groups=" + groupsConfigurationBuilder +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/IndexingConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/IndexingConfigurationBuilder.java
@@ -6,6 +6,7 @@ import java.util.Properties;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.util.TypedProperties;
 import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -177,10 +178,16 @@ public class IndexingConfigurationBuilder extends AbstractConfigurationChildBuil
          if (clustering().cacheMode().isInvalidation()) {
             throw log.invalidConfigurationIndexingWithInvalidation();
          }
+      }
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
+      if (index.isEnabled()) {
          // Check that the query module is on the classpath.
          try {
             String clazz = "org.infinispan.query.Search";
-            Util.loadClassStrict( clazz, getClass().getClassLoader() );
+            Util.loadClassStrict( clazz, globalConfig.classLoader() );
          } catch (ClassNotFoundException e) {
             throw log.invalidConfigurationIndexingWithoutModule();
          }

--- a/core/src/main/java/org/infinispan/configuration/cache/InterceptorConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/InterceptorConfigurationBuilder.java
@@ -6,6 +6,7 @@ import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.util.TypedProperties;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.configuration.cache.InterceptorConfiguration.Position;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.interceptors.base.BaseCustomInterceptor;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.util.logging.Log;
@@ -145,6 +146,10 @@ public class InterceptorConfigurationBuilder extends AbstractCustomInterceptorsC
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public InterceptorConfiguration create() {
       return new InterceptorConfiguration(after, before, interceptor, index, position, TypedProperties.toTypedProperties(properties));
    }
@@ -167,5 +172,4 @@ public class InterceptorConfigurationBuilder extends AbstractCustomInterceptorsC
       return "InterceptorConfigurationBuilder [after=" + after + ", before=" + before + ", interceptor=" + interceptor + ", index=" + index + ", position=" + position
             + ", properties=" + properties + "]";
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/InvocationBatchingConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/InvocationBatchingConfigurationBuilder.java
@@ -3,6 +3,7 @@ package org.infinispan.configuration.cache;
 import static org.infinispan.transaction.TransactionMode.NON_TRANSACTIONAL;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -40,6 +41,10 @@ public class InvocationBatchingConfigurationBuilder extends AbstractConfiguratio
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public InvocationBatchingConfiguration create() {
       return new InvocationBatchingConfiguration(enabled);
    }
@@ -57,5 +62,4 @@ public class InvocationBatchingConfigurationBuilder extends AbstractConfiguratio
             "enabled=" + enabled +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/JMXStatisticsConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/JMXStatisticsConfigurationBuilder.java
@@ -1,6 +1,7 @@
 package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * Determines whether statistics are gather and reported.
@@ -45,6 +46,10 @@ public class JMXStatisticsConfigurationBuilder extends AbstractConfigurationChil
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public JMXStatisticsConfiguration create() {
       return new JMXStatisticsConfiguration(enabled);
    }
@@ -62,5 +67,4 @@ public class JMXStatisticsConfigurationBuilder extends AbstractConfigurationChil
             "enabled=" + enabled +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/L1ConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/L1ConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -102,6 +103,10 @@ public class L1ConfigurationBuilder extends AbstractClusteringConfigurationChild
             throw new CacheConfigurationException("Using a L1 lifespan of 0 or a negative value is meaningless");
 
       }
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/LockingConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/LockingConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
@@ -124,6 +125,10 @@ public class LockingConfigurationBuilder extends AbstractConfigurationChildBuild
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public LockingConfiguration create() {
       return new LockingConfiguration(concurrencyLevel, isolationLevel, lockAcquisitionTimeout, useLockStriping, writeSkewCheck);
    }
@@ -149,5 +154,4 @@ public class LockingConfigurationBuilder extends AbstractConfigurationChildBuild
             ", writeSkewCheck=" + writeSkewCheck +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/PartitionHandlingConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/PartitionHandlingConfigurationBuilder.java
@@ -1,6 +1,7 @@
 package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -33,6 +34,10 @@ public class PartitionHandlingConfigurationBuilder extends AbstractClusteringCon
       if (enabled && clustering().cacheMode().isReplicated()) {
          log.warnPartitionHandlingForReplicatedCaches();
       }
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/PersistenceConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/PersistenceConfigurationBuilder.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.ConfigurationUtils;
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * Configuration for cache stores.
@@ -109,6 +110,13 @@ public class PersistenceConfigurationBuilder extends AbstractConfigurationChildB
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+      for (StoreConfigurationBuilder<?, ?> b : stores) {
+         b.validate(globalConfig);
+      }
+   }
+
+   @Override
    public PersistenceConfiguration create() {
       List<StoreConfiguration> stores = new ArrayList<StoreConfiguration>(this.stores.size());
       for (StoreConfigurationBuilder<?, ?> loader : this.stores)
@@ -143,5 +151,4 @@ public class PersistenceConfigurationBuilder extends AbstractConfigurationChildB
             ", passivation=" + passivation +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/RecoveryConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/RecoveryConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 import static org.infinispan.configuration.cache.RecoveryConfiguration.DEFAULT_RECOVERY_INFO_CACHE;
 
@@ -71,6 +72,10 @@ public class RecoveryConfigurationBuilder extends AbstractTransportConfiguration
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public RecoveryConfiguration create() {
       return new RecoveryConfiguration(enabled, recoveryInfoCacheName);
    }
@@ -90,5 +95,4 @@ public class RecoveryConfigurationBuilder extends AbstractTransportConfiguration
             ", recoveryInfoCacheName='" + recoveryInfoCacheName + '\'' +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/SecurityConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/SecurityConfigurationBuilder.java
@@ -1,6 +1,7 @@
 package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * SecurityConfigurationBuilder.
@@ -21,6 +22,10 @@ public class SecurityConfigurationBuilder extends AbstractConfigurationChildBuil
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public SecurityConfiguration create() {
       return new SecurityConfiguration(authorizationBuilder.create());
    }
@@ -35,5 +40,4 @@ public class SecurityConfigurationBuilder extends AbstractConfigurationChildBuil
    public AuthorizationConfigurationBuilder authorization() {
       return authorizationBuilder;
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/SingletonStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/SingletonStoreConfigurationBuilder.java
@@ -2,7 +2,9 @@ package org.infinispan.configuration.cache;
 
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 public class SingletonStoreConfigurationBuilder<S> extends AbstractStoreConfigurationChildBuilder<S> implements Builder<SingletonStoreConfiguration> {
 
@@ -67,6 +69,14 @@ public class SingletonStoreConfigurationBuilder<S> extends AbstractStoreConfigur
 
    @Override
    public void validate() {
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
+      if (globalConfig.transport().transport() == null) {
+         throw new CacheConfigurationException("Must have a transport set in the global configuration in " +
+               "order to configure a singleton store");
+      }
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/SitesConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/SitesConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -65,6 +66,15 @@ public class SitesConfigurationBuilder extends AbstractConfigurationChildBuilder
          if (!found) {
             throw new CacheConfigurationException("The site '" + site + "' should be defined within the set of backups!");
          }
+      }
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
+      backupForBuilder.validate(globalConfig);
+
+      for (BackupConfigurationBuilder bcb : backups) {
+         bcb.validate(globalConfig);
       }
    }
 

--- a/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StateTransferConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -92,6 +93,10 @@ public class StateTransferConfigurationBuilder extends
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public  StateTransferConfiguration create() {
       // If replicated or distributed and fetch state transfer was not explicitly
       // disabled, then force enabling of state transfer
@@ -139,5 +144,4 @@ public class StateTransferConfigurationBuilder extends
             ", timeout=" + timeout +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/StoreAsBinaryConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/StoreAsBinaryConfigurationBuilder.java
@@ -1,6 +1,7 @@
 package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * Controls whether when stored in memory, keys and values are stored as references to their original objects, or in
@@ -96,6 +97,10 @@ public class StoreAsBinaryConfigurationBuilder extends AbstractConfigurationChil
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public StoreAsBinaryConfiguration create() {
       return new StoreAsBinaryConfiguration(
             enabled, storeKeysAsBinary, storeValuesAsBinary);
@@ -118,5 +123,4 @@ public class StoreAsBinaryConfigurationBuilder extends AbstractConfigurationChil
             ", storeValuesAsBinary=" + storeValuesAsBinary +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/SyncConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/SyncConfigurationBuilder.java
@@ -3,6 +3,7 @@ package org.infinispan.configuration.cache;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * If configured all communications are synchronous, in that whenever a thread sends a message sent
@@ -36,7 +37,10 @@ public class SyncConfigurationBuilder extends AbstractClusteringConfigurationChi
 
    @Override
    public void validate() {
+   }
 
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
    }
 
    @Override
@@ -56,5 +60,4 @@ public class SyncConfigurationBuilder extends AbstractClusteringConfigurationChi
             "replTimeout=" + replTimeout +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/TakeOfflineConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TakeOfflineConfigurationBuilder.java
@@ -1,6 +1,7 @@
 package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * @author Mircea Markus
@@ -19,6 +20,10 @@ public class TakeOfflineConfigurationBuilder extends AbstractConfigurationChildB
 
    @Override
    public void validate() {
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
 import org.infinispan.transaction.TransactionProtocol;
@@ -277,6 +278,11 @@ public class TransactionConfigurationBuilder extends AbstractConfigurationChildB
          }
       }
       recovery.validate();
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
+      recovery.validate(globalConfig);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/UnsafeConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/UnsafeConfigurationBuilder.java
@@ -1,6 +1,7 @@
 package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * Controls certain tuning parameters that may break some of Infinispan's public API contracts in exchange for better
@@ -38,6 +39,10 @@ public class UnsafeConfigurationBuilder extends AbstractConfigurationChildBuilde
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public UnsafeConfiguration create() {
       return new UnsafeConfiguration(unreliableReturnValues);
    }
@@ -55,5 +60,4 @@ public class UnsafeConfigurationBuilder extends AbstractConfigurationChildBuilde
             "unreliableReturnValues=" + unreliableReturnValues +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/VersioningConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/VersioningConfigurationBuilder.java
@@ -1,6 +1,7 @@
 package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 public class VersioningConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<VersioningConfiguration> {
 
@@ -36,6 +37,10 @@ public class VersioningConfigurationBuilder extends AbstractConfigurationChildBu
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public VersioningConfiguration create() {
       return new VersioningConfiguration(enabled, scheme);
    }
@@ -55,5 +60,4 @@ public class VersioningConfigurationBuilder extends AbstractConfigurationChildBu
             ", scheme=" + scheme +
             '}';
    }
-
 }

--- a/core/src/main/java/org/infinispan/configuration/cache/XSiteStateTransferConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/XSiteStateTransferConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.configuration.cache;
 
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 import java.util.concurrent.TimeUnit;
 
@@ -31,6 +32,10 @@ public class XSiteStateTransferConfigurationBuilder extends AbstractConfiguratio
       if (timeout <= 0) {
          throw new CacheConfigurationException("Timeout must be higher or equals than 1 (one).");
       }
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
    }
 
    /**

--- a/core/src/test/java/org/infinispan/configuration/ConfigurationUnitTest.java
+++ b/core/src/test/java/org/infinispan/configuration/ConfigurationUnitTest.java
@@ -266,12 +266,9 @@ public class ConfigurationUnitTest extends AbstractInfinispanTest {
 
    @Test(expectedExceptions = CacheConfigurationException.class)
    public void testWrongCacheModeConfiguration() throws Exception {
-      withCacheManager(new CacheManagerCallable(createTestCacheManager()) {
-         @Override
-         public void call() {
-            cm.getCache().put("key", "value");
-         }
-      });
+      ConfigurationBuilder config = new ConfigurationBuilder();
+      config.clustering().cacheMode(CacheMode.REPL_ASYNC);
+      TestCacheManagerFactory.createCacheManager(config);
    }
 
    public void testCacheModeConfiguration() throws Exception {
@@ -286,7 +283,7 @@ public class ConfigurationUnitTest extends AbstractInfinispanTest {
    private EmbeddedCacheManager createTestCacheManager() {
       ConfigurationBuilder config = new ConfigurationBuilder();
       config.clustering().cacheMode(CacheMode.REPL_ASYNC);
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(config);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager(config);
       config = new ConfigurationBuilder();
       cm.defineConfiguration("local", config.build());
       return cm;

--- a/core/src/test/java/org/infinispan/configuration/LocalConfigurationValidation2Test.java
+++ b/core/src/test/java/org/infinispan/configuration/LocalConfigurationValidation2Test.java
@@ -1,0 +1,41 @@
+package org.infinispan.configuration;
+
+import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * LocalConfigurationValidationTest.
+ *
+ * @author William Burns
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "configuration.LocalConfigurationValidation2Test")
+public class LocalConfigurationValidation2Test extends SingleCacheManagerTest {
+
+   public void testCacheModeConfiguration() {
+      cacheManager.getCache().put("key", "value");
+   }
+
+   @Test(expectedExceptions = CacheConfigurationException.class)
+   public void testWrongCacheModeConfiguration() {
+      ConfigurationBuilder cb = new ConfigurationBuilder();
+      cb.clustering().cacheMode(CacheMode.REPL_ASYNC);
+      cacheManager.defineConfiguration("repl_async", cb.build());
+      cacheManager.getCache("repl_async");
+   }
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder().nonClusteredDefault();
+      ConfigurationBuilder cb = new ConfigurationBuilder();
+      cb.clustering().cacheMode(CacheMode.LOCAL);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(gcb, cb);
+      return cm;
+   }
+}

--- a/core/src/test/java/org/infinispan/configuration/ParserOverrideTest.java
+++ b/core/src/test/java/org/infinispan/configuration/ParserOverrideTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.configuration;
 
+import static org.infinispan.test.TestingUtil.JGROUPS_CONFIG;
 import static org.infinispan.test.TestingUtil.INFINISPAN_START_TAG;
 import static org.infinispan.test.TestingUtil.withCacheManager;
 
@@ -23,7 +24,7 @@ public class ParserOverrideTest {
     */
    public void testNamedCacheOverride() throws Exception {
       final String cacheName = "asyncRepl";
-      String xml1 = INFINISPAN_START_TAG +
+      String xml1 = INFINISPAN_START_TAG + JGROUPS_CONFIG +
             "<cache-container name=\"1\" default-cache=\"" + cacheName + "\">" +
             "   <replicated-cache name=\"" + cacheName + "\" mode=\"ASYNC\" async-marshalling=\"false\">\n" +
             "      <state-transfer enabled=\"false\"/>\n" +
@@ -33,7 +34,7 @@ public class ParserOverrideTest {
             "   </replicated-cache>\n" +
             "</cache-container>" +
             TestingUtil.INFINISPAN_END_TAG;
-      String xml2 = INFINISPAN_START_TAG +
+      String xml2 = INFINISPAN_START_TAG + JGROUPS_CONFIG +
             "<cache-container name=\"2\" default-cache=\"" + cacheName + "\">" +
             "   <replicated-cache name=\"" + cacheName + "\" mode=\"SYNC\" remote-timeout=\"30000\">\n" +
             "      <state-transfer enabled=\"true\"/>\n" +
@@ -71,7 +72,7 @@ public class ParserOverrideTest {
     * This test makes sure that both defaults are applied to a named cache
     */
    public void testDefaultCacheOverride() throws Exception {
-      String xml1 = INFINISPAN_START_TAG +
+      String xml1 = INFINISPAN_START_TAG + JGROUPS_CONFIG +
             "<cache-container name=\"1\" default-cache=\"default-cache\">" +
             "   <replicated-cache name=\"default-cache\" mode=\"ASYNC\" statistics=\"true\">\n" +
             "      <state-transfer enabled=\"false\"/>\n" +
@@ -81,7 +82,7 @@ public class ParserOverrideTest {
             "   </replicated-cache>\n" +
             "</cache-container>" +
             TestingUtil.INFINISPAN_END_TAG;
-      String xml2 = INFINISPAN_START_TAG +
+      String xml2 = INFINISPAN_START_TAG + JGROUPS_CONFIG +
             "<cache-container name=\"2\" default-cache=\"default-cache\">" +
             "   <replicated-cache name=\"default-cache\" mode=\"SYNC\" remote-timeout=\"30000\">\n" +
             "      <state-transfer enabled=\"true\"/>\n" +
@@ -122,7 +123,7 @@ public class ParserOverrideTest {
     */
    public void testDefaultAndNamedCacheOverride() throws Exception {
       final String cacheName = "ourCache";
-      String xml1 = INFINISPAN_START_TAG +
+      String xml1 = INFINISPAN_START_TAG + JGROUPS_CONFIG +
             "<cache-container name=\"1\" default-cache=\"default-cache\">" +
             "   <replicated-cache name=\"default-cache\" mode=\"ASYNC\" statistics=\"true\" deadlock-detection-spin=\"1221\">\n" +
             "      <state-transfer enabled=\"false\"/>\n" +
@@ -133,7 +134,7 @@ public class ParserOverrideTest {
             "   <replicated-cache name=\"" + cacheName + "\" mode=\"ASYNC\" queue-flush-interval=\"105\" queue-size=\"341\" statistics=\"true\" deadlock-detection-spin=\"1223\" />\n" +
             "</cache-container>" +
             TestingUtil.INFINISPAN_END_TAG;
-      String xml2 = INFINISPAN_START_TAG +
+      String xml2 = INFINISPAN_START_TAG + JGROUPS_CONFIG +
             "<cache-container name=\"2\" default-cache=\"default-cache\">" +
             "   <replicated-cache name=\"default-cache\" mode=\"SYNC\" deadlock-detection-spin=\"1222\" remote-timeout=\"30000\">\n" +
             "      <state-transfer enabled=\"true\"/>\n" +

--- a/core/src/test/java/org/infinispan/configuration/module/MyModuleConfigurationBuilder.java
+++ b/core/src/test/java/org/infinispan/configuration/module/MyModuleConfigurationBuilder.java
@@ -3,6 +3,7 @@ package org.infinispan.configuration.module;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.configuration.cache.AbstractModuleConfigurationBuilder;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  *
@@ -25,6 +26,10 @@ public class MyModuleConfigurationBuilder extends AbstractModuleConfigurationBui
 
    @Override
    public void validate() {
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -100,6 +100,9 @@ public class TestingUtil {
    private static final Log log = LogFactory.getLog(TestingUtil.class);
    private static final Random random = new Random();
    public static final String TEST_PATH = "infinispanTempFiles";
+   public static final String JGROUPS_CONFIG = "<jgroups>\n" +
+         "      <stack-file name=\"tcp\" path=\"jgroups-tcp.xml\"/>\n" +
+         "   </jgroups>";
    public static final String INFINISPAN_START_TAG = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<infinispan\n" +
          "      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
          "      xsi:schemaLocation=\"urn:infinispan:config:7.0 http://www.infinispan.org/schemas/infinispan-config-7.0.xsd\"\n" +

--- a/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestCacheManagerFactory.java
@@ -18,6 +18,7 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
@@ -344,7 +345,8 @@ public class TestCacheManagerFactory {
    }
 
    private static DefaultCacheManager newDefaultCacheManager(boolean start, GlobalConfigurationBuilder gc, ConfigurationBuilder c) {
-      DefaultCacheManager defaultCacheManager = new DefaultCacheManager(gc.build(), c.build(), start);
+      GlobalConfiguration globalConfiguration = gc.build();
+      DefaultCacheManager defaultCacheManager = new DefaultCacheManager(globalConfiguration, c.build(globalConfiguration), start);
       TestResourceTracker.addResource(new TestResourceTracker.CacheManagerCleaner(defaultCacheManager));
       return defaultCacheManager;
    }

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/AbstractJdbcStoreConfigurationBuilder.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/AbstractJdbcStoreConfigurationBuilder.java
@@ -8,6 +8,7 @@ import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.configuration.cache.AbstractStoreConfigurationBuilder;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.persistence.jdbc.Dialect;
 import org.infinispan.persistence.jdbc.connectionfactory.ConnectionFactory;
 import org.infinispan.persistence.jdbc.logging.Log;
@@ -85,6 +86,15 @@ public abstract class AbstractJdbcStoreConfigurationBuilder<T extends AbstractJd
       } else if (!manageConnectionFactory && connectionFactory != null) {
          throw log.unmanagedConnectionFactory();
       }
+
+      if (connectionFactory != null) {
+         connectionFactory.validate();
+      }
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
+      // Can't validate global config with connection factory
    }
 
    @Override

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/ManagedConnectionFactoryConfigurationBuilder.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/ManagedConnectionFactoryConfigurationBuilder.java
@@ -1,6 +1,7 @@
 package org.infinispan.persistence.jdbc.configuration;
 
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * ManagedConnectionFactoryConfigurationBuilder.
@@ -23,7 +24,13 @@ public class ManagedConnectionFactoryConfigurationBuilder<S extends AbstractJdbc
 
    @Override
    public void validate() {
-      throw new CacheConfigurationException("The jndiUrl has not been specified");
+      if (jndiUrl == null) {
+         throw new CacheConfigurationException("The jndiUrl has not been specified");
+      }
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
    }
 
    @Override

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/PooledConnectionFactoryConfigurationBuilder.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/PooledConnectionFactoryConfigurationBuilder.java
@@ -3,6 +3,7 @@ package org.infinispan.persistence.jdbc.configuration;
 import java.sql.Driver;
 
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * PooledConnectionFactoryConfigurationBuilder.
@@ -52,6 +53,10 @@ public class PooledConnectionFactoryConfigurationBuilder<S extends AbstractJdbcS
       if (connectionUrl == null) {
          throw new CacheConfigurationException("Missing connectionUrl parameter");
       }
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
    }
 
    @Override

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/SimpleConnectionFactoryConfigurationBuilder.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/SimpleConnectionFactoryConfigurationBuilder.java
@@ -3,6 +3,7 @@ package org.infinispan.persistence.jdbc.configuration;
 import java.sql.Driver;
 
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  * SimpleConnectionFactoryBuilder.
@@ -52,6 +53,10 @@ public class SimpleConnectionFactoryConfigurationBuilder<S extends AbstractJdbcS
       if (connectionUrl == null) {
          throw new CacheConfigurationException("A connectionUrl has not been specified");
       }
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
    }
 
    @Override

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/TableManipulationConfigurationBuilder.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/TableManipulationConfigurationBuilder.java
@@ -3,6 +3,7 @@ package org.infinispan.persistence.jdbc.configuration;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.Self;
 import org.infinispan.commons.logging.LogFactory;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.persistence.jdbc.Dialect;
 import org.infinispan.persistence.jdbc.TableManipulation;
 import org.infinispan.persistence.jdbc.logging.Log;
@@ -135,6 +136,10 @@ public abstract class TableManipulationConfigurationBuilder<B extends AbstractJd
       validateIfSet("timestampColumnName", timestampColumnName);
       validateIfSet("timestampColumnType", timestampColumnType);
       validateIfSet("tableNamePrefix", tableNamePrefix);
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
    }
 
    private void validateIfSet(String name, String value) {

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/NonStringKeyPreloadTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/NonStringKeyPreloadTest.java
@@ -12,6 +12,7 @@ import org.infinispan.commons.CacheException;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.BuiltBy;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.persistence.jdbc.configuration.AbstractJdbcStoreConfigurationBuilder;
@@ -193,6 +194,10 @@ public class NonStringKeyPreloadTest extends AbstractInfinispanTest {
 
       @Override
       public void validate() {
+      }
+
+      @Override
+      public void validate(GlobalConfiguration globalConfig) {
       }
 
       @Override

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/ConnectionPoolConfigurationBuilder.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/ConnectionPoolConfigurationBuilder.java
@@ -1,6 +1,7 @@
 package org.infinispan.persistence.remote.configuration;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  *
@@ -116,6 +117,10 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteStoreConfi
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public ConnectionPoolConfiguration create() {
       return new ConnectionPoolConfiguration(exhaustedAction, maxActive, maxTotal, maxIdle, minIdle, timeBetweenEvictionRuns, minEvictableIdleTime, testWhileIdle);
    }
@@ -132,5 +137,4 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteStoreConfi
       testWhileIdle = template.testWhileIdle();
       return this;
    }
-
 }

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/ExecutorFactoryConfigurationBuilder.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/ExecutorFactoryConfigurationBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.persistence.remote.configuration;
 
 import java.util.Properties;
 
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.executors.DefaultExecutorFactory;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.executors.ExecutorFactory;
@@ -68,6 +69,10 @@ public class ExecutorFactoryConfigurationBuilder extends AbstractRemoteStoreConf
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public ExecutorFactoryConfiguration create() {
       return new ExecutorFactoryConfiguration(factory, TypedProperties.toTypedProperties(properties));
    }
@@ -84,5 +89,4 @@ public class ExecutorFactoryConfigurationBuilder extends AbstractRemoteStoreConf
    public String toString() {
       return "ExecutorFactoryConfigurationBuilder{" + "factory=" + factory + ", properties=" + properties + '}';
    }
-
 }

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteServerConfigurationBuilder.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteServerConfigurationBuilder.java
@@ -1,6 +1,7 @@
 package org.infinispan.persistence.remote.configuration;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 public class RemoteServerConfigurationBuilder extends AbstractRemoteStoreConfigurationChildBuilder<RemoteStoreConfigurationBuilder> implements
       Builder<RemoteServerConfiguration> {
@@ -26,6 +27,10 @@ public class RemoteServerConfigurationBuilder extends AbstractRemoteStoreConfigu
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public RemoteServerConfiguration create() {
       return new RemoteServerConfiguration(host, port);
    }
@@ -37,5 +42,4 @@ public class RemoteServerConfigurationBuilder extends AbstractRemoteStoreConfigu
 
       return this;
    }
-
 }

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/ConnectionPoolConfigurationBuilder.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/ConnectionPoolConfigurationBuilder.java
@@ -19,6 +19,7 @@
 package org.infinispan.persistence.rest.configuration;
 
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.global.GlobalConfiguration;
 
 /**
  *
@@ -78,6 +79,10 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRestStoreConfigu
    }
 
    @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
    public ConnectionPoolConfiguration create() {
       return new ConnectionPoolConfiguration(connectionTimeout, maxConnectionsPerHost, maxTotalConnections, bufferSize, socketTimeout, tcpNoDelay);
    }
@@ -92,5 +97,4 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRestStoreConfigu
       this.tcpNoDelay = template.tcpNoDelay();
       return this;
    }
-
 }

--- a/query/src/test/resources/configuration-parsing-test.xml
+++ b/query/src/test/resources/configuration-parsing-test.xml
@@ -4,6 +4,10 @@
       xsi:schemaLocation="urn:infinispan:config:7.0 http://www.infinispan.org/schemas/infinispan-config-7.0.xsd"
       xmlns="urn:infinispan:config:7.0">
 
+    <jgroups>
+        <stack-file name="tcp" path="jgroups-tcp.xml"/>
+    </jgroups>
+
    <cache-container default-cache="default" statistics="true">
       <jmx duplicate-domains="true" />
       <local-cache name="default">


### PR DESCRIPTION
- Added new validate method that provides access to GlobalConfiguration
- Changed IndexingConfigurationBuilder to use GlobalConfiguration CP
- Added Clustering validations to ensure transport is set

https://issues.jboss.org/browse/ISPN-4639
