### PR TITLE
ISPN-4678 Trim down ExpandableMarshalledValueByteStream to the actual da...

### DIFF
--- a/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
@@ -3,9 +3,12 @@ package org.infinispan.container.entries;
 import org.infinispan.atomic.impl.AtomicHashMap;
 import org.infinispan.commons.util.Util;
 import org.infinispan.container.DataContainer;
+import org.infinispan.marshall.core.MarshalledValue;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+
+import java.util.Arrays;
 
 import static org.infinispan.commons.util.Util.toStr;
 import static org.infinispan.container.entries.ReadCommittedEntry.Flags.*;
@@ -162,11 +165,22 @@ public class ReadCommittedEntry implements MVCCEntry {
             // Can't just rely on the entry's metadata because it could have
             // been modified by the interceptor chain (i.e. new version
             // generated if none provided by the user)
-            container.put(key, value,
+            container.put(compact(key), compact(value),
                   providedMetadata == null ? metadata : providedMetadata);
          }
          reset();
       }
+   }
+
+   private Object compact(Object val) {
+      if (val instanceof MarshalledValue) {
+         MarshalledValue marshalled = (MarshalledValue) val;
+         if (marshalled.getRaw().size() < marshalled.getRaw().getRaw().length) {
+            byte[] compactedArray = Arrays.copyOfRange(marshalled.getRaw().getRaw(), 0, marshalled.getRaw().size());
+            return new MarshalledValue(compactedArray, marshalled.hashCode(), marshalled.getMarshaller());
+         }
+      }
+      return val;
    }
 
    private void reset() {

--- a/core/src/main/java/org/infinispan/marshall/core/MarshalledValue.java
+++ b/core/src/main/java/org/infinispan/marshall/core/MarshalledValue.java
@@ -123,6 +123,10 @@ public final class MarshalledValue implements Externalizable {
       return deserialize();
    }
 
+   public StreamingMarshaller getMarshaller() {
+      return marshaller;
+   }
+
    @Override
    public boolean equals(Object o) {
       if (this == o) return true;


### PR DESCRIPTION
Some data to defend this solution:) ....

When using domain class TIN with four fields of types String (id, name, surname, custom text) the memory savings and throughput are following, when storing 500 000 TIN objects in the cache:
## Without the fix:

GC:
99,353: [Full GC (System) [PSYoungGen: 132397K->75921K(296704K)] [ParOldGen: 890237K->890237K(890240K)] 1022635K->966159K(1186944K) [PSPermGen: 60296K->60295K(70464K)], 0,7199160 secs]
Time to store 500k objects in cache: 10208 ms
## With the fix:

GC: 
98,775: [Full GC (System) [PSYoungGen: 64K->0K(338688K)] [ParOldGen: 615453K->544657K(889536K)] 615517K->544657K(1228224K) [PSPermGen: 60722K->60308K(121344K)], 0,9099400 secs]
Time to store 500k objects in cache: 6783 ms
