### PR TITLE
Rolling upgrades tests ready for jbossas and wildfly running simultaneou...

### DIFF
--- a/server/integration/testsuite/README.txt
+++ b/server/integration/testsuite/README.txt
@@ -20,6 +20,12 @@ Currently these subsets are predefined:
                                       2) -Dnew.server.schema.version=7.0 -- used to decide which snippet to use during
                                           transformation of a configuration for new servers in the clustered scenario
                                       Configuration snippets for new cluster are prepared for versions: 6.0, 6.1, 7.0)
+  -P suite.rolling.upgrades.dist     (Distribution case of Rolling upgrades)
+
+  -P suite.rolling.upgrades.jbossas       (This profile needs to be used when running Rolling upgrades with
+                                           old Infinispan server based on JBoss AS)
+  -P suite.rolling.upgrades.dist.jbossas  (Distribution case of Rolling upgrades with
+                                           old Infinispan server based on JBoss AS)
 
   -P suite.others                    (Tests that do not belong to any of the suites above. Useful when running a single test that's outside
                                       of any pre-defined group)

--- a/server/integration/testsuite/build-testsuite.xml
+++ b/server/integration/testsuite/build-testsuite.xml
@@ -149,6 +149,8 @@
                 <delete dir="${server.old.dist}-tmp" />
                 <transform transformDir="${server.old.dist}/standalone/configuration" in="standalone.xml" out="standalone.xml"
                            removeRestSecurity="true"/>
+                <transform transformDir="${server.old.dist}/standalone/configuration" in="clustered.xml" out="clustered.xml"
+                           removeRestSecurity="true"/>
 
                 <copy todir="${server2.old.dist}">
                     <fileset dir="${server.old.dist}" />
@@ -177,6 +179,13 @@
                    infinispanServerEndpoint="${other.parts}/rolling-upgrades-server-endpoint-${new.server.schema.version}.xml"
                    addNewHotrodSocketBinding="${other.parts}/socket-binding-hotrod-store.xml"
                    modifyMulticastAddress="${other.parts}/switch-multicast-address.xml"/>
+        <transform in="clustered.xml" out="examples/clustered-rest-rolling-upgrade.xml"
+                   modifyRemoteDestination="${other.parts}/rest-remote-destination.xml"
+                   modifyInfinispan="${infinispan.parts}/rolling-upgrades-clustered-rest-${new.server.schema.version}.xml"
+                   infinispanServerEndpoint="${other.parts}/rolling-upgrades-server-endpoint-${new.server.schema.version}.xml"
+                   addNewRestSocketBinding="${other.parts}/socket-binding-rest-store.xml"
+                   modifyMulticastAddress="${other.parts}/switch-multicast-address.xml"
+                   removeRestSecurity="true"/>
         <transform in="examples/standalone-rest-rolling-upgrade.xml" out="examples/standalone-rest-rolling-upgrade.xml"
                    modifyRemoteDestination="${other.parts}/rest-remote-destination.xml" removeRestSecurity="true"/>
         <transform in="examples/standalone-compatibility-mode.xml" out="examples/standalone-compatibility-mode.xml" removeRestSecurity="true"/>
@@ -279,28 +288,28 @@
                 <configure-jdbc in="@{in}" tablePrefix="STRING_INVALIDATION"/>
             </jdbc-conf>
         </transform>
-        <transform in="standalone.xml" out="testsuite/hotrod-auth.xml" 
-            modifyInfinispan="${infinispan.parts}/local-secured.xml"
-            hotrodAuth="${infinispan.parts}/hotrod-auth.xml" />
-       <transform in="standalone.xml" out="testsuite/hotrod-auth-qop.xml" 
-            modifyInfinispan="${infinispan.parts}/local-secured.xml"
-            hotrodAuth="${infinispan.parts}/hotrod-auth-qop.xml" />
-       <transform in="standalone.xml" out="testsuite/hotrod-auth-ldap.xml" 
-    	    modifyInfinispan="${infinispan.parts}/local-secured.xml"
-       	    hotrodAuth="${infinispan.parts}/hotrod-auth-ldap.xml"
-    	    addSecRealm="${other.parts}/ldap-security-realm.xml"
-       	    addConnection="${other.parts}/ldap-connection.xml"/>
-       <transform in="standalone.xml" out="testsuite/hotrod-auth-ldap-ssl.xml" 
-    	    modifyInfinispan="${infinispan.parts}/local-secured.xml"
-    	    hotrodAuth="${infinispan.parts}/hotrod-auth-ldap.xml"
-       	    hotrodEncrypt="${infinispan.parts}/hotrod-ssl.xml"
-    	    addSecRealm="${other.parts}/ldap-security-realm-with-ssl.xml"
-    	    addConnection="${other.parts}/ldap-connection-ssl.xml"/>	
-       <transform in="standalone.xml" out="testsuite/hotrod-auth-krb.xml" 
-            modifyInfinispan="${infinispan.parts}/local-secured.xml"
-            hotrodAuth="${infinispan.parts}/hotrod-auth-krb.xml" 
-            addKrbOpts="${other.parts}/kerberos-properties.xml"
-            addKrbSecDomain="${other.parts}/kerberos-security-domain.xml" />
+        <transform in="standalone.xml" out="testsuite/hotrod-auth.xml"
+                   modifyInfinispan="${infinispan.parts}/local-secured.xml"
+                   hotrodAuth="${infinispan.parts}/hotrod-auth.xml" />
+        <transform in="standalone.xml" out="testsuite/hotrod-auth-qop.xml"
+                   modifyInfinispan="${infinispan.parts}/local-secured.xml"
+                   hotrodAuth="${infinispan.parts}/hotrod-auth-qop.xml" />
+        <transform in="standalone.xml" out="testsuite/hotrod-auth-ldap.xml"
+                   modifyInfinispan="${infinispan.parts}/local-secured.xml"
+                   hotrodAuth="${infinispan.parts}/hotrod-auth-ldap.xml"
+                   addSecRealm="${other.parts}/ldap-security-realm.xml"
+                   addConnection="${other.parts}/ldap-connection.xml"/>
+        <transform in="standalone.xml" out="testsuite/hotrod-auth-ldap-ssl.xml"
+                   modifyInfinispan="${infinispan.parts}/local-secured.xml"
+                   hotrodAuth="${infinispan.parts}/hotrod-auth-ldap.xml"
+                   hotrodEncrypt="${infinispan.parts}/hotrod-ssl.xml"
+                   addSecRealm="${other.parts}/ldap-security-realm-with-ssl.xml"
+                   addConnection="${other.parts}/ldap-connection-ssl.xml"/>
+        <transform in="standalone.xml" out="testsuite/hotrod-auth-krb.xml"
+                   modifyInfinispan="${infinispan.parts}/local-secured.xml"
+                   hotrodAuth="${infinispan.parts}/hotrod-auth-krb.xml"
+                   addKrbOpts="${other.parts}/kerberos-properties.xml"
+                   addKrbSecDomain="${other.parts}/kerberos-security-domain.xml" />
     </target>
 
     <macrodef name="transform">
@@ -318,6 +327,7 @@
         <attribute name="modifyOutboundSocketBindingHotRod" default="false"/>
         <attribute name="addHotrodSocketBinding" default="false"/>
         <attribute name="addNewHotrodSocketBinding" default="false"/>
+        <attribute name="addNewRestSocketBinding" default="false"/>
         <attribute name="removeRestSecurity" default="true"/>
         <attribute name="infinispanServerEndpoint" default="false"/>
         <attribute name="infinispanFile" default="false"/>
@@ -351,6 +361,7 @@
                 <param name="modifyOutboundSocketBindingHotRod" expression="@{modifyOutboundSocketBindingHotRod}"/>
                 <param name="addHotrodSocketBinding" expression="@{addHotrodSocketBinding}"/>
                 <param name="addNewHotrodSocketBinding" expression="@{addNewHotrodSocketBinding}"/>
+                <param name="addNewRestSocketBinding" expression="@{addNewRestSocketBinding}"/>
                 <param name="removeRestSecurity" expression="@{removeRestSecurity}"/>
                 <param name="infinispanServerEndpoint" expression="@{infinispanServerEndpoint}"/>
                 <param name="infinispanFile" expression="@{infinispanFile}"/>

--- a/server/integration/testsuite/pom.xml
+++ b/server/integration/testsuite/pom.xml
@@ -236,6 +236,8 @@
         <old.server.schema.version>6.1</old.server.schema.version>
         <new.server.schema.version>7.0</new.server.schema.version>
 
+        <start.jboss.as.manually>false</start.jboss.as.manually>
+
         <server.jvm>${env.JAVA_HOME}</server.jvm>
         <resources.dir>${basedir}/src/test/resources</resources.dir>
 
@@ -250,12 +252,15 @@
         <node2.ip>127.0.0.1</node2.ip>
         <node3.ip>127.0.0.1</node3.ip>
         <mcast.ip>234.99.54.14</mcast.ip> <!-- Default multicast address. -->
