### PR TITLE
ISPN-4760 Cluster registry doesn't work when rebalancing is disabled

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
@@ -19,6 +19,7 @@ import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.util.concurrent.NotifyingNotifiableFuture;
 import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
@@ -103,14 +104,20 @@ public class RpcManagerImpl implements RpcManager, JmxStatisticsExposer {
    @ManagedAttribute(description = "Retrieves the committed view.", displayName = "Committed view", dataType = DataType.TRAIT)
    public String getCommittedViewAsString() {
       CacheTopology cacheTopology = stateTransferManager.getCacheTopology();
-      return cacheTopology != null ? cacheTopology.getCurrentCH().getMembers().toString() : "N/A";
+      if (cacheTopology == null)
+         return "N/A";
+
+      return cacheTopology.getCurrentCH().getMembers().toString();
    }
 
    @ManagedAttribute(description = "Retrieves the pending view.", displayName = "Pending view", dataType = DataType.TRAIT)
    public String getPendingViewAsString() {
       CacheTopology cacheTopology = stateTransferManager.getCacheTopology();
-      return (cacheTopology != null && cacheTopology.getPendingCH() != null)
-            ? cacheTopology.getPendingCH().getMembers().toString() : "N/A";
+      if (cacheTopology == null)
+         return "N/A";
+
+      ConsistentHash pendingCH = cacheTopology.getPendingCH();
+      return pendingCH != null ? pendingCH.getMembers().toString() : "null";
    }
 
    private boolean useReplicationQueue(boolean sync) {

--- a/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
@@ -1,14 +1,5 @@
 package org.infinispan.topology;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.util.Immutables;
 import org.infinispan.commons.util.InfinispanCollections;
@@ -17,9 +8,19 @@ import org.infinispan.distribution.ch.ConsistentHashFactory;
 import org.infinispan.partionhandling.impl.AvailabilityMode;
 import org.infinispan.partionhandling.impl.AvailabilityStrategy;
 import org.infinispan.partionhandling.impl.AvailabilityStrategyContext;
+import org.infinispan.registry.impl.ClusterRegistryImpl;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
 * Keeps track of a cache's status: members, current/pending consistent hashes, and rebalance status
@@ -556,7 +557,7 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
          }
 
          CacheTopology cacheTopology = getCurrentTopology();
-         if (!isRebalanceEnabled()) {
+         if (!isRebalanceEnabled() && !cacheName.equals(ClusterRegistryImpl.GLOBAL_REGISTRY_CACHE_NAME)) {
             log.tracef("Postponing rebalance for cache %s, rebalancing is disabled", cacheName);
             return;
          }

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManager.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManager.java
@@ -82,4 +82,9 @@ public interface LocalTopologyManager {
     * @return {@code true} if the cache is using the total order protocol, {@code false} otherwise.
     */
    boolean isTotalOrderCache(String cacheName);
+
+   /**
+    * Enable or disable rebalancing in the entire cluster.
+    */
+   void setRebalancingEnabled(boolean enabled) throws Exception;
 }

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -342,6 +342,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
       return (Boolean) executeOnCoordinator(command, getGlobalTimeout());
    }
 
+   @Override
    public void setRebalancingEnabled(boolean enabled) throws Exception {
       CacheTopologyControlCommand.Type type = enabled ? CacheTopologyControlCommand.Type.POLICY_ENABLE
             : CacheTopologyControlCommand.Type.POLICY_DISABLE;

--- a/core/src/main/java/org/infinispan/util/AbstractControlledLocalTopologyManager.java
+++ b/core/src/main/java/org/infinispan/util/AbstractControlledLocalTopologyManager.java
@@ -77,6 +77,11 @@ public abstract class AbstractControlledLocalTopologyManager implements LocalTop
       return delegate.getStableCacheTopology(cacheName);
    }
 
+   @Override
+   public void setRebalancingEnabled(boolean enabled) throws Exception {
+      delegate.setRebalancingEnabled(enabled);
+   }
+
    // Arbitrary value, only need to start after JGroupsTransport
    @Start(priority = 100)
    public final void startDelegate() {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4760
- Rebalancing should always be enabled for the cluster registry cache
- Fix StateTransferSuppressIT
