### PR TITLE
ISPN-4561 CacheManager.stop with indexing to Infinispan fails

### DIFF
--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -4,11 +4,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +58,8 @@ import org.infinispan.security.AuthorizationPermission;
 import org.infinispan.security.impl.AuthorizationHelper;
 import org.infinispan.security.impl.PrincipalRoleMapperContextImpl;
 import org.infinispan.security.impl.SecureCacheImpl;
+import org.infinispan.util.CyclicDependencyException;
+import org.infinispan.util.DependencyGraph;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -116,6 +119,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
    private final GlobalComponentRegistry globalComponentRegistry;
    private volatile boolean stopping;
    private final AuthorizationHelper authzHelper;
+   private final DependencyGraph<String> cacheDependencyGraph = new DependencyGraph<>();
 
    /**
     * Constructs and starts a default instance of the CacheManager, using configuration defaults.  See {@link org.infinispan.configuration.cache.Configuration Configuration}
@@ -482,6 +486,8 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
 
             // Remove cache configuration and remove it from the computed cache name list
             configurationOverrides.remove(cacheName);
+            // Remove cache from dependency graph
+            cacheDependencyGraph.remove(cacheName);
          } catch (Throwable t) {
             throw new CacheException("Error removing cache", t);
          }
@@ -608,6 +614,13 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
       log.debugf("Started cache manager %s on %s", clusterName, nodeName);
    }
 
+   private void terminate(Cache cache) {
+      if (cache != null) {
+            unregisterCacheMBean(cache);
+            cache.stop();
+      }
+   }
+
    @Override
    public void stop() {
       authzHelper.checkPermission(AuthorizationPermission.LIFECYCLE);
@@ -618,26 +631,29 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
             if (!stopping) {
                log.debugf("Stopping cache manager %s on %s", globalConfiguration.transport().clusterName(), getAddress());
                stopping = true;
+               Set<String> cachesToStop = new LinkedHashSet<>();
+               boolean defaultCacheHasDependency = false;
+               // stop ordered caches first
+               try {
+                  List<String> ordered = cacheDependencyGraph.topologicalSort();
+                  defaultCacheHasDependency = ordered.contains(DEFAULT_CACHE_NAME);
+                  cachesToStop.addAll(ordered);
+               } catch (CyclicDependencyException e) {
+                  log.stopOrderIgnored();
+               }
+               cachesToStop.addAll(caches.keySet());
                // make sure we stop the default cache LAST!
                Cache<?, ?> defaultCache = null;
-               for (Map.Entry<String, CacheWrapper> entry : caches.entrySet()) {
-                  if (entry.getKey().equals(ClusterRegistryImpl.GLOBAL_REGISTRY_CACHE_NAME)) {
+               for (String cacheName : cachesToStop) {
+                  if (cacheName.equals(ClusterRegistryImpl.GLOBAL_REGISTRY_CACHE_NAME)) {
                      // will be stopped by the GCR
-                  } else if (entry.getKey().equals(DEFAULT_CACHE_NAME)) {
-                     defaultCache = entry.getValue().cache;
+                  } else if (cacheName.equals(DEFAULT_CACHE_NAME) && !defaultCacheHasDependency) {
+                     defaultCache = this.caches.get(cacheName).cache;
                   } else {
-                     Cache<?, ?> c = entry.getValue().cache;
-                     if (c != null) {
-                        unregisterCacheMBean(c);
-                        c.stop();
-                     }
+                     terminate(this.caches.get(cacheName).cache);
                   }
                }
-
-               if (defaultCache != null) {
-                  unregisterCacheMBean(defaultCache);
-                  defaultCache.stop();
-               }
+               terminate(defaultCache);
                globalComponentRegistry.getComponent(CacheManagerJmxRegistration.class).stop();
                globalComponentRegistry.stop();
 
@@ -844,6 +860,11 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
    @Override
    public GlobalComponentRegistry getGlobalComponentRegistry() {
       return globalComponentRegistry;
+   }
+
+   @Override
+   public void addCacheDependency(String from, String to) {
+      cacheDependencyGraph.addDependency(from, to);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
@@ -224,4 +224,15 @@ public interface EmbeddedCacheManager extends CacheContainer, Listenable {
    Transport getTransport();
 
    GlobalComponentRegistry getGlobalComponentRegistry();
+
+   /**
+    * Add a dependency between two caches. The cache manager will make sure that
+    * a cache is stopped before any of its dependencies
+    * 
+    * @param from cache name
+    * @param to cache name
+    * @since 7.0
+    */
+   void addCacheDependency(String from, String to);
+
 }

