### PR TITLE
ISPN-3979 JdbcStringBasedStore loading of Key2StringMapper class is too

### DIFF
--- a/core/src/test/java/org/infinispan/util/PersistenceMockUtil.java
+++ b/core/src/test/java/org/infinispan/util/PersistenceMockUtil.java
@@ -19,6 +19,7 @@ import org.infinispan.test.AbstractInfinispanTest;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -47,7 +48,7 @@ public class PersistenceMockUtil {
 
    public static Cache mockCache(String name, Configuration configuration, TimeService timeService) {
       String cacheName = "mock-cache-" + name;
-      AdvancedCache cache = mock(AdvancedCache.class);
+      AdvancedCache cache = mock(AdvancedCache.class, RETURNS_DEEP_STUBS);
 
       GlobalConfiguration gc = new GlobalConfigurationBuilder().build();
 
@@ -58,6 +59,7 @@ public class PersistenceMockUtil {
       ComponentRegistry registry = new ComponentRegistry(cacheName, configuration, cache, gcr,
                                                          configuration.getClass().getClassLoader());
 
+      when(cache.getCacheManager().getCacheManagerConfiguration()) .thenReturn(gc);
       when(cache.getName()).thenReturn(cacheName);
       when(cache.getAdvancedCache()).thenReturn(cache);
       when(cache.getComponentRegistry()).thenReturn(registry);

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
@@ -16,6 +16,8 @@ import java.util.concurrent.Future;
 
 import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.filter.KeyFilter;
 import org.infinispan.marshall.core.MarshalledEntry;
 import org.infinispan.persistence.TaskContextImpl;
@@ -80,6 +82,7 @@ public class JdbcStringBasedStore implements AdvancedLoadWriteStore {
    private TableManipulation tableManipulation;
    private InitializationContext ctx;
    private String cacheName;
+   private GlobalConfiguration globalConfiguration;
 
 
    @Override
@@ -87,6 +90,7 @@ public class JdbcStringBasedStore implements AdvancedLoadWriteStore {
       this.configuration = ctx.getConfiguration();
       this.ctx = ctx;
       cacheName = ctx.getCache().getName();
+      globalConfiguration = ctx.getCache().getCacheManager().getCacheManagerConfiguration();
    }
 
    @Override
@@ -97,7 +101,8 @@ public class JdbcStringBasedStore implements AdvancedLoadWriteStore {
          initializeConnectionFactory(factory);
       }
       try {
-         Object mapper = Class.forName(configuration.key2StringMapper()).newInstance();
+         Object mapper = Util.loadClassStrict(configuration.key2StringMapper(),
+                                              globalConfiguration.classLoader()).newInstance();
          if (mapper instanceof Key2StringMapper) key2StringMapper = (Key2StringMapper) mapper;
       } catch (Exception e) {
          log.errorf("Trying to instantiate %s, however it failed due to %s", configuration.key2StringMapper(),


### PR DESCRIPTION
restrictive
- Key2StringMapper class is now loaded using ClassLoader from
- GlobalConfiguration

https://issues.jboss.org/browse/ISPN-3979