-        <jvm.ip.stack>-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false -Djboss.default.multicast.address=${mcast.ip}</jvm.ip.stack>
+        <jvm.ip.stack>-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false
+            -Djboss.default.multicast.address=${mcast.ip}
+        </jvm.ip.stack>
         <server.jvm.args>${jvm.ip.stack} ${jvm.memory.args} ${transport.stack} ${jvm.x64.args}</server.jvm.args>
         <log4j.configuration>log4j.xml</log4j.configuration>
         <suite.manual.phase>integration-test</suite.manual.phase>
         <suite.queries.phase>integration-test</suite.queries.phase>
         <suite.rollups.manual.phase>none</suite.rollups.manual.phase>
+        <suite.rollups.manual.dist.phase>none</suite.rollups.manual.dist.phase>
         <suite.client.local.phase>integration-test</suite.client.local.phase>
         <suite.client.dist.phase>integration-test</suite.client.dist.phase>
         <suite.client.repl.phase>integration-test</suite.client.repl.phase>
@@ -263,7 +268,7 @@
 
         <suite.manual.include>**/*.java</suite.manual.include>
         <suite.manual.exclude.groups>
-            org.infinispan.server.test.category.ClientLocal,org.infinispan.server.test.category.ClientClustered,org.infinispan.server.test.category.RollingUpgrades,org.infinispan.server.test.category.Unstable,org.infinispan.server.test.category.Osgi,
+            org.infinispan.server.test.category.ClientLocal,org.infinispan.server.test.category.ClientClustered,org.infinispan.server.test.category.RollingUpgrades,org.infinispan.server.test.category.RollingUpgradesDist,org.infinispan.server.test.category.Unstable,org.infinispan.server.test.category.Osgi,
             org.infinispan.server.test.category.Security, org.infinispan.server.test.category.Queries
         </suite.manual.exclude.groups>
         <suite.client.local.config>testsuite/standalone-default-local.xml</suite.client.local.config>
@@ -384,7 +389,7 @@
                                 <!-- It happens when you do not specify namespaces in the XSLT templates for the newly added nodes
                                      then the IBM jdk transformation is adding empty namespace there - not possible to influence this
                                      behaviour by any environmental property - this is a bit workaround for it -->
-                                <echo message="Removing empty xmlns attributes (xmlns='') which IBM JDK could produce" />
+                                <echo message="Removing empty xmlns attributes (xmlns='') which IBM JDK could produce"/>
                                 <replace dir="target" value="">
                                     <include name="server/node*/standalone/configuration/**/*.xml"/>
                                     <replacetoken><![CDATA[xmlns=""]]></replacetoken>
@@ -407,7 +412,7 @@
                                     <equals arg1="${database}" arg2="h2"/>
                                 </condition>
                                 <first id="first.h2.jar">
-                                    <fileset dir="${server1.dist}/modules" includes="**/h2-*.jar" />
+                                    <fileset dir="${server1.dist}/modules" includes="**/h2-*.jar"/>
                                 </first>
                                 <echo>Run H2 TCP server?: ${run.h2.server}</echo>
                             </target>
@@ -476,6 +481,7 @@
                         <server3.old.dist>${server3.old.dist}</server3.old.dist>
                         <old.server.schema.version>${old.server.schema.version}</old.server.schema.version>
                         <new.server.schema.version>${new.server.schema.version}</new.server.schema.version>
+                        <start.jboss.as.manually>${start.jboss.as.manually}</start.jboss.as.manually>
                         <server.jvm>${server.jvm}</server.jvm>
                         <server.jvm.args>${server.jvm.args}</server.jvm.args>
                         <log4j.configuration>${log4j.configuration}</log4j.configuration>
@@ -565,6 +571,21 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>suite-rollups-manual-dist</id>
+                        <phase>${suite.rollups.manual.dist.phase}</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <reportNameSuffix>${old.server.schema.version}-to-${new.server.schema.version}</reportNameSuffix>
+                            <groups>org.infinispan.server.test.category.RollingUpgradesDist</groups>
+                            <excludedGroups>${groups.unstable}</excludedGroups>
+                            <systemPropertyVariables>
+                                <arquillian.launch>suite-rollups-manual-dist</arquillian.launch>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>suite-client-local</id>
                         <phase>${suite.client.local.phase}</phase>
                         <goals>
@@ -629,59 +650,59 @@
             </plugin>
         </plugins>
         <pluginManagement>
-           <plugins>
-              <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-              <plugin>
-                 <groupId>org.eclipse.m2e</groupId>
-                 <artifactId>lifecycle-mapping</artifactId>
-                 <version>1.0.0</version>
-                 <configuration>
-                    <lifecycleMappingMetadata>
-                       <pluginExecutions>
-                          <pluginExecution>
-                             <pluginExecutionFilter>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-antrun-plugin</artifactId>
-                                <versionRange>[1.7,)</versionRange>
-                                <goals>
-                                   <goal>run</goal>
-                                </goals>
-                             </pluginExecutionFilter>
-                             <action>
-                                <ignore></ignore>
-                             </action>
-                          </pluginExecution>
-                          <pluginExecution>
-                             <pluginExecutionFilter>
-                                <groupId>org.apache.maven.plugins</groupId>
-                                <artifactId>maven-dependency-plugin</artifactId>
-                                <versionRange>[2.6,)</versionRange>
-                                <goals>
-                                   <goal>copy</goal>
-                                </goals>
-                             </pluginExecutionFilter>
-                             <action>
-                                <ignore></ignore>
-                             </action>
-                          </pluginExecution>
-                          <pluginExecution>
-                             <pluginExecutionFilter>
-                                <groupId>org.apache.servicemix.tooling</groupId>
-                                <artifactId>depends-maven-plugin</artifactId>
-                                <versionRange>[1.2,)</versionRange>
-                                <goals>
-                                   <goal>generate-depends-file</goal>
-                                </goals>
-                             </pluginExecutionFilter>
-                             <action>
-                                <ignore></ignore>
-                             </action>
-                          </pluginExecution>
-                       </pluginExecutions>
-                    </lifecycleMappingMetadata>
-                 </configuration>
-              </plugin>
-           </plugins>
+            <plugins>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-antrun-plugin</artifactId>
+                                        <versionRange>[1.7,)</versionRange>
+                                        <goals>
+                                            <goal>run</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-dependency-plugin</artifactId>
+                                        <versionRange>[2.6,)</versionRange>
+                                        <goals>
+                                            <goal>copy</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.servicemix.tooling</groupId>
+                                        <artifactId>depends-maven-plugin</artifactId>
+                                        <versionRange>[1.2,)</versionRange>
+                                        <goals>
+                                            <goal>generate-depends-file</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
         </pluginManagement>
     </build>
 
@@ -798,7 +819,169 @@
                 <suite.client.local.phase>none</suite.client.local.phase>
                 <suite.client.dist.phase>none</suite.client.dist.phase>
                 <suite.client.repl.phase>none</suite.client.repl.phase>
+                <start.jboss.as.manually>false</start.jboss.as.manually>
             </properties>
