### PR TITLE
ISPN-4792 RemoteClusterListener still invokes filter/converter

### DIFF
--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplicateCallable.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplicateCallable.java
@@ -13,6 +13,8 @@ import org.infinispan.filter.KeyValueFilter;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.notifications.cachelistener.filter.CacheEventConverter;
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilter;
+import org.infinispan.notifications.cachelistener.filter.CompositeCacheEventFilter;
+import org.infinispan.notifications.cachelistener.filter.PostCacheEventFilter;
 import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifier;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.util.concurrent.WithinThreadExecutor;
@@ -86,7 +88,7 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
                if (!alreadyInstalled) {
                   RemoteClusterListener listener = new RemoteClusterListener(identifier, origin, distExecutor, cacheNotifier,
                                                                            cacheManagerNotifier);
-                  cacheNotifier.addListener(listener, filter, converter);
+                  cacheNotifier.addListener(listener, filter != null ? new CompositeCacheEventFilter(new PostCacheEventFilter(), filter) : null, converter);
                   cacheManagerNotifier.addListener(listener);
                   // It is possible the member is now gone after registered, if so we have to remove just to be sure
                   if (!cacheManager.getMembers().contains(origin)) {

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/filter/CompositeCacheEventFilter.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/filter/CompositeCacheEventFilter.java
@@ -1,0 +1,24 @@
+package org.infinispan.notifications.cachelistener.filter;
+
+import org.infinispan.metadata.Metadata;
+
+/**
+ * Allows AND-composing several cache event filters.
+ *
+ * @author wburns
+ * @since 7.0
+ */
+public class CompositeCacheEventFilter<K, V> implements CacheEventFilter<K, V> {
+   private final CacheEventFilter<? super K, ? super V>[] filters;
+
+   public CompositeCacheEventFilter(CacheEventFilter<? super K, ? super V>... filters) {
+      this.filters = filters;
+   }
+
+   @Override
+   public boolean accept(K key, V oldValue, Metadata oldMetadata, V newValue, Metadata newMetadata, EventType eventType) {
+      for (CacheEventFilter<? super K, ? super V> k : filters)
+         if (!k.accept(key, oldValue, oldMetadata, newValue, newMetadata, eventType)) return false;
+      return true;
+   }
+}

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/filter/PostCacheEventFilter.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/filter/PostCacheEventFilter.java
@@ -1,0 +1,16 @@
+package org.infinispan.notifications.cachelistener.filter;
+
+import org.infinispan.metadata.Metadata;
+
+/**
+ * A Filter that only allows post events to be accepted.
+ *
+ * @author wburns
+ * @since 7.0
+ */
+public class PostCacheEventFilter<K, V> implements CacheEventFilter<K, V> {
+   @Override
+   public boolean accept(K key, V oldValue, Metadata oldMetadata, V newValue, Metadata newMetadata, EventType eventType) {
+      return !eventType.isPreEvent();
+   }
+}


### PR DESCRIPTION
- Added post filter so only post events are passed to cluster listeners

https://issues.jboss.org/browse/ISPN-4792
