### PR TITLE
ISPN-4822 MassIndexer is not ClusteredQuery friendly

### DIFF
--- a/query/src/main/java/org/infinispan/query/MassIndexer.java
+++ b/query/src/main/java/org/infinispan/query/MassIndexer.java
@@ -1,6 +1,7 @@
 package org.infinispan.query;
 
 import org.infinispan.jmx.annotations.MBean;
+import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
 
 /**
@@ -17,6 +18,11 @@ import org.infinispan.jmx.annotations.ManagedOperation;
 @MBean(objectName = "MassIndexer",
       description = "Component that rebuilds the index from the cached data")
 public interface MassIndexer {
+
+   @ManagedAttribute(displayName = "flushPerNode enabled", description = "Flush indexes per node instead of once only", writable = true)
+   boolean isFlushPerNodeEnabled();
+
+   void setFlushPerNodeEnabled(boolean enabled);
 
    //TODO Add more parameters here, like timeout when it will be implemented
    //(see ISPN-1313, and ISPN-1042 for task cancellation)

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -54,6 +54,7 @@ import org.infinispan.query.impl.externalizers.LuceneTermExternalizer;
 import org.infinispan.query.impl.externalizers.LuceneTermQueryExternalizer;
 import org.infinispan.query.impl.externalizers.LuceneTopDocsExternalizer;
 import org.infinispan.query.impl.externalizers.LuceneTopFieldDocsExternalizer;
+import org.infinispan.query.impl.massindex.IndexCleanCallable;
 import org.infinispan.query.impl.massindex.MapReduceMassIndexer;
 import org.infinispan.query.logging.Log;
 import org.infinispan.query.spi.ProgrammaticSearchMappingProvider;
@@ -344,6 +345,7 @@ public class LifecycleManager extends AbstractModuleLifecycle {
       externalizerMap.put(ExternalizerIds.LUCENE_FIELD_SCORE_DOC, new LuceneFieldDocExternalizer());
       externalizerMap.put(ExternalizerIds.LUCENE_SCORE_DOC, new LuceneScoreDocExternalizer());
       externalizerMap.put(ExternalizerIds.LUCENE_TOPFIELDDOCS, new LuceneTopFieldDocsExternalizer());
+      externalizerMap.put(ExternalizerIds.INDEX_CLEAN_CALLABLE, new IndexCleanCallable.Externalizer());
    }
 
 }

--- a/query/src/main/java/org/infinispan/query/impl/externalizers/ExternalizerIds.java
+++ b/query/src/main/java/org/infinispan/query/impl/externalizers/ExternalizerIds.java
@@ -34,4 +34,6 @@ public interface ExternalizerIds {
    Integer LUCENE_FIELD_SCORE_DOC = 1610;
 
    Integer FILTER_RESULT = 1611;
+   
+   Integer INDEX_CLEAN_CALLABLE = 1612;
 }

--- a/query/src/main/java/org/infinispan/query/impl/massindex/IndexCleanCallable.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/IndexCleanCallable.java
@@ -1,0 +1,59 @@
+package org.infinispan.query.impl.massindex;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.util.Util;
+import org.infinispan.distexec.DistributedCallable;
+import org.infinispan.query.backend.QueryInterceptor;
+import org.infinispan.query.impl.ComponentRegistryUtils;
+import org.infinispan.query.impl.externalizers.ExternalizerIds;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Set;
+
+/**
+ * Used to clean indexes across the cluster.
+ *
+ * @author gustavonalle
+ * @since 7.0
+ */
+public class IndexCleanCallable implements DistributedCallable<Void, Void, Void> {
+   private QueryInterceptor queryInterceptor;
+
+   @Override
+   public Void call() throws Exception {
+      queryInterceptor.purgeAllIndexes();
+      return null;
+   }
+
+   @Override
+   public void setEnvironment(Cache cache, Set inputKeys) {
+      this.queryInterceptor = ComponentRegistryUtils.getQueryInterceptor(cache);
+   }
+
+   public static class Externalizer extends AbstractExternalizer<IndexCleanCallable> {
+
+      @Override
+      @SuppressWarnings("ALL")
+      public Set<Class<? extends IndexCleanCallable>> getTypeClasses() {
+         return Util.<Class<? extends IndexCleanCallable>>asSet(IndexCleanCallable.class);
+      }
+
+      @Override
+      public void writeObject(ObjectOutput output, IndexCleanCallable object) throws IOException {
+      }
+
+      @Override
+      public IndexCleanCallable readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+         return new IndexCleanCallable();
+      }
+
+      @Override
+      public Integer getId() {
+         return ExternalizerIds.INDEX_CLEAN_CALLABLE;
+      }
+   }
+
+}

