### PR TITLE
ISPN-4523 Test for HR PLAIN auth against LDAP over SSL

### DIFF
--- a/integrationtests/security-it/src/test/java/org/infinispan/test/integration/security/utils/ApacheDSLdapSSL.java
+++ b/integrationtests/security-it/src/test/java/org/infinispan/test/integration/security/utils/ApacheDSLdapSSL.java
@@ -1,0 +1,29 @@
+
+ package org.infinispan.test.integration.security.utils;
+
+import org.apache.directory.server.protocol.shared.transport.TcpTransport;
+import org.apache.directory.server.protocol.shared.transport.Transport;
+
+/** 
+ * @author vjuranek
+ * @since 7.0
+ */
+public class ApacheDSLdapSSL extends ApacheDsLdap {
+   
+   public static final int LDAPS_PORT = 10636;
+   
+   public ApacheDSLdapSSL(String hostname, String keystorePath, String keystorePasswd) throws Exception {
+      super(hostname);
+      addLdaps(keystorePath, keystorePasswd);
+   }
+   
+   
+   public void addLdaps(final String keystorePath, final String keystorePasswd) throws Exception {
+      Transport ldaps = new TcpTransport(LDAPS_PORT);
+      ldaps.enableSSL(true);
+      ldapServer.addTransports(ldaps);
+      ldapServer.setKeystoreFile(keystorePath);
+      ldapServer.setCertificatePassword(keystorePasswd);
+   }
+
+}

