### PR TITLE
[ISPN-4645] Many XSD default values do not match the defaults from the

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/AsyncConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AsyncConfigurationBuilder.java
@@ -18,7 +18,7 @@ public class AsyncConfigurationBuilder extends AbstractClusteringConfigurationCh
 
    private boolean asyncMarshalling = false;
    private ReplicationQueue replicationQueue;
-   private long replicationQueueInterval = TimeUnit.SECONDS.toMillis(5);
+   private long replicationQueueInterval = 10;
    private int replicationQueueMaxElements = 1000;
    private boolean useReplicationQueue = false;
 

--- a/core/src/main/java/org/infinispan/configuration/cache/ClusterLoaderConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ClusterLoaderConfigurationBuilder.java
@@ -6,7 +6,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 public class ClusterLoaderConfigurationBuilder extends AbstractStoreConfigurationBuilder<ClusterLoaderConfiguration, ClusterLoaderConfigurationBuilder> {
-   private long remoteCallTimeout;
+   private long remoteCallTimeout = TimeUnit.SECONDS.toMillis(15);
 
    public ClusterLoaderConfigurationBuilder(PersistenceConfigurationBuilder builder) {
       super(builder);

--- a/core/src/main/java/org/infinispan/configuration/cache/L1ConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/L1ConfigurationBuilder.java
@@ -20,7 +20,7 @@ public class L1ConfigurationBuilder extends AbstractClusteringConfigurationChild
    private boolean enabled = false;
    private int invalidationThreshold = 0;
    private long lifespan = TimeUnit.MINUTES.toMillis(10);
-   private long cleanupTaskFrequency = TimeUnit.MINUTES.toMillis(10);
+   private long cleanupTaskFrequency = TimeUnit.MINUTES.toMillis(1);
 
    L1ConfigurationBuilder(ClusteringConfigurationBuilder builder) {
       super(builder);

--- a/core/src/main/resources/schema/infinispan-config-7.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-7.0.xsd
@@ -641,12 +641,12 @@
         <xs:documentation>If true, a pool of shared locks is maintained for all entries that need to be locked. Otherwise, a lock is created per entry in the cache. Lock striping helps control memory footprint but may reduce concurrency in the system.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="acquire-timeout" type="xs:long" default="15000">
+    <xs:attribute name="acquire-timeout" type="xs:long" default="10000">
       <xs:annotation>
         <xs:documentation>Maximum time to attempt a particular lock acquisition.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="concurrency-level" type="xs:int" default="1000">
+    <xs:attribute name="concurrency-level" type="xs:int" default="32">
       <xs:annotation>
         <xs:documentation>Concurrency level for lock containers. Adjust this value according to the number of concurrent threads interacting with Infinispan.</xs:documentation>
       </xs:annotation>
@@ -726,7 +726,7 @@
         <xs:documentation>Sets the cache eviction strategy. Available options are 'UNORDERED', 'FIFO', 'LRU', 'LIRS' and 'NONE' (to disable eviction).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="max-entries" type="xs:int" default="10000">
+    <xs:attribute name="max-entries" type="xs:int" default="-1">
       <xs:annotation>
         <xs:documentation>Maximum number of entries in a cache instance. If selected value is not a power of two the actual value will default to the least power of two larger than selected value. -1 means no limit.</xs:documentation>
       </xs:annotation>
@@ -751,7 +751,7 @@
         <xs:documentation>Maximum lifespan of a cache entry, after which the entry is expired cluster-wide, in milliseconds. -1 means the entries never expire.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="interval" type="xs:long" default="5000">
+    <xs:attribute name="interval" type="xs:long" default="60000">
       <xs:annotation>
         <xs:documentation>Interval (in milliseconds) between subsequent runs to purge expired entries from memory and any cache stores. If you wish to disable the periodic eviction process altogether, set interval to -1.</xs:documentation>
       </xs:annotation>
@@ -978,7 +978,7 @@
         </xs:attribute>
         <xs:attribute name="queue-size" type="xs:int" default="0">
           <xs:annotation>
-            <xs:documentation>In ASYNC mode, this attribute can be used to trigger flushing of the queue when it reaches a specific threshold.</xs:documentation>
+            <xs:documentation>In ASYNC mode, this attribute can be used to trigger flushing of the queue when it reaches a specific threshold. A value of 0 (the default) disables the replication queue.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="queue-flush-interval" type="xs:long" default="10">
@@ -986,7 +986,7 @@
             <xs:documentation>In ASYNC mode, this attribute controls how often the asynchronous thread used to flush the replication queue runs. This should be a positive integer which represents thread wakeup time in milliseconds.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="remote-timeout" type="xs:long" default="17500">
+        <xs:attribute name="remote-timeout" type="xs:long" default="15000">
           <xs:annotation>
             <xs:documentation>In SYNC mode, the timeout (in ms) used to wait for an acknowledgment when making a remote call, after which the call is aborted and an exception is thrown.</xs:documentation>
           </xs:annotation>
@@ -1036,7 +1036,7 @@
             <xs:documentation>Number of cluster-wide replicas for each cache entry.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="segments" type="xs:int" default="80">
+        <xs:attribute name="segments" type="xs:int" default="60">
           <xs:annotation>
             <xs:documentation>Number of hash space segments (per cluster). The recommended value is 10 * cluster size. The default value is 80</xs:documentation>
           </xs:annotation>
@@ -1109,7 +1109,7 @@
   <xs:complexType name="cluster-loader">
     <xs:complexContent>
       <xs:extension base="tns:loader">
-        <xs:attribute name="remote-timeout" type="xs:long">
+        <xs:attribute name="remote-timeout" type="xs:long" default="15000">
           <xs:annotation>
             <xs:documentation>The timeout when performing remote calls.</xs:documentation>
           </xs:annotation>

--- a/core/src/test/java/org/infinispan/configuration/cache/L1ConfigurationBuilderTest.java
+++ b/core/src/test/java/org/infinispan/configuration/cache/L1ConfigurationBuilderTest.java
@@ -22,7 +22,7 @@ public class L1ConfigurationBuilderTest {
       L1Configuration l1Config = config.clustering().l1();
 
       assertTrue(l1Config.enabled());
-      assertEquals(l1Config.cleanupTaskFrequency(), TimeUnit.MINUTES.toMillis(10));
+      assertEquals(l1Config.cleanupTaskFrequency(), TimeUnit.MINUTES.toMillis(1));
       assertEquals(l1Config.invalidationThreshold(), 0);
       assertEquals(l1Config.lifespan(), TimeUnit.MINUTES.toMillis(10));
    }

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAuthorizationResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAuthorizationResource.java
@@ -49,7 +49,7 @@ public class CacheAuthorizationResource extends SimpleResourceDefinition {
             .setXmlName(Attribute.ENABLED.getLocalName())
             .setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .setDefaultValue(new ModelNode().set(true))
+            .setDefaultValue(new ModelNode().set(false))
             .build()
     ;
 

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusterLoaderResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusterLoaderResource.java
@@ -30,6 +30,7 @@ public class ClusterLoaderResource extends BaseLoaderResource {
                     .setXmlName(Attribute.REMOTE_TIMEOUT.getLocalName())
                     .setAllowExpression(false)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(new ModelNode().set(15000L))
                     .build();
 
     static final AttributeDefinition[] CLUSTER_LOADER_ATTRIBUTES = {REMOTE_TIMEOUT};

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheResource.java
@@ -85,7 +85,7 @@ public class ClusteredCacheResource extends CacheResource  {
                     .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setDefaultValue(new ModelNode().set(17500))
+                    .setDefaultValue(new ModelNode().set(15000))
                     .build();
 
     static final AttributeDefinition[] CLUSTERED_CACHE_ATTRIBUTES = { ASYNC_MARSHALLING, MODE, QUEUE_SIZE, QUEUE_FLUSH_INTERVAL, REMOTE_TIMEOUT};

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LockingResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LockingResource.java
@@ -54,7 +54,7 @@ public class LockingResource extends SimpleResourceDefinition {
                     .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setDefaultValue(new ModelNode().set(15000))
+                    .setDefaultValue(new ModelNode().set(10000))
                     .build();
 
     static final SimpleAttributeDefinition CONCURRENCY_LEVEL =
@@ -62,7 +62,7 @@ public class LockingResource extends SimpleResourceDefinition {
                     .setXmlName(Attribute.CONCURRENCY_LEVEL.getLocalName())
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setDefaultValue(new ModelNode().set(1000))
+                    .setDefaultValue(new ModelNode().set(32))
                     .build();
 
     static final SimpleAttributeDefinition ISOLATION =
@@ -71,6 +71,7 @@ public class LockingResource extends SimpleResourceDefinition {
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setValidator(new EnumValidator<IsolationLevel>(IsolationLevel.class, true, false))
+                    .setDefaultValue(new ModelNode().set(IsolationLevel.READ_COMMITTED.name()))
                     .build();
 
     static final SimpleAttributeDefinition STRIPING =


### PR DESCRIPTION
corresponding configuration builder

https://issues.jboss.org/browse/ISPN-4645

Updated *ConfigurationBuilder and XSD files to have the correct default
values
Modified test case code that verifies the default value for L1
configuration