--- a/query/src/main/java/org/infinispan/query/impl/massindex/IndexPurger.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/IndexPurger.java
@@ -1,0 +1,13 @@
+package org.infinispan.query.impl.massindex;
+
+/**
+ * Remove all indexes associated with a cache.
+ *
+ * @author gustavonalle
+ * @since 7.0
+ */
+public interface IndexPurger {
+
+   public void purge();
+
+}

--- a/query/src/main/java/org/infinispan/query/impl/massindex/IndexingMapper.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/IndexingMapper.java
@@ -22,6 +22,7 @@ import org.infinispan.query.impl.ComponentRegistryUtils;
  */
 public final class IndexingMapper implements Mapper<Object, Object, Object, LuceneWork> {
 
+   private final boolean flushPerNode;
    private AdvancedCache cache;
    private SearchFactoryIntegrator searchFactory;
    private QueryInterceptor queryInterceptor;
@@ -29,6 +30,10 @@ public final class IndexingMapper implements Mapper<Object, Object, Object, Luce
    private DefaultMassIndexerProgressMonitor progressMonitor;
    private DefaultBatchBackend defaultBatchBackend;
 
+   public IndexingMapper(boolean flushPerNode) {
+      this.flushPerNode = flushPerNode;
+   }
+   
    public void initialize(Cache inputCache) {
       this.cache = inputCache.getAdvancedCache();
       this.queryInterceptor = ComponentRegistryUtils.getQueryInterceptor(cache);
@@ -75,7 +80,9 @@ public final class IndexingMapper implements Mapper<Object, Object, Object, Luce
     * make sure we don't return control to user before all work was processed and flushed.
     */
    public void flush() {
-      defaultBatchBackend.flush(searchFactory.getIndexedTypes());
+      if (flushPerNode) {
+         defaultBatchBackend.flush(searchFactory.getIndexedTypes());
+      }
    }
 
 }

--- a/query/src/main/java/org/infinispan/query/impl/massindex/MapReduceInitializer.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/MapReduceInitializer.java
@@ -7,7 +7,7 @@ import org.infinispan.distexec.mapreduce.spi.MapReduceTaskLifecycle;
 
 /**
  * Initializes the custom Map Reduce tasks we use to rebuild indexes
- *  
+ * 
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
  */
 public class MapReduceInitializer implements MapReduceTaskLifecycle {
@@ -22,7 +22,10 @@ public class MapReduceInitializer implements MapReduceTaskLifecycle {
 
    @Override
    public <KIn, VIn, KOut, VOut> void onPostExecute(Mapper<KIn, VIn, KOut, VOut> mapper) {
-      //nothing to do
+      if (mapper instanceof IndexingMapper) {
+         IndexingMapper im = (IndexingMapper) mapper;
+         im.flush();
+      }
    }
 
    @Override

--- a/query/src/main/java/org/infinispan/query/impl/massindex/PerNodeIndexPurger.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/PerNodeIndexPurger.java
@@ -1,0 +1,46 @@
+package org.infinispan.query.impl.massindex;
+
+import org.infinispan.Cache;
+import org.infinispan.distexec.DefaultExecutorService;
+import org.infinispan.distexec.DistributedExecutorService;
+import org.infinispan.query.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Purges all indexes in the cluster, on a per node basis.
+ *
+ * @author gustavonalle
+ * @since 7.0
+ */
+public class PerNodeIndexPurger implements IndexPurger {
+
+   private static final Log LOG = LogFactory.getLog(PerNodeIndexPurger.class, Log.class);
+   private static final int TIMEOUT_SECONDS = 10;
+   private final Cache cache;
+
+   public PerNodeIndexPurger(Cache cache) {
+      this.cache = cache;
+   }
+
+   @Override
+   public void purge() {
+      DistributedExecutorService distributedExecutorService = new DefaultExecutorService(cache);
+      List<Future<Void>> futures = distributedExecutorService.submitEverywhere(new IndexCleanCallable());
+      for (Future f : futures) {
+         try {
+            f.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.errorPurgingIndexes(e);
+         } catch (ExecutionException | TimeoutException e) {
+            LOG.errorPurgingIndexes(e);
+         }
+      }
+   }
+}

--- a/query/src/main/java/org/infinispan/query/impl/massindex/SingleNodeIndexPurger.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/SingleNodeIndexPurger.java
@@ -1,0 +1,26 @@
+package org.infinispan.query.impl.massindex;
+
+import org.infinispan.Cache;
+import org.infinispan.query.backend.QueryInterceptor;
+import org.infinispan.query.impl.ComponentRegistryUtils;
+
+/**
+ * Delete all indexes associated with a cache.
+ *
+ * @author gustavonalle
+ * @since 7.0
+ */
+public class SingleNodeIndexPurger implements IndexPurger {
+
+   private final Cache cache;
+
+   public SingleNodeIndexPurger(Cache cache) {
+      this.cache = cache;
+   }
+
+   public void purge() {
+      QueryInterceptor queryInterceptor = ComponentRegistryUtils.getQueryInterceptor(cache);
+      queryInterceptor.purgeAllIndexes();
+   }
+
+}

--- a/query/src/main/java/org/infinispan/query/logging/Log.java
+++ b/query/src/main/java/org/infinispan/query/logging/Log.java
@@ -75,4 +75,7 @@ public interface Log extends org.infinispan.util.logging.Log {
    @Message(value = "Cache named '%1$s' is being shut down. No longer accepting remote commands.", id = 14013)
    CacheException cacheIsStoppingNoCommandAllowed(String cacheName);
 
+   @LogMessage(level = ERROR)
+   @Message(value = "Could not purge indexes", id = 14014)
+   void errorPurgingIndexes(@Cause Exception e);   
 }

--- a/query/src/test/java/org/infinispan/query/distributed/DistributedMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/DistributedMassIndexingTest.java
@@ -16,8 +16,9 @@ import org.infinispan.query.helper.StaticTestingErrorHandler;
 import org.infinispan.query.queries.faceting.Car;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.junit.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
@@ -35,10 +36,14 @@ public class DistributedMassIndexingTest extends MultipleCacheManagersTest {
       "LuceneIndexesLocking",
    };
 
+   protected String getConfigurationFile() {
+      return "dynamic-indexing-distribution.xml";
+   }
+
    @Override
    protected void createCacheManagers() throws Throwable {
       for (int i = 0; i < NUM_NODES; i++) {
-         EmbeddedCacheManager cacheManager = TestCacheManagerFactory.fromXml("dynamic-indexing-distribution.xml");
+         EmbeddedCacheManager cacheManager = TestCacheManagerFactory.fromXml(getConfigurationFile());
          registerCacheManager(cacheManager);
          Cache cache = cacheManager.getCache();
          caches.add(cache);
@@ -88,6 +93,6 @@ public class DistributedMassIndexingTest extends MultipleCacheManagersTest {
       QueryBuilder carQueryBuilder = searchManager.buildQueryBuilderForClass(Car.class).get();
       Query fullTextQuery = carQueryBuilder.keyword().onField("make").matching(carMake).createQuery();
       CacheQuery cacheQuery = searchManager.getQuery(fullTextQuery, Car.class);
-      Assert.assertEquals(expectedCount, cacheQuery.getResultSize());
+      assertEquals(expectedCount, cacheQuery.getResultSize());
    }
 }

--- a/query/src/test/resources/unshared-indexing-distribution.xml
+++ b/query/src/test/resources/unshared-indexing-distribution.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:infinispan:config:7.0 http://www.infinispan.org/schemas/infinispan-config-7.0.xsd" xmlns="urn:infinispan:config:7.0">
+   <cache-container name="QueryEnabledGrid-Dist" default-cache="default" statistics="true">
+      <transport cluster="Infinispan-Query-Cluster" />
+      <jmx duplicate-domains="true" />
+      <distributed-cache name="default" mode="SYNC" remote-timeout="20000" statistics="true">
+         <locking acquire-timeout="20000" write-skew="false" concurrency-level="500" striping="false" />
+         <eviction max-entries="-1" strategy="NONE" />
+         <expiration max-idle="-1" />
+         <indexing index="LOCAL">
+               <property name="default.directory_provider">infinispan</property>
+               <property name="error_handler">org.infinispan.query.helper.StaticTestingErrorHandler</property>
+         </indexing>
+         <state-transfer timeout="480000" enabled="true" />
+      </distributed-cache>
+      <local-cache name="LuceneIndexesMetadata" />
+      <local-cache name="LuceneIndexesData" />
+      <local-cache name="LuceneIndexesLocking" />
+   </cache-container>
+</infinispan>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4822

Introduced an optional configuration parameter for the MassIndexer called __flushPerNode__ (false by default). 

When enabled, will purge and flush (commit) indexes on a per node basis. This is necessary for ClusteredQuery, where each node has an independent index.

I'm aware that we already have lots of properties in query, but the issue here is that it's not possible to reliably detect if an index is shared or not by only looking at configuration.