### PR TITLE
ISPN-4691 Custom remote events should ship the originating event type

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/event/ClientEvent.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/event/ClientEvent.java
@@ -6,8 +6,7 @@ package org.infinispan.client.hotrod.event;
 public interface ClientEvent {
    static enum Type {
       CLIENT_CACHE_ENTRY_CREATED, CLIENT_CACHE_ENTRY_MODIFIED,
-      CLIENT_CACHE_ENTRY_REMOVED, CLIENT_CACHE_ENTRY_CUSTOM,
-      CLIENT_CACHE_FAILOVER
+      CLIENT_CACHE_ENTRY_REMOVED, CLIENT_CACHE_FAILOVER
    }
 
    Type getType();

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
@@ -204,13 +204,13 @@ public class Codec20 implements Codec, HotRodConstants {
       };
    }
 
-   private ClientCacheEntryCustomEvent<Object> createCustomEvent(final Object eventData, ClientEvent.Type evenType) {
+   private ClientCacheEntryCustomEvent<Object> createCustomEvent(final Object eventData, final ClientEvent.Type eventType) {
       return new ClientCacheEntryCustomEvent<Object>() {
          @Override public Object getEventData() { return eventData; }
-         @Override public Type getType() { return Type.CLIENT_CACHE_ENTRY_CREATED; }
+         @Override public Type getType() { return eventType; }
          @Override
          public String toString() {
-            return "ClientCacheEntryCustomEvent(" + "eventData=" + eventData + ")";
+            return "ClientCacheEntryCustomEvent(" + "eventData=" + eventData + ", eventType=" + eventType + ")";
          }
       };
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterEventsTest.java
@@ -108,13 +108,13 @@ public class ClientClusterEventsTest extends MultiHotRodServersTest {
             RemoteCache<Integer, String> c3 = client(2).getCache();
             eventListener.expectNoEvents();
             c3.put(1, "one");
-            eventListener.expectSingleCustomEvent(1, "one");
+            eventListener.expectOnlyCreatedCustomEvent(1, "one");
             c3.put(2, "two");
-            eventListener.expectSingleCustomEvent(2, "two");
+            eventListener.expectOnlyCreatedCustomEvent(2, "two");
             c3.remove(1);
-            eventListener.expectSingleCustomEvent(1, null);
+            eventListener.expectOnlyRemovedCustomEvent(1, null);
             c3.remove(2);
-            eventListener.expectSingleCustomEvent(2, null);
+            eventListener.expectOnlyRemovedCustomEvent(2, null);
          }
       });
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientCustomEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientCustomEventsTest.java
@@ -34,11 +34,11 @@ public class ClientCustomEventsTest extends SingleHotRodServerTest {
             RemoteCache<Integer, String> cache = rcm.getCache();
             eventListener.expectNoEvents();
             cache.put(1, "one");
-            eventListener.expectSingleCustomEvent(1, "one");
+            eventListener.expectOnlyCreatedCustomEvent(1, "one");
             cache.put(1, "newone");
-            eventListener.expectSingleCustomEvent(1, "newone");
+            eventListener.expectOnlyModifiedCustomEvent(1, "newone");
             cache.remove(1);
-            eventListener.expectSingleCustomEvent(1, null);
+            eventListener.expectOnlyRemovedCustomEvent(1, null);
          }
       });
    }
@@ -51,9 +51,9 @@ public class ClientCustomEventsTest extends SingleHotRodServerTest {
             RemoteCache<Integer, String> cache = rcm.getCache();
             eventListener.expectNoEvents();
             cache.put(1, "one");
-            eventListener.expectSingleCustomEvent(1, "one");
+            eventListener.expectOnlyCreatedCustomEvent(1, "one");
             cache.put(2, "two");
-            eventListener.expectSingleCustomEvent(2, null);
+            eventListener.expectOnlyCreatedCustomEvent(2, null);
          }
       });
    }
@@ -65,7 +65,7 @@ public class ClientCustomEventsTest extends SingleHotRodServerTest {
       withClientListener(staticEventListener, new RemoteCacheManagerCallable(remoteCacheManager) {
          @Override
          public void call() {
-            staticEventListener.expectSingleCustomEvent(1, "one");
+            staticEventListener.expectOnlyCreatedCustomEvent(1, "one");
          }
       });
       final DynamicCustomEventLogListener dynamicEventListener = new DynamicCustomEventLogListener();
@@ -73,7 +73,7 @@ public class ClientCustomEventsTest extends SingleHotRodServerTest {
       withClientListener(dynamicEventListener, null, new Object[]{2}, new RemoteCacheManagerCallable(remoteCacheManager) {
          @Override
          public void call() {
-            dynamicEventListener.expectSingleCustomEvent(2, null);
+            dynamicEventListener.expectOnlyCreatedCustomEvent(2, null);
          }
       });
    }

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedHotRodTest.java
@@ -328,13 +328,13 @@ public class EmbeddedHotRodTest extends AbstractInfinispanTest {
          eventListener.expectNoEvents();
          remote.put(1, "one");
          assertEquals("one", embedded.get(1));
-         eventListener.expectSingleCustomEvent(1, "one");
+         eventListener.expectOnlyCreatedCustomEvent(1, "one");
          remote.put(1, "new-one");
          assertEquals("new-one", embedded.get(1));
-         eventListener.expectSingleCustomEvent(1, "new-one");
+         eventListener.expectOnlyModifiedCustomEvent(1, "new-one");
          remote.remove(1);
          assertNull(embedded.get(1));
-         eventListener.expectSingleCustomEvent(1, null);
+         eventListener.expectOnlyRemovedCustomEvent(1, null);
       } finally {
          remote.removeClientListener(eventListener);
       }
@@ -349,16 +349,16 @@ public class EmbeddedHotRodTest extends AbstractInfinispanTest {
          eventListener.expectNoEvents();
          remote.put(1, "one");
          assertEquals("one", embedded.get(1));
-         eventListener.expectSingleCustomEvent(1, "one");
+         eventListener.expectOnlyCreatedCustomEvent(1, "one");
          remote.put(2, "two");
          assertEquals("two", embedded.get(2));
-         eventListener.expectSingleCustomEvent(2, null);
+         eventListener.expectOnlyCreatedCustomEvent(2, null);
          remote.remove(1);
          assertNull(embedded.get(1));
-         eventListener.expectSingleCustomEvent(1, null);
+         eventListener.expectOnlyRemovedCustomEvent(1, null);
          remote.remove(2);
          assertNull(embedded.get(2));
-         eventListener.expectSingleCustomEvent(2, null);
+         eventListener.expectOnlyRemovedCustomEvent(2, null);
       } finally {
          remote.removeClientListener(eventListener);
       }


### PR DESCRIPTION
- Effectively, this is a JIRA to align with what's in documentation: Custom events should carry information on the type of the original event, whether it's created, modified or removed.
