### PR TITLE
ISPN-4745 Cluster Listener TX Batch incorrect when sending multiple

### DIFF
--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/RemoteClusterListener.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/RemoteClusterListener.java
@@ -120,9 +120,9 @@ public class RemoteClusterListener {
             if (log.isTraceEnabled()) {
                log.tracef("Submitting Event(s) %s to cluster listener to %s", eventsToSend, origin);
             }
-            // Force the execution to wait until completed
-            distExecService.submit(origin, new ClusterEventCallable(id, eventsToSend)).get();
          }
+         // Force the execution to wait until completed
+         distExecService.submit(origin, new ClusterEventCallable(id, eventsToSend)).get();
       }
    }
 }

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerTxTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerTxTest.java
@@ -211,4 +211,33 @@ public abstract class AbstractClusterListenerTxTest extends AbstractClusterListe
 
       assertEquals(clusterListener.events.size(), 0);
    }
+
+   @Test
+   public void testMultipleKeysSameOwnerBatchNotified() throws SystemException, NotSupportedException, HeuristicRollbackException,
+                                                          HeuristicMixedException, RollbackException {
+      Cache<Object, String> cache0 = cache(0, CACHE_NAME);
+      Cache<Object, String> cache1 = cache(1, CACHE_NAME);
+      Cache<Object, String> cache2 = cache(2, CACHE_NAME);
+
+      ClusterListener clusterListener = new ClusterListener();
+      cache0.addListener(clusterListener);
+
+      MagicKey key1 = new MagicKey(cache1);
+      MagicKey key2 = new MagicKey(cache1);
+
+      TransactionManager tm = cache2.getAdvancedCache().getTransactionManager();
+      tm.begin();
+
+      cache2.put(key1, FIRST_VALUE);
+      assertEquals(clusterListener.events.size(), 0);
+
+      cache2.put(key2, SECOND_VALUE);
+      assertEquals(clusterListener.events.size(), 0);
+
+      tm.commit();
+
+      assertEquals(clusterListener.events.size(), 2);
+      verifyCreation(clusterListener.events, key1, FIRST_VALUE);
+      verifyCreation(clusterListener.events, key2, SECOND_VALUE);
+   }
 }


### PR DESCRIPTION
events
- Fixed typo where the events were sent inside the for loop

https://issues.jboss.org/browse/ISPN-4745
