### PR TITLE
ISPN-4696 SuspectException kills operation on ClusterRegistryImpl

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
@@ -454,7 +454,7 @@ public class CommandAwareRpcDispatcher extends RpcDispatcher {
                   if (ignoreLeavers && e.getCause() instanceof SuspectedException) {
                      log.tracef(formatString("Ignoring node %s that left during the remote call", target));
                   } else {
-                     throw e;
+                     throw wrapThrowableInException(e.getCause());
                   }
                }
             }
@@ -478,6 +478,14 @@ public class CommandAwareRpcDispatcher extends RpcDispatcher {
       }
 
       return retval;
+   }
+
+   private static Exception wrapThrowableInException(Throwable t) {
+      if (t instanceof Exception) {
+         return (Exception) t;
+      } else {
+         return new CacheException(t);
+      }
    }
 
    private static boolean isRsvpCommand(ReplicableCommand command) {

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/SuspectException.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/SuspectException.java
@@ -44,4 +44,14 @@ public class SuspectException extends CacheException {
       return suspect;
    }
 
+   public static boolean isSuspectExceptionInChain(Throwable t) {
+      Throwable innerThrowable = t;
+      do {
+         if (innerThrowable instanceof SuspectException) {
+            return true;
+         }
+      } while ((innerThrowable = innerThrowable.getCause()) != null);
+      return false;
+   }
+
 }


### PR DESCRIPTION
- Added retry for ClusterRegistry operations

https://issues.jboss.org/browse/ISPN-4696

Note this is only a stop gap solution for the time being since we do not know yet how we want to fully handle nodes leaving during a commit.  At least with the ClusterRegistry we know we can easily retry the command.