+        </profile>
+        <profile>
+            <id>suite.rolling.upgrades.dist</id>
+            <properties>
+                <suite.manual.phase>none</suite.manual.phase>
+                <suite.queries.phase>none</suite.queries.phase>
+                <suite.rollups.manual.dist.phase>integration-test</suite.rollups.manual.dist.phase>
+                <suite.client.local.phase>none</suite.client.local.phase>
+                <suite.client.dist.phase>none</suite.client.dist.phase>
+                <suite.client.repl.phase>none</suite.client.repl.phase>
+                <start.jboss.as.manually>false</start.jboss.as.manually>
+            </properties>
+        </profile>
+        <profile>
+            <id>suite.rolling.upgrades.jbossas</id>
+            <properties>
+                <suite.manual.phase>none</suite.manual.phase>
+                <suite.queries.phase>none</suite.queries.phase>
+                <suite.rollups.manual.phase>integration-test</suite.rollups.manual.phase>
+                <suite.client.local.phase>none</suite.client.local.phase>
+                <suite.client.dist.phase>none</suite.client.dist.phase>
+                <suite.client.repl.phase>none</suite.client.repl.phase>
+                <!--don't use controller.start("any-jboss-as-old"); code in test -->
+                <start.jboss.as.manually>true</start.jboss.as.manually>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>infinispan-server-startup</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant antfile="${basedir}/src/test/resources/ant/start-jbossas.xml"
+                                             target="start-jbossas">
+                                            <property name="server-dist" value="${server.old.dist}"/>
+                                            <property name="port-offset" value="100"/>
+                                            <property name="management-port" value="10090"/>
+                                            <property name="hotrod-port" value="11322"/>
+                                            <property name="jboss.node.name" value="node1"/>
+                                            <property name="configuration-file" value="standalone.xml"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>infinispan-server-shutdown</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant antfile="${basedir}/src/test/resources/ant/kill-jbossas.xml"
+                                             target="kill-jbossas">
+                                            <property name="hotrod-port" value="11322"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>suite.rolling.upgrades.dist.jbossas</id>
+            <properties>
+                <suite.manual.phase>none</suite.manual.phase>
+                <suite.queries.phase>none</suite.queries.phase>
+                <suite.rollups.manual.dist.phase>integration-test</suite.rollups.manual.dist.phase>
+                <suite.client.local.phase>none</suite.client.local.phase>
+                <suite.client.dist.phase>none</suite.client.dist.phase>
+                <suite.client.repl.phase>none</suite.client.repl.phase>
+                <!--don't use controller.start("any-jboss-as-old"); code in test -->
+                <start.jboss.as.manually>true</start.jboss.as.manually>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>infinispan-server-startup-200</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant antfile="${basedir}/src/test/resources/ant/start-jbossas.xml"
+                                             target="start-jbossas">
+                                            <property name="server-dist" value="${server2.old.dist}"/>
+                                            <property name="port-offset" value="200"/>
+                                            <property name="management-port" value="10190"/>
+                                            <property name="hotrod-port" value="11422"/>
+                                            <property name="jboss.node.name" value="node2"/>
+                                            <property name="configuration-file" value="clustered.xml"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>infinispan-server-startup-300</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant antfile="${basedir}/src/test/resources/ant/start-jbossas.xml"
+                                             target="start-jbossas">
+                                            <property name="server-dist" value="${server3.old.dist}"/>
+                                            <property name="port-offset" value="300"/>
+                                            <property name="management-port" value="10290"/>
+                                            <property name="hotrod-port" value="11522"/>
+                                            <property name="jboss.node.name" value="node3"/>
+                                            <property name="configuration-file" value="clustered.xml"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>infinispan-server-shutdown-200</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant antfile="${basedir}/src/test/resources/ant/kill-jbossas.xml"
+                                             target="kill-jbossas">
+                                            <property name="hotrod-port" value="11422"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>infinispan-server-shutdown-300</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant antfile="${basedir}/src/test/resources/ant/kill-jbossas.xml"
+                                             target="kill-jbossas">
+                                            <property name="hotrod-port" value="11522"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>client.rest</id>
@@ -885,24 +1068,15 @@
                                 </goals>
                                 <configuration>
                                     <target>
-                                        <exec executable="bash" osfamily="unix" spawn="true">
-                                            <arg line="${server1.dist}/bin/standalone.sh -c testsuite/clustered-indexing.xml"/>
-                                            <env key="JBOSS_HOME" value="${server1.dist}"/>
-                                            <env key="JAVA_OPTS" value="${server.jvm.args} -Djboss.socket.binding.port-offset=0 -Djboss.node.name=jdg"/>
-                                        </exec>
-                                        <exec executable="${server1.dist}/bin/standalone.bat" osfamily="windows" spawn="true">
-                                            <arg line="-c testsuite/clustered-indexing.xml"/>
-                                            <env key="JBOSS_HOME" value="${server1.dist}"/>
-                                            <env key="JAVA_OPTS" value="${server.jvm.args} -Djboss.socket.binding.port-offset=0 -Djboss.node.name=jdg"/>
-                                        </exec>
-                                        <echo>Waiting for Infinispan server to start</echo>
-                                        <waitfor maxwait="15" maxwaitunit="second" checkevery="1" checkeveryunit="second">
-                                            <and>
-                                                <socket server="127.0.0.1" port="9990"/>
-                                                <socket server="127.0.0.1" port="11222"/>
-                                            </and>
-                                        </waitfor>
-                                        <echo message="Infinispan server started"/>
+                                        <ant antfile="${basedir}/src/test/resources/ant/start-jbossas.xml"
+                                             target="start-jbossas">
+                                            <property name="server-dist" value="${server1.dist}"/>
+                                            <property name="port-offset" value="0"/>
+                                            <property name="management-port" value="9990"/>
+                                            <property name="hotrod-port" value="11222"/>
+                                            <property name="jboss.node.name" value="jdg"/>
+                                            <property name="configuration-file" value="testsuite/clustered-indexing.xml"/>
+                                        </ant>
                                     </target>
                                 </configuration>
                             </execution>
@@ -914,43 +1088,10 @@
                                 </goals>
                                 <configuration>
                                     <target>
-                                        <exec executable="${server.jvm}/bin/jps" output="jps.pid" osfamily="unix"/>
-                                        <loadfile srcfile="jps.pid" property="pid" failonerror="false">
-                                            <filterchain>
-                                                <linecontains>
-                                                    <contains value="jboss-modules.jar"/>
-                                                </linecontains>
-                                                <tokenfilter>
-                                                    <deletecharacters chars="jboss-modules.jar"/>
-                                                    <ignoreblank/>
-                                                </tokenfilter>
-                                                <striplinebreaks/>
-                                            </filterchain>
-                                        </loadfile>
-                                        <exec executable="netstat" output="jps.pid" osfamily="windows">
-                                            <arg line="-aon"/>
-                                        </exec>
-                                        <loadfile srcfile="jps.pid" property="pid" failonerror="false">
-                                            <filterchain>
-                                                <linecontains>
-                                                    <contains value="LISTENING"/>
-                                                    <contains value=":11222"/>
-                                                </linecontains>
-                                                <tokenfilter>
-                                                    <replaceregex pattern=".*LISTENING([ \t]+)([0-9]+)" replace="\2" flags="gi"/>
-                                                    <ignoreblank/>
-                                                </tokenfilter>
-                                                <striplinebreaks/>
-                                            </filterchain>
-                                        </loadfile>
-                                        <echo message="Killing Infinispan server with PID - ${pid}"/>
-                                        <exec executable="kill" osfamily="unix">
-                                            <arg line="-9 ${pid}"/>
-                                        </exec>
-                                        <exec executable="taskkill" osfamily="windows">
-                                            <arg line="/F /T /PID ${pid}"/>
-                                        </exec>
-                                        <delete file="jps.pid"/>
+                                        <ant antfile="${basedir}/src/test/resources/ant/kill-jbossas.xml"
+                                             target="kill-jbossas">
+                                            <property name="hotrod-port" value="11222"/>
+                                        </ant>
                                     </target>
                                 </configuration>
                             </execution>
@@ -989,7 +1130,9 @@
         <profile>
             <id>ipv6</id>
             <activation>
-                <property><name>ts.ipv6</name></property>
+                <property>
+                    <name>ts.ipv6</name>
+                </property>
             </activation>
             <properties>
                 <!-- Override IPv4 defaults from the top. -->
@@ -999,8 +1142,10 @@
                 <node0.ip>[::1]</node0.ip>
                 <node1.ip>[::1]</node1.ip>
                 <node2.ip>[::1]</node2.ip>
-                <mcast.ip>[ff01::1]</mcast.ip>      <!-- ff01::1  is IPv6 Node-Local scope mcast addr. -->
-                <jvm.ip.stack>-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true -Djboss.default.multicast.address=${mcast.ip}</jvm.ip.stack>
+                <mcast.ip>[ff01::1]</mcast.ip> <!-- ff01::1  is IPv6 Node-Local scope mcast addr. -->
+                <jvm.ip.stack>-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true
+                    -Djboss.default.multicast.address=${mcast.ip}
+                </jvm.ip.stack>
             </properties>
         </profile>
 

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/category/RollingUpgrades.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/category/RollingUpgrades.java
@@ -1,7 +1,7 @@
 package org.infinispan.server.test.category;
 
 /**
- * {@link org.junit.experimental.categories.Category} tag for clustered client tests.
+ * {@link org.junit.experimental.categories.Category} tag for Rolling Upgrades tests.
  *
  * @author <a href="mailto:tsykora@redhat.com">Tomas Sykora</a>
  *

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/category/RollingUpgradesDist.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/category/RollingUpgradesDist.java
@@ -1,0 +1,11 @@
+package org.infinispan.server.test.category;
+
+/**
+ * {@link org.junit.experimental.categories.Category} tag for Rolling Upgrades distributed tests.
+ *
+ * @author <a href="mailto:tsykora@redhat.com">Tomas Sykora</a>
+ *
+ */
+public class RollingUpgradesDist {
+
+}

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/HotRodRollingUpgradesDistIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/HotRodRollingUpgradesDistIT.java
@@ -1,0 +1,197 @@
+package org.infinispan.server.test.rollingupgrades;
+
+import javax.management.ObjectName;
+
+import org.infinispan.arquillian.core.InfinispanResource;
+import org.infinispan.arquillian.core.RemoteInfinispanServers;
+import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.impl.ConfigurationProperties;
+import org.infinispan.server.test.category.RollingUpgradesDist;
+import org.infinispan.server.test.util.RemoteCacheManagerFactory;
+import org.infinispan.server.test.util.RemoteInfinispanMBeans;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for rolling upgrades functionality, distribution mode.
+ *
+ * @author Tomas Sykora (tsykora@redhat.com)
+ */
+@RunWith(Arquillian.class)
+@Category({RollingUpgradesDist.class})
+public class HotRodRollingUpgradesDistIT {
+
+    @InfinispanResource
+    RemoteInfinispanServers serverManager;
+
+    static final String DEFAULT_CACHE_NAME = "default";
+
+    @ArquillianResource
+    ContainerController controller;
+
+    RemoteCacheManagerFactory rcmFactory;
+
+    @Before
+    public void setUp() {
+        rcmFactory = new RemoteCacheManagerFactory();
+    }
+
+    @After
+    public void tearDown() {
+        if (rcmFactory != null) {
+            rcmFactory.stopManagers();
+        }
+        rcmFactory = null;
+    }
+
+    @Test
+    public void testHotRodRollingUpgradesDiffVersionsDist() throws Exception {
+        // Target nodes
+        final int managementPortServer1 = 9990;
+        MBeanServerConnectionProvider provider1;
+        // Source node
+        int managementPortServer3 = 10199;
+        MBeanServerConnectionProvider provider3;
+
+        try {
+
+            if (!Boolean.parseBoolean(System.getProperty("start.jboss.as.manually"))) {
+                // start it by Arquillian
+                controller.start("hotrod-rolling-upgrade-3-old-dist");
+                controller.start("hotrod-rolling-upgrade-4-old-dist");
+                managementPortServer3 = 10190;
+            }
+
+            // we use PROTOCOL_VERSION_12 here because older servers does not support higher versions
+            ConfigurationBuilder builder3 = new ConfigurationBuilder();
+            builder3.addServer()
+                    .host("127.0.0.1")
+                    .port(11422)
+                    .protocolVersion(ConfigurationProperties.PROTOCOL_VERSION_12);
+
+            RemoteCacheManager rcm3 = new RemoteCacheManager(builder3.build());
+            final RemoteCache<String, String> c3 = rcm3.getCache("default");
+
+            ConfigurationBuilder builder4 = new ConfigurationBuilder();
+            builder4.addServer()
+                    .host("127.0.0.1")
+                    .port(11522)
+                    .protocolVersion(ConfigurationProperties.PROTOCOL_VERSION_12);
+
+            RemoteCacheManager rcm4 = new RemoteCacheManager(builder4.build());
+            final RemoteCache<String, String> c4 = rcm4.getCache("default");
+
+            c3.put("key1", "value1");
+            assertEquals("value1", c3.get("key1"));
+            c4.put("keyx1", "valuex1");
+            assertEquals("valuex1", c4.get("keyx1"));
+
+            for (int i = 0; i < 50; i++) {
+                c3.put("keyLoad" + i, "valueLoad" + i);
+                c4.put("keyLoadx" + i, "valueLoadx" + i);
+            }
+
+            controller.start("hotrod-rolling-upgrade-1-dist");
+            controller.start("hotrod-rolling-upgrade-2-dist");
+
+            RemoteInfinispanMBeans s1 = createRemotes("hotrod-rolling-upgrade-1-dist", "clustered-new", DEFAULT_CACHE_NAME);
+            final RemoteCache<Object, Object> c1 = createCache(s1);
+
+            RemoteInfinispanMBeans s2 = createRemotes("hotrod-rolling-upgrade-2-dist", "clustered-new", DEFAULT_CACHE_NAME);
+            final RemoteCache<Object, Object> c2 = createCache(s2);
+
+            // test cross-fetching of entries from stores
+            assertEquals("Can't access etries stored in source node (target's RemoteCacheStore).", "value1", c1.get("key1"));
+            assertEquals("Can't access etries stored in source node (target's RemoteCacheStore).", "valuex1", c1.get("keyx1"));
+            assertEquals("Can't access etries stored in source node (target's RemoteCacheStore).", "value1", c2.get("key1"));
+            assertEquals("Can't access etries stored in source node (target's RemoteCacheStore).", "valuex1", c2.get("keyx1"));
+
+            provider1 = new MBeanServerConnectionProvider(s1.server.getHotrodEndpoint().getInetAddress().getHostName(),
+                    managementPortServer1);
+
+            provider3 = new MBeanServerConnectionProvider("127.0.0.1", managementPortServer3);
+
+            final ObjectName rollMan3 = new ObjectName("jboss.infinispan:type=Cache," + "name=\"default(dist_sync)\","
+                    + "manager=\"clustered\"," + "component=RollingUpgradeManager");
+
+            invokeOperation(provider3, rollMan3.toString(), "recordKnownGlobalKeyset", new Object[]{}, new String[]{});
+
+            final ObjectName rollMan1 = new ObjectName("jboss.infinispan:type=Cache," + "name=\"default(dist_sync)\","
+                    + "manager=\"clustered-new\"," + "component=RollingUpgradeManager");
+
+            invokeOperation(provider1, rollMan1.toString(), "synchronizeData", new Object[]{"hotrod"},
+                    new String[]{"java.lang.String"});
+
+            invokeOperation(provider1, rollMan1.toString(), "disconnectSource", new Object[]{"hotrod"},
+                    new String[]{"java.lang.String"});
+
+            // is source (RemoteCacheStore) really disconnected?
+            c3.put("disconnected", "source");
+            c4.put("disconnectedx", "sourcex");
+
+            assertEquals("Can't obtain value from cache3 (source node).", "source", c3.get("disconnected"));
+            assertEquals("Can't obtain value from cache4 (source node).", "source", c4.get("disconnected"));
+            assertEquals("Can't obtain value from cache3 (source node).", "sourcex", c3.get("disconnectedx"));
+            assertEquals("Can't obtain value from cache4 (source node).", "sourcex", c4.get("disconnectedx"));
+
+            assertNull("Source node entries should NOT be accessible from target node (after RCS disconnection)",
+                    c1.get("disconnected"));
+            assertNull("Source node entries should NOT be accessible from target node (after RCS disconnection)",
+                    c2.get("disconnected"));
+            assertNull("Source node entries should NOT be accessible from target node (after RCS disconnection)",
+                    c1.get("disconnectedx"));
+            assertNull("Source node entries should NOT be accessible from target node (after RCS disconnection)",
+                    c2.get("disconnectedx"));
+
+            // all entries migrated?
+            assertEquals("Entry was not successfully migrated.", "value1", c1.get("key1"));
+            for (int i = 0; i < 50; i++) {
+                assertEquals("Entry was not successfully migrated.", "valueLoad" + i, c1.get("keyLoad" + i));
+                // it is clustered, all entries should be migrated and accessible
+                assertEquals("Entry was not successfully migrated.", "valueLoadx" + i, c1.get("keyLoadx" + i));
+            }
+        } finally {
+            if (controller.isStarted("hotrod-rolling-upgrade-1-dist")) {
+                controller.stop("hotrod-rolling-upgrade-1-dist");
+            }
+            if (controller.isStarted("hotrod-rolling-upgrade-2-dist")) {
+                controller.stop("hotrod-rolling-upgrade-2-dist");
+            }
+            if (controller.isStarted("hotrod-rolling-upgrade-3-old-dist")) {
+                controller.stop("hotrod-rolling-upgrade-3-old-dist");
+            }
+            if (controller.isStarted("hotrod-rolling-upgrade-4-old-dist")) {
+                controller.stop("hotrod-rolling-upgrade-4-old-dist");
+            }
+        }
+    }
+
+    protected RemoteCache<Object, Object> createCache(RemoteInfinispanMBeans cacheBeans) {
+        return createCache(cacheBeans, ConfigurationProperties.DEFAULT_PROTOCOL_VERSION);
+    }
+
+    protected RemoteCache<Object, Object> createCache(RemoteInfinispanMBeans cacheBeans, String protocolVersion) {
+        return rcmFactory.createCache(cacheBeans, protocolVersion);
+    }
+
+    protected RemoteInfinispanMBeans createRemotes(String serverName, String managerName, String cacheName) {
+        return RemoteInfinispanMBeans.create(serverManager, serverName, cacheName, managerName);
+    }
+
+    private Object invokeOperation(MBeanServerConnectionProvider provider, String mbean, String operationName, Object[] params,
+                                   String[] signature) throws Exception {
+        return provider.getConnection().invoke(new ObjectName(mbean), operationName, params, signature);
+    }
+}

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/HotRodRollingUpgradesIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/HotRodRollingUpgradesIT.java
@@ -2,11 +2,12 @@ package org.infinispan.server.test.rollingupgrades;
 
 import javax.management.ObjectName;
 
-import org.apache.log4j.Logger;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServers;
 import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
 import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 import org.infinispan.server.test.category.RollingUpgrades;
 import org.infinispan.server.test.util.RemoteCacheManagerFactory;
