### PR TITLE
ISPN-2538 Endless loop in TreeMap.remove at shutdown of query-enabled

### DIFF
--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -1,5 +1,6 @@
 package org.infinispan.query.impl;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
@@ -70,7 +71,9 @@ public class LifecycleManager extends AbstractModuleLifecycle {
 
    private static final Log log = LogFactory.getLog(LifecycleManager.class, Log.class);
 
-   private final Map<String, SearchFactoryIntegrator> searchFactoriesToShutdown = new TreeMap<String,SearchFactoryIntegrator>();
+   // Synchronized map in case if concurrent requests to shutdown are met
+   private final Map<String, SearchFactoryIntegrator> searchFactoriesToShutdown = Collections.synchronizedMap(
+         new TreeMap<String,SearchFactoryIntegrator>());
 
    private static final Object REMOVED_REGISTRY_COMPONENT = new Object();
 


### PR DESCRIPTION
cache
- Changed map to be synchronized

https://issues.jboss.org/browse/ISPN-2538
