### PR TITLE
ISPN-4731 Google Collections removed from shrinkwrap-resolver-impl-maven

### DIFF
--- a/integrationtests/as-lucene-directory/pom.xml
+++ b/integrationtests/as-lucene-directory/pom.xml
@@ -19,6 +19,11 @@
          <artifactId>infinispan-core</artifactId>
          <scope>test</scope>
       </dependency>
+       <dependency>
+           <groupId>com.google.guava</groupId>
+           <artifactId>guava</artifactId>
+           <scope>test</scope>
+       </dependency>
       <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-core</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -544,6 +544,11 @@
             <version>${version.shrinkwrapResolver}</version>
             <type>pom</type>
             <scope>import</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>${version.shrinkwrapResolver}</version>
             <exclusions>
                <exclusion>
                   <groupId>com.google.collections</groupId>
@@ -964,6 +969,11 @@
             <artifactId>lucene-analyzers-common</artifactId>
             <version>${version.lucene}</version>
          </dependency>
+          <dependency>
+              <groupId>com.google.guava</groupId>
+              <artifactId>guava</artifactId>
+              <version>${version.guava}</version>
+          </dependency>
       </dependencies>
    </dependencyManagement>
    <dependencies>


### PR DESCRIPTION
Hi

Unfortunately Fix: https://github.com/infinispan/infinispan/pull/2878 didn't work. We need to explicitly removed Google Collections from shrinkwrap-resolver-impl-maven.

Best regards
Sebastian
