### PR TITLE
ISPN-4699 Non indexed query fails when a cachestore is used

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodNonIndexedSingleFileStoreQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodNonIndexedSingleFileStoreQueryTest.java
@@ -1,0 +1,40 @@
+package org.infinispan.client.hotrod.query;
+
+import org.infinispan.commons.equivalence.ByteArrayEquivalence;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.Test;
+
+/**
+ * @author anistor@redhat.com
+ * @since 7.0
+ */
+@Test(testName = "client.hotrod.query.HotRodNonIndexedSingleFileStoreQueryTest", groups = "functional")
+public class HotRodNonIndexedSingleFileStoreQueryTest extends HotRodNonIndexedQueryTest {
+
+   private final String tmpDirectory = TestingUtil.tmpDirectory(getClass());
+
+   @Override
+   protected void teardown() {
+      try {
+         super.teardown();
+      } finally {
+         TestingUtil.recursiveFileRemove(tmpDirectory);
+      }
+   }
+
+   @Override
+   protected ConfigurationBuilder getConfigurationBuilder() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.dataContainer().keyEquivalence(ByteArrayEquivalence.INSTANCE)
+            .persistence()
+            .addStore(SingleFileStoreConfigurationBuilder.class)
+            .location(tmpDirectory);
+
+      // ensure the data container contains minimal data so the store will need to be accessed to get the rest
+      builder.locking().concurrencyLevel(1).dataContainer().eviction().maxEntries(1);
+
+      return builder;
+   }
+}

--- a/core/src/main/java/org/infinispan/iteration/impl/LocalEntryRetriever.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/LocalEntryRetriever.java
@@ -3,7 +3,9 @@ package org.infinispan.iteration.impl;
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.commons.util.concurrent.ParallelIterableMap;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.DataContainer;
@@ -31,7 +33,6 @@ import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.persistence.spi.AdvancedCacheLoader;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.TimeService;
-import org.infinispan.util.concurrent.ConcurrentHashSet;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.concurrent.WithinThreadExecutor;
 import org.infinispan.util.logging.Log;
