### PR TITLE
ISPN-4377 Make receiving state option for Hot Rod remote events

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/annotation/ClientListener.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/annotation/ClientListener.java
@@ -6,11 +6,62 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * Annotation that marks a class to receive remote events from Hot Rod caches.
+ * Classes with this annotation are expected to have at least one callback
+ * annotated with one of the events it can receive:
+ * {@link org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated},
+ * {@link org.infinispan.client.hotrod.annotation.ClientCacheEntryModified},
+ * {@link org.infinispan.client.hotrod.annotation.ClientCacheEntryRemoved},
+ * {@link org.infinispan.client.hotrod.annotation.ClientCacheFailover}
+ *
  * @author Galder Zamarreño
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface ClientListener {
+
+   /**
+    * Defines the key/value filter factory for this client listener. Filter
+    * factories create filters that help decide which events should be sent
+    * to this client listener. This helps with reducing traffic from server
+    * to client. By default, no filtering is applied.
+    */
    String filterFactoryName() default "";
+
+   /**
+    * Defines the converter factory for this client listener. Converter
+    * factories create event converters that customize the contents of the
+    * events sent to this listener. When event customization is enabled,
+    * {@link org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated},
+    * {@link org.infinispan.client.hotrod.annotation.ClientCacheEntryModified},
+    * and {@link org.infinispan.client.hotrod.annotation.ClientCacheEntryRemoved}
+    * callbacks receive {@link org.infinispan.client.hotrod.event.ClientCacheEntryCustomEvent}
+    * instances as parameters instead of their corresponding create/modified/removed
+    * event. Event customization helps reduce the payload of events, or
+    * increase to send even more information back to the client listener.
+    * By default, no event customization is applied.
+    */
    String converterFactoryName() default "";
+
+   /**
+    * This flag enables cached state to be sent back to remote clients when
+    * either adding a cache listener for the first time, or when the node where
+    * a remote listener is registered changes. When enabled, state is sent
+    * back as cache entry created events to the clients. In the special case
+    * that the node where the remote listener is registered changes, before
+    * sending any cache entry created events, the client receives a failover
+    * event so that it's aware of the change of node. This is useful in order
+    * to do local clean up before receiving the state again. For example, a
+    * client building a local near cache and keeping it up to date with remote
+    * events might decide to clear in when the failover event is received and
+    * before the state is received.
+    *
+    * If disabled, no state is sent back to the client when adding a listener,
+    * nor it gets state when the node where the listener is registered changes.
+    *
+    * By default, including state is disabled in order to provide best
+    * performance. If clients must receive all events, enable including state.
+    */
+   boolean includeCurrentState() default false;
+
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AddClientListenerOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AddClientListenerOperation.java
@@ -82,6 +82,7 @@ public class AddClientListenerOperation extends RetryOnFailureOperation<Short> {
 
       HeaderParams params = writeHeader(transport, ADD_CLIENT_LISTENER_REQUEST);
       transport.writeArray(listenerId);
+      transport.writeByte((short)(clientListener.includeCurrentState() ? 1 : 0));
 
       writeNamedFactory(transport, clientListener.filterFactoryName(), filterFactoryParams);
       writeNamedFactory(transport, clientListener.converterFactoryName(), converterFactoryParams);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/CustomEventLogListener.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/CustomEventLogListener.java
@@ -111,8 +111,14 @@ public abstract class CustomEventLogListener {
    @ClientListener(converterFactoryName = "static-converter-factory")
    public static class StaticCustomEventLogListener extends CustomEventLogListener {}
 
+   @ClientListener(converterFactoryName = "static-converter-factory", includeCurrentState = true)
+   public static class StaticCustomEventLogWithStateListener extends CustomEventLogListener {}
+
    @ClientListener(converterFactoryName = "dynamic-converter-factory")
    public static class DynamicCustomEventLogListener extends CustomEventLogListener {}
+
+   @ClientListener(converterFactoryName = "dynamic-converter-factory", includeCurrentState = true)
+   public static class DynamicCustomEventWithStateLogListener extends CustomEventLogListener {}
 
    @NamedFactory(name = "static-converter-factory")
    public static class StaticConverterFactory implements ConverterFactory {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EventLogListener.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EventLogListener.java
@@ -191,8 +191,8 @@ public class EventLogListener<K> {
       return false;
    }
 
-   public void expectFailoverEvent(EventLogListener eventListener) {
-      eventListener.pollEvent(ClientEvent.Type.CLIENT_CACHE_FAILOVER);
+   public void expectFailoverEvent() {
+      pollEvent(ClientEvent.Type.CLIENT_CACHE_FAILOVER);
    }
 
    @ClientListener(filterFactoryName = "static-filter-factory")
@@ -201,10 +201,22 @@ public class EventLogListener<K> {
       public StaticFilteredEventLogListener(boolean compatibility) { super(compatibility); }
    }
 
+   @ClientListener(filterFactoryName = "static-filter-factory", includeCurrentState = true)
+   public static class StaticFilteredEventLogWithStateListener<K> extends EventLogListener<K> {
+      public StaticFilteredEventLogWithStateListener() {}
+      public StaticFilteredEventLogWithStateListener(boolean compatibility) { super(compatibility); }
+   }
+
    @ClientListener(filterFactoryName = "dynamic-filter-factory")
    public static class DynamicFilteredEventLogListener<K> extends EventLogListener<K> {
       public DynamicFilteredEventLogListener() {}
       public DynamicFilteredEventLogListener(boolean compatibility) { super(compatibility); }
+   }
+
+   @ClientListener(filterFactoryName = "dynamic-filter-factory", includeCurrentState = true)
+   public static class DynamicFilteredEventLogWithStateListener<K> extends EventLogListener<K> {
+      public DynamicFilteredEventLogWithStateListener() {}
+      public DynamicFilteredEventLogWithStateListener(boolean compatibility) { super(compatibility); }
    }
 
    @NamedFactory(name = "static-filter-factory")

--- a/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
@@ -470,23 +470,36 @@ enabled by default.
 
 ====== Client Event Listener State Consumption
 
-If a client listener is added in a cache already containing data, the server
-iterates over the cache contents and sends an event for each entry to the
-client as a `ClientCacheEntryCreated` (or custom event if configured).
-This allows clients to build some  local data structures based on the existing
-content. Once the content has been iterated over, events are received as normal,
-as cache updates are received. If the cache is clustered, the entire cluster
-wide contents are iterated over.
+Client listener annotation has an optional `includeCurrentState` attribute
+that specifies whether state will be sent to the client when the listener is
+added or when there's a failover of the listener.
+
+By default, `includeCurrentState` is false, but if set to true and a client
+listener is added in a cache already containing data, the server iterates over
+the cache contents and sends an event for each entry to the client as a
+`ClientCacheEntryCreated` (or custom event if configured). This allows clients
+to build some local data structures based on the existing content. Once the
+content has been iterated over, events are received as normal, as cache
+updates are received.  If the cache is clustered, the entire cluster wide
+contents are iterated over.
+
+`includeCurrentState` also controls whether state is received when the node
+where the client event listener is registered fails and it's moved to a
+different node. The next section discusses this topic in depth.
 
 ====== Client Event Listener Failure Handling
 
 When a Hot Rod client registers a client listener, it does so in a single
 node in a cluster. If that node fails, the Java Hot Rod client detects that
 transparently and fails over all listeners registered in the node that failed
-to another node. During this fail over, the client might miss some events,
-which is why when the listeners are registered in a new node, the cache
-contents are iterated over and `ClientCacheEntryCreated` events (or custom
-events if configured) are generated.
+to another node.
+
+During this fail over the client might miss some events. To avoid missing
+these events, the client listener annotation contains an optional parameter
+called `includeCurrentState` which if set to true, when the failover happens,
+the cache contents can iterated over and `ClientCacheEntryCreated` events
+(or custom events if configured) are generated. By default,
+`includeCurrentState` is set to false.
 
 Java Hot Rod clients can be made aware of such fail over event by adding a
 callback to handle it:

--- a/documentation/src/main/asciidoc/user_guide/chapter-64-Hot_Rod_Protocol.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-64-Hot_Rod_Protocol.adoc
@@ -1147,6 +1147,12 @@ Request format:
 | Field Name          | Size       | Value
 | Header | variable | Request header
 | Listener ID   | byte array   | Listener identifier
+| Include state | byte         | When this byte is set to `1`, cached state is
+sent back to remote clients when either adding a cache listener for the first
+time, or when the node where a remote listener is registered changes in a clustered
+environment. When enabled, state is sent back as cache entry created events to
+the clients. If set to `0`, no state is sent back to the client when adding a listener,
+nor it gets state when the node where the listener is registered changes.
 | Key/value filter factory name | string | Optional name of the key/value filter
 factory to be used with this listener. The factory is used to create key/value
 filter instances which allow events to be filtered directly in the Hot Rod

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
@@ -310,10 +310,11 @@ object Decoder2x extends AbstractVersionedDecoder with ServerConstants with Log 
          }
          case AddClientListenerRequest =>
             val listenerId = readRangedBytes(buffer)
+            val includeState = if (buffer.readByte() == 0) false else true
             val filterFactoryInfo = readNamedFactory(buffer)
             val converterFactoryInfo = readNamedFactory(buffer)
             val reg = server.getClientListenerRegistry
-            reg.addClientListener(ch, h, listenerId, cache, filterFactoryInfo, converterFactoryInfo)
+            reg.addClientListener(ch, h, listenerId, cache, includeState, filterFactoryInfo, converterFactoryInfo)
             createSuccessResponse(h, null)
          case RemoveClientListenerRequest =>
             val listenerId = readRangedBytes(buffer)

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/AbstractHotRodClusterEventsTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/AbstractHotRodClusterEventsTest.scala
@@ -55,14 +55,14 @@ abstract class AbstractHotRodClusterEventsTest extends HotRodMultiNodeTest {
       val client2 = clients.tail.head
       val client3 = clients.tail.tail.head
       val listener1 = new EventLogListener
-      withClientListener(client1, listener1, None, None) { () =>
+      withClientListener(client1, listener1, includeState = false, None, None) { () =>
          val key = k(m)
          client2.put(key, 0, 0, v(m))
-         expectOnlyCreatedEvent(key)(listener1, anyCache())
+         listener1.expectOnlyCreatedEvent(key)(anyCache())
          client3.put(key, 0, 0, v(m, "v2-"))
-         expectOnlyModifiedEvent(key)(listener1, anyCache())
+         listener1.expectOnlyModifiedEvent(key)(anyCache())
          client2.remove(key)
-         expectOnlyRemovedEvent(key)(listener1, anyCache())
+         listener1.expectOnlyRemovedEvent(key)(anyCache())
       }
    }
 
@@ -70,18 +70,18 @@ abstract class AbstractHotRodClusterEventsTest extends HotRodMultiNodeTest {
       val client1 = clients.head
       val listener1 = new EventLogListener
       val key = k(m)
-      withClientListener(client1, listener1, None, None) { () =>
+      withClientListener(client1, listener1, includeState = false, None, None) { () =>
          client1.put(key, 0, 0, v(m))
-         expectOnlyCreatedEvent(key)(listener1, anyCache())
+         listener1.expectOnlyCreatedEvent(key)(anyCache())
          client1.put(key, 0, 0, v(m, "v2-"))
-         expectOnlyModifiedEvent(key)(listener1, anyCache())
+         listener1.expectOnlyModifiedEvent(key)(anyCache())
          client1.remove(key)
-         expectOnlyRemovedEvent(key)(listener1, anyCache())
+         listener1.expectOnlyRemovedEvent(key)(anyCache())
       }
       client1.put(key, 0, 0, v(m))
-      expectNoEvents()(listener1)
+      listener1.expectNoEvents()
       client1.remove(key)
-      expectNoEvents()(listener1)
+      listener1.expectNoEvents()
    }
 
    def testNoEventsAfterRemovingListenerInDifferentNode(m: Method) {
@@ -89,22 +89,22 @@ abstract class AbstractHotRodClusterEventsTest extends HotRodMultiNodeTest {
       val client2 = clients.tail.head
       val listener1 = new EventLogListener
       val key = k(m)
-      assertStatus(client1.addClientListener(listener1, None, None), Success)
+      assertStatus(client1.addClientListener(listener1, includeState = false, None, None), Success)
       try {
          client1.put(key, 0, 0, v(m))
-         expectOnlyCreatedEvent(key)(listener1, anyCache())
+         listener1.expectOnlyCreatedEvent(key)(anyCache())
          client1.put(key, 0, 0, v(m, "v2-"))
-         expectOnlyModifiedEvent(key)(listener1, anyCache())
+         listener1.expectOnlyModifiedEvent(key)(anyCache())
          client1.remove(key)
-         expectOnlyRemovedEvent(key)(listener1, anyCache())
+         listener1.expectOnlyRemovedEvent(key)(anyCache())
          // Use a client connected to a different node to attempt trying to remove listener
          client2.removeClientListener(listener1.getId)
          // The removal has no effect since the listener information is not clustered
          // Removal needs to be done in the node where the listener was added
          client1.put(key, 0, 0, v(m))
-         expectOnlyCreatedEvent(key)(listener1, anyCache())
+         listener1.expectOnlyCreatedEvent(key)(anyCache())
          client1.remove(key)
-         expectOnlyRemovedEvent(key)(listener1, anyCache())
+         listener1.expectOnlyRemovedEvent(key)(anyCache())
       } finally {
          assertStatus(client1.removeClientListener(listener1.getId), Success)
       }
@@ -114,13 +114,13 @@ abstract class AbstractHotRodClusterEventsTest extends HotRodMultiNodeTest {
       val client1 = clients.head
       val newClient = new HotRodClient("127.0.0.1", servers.tail.head.getPort, cacheName, 60, protocolVersion)
       val listener = new EventLogListener
-      assertStatus(newClient.addClientListener(listener, None, None), Success)
+      assertStatus(newClient.addClientListener(listener, includeState = false, None, None), Success)
       val key = k(m)
       client1.put(key, 0, 0, v(m))
-      expectOnlyCreatedEvent(key)(listener, anyCache())
+      listener.expectOnlyCreatedEvent(key)(anyCache())
       newClient.stop.await()
       client1.put(k(m, "k2-"), 0, 0, v(m))
-      expectNoEvents()(listener)
+      listener.expectNoEvents()
       client1.remove(key)
       client1.remove(k(m, "k2-"))
    }
@@ -131,26 +131,26 @@ abstract class AbstractHotRodClusterEventsTest extends HotRodMultiNodeTest {
       val client3 = clients.tail.tail.head
       val listener1 = new EventLogListener
       val listener2 = new EventLogListener
-      withClientListener(client1, listener1, None, None) { () =>
+      withClientListener(client1, listener1, includeState = false, None, None) { () =>
          val key = k(m)
          client2.put(key, 0, 0, v(m))
-         expectOnlyCreatedEvent(key)(listener1, anyCache())
+         listener1.expectOnlyCreatedEvent(key)(anyCache())
          client2.remove(key)
-         expectOnlyRemovedEvent(key)(listener1, anyCache())
+         listener1.expectOnlyRemovedEvent(key)(anyCache())
          val newServer = startClusteredServer(servers.last.getPort + 50)
          try {
             val client2 = new HotRodClient("127.0.0.1", newServer.getPort, cacheName, 60, protocolVersion)
-            withClientListener(client2, listener2, None, None) { () =>
+            withClientListener(client2, listener2, includeState = false, None, None) { () =>
                val newKey = k(m, "k2-")
                client3.put(newKey, 0, 0, v(m))
-               expectOnlyCreatedEvent(newKey)(listener1, anyCache())
-               expectOnlyCreatedEvent(newKey)(listener2, anyCache())
+               listener1.expectOnlyCreatedEvent(newKey)(anyCache())
+               listener2.expectOnlyCreatedEvent(newKey)(anyCache())
                client1.put(newKey, 0, 0, v(m, "v2-"))
-               expectOnlyModifiedEvent(newKey)(listener1, anyCache())
-               expectOnlyModifiedEvent(newKey)(listener2, anyCache())
+               listener1.expectOnlyModifiedEvent(newKey)(anyCache())
+               listener2.expectOnlyModifiedEvent(newKey)(anyCache())
                client2.remove(newKey)
-               expectOnlyRemovedEvent(newKey)(listener1, anyCache())
-               expectOnlyRemovedEvent(newKey)(listener2, anyCache())
+               listener1.expectOnlyRemovedEvent(newKey)(anyCache())
+               listener2.expectOnlyRemovedEvent(newKey)(anyCache())
             }
          } finally {
             stopClusteredServer(newServer)
@@ -159,14 +159,14 @@ abstract class AbstractHotRodClusterEventsTest extends HotRodMultiNodeTest {
          }
 
          client3.put(key, 0, 0, v(m, "v2-"))
-         expectOnlyCreatedEvent(key)(listener1, anyCache())
-         expectNoEvents()(listener2)
+         listener1.expectOnlyCreatedEvent(key)(anyCache())
+         listener2.expectNoEvents()
          client3.put(key, 0, 0, v(m, "v3-"))
-         expectOnlyModifiedEvent(key)(listener1, anyCache())
-         expectNoEvents()(listener2)
+         listener1.expectOnlyModifiedEvent(key)(anyCache())
+         listener2.expectNoEvents()
          client2.remove(key)
-         expectOnlyRemovedEvent(key)(listener1, anyCache())
-         expectNoEvents()(listener2)
+         listener1.expectOnlyRemovedEvent(key)(anyCache())
+         listener2.expectNoEvents()
       }
    }
 
@@ -178,13 +178,13 @@ abstract class AbstractHotRodClusterEventsTest extends HotRodMultiNodeTest {
       val key1 = k(m, "k1-")
       withClusterClientListener(client1, listener1, filterFactory, None, Some(key1)) { () =>
          client2.put(k(m, "k-99"), 0, 0, v(m))
-         expectNoEvents()(listener1)
+         listener1.expectNoEvents()
          client2.remove(k(m, "k-99"))
-         expectNoEvents()(listener1)
+         listener1.expectNoEvents()
          client2.put(key1, 0, 0, v(m))
-         expectOnlyCreatedEvent(key1)(listener1, anyCache())
+         listener1.expectOnlyCreatedEvent(key1)(anyCache())
          client1.remove(key1)
-         expectOnlyRemovedEvent(key1)(listener1, anyCache())
+         listener1.expectOnlyRemovedEvent(key1)(anyCache())
       }
    }
 
@@ -197,15 +197,15 @@ abstract class AbstractHotRodClusterEventsTest extends HotRodMultiNodeTest {
       withClusterClientListener(client1, listener1, filterFactory, None) { () =>
          val key1 = k(m, "k1-")
          client2.put(k(m, "k-99"), 0, 0, v(m))
-         expectNoEvents()(listener1)
+         listener1.expectNoEvents()
          client2.remove(k(m, "k-99"))
-         expectNoEvents()(listener1)
+         listener1.expectNoEvents()
          client2.put(key1, 0, 0, v(m))
-         expectNoEvents()(listener1)
+         listener1.expectNoEvents()
          client2.put(dynamicAcceptedKey, 0, 0, v(m))
-         expectOnlyCreatedEvent(dynamicAcceptedKey)(listener1, anyCache())
+         listener1.expectOnlyCreatedEvent(dynamicAcceptedKey)(anyCache())
          client1.remove(dynamicAcceptedKey)
-         expectOnlyRemovedEvent(dynamicAcceptedKey)(listener1, anyCache())
+         listener1.expectOnlyRemovedEvent(dynamicAcceptedKey)(anyCache())
       }
    }
 
@@ -223,13 +223,13 @@ abstract class AbstractHotRodClusterEventsTest extends HotRodMultiNodeTest {
 
          val key99 = k(m, "k-99")
          client2.put(key99, 0, 0, v(m))
-         expectSingleCustomEvent(Array(key99.length.toByte) ++ key99)(listener1, anyCache())
+         listener1.expectSingleCustomEvent(Array(key99.length.toByte) ++ key99)(anyCache())
          client2.put(key1, 0, 0, v(m))
-         expectSingleCustomEvent(Array(key1Length) ++ key1 ++ Array(valueLength) ++ value)(listener1, anyCache())
+         listener1.expectSingleCustomEvent(Array(key1Length) ++ key1 ++ Array(valueLength) ++ value)(anyCache())
          client2.remove(key99)
-         expectSingleCustomEvent(Array(key99.length.toByte) ++ key99)(listener1, anyCache())
+         listener1.expectSingleCustomEvent(Array(key99.length.toByte) ++ key99)(anyCache())
          client2.remove(key1)
-         expectSingleCustomEvent(Array(key1Length) ++ key1)(listener1, anyCache())
+         listener1.expectSingleCustomEvent(Array(key1Length) ++ key1)(anyCache())
       }
    }
 
@@ -248,13 +248,13 @@ abstract class AbstractHotRodClusterEventsTest extends HotRodMultiNodeTest {
 
          val key99 = k(m, "k-99")
          client2.put(key99, 0, 0, v(m))
-         expectSingleCustomEvent(Array(key99.length.toByte) ++ key99)(listener1, anyCache())
+         listener1.expectSingleCustomEvent(Array(key99.length.toByte) ++ key99)(anyCache())
          client2.put(key1, 0, 0, v(m))
-         expectSingleCustomEvent(Array(key1Length) ++ key1)(listener1, anyCache())
+         listener1.expectSingleCustomEvent(Array(key1Length) ++ key1)(anyCache())
          client2.put(convertedKey, 0, 0, v(m))
-         expectSingleCustomEvent(Array(convertedKeyLength) ++ convertedKey ++ Array(valueLength) ++ value)(listener1, anyCache())
+         listener1.expectSingleCustomEvent(Array(convertedKeyLength) ++ convertedKey ++ Array(valueLength) ++ value)(anyCache())
          client1.remove(convertedKey)
-         expectSingleCustomEvent(Array(convertedKeyLength) ++ convertedKey)(listener1, anyCache())
+         listener1.expectSingleCustomEvent(Array(convertedKeyLength) ++ convertedKey)(anyCache())
       }
    }
 
@@ -269,15 +269,37 @@ abstract class AbstractHotRodClusterEventsTest extends HotRodMultiNodeTest {
       client2.put(k2, 0, 0, v2)
       client3.put(k3, 0, 0, v3)
       val listener1 = new EventLogListener
-      withClientListener(client1, listener1, None, None) { () =>
+      withClientListener(client1, listener1, includeState = true, None, None) { () =>
          val keys = List(k1, k2, k3)
-         expectUnorderedEvents(keys, Event.Type.CACHE_ENTRY_CREATED)(listener1, anyCache())
+         listener1.expectUnorderedEvents(keys, Event.Type.CACHE_ENTRY_CREATED)(anyCache())
          client1.remove(k1)
-         expectOnlyRemovedEvent(k1)(listener1, anyCache())
+         listener1.expectOnlyRemovedEvent(k1)(anyCache())
          client2.remove(k2)
-         expectOnlyRemovedEvent(k2)(listener1, anyCache())
+         listener1.expectOnlyRemovedEvent(k2)(anyCache())
          client3.remove(k3)
-         expectOnlyRemovedEvent(k3)(listener1, anyCache())
+         listener1.expectOnlyRemovedEvent(k3)(anyCache())
+      }
+   }
+
+   def testNoEventReplayAfterAddingListenerInCluster(m: Method) {
+      val client1 = clients.head
+      val client2 = clients.tail.head
+      val client3 = clients.tail.tail.head
+      val (k1, v1) = (k(m, "k1-"), v(m, "v1-"))
+      val (k2, v2) = (k(m, "k2-"), v(m, "v2-"))
+      val (k3, v3) = (k(m, "k3-"), v(m, "v3-"))
+      client1.put(k1, 0, 0, v1)
+      client2.put(k2, 0, 0, v2)
+      client3.put(k3, 0, 0, v3)
+      val listener1 = new EventLogListener
+      withClientListener(client1, listener1, includeState = false, None, None) { () =>
+         listener1.expectNoEvents()
+         client1.remove(k1)
+         listener1.expectOnlyRemovedEvent(k1)(anyCache())
+         client2.remove(k2)
+         listener1.expectOnlyRemovedEvent(k2)(anyCache())
+         client3.remove(k3)
+         listener1.expectOnlyRemovedEvent(k3)(anyCache())
       }
    }
 
@@ -286,11 +308,11 @@ abstract class AbstractHotRodClusterEventsTest extends HotRodMultiNodeTest {
 
    private def withClusterClientListener(client: HotRodClient, listener: TestClientListener,
            filterFactory: NamedFactory, converterFactory: NamedFactory,
-           staticKey: Option[Bytes] = None)
+           staticKey: Option[Bytes] = None, includeState: Boolean = false)
            (fn: () => Unit): Unit = {
       filters.foreach(_.staticKey = staticKey)
       converters.foreach(_.staticKey = staticKey)
-      assertStatus(client.addClientListener(listener, filterFactory, converterFactory), Success)
+      assertStatus(client.addClientListener(listener, includeState, filterFactory, converterFactory), Success)
       try {
          fn()
       } finally {

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/EventLogListener.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/EventLogListener.scala
@@ -1,9 +1,15 @@
 package org.infinispan.server.hotrod.event
 
-import org.infinispan.server.hotrod.test.{TestCustomEvent, TestKeyEvent, TestKeyWithVersionEvent, TestClientListener}
-import java.util.concurrent.{BlockingQueue, TimeUnit, ArrayBlockingQueue}
+import java.util.concurrent.{ArrayBlockingQueue, BlockingQueue, TimeUnit}
+
+import org.infinispan.container.versioning.NumericVersion
 import org.infinispan.notifications.cachelistener.event.Event
-import org.infinispan.server.hotrod.Bytes
+import org.infinispan.server.hotrod._
+import org.infinispan.server.hotrod.test.HotRodTestingUtil._
+import org.infinispan.server.hotrod.test.{TestClientListener, TestCustomEvent, TestKeyEvent, TestKeyWithVersionEvent}
+import org.testng.AssertJUnit.{assertEquals, assertFalse, assertNotNull}
+
+import scala.collection.mutable.ListBuffer
 
 /**
  * @author Galder Zamarreño
@@ -39,4 +45,96 @@ private[event] class EventLogListener extends TestClientListener {
    override def onCustom(event: TestCustomEvent): Unit = customEvents.add(event)
 
    override def getId: Bytes = Array[Byte](1, 2, 3)
+
+   def expectNoEvents(eventType: Option[Event.Type] = None): Unit = {
+      eventType match {
+         case None =>
+            assertEquals(0, queueSize(Event.Type.CACHE_ENTRY_CREATED))
+            assertEquals(0, queueSize(Event.Type.CACHE_ENTRY_MODIFIED))
+            assertEquals(0, queueSize(Event.Type.CACHE_ENTRY_REMOVED))
+            assertEquals(0, customQueueSize())
+         case Some(t) =>
+            assertEquals(0, queueSize(t))
+      }
+   }
+
+   def expectOnlyRemovedEvent(k: Bytes)(implicit cache: Cache): Unit = {
+      expectSingleEvent(k, Event.Type.CACHE_ENTRY_REMOVED)
+      expectNoEvents(Some(Event.Type.CACHE_ENTRY_CREATED))
+      expectNoEvents(Some(Event.Type.CACHE_ENTRY_MODIFIED))
+   }
+
+   def expectOnlyModifiedEvent(k: Bytes)(implicit cache: Cache): Unit = {
+      expectSingleEvent(k, Event.Type.CACHE_ENTRY_MODIFIED)
+      expectNoEvents(Some(Event.Type.CACHE_ENTRY_CREATED))
+      expectNoEvents(Some(Event.Type.CACHE_ENTRY_REMOVED))
+   }
+
+   def expectOnlyCreatedEvent(k: Bytes)(implicit cache: Cache): Unit = {
+      expectSingleEvent(k, Event.Type.CACHE_ENTRY_CREATED)
+      expectNoEvents(Some(Event.Type.CACHE_ENTRY_MODIFIED))
+      expectNoEvents(Some(Event.Type.CACHE_ENTRY_REMOVED))
+   }
+
+   def expectSingleEvent(k: Bytes, eventType: Event.Type)(implicit cache: Cache): Unit = {
+      expectEvent(k, eventType)
+      assertEquals(0, queueSize(eventType))
+   }
+
+   def expectEvent(k: Bytes, eventType: Event.Type)(implicit cache: Cache): Unit = {
+      val event = pollEvent(eventType)
+      assertNotNull(event)
+      event match {
+         case t: TestKeyWithVersionEvent =>
+            assertByteArrayEquals(k, t.key)
+            assertEquals(serverDataVersion(k, cache), t.dataVersion)
+         case t: TestKeyEvent =>
+            assertByteArrayEquals(k, t.key)
+      }
+   }
+
+   def expectUnorderedEvents(keys: Seq[Bytes], eventType: Event.Type)(implicit cache: Cache): Unit = {
+      val assertedKeys = ListBuffer[Bytes]()
+
+      def checkUnorderedKeyEvent(key: Bytes, eventKey: Bytes): Boolean = {
+         if (java.util.Arrays.equals(key, eventKey)) {
+            assertFalse(assertedKeys.contains(key))
+            assertedKeys += key
+            true
+         } else false
+      }
+
+      for (i <- 0 until keys.size) {
+         val event = pollEvent(eventType)
+         assertNotNull(event)
+         val initialSize = assertedKeys.size
+         keys.foreach { key =>
+            event match {
+               case t: TestKeyWithVersionEvent =>
+                  val keyMatched = checkUnorderedKeyEvent(key, t.key)
+                  if (keyMatched)
+                     assertEquals(serverDataVersion(key, cache), t.dataVersion)
+               case t: TestKeyEvent =>
+                  checkUnorderedKeyEvent(key, t.key)
+            }
+         }
+         val finalSize = assertedKeys.size
+         assertEquals(initialSize + 1, finalSize)
+      }
+   }
+
+   def expectSingleCustomEvent(eventData: Bytes)(implicit cache: Cache): Unit = {
+      val event = pollCustom()
+      assertNotNull(event)
+      event match {
+         case t: TestCustomEvent => assertByteArrayEquals(eventData, t.eventData)
+      }
+      val remaining = customQueueSize()
+      assertEquals(0, remaining)
+   }
+
+   def serverDataVersion(k: Bytes, cache: Cache): Long =
+      cache.getCacheEntry(k)
+              .getMetadata.version().asInstanceOf[NumericVersion].getVersion
+
 }

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/HotRodCustomEventsTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/HotRodCustomEventsTest.scala
@@ -1,7 +1,6 @@
 package org.infinispan.server.hotrod.event
 
 import java.lang.reflect.Method
-import java.util
 import java.util.concurrent.{TimeUnit, ArrayBlockingQueue}
 import org.infinispan.filter.{ConverterFactory, Converter}
 import org.infinispan.manager.EmbeddedCacheManager
@@ -18,90 +17,98 @@ import org.testng.annotations.Test
 @Test(groups = Array("functional"), testName = "server.hotrod.event.HotRodCustomEventsTest")
 class HotRodCustomEventsTest extends HotRodSingleNodeTest {
 
-   val converterFactory = new TestConverterFactory
-
    override protected def createStartHotRodServer(cacheManager: EmbeddedCacheManager): HotRodServer = {
       val builder = new HotRodServerConfigurationBuilder
       // Storing unmarshalled byte arrays, so nullify default marshaller
       builder.marshallerClass(null)
       val server = HotRodTestingUtil.startHotRodServer(cacheManager, builder)
-      server.addConverterFactory("test-converter-factory", converterFactory)
+      server.addConverterFactory("static-converter-factory", new StaticConverterFactory)
+      server.addConverterFactory("dynamic-converter-factory", new DynamicConverterFactory)
       server
    }
 
    def testCustomEvents(m: Method) {
-      implicit val eventListener = new CustomEventListener
-      converterFactory.dynamic = false
-      withClientListener(converterFactory = Some(("test-converter-factory", List.empty))) { () =>
-         expectNoEvents()
+      implicit val eventListener = new EventLogListener
+      withClientListener(converterFactory = Some(("static-converter-factory", List.empty))) { () =>
+         eventListener.expectNoEvents()
          val key = k(m)
          val keyLength = key.length.toByte
          val value = v(m)
          val valueLength = value.length.toByte
          client.put(key, 0, 0, value)
-         expectSingleCustomEvent(Array(keyLength) ++ key ++ Array(valueLength) ++ value)
+         eventListener.expectSingleCustomEvent(Array(keyLength) ++ key ++ Array(valueLength) ++ value)
          val value2 = v(m, "v2-")
          val value2Length = value2.length.toByte
          client.put(key, 0, 0, value2)
-         expectSingleCustomEvent(Array(keyLength) ++ key ++ Array(value2Length) ++ value2)
+         eventListener.expectSingleCustomEvent(Array(keyLength) ++ key ++ Array(value2Length) ++ value2)
          client.remove(key)
-         expectSingleCustomEvent(Array(keyLength) ++ key)
+         eventListener.expectSingleCustomEvent(Array(keyLength) ++ key)
       }
    }
 
    def testParameterBasedConversion(m: Method) {
-      implicit val eventListener = new CustomEventListener
-      converterFactory.dynamic = true
+      implicit val eventListener = new EventLogListener
       val customConvertKey = Array[Byte](4, 5, 6)
       val customConvertKeyLength = customConvertKey.length.toByte
-      withClientListener(converterFactory = Some(("test-converter-factory", List(Array[Byte](4, 5, 6))))) { () =>
-         expectNoEvents()
+      withClientListener(converterFactory = Some(("dynamic-converter-factory", List(Array[Byte](4, 5, 6))))) { () =>
+         eventListener.expectNoEvents()
          val key = k(m)
          val keyLength = key.length.toByte
          val value = v(m)
          val valueLength = value.length.toByte
          client.put(key, 0, 0, value)
-         expectSingleCustomEvent(Array(keyLength) ++ key ++ Array(valueLength) ++ value)
+         eventListener.expectSingleCustomEvent(Array(keyLength) ++ key ++ Array(valueLength) ++ value)
          val value2 = v(m, "v2-")
          val value2Length = value2.length.toByte
          client.put(key, 0, 0, value2)
-         expectSingleCustomEvent(Array(keyLength) ++ key ++ Array(value2Length) ++ value2)
+         eventListener.expectSingleCustomEvent(Array(keyLength) ++ key ++ Array(value2Length) ++ value2)
          client.remove(key)
-         expectSingleCustomEvent(Array(keyLength) ++ key)
+         eventListener.expectSingleCustomEvent(Array(keyLength) ++ key)
          client.put(customConvertKey, 0, 0, value)
-         expectSingleCustomEvent(Array(customConvertKeyLength) ++ customConvertKey)
+         eventListener.expectSingleCustomEvent(Array(customConvertKeyLength) ++ customConvertKey)
+      }
+   }
+
+   def testConvertedEventsNoReplay(m: Method) {
+      implicit val eventListener = new EventLogListener
+      val key = Array[Byte](1)
+      val value = Array[Byte](2)
+      client.put(key, 0, 0, value)
+      withClientListener(converterFactory = Some(("static-converter-factory", List.empty))) { () =>
+         eventListener.expectNoEvents()
       }
    }
 
    def testConvertedEventsReplay(m: Method) {
-      implicit val eventListener = new CustomEventListener
-      converterFactory.dynamic = false
+      implicit val eventListener = new EventLogListener
       val key = Array[Byte](1)
       val keyLength = key.length.toByte
       val value = Array[Byte](2)
       val valueLength = value.length.toByte
       client.put(key, 0, 0, value)
-      withClientListener(converterFactory = Some(("test-converter-factory", List.empty))) { () =>
-         expectSingleCustomEvent(Array(keyLength) ++ key ++ Array(valueLength) ++ value)
+      withClientListener(converterFactory = Some(("static-converter-factory", List.empty)), includeState = true) { () =>
+         eventListener.expectSingleCustomEvent(Array(keyLength) ++ key ++ Array(valueLength) ++ value)
       }
    }
 
-   private class CustomEventListener extends TestClientListener {
-      private val customEvents =  new ArrayBlockingQueue[TestCustomEvent](128)
-
-      override def customQueueSize(): Int = customEvents.size()
-      override def pollCustom(): TestCustomEvent = customEvents.poll(10, TimeUnit.SECONDS)
-      override def onCustom(event: TestCustomEvent): Unit = customEvents.add(event)
-      override def getId: Bytes = Array[Byte](1, 2, 3)
-   }
-
-   class TestConverterFactory extends ConverterFactory {
-      var dynamic = false
+   class StaticConverterFactory extends ConverterFactory {
       override def getConverter[K, V, C](params: Array[AnyRef]): Converter[K, V, C] = {
          new Converter[Bytes, Bytes, Bytes] {
             override def convert(key: Bytes, value: Bytes, metadata: Metadata): Bytes = {
                val keyLength = key.length.toByte
-               if (value == null || (dynamic && util.Arrays.equals(params.head.asInstanceOf[Bytes], key)))
+               if (value == null) Array(keyLength) ++ key
+               else Array(keyLength) ++ key ++ Array(value.length.toByte) ++ value
+            }
+         }.asInstanceOf[Converter[K, V, C]] // ugly but it works :|
+      }
+   }
+
+   class DynamicConverterFactory extends ConverterFactory {
+      override def getConverter[K, V, C](params: Array[AnyRef]): Converter[K, V, C] = {
+         new Converter[Bytes, Bytes, Bytes] {
+            override def convert(key: Bytes, value: Bytes, metadata: Metadata): Bytes = {
+               val keyLength = key.length.toByte
+               if (value == null || java.util.Arrays.equals(params.head.asInstanceOf[Bytes], key))
                   Array(keyLength) ++ key
                else
                   Array(keyLength) ++ key ++ Array(value.length.toByte) ++ value

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/HotRodEventsTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/HotRodEventsTest.scala
@@ -15,116 +15,116 @@ class HotRodEventsTest extends HotRodSingleNodeTest {
    def testCreatedEvent(m: Method) {
       implicit val eventListener = new EventLogListener
       withClientListener() { () =>
-         expectNoEvents()
+         eventListener.expectNoEvents()
          val key = k(m)
          client.put(key, 0, 0, v(m))
-         expectOnlyCreatedEvent(key)
+         eventListener.expectOnlyCreatedEvent(key)
       }
    }
 
    def testModifiedEvent(m: Method) {
       implicit val eventListener = new EventLogListener
       withClientListener() { () =>
-         expectNoEvents()
+         eventListener.expectNoEvents()
          val key = k(m)
          client.put(key, 0, 0, v(m))
-         expectOnlyCreatedEvent(key)
+         eventListener.expectOnlyCreatedEvent(key)
          client.put(key, 0, 0, v(m, "v2-"))
-         expectOnlyModifiedEvent(key)
+         eventListener.expectOnlyModifiedEvent(key)
       }
    }
 
    def testRemovedEvent(m: Method) {
       implicit val eventListener = new EventLogListener
       withClientListener() { () =>
-         expectNoEvents()
+         eventListener.expectNoEvents()
          val key = k(m)
          client.put(key, 0, 0, v(m))
-         expectOnlyCreatedEvent(key)
+         eventListener.expectOnlyCreatedEvent(key)
          client.remove(key)
-         expectOnlyRemovedEvent(key)
+         eventListener.expectOnlyRemovedEvent(key)
       }
    }
 
    def testReplaceEvents(m: Method) {
       implicit val eventListener = new EventLogListener
       withClientListener() { () =>
-         expectNoEvents()
+         eventListener.expectNoEvents()
          val key = k(m)
          client.replace(key, 0, 0, v(m))
-         expectNoEvents()
+         eventListener.expectNoEvents()
          client.put(key, 0, 0, v(m))
-         expectOnlyCreatedEvent(key)
+         eventListener.expectOnlyCreatedEvent(key)
          client.replace(key, 0, 0, v(m, "v2-"))
-         expectOnlyModifiedEvent(key)
+         eventListener.expectOnlyModifiedEvent(key)
       }
    }
 
    def testPutIfAbsentEvents(m: Method) {
       implicit val eventListener = new EventLogListener
       withClientListener() { () =>
-         expectNoEvents()
+         eventListener.expectNoEvents()
          val key = k(m)
          client.putIfAbsent(key, 0, 0, v(m))
-         expectOnlyCreatedEvent(key)
+         eventListener.expectOnlyCreatedEvent(key)
          client.putIfAbsent(key, 0, 0, v(m, "v2-"))
-         expectNoEvents()
+         eventListener.expectNoEvents()
       }
    }
 
    def testReplaceIfUnmodifiedEvents(m: Method) {
       implicit val eventListener = new EventLogListener
       withClientListener() { () =>
-         expectNoEvents()
+         eventListener.expectNoEvents()
          val key = k(m)
          client.replaceIfUnmodified(key, 0, 0, v(m), 0)
-         expectNoEvents()
+         eventListener.expectNoEvents()
          client.put(key, 0, 0, v(m))
-         expectOnlyCreatedEvent(key)
+         eventListener.expectOnlyCreatedEvent(key)
          client.replaceIfUnmodified(key, 0, 0, v(m), 0)
-         expectNoEvents()
+         eventListener.expectNoEvents()
          val resp = client.getWithVersion(k(m), 0)
          assertSuccess(resp, v(m), 0)
          client.replaceIfUnmodified(k(m), 0, 0, v(m, "v1-"), resp.dataVersion)
-         expectOnlyModifiedEvent(key)
+         eventListener.expectOnlyModifiedEvent(key)
       }
    }
 
    def testRemoveIfUnmodifiedEvents(m: Method) {
       implicit val eventListener = new EventLogListener
       withClientListener() { () =>
-         expectNoEvents()
+         eventListener.expectNoEvents()
          val key = k(m)
          client.removeIfUnmodified(key, 0, 0, v(m), 0)
-         expectNoEvents()
+         eventListener.expectNoEvents()
          client.put(key, 0, 0, v(m))
-         expectOnlyCreatedEvent(key)
+         eventListener.expectOnlyCreatedEvent(key)
          client.removeIfUnmodified(key, 0, 0, v(m), 0)
-         expectNoEvents()
+         eventListener.expectNoEvents()
          val resp = client.getWithVersion(k(m), 0)
          assertSuccess(resp, v(m), 0)
          client.removeIfUnmodified(k(m), 0, 0, v(m, "v1-"), resp.dataVersion)
-         expectOnlyRemovedEvent(key)
+         eventListener.expectOnlyRemovedEvent(key)
       }
    }
 
    def testClearEvents(m: Method) {
       implicit val eventListener = new EventLogListener
       withClientListener() { () =>
-         expectNoEvents()
+         eventListener.expectNoEvents()
          val key1 = k(m, "k1")
          val key2 = k(m, "k2")
          val key3 = k(m, "k3")
          client.put(key1, 0, 0, v(m))
-         expectOnlyCreatedEvent(key1)
+         eventListener.expectOnlyCreatedEvent(key1)
          client.put(key2, 0, 0, v(m))
-         expectOnlyCreatedEvent(key2)
+         eventListener.expectOnlyCreatedEvent(key2)
          client.put(key3, 0, 0, v(m))
-         expectOnlyCreatedEvent(key3)
+         eventListener.expectOnlyCreatedEvent(key3)
          client.clear
          // Order in which clear operates cannot be guaranteed
          val keys = List(key1, key2, key3)
-         expectUnorderedEvents(keys, Event.Type.CACHE_ENTRY_REMOVED)
+         eventListener.expectUnorderedEvents(keys, Event.Type.CACHE_ENTRY_REMOVED)
       }
    }
 
@@ -132,18 +132,18 @@ class HotRodEventsTest extends HotRodSingleNodeTest {
       implicit val eventListener = new EventLogListener
       val key = k(m)
       client.put(key, 0, 0, v(m))
-      expectNoEvents()
+      eventListener.expectNoEvents()
       client.put(key, 0, 0, v(m, "v2-"))
-      expectNoEvents()
+      eventListener.expectNoEvents()
       client.remove(key)
       withClientListener() { () =>
          val key = k(m, "k2-")
          client.put(key, 0, 0, v(m))
-         expectSingleEvent(key, Event.Type.CACHE_ENTRY_CREATED)
+         eventListener.expectSingleEvent(key, Event.Type.CACHE_ENTRY_CREATED)
          client.put(key, 0, 0, v(m, "v2-"))
-         expectSingleEvent(key, Event.Type.CACHE_ENTRY_MODIFIED)
+         eventListener.expectSingleEvent(key, Event.Type.CACHE_ENTRY_MODIFIED)
          client.remove(key)
-         expectSingleEvent(key, Event.Type.CACHE_ENTRY_REMOVED)
+         eventListener.expectSingleEvent(key, Event.Type.CACHE_ENTRY_REMOVED)
       }
    }
 
@@ -152,19 +152,19 @@ class HotRodEventsTest extends HotRodSingleNodeTest {
       withClientListener() { () =>
          val key = k(m)
          client.put(key, 0, 0, v(m))
-         expectSingleEvent(key, Event.Type.CACHE_ENTRY_CREATED)
+         eventListener.expectSingleEvent(key, Event.Type.CACHE_ENTRY_CREATED)
          client.put(key, 0, 0, v(m, "v2-"))
-         expectSingleEvent(key, Event.Type.CACHE_ENTRY_MODIFIED)
+         eventListener.expectSingleEvent(key, Event.Type.CACHE_ENTRY_MODIFIED)
          client.remove(key)
-         expectSingleEvent(key, Event.Type.CACHE_ENTRY_REMOVED)
+         eventListener.expectSingleEvent(key, Event.Type.CACHE_ENTRY_REMOVED)
       }
       val key = k(m, "k2-")
       client.put(key, 0, 0, v(m))
-      expectNoEvents()
+      eventListener.expectNoEvents()
       client.put(key, 0, 0, v(m, "v2-"))
-      expectNoEvents()
+      eventListener.expectNoEvents()
       client.remove(key)
-      expectNoEvents()
+      eventListener.expectNoEvents()
    }
 
    def testEventReplayAfterAddingListener(m: Method) {
@@ -175,8 +175,8 @@ class HotRodEventsTest extends HotRodSingleNodeTest {
       client.put(k1, 0, 0, v1)
       client.put(k2, 0, 0, v2)
       client.put(k3, 0, 0, v3)
-      withClientListener() { () =>
-         expectUnorderedEvents(List(k1, k2, k3), Event.Type.CACHE_ENTRY_CREATED)
+      withClientListener(includeState = true) { () =>
+         eventListener.expectUnorderedEvents(List(k1, k2, k3), Event.Type.CACHE_ENTRY_CREATED)
       }
    }
 

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/HotRodFilterEventsTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/HotRodFilterEventsTest.scala
@@ -17,54 +17,50 @@ import org.testng.annotations.Test
 @Test(groups = Array("functional"), testName = "server.hotrod.event.HotRodFilterEventsTest")
 class HotRodFilterEventsTest extends HotRodSingleNodeTest {
 
-   val staticKey = Array[Byte](1, 2, 3)
-   val keyValueFilterFactory = new AcceptedKeyValueFilterFactory()
-
    override protected def createStartHotRodServer(cacheManager: EmbeddedCacheManager): HotRodServer = {
       val builder = new HotRodServerConfigurationBuilder
       builder.marshallerClass(null)
       val server = startHotRodServer(cacheManager, builder)
-      server.addKeyValueFilterFactory("test-filter-factory", keyValueFilterFactory)
+      server.addKeyValueFilterFactory("static-filter-factory", new StaticKeyValueFilterFactory(Array[Byte](1, 2, 3)))
+      server.addKeyValueFilterFactory("dynamic-filter-factory", new DynamicKeyValueFilterFactory())
       server
    }
 
    def testFilteredEvents(m: Method) {
       implicit val eventListener = new EventLogListener
       val acceptedKey = Array[Byte](1, 2, 3)
-      keyValueFilterFactory.dynamic = false
-      withClientListener(Some(("test-filter-factory", List.empty))) { () =>
-         expectNoEvents()
+      withClientListener(filterFactory = Some(("static-filter-factory", List.empty))) { () =>
+         eventListener.expectNoEvents()
          val key = k(m)
          client.put(key, 0, 0, v(m))
-         expectNoEvents()
+         eventListener.expectNoEvents()
          client.put(acceptedKey, 0, 0, v(m))
-         expectSingleEvent(acceptedKey, Event.Type.CACHE_ENTRY_CREATED)
+         eventListener.expectSingleEvent(acceptedKey, Event.Type.CACHE_ENTRY_CREATED)
          client.put(acceptedKey, 0, 0, v(m, "v2-"))
-         expectSingleEvent(acceptedKey, Event.Type.CACHE_ENTRY_MODIFIED)
+         eventListener.expectSingleEvent(acceptedKey, Event.Type.CACHE_ENTRY_MODIFIED)
          client.remove(key)
-         expectNoEvents()
+         eventListener.expectNoEvents()
          client.remove(acceptedKey)
-         expectSingleEvent(acceptedKey, Event.Type.CACHE_ENTRY_REMOVED)
+         eventListener.expectSingleEvent(acceptedKey, Event.Type.CACHE_ENTRY_REMOVED)
       }
    }
 
    def testParameterBasedFiltering(m: Method) {
       implicit val eventListener = new EventLogListener
       val acceptedKey = Array[Byte](4, 5, 6)
-      keyValueFilterFactory.dynamic = true
-      withClientListener(Some(("test-filter-factory", List(Array[Byte](4, 5, 6))))) { () =>
-         expectNoEvents()
+      withClientListener(filterFactory = Some(("dynamic-filter-factory", List(Array[Byte](4, 5, 6))))) { () =>
+         eventListener.expectNoEvents()
          val key = k(m)
          client.put(key, 0, 0, v(m))
-         expectNoEvents()
+         eventListener.expectNoEvents()
          client.put(acceptedKey, 0, 0, v(m))
-         expectSingleEvent(acceptedKey, Event.Type.CACHE_ENTRY_CREATED)
+         eventListener.expectSingleEvent(acceptedKey, Event.Type.CACHE_ENTRY_CREATED)
          client.put(acceptedKey, 0, 0, v(m, "v2-"))
-         expectSingleEvent(acceptedKey, Event.Type.CACHE_ENTRY_MODIFIED)
+         eventListener.expectSingleEvent(acceptedKey, Event.Type.CACHE_ENTRY_MODIFIED)
          client.remove(key)
-         expectNoEvents()
+         eventListener.expectNoEvents()
          client.remove(acceptedKey)
-         expectSingleEvent(acceptedKey, Event.Type.CACHE_ENTRY_REMOVED)
+         eventListener.expectSingleEvent(acceptedKey, Event.Type.CACHE_ENTRY_REMOVED)
       }
    }
 
@@ -76,21 +72,46 @@ class HotRodFilterEventsTest extends HotRodSingleNodeTest {
       client.put(key, 0, 0, v(m))
       client.put(staticAcceptedKey, 0, 0, v(m))
       client.put(dynamicAcceptedKey, 0, 0, v(m))
-      withClientListener(Some(("test-filter-factory", List.empty))) { () =>
-         expectSingleEvent(staticAcceptedKey, Event.Type.CACHE_ENTRY_CREATED)
+      withClientListener(filterFactory = Some(("static-filter-factory", List.empty)), includeState = true) { () =>
+         eventListener.expectSingleEvent(staticAcceptedKey, Event.Type.CACHE_ENTRY_CREATED)
       }
-      keyValueFilterFactory.dynamic = true
-      withClientListener(Some(("test-filter-factory", List(Array[Byte](7, 8, 9))))) { () =>
-         expectSingleEvent(dynamicAcceptedKey, Event.Type.CACHE_ENTRY_CREATED)
+      withClientListener(filterFactory = Some(("dynamic-filter-factory", List(Array[Byte](7, 8, 9)))), includeState = true) { () =>
+         eventListener.expectSingleEvent(dynamicAcceptedKey, Event.Type.CACHE_ENTRY_CREATED)
       }
    }
 
-   class AcceptedKeyValueFilterFactory extends KeyValueFilterFactory {
-      var dynamic = false
+   def testFilteredEventsNoReplay(m: Method) {
+      implicit val eventListener = new EventLogListener
+      val staticAcceptedKey = Array[Byte](1, 2, 3)
+      val dynamicAcceptedKey = Array[Byte](7, 8, 9)
+      val key = k(m)
+      client.put(key, 0, 0, v(m))
+      client.put(staticAcceptedKey, 0, 0, v(m))
+      client.put(dynamicAcceptedKey, 0, 0, v(m))
+      withClientListener(filterFactory = Some(("static-filter-factory", List.empty)), includeState = false) { () =>
+         eventListener.expectNoEvents()
+      }
+      withClientListener(filterFactory = Some(("dynamic-filter-factory", List(Array[Byte](7, 8, 9)))), includeState = false) { () =>
+         eventListener.expectNoEvents()
+      }
+   }
+
+   class StaticKeyValueFilterFactory(staticKey: Bytes) extends KeyValueFilterFactory {
       override def getKeyValueFilter[K, V](params: Array[AnyRef]): KeyValueFilter[K, V] = {
          new KeyValueFilter[Bytes, Bytes] {
             override def accept(key: Bytes, value: Bytes, metadata: Metadata): Boolean = {
-               val acceptedKey = if (dynamic) params.head.asInstanceOf[Bytes] else staticKey
+               if (util.Arrays.equals(key, staticKey)) true else false
+            }
+
+         }
+      }.asInstanceOf[KeyValueFilter[K, V]]
+   }
+
+   class DynamicKeyValueFilterFactory extends KeyValueFilterFactory {
+      override def getKeyValueFilter[K, V](params: Array[AnyRef]): KeyValueFilter[K, V] = {
+         new KeyValueFilter[Bytes, Bytes] {
+            override def accept(key: Bytes, value: Bytes, metadata: Metadata): Boolean = {
+               val acceptedKey = params.head.asInstanceOf[Bytes]
                if (util.Arrays.equals(key, acceptedKey)) true else false
             }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4377
- Add attribute to @ClientListener annotation to decide whether to send back state to clients when adding listener or upon failover.
- Refactored Hot Rod server event log listener to add assertions to the listener itself.
- Added missing javadoc to @ClientListener.
- Modified addListener protocol operation to support optional inclusion of state.
- Updated Hot Rod protocol 2.0 specification to add new flag for addListener operation.
- Updated Hot Rod client documentation to specify how include current state functionality works both when adding a new listener for the first time, and upon failover.
