### PR TITLE
ISPN-4731 Updated order or test dependencies

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -544,6 +544,12 @@
             <version>${version.shrinkwrapResolver}</version>
             <type>pom</type>
             <scope>import</scope>
+            <exclusions>
+               <exclusion>
+                  <groupId>com.google.collections</groupId>
+                  <artifactId>google-collections</artifactId>
+               </exclusion>
+            </exclusions>
          </dependency>
          <dependency>
             <groupId>org.jboss.spec</groupId>


### PR DESCRIPTION
Hi

Please take a look at fix for: https://issues.jboss.org/browse/ISPN-4731

The main idea is to move weld-core before shrinkwrap-resolver-impl-maven. This will cause that Guava library (which is a transitive dependency of Weld) will be before Google Collections (which is a transitive dependency of Shrinkwrap's Maven Resolver). Without this change new version of Weld will throw errors during initialization. 

Note that this is one of the fastest solutions (more verbose would involve excluding Google Collections). However there is no impact to the user - only for tests. 

Best regards
Sebastian
