### PR TITLE
ISPN-4704 Cluster Listener REPL may not notify properly based on owner

### DIFF
--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
@@ -831,7 +831,7 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
                      handler = currentQueue;
                   }
                }
-               returnValue = new ClusteredListenerInvocation<K, V>(invocation, handler, filter, converter, identifier);
+               returnValue = new ClusteredListenerInvocation<K, V>(invocation, handler, filter, converter, onlyPrimary, identifier);
             } else {
 //               TODO: this is removed until non cluster listeners are supported
 //               QueueingSegmentListener handler = segmentHandler.get(identifier);
@@ -886,11 +886,11 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
 
       private final QueueingSegmentListener<K, V, CacheEntryEvent<K, V>> handler;
 
-
       public ClusteredListenerInvocation(ListenerInvocation<Event<K, V>> invocation, QueueingSegmentListener handler,
                                        KeyValueFilter<? super K, ? super V> filter,
-                                       Converter<? super K, ? super V, ?> converter, UUID identifier)  {
-         super(invocation, filter, converter, true, true, identifier);
+                                       Converter<? super K, ? super V, ?> converter, boolean onlyPrimary,
+                                       UUID identifier)  {
+         super(invocation, filter, converter, onlyPrimary, true, identifier);
          this.handler = handler;
       }
 

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerNonTxTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerNonTxTest.java
@@ -38,7 +38,7 @@ public abstract class AbstractClusterListenerNonTxTest extends AbstractClusterLi
       Cache<Object, String> cache1 = cache(1, CACHE_NAME);
       Cache<Object, String> cache2 = cache(2, CACHE_NAME);
 
-      ClusterListener clusterListener = new ClusterListener();
+      ClusterListener clusterListener = listener();
       cache0.addListener(clusterListener);
 
       CheckPoint checkPoint = new CheckPoint();

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerTest.java
@@ -64,13 +64,17 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
       super(tx, cacheMode);
    }
 
