### PR TITLE
ISPN-4574 Fix StateTransferSuppressIT failure

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
@@ -102,14 +102,15 @@ public class RpcManagerImpl implements RpcManager, JmxStatisticsExposer {
 
    @ManagedAttribute(description = "Retrieves the committed view.", displayName = "Committed view", dataType = DataType.TRAIT)
    public String getCommittedViewAsString() {
-      return localTopologyManager == null ? "N/A" : String.valueOf(localTopologyManager.getCacheTopology(cacheName)
-            .getCurrentCH());
+      CacheTopology cacheTopology = stateTransferManager.getCacheTopology();
+      return cacheTopology != null ? cacheTopology.getCurrentCH().getMembers().toString() : "N/A";
    }
 
    @ManagedAttribute(description = "Retrieves the pending view.", displayName = "Pending view", dataType = DataType.TRAIT)
    public String getPendingViewAsString() {
-      return localTopologyManager == null ? "N/A" : String.valueOf(localTopologyManager.getCacheTopology(cacheName)
-            .getPendingCH());
+      CacheTopology cacheTopology = stateTransferManager.getCacheTopology();
+      return (cacheTopology != null && cacheTopology.getPendingCH() != null)
+            ? cacheTopology.getPendingCH().getMembers().toString() : "N/A";
    }
 
    private boolean useReplicationQueue(boolean sync) {

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/jmx/suppress/statetransfer/StateTransferSuppressIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/jmx/suppress/statetransfer/StateTransferSuppressIT.java
@@ -63,9 +63,9 @@ public class StateTransferSuppressIT {
     final String PENDING_VIEW_AS_STRING_ATTR_NAME = "PendingViewAsString";
 
     /* JMX result views */
-    private final String OWNERS_2_MEMBERS_NODE1_NODE2 = "DefaultConsistentHash{numSegments=60, numOwners=2, members=[node0/" + getCacheManagerName() + ", node1/" + getCacheManagerName() + "]}";
-    private final String OWNERS_2_MEMBERS_NODE2_NODE3 = "DefaultConsistentHash{numSegments=60, numOwners=2, members=[node1/" + getCacheManagerName() + ", node2/" + getCacheManagerName() + "]}";
-    private final String OWNERS_2_MEMBERS_NODE1_NODE2_NODE3 = "DefaultConsistentHash{numSegments=60, numOwners=2, members=[node0/" + getCacheManagerName() + ", node1/" + getCacheManagerName() + ", node2/" + getCacheManagerName() + "]}";
+    private final String OWNERS_2_MEMBERS_NODE1_NODE2 = "[node0/" + getCacheManagerName() + ", node1/" + getCacheManagerName() + "]";
+    private final String OWNERS_2_MEMBERS_NODE2_NODE3 = "[node1/" + getCacheManagerName() + ", node2/" + getCacheManagerName() + "]";
+    private final String OWNERS_2_MEMBERS_NODE1_NODE2_NODE3 = "[node0/" + getCacheManagerName() + ", node1/" + getCacheManagerName() + ", node2/" + getCacheManagerName() + "]";
 
     /* server module MBeans */
     private final String LOCAL_TOPOLOGY_MANAGER = "jboss.infinispan:type=CacheManager,name=\"" + getCacheManagerName() + "\",component=LocalTopologyManager";


### PR DESCRIPTION
The DefaultConsistentHash.toString() change in https://github.com/infinispan/infinispan/pull/2860 broke StateTransferSuppressIT.

Change RpcManagerImpl.getCommittedViewAsString and getPendingViewAsString
to return only the list of members.

.