--- a/integrationtests/security-it/src/test/java/org/infinispan/test/integration/security/utils/ApacheDsLdap.java
+++ b/integrationtests/security-it/src/test/java/org/infinispan/test/integration/security/utils/ApacheDsLdap.java
@@ -28,8 +28,8 @@ public class ApacheDsLdap {
    public static final int LDAP_PORT = 10389;
    public static final String LDAP_INIT_FILE = "ldif/ispn-test.ldif";
 
-   private DirectoryService directoryService;
-   private LdapServer ldapServer;
+   protected DirectoryService directoryService;
+   protected LdapServer ldapServer;
    
    public ApacheDsLdap(String hostname) throws Exception {
       createDs();

--- a/server/integration/testsuite/build-testsuite.xml
+++ b/server/integration/testsuite/build-testsuite.xml
@@ -120,7 +120,7 @@
         </copy>
     </target>
 
-    <target name="create-all-distros" depends="transform-distro1-configs" description="Create all Infinispan server home directories used in the testsuite">	
+    <target name="create-all-distros" depends="transform-distro1-configs" description="Create all Infinispan server home directories used in the testsuite">
         <copy todir="${server2.dist}">
             <fileset dir="${server1.dist}" />
         </copy>
@@ -290,6 +290,12 @@
        	    hotrodAuth="${infinispan.parts}/hotrod-auth-ldap.xml"
     	    addSecRealm="${other.parts}/ldap-security-realm.xml"
        	    addConnection="${other.parts}/ldap-connection.xml"/>
+       <transform in="standalone.xml" out="testsuite/hotrod-auth-ldap-ssl.xml" 
+    	    modifyInfinispan="${infinispan.parts}/local-secured.xml"
+    	    hotrodAuth="${infinispan.parts}/hotrod-auth-ldap.xml"
+       	    hotrodEncrypt="${infinispan.parts}/hotrod-ssl.xml"
+    	    addSecRealm="${other.parts}/ldap-security-realm-with-ssl.xml"
+    	    addConnection="${other.parts}/ldap-connection-ssl.xml"/>	
        <transform in="standalone.xml" out="testsuite/hotrod-auth-krb.xml" 
             modifyInfinispan="${infinispan.parts}/local-secured.xml"
             hotrodAuth="${infinispan.parts}/hotrod-auth-krb.xml" 
@@ -318,6 +324,7 @@
         <attribute name="filtering" default="false"/>
         <attribute name="addEncrypt" default="false"/>
         <attribute name="hotrodAuth" default="false"/>
+    	<attribute name="hotrodEncrypt" default="false"/>
     	<attribute name="addKrbOpts" default="false"/>
     	<attribute name="addKrbSecDomain" default="false"/>
     	<attribute name="addSecRealm" default="false"/>
@@ -334,6 +341,7 @@
                 <param name="modifyRelay" expression="@{modifyRelay}"/>
                 <param name="addEncrypt" expression="@{addEncrypt}"/>
                 <param name="hotrodAuth" expression="@{hotrodAuth}"/>
+            	<param name="hotrodEncrypt" expression="@{hotrodEncrypt}"/>
             	<param name="addKrbOpts" expression="@{addKrbOpts}"/>
             	<param name="addKrbSecDomain" expression="@{addKrbSecDomain}"/>
             	<param name="addSecRealm" expression="@{addSecRealm}"/>

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/security/HotRodPlainAuthLdapOverSslIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/security/HotRodPlainAuthLdapOverSslIT.java
@@ -1,0 +1,79 @@
+package org.infinispan.server.test.client.hotrod.security;
+
+import java.io.File;
+
+import org.infinispan.arquillian.core.InfinispanResource;
+import org.infinispan.arquillian.core.RemoteInfinispanServer;
+import org.infinispan.arquillian.core.RunningServer;
+import org.infinispan.arquillian.core.WithRunningServer;
+import org.infinispan.server.test.category.Security;
+import org.infinispan.server.test.util.ITestUtils;
+import org.infinispan.test.integration.security.utils.ApacheDSLdapSSL;
+import org.infinispan.test.integration.security.utils.ApacheDsLdap;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@Category({ Security.class })
+@WithRunningServer(@RunningServer(name = "hotrodAuthLdapOverSsl"))
+public class HotRodPlainAuthLdapOverSslIT extends HotRodSaslAuthTestBase {
+
+   private static final String KEYSTORE_NAME = "keystore_client.jks";
+   private static final String KEYSTORE_PASSWORD = "secret";
+
+   private static ApacheDsLdap ldap;
+
+   @InfinispanResource("hotrodAuthLdapOverSsl")
+   private RemoteInfinispanServer server;
+
+   @BeforeClass
+   public static void kerberosSetup() throws Exception {
+      ldap = new ApacheDSLdapSSL("localhost", ITestUtils.SERVER_CONFIG_DIR + File.separator + KEYSTORE_NAME,
+            KEYSTORE_PASSWORD);
+      ldap.start();
+   }
+
+   @AfterClass
+   public static void ldapTearDown() throws Exception {
+      ldap.stop();
+   }
+
+   @Override
+   public String getTestedMech() {
+      return "PLAIN";
+   }
+
+   @Override
+   public String getHRServerHostname() {
+      return server.getHotrodEndpoint().getInetAddress().getHostName();
+   }
+
+   @Override
+   public int getHRServerPort() {
+      return server.getHotrodEndpoint().getPort();
+   }
+
+   @Override
+   public void initAsAdmin() {
+      initializeOverSsl(ADMIN_LOGIN, ADMIN_PASSWD);
+   }
+
+   @Override
+   public void initAsReader() {
+      initializeOverSsl(READER_LOGIN, READER_PASSWD);
+   }
+
+   @Override
+   public void initAsWriter() {
+      initializeOverSsl(WRITER_LOGIN, WRITER_PASSWD);
+   }
+
+   @Override
+   public void initAsSupervisor() {
+      initializeOverSsl(SUPERVISOR_LOGIN, SUPERVISOR_PASSWD);
+   }
+
+}

--- a/server/integration/testsuite/src/test/resources/arquillian.xml
+++ b/server/integration/testsuite/src/test/resources/arquillian.xml
@@ -930,5 +930,18 @@
                 <property name="waitForPorts">11211 11222 8080</property>
             </configuration>
         </container>
+        <container qualifier="hotrodAuthLdapOverSsl" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="managementAddress">${node0.ip}</property>
+                <property name="serverConfig">testsuite/hotrod-auth-ldap-ssl.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                </property>
+                <property name="managementPort">9990</property>
+                <property name="waitForPorts">11211 11222 8080</property>
+            </configuration>
+        </container>
     </group>
 </arquillian>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/hotrod-ssl.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/hotrod-ssl.xml
@@ -1,0 +1,1 @@
+                <encryption security-realm="LdapRealm" require-ssl-client-auth="true" />

--- a/server/integration/testsuite/src/test/resources/config/parts/ldap-connection-ssl.xml
+++ b/server/integration/testsuite/src/test/resources/config/parts/ldap-connection-ssl.xml
@@ -1,0 +1,3 @@
+        <outbound-connections>
+            <ldap name="ldap_connection" url="ldap://localhost:10636" search-dn="uid=admin,ou=People,dc=infinispan,dc=org" search-credential="strongPassword" security-realm="LdapRealm"/>
+        </outbound-connections>

--- a/server/integration/testsuite/src/test/resources/config/parts/ldap-security-realm-with-ssl.xml
+++ b/server/integration/testsuite/src/test/resources/config/parts/ldap-security-realm-with-ssl.xml
@@ -1,0 +1,13 @@
+            <security-realm name="LdapRealm">
+                <server-identities>
+                    <ssl>
+                        <keystore path="keystore_server.jks" relative-to="jboss.server.config.dir" keystore-password="secret"/>
+                    </ssl>
+                </server-identities>
+                <authentication>
+                    <truststore path="truststore_server.jks" relative-to="jboss.server.config.dir" keystore-password="secret"/>
+                    <ldap connection="ldap_connection" recursive="true" base-dn="ou=People,dc=infinispan,dc=org">
+                        <username-filter attribute="uid" />
+                    </ldap>
+                </authentication>
+            </security-realm>

--- a/server/integration/testsuite/src/test/resources/config/xslt/config-modifier.xsl
+++ b/server/integration/testsuite/src/test/resources/config/xslt/config-modifier.xsl
@@ -31,6 +31,7 @@
     <xsl:param name="addAuth">false</xsl:param>
     <xsl:param name="addEncrypt">false</xsl:param>
     <xsl:param name="hotrodAuth">false</xsl:param>
+    <xsl:param name="hotrodEncrypt">false</xsl:param>
     <xsl:param name="addKrbOpts">false</xsl:param>
     <xsl:param name="addKrbSecDomain">false</xsl:param>
     <xsl:param name="addSecRealm">false</xsl:param>
@@ -276,12 +277,12 @@
     </xsl:template>
 
     <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $nsEndpoint)]//*[local-name()='hotrod-connector']/*[local-name()='topology-state-transfer']">
-        <xsl:if test="$hotrodAuth = 'false'">
-            <xsl:call-template name="copynode"/>
-        </xsl:if>
+        <xsl:call-template name="copynode"/>
         <xsl:if test="$hotrodAuth != 'false'">
-            <xsl:call-template name="copynode"/>
             <xsl:copy-of select="document($hotrodAuth)"/>
+        </xsl:if>
+        <xsl:if test="$hotrodEncrypt != 'false'">
+            <xsl:copy-of select="document($hotrodEncrypt)"/>
         </xsl:if>
     </xsl:template>
 


### PR DESCRIPTION
Covers end-to-end SSL encryption between HR client and server
as well as between HR server and LDAP server.

https://issues.jboss.org/browse/ISPN-4523
