### PR TITLE
ISPN-4690 Upgrade to Scala 2.11.2

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -68,7 +68,9 @@
       <version.netty>4.0.20.Final</version.netty>
       <version.osgi>4.3.1</version.osgi>
       <version.rhq>4.4.0</version.rhq>
-      <version.scala>2.10.2</version.scala>
+      <version.scala.major>2.11</version.scala.major>
+      <version.scala>${version.scala.major}.2</version.scala>
+      <version.scala.xml>1.0.2</version.scala.xml>
       <version.xstream>1.4.7</version.xstream>
    </properties>
 
@@ -324,6 +326,11 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${version.scala}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-xml_${version.scala.major}</artifactId>
+            <version>${version.scala.xml}</version>
          </dependency>
          <dependency>
             <groupId>com.thoughtworks.xstream</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -170,7 +170,7 @@
       <version.maven.buildhelper>1.8</version.maven.buildhelper>
       <version.maven.bundle>2.4.0</version.maven.bundle>
       <version.maven.source>2.2.1</version.maven.source>
-      <version.maven.genjavadoc>0.5</version.maven.genjavadoc>
+      <version.maven.genjavadoc>0.8</version.maven.genjavadoc>
       <version.maven.scala>2.15.2</version.maven.scala>
       <version.maven.surefire>2.17</version.maven.surefire>
       <version.maven.invoker>1.8</version.maven.invoker>
@@ -1336,7 +1336,7 @@
                    <compilerPlugins>
                       <compilerPlugin>
                          <groupId>com.typesafe.genjavadoc</groupId>
-                         <artifactId>genjavadoc-plugin_2.10.2</artifactId>
+                         <artifactId>genjavadoc-plugin_${version.scala}</artifactId>
                          <version>${version.maven.genjavadoc}</version>
                       </compilerPlugin>
                    </compilerPlugins>

--- a/server/core/src/main/scala/org/infinispan/server/core/CacheValue.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/CacheValue.scala
@@ -23,9 +23,8 @@ import java.lang.StringBuilder
  * @since 4.1
  * @deprecated
  */
-@serializable
 @deprecated
-class CacheValue(val data: Array[Byte], val version: Long) {
+class CacheValue(val data: Array[Byte], val version: Long) extends Serializable {
 
    override def toString = {
       new StringBuilder().append("CacheValue").append("{")
@@ -65,6 +64,6 @@ object CacheValue {
       }
 
       override def getTypeClasses =
-         asJavaSet(Set[java.lang.Class[_ <: CacheValue]](classOf[CacheValue]))
+         setAsJavaSet(Set[java.lang.Class[_ <: CacheValue]](classOf[CacheValue]))
    }
 }

--- a/server/integration/build/build.xml
+++ b/server/integration/build/build.xml
@@ -236,6 +236,10 @@
          <maven-resource group="org.scala-lang" artifact="scala-library" />
       </module-def>
 
+      <module-def name="org.scala-lang.modules.xml">
+         <maven-resource group="org.scala-lang.modules" artifact="scala-xml_2.11" />
+      </module-def>
+
       <module-def name="org.apache.lucene">
          <maven-resource group="org.apache.lucene" artifact="lucene-core" />
          <maven-resource group="org.apache.lucene" artifact="lucene-queries" />

--- a/server/integration/build/src/main/resources/modules/system/layers/base/org/infinispan/server/rest/main/module.xml
+++ b/server/integration/build/src/main/resources/modules/system/layers/base/org/infinispan/server/rest/main/module.xml
@@ -44,6 +44,7 @@
       <module name="org.jboss.marshalling" services="import"/>
       <module name="org.jboss.resteasy.resteasy-jaxrs" />
       <module name="org.scala-lang.library" />
+      <module name="org.scala-lang.modules.xml" />
       <module name="org.jgroups" />
    </dependencies>
 </module>

--- a/server/integration/build/src/main/resources/modules/system/layers/base/org/scala-lang/modules/xml/main/module.xml
+++ b/server/integration/build/src/main/resources/modules/system/layers/base/org/scala-lang/modules/xml/main/module.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   ~ Copyright 2011 Red Hat, Inc. and/or its affiliates.
+   ~
+   ~ This is free software; you can redistribute it and/or modify it
+   ~ under the terms of the GNU Lesser General Public License as
+   ~ published by the Free Software Foundation; either version 2.1 of
+   ~ the License, or (at your option) any later version.
+   ~
+   ~ This software is distributed in the hope that it will be useful,
+   ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+   ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   ~ Lesser General Public License for more details.
+   ~
+   ~ You should have received a copy of the GNU Lesser General Public
+   ~ License along with this library; if not, write to the Free Software
+   ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   ~ 02110-1301 USA
+-->
+<module xmlns="urn:jboss:module:1.3" name="org.scala-lang.modules.xml">
+    <resources>
+       <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+       <module name="org.scala-lang.library" />
+    </dependencies>
+</module>

--- a/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedValue.scala
+++ b/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedValue.scala
@@ -20,10 +20,9 @@ import java.lang.StringBuilder
  * @author Galder Zamarreño
  * @since 4.1
  */
-@serializable
 // TODO: Create a Metadata extension for Memcached value and add flags, removing this class
 class MemcachedValue(override val data: Array[Byte], override val version: Long, val flags: Long)
-      extends CacheValue(data, version) {
+      extends CacheValue(data, version) with Serializable {
 
    override def toString = {
       new StringBuilder().append("MemcachedValue").append("{")
@@ -53,6 +52,6 @@ object MemcachedValue {
       }
 
       override def getTypeClasses =
-         asJavaSet(Set[java.lang.Class[_ <: MemcachedValue]](classOf[MemcachedValue]))
+         setAsJavaSet(Set[java.lang.Class[_ <: MemcachedValue]](classOf[MemcachedValue]))
    }
 }

--- a/server/rest/pom.xml
+++ b/server/rest/pom.xml
@@ -68,6 +68,11 @@
         <artifactId>infinispan-server-core</artifactId>
       </dependency>
 
+      <dependency>
+         <groupId>org.scala-lang.modules</groupId>
+         <artifactId>scala-xml_${version.scala.major}</artifactId>
+      </dependency>
+
       <!-- and now for unit and integration tests -->
       <dependency>
          <groupId>org.mortbay.jetty</groupId>


### PR DESCRIPTION
- Minor compilation adjustments were required, including: switching to new scala.concurrent classes added in 2.10, extend Serializable trait instead of annotation, and use refactored Java conversion methods.
- Scala XML module has been separated, so REST server needs a new dependency, which it has also been added to Infinispan server as a new module.
