### PR TITLE
ISPN-4029 Reworked NotifyingFutureTest

### DIFF
--- a/core/src/test/java/org/infinispan/assertions/ExceptionAssertion.java
+++ b/core/src/test/java/org/infinispan/assertions/ExceptionAssertion.java
@@ -1,0 +1,37 @@
+package org.infinispan.assertions;
+
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * Custom assertion for testing exceptions.
+ *
+ * @author Sebastian Laskawiec
+ */
+public class ExceptionAssertion {
+
+   private Exception actual;
+
+   private ExceptionAssertion(Exception actual) {
+      this.actual = actual;
+   }
+
+   public static ExceptionAssertion assertThat(Exception actual) {
+      return new ExceptionAssertion(actual);
+   }
+
+   public ExceptionAssertion IsNotNull() {
+      assertNotNull(actual);
+      return this;
+   }
+
+   public ExceptionAssertion isTypeOf(Class<? extends Exception> exceptionClass) {
+      assertTrue(actual.getClass().isAssignableFrom(exceptionClass));
+      return this;
+   }
+
+   public ExceptionAssertion hasCauseTypeOf(Class<?> cause) {
+      assertTrue(actual.getCause().getClass().isAssignableFrom(cause));
+      return this;
+   }
+}

--- a/core/src/test/java/org/infinispan/assertions/FutureAssertion.java
+++ b/core/src/test/java/org/infinispan/assertions/FutureAssertion.java
@@ -1,0 +1,44 @@
+package org.infinispan.assertions;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.testng.Assert.*;
+
+/**
+ * Custom assertion for {@link org.infinispan.commons.util.concurrent.NotifyingFuture}
+ *
+ * @author Sebastian Laskawiec
+ */
+public class FutureAssertion<T> {
+
+   private int futureGetTimeoutMs;
+
+   private Future<T> actual;
+
+   private FutureAssertion(Future<T> actual, int futureGetTimeoutMs) {
+      this.actual = actual;
+      this.futureGetTimeoutMs = futureGetTimeoutMs;
+   }
+
+   public static <T> FutureAssertion<T> assertThat(Future<T> actual, int futureGetTimeoutMs) {
+      return new FutureAssertion<>(actual, futureGetTimeoutMs);
+   }
+
+   public FutureAssertion<T> isDone() {
+      assertTrue(actual.isDone());
+      return this;
+   }
+
+   public FutureAssertion<T> isNotCanceled() {
+      assertFalse(actual.isCancelled());
+      return this;
+   }
+
+   public FutureAssertion<T> hasValue(T value) throws ExecutionException, InterruptedException, TimeoutException {
+      assertEquals(actual.get(futureGetTimeoutMs, TimeUnit.MILLISECONDS), value);
+      return this;
+   }
+}


### PR DESCRIPTION
Hi

Please take a look at reworked NotificationFutureTest. These are the steps I performed
1. Removed Thread.sleep() since it can't be trusted (especially when testing on CI server with many slaves)
2. It turned out that all testDone tests were acting exactly the same without Thread.sleep. So I combined them.
3. I reworked the test a bit and added custom assertions.

Best regards
Sebastian