@@ -20,7 +21,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.*;
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for rolling upgrades functionality.
@@ -30,8 +32,6 @@ import static org.junit.Assert.*;
 @RunWith(Arquillian.class)
 @Category({RollingUpgrades.class})
 public class HotRodRollingUpgradesIT {
-
-    private static final Logger log = Logger.getLogger(HotRodRollingUpgradesIT.class);
 
     @InfinispanResource
     RemoteInfinispanServers serverManager;
@@ -62,14 +62,25 @@ public class HotRodRollingUpgradesIT {
         final int managementPortServer1 = 9990;
         MBeanServerConnectionProvider provider1;
         // Source node
-        final int managementPortServer2 = 10099;
+        int managementPortServer2 = 10099; //jboss-as mgmt port
         MBeanServerConnectionProvider provider2;
 
-        controller.start("hotrod-rolling-upgrade-2-old");
         try {
-            // we use PROTOCOL_VERSION_12 here because older servers does not support higher versions
-            RemoteInfinispanMBeans s2 = createRemotes("hotrod-rolling-upgrade-2-old", "local", DEFAULT_CACHE_NAME);
-            final RemoteCache<Object, Object> c2 = createCache(s2, ConfigurationProperties.PROTOCOL_VERSION_12);
+
+            if (!Boolean.parseBoolean(System.getProperty("start.jboss.as.manually"))) {
+                // start it by Arquillian
+                controller.start("hotrod-rolling-upgrade-2-old");
+                managementPortServer2 = 10090;
+            }
+
+            ConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.addServer()
+                   .host("127.0.0.1")
+                   .port(11322)
+                   .protocolVersion(ConfigurationProperties.PROTOCOL_VERSION_12);
+
+            RemoteCacheManager rcm = new RemoteCacheManager(builder.build());
+            final RemoteCache<String, String> c2 = rcm.getCache("default");
 
             c2.put("key1", "value1");
             assertEquals("value1", c2.get("key1"));
@@ -85,15 +96,15 @@ public class HotRodRollingUpgradesIT {
 
             assertEquals("Can't access etries stored in source node (target's RemoteCacheStore).", "value1", c1.get("key1"));
 
-            provider1 = new MBeanServerConnectionProvider(s1.server.getHotrodEndpoint().getInetAddress().getHostName(),
-                    managementPortServer1);
-            provider2 = new MBeanServerConnectionProvider(s2.server.getHotrodEndpoint().getInetAddress().getHostName(),
-                    managementPortServer2);
+            provider2 = new MBeanServerConnectionProvider("127.0.0.1", managementPortServer2);
 
             final ObjectName rollMan = new ObjectName("jboss.infinispan:type=Cache," + "name=\"default(local)\","
                     + "manager=\"local\"," + "component=RollingUpgradeManager");
 
             invokeOperation(provider2, rollMan.toString(), "recordKnownGlobalKeyset", new Object[]{}, new String[]{});
+
+            provider1 = new MBeanServerConnectionProvider(s1.server.getHotrodEndpoint().getInetAddress().getHostName(),
+                    managementPortServer1);
 
             invokeOperation(provider1, rollMan.toString(), "synchronizeData", new Object[]{"hotrod"},
                     new String[]{"java.lang.String"});
@@ -118,110 +129,6 @@ public class HotRodRollingUpgradesIT {
             }
             if (controller.isStarted("hotrod-rolling-upgrade-2-old")) {
                 controller.stop("hotrod-rolling-upgrade-2-old");
-            }
-        }
-    }
-
-    @Test
-    public void testHotRodRollingUpgradesDiffVersionsDist() throws Exception {
-        // Target nodes
-        final int managementPortServer1 = 9990;
-        MBeanServerConnectionProvider provider1;
-        // Source node
-        final int managementPortServer3 = 10199;
-        MBeanServerConnectionProvider provider3;
-
-        controller.start("hotrod-rolling-upgrade-3-old-dist");
-        controller.start("hotrod-rolling-upgrade-4-old-dist");
-        try {
-            // we use PROTOCOL_VERSION_12 here because older servers does not support higher versions
-            RemoteInfinispanMBeans s3 = createRemotes("hotrod-rolling-upgrade-3-old-dist", "clustered", DEFAULT_CACHE_NAME);
-            final RemoteCache<Object, Object> c3 = createCache(s3, ConfigurationProperties.PROTOCOL_VERSION_12);
-
-            RemoteInfinispanMBeans s4 = createRemotes("hotrod-rolling-upgrade-4-old-dist", "clustered", DEFAULT_CACHE_NAME);
-            final RemoteCache<Object, Object> c4 = createCache(s4, ConfigurationProperties.PROTOCOL_VERSION_12);
-
-            c3.put("key1", "value1");
-            assertEquals("value1", c3.get("key1"));
-            c4.put("keyx1", "valuex1");
-            assertEquals("valuex1", c4.get("keyx1"));
-
-            for (int i = 0; i < 50; i++) {
-                c3.put("keyLoad" + i, "valueLoad" + i);
-                c4.put("keyLoadx" + i, "valueLoadx" + i);
-            }
-
-            controller.start("hotrod-rolling-upgrade-1-dist");
-            controller.start("hotrod-rolling-upgrade-2-dist");
-
-            RemoteInfinispanMBeans s1 = createRemotes("hotrod-rolling-upgrade-1-dist", "clustered-new", DEFAULT_CACHE_NAME);
-            final RemoteCache<Object, Object> c1 = createCache(s1);
-
-            RemoteInfinispanMBeans s2 = createRemotes("hotrod-rolling-upgrade-2-dist", "clustered-new", DEFAULT_CACHE_NAME);
-            final RemoteCache<Object, Object> c2 = createCache(s2);
-
-            // test cross-fetching of entries from stores
-            assertEquals("Can't access etries stored in source node (target's RemoteCacheStore).", "value1", c1.get("key1"));
-            assertEquals("Can't access etries stored in source node (target's RemoteCacheStore).", "valuex1", c1.get("keyx1"));
-            assertEquals("Can't access etries stored in source node (target's RemoteCacheStore).", "value1", c2.get("key1"));
-            assertEquals("Can't access etries stored in source node (target's RemoteCacheStore).", "valuex1", c2.get("keyx1"));
-
-            provider1 = new MBeanServerConnectionProvider(s1.server.getHotrodEndpoint().getInetAddress().getHostName(),
-                    managementPortServer1);
-            provider3 = new MBeanServerConnectionProvider(s3.server.getHotrodEndpoint().getInetAddress().getHostName(),
-                    managementPortServer3);
-
-            final ObjectName rollMan3 = new ObjectName("jboss.infinispan:type=Cache," + "name=\"default(dist_sync)\","
-                    + "manager=\"clustered\"," + "component=RollingUpgradeManager");
-
-            invokeOperation(provider3, rollMan3.toString(), "recordKnownGlobalKeyset", new Object[]{}, new String[]{});
-
-            final ObjectName rollMan1 = new ObjectName("jboss.infinispan:type=Cache," + "name=\"default(dist_sync)\","
-                    + "manager=\"clustered-new\"," + "component=RollingUpgradeManager");
-
-            invokeOperation(provider1, rollMan1.toString(), "synchronizeData", new Object[]{"hotrod"},
-                    new String[]{"java.lang.String"});
-
-            invokeOperation(provider1, rollMan1.toString(), "disconnectSource", new Object[]{"hotrod"},
-                    new String[]{"java.lang.String"});
-
-            // is source (RemoteCacheStore) really disconnected?
-            c3.put("disconnected", "source");
-            c4.put("disconnectedx", "sourcex");
-
-            assertEquals("Can't obtain value from cache3 (source node).", "source", c3.get("disconnected"));
-            assertEquals("Can't obtain value from cache4 (source node).", "source", c4.get("disconnected"));
-            assertEquals("Can't obtain value from cache3 (source node).", "sourcex", c3.get("disconnectedx"));
-            assertEquals("Can't obtain value from cache4 (source node).", "sourcex", c4.get("disconnectedx"));
-
-            assertNull("Source node entries should NOT be accessible from target node (after RCS disconnection)",
-                    c1.get("disconnected"));
-            assertNull("Source node entries should NOT be accessible from target node (after RCS disconnection)",
-                    c2.get("disconnected"));
-            assertNull("Source node entries should NOT be accessible from target node (after RCS disconnection)",
-                    c1.get("disconnectedx"));
-            assertNull("Source node entries should NOT be accessible from target node (after RCS disconnection)",
-                    c2.get("disconnectedx"));
-
-            // all entries migrated?
-            assertEquals("Entry was not successfully migrated.", "value1", c1.get("key1"));
-            for (int i = 0; i < 50; i++) {
-                assertEquals("Entry was not successfully migrated.", "valueLoad" + i, c1.get("keyLoad" + i));
-                // it is clustered, all entries should be migrated and accessible
-                assertEquals("Entry was not successfully migrated.", "valueLoadx" + i, c1.get("keyLoadx" + i));
-            }
-        } finally {
-            if (controller.isStarted("hotrod-rolling-upgrade-1-dist")) {
-                controller.stop("hotrod-rolling-upgrade-1-dist");
-            }
-            if (controller.isStarted("hotrod-rolling-upgrade-2-dist")) {
-                controller.stop("hotrod-rolling-upgrade-2-dist");
-            }
-            if (controller.isStarted("hotrod-rolling-upgrade-3-old-dist")) {
-                controller.stop("hotrod-rolling-upgrade-3-old-dist");
-            }
-            if (controller.isStarted("hotrod-rolling-upgrade-4-old-dist")) {
-                controller.stop("hotrod-rolling-upgrade-4-old-dist");
             }
         }
     }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/RestRollingUpgradesDistIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/RestRollingUpgradesDistIT.java
@@ -1,0 +1,166 @@
+package org.infinispan.server.test.rollingupgrades;
+
+import javax.management.ObjectName;
+import javax.servlet.http.HttpServletResponse;
+
+import org.infinispan.arquillian.core.InfinispanResource;
+import org.infinispan.arquillian.core.RemoteInfinispanServers;
+import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
+import org.infinispan.server.test.category.RollingUpgradesDist;
+import org.infinispan.server.test.client.rest.RESTHelper;
+import org.infinispan.server.test.util.RemoteInfinispanMBeans;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.infinispan.server.test.client.rest.RESTHelper.fullPathKey;
+import static org.infinispan.server.test.client.rest.RESTHelper.get;
+import static org.infinispan.server.test.client.rest.RESTHelper.post;
+
+/**
+ * Tests for REST rolling upgrades.
+ *
+ * @author Tomas Sykora (tsykora@redhat.com)
+ * @author Martin Gencur (mgencur@redhat.com)
+ */
+@RunWith(Arquillian.class)
+@Category({RollingUpgradesDist.class})
+public class RestRollingUpgradesDistIT {
+
+    @InfinispanResource
+    RemoteInfinispanServers serverManager;
+
+    static final String DEFAULT_CACHE_NAME = "default";
+    static final int PORT_OFFSET = 100;
+    static final int PORT_OFFSET_200 = 200;
+    static final int PORT_OFFSET_300 = 300;
+
+    @ArquillianResource
+    ContainerController controller;
+
+    @Test
+    public void testRestRollingUpgradesDiffVersionsDist() throws Exception {
+        // Target node
+        final int managementPortServer1 = 9990;
+        MBeanServerConnectionProvider provider1;
+        final int managementPortServer2 = 10090;
+        // Source node
+        int managementPortServer3 = 10199;
+        MBeanServerConnectionProvider provider3;
+
+        if (!Boolean.parseBoolean(System.getProperty("start.jboss.as.manually"))) {
+            // start it by Arquillian
+            controller.start("rest-rolling-upgrade-3-old-dist");
+            controller.start("rest-rolling-upgrade-4-old-dist");
+            managementPortServer3 = 10190;
+        }
+
+        try {
+            // port offset 200, server3, index 0 in RESTHelper
+            RESTHelper.addServer("127.0.0.1", "/rest");
+
+            // port offset 300, server4, index 1 in RESTHelper
+            RESTHelper.addServer("127.0.0.1", "/rest");
+
+            post(fullPathKey(0, DEFAULT_CACHE_NAME, "key1", PORT_OFFSET_200), "data", "text/html");
+            get(fullPathKey(0, DEFAULT_CACHE_NAME, "key1", PORT_OFFSET_200), "data");
+            post(fullPathKey(1, DEFAULT_CACHE_NAME, "key1x", PORT_OFFSET_300), "datax", "text/html");
+            get(fullPathKey(1, DEFAULT_CACHE_NAME, "key1x", PORT_OFFSET_300), "datax");
+
+            for (int i = 0; i < 50; i++) {
+                post(fullPathKey(0, DEFAULT_CACHE_NAME, "keyLoad" + i, PORT_OFFSET_200), "valueLoad" + i, "text/html");
+                post(fullPathKey(1, DEFAULT_CACHE_NAME, "keyLoadx" + i, PORT_OFFSET_300), "valueLoadx" + i, "text/html");
+            }
+
+            controller.start("rest-rolling-upgrade-1-dist");
+            controller.start("rest-rolling-upgrade-2-dist");
+
+            // port offset 0, server0, index 2 in RESTHelper
+            RemoteInfinispanMBeans s1 = createRemotes("rest-rolling-upgrade-1-dist", "clustered-new", DEFAULT_CACHE_NAME);
+            RESTHelper.addServer(s1.server.getRESTEndpoint().getInetAddress().getHostName(), s1.server.getRESTEndpoint().getContextPath());
+
+            // port offset 100, server1, index 3 in RESTHelper
+            RemoteInfinispanMBeans s2 = createRemotes("rest-rolling-upgrade-2-dist", "clustered-new", DEFAULT_CACHE_NAME);
+            RESTHelper.addServer(s2.server.getRESTEndpoint().getInetAddress().getHostName(), s2.server.getRESTEndpoint().getContextPath());
+
+            // test cross-fetching of entries from stores
+            // if fails, it probably can't access entries stored in source node (target's RemoteCacheStore).
+            get(fullPathKey(2, DEFAULT_CACHE_NAME, "key1", 0), "data");
+            get(fullPathKey(2, DEFAULT_CACHE_NAME, "key1x", 0), "datax");
+            get(fullPathKey(3, DEFAULT_CACHE_NAME, "key1", PORT_OFFSET), "data");
+            get(fullPathKey(3, DEFAULT_CACHE_NAME, "key1x", PORT_OFFSET), "datax");
+
+            provider1 = new MBeanServerConnectionProvider(s1.server.getRESTEndpoint().getInetAddress().getHostName(),
+                    managementPortServer1);
+
+            provider3 = new MBeanServerConnectionProvider("127.0.0.1", managementPortServer3);
+
+            final ObjectName rollMan3 = new ObjectName("jboss.infinispan:type=Cache," + "name=\"default(dist_sync)\","
+                    + "manager=\"clustered\"," + "component=RollingUpgradeManager");
+
+            invokeOperation(provider3, rollMan3.toString(), "recordKnownGlobalKeyset", new Object[]{}, new String[]{});
+
+            final ObjectName rollMan1 = new ObjectName("jboss.infinispan:type=Cache," + "name=\"default(dist_sync)\","
+                    + "manager=\"clustered-new\"," + "component=RollingUpgradeManager");
+
+            invokeOperation(provider1, rollMan1.toString(), "synchronizeData", new Object[]{"rest"},
+                    new String[]{"java.lang.String"});
+
+            invokeOperation(provider1, rollMan1.toString(), "disconnectSource", new Object[]{"rest"},
+                    new String[]{"java.lang.String"});
+
+            invokeOperation(new MBeanServerConnectionProvider(s2.server.getRESTEndpoint().getInetAddress().getHostName(),
+                            managementPortServer2), rollMan1.toString(), "disconnectSource", new Object[]{"rest"},
+                    new String[]{"java.lang.String"});
+
+            // 2 puts into source cluster
+            post(fullPathKey(0, DEFAULT_CACHE_NAME, "disconnected", PORT_OFFSET_200), "source", "text/html");
+            post(fullPathKey(1, DEFAULT_CACHE_NAME, "disconnectedx", PORT_OFFSET_300), "sourcex", "text/html");
+
+            get(fullPathKey(0, DEFAULT_CACHE_NAME, "disconnected", PORT_OFFSET_200), "source");
+            get(fullPathKey(0, DEFAULT_CACHE_NAME, "disconnectedx", PORT_OFFSET_200), "sourcex");
+            get(fullPathKey(1, DEFAULT_CACHE_NAME, "disconnected", PORT_OFFSET_300), "source");
+            get(fullPathKey(1, DEFAULT_CACHE_NAME, "disconnectedx", PORT_OFFSET_300), "sourcex");
+
+            // is RemoteCacheStore really disconnected?
+            // source node entries should NOT be accessible from target node now
+            get(fullPathKey(2, DEFAULT_CACHE_NAME, "disconnected", 0), HttpServletResponse.SC_NOT_FOUND);
+            get(fullPathKey(3, DEFAULT_CACHE_NAME, "disconnected", PORT_OFFSET), HttpServletResponse.SC_NOT_FOUND);
+            get(fullPathKey(2, DEFAULT_CACHE_NAME, "disconnectedx", 0), HttpServletResponse.SC_NOT_FOUND);
+            get(fullPathKey(3, DEFAULT_CACHE_NAME, "disconnectedx", PORT_OFFSET), HttpServletResponse.SC_NOT_FOUND);
+
+            // all entries migrated?
+            get(fullPathKey(2, DEFAULT_CACHE_NAME, "key1", 0), "data");
+            for (int i = 0; i < 50; i++) {
+                get(fullPathKey(2, DEFAULT_CACHE_NAME, "keyLoad" + i, 0), "valueLoad" + i);
+                // clustered => all entries should be migrated and accessible
+                get(fullPathKey(2, DEFAULT_CACHE_NAME, "keyLoadx" + i, 0), "valueLoadx" + i);
+            }
+        } finally {
+            if (controller.isStarted("rest-rolling-upgrade-1-dist")) {
+                controller.stop("rest-rolling-upgrade-1-dist");
+            }
+            if (controller.isStarted("rest-rolling-upgrade-2-dist")) {
+                controller.stop("rest-rolling-upgrade-2-dist");
+            }
+            if (controller.isStarted("rest-rolling-upgrade-3-old-dist")) {
+                controller.stop("rest-rolling-upgrade-3-old-dist");
+            }
+            if (controller.isStarted("rest-rolling-upgrade-4-old-dist")) {
+                controller.stop("rest-rolling-upgrade-4-old-dist");
+            }
+        }
+    }
+
+    protected RemoteInfinispanMBeans createRemotes(String serverName, String managerName, String cacheName) {
+        return RemoteInfinispanMBeans.create(serverManager, serverName, cacheName, managerName);
+    }
+
+    private Object invokeOperation(MBeanServerConnectionProvider provider, String mbean, String operationName, Object[] params,
+                                   String[] signature) throws Exception {
+        return provider.getConnection().invoke(new ObjectName(mbean), operationName, params, signature);
+    }
+}

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/RestRollingUpgradesIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/RestRollingUpgradesIT.java
@@ -45,13 +45,18 @@ public class RestRollingUpgradesIT {
         final int managementPortServer1 = 9990;
         MBeanServerConnectionProvider provider1;
         // Source node
-        final int managementPortServer2 = 10099;
+        int managementPortServer2 = 10099;
         MBeanServerConnectionProvider provider2;
 
-        controller.start("rest-rolling-upgrade-2-old");
         try {
-            RemoteInfinispanMBeans s2 = createRemotes("rest-rolling-upgrade-2-old", "local", DEFAULT_CACHE_NAME);
-            RESTHelper.addServer(s2.server.getRESTEndpoint().getInetAddress().getHostName(), s2.server.getRESTEndpoint().getContextPath());
+
+            if (!Boolean.parseBoolean(System.getProperty("start.jboss.as.manually"))) {
+                // start it by Arquillian
+                controller.start("rest-rolling-upgrade-2-old");
+                managementPortServer2 = 10090;
+            }
+
+            RESTHelper.addServer("127.0.0.1", "/rest");
 
             post(fullPathKey(0, DEFAULT_CACHE_NAME, "key1", PORT_OFFSET), "data", "text/html");
             get(fullPathKey(0, DEFAULT_CACHE_NAME, "key1", PORT_OFFSET), "data");
@@ -69,8 +74,8 @@ public class RestRollingUpgradesIT {
 
             provider1 = new MBeanServerConnectionProvider(s1.server.getRESTEndpoint().getInetAddress().getHostName(),
                     managementPortServer1);
-            provider2 = new MBeanServerConnectionProvider(s2.server.getRESTEndpoint().getInetAddress().getHostName(),
-                    managementPortServer2);
+
+            provider2 = new MBeanServerConnectionProvider("127.0.0.1", managementPortServer2);
 
             final ObjectName rollMan = new ObjectName("jboss.infinispan:type=Cache," + "name=\"default(local)\","
                     + "manager=\"local\"," + "component=RollingUpgradeManager");

--- a/server/integration/testsuite/src/test/resources/ant/kill-jbossas.xml
+++ b/server/integration/testsuite/src/test/resources/ant/kill-jbossas.xml
@@ -1,0 +1,41 @@
+<project name="testsuite">
+    <target name="kill-jbossas">
+        <exec executable="${server.jvm}/bin/jps" output="jps.pid" osfamily="unix"/>
+        <loadfile srcfile="jps.pid" property="pid" failonerror="false">
+            <filterchain>
+                <linecontains>
+                    <contains value="jboss-modules.jar"/>
+                </linecontains>
+                <tokenfilter>
+                    <deletecharacters chars="jboss-modules.jar"/>
+                    <ignoreblank/>
+                </tokenfilter>
+                <striplinebreaks/>
+            </filterchain>
+        </loadfile>
+        <exec executable="netstat" output="jps.pid" osfamily="windows">
+            <arg line="-aon"/>
+        </exec>
+        <loadfile srcfile="jps.pid" property="pid" failonerror="false">
+            <filterchain>
+                <linecontains>
+                    <contains value="LISTENING"/>
+                    <contains value=":${hotrod-port}"/>
+                </linecontains>
+                <tokenfilter>
+                    <replaceregex pattern=".*LISTENING([ \t]+)([0-9]+)" replace="\2" flags="gi"/>
+                    <ignoreblank/>
+                </tokenfilter>
+                <striplinebreaks/>
+            </filterchain>
+        </loadfile>
+        <echo message="Killing Infinispan server with PID - ${pid}"/>
+        <exec executable="kill" osfamily="unix">
+            <arg line="-9 ${pid}"/>
+        </exec>
+        <exec executable="taskkill" osfamily="windows">
+            <arg line="/F /T /PID ${pid}"/>
+        </exec>
+        <delete file="jps.pid"/>
+    </target>
+</project>

--- a/server/integration/testsuite/src/test/resources/ant/start-jbossas.xml
+++ b/server/integration/testsuite/src/test/resources/ant/start-jbossas.xml
@@ -1,0 +1,20 @@
+<project name="testsuite">
+    <target name="start-jbossas">
+        <exec executable="bash" osfamily="unix" spawn="true">
+            <arg line="${server-dist}/bin/standalone.sh -c ${configuration-file}"/>
+            <env key="JAVA_OPTS" value="${server.jvm.args} -Djboss.socket.binding.port-offset=${port-offset} -Djboss.node.name=${jboss.node.name}"/>
+        </exec>
+        <exec executable="${server-dist}/bin/standalone.bat" osfamily="windows" spawn="true">
+            <arg line="-c ${configuration-file}"/>
+            <env key="JAVA_OPTS" value="${server.jvm.args} -Djboss.socket.binding.port-offset=${port-offset} -Djboss.node.name=${jboss.node.name}"/>
+        </exec>
+        <echo>Waiting for Infinispan server to start</echo>
+        <waitfor maxwait="15" maxwaitunit="second" checkevery="1" checkeveryunit="second">
+            <and>
+                <socket server="127.0.0.1" port="${management-port}"/>
+                <socket server="127.0.0.1" port="${hotrod-port}"/>
+            </and>
+        </waitfor>
+        <echo message="Infinispan server started (JBossAS based, port offset ${port-offset})"/>
+    </target>
+</project>

--- a/server/integration/testsuite/src/test/resources/arquillian.xml
+++ b/server/integration/testsuite/src/test/resources/arquillian.xml
@@ -779,6 +779,7 @@
                 <property name="javaHome">${server.jvm}</property>
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
+                <property name="allowConnectingToRunningServer">true</property>
                 <property name="serverConfig">examples/standalone-hotrod-rolling-upgrade.xml</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
                 </property>
@@ -790,6 +791,7 @@
             <configuration>
                 <property name="javaHome">${server.jvm}</property>
                 <property name="jbossHome">${server.old.dist}</property>
+                <property name="allowConnectingToRunningServer">true</property>
                 <property name="serverConfig">standalone.xml</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
                     -Djboss.socket.binding.port-offset=100
@@ -798,12 +800,41 @@
                 <property name="waitForPorts">11311 11322 8180</property>
             </configuration>
         </container>
+         <!--REST Rolling Upgrades -->
+        <container qualifier="rest-rolling-upgrade-1" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="serverConfig">examples/standalone-rest-rolling-upgrade.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                </property>
+                <property name="managementPort">9990</property>
+                <property name="waitForPorts">11211 11222 8080</property>
+            </configuration>
+        </container>
+        <container qualifier="rest-rolling-upgrade-2-old" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server.old.dist}</property>
+                <property name="serverConfig">standalone.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                -Djboss.socket.binding.port-offset=100
+                </property>
+                <property name="managementPort">10090</property>
+                <property name="waitForPorts">11311 11322 8180</property>
+            </configuration>
+        </container>
+    </group>
+    <group qualifier="suite-rollups-manual-dist">
         <!-- Dist case, source: node0 and node1, targets: node2 and node3 -->
         <container qualifier="hotrod-rolling-upgrade-1-dist" mode="manual">
             <configuration>
                 <property name="javaHome">${server.jvm}</property>
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
+                <property name="allowConnectingToRunningServer">true</property>
                 <property name="serverConfig">examples/clustered-hotrod-rolling-upgrade.xml</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
                     -Dremote.destination.port=11422
@@ -817,6 +848,7 @@
                 <property name="javaHome">${server.jvm}</property>
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
+                <property name="allowConnectingToRunningServer">true</property>
                 <property name="serverConfig">examples/clustered-hotrod-rolling-upgrade.xml</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
                     -Djboss.socket.binding.port-offset=100 -Dremote.destination.port=11522
@@ -845,33 +877,62 @@
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node3 -Djboss.bind.address.management=${node3.ip} -Djboss.bind.address=${node3.ip}
                     -Djboss.socket.binding.port-offset=300
                 </property>
-                <property name="managementPort">10299</property>
+                <property name="managementPort">10290</property>
                 <property name="waitForPorts">11511 11522 8380</property>
             </configuration>
         </container>
-        <!-- REST Rolling Upgrades -->
-        <container qualifier="rest-rolling-upgrade-1" mode="manual">
+        <!-- REST -->
+        <!-- Dist case, source: node0 and node1, targets: node2 and node3 -->
+        <container qualifier="rest-rolling-upgrade-1-dist" mode="manual">
             <configuration>
                 <property name="javaHome">${server.jvm}</property>
                 <property name="jbossHome">${server1.dist}</property>
-                <property name="serverConfig">examples/standalone-rest-rolling-upgrade.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="managementAddress">${node0.ip}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="serverConfig">examples/clustered-rest-rolling-upgrade.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dremote.destination.port=8280
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
             </configuration>
         </container>
-        <container qualifier="rest-rolling-upgrade-2-old" mode="manual">
+        <container qualifier="rest-rolling-upgrade-2-dist" mode="manual">
             <configuration>
                 <property name="javaHome">${server.jvm}</property>
-                <property name="jbossHome">${server.old.dist}</property>
-                <property name="serverConfig">standalone.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
-                    -Djboss.socket.binding.port-offset=100
+                <property name="jbossHome">${server2.dist}</property>
+                <property name="managementAddress">${node1.ip}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="serverConfig">examples/clustered-rest-rolling-upgrade.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Dremote.destination.port=8380
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
+            </configuration>
+        </container>
+        <container qualifier="rest-rolling-upgrade-3-old-dist" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server2.old.dist}</property>
+                <property name="serverConfig">clustered.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node2 -Djboss.bind.address.management=${node2.ip} -Djboss.bind.address=${node2.ip}
+                    -Djboss.socket.binding.port-offset=200
+                </property>
+                <property name="managementPort">10190</property>
+                <property name="waitForPorts">11411 11422 8280</property>
+            </configuration>
+        </container>
+        <container qualifier="rest-rolling-upgrade-4-old-dist" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server3.old.dist}</property>
+                <property name="serverConfig">clustered.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node3 -Djboss.bind.address.management=${node3.ip} -Djboss.bind.address=${node3.ip}
+                    -Djboss.socket.binding.port-offset=300
+                </property>
+                <property name="managementPort">10290</property>
+                <property name="waitForPorts">11511 11522 8380</property>
             </configuration>
         </container>
     </group>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/rolling-upgrades-clustered-rest-6.0.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/rolling-upgrades-clustered-rest-6.0.xml
@@ -1,0 +1,22 @@
+        <subsystem xmlns="urn:infinispan:server:core:6.0" default-cache-container="clustered-new">
+            <cache-container name="clustered-new" default-cache="default">
+                <transport stack="${jboss.default.jgroups.stack:udp}" executor="infinispan-transport" lock-timeout="240000"/>
+                <distributed-cache name="default"
+                                     start="EAGER"
+                                     mode="SYNC"
+                                     segments="1"
+                                     owners="2"
+                                     batching="false"
+                                     l1-lifespan="0"
+                                     remote-timeout="30000">
+                    <transaction mode="NONE"/>
+                    <rest-store path="/rest/default" shared="true" purge="false" passivation="false">
+                        <connection-pool connection-timeout="60000" socket-timeout="60000" tcp-no-delay="true" max-connections-per-host="4" max-total-connections="20"/>
+                        <remote-server outbound-socket-binding="remote-store-rest-server"/>
+                    </rest-store>
+                </distributed-cache>
+            </cache-container>
+            <cache-container name="security"/>
+        </subsystem>
+
+

--- a/server/integration/testsuite/src/test/resources/config/infinispan/rolling-upgrades-clustered-rest-6.1.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/rolling-upgrades-clustered-rest-6.1.xml
@@ -1,0 +1,22 @@
+        <subsystem xmlns="urn:infinispan:server:core:6.1" default-cache-container="clustered-new">
+            <cache-container name="clustered-new" default-cache="default">
+                <transport stack="${jboss.default.jgroups.stack:udp}" executor="infinispan-transport" lock-timeout="240000"/>
+                <distributed-cache name="default"
+                                     start="EAGER"
+                                     mode="SYNC"
+                                     segments="1"
+                                     owners="2"
+                                     batching="false"
+                                     l1-lifespan="0"
+                                     remote-timeout="30000">
+                    <transaction mode="NONE"/>
+                    <rest-store path="/rest/default" shared="true" purge="false" passivation="false">
+                        <connection-pool connection-timeout="60000" socket-timeout="60000" tcp-no-delay="true" max-connections-per-host="4" max-total-connections="20"/>
+                        <remote-server outbound-socket-binding="remote-store-rest-server"/>
+                    </rest-store>
+                </distributed-cache>
+            </cache-container>
+            <cache-container name="security"/>
+        </subsystem>
+
+

--- a/server/integration/testsuite/src/test/resources/config/infinispan/rolling-upgrades-clustered-rest-7.0.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/rolling-upgrades-clustered-rest-7.0.xml
@@ -1,0 +1,22 @@
+        <subsystem xmlns="urn:infinispan:server:core:7.0" default-cache-container="clustered-new">
+            <cache-container name="clustered-new" default-cache="default">
+                <transport stack="${jboss.default.jgroups.stack:udp}" executor="infinispan-transport" lock-timeout="240000"/>
+                <distributed-cache name="default"
+                                     start="EAGER"
+                                     mode="SYNC"
+                                     segments="1"
+                                     owners="2"
+                                     batching="false"
+                                     l1-lifespan="0"
+                                     remote-timeout="30000">
+                    <transaction mode="NONE"/>
+                    <rest-store path="/rest/default" shared="true" purge="false" passivation="false">
+                        <connection-pool connection-timeout="60000" socket-timeout="60000" tcp-no-delay="true" max-connections-per-host="4" max-total-connections="20"/>
+                        <remote-server outbound-socket-binding="remote-store-rest-server"/>
+                    </rest-store>
+                </distributed-cache>
+            </cache-container>
+            <cache-container name="security"/>
+        </subsystem>
+
+

--- a/server/integration/testsuite/src/test/resources/config/parts/rest-remote-destination.xml
+++ b/server/integration/testsuite/src/test/resources/config/parts/rest-remote-destination.xml
@@ -1,1 +1,1 @@
-<remote-destination host="${jboss.bind.address:127.0.0.1}" port="8180"/>
+<remote-destination host="${jboss.bind.address:127.0.0.1}" port="${remote.destination.port:8180}"/>

--- a/server/integration/testsuite/src/test/resources/config/parts/socket-binding-rest-store.xml
+++ b/server/integration/testsuite/src/test/resources/config/parts/socket-binding-rest-store.xml
@@ -1,0 +1,3 @@
+<outbound-socket-binding name="remote-store-rest-server">
+    <remote-destination host="127.0.0.1" port="${remote.destination.port:8280}"/>
+</outbound-socket-binding>

--- a/server/integration/versions/pom.xml
+++ b/server/integration/versions/pom.xml
@@ -33,7 +33,7 @@
       <version.org.jboss.modules>1.3.3.Final</version.org.jboss.modules>
       <version.junit>4.11</version.junit>
       <version.org.infinispan>${project.version}</version.org.infinispan>
-      <version.org.infinispan.arquillian.container>1.2.0.Alpha1</version.org.infinispan.arquillian.container>
+      <version.org.infinispan.arquillian.container>1.2.0.Alpha2</version.org.infinispan.arquillian.container>
       <version.org.slf4j>1.7.2</version.org.slf4j>
       <version.org.wildfly>8.1.0.Final</version.org.wildfly>
       <version.org.xerial.snappy>1.0.5</version.org.xerial.snappy>
@@ -295,7 +295,7 @@
          <dependency>
             <groupId>org.infinispan.arquillian.container</groupId>
             <artifactId>infinispan-arquillian-container-managed</artifactId>
-            <version>${version.org.infinispan.arquillian.containern}</version>
+            <version>${version.org.infinispan.arquillian.container}</version>
             <scope>test</scope>
          </dependency>
 


### PR DESCRIPTION
...sly

https://issues.jboss.org/browse/ISPN-4421

!!! This depends on https://github.com/infinispan/infinispan-arquillian-container/pull/32 !!!

No luck with multi-container extension and convincing Wildfly guys to rename packages in order to be able to recognize jboss-as and wildfly container adapter on class path.

Created this PR with OLD jboss-as based Infinispan servers from maven. 

3 new profiles were created -- see readme for more info. 
-P suite.rolling.upgrades.dist
-P suite.rolling.upgrades.jbossas
-P suite.rolling.upgrades.dist.jbossas

Note: there is a bug in RestRollingUpgrades where example config file is missing:
extension module="org.wildfly.extension.io"
extension module="org.wildfly.extension.undertow" 
ignore this failure, will be OK once fixed.
