### PR TITLE
ISPN-4631 Add explicit check that cluster was formed

### DIFF
--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
@@ -1,7 +1,7 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
-   
+ 
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
@@ -39,10 +39,10 @@
           mcast_addr="${jgroups.mping.mcast_addr:228.2.4.6}"
           mcast_port="${jgroups.mping.mcast_port:43366}"
           ip_ttl="${jgroups.udp.ip_ttl:2}"
-          num_initial_members="3" timeout="2000"/>
+          num_initial_members="2" timeout="2000"/>
 
    <MERGE3/>
-
+ 
    <FD_SOCK/>
    <FD_ALL timeout="15000" interval="3000"/>
 
@@ -60,12 +60,10 @@
               max_msg_batch_size="100"
               conn_expiry_timeout="0"/>
 
-   <SASL mech="DIGEST-MD5"
-         client_name="coordinator_user"
-         client_password="coordinator_password"
-         server_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropAuthUserCallbackHandler"
-         client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" 
-         sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
+   <SASL mech="GSSAPI"
+         server_name="node0/clustered"
+         login_module_name="krb-node0"
+         server_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" />
          
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
@@ -39,7 +39,7 @@
           mcast_addr="${jgroups.mping.mcast_addr:228.2.4.6}"
           mcast_port="${jgroups.mping.mcast_port:43366}"
           ip_ttl="${jgroups.udp.ip_ttl:2}"
-          num_initial_members="3" timeout="2000"/>
+          num_initial_members="2" timeout="2000"/>
 
    <MERGE3/>
 
@@ -62,7 +62,7 @@
               
    <SASL mech="GSSAPI"
          server_name="node0/clustered"
-         login_module_name="krb-node1" />
+         login_module_name="krb-node1-fail" />
 
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
@@ -1,7 +1,7 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
- 
+
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
@@ -39,10 +39,10 @@
           mcast_addr="${jgroups.mping.mcast_addr:228.2.4.6}"
           mcast_port="${jgroups.mping.mcast_port:43366}"
           ip_ttl="${jgroups.udp.ip_ttl:2}"
-          num_initial_members="3" timeout="2000"/>
+          num_initial_members="2" timeout="2000"/>
 
    <MERGE3/>
- 
+
    <FD_SOCK/>
    <FD_ALL timeout="15000" interval="3000"/>
 
@@ -59,14 +59,14 @@
               xmit_table_max_compaction_time="10000"
               max_msg_batch_size="100"
               conn_expiry_timeout="0"/>
-
+              
    <SASL mech="GSSAPI"
          server_name="node0/clustered"
-         login_module_name="krb-node0"
-         server_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" />
-         
+         login_module_name="krb-node1" />
+
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+   
 
    <UFC max_credits="2m" min_threshold="0.40"/>
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
@@ -1,8 +1,8 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
-   
-   <TCP bind_port="7800" port_range="10"
+
+   <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
          loopback="false"
@@ -39,7 +39,7 @@
           mcast_addr="${jgroups.mping.mcast_addr:228.2.4.6}"
           mcast_port="${jgroups.mping.mcast_port:43366}"
           ip_ttl="${jgroups.udp.ip_ttl:2}"
-          num_initial_members="3" timeout="2000"/>
+          num_initial_members="2" timeout="2000"/>
 
    <MERGE3/>
 
@@ -59,13 +59,16 @@
               xmit_table_max_compaction_time="10000"
               max_msg_batch_size="100"
               conn_expiry_timeout="0"/>
-              
-   <SASL mech="DIGEST-MD5" 
-         client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" />
 
+   <SASL mech="DIGEST-MD5"
+         client_name="coordinator_user"
+         client_password="coordinator_password"
+         server_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler"
+         client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" 
+         sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
+         
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
-   
 
    <UFC max_credits="2m" min_threshold="0.40"/>
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
@@ -1,8 +1,8 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
-
-   <TCP  bind_port="7800" port_range="10"
+   
+   <TCP bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
          loopback="false"
@@ -39,7 +39,7 @@
           mcast_addr="${jgroups.mping.mcast_addr:228.2.4.6}"
           mcast_port="${jgroups.mping.mcast_port:43366}"
           ip_ttl="${jgroups.udp.ip_ttl:2}"
-          num_initial_members="3" timeout="2000"/>
+          num_initial_members="2" timeout="2000"/>
 
    <MERGE3/>
 
@@ -59,16 +59,13 @@
               xmit_table_max_compaction_time="10000"
               max_msg_batch_size="100"
               conn_expiry_timeout="0"/>
+              
+   <SASL mech="DIGEST-MD5" 
+         client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" />
 
-   <SASL mech="DIGEST-MD5"
-         client_name="coordinator_user"
-         client_password="coordinator_password"
-         server_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler"
-         client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" 
-         sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
-         
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+   
 
    <UFC max_credits="2m" min_threshold="0.40"/>
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
@@ -1,7 +1,7 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
-
+   
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"
@@ -39,7 +39,7 @@
           mcast_addr="${jgroups.mping.mcast_addr:228.2.4.6}"
           mcast_port="${jgroups.mping.mcast_port:43366}"
           ip_ttl="${jgroups.udp.ip_ttl:2}"
-          num_initial_members="3" timeout="2000"/>
+          num_initial_members="2" timeout="2000"/>
 
    <MERGE3/>
 
@@ -59,14 +59,16 @@
               xmit_table_max_compaction_time="10000"
               max_msg_batch_size="100"
               conn_expiry_timeout="0"/>
-              
-   <SASL mech="GSSAPI"
-         server_name="node0/clustered"
-         login_module_name="krb-node1-fail" />
 
+   <SASL mech="DIGEST-MD5"
+         client_name="coordinator_user"
+         client_password="coordinator_password"
+         server_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropAuthUserCallbackHandler"
+         client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" 
+         sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
+         
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
    <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
-   
 
    <UFC max_credits="2m" min_threshold="0.40"/>
    <MFC max_credits="2m" min_threshold="0.40"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4631
- Added check that cluster has 2 members
- Adjust initial number of nodes to avoid delays
- Renamed jgroups config files to "tcp" as transport was switched to TCP
