### PR TITLE
ISPN-2125 Weld SE Integration test

### DIFF
--- a/cdi/extension/pom.xml
+++ b/cdi/extension/pom.xml
@@ -163,6 +163,41 @@
                </bytecodeInjections>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+             <artifactId>maven-invoker-plugin</artifactId>
+             <version>${version.maven.invoker}</version>
+             <configuration>
+                <addTestClassPath>true</addTestClassPath>
+                <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                <pomIncludes>
+                   <pomInclude>*/pom.xml</pomInclude>
+                </pomIncludes>
+                <postBuildHookScript>verify</postBuildHookScript>
+                <streamLogs>true</streamLogs>
+                <goals>
+                   <goal>clean</goal>
+                   <goal>package</goal>
+                </goals>
+                <properties>
+                   <!-- Skip tests parent's tests are skipped -->
+                   <maven.test.skip.exec>${maven.test.skip.exec}</maven.test.skip.exec>
+                   <skipTests>${skipTests}</skipTests>
+                   <!-- maven.surefire.debug>-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005 -Xnoagent -Djava.compiler=NONE</maven.surefire.debug -->
+                   <!-- If logging enabled by client, pass it on -->
+                   <log4j.configuration>${log4j.configuration}</log4j.configuration>
+                </properties>
+             </configuration>
+             <executions>
+                <execution>
+                   <id>integration-test</id>
+                   <goals>
+                      <goal>install</goal>
+                      <goal>run</goal>
+                   </goals>
+                </execution>
+             </executions>
+         </plugin>
       </plugins>
       <pluginManagement>
          <plugins>

--- a/cdi/extension/src/it/cdi-weld-se-it/pom.xml
+++ b/cdi/extension/src/it/cdi-weld-se-it/pom.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-parent</artifactId>
+      <version>7.0.0-SNAPSHOT</version>
+      <relativePath>../../../../../parent/pom.xml</relativePath>
+   </parent>
+
+    <artifactId>infinispan-cdi-weld-se-it</artifactId>
+    <name>Integration tests: Weld SE CDI tests</name>
+    <description>Integration tests for Infinispan CDI and Weld SE</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>infinispan-cdi</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>infinispan-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.8</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/cdi/extension/src/it/cdi-weld-se-it/src/test/java/org/infinispan/integrationtests/cdi/weld/CDITestingBean.java
+++ b/cdi/extension/src/it/cdi-weld-se-it/src/test/java/org/infinispan/integrationtests/cdi/weld/CDITestingBean.java
@@ -1,0 +1,26 @@
+package org.infinispan.integrationtests.cdi.weld;
+
+import org.infinispan.Cache;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+/**
+ * CDI bean for testing.
+ *
+ * @author Sebastian Laskawiec
+ */
+@ApplicationScoped
+public class CDITestingBean {
+
+   @Inject
+   private Cache<String, String> cache;
+
+   public void putValueInCache(String key, String value) {
+      cache.put(key, value);
+   }
+
+   public String getValueFromCache(String key) {
+      return cache.get(key);
+   }
+}

--- a/cdi/extension/src/it/cdi-weld-se-it/src/test/java/org/infinispan/integrationtests/cdi/weld/Config.java
+++ b/cdi/extension/src/it/cdi-weld-se-it/src/test/java/org/infinispan/integrationtests/cdi/weld/Config.java
@@ -1,0 +1,41 @@
+package org.infinispan.integrationtests.cdi.weld;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.eviction.EvictionStrategy;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.TestingUtil;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Disposes;
+import javax.enterprise.inject.Produces;
+
+/**
+ * Cache configuration
+ *
+ * @author Sebastian Laskawiec
+ */
+@ApplicationScoped
+public class Config {
+
+   @Produces
+   @ApplicationScoped
+   public EmbeddedCacheManager defaultEmbeddedCacheManager() {
+      return new DefaultCacheManager(new ConfigurationBuilder()
+            .eviction()
+            .strategy(EvictionStrategy.LRU)
+            .maxEntries(100)
+            .build());
+   }
+
+   /**
+    * Stops cache manager.
+    *
+    * @param cacheManager to be stopped
+    */
+   @SuppressWarnings("unused")
+   public void killCacheManager(@Disposes EmbeddedCacheManager cacheManager) {
+      TestingUtil.killCacheManagers(cacheManager);
+   }
+
+}

--- a/cdi/extension/src/it/cdi-weld-se-it/src/test/java/org/infinispan/integrationtests/cdi/weld/WeldStandaloneTest.java
+++ b/cdi/extension/src/it/cdi-weld-se-it/src/test/java/org/infinispan/integrationtests/cdi/weld/WeldStandaloneTest.java
@@ -1,0 +1,30 @@
+package org.infinispan.integrationtests.cdi.weld;
+
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests Weld integration in standalone (desktop) app.
+ *
+ * @author Sebastian Laskawiec
+ */
+@Test(groups="functional", testName="cdi.test.weld.WeldStandaloneTest")
+public class WeldStandaloneTest {
+
+   public void testWeldStandaloneInitialisation() throws Exception {
+      //given
+      WeldContainer weld = new Weld().initialize();
+      CDITestingBean testedBean = weld.instance().select(CDITestingBean.class).get();
+
+      //when
+      testedBean.putValueInCache("test", "abcd");
+      String retrievedValue = testedBean.getValueFromCache("test");
+
+      //then
+      assertEquals(retrievedValue, "abcd");
+   }
+
+}

--- a/cdi/extension/src/it/cdi-weld-se-it/src/test/resources/META-INF/beans.xml
+++ b/cdi/extension/src/it/cdi-weld-se-it/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:weld="http://jboss.org/schema/weld/beans"
+       xsi:schemaLocation="
+          http://java.sun.com/xml/ns/javaee http://docs.jboss.org/cdi/beans_1_0.xsd
+          http://jboss.org/schema/weld/beans http://jboss.org/schema/weld/beans_1_1.xsd">
+
+    <weld:scan>
+        <weld:include name="**"/>
+    </weld:scan>
+
+</beans>


### PR DESCRIPTION
Hi!

Please take a look at https://issues.jboss.org/browse/ISPN-2125 implementation.

I decided to implement this test as a separate module. There are a couple of reasons for that:
1. Within cdi/extension module we have plenty of test producers of EmbeddedCacheManagers. Since we are not using Arquillian we don't control classpath and there is no easy way to ensure we load the correct one.
2. cdi/extension already uses "Weld EE 1.1 - Embedded" Arquillian extension. It is pretty hard (if not impossible) to introduce another "Weld SE 1.1 - Embedded" extension.

Best regards
Sebastian