+   protected ClusterListener listener() {
+      return new ClusterListener();
+   }
+
    @Test
    public void testCreateFromNonOwnerWithListenerNotOwner() {
       Cache<Object, String> cache0 = cache(0, CACHE_NAME);
       Cache<Object, String> cache1 = cache(1, CACHE_NAME);
       Cache<Object, String> cache2 = cache(2, CACHE_NAME);
 
-      ClusterListener clusterListener = new ClusterListener();
+      ClusterListener clusterListener = listener();
       cache0.addListener(clusterListener);
 
       MagicKey key = new MagicKey(cache1, cache2);
@@ -83,7 +87,7 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
       Cache<Object, String> cache1 = cache(1, CACHE_NAME);
       Cache<Object, String> cache2 = cache(2, CACHE_NAME);
 
-      ClusterListener clusterListener = new ClusterListener();
+      ClusterListener clusterListener = listener();
       cache0.addListener(clusterListener);
 
       MagicKey key = new MagicKey(cache1, cache0);
@@ -95,7 +99,7 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
    public void testLocalNodeOwnerAndClusterListener() {
       Cache<Object, String> cache0 = cache(0, CACHE_NAME);
 
-      ClusterListener clusterListener = new ClusterListener();
+      ClusterListener clusterListener = listener();
       cache0.addListener(clusterListener);
 
       MagicKey key = new MagicKey(cache0);
@@ -109,7 +113,7 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
       Cache<Object, String> cache1 = cache(1, CACHE_NAME);
       Cache<Object, String> cache2 = cache(2, CACHE_NAME);
 
-      ClusterListener clusterListener = new ClusterListener();
+      ClusterListener clusterListener = listener();
       cache0.addListener(clusterListener);
 
       MagicKey key = new MagicKey(cache1, cache2);
@@ -148,7 +152,7 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
    protected void testFilter(Object keyToFilterOut, Object keyToUse, Long lifespan, KeyValueFilter<? super Object, ? super String> filter) {
       Cache<Object, String> cache0 = cache(0, CACHE_NAME);
 
-      ClusterListener clusterListener = new ClusterListener();
+      ClusterListener clusterListener = listener();
       cache0.addListener(clusterListener, filter, null);
 
       cache0.put(keyToFilterOut, FIRST_VALUE);
@@ -214,7 +218,7 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
    protected void testSimpleConverter(Object key) {
       Cache<Object, String> cache0 = cache(0, CACHE_NAME);
 
-      ClusterListener clusterListener = new ClusterListener();
+      ClusterListener clusterListener = listener();
       cache0.addListener(clusterListener, null, new StringTruncator(0, 2));
 
       verifySimpleInsertion(cache0, key, FIRST_VALUE, null, clusterListener, FIRST_VALUE.substring(0, 2));
@@ -224,7 +228,7 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
                                     Converter<Object, ? super String, C> converter) {
       Cache<Object, String> cache0 = cache(0, CACHE_NAME);
 
-      ClusterListener clusterListener = new ClusterListener();
+      ClusterListener clusterListener = listener();
       cache0.addListener(clusterListener, null, converter);
 
       verifySimpleInsertion(cache0, key, value, lifespan, clusterListener, resultingValue);
@@ -236,7 +240,7 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
       Cache<Object, String> cache1 = cache(1, CACHE_NAME);
       Cache<Object, String> cache2 = cache(2, CACHE_NAME);
 
-      ClusterListener clusterListener = new ClusterListener();
+      ClusterListener clusterListener = listener();
       cache0.addListener(clusterListener);
 
       int cache1ListenerSize = cache1.getAdvancedCache().getListeners().size();
@@ -260,7 +264,7 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
    public void testNodeComesUpWithClusterListenerAlreadyInstalled() {
       Cache<Object, String> cache0 = cache(0, CACHE_NAME);
 
-      ClusterListener clusterListener = new ClusterListener();
+      ClusterListener clusterListener = listener();
       cache0.addListener(clusterListener);
 
       log.info("Adding a new node ..");
@@ -278,7 +282,7 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
       final String keyToFilter = "filter-me";
       Cache<Object, String> cache0 = cache(0, CACHE_NAME);
 
-      ClusterListener clusterListener = new ClusterListener();
+      ClusterListener clusterListener = listener();
       cache0.addListener(clusterListener, new KeyFilterAsKeyValueFilter<Object, String>(
             new CollectionKeyFilter<Object>(Collections.singleton(keyToFilter), true)), new StringTruncator(0, 3));
 
@@ -306,7 +310,7 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
       int initialCache1ListenerSize = cache1.getAdvancedCache().getListeners().size();
       int initialCache2ListenerSize = cache2.getAdvancedCache().getListeners().size();
 
-      ClusterListener clusterListener = new ClusterListener();
+      ClusterListener clusterListener = listener();
       cache0.addListener(clusterListener);
 
       // Adding a cluster listener should add to each node in cluster
@@ -333,7 +337,7 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
       int initialCache1ListenerSize = cache1.getAdvancedCache().getListeners().size();
       int initialCache2ListenerSize = cache2.getAdvancedCache().getListeners().size();
 
-      ClusterListener clusterListener = new ClusterListener();
+      ClusterListener clusterListener = listener();
       cache0.addListener(clusterListener);
 
       // Adding a cluster listener should add to each node in cluster
@@ -343,7 +347,7 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
       assertEquals(cache2.getAdvancedCache().getListeners().size(), initialCache2ListenerSize +
             (cacheMode.isDistributed() ? 1 : 0));
 
-      ClusterListener clusterListener2 = new ClusterListener();
+      ClusterListener clusterListener2 = listener();
       cache0.addListener(clusterListener2);
 
       // Adding a second cluster listener should add to each node in cluster as well
@@ -392,7 +396,7 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
       Object key = new MagicKey(cache1, cache2);
       cache1.put(key, "some-key");
 
-      final ClusterListener clusterListener = new ClusterListener();
+      final ClusterListener clusterListener = listener();
       cache0.addListener(clusterListener);
 
       log.info("Killing node 1 ..");
@@ -403,6 +407,6 @@ public abstract class AbstractClusterListenerTest extends AbstractClusterListene
       TestingUtil.blockUntilViewsReceived(10000, false, cacheManagers);
       TestingUtil.waitForRehashToComplete(caches(CACHE_NAME));
 
-      assertEquals(0, clusterListener.events.size());
+      assertEquals(clusterListener.hasIncludeState() ? 1 : 0, clusterListener.events.size());
    }
 }

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
@@ -95,6 +95,17 @@ public abstract class AbstractClusterListenerUtilTest extends MultipleCacheManag
          log.debugf("Adding new cluster event %s", event);
          events.add(event);
       }
+
+      protected boolean hasIncludeState() {
+         return false;
+      }
+   }
+
+   @Listener(clustered = true, includeCurrentState = true)
+   protected class ClusterListenerWithIncludeCurrentState extends ClusterListener {
+      protected boolean hasIncludeState() {
+         return true;
+      }
    }
 
    protected static class LifespanFilter<K, V> implements KeyValueFilter<K, V>, Serializable {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerDistInitialStateTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerDistInitialStateTest.java
@@ -1,0 +1,18 @@
+package org.infinispan.notifications.cachelistener.cluster;
+
+import org.testng.annotations.Test;
+
+/**
+ * Cluster listener test to make sure that when include current state is enabled that listeners still work properly
+ * in a distributed cache
+ *
+ * @author wburns
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "notifications.cachelistener.cluster.ClusterListenerDistInitialStateTest")
+public class ClusterListenerDistInitialStateTest extends ClusterListenerDistTest {
+   @Override
+   protected ClusterListener listener() {
+      return new ClusterListenerWithIncludeCurrentState();
+   }
+}

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerDistTxInitialStateTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerDistTxInitialStateTest.java
@@ -1,0 +1,18 @@
+package org.infinispan.notifications.cachelistener.cluster;
+
+import org.testng.annotations.Test;
+
+/**
+ * Cluster listener test to make sure that when include current state is enabled that listeners still work properly
+ * in a distributed transactional cache
+ *
+ * @author wburns
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "notifications.cachelistener.cluster.ClusterListenerDistTxInitialStateTest")
+public class ClusterListenerDistTxInitialStateTest extends ClusterListenerDistTxTest {
+   @Override
+   protected ClusterListener listener() {
+      return new ClusterListenerWithIncludeCurrentState();
+   }
+}

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplInitialStateTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplInitialStateTest.java
@@ -1,0 +1,41 @@
+package org.infinispan.notifications.cachelistener.cluster;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.write.PutKeyValueCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.distribution.BlockingInterceptor;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.interceptors.EntryWrappingInterceptor;
+import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent;
+import org.infinispan.notifications.cachelistener.event.Event;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.tx.dld.ControlledRpcManager;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.testng.AssertJUnit.*;
+
+/**
+ * Cluster listener test to make sure that when include current state is enabled that listeners still work properly
+ * in a replicated cache
+ *
+ * @author wburns
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "notifications.cachelistener.cluster.ClusterListenerReplInitialStateTest")
+public class ClusterListenerReplInitialStateTest extends ClusterListenerReplTest {
+   @Override
+   protected ClusterListener listener() {
+      return new ClusterListenerWithIncludeCurrentState();
+   }
+}

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplTxInitialStateTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplTxInitialStateTest.java
@@ -1,0 +1,18 @@
+package org.infinispan.notifications.cachelistener.cluster;
+
+import org.testng.annotations.Test;
+
+/**
+ * Cluster listener test to make sure that when include current state is enabled that listeners still work properly
+ * in a replicated transactional cache
+ *
+ * @author wburns
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "notifications.cachelistener.cluster.ClusterListenerReplTxInitialStateTest")
+public class ClusterListenerReplTxInitialStateTest extends ClusterListenerReplTxTest {
+   @Override
+   protected ClusterListener listener() {
+      return new ClusterListenerWithIncludeCurrentState();
+   }
+}


### PR DESCRIPTION
- Fixed issue when using initial state that non owner wasn't notified

https://issues.jboss.org/browse/ISPN-4704