@@ -76,6 +77,7 @@ public class LocalEntryRetriever<K, V> implements EntryRetriever<K, V> {
    protected Cache<K, V> cache;
    protected TimeService timeService;
    protected InternalEntryFactory entryFactory;
+   protected Equivalence<K> keyEquivalence;
 
    protected final Executor withinThreadExecutor = new WithinThreadExecutor();
 
@@ -94,6 +96,7 @@ public class LocalEntryRetriever<K, V> implements EntryRetriever<K, V> {
       this.cache = cache;
 
       this.passivationEnabled = config.persistence().passivation();
+      this.keyEquivalence = config.dataContainer().keyEquivalence();
    }
 
    public LocalEntryRetriever(int batchSize, long timeout, TimeUnit unit) {
@@ -198,7 +201,7 @@ public class LocalEntryRetriever<K, V> implements EntryRetriever<K, V> {
          @Override
          public void run() {
             try {
-               final Set<K> processedKeys = new ConcurrentHashSet<K>();
+               final Set<K> processedKeys = CollectionFactory.makeSet(keyEquivalence);
                Queue<CacheEntry<K, C>> queue = new ArrayDeque<CacheEntry<K, C>>(batchSize) {
                   @Override
                   public boolean add(CacheEntry<K, C> kcEntry) {
@@ -220,7 +223,7 @@ public class LocalEntryRetriever<K, V> implements EntryRetriever<K, V> {
                                                                           entry);
                      K key = clone.getKey();
                      if (filter != null) {
-                        if (filter instanceof KeyValueFilterConverter && usedConverter == null) {
+                        if (usedConverter == null && filter instanceof KeyValueFilterConverter) {
                            C converted = ((KeyValueFilterConverter<K, V, C>)filter).filterAndConvert(
                                  key, clone.getValue(), clone.getMetadata());
                            if (converted != null) {
@@ -247,11 +250,14 @@ public class LocalEntryRetriever<K, V> implements EntryRetriever<K, V> {
                         cache.addListener(listener);
                      }
                      KeyFilter<K> loaderFilter;
-                     if (filter != null) {
+                     if (filter == null || usedConverter == null && filter instanceof KeyValueFilterConverter) {
+                        loaderFilter = new CollectionKeyFilter<K>(processedKeys);
+                     } else {
                         loaderFilter = new CompositeKeyFilter<K>(new CollectionKeyFilter<K>(processedKeys),
                                                                  new KeyValueFilterAsKeyFilter<K>(filter));
-                     } else {
-                        loaderFilter = new CollectionKeyFilter<K>(processedKeys);
+                     }
+                     if (usedConverter == null && filter instanceof KeyValueFilterConverter) {
+                        action = new MapAction(batchSize, (KeyValueFilterConverter) filter, queue, handler);
                      }
                      persistenceManager.processOnAllStores(withinThreadExecutor, loaderFilter,
                                                            new KeyValueActionForCacheLoaderTask(action), true, true);
@@ -308,6 +314,9 @@ public class LocalEntryRetriever<K, V> implements EntryRetriever<K, V> {
          CacheEntry<K, C> clone = (CacheEntry<K, C>)kvInternalCacheEntry.clone();
          if (converter != null) {
             C value = converter.convert(k, kvInternalCacheEntry.getValue(), kvInternalCacheEntry.getMetadata());
+            if (value == null && converter instanceof KeyValueFilterConverter) {
+               return;
+            }
             clone.setValue(value);
          }
 
@@ -317,7 +326,7 @@ public class LocalEntryRetriever<K, V> implements EntryRetriever<K, V> {
             try {
                handler.handleBatch(false, queue);
             } catch (InterruptedException e) {
-               Thread.currentThread().interrupt();;
+               Thread.currentThread().interrupt();
             }
             queue.clear();
          }

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManager.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManager.java
@@ -10,7 +10,6 @@ import org.infinispan.filter.KeyFilter;
 import org.infinispan.lifecycle.Lifecycle;
 import org.infinispan.persistence.spi.AdvancedCacheLoader;
 import org.infinispan.marshall.core.MarshalledEntry;
-import org.infinispan.marshall.core.MarshalledEntryImpl;
 
 /**
  * Defines the logic for interacting with the chain of external storage.

--- a/core/src/test/java/org/infinispan/persistence/BaseStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/BaseStoreFunctionalTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.persistence;
 
-import static org.infinispan.test.TestingUtil.withCacheManager;
 import static org.junit.Assert.*;
 
 import java.io.Serializable;
@@ -19,7 +18,6 @@ import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.persistence.spi.PersistenceException;
-import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedClusteredDummyInMemoryStoreQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedClusteredDummyInMemoryStoreQueryDslConditionsTest.java
@@ -1,0 +1,26 @@
+package org.infinispan.query.dsl.embedded;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * @author anistor@redhat.com
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "query.dsl.NonIndexedClusteredDummyInMemoryStoreQueryDslConditionsTest")
+public class NonIndexedClusteredDummyInMemoryStoreQueryDslConditionsTest extends NonIndexedQueryDslConditionsTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder cfg = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+      cfg.persistence()
+            .addStore(DummyInMemoryStoreConfigurationBuilder.class);
+
+      // ensure the data container contains minimal data so the store will need to be accessed to get the rest
+      cfg.locking().concurrencyLevel(1).dataContainer().eviction().maxEntries(1);
+
+      createClusteredCaches(2, cfg);
+   }
+}

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedClusteredQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedClusteredQueryDslConditionsTest.java
@@ -1,0 +1,19 @@
+package org.infinispan.query.dsl.embedded;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * @author anistor@redhat.com
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "query.dsl.NonIndexedClusteredQueryDslConditionsTest")
+public class NonIndexedClusteredQueryDslConditionsTest extends NonIndexedQueryDslConditionsTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder cfg = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+      createClusteredCaches(2, cfg);
+   }
+}

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedSingleFileStoreQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedSingleFileStoreQueryDslConditionsTest.java
@@ -1,0 +1,41 @@
+package org.infinispan.query.dsl.embedded;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Test for non-indexed query on a cache with a single-file store.
+ *
+ * @author anistor@redhat.com
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "query.dsl.NonIndexedSingleFileStoreQueryDslConditionsTest")
+public class NonIndexedSingleFileStoreQueryDslConditionsTest extends NonIndexedQueryDslConditionsTest {
+
+   private final String tmpDirectory = TestingUtil.tmpDirectory(getClass());
+
+   @Override
+   protected void destroy() {
+      try {
+         super.destroy();
+      } finally {
+         TestingUtil.recursiveFileRemove(tmpDirectory);
+      }
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder cfg = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+      cfg.persistence()
+            .addStore(SingleFileStoreConfigurationBuilder.class)
+            .location(tmpDirectory);
+
+      // ensure the data container contains minimal data so the store will need to be accessed to get the rest
+      cfg.locking().concurrencyLevel(1).dataContainer().eviction().maxEntries(1);
+
+      createClusteredCaches(1, cfg);
+   }
+}


### PR DESCRIPTION
- add new tests to cover this case
- FilterAndConverter.filterAndConvert should not fail if the value is null
- LocalEntryRetriever should use a MapAction configured with the appropriate converter

Jira: https://issues.jboss.org/browse/ISPN-4699
