### PR TITLE
CustomFailurePolicy's init method is now called. Fixes ISPN-4781.

### DIFF
--- a/core/src/main/java/org/infinispan/xsite/BackupSenderImpl.java
+++ b/core/src/main/java/org/infinispan/xsite/BackupSenderImpl.java
@@ -96,6 +96,7 @@ public class BackupSenderImpl implements BackupSender {
                throw new IllegalStateException("Backup policy class missing for custom failure policy!");
             }
             CustomFailurePolicy instance = Util.getInstance(backupPolicy, globalConfig.classLoader());
+            instance.init(cache);
             siteFailurePolicy.put(bc.site(), instance);
          }
          OfflineStatus offline = new OfflineStatus(bc.takeOffline(), timeService);


### PR DESCRIPTION
Fixes https://issues.jboss.org/browse/ISPN-4781. 'init(Cache<K, V> cache)' is now called on XSite custom failure policies.