--- a/core/src/main/java/org/infinispan/manager/impl/AbstractDelegatingEmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/impl/AbstractDelegatingEmbeddedCacheManager.java
@@ -152,6 +152,11 @@ public class AbstractDelegatingEmbeddedCacheManager implements EmbeddedCacheMana
    }
 
    @Override
+   public void addCacheDependency(String from, String to) {
+      cm.addCacheDependency(from, to);
+   }
+
+   @Override
    public void addListener(Object listener) {
       cm.addListener(listener);
    }

--- a/core/src/main/java/org/infinispan/util/CyclicDependencyException.java
+++ b/core/src/main/java/org/infinispan/util/CyclicDependencyException.java
@@ -1,0 +1,16 @@
+package org.infinispan.util;
+
+/**
+ * Thrown when a cyclic dependency exist
+ * @author gustavonalle
+ * @since 7.0
+ */
+public class CyclicDependencyException extends Exception {
+   public CyclicDependencyException(String message) {
+      super(message);
+   }
+
+   protected CyclicDependencyException(String message, Throwable cause) {
+      super(message, cause);
+   }
+}

--- a/core/src/main/java/org/infinispan/util/DependencyGraph.java
+++ b/core/src/main/java/org/infinispan/util/DependencyGraph.java
@@ -1,0 +1,213 @@
+package org.infinispan.util;
+
+import net.jcip.annotations.ThreadSafe;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ *  Graph to track dependencies between objects
+ *
+ * @author gustavonalle
+ * @since 7.0
+ */
+@ThreadSafe
+public final class DependencyGraph<T> {
+
+   private final Map<T, Set<T>> outgoingEdges = new HashMap<>();
+   private final Map<T, Set<T>> incomingEdges = new HashMap<>();
+
+   private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+   /**
+    * Calculates a topological sort of the graph, in linear time
+    *
+    * @return List<T> elements sorted respecting dependencies
+    * @throws CyclicDependencyException if cycles are present in the graph and thus no topological sort is possible
+    */
+   public List<T> topologicalSort() throws CyclicDependencyException {
+      lock.readLock().lock();
+      try {
+         ArrayList<T> result = new ArrayList<>();
+         Deque<T> noIncomingEdges = new ArrayDeque<>();
+
+         Map<T, Integer> temp = new HashMap<>();
+         for (Map.Entry<T, Set<T>> incoming : incomingEdges.entrySet()) {
+            int size = incoming.getValue().size();
+            T key = incoming.getKey();
+            temp.put(key, size);
+            if (size == 0) {
+               noIncomingEdges.add(key);
+            }
+         }
+
+         while (!noIncomingEdges.isEmpty()) {
+            T n = noIncomingEdges.poll();
+            result.add(n);
+            temp.remove(n);
+            Set<T> elements = outgoingEdges.get(n);
+            if (elements != null) {
+               for (T m : elements) {
+                  Integer count = temp.get(m);
+                  temp.put(m, --count);
+                  if (count == 0) {
+                     noIncomingEdges.add(m);
+                  }
+               }
+            }
+         }
+         if (!temp.isEmpty()) {
+            throw new CyclicDependencyException("Cycle detected");
+         } else {
+            return result;
+         }
+      } finally {
+         lock.readLock().unlock();
+      }
+   }
+
+   /**
+    * Add a dependency between two elements
+    * @param from From element
+    * @param to To element
+    */
+   public void addDependency(T from, T to) {
+      if (from == null || to == null || from.equals(to)) {
+         throw new IllegalArgumentException("Invalid parameters");
+      }
+      lock.writeLock().lock();
+      try {
+         if (addOutgoingEdge(from, to)) {
+            addIncomingEdge(to, from);
+         }
+      } finally {
+         lock.writeLock().unlock();
+      }
+   }
+
+   /**
+    * Remove a dependency
+    * @param from From element
+    * @param to To element
+    * @throws java.lang.IllegalArgumentException if either to or from don't exist
+    */
+   public void removeDependency(T from, T to) {
+      lock.writeLock().lock();
+      try {
+         Set<T> dependencies = outgoingEdges.get(from);
+         if (dependencies == null || !dependencies.contains(to)) {
+            throw new IllegalArgumentException("Inexistent dependency");
+         }
+         dependencies.remove(to);
+         incomingEdges.get(to).remove(from);
+      } finally {
+         lock.writeLock().unlock();
+      }
+   }
+
+   public void clearAll() {
+      lock.writeLock().lock();
+      try {
+         outgoingEdges.clear();
+         incomingEdges.clear();
+      } finally {
+         lock.writeLock().unlock();
+      }
+   }
+
+   private void addIncomingEdge(T to, T from) {
+      Set<T> incoming = incomingEdges.get(to);
+      if (incoming == null) {
+         incomingEdges.put(to, newInitialSet(from));
+      } else {
+         incoming.add(from);
+      }
+      if (!incomingEdges.containsKey(from)) {
+         incomingEdges.put(from, new HashSet<T>());
+      }
+   }
+
+   private boolean addOutgoingEdge(T from, T to) {
+      Set<T> outgoing = outgoingEdges.get(from);
+      if (outgoing == null) {
+         outgoingEdges.put(from, newInitialSet(to));
+         return true;
+      }
+      return outgoing.add(to);
+   }
+
+   private Set<T> newInitialSet(T element) {
+      Set<T> elements = new HashSet<>();
+      elements.add(element);
+      return elements;
+   }
+
+   /**
+    * Check if an element is depended on
+    *
+    * @param element Element stored in the graph
+    * @return true if exists any dependency on element
+    * @throws java.lang.IllegalArgumentException if element is not present in the graph
+    */
+   public boolean hasDependent(T element) {
+      lock.readLock().lock();
+      try {
+         Set<T> ts = this.incomingEdges.get(element);
+         return ts != null && ts.size() > 0;
+      } finally {
+         lock.readLock().unlock();
+      }
+
+   }
+
+   /**
+    * Return the dependents
+    * @param element Element contained in the graph
+    * @return list of elements depending on element
+    */
+   public Set<T> getDependents(T element) {
+      lock.readLock().lock();
+      try {
+         Set<T> dependants = this.incomingEdges.get(element);
+         if (dependants == null || dependants.isEmpty()) {
+            return new HashSet<>();
+         }
+         return Collections.unmodifiableSet(this.incomingEdges.get(element));
+      } finally {
+         lock.readLock().unlock();
+      }
+
+   }
+
+   /**
+    * Remove element from the graph
+    *
+    * @param element the element
+    */
+   public void remove(T element) {
+      lock.writeLock().lock();
+      try {
+         if (outgoingEdges.remove(element) != null) {
+            for (Set<T> values : outgoingEdges.values()) {
+               values.remove(element);
+            }
+         }
+         if (incomingEdges.remove(element) != null) {
+            for (Set<T> values : incomingEdges.values()) {
+               values.remove(element);
+            }
+         }
+      } finally {
+         lock.writeLock().unlock();
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1182,4 +1182,8 @@ public interface Log extends BasicLogger {
    @LogMessage(level = ERROR)
    @Message(value = "After merge, cache %s still hasn't recovered a majority of members (lost %d out of %d) and must stay in degraded mode", id = 320)
    void keepingDegradedModeAfterMergeMinorityPartition(String cacheName, int lostMembersCount, int stableMembersCount);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Cyclic dependency detected between caches, stop order ignored", id = 321)
+   void stopOrderIgnored();
 }

--- a/core/src/test/java/org/infinispan/manager/CacheDependencyTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheDependencyTest.java
@@ -1,0 +1,137 @@
+package org.infinispan.manager;
+
+import org.infinispan.Cache;
+import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachemanagerlistener.annotation.CacheStopped;
+import org.infinispan.notifications.cachemanagerlistener.event.CacheStoppedEvent;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.infinispan.commons.api.BasicCacheContainer.DEFAULT_CACHE_NAME;
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * @author gustavonalle
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "manager.CacheDependencyTest")
+@CleanupAfterMethod
+public class CacheDependencyTest extends SingleCacheManagerTest {
+
+   @Test
+   public void testExplicitStop() {
+      Cache<?, ?> cacheA = cacheManager.getCache("A");
+      Cache<?, ?> cacheB = cacheManager.getCache("B");
+
+      cacheManager.addCacheDependency("A", "B");
+
+      cacheB.stop();
+      cacheA.stop();
+
+      assertAllTerminated(cacheA, cacheB);
+   }
+
+   @Test
+   public void testDependencyOnStoppedCaches() {
+      Cache<?, ?> cacheA = cacheManager.getCache("A");
+      Cache<?, ?> cacheB = cacheManager.getCache("B");
+      cacheA.stop();
+
+      cacheManager.addCacheDependency("A", "B");
+
+      CacheEventListener listener = new CacheEventListener();
+      cacheManager.addListener(listener);
+
+      cacheManager.stop();
+
+      assertAllTerminated(cacheA, cacheB);
+      assertEquals(Arrays.asList("B", DEFAULT_CACHE_NAME), listener.stopOrder);
+   }
+
+   @Test
+   public void testCyclicDependencies() {
+      Cache<?, ?> cacheA = cacheManager.getCache("A");
+      Cache<?, ?> cacheB = cacheManager.getCache("B");
+
+      cacheManager.addCacheDependency("A", "B");
+      cacheManager.addCacheDependency("B", "A");
+
+      // Order will not be enforced
+      cacheManager.stop();
+
+      assertAllTerminated(cacheA, cacheB);
+   }
+
+   @Test
+   public void testStopCacheManager() {
+      CacheEventListener listener = new CacheEventListener();
+      cacheManager.addListener(listener);
+
+      Cache<?, ?> cacheA = cacheManager.getCache("A");
+      Cache<?, ?> cacheB = cacheManager.getCache("B");
+      Cache<?, ?> cacheC = cacheManager.getCache("C");
+      Cache<?, ?> cacheD = cacheManager.getCache("D");
+
+      cacheManager.addCacheDependency("A", "B");
+      cacheManager.addCacheDependency("A", "C");
+      cacheManager.addCacheDependency("A", "D");
+      cacheManager.addCacheDependency("B", "C");
+      cacheManager.addCacheDependency("B", "D");
+      cacheManager.addCacheDependency("D", "C");
+
+      cacheManager.stop();
+
+      assertAllTerminated(cacheA, cacheB, cacheC, cacheD);
+      assertEquals(Arrays.asList("A", "B", "D", "C", DEFAULT_CACHE_NAME), listener.stopOrder);
+   }
+
+   @Test
+   public void testRemoveCache() {
+      Cache<?, ?> cacheA = cacheManager.getCache("A");
+      Cache<?, ?> cacheB = cacheManager.getCache("B");
+      Cache<?, ?> cacheC = cacheManager.getCache("C");
+
+      cacheManager.addCacheDependency("A", "B");
+      cacheManager.addCacheDependency("A", "C");
+      cacheManager.addCacheDependency("B", "C");
+
+      cacheManager.removeCache("B");
+
+      CacheEventListener listener = new CacheEventListener();
+      cacheManager.addListener(listener);
+
+      cacheManager.stop();
+
+      assertAllTerminated(cacheA, cacheB, cacheC);
+      assertEquals(Arrays.asList("A", "C", DEFAULT_CACHE_NAME), listener.stopOrder);
+
+   }
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      return TestCacheManagerFactory.createCacheManager();
+   }
+
+   @Listener
+   private static final class CacheEventListener {
+      private final List<String> stopOrder = new ArrayList<>();
+
+      @CacheStopped
+      public void cacheStopped(CacheStoppedEvent cse) {
+         stopOrder.add(cse.getCacheName());
+      }
+   }
+
+   private void assertAllTerminated(Cache<?, ?>... caches) {
+      for (Cache<?, ?> cache : caches) {
+         assert cache.getStatus() == ComponentStatus.TERMINATED;
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/util/DependencyGraphTest.java
+++ b/core/src/test/java/org/infinispan/util/DependencyGraphTest.java
@@ -1,0 +1,204 @@
+package org.infinispan.util;
+
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Tests functionality in {@link org.infinispan.util.DependencyGraph}.
+ *
+ * @author gustavonalle
+ * @since 7.0
+ */
+@Test(testName = "util.DependencyGraphTest", groups = "unit")
+public class DependencyGraphTest {
+
+   @Test
+   public void testEmpty() throws CyclicDependencyException {
+      assertTrue(new DependencyGraph().topologicalSort().isEmpty());
+   }
+
+   @Test
+   public void testLinear() throws CyclicDependencyException {
+      DependencyGraph<Integer> graph = new DependencyGraph<>();
+      int size = 100;
+      for (int i = 1; i <= size; i++) {
+         graph.addDependency(i, i - 1);
+      }
+      List sort = graph.topologicalSort();
+
+      assertTrue(sort.size() == size + 1);
+      assertTrue(sort.get(0) == 100);
+      assertTrue(sort.get(100) == 0);
+   }
+
+   @Test
+   public void testNonLinear() throws CyclicDependencyException {
+      DependencyGraph<String> graph = new DependencyGraph<>();
+      String A = "a";
+      String B = "b";
+      String C = "c";
+      String D = "d";
+      graph.addDependency(C, B);
+      graph.addDependency(C, D);
+      graph.addDependency(B, A);
+      graph.addDependency(A, D);
+      List<String> sort = graph.topologicalSort();
+
+      assertEquals(sort, Arrays.asList(C, B, A, D));
+   }
+
+   @Test
+   public void testIdempotency() throws CyclicDependencyException {
+      DependencyGraph<String> g = new DependencyGraph<>();
+      g.addDependency("N1", "N2");
+      g.addDependency("N2", "N3");
+      g.addDependency("N1", "N2");
+      g.addDependency("N2", "N3");
+
+      assertTrue(g.topologicalSort().size() == 3);
+      assertEquals(g.topologicalSort(), Arrays.asList("N1", "N2", "N3"));
+   }
+
+   @Test
+   public void testDependent() throws CyclicDependencyException {
+      DependencyGraph<String> graph = new DependencyGraph<>();
+      graph.addDependency("A", "B");
+      graph.addDependency("A", "C");
+      graph.addDependency("A", "D");
+      graph.addDependency("D", "F");
+
+      assertTrue(graph.hasDependent("B"));
+      assertTrue(graph.hasDependent("C"));
+      assertTrue(graph.hasDependent("D"));
+      assertTrue(graph.hasDependent("F"));
+      assertFalse(graph.hasDependent("A"));
+      assertTrue(graph.getDependents("A").isEmpty());
+      assertEquals(graph.getDependents("B").iterator().next(), "A");
+      assertEquals(graph.getDependents("C").iterator().next(), "A");
+      assertEquals(graph.getDependents("D").iterator().next(), "A");
+      assertEquals(graph.getDependents("F").iterator().next(), "D");
+   }
+
+   @Test
+   public void testConcurrentAccess() throws Exception {
+      DependencyGraph<String> graph = new DependencyGraph<>();
+      ExecutorService service = Executors.newCachedThreadPool();
+      CountDownLatch startLatch = new CountDownLatch(1);
+      int threads = 20;
+      ArrayList<Future<?>> futures = new ArrayList<>();
+      for (int i = 0; i < threads; i++) {
+         futures.add(submitTask("A", "B", startLatch, service, graph));
+         futures.add(submitTask("A", "C", startLatch, service, graph));
+         futures.add(submitTask("A", "D", startLatch, service, graph));
+         futures.add(submitTask("A", "B", startLatch, service, graph));
+         futures.add(submitTask("D", "B", startLatch, service, graph));
+         futures.add(submitTask("D", "C", startLatch, service, graph));
+         futures.add(submitTask("C", "B", startLatch, service, graph));
+      }
+      startLatch.countDown();
+      awaitAll(futures);
+
+      assertEquals(graph.topologicalSort(), Arrays.asList("A", "D", "C", "B"));
+   }
+
+   @Test
+   public void testRemoveDependency() throws CyclicDependencyException {
+      DependencyGraph<String> g = new DependencyGraph<>();
+      g.addDependency("E", "B");
+      g.addDependency("E", "C");
+      g.addDependency("E", "D");
+      g.addDependency("B", "D");
+      g.addDependency("B", "C");
+      g.addDependency("C", "D");
+
+      assertEquals(g.topologicalSort(), Arrays.asList("E", "B", "C", "D"));
+
+      g.removeDependency("E", "B");
+      g.addDependency("B", "E");
+
+      assertEquals(g.topologicalSort(), Arrays.asList("B", "E", "C", "D"));
+
+      g.clearAll();
+
+      assertTrue(g.topologicalSort().isEmpty());
+   }
+
+   @Test
+   public void testRemoveElement() throws CyclicDependencyException {
+      DependencyGraph<String> g = new DependencyGraph<>();
+      g.addDependency("E", "B");
+      g.addDependency("E", "C");
+      g.addDependency("E", "D");
+      g.addDependency("B", "D");
+      g.addDependency("B", "C");
+      g.addDependency("C", "D");
+
+      assertEquals(g.topologicalSort(), Arrays.asList("E", "B", "C", "D"));
+
+      g.remove("C");
+      assertEquals(g.topologicalSort(), Arrays.asList("E", "B", "D"));
+
+      g.remove("B");
+      assertEquals(g.topologicalSort(), Arrays.asList("E", "D"));
+
+      g.remove("E");
+      assertEquals(g.topologicalSort(), Arrays.asList("D"));
+
+      g.remove("D");
+      assertTrue(g.topologicalSort().isEmpty());
+   }
+
+   @Test(expectedExceptions = IllegalArgumentException.class)
+   public void testAddSelf() {
+      new DependencyGraph<>().addDependency("N", "N");
+   }
+
+   @Test(expectedExceptions = IllegalArgumentException.class)
+   public void testAdNull() {
+      new DependencyGraph<>().addDependency("N", null);
+   }
+
+   @Test(expectedExceptions = CyclicDependencyException.class)
+   public void testCycle() throws CyclicDependencyException {
+      DependencyGraph<Object> graph = new DependencyGraph<>();
+      Object o1 = new Object();
+      Object o2 = new Object();
+      Object o3 = new Object();
+      graph.addDependency(o1, o2);
+      graph.addDependency(o2, o3);
+      graph.addDependency(o3, o1);
+      graph.topologicalSort();
+   }
+
+   private Future<?> submitTask(final String from, final String to, final CountDownLatch waitingFor, ExecutorService onExecutor, final DependencyGraph<String> graph) {
+      return onExecutor.submit(new Runnable() {
+         @Override
+         public void run() {
+            try {
+               waitingFor.await();
+               graph.addDependency(from, to);
+            } catch (InterruptedException ignored) {
+            }
+         }
+      });
+   }
+
+   private void awaitAll(List<Future<?>> futures) throws Exception {
+      for (Future f : futures) {
+         f.get(10, TimeUnit.SECONDS);
+      }
+   }
+
+
+}

--- a/query/src/main/java/org/infinispan/query/impl/IndexPropertyInspector.java
+++ b/query/src/main/java/org/infinispan/query/impl/IndexPropertyInspector.java
@@ -1,0 +1,50 @@
+package org.infinispan.query.impl;
+
+import org.hibernate.search.cfg.Environment;
+import org.infinispan.commons.util.CollectionFactory;
+import org.infinispan.query.indexmanager.InfinispanIndexManager;
+
+import java.util.Properties;
+import java.util.Set;
+
+import static org.hibernate.search.infinispan.InfinispanIntegration.*;
+
+/**
+ * Extract useful information from indexing configuration
+ *
+ * @author gustavonalle
+ * @since 7.0
+ */
+public final class IndexPropertyInspector {
+
+   public static String getLockingCacheName(Properties properties) {
+      return getPropertyFor(LOCKING_CACHENAME, properties, DEFAULT_LOCKING_CACHENAME);
+   }
+
+   public static String getDataCacheName(Properties properties) {
+      return getPropertyFor(DATA_CACHENAME, properties, DEFAULT_INDEXESDATA_CACHENAME);
+   }
+
+   public static String getMetadataCacheName(Properties properties) {
+      return getPropertyFor(METADATA_CACHENAME, properties, DEFAULT_INDEXESMETADATA_CACHENAME);
+   }
+
+   public static boolean hasInfinispanDirectory(Properties properties) {
+      String indexManager = getPropertyFor(Environment.INDEX_MANAGER_IMPL_NAME, properties, null);
+      String directoryProvider = getPropertyFor("directory_provider", properties, null);
+      return (directoryProvider != null && "infinispan".equals(directoryProvider)) ||
+            (indexManager != null && indexManager.equals(InfinispanIndexManager.class.getName()));
+   }
+
+   private static String getPropertyFor(String suffix, Properties properties, String defaultValue) {
+      Set<String> propertyNames = properties.stringPropertyNames();
+      String propertyValue = null;
+      for (String propertyName : propertyNames) {
+         if (propertyName.endsWith(suffix)) {
+            propertyValue = properties.getProperty(propertyName);
+         }
+      }
+      return propertyValue == null ? defaultValue : propertyValue;
+   }
+
+}

--- a/query/src/test/java/org/infinispan/query/backend/IndexCacheStopTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/IndexCacheStopTest.java
@@ -1,0 +1,190 @@
+package org.infinispan.query.backend;
+
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.Index;
+import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.manager.CacheContainer;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.CacheQuery;
+import org.infinispan.query.Search;
+import org.infinispan.query.test.Person;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.util.CyclicDependencyException;
+import org.infinispan.util.DependencyGraph;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.infinispan.test.fwk.TestCacheManagerFactory.createClusteredCacheManager;
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Tests for cache stop order when storing indexes on infinispan
+ *
+ * @author gustavonalle
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "query.backend.IndexCacheStopTest")
+public class IndexCacheStopTest extends AbstractInfinispanTest {
+
+   private static final int CACHE_SIZE = 10;
+
+   @Test
+   public void testIndexingOnDefaultCache() {
+      EmbeddedCacheManager cacheManager = createClusteredCacheManager(getIndexedConfig());
+      startAndIndexData(null, cacheManager);
+      cacheManager.stop();
+
+      assertEquals(cacheManager.getStatus(), ComponentStatus.TERMINATED);
+   }
+
+   @Test
+   public void testIndexingOnNamedCache() {
+      EmbeddedCacheManager cacheManager = createClusteredCacheManager(getIndexedConfig());
+      startAndIndexData("custom", cacheManager);
+      cacheManager.stop();
+
+      assertEquals(cacheManager.getStatus(), ComponentStatus.TERMINATED);
+   }
+
+   @Test
+   public void testIndexingOnMultipleCaches() {
+      EmbeddedCacheManager cacheManager = createClusteredCacheManager();
+      cacheManager.defineConfiguration("cache1", getIndexedConfig().build());
+      cacheManager.defineConfiguration("cache2", getIndexedConfigWithCustomCaches("lockCache", "metadataCache", "dataCache").build());
+      startAndIndexData("cache1", cacheManager);
+      startAndIndexData("cache2", cacheManager);
+      cacheManager.stop();
+
+      assertEquals(cacheManager.getStatus(), ComponentStatus.TERMINATED);
+   }
+
+   @Test
+   public void testIndexingWithInfinispanIndexManager() {
+      EmbeddedCacheManager cacheManager = createClusteredCacheManager();
+      cacheManager.defineConfiguration("cache", getIndexedConfigWithInfinispanIndexManager().build());
+      startAndIndexData("cache", cacheManager);
+      cacheManager.stop();
+
+      assertEquals(cacheManager.getStatus(), ComponentStatus.TERMINATED);
+   }
+
+
+   @Test
+   public void testIndexingWithCustomLock() throws CyclicDependencyException {
+      EmbeddedCacheManager cacheManager = createClusteredCacheManager();
+      DependencyGraph<String> graph = TestingUtil.extractField(cacheManager, "cacheDependencyGraph");
+      cacheManager.defineConfiguration("cache", getIndexedConfigWithCustomLock().build());
+      startAndIndexData("cache", cacheManager);
+      cacheManager.stop();
+
+      List<String> cacheOrder = graph.topologicalSort();
+
+      assertTrue(cacheOrder.indexOf("cache") < cacheOrder.indexOf("LuceneIndexesData"));
+      assertTrue(cacheOrder.indexOf("cache") < cacheOrder.indexOf("LuceneIndexesMetadata"));
+      assertTrue(cacheOrder.indexOf("cache") < cacheOrder.indexOf("LuceneIndexesLocking"));
+      assertEquals(cacheManager.getStatus(), ComponentStatus.TERMINATED);
+   }
+
+   @Test
+   public void testIndexingOnCacheItself() throws CyclicDependencyException {
+      EmbeddedCacheManager cacheManager = createClusteredCacheManager();
+      cacheManager.defineConfiguration("single", getIndexedConfigWithCustomCaches("single", "single", "single").build());
+      startAndIndexData("single", cacheManager);
+      cacheManager.stop();
+
+      assertEquals(cacheManager.getStatus(), ComponentStatus.TERMINATED);
+   }
+
+   @Test
+   public void testIndexingMultipleDirectoriesOnSameCache() throws CyclicDependencyException {
+      EmbeddedCacheManager cacheManager = createClusteredCacheManager();
+      cacheManager.defineConfiguration("cacheA", getIndexedConfigWithCustomCaches("single", "single", "single").build());
+      cacheManager.defineConfiguration("cacheB", getIndexedConfigWithCustomCaches("single", "single", "single").build());
+      startAndIndexData("cacheA", cacheManager);
+      startAndIndexData("cacheB", cacheManager);
+      cacheManager.stop();
+
+      assertEquals(cacheManager.getStatus(), ComponentStatus.TERMINATED);
+   }
+
+   @Test
+   public void testIndexingHierarchically() throws CyclicDependencyException {
+      EmbeddedCacheManager cacheManager = createClusteredCacheManager();
+      cacheManager.defineConfiguration("cacheC", getIndexedConfigWithCustomCaches("cacheB", "cacheB", "cacheB").build());
+      cacheManager.defineConfiguration("cacheB", getIndexedConfigWithCustomCaches("cacheA", "cacheA", "cacheA").build());
+      cacheManager.defineConfiguration("cacheA", getIndexedConfig().build());
+      startAndIndexData("cacheA", cacheManager);
+      startAndIndexData("cacheB", cacheManager);
+      startAndIndexData("cacheC", cacheManager);
+      cacheManager.stop();
+
+      assertEquals(cacheManager.getStatus(), ComponentStatus.TERMINATED);
+   }
+
+   private void startAndIndexData(String cacheName, CacheContainer cacheContainer) {
+      Cache<Integer, Person> cache;
+      if (cacheName == null) {
+         cache = cacheContainer.getCache();
+      } else {
+         cache = cacheContainer.getCache(cacheName);
+      }
+      populateData(cache);
+      assertIndexPopulated(cache);
+   }
+
+   private void assertIndexPopulated(Cache<Integer, Person> cache) {
+      CacheQuery query = Search.getSearchManager(cache).getQuery(new MatchAllDocsQuery(), Person.class);
+      assertEquals(query.list().size(), CACHE_SIZE);
+   }
+
+   private void populateData(Cache<Integer, Person> cache) {
+      for (int i = 0; i < CACHE_SIZE; i++) {
+         cache.put(i, new Person("name" + i, "blurb" + i, i));
+      }
+   }
+
+   private ConfigurationBuilder getBaseConfig() {
+      ConfigurationBuilder cfg = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+      cfg.clustering().cacheMode(CacheMode.DIST_SYNC)
+            .transaction().transactionMode(TransactionMode.TRANSACTIONAL).recovery().disable()
+            .locking()
+            .lockAcquisitionTimeout(10000);
+      return cfg;
+   }
+
+   private ConfigurationBuilder getIndexedConfig() {
+      ConfigurationBuilder cfg = getBaseConfig();
+      cfg.indexing().index(Index.ALL).addProperty("default.directory_provider", "infinispan");
+      return cfg;
+   }
+
+   private ConfigurationBuilder getIndexedConfigWithCustomCaches(String lockCache, String metadataCache, String dataCache) {
+      ConfigurationBuilder cfg = getIndexedConfig();
+      cfg.indexing().index(Index.ALL)
+            .addProperty("default.locking_cachename", lockCache)
+            .addProperty("default.data_cachename", dataCache)
+            .addProperty("default.metadata_cachename", metadataCache);
+      return cfg;
+   }
+
+   private ConfigurationBuilder getIndexedConfigWithInfinispanIndexManager() {
+      ConfigurationBuilder cfg = getIndexedConfig();
+      cfg.indexing().index(Index.ALL).addProperty("default.indexmanager", "org.infinispan.query.indexmanager.InfinispanIndexManager");
+      return cfg;
+   }
+
+   private ConfigurationBuilder getIndexedConfigWithCustomLock() {
+      ConfigurationBuilder cfg = getIndexedConfig();
+      cfg.indexing().index(Index.ALL).addProperty("default.locking_strategy", "none");
+      return cfg;
+   }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4561

As discussed, introduced a graph to store cache dependencies and enforce it at stop time, plus an API to interact with that. Query will register cache dependencies accordingly. Backporting should be straighforward.
