### PR TITLE
ISPN-3807 Cache the result of HQL query parser to be reused

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/query/RemoteQueryBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/query/RemoteQueryBuilder.java
@@ -27,7 +27,9 @@ public final class RemoteQueryBuilder extends BaseQueryBuilder<Query> {
    @Override
    public Query build() {
       String jpqlString = accept(new RemoteJPAQueryGenerator(serializationContext));
-      log.tracef("JPQL string : %s", jpqlString);
+      if (log.isTraceEnabled()) {
+         log.tracef("JPQL string : %s", jpqlString);
+      }
       return new RemoteQuery(cache, serializationContext, jpqlString, startOffset, maxResults);
    }
 }

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/impl/JPAQueryGenerator.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/impl/JPAQueryGenerator.java
@@ -11,6 +11,7 @@ import java.util.TimeZone;
 
 /**
  * Generates a JPA query to satisfy the condition created with the builder.
+ * TODO This class is not immutable and thread safe.
  *
  * @author anistor@redhat.com
  * @since 6.0

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/impl/Visitor.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/impl/Visitor.java
@@ -6,39 +6,39 @@ import org.infinispan.query.dsl.Query;
  * @author anistor@redhat.com
  * @since 6.0
  */
-interface Visitor<ResultType> {
+interface Visitor<ReturnType> {
 
-   ResultType visit(EqOperator operator);
+   ReturnType visit(EqOperator operator);
 
-   ResultType visit(GtOperator operator);
+   ReturnType visit(GtOperator operator);
 
-   ResultType visit(GteOperator operator);
+   ReturnType visit(GteOperator operator);
 
-   ResultType visit(LtOperator operator);
+   ReturnType visit(LtOperator operator);
 
-   ResultType visit(LteOperator operator);
+   ReturnType visit(LteOperator operator);
 
-   ResultType visit(BetweenOperator operator);
+   ReturnType visit(BetweenOperator operator);
 
-   ResultType visit(LikeOperator operator);
+   ReturnType visit(LikeOperator operator);
 
-   ResultType visit(IsNullOperator operator);
+   ReturnType visit(IsNullOperator operator);
 
-   ResultType visit(InOperator operator);
+   ReturnType visit(InOperator operator);
 
-   ResultType visit(ContainsOperator operator);
+   ReturnType visit(ContainsOperator operator);
 
-   ResultType visit(ContainsAllOperator operator);
+   ReturnType visit(ContainsAllOperator operator);
 
-   ResultType visit(ContainsAnyOperator operator);
+   ReturnType visit(ContainsAnyOperator operator);
 
-   ResultType visit(AttributeCondition attributeCondition);
+   ReturnType visit(AttributeCondition attributeCondition);
 
-   ResultType visit(AndCondition booleanCondition);
+   ReturnType visit(AndCondition booleanCondition);
 
-   ResultType visit(OrCondition booleanCondition);
+   ReturnType visit(OrCondition booleanCondition);
 
-   ResultType visit(NotCondition notCondition);
+   ReturnType visit(NotCondition notCondition);
 
-   <T extends Query> ResultType visit(BaseQueryBuilder<T> baseQueryBuilder);
+   <T extends Query> ReturnType visit(BaseQueryBuilder<T> baseQueryBuilder);
 }

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/EmbeddedLuceneQueryFactory.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/EmbeddedLuceneQueryFactory.java
@@ -14,20 +14,23 @@ public final class EmbeddedLuceneQueryFactory extends BaseQueryFactory<LuceneQue
 
    private final SearchManager searchManager;
 
+   private final QueryCache queryCache;
+
    private final EntityNamesResolver entityNamesResolver;
 
-   public EmbeddedLuceneQueryFactory(SearchManager searchManager, EntityNamesResolver entityNamesResolver) {
+   public EmbeddedLuceneQueryFactory(SearchManager searchManager, QueryCache queryCache, EntityNamesResolver entityNamesResolver) {
       this.searchManager = searchManager;
+      this.queryCache = queryCache;
       this.entityNamesResolver = entityNamesResolver;
    }
 
    @Override
    public QueryBuilder<LuceneQuery> from(Class type) {
-      return new EmbeddedLuceneQueryBuilder(this, searchManager, entityNamesResolver, type.getCanonicalName());
+      return new EmbeddedLuceneQueryBuilder(this, searchManager, queryCache, entityNamesResolver, type.getCanonicalName());
    }
 
    @Override
    public QueryBuilder<LuceneQuery> from(String type) {
-      return new EmbeddedLuceneQueryBuilder(this, searchManager, entityNamesResolver, type);
+      return new EmbeddedLuceneQueryBuilder(this, searchManager, queryCache, entityNamesResolver, type);
    }
 }

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryCache.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryCache.java
@@ -1,0 +1,103 @@
+package org.infinispan.query.dsl.embedded.impl;
+
+import net.jcip.annotations.ThreadSafe;
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.eviction.EvictionStrategy;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.logging.Log;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.util.KeyValuePair;
+import org.infinispan.util.logging.LogFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A local cache for 'parsed' queries. Each cache manager has one instance.
+ *
+ * @author anistor@redhat.com
+ * @since 7.0
+ */
+@ThreadSafe
+public class QueryCache {
+
+   private static final Log log = LogFactory.getLog(QueryCache.class, Log.class);
+
+   /**
+    * Users can define a cache configuration with this name if they need to fine tune query caching. If they do not do
+    * so a default config is used (see {@link QueryCache#getDefaultQueryCacheConfig()}).
+    */
+   public static final String QUERY_CACHE_NAME = "__query_cache__";
+
+   /**
+    * Max number of cached entries.
+    */
+   private static final int MAX_ENTRIES = 200;
+
+   /**
+    * Cache entry lifespan in seconds.
+    */
+   private static final int ENTRY_LIFESPAN = 300;
+
+   private EmbeddedCacheManager cacheManager;
+
+   private volatile Cache<KeyValuePair<String, Class>, Object> lazyCache;
+
+   @Inject
+   public void init(EmbeddedCacheManager cacheManager) {
+      this.cacheManager = cacheManager;
+   }
+
+   /**
+    * Gets the cache object. The key used for lookup if a pair containing the query string and the Class of the cached
+    * query object.
+    */
+   public <T> T get(KeyValuePair<String, Class> queryKey) {
+      Object cachedResult = getCache().get(queryKey);
+      if (cachedResult != null) {
+         log.debugf("QueryCache hit: %s, %s", queryKey.getKey(), queryKey.getValue());
+      }
+      return (T) cachedResult;
+   }
+
+   public void put(KeyValuePair<String, Class> queryKey, Object queryParsingResult) {
+      getCache().put(queryKey, queryParsingResult);
+   }
+
+   /**
+    * Obtain the cache. Start it lazily when needed.
+    */
+   private Cache<KeyValuePair<String, Class>, Object> getCache() {
+      Cache<KeyValuePair<String, Class>, Object> cache = lazyCache;
+
+      if (cache == null) {
+         synchronized (this) {
+            if (lazyCache == null) {
+               // define the query cache configuration if it does not already exist (from a previous call or manually defined by the user)
+               if (cacheManager.getCacheConfiguration(QUERY_CACHE_NAME) == null) {
+                  cacheManager.defineConfiguration(QUERY_CACHE_NAME, getDefaultQueryCacheConfig().build());
+               }
+
+               cache = lazyCache = cacheManager.getCache(QUERY_CACHE_NAME);
+            }
+         }
+      }
+
+      return cache;
+   }
+
+   private ConfigurationBuilder getDefaultQueryCacheConfig() {
+      ConfigurationBuilder cfgBuilder = new ConfigurationBuilder();
+      cfgBuilder
+            .clustering().cacheMode(CacheMode.LOCAL)
+            .transaction().transactionMode(TransactionMode.NON_TRANSACTIONAL)
+            .dataContainer().expiration()
+            .maxIdle(ENTRY_LIFESPAN, TimeUnit.SECONDS)
+            .dataContainer().eviction()
+            .maxEntries(MAX_ENTRIES)
+            .strategy(EvictionStrategy.LIRS);
+      return cfgBuilder;
+   }
+}

--- a/query/src/main/java/org/infinispan/query/impl/ComponentRegistryUtils.java
+++ b/query/src/main/java/org/infinispan/query/impl/ComponentRegistryUtils.java
@@ -3,6 +3,7 @@ package org.infinispan.query.impl;
 import org.infinispan.Cache;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.query.backend.QueryInterceptor;
+import org.infinispan.query.dsl.embedded.impl.QueryCache;
 
 /**
  * Component registry utilities
@@ -32,4 +33,7 @@ public class ComponentRegistryUtils {
       return getComponent(cache, QueryInterceptor.class);
    }
 
+   public static QueryCache getQueryCache(Cache<?, ?> cache) {
+      return cache.getCacheManager().getGlobalComponentRegistry().getComponent(QueryCache.class);
+   }
 }

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -41,6 +41,7 @@ import org.infinispan.query.backend.IndexModificationStrategy;
 import org.infinispan.query.backend.QueryInterceptor;
 import org.infinispan.query.backend.SearchableCacheConfiguration;
 import org.infinispan.query.clustered.QueryBox;
+import org.infinispan.query.dsl.embedded.impl.QueryCache;
 import org.infinispan.query.dsl.embedded.impl.FilterAndConverter;
 import org.infinispan.query.impl.externalizers.ClusteredTopDocsExternalizer;
 import org.infinispan.query.impl.externalizers.ExternalizerIds;
@@ -294,6 +295,9 @@ public class LifecycleManager extends AbstractModuleLifecycle {
 
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalCfg) {
+      QueryCache queryCache = new QueryCache();
+      gcr.registerComponent(queryCache, QueryCache.class);
+
       Map<Integer,AdvancedExternalizer<?>> externalizerMap = globalCfg.serialization().advancedExternalizers();
       externalizerMap.put(ExternalizerIds.FILTER_AND_CONVERTER, new FilterAndConverter.FilterAndConverterExternalizer());
       externalizerMap.put(ExternalizerIds.FILTER_RESULT, new FilterAndConverter.FilterResultExternalizer());

--- a/query/src/main/java/org/infinispan/query/impl/SearchManagerImpl.java
+++ b/query/src/main/java/org/infinispan/query/impl/SearchManagerImpl.java
@@ -18,6 +18,7 @@ import org.infinispan.query.clustered.ClusteredCacheQueryImpl;
 import org.infinispan.query.dsl.QueryFactory;
 import org.infinispan.query.dsl.embedded.LuceneQuery;
 import org.infinispan.query.dsl.embedded.impl.EmbeddedLuceneQueryFactory;
+import org.infinispan.query.dsl.embedded.impl.QueryCache;
 import org.infinispan.query.impl.massindex.MapReduceMassIndexer;
 import org.infinispan.query.spi.SearchManagerImplementor;
 
@@ -34,6 +35,7 @@ public class SearchManagerImpl implements SearchManagerImplementor {
    private final AdvancedCache<?, ?> cache;
    private final SearchFactoryIntegrator searchFactory;
    private final QueryInterceptor queryInterceptor;
+   private final QueryCache queryCache;
    private TimeoutExceptionFactory timeoutExceptionFactory;
 
    public SearchManagerImpl(AdvancedCache<?, ?> cache) {
@@ -43,6 +45,7 @@ public class SearchManagerImpl implements SearchManagerImplementor {
       this.cache = cache;
       this.searchFactory = ComponentRegistryUtils.getComponent(cache, SearchFactoryIntegrator.class);
       this.queryInterceptor = ComponentRegistryUtils.getQueryInterceptor(cache);
+      this.queryCache = ComponentRegistryUtils.getQueryCache(cache);
    }
 
    @Override
@@ -59,7 +62,7 @@ public class SearchManagerImpl implements SearchManagerImplementor {
             return queryInterceptor.isIndexed(clazz) ? clazz : null;
          }
       };
-      return new EmbeddedLuceneQueryFactory(this, entityNamesResolver);
+      return new EmbeddedLuceneQueryFactory(this, queryCache, entityNamesResolver);
    }
 
    /* (non-Javadoc)

--- a/query/src/test/java/org/infinispan/query/impl/QueryCacheEmbeddedTest.java
+++ b/query/src/test/java/org/infinispan/query/impl/QueryCacheEmbeddedTest.java
@@ -1,0 +1,125 @@
+package org.infinispan.query.impl;
+
+import org.hibernate.hql.lucene.LuceneQueryParsingResult;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.Index;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.Search;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryBuilder;
+import org.infinispan.query.dsl.QueryFactory;
+import org.infinispan.query.dsl.embedded.impl.QueryCache;
+import org.infinispan.query.dsl.embedded.testdomain.hsearch.UserHS;
+import org.infinispan.query.dsl.impl.BaseQueryBuilder;
+import org.infinispan.query.dsl.impl.JPAQueryGenerator;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.util.KeyValuePair;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author anistor@redhat.com
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "query.impl.QueryCacheEmbeddedTest")
+public class QueryCacheEmbeddedTest extends SingleCacheManagerTest {
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      ConfigurationBuilder cfg = getDefaultStandaloneCacheConfig(true);
+      cfg.transaction()
+            .transactionMode(TransactionMode.TRANSACTIONAL)
+            .indexing().index(Index.ALL)
+            .addProperty("default.directory_provider", "ram")
+            .addProperty("lucene_version", "LUCENE_CURRENT");
+      return TestCacheManagerFactory.createCacheManager(cfg);
+   }
+
+   public void testQueryCache() throws Exception {
+      // persist one User object to ensure the index exists and queries can be validated against it
+      UserHS user = new UserHS();
+      user.setId(1);
+      user.setName("John");
+      cache.put("user_" + user.getId(), user);
+
+      // spy on the query cache
+      QueryCache queryCache = TestingUtil.extractGlobalComponent(cacheManager, QueryCache.class);
+      QueryCache queryCacheSpy = spy(queryCache);
+      TestingUtil.replaceComponent(cacheManager, QueryCache.class, queryCacheSpy, true);
+
+      // obtain the query factory and create a query builder
+      QueryFactory qf = Search.getQueryFactory(cache);
+      QueryBuilder<Query> queryQueryBuilder = qf.from(UserHS.class)
+            .having("name").eq("John")
+            .toBuilder();
+
+      // compute the same jpa query as it would be generated for the above query
+      String jpaQuery = ((BaseQueryBuilder<Query>) queryQueryBuilder).accept(new JPAQueryGenerator());
+
+      // everything set up, test follows ...
+
+      AtomicReference<Object> lastGetResult = captureLastGetResult(queryCacheSpy);
+
+      KeyValuePair<String, Class> queryCacheKey = new KeyValuePair<String, Class>(jpaQuery, LuceneQueryParsingResult.class);
+
+      // ensure that the query cache does not have it already
+      LuceneQueryParsingResult cachedParsingResult = queryCache.get(queryCacheKey);
+      assertNull(cachedParsingResult);
+
+      // first attempt to build the query (cache is empty)
+      queryQueryBuilder.build();
+
+      // ensure the query cache has it now
+      cachedParsingResult = queryCache.get(queryCacheKey);
+      assertNotNull(cachedParsingResult);
+
+      // check interaction with query cache - expect a cache miss
+      InOrder inOrder = inOrder(queryCacheSpy);
+      inOrder.verify(queryCacheSpy, calls(1)).get(queryCacheKey);
+      ArgumentCaptor<LuceneQueryParsingResult> captor = ArgumentCaptor.forClass(LuceneQueryParsingResult.class);
+      inOrder.verify(queryCacheSpy, calls(1)).put(eq(queryCacheKey), captor.capture());
+      inOrder.verifyNoMoreInteractions();
+      assertNull(lastGetResult.get());
+      assertTrue(captor.getValue() == cachedParsingResult);  // == is intentional here!
+
+      // reset interaction and try again
+      reset(queryCacheSpy);
+      lastGetResult = captureLastGetResult(queryCacheSpy);
+
+      // second attempt to build the query
+      queryQueryBuilder.build();
+
+      // check interaction with query cache - expect a cache hit
+      inOrder = inOrder(queryCacheSpy);
+      inOrder.verify(queryCacheSpy, calls(1)).get(queryCacheKey);
+      inOrder.verify(queryCacheSpy, never()).put(any(KeyValuePair.class), any(LuceneQueryParsingResult.class));
+      inOrder.verifyNoMoreInteractions();
+      assertTrue(lastGetResult.get() == cachedParsingResult);  // == is intentional here!
+   }
+
+   private AtomicReference<Object> captureLastGetResult(QueryCache queryCacheSpy) {
+      final AtomicReference<Object> lastResult = new AtomicReference<Object>();
+      doAnswer(new Answer<Object>() {
+         @Override
+         public Object answer(InvocationOnMock invocation) throws Throwable {
+            Object result = invocation.callRealMethod();
+            lastResult.set(result);
+            return result;
+         }
+      }).when(queryCacheSpy).get(any(KeyValuePair.class));
+      return lastResult;
+   }
+}


### PR DESCRIPTION
Use a local cache with expiring entries to store the result of the HQL parsing and reuse it
if same query is executed.

Jira: https://issues.jboss.org/browse/ISPN-3807
