### PR TITLE
ISPN-4693 Initial submission of handling for orphaned transactions.

### DIFF
--- a/core/src/main/java/org/infinispan/transaction/impl/AbstractCacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/AbstractCacheTransaction.java
@@ -68,6 +68,11 @@ public abstract class AbstractCacheTransaction implements CacheTransaction {
    private volatile boolean isMarkedForRollback;
 
    /**
+    * Mark the time this tx object was created
+    */
+   private final long txCreationTime;
+   
+   /**
     * Used internally by the {@link #waitForLockRelease} method in order to notify other transactions that wait on this
     * one to complete.
     */
@@ -90,10 +95,11 @@ public abstract class AbstractCacheTransaction implements CacheTransaction {
       isMarkedForRollback = markForRollback;
    }
 
-   public AbstractCacheTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
+   public AbstractCacheTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
       this.tx = tx;
       this.topologyId = topologyId;
       this.keyEquivalence = keyEquivalence;
+      this.txCreationTime = txCreationTime;
    }
 
    @Override
@@ -351,5 +357,10 @@ public abstract class AbstractCacheTransaction implements CacheTransaction {
 
    protected final void internalSetStateTransferFlag(Flag stateTransferFlag) {
       this.stateTransferFlag = stateTransferFlag;
+   }
+   
+   @Override
+   public long getCreationTime() {
+      return txCreationTime;
    }
 }

--- a/core/src/main/java/org/infinispan/transaction/impl/LocalTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/LocalTransaction.java
@@ -47,8 +47,8 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
    private boolean commitOrRollbackSent;
 
    public LocalTransaction(Transaction transaction, GlobalTransaction tx,
-         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence) {
-      super(tx, topologyId, keyEquivalence);
+         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
+      super(tx, topologyId, keyEquivalence, txCreationTime);
       this.transaction = transaction;
       this.implicitTransaction = implicitTransaction;
    }

--- a/core/src/main/java/org/infinispan/transaction/impl/RemoteTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/RemoteTransaction.java
@@ -40,8 +40,9 @@ public class RemoteTransaction extends AbstractCacheTransaction implements Clone
    private volatile TotalOrderRemoteTransactionState transactionState;
    private final Object transactionStateLock = new Object();
 
-   public RemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
-      super(tx, topologyId, keyEquivalence);
+   public RemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId,
+                            Equivalence<Object> keyEquivalence, long txCreationTime) {
+      super(tx, topologyId, keyEquivalence, txCreationTime);
       this.modifications = modifications == null || modifications.length == 0
             ? InfinispanCollections.<WriteCommand>emptyList()
             : Arrays.asList(modifications);
@@ -49,8 +50,8 @@ public class RemoteTransaction extends AbstractCacheTransaction implements Clone
             this.modifications.size(), keyEquivalence, AnyEquivalence.<CacheEntry>getInstance());
    }
 
-   public RemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
-      super(tx, topologyId, keyEquivalence);
+   public RemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
+      super(tx, topologyId, keyEquivalence, txCreationTime);
       this.modifications = new LinkedList<WriteCommand>();
       lookedUpEntries = CollectionFactory.makeMap(2, keyEquivalence, AnyEquivalence.<CacheEntry>getInstance());
    }

--- a/core/src/main/java/org/infinispan/transaction/synchronization/SyncLocalTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/synchronization/SyncLocalTransaction.java
@@ -15,8 +15,8 @@ import javax.transaction.Transaction;
 public class SyncLocalTransaction extends LocalTransaction {
 
    public SyncLocalTransaction(Transaction transaction, GlobalTransaction tx,
-         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence) {
-      super(transaction, tx, implicitTransaction, topologyId, keyEquivalence);
+         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
+      super(transaction, tx, implicitTransaction, topologyId, keyEquivalence, txCreationTime);
    }
 
    private boolean enlisted;

--- a/core/src/main/java/org/infinispan/transaction/xa/CacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/CacheTransaction.java
@@ -123,4 +123,6 @@ public interface CacheTransaction {
     *         exists, the key has not been read.
     */
    EntryVersionsMap getVersionsRead();
+
+   long getCreationTime();
 }

--- a/core/src/main/java/org/infinispan/transaction/xa/LocalXaTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/LocalXaTransaction.java
@@ -18,8 +18,8 @@ public class LocalXaTransaction extends LocalTransaction {
    private Xid xid;
 
    public LocalXaTransaction(Transaction transaction, GlobalTransaction tx,
-         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence) {
-      super(transaction, tx, implicitTransaction, topologyId, keyEquivalence);
+         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
+      super(transaction, tx, implicitTransaction, topologyId, keyEquivalence, txCreationTime);
    }
 
    public void setXid(Xid xid) {

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareLocalTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareLocalTransaction.java
@@ -19,8 +19,8 @@ public class RecoveryAwareLocalTransaction extends LocalXaTransaction implements
    private boolean completionFailed;
 
    public RecoveryAwareLocalTransaction(Transaction transaction, GlobalTransaction tx,
-         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence) {
-      super(transaction, tx, implicitTransaction, topologyId, keyEquivalence);
+         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
+      super(transaction, tx, implicitTransaction, topologyId, keyEquivalence, txCreationTime);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareRemoteTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareRemoteTransaction.java
@@ -28,12 +28,14 @@ public class RecoveryAwareRemoteTransaction extends RemoteTransaction implements
 
    private Integer status;
 
-   public RecoveryAwareRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
-      super(modifications, tx, topologyId, keyEquivalence);
+   public RecoveryAwareRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId,
+                                         Equivalence<Object> keyEquivalence, long txCreationTime) {
+      super(modifications, tx, topologyId, keyEquivalence, txCreationTime);
    }
 
-   public RecoveryAwareRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence) {
-      super(tx, topologyId, keyEquivalence);
+   public RecoveryAwareRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence,
+                                         long txCreationTime) {
+      super(tx, topologyId, keyEquivalence, txCreationTime);
    }
 
    /**

--- a/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
@@ -1,8 +1,9 @@
 package org.infinispan.tx;
 
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
 import org.infinispan.Cache;
 import org.infinispan.commands.CommandsFactory;
-import org.infinispan.commands.CommandsFactoryImpl;
 import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
@@ -22,9 +23,6 @@ import org.infinispan.transaction.xa.TransactionXaAdapter;
 import org.infinispan.transaction.xa.XaTransactionTable;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import javax.transaction.xa.XAException;
-import javax.transaction.xa.XAResource;
 
 import java.util.UUID;
 
@@ -59,7 +57,7 @@ public class TransactionXaAdapterTmIntegrationTest {
       gtf.init(false, false, true, false);
       globalTransaction = gtf.newGlobalTransaction(null, false);
       DummyBaseTransactionManager tm = new DummyBaseTransactionManager();
-      localTx = new LocalXaTransaction(new DummyTransaction(tm), globalTransaction, false, 1, AnyEquivalence.getInstance());
+      localTx = new LocalXaTransaction(new DummyTransaction(tm), globalTransaction, false, 1, AnyEquivalence.getInstance(), 0);
       xid = new DummyXid(uuid);
 
       InvocationContextFactory icf = new TransactionalInvocationContextFactory();


### PR DESCRIPTION
Based off of production settings, I needed to iterate over both maps, since there are conditions where a local transaction can be orphaned as well.  

I'm wondering if instead of a rollback command, we directly grab the lock container and release the locks that way (and removing the transactions from the table via the existing methods).  I don't see how any exception can occur before the lock interceptors, but I'm not as familiar with the 7.0 code. 

EDIT: No lock container manipulation.
