### PR TITLE
ISPN-3792 Add metadata parameter to putForExternalRead

### DIFF
--- a/core/src/main/java/org/infinispan/AdvancedCache.java
+++ b/core/src/main/java/org/infinispan/AdvancedCache.java
@@ -355,6 +355,8 @@ public interface AdvancedCache<K, V> extends Cache<K, V> {
     * @since 5.3
     */
    V putIfAbsent(K key, V value, Metadata metadata);
+   
+   void putForExternalRead(K key, V value, Metadata metadata);
 
    /**
     * Asynchronous version of {@link #put(Object, Object, Metadata)} which stores

--- a/core/src/main/java/org/infinispan/Cache.java
+++ b/core/src/main/java/org/infinispan/Cache.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The central interface of Infinispan.  A Cache provides a highly concurrent, optionally distributed data structure
@@ -109,6 +110,8 @@ public interface Cache<K, V> extends BasicCache<K, V>, BatchingCache, FilteringL
     * @throws IllegalStateException if {@link #getStatus()} would not return {@link ComponentStatus#RUNNING}.
     */
    void putForExternalRead(K key, V value);
+   void putForExternalRead(K key, V value, long lifespan, TimeUnit unit);
+   void putForExternalRead(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit);
 
    /**
     * Evicts an entry from the memory of the cache.  Note that the entry is <i>not</i> removed from any configured cache

--- a/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingAdvancedCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingAdvancedCache.java
@@ -226,8 +226,17 @@ public class AbstractDelegatingAdvancedCache<K, V> extends AbstractDelegatingCac
       return cache.putAsync(key, value, metadata);
    }
 
+   @Override
+   public void putForExternalRead(K key, V value, Metadata metadata) {
+      cache.putForExternalRead(key, value, metadata);
+   }
+
    protected final void putForExternalRead(K key, V value, EnumSet<Flag> flags, ClassLoader classLoader) {
       ((CacheImpl<K, V>) cache).putForExternalRead(key, value, flags, classLoader);
+   }
+
+   protected final void putForExternalRead(K key, V value, Metadata metadata, EnumSet<Flag> flags, ClassLoader classLoader) {
+      ((CacheImpl<K, V>) cache).putForExternalRead(key, value, metadata, flags, classLoader);
    }
 
    public interface AdvancedCacheWrapper<K, V> {

--- a/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingCache.java
@@ -38,6 +38,16 @@ public abstract class AbstractDelegatingCache<K, V> implements Cache<K, V> {
    public void putForExternalRead(K key, V value) {
       cache.putForExternalRead(key, value);
    }
+   
+   @Override
+   public void putForExternalRead(K key, V value, long lifespan, TimeUnit unit) {
+      cache.putForExternalRead(key, value, lifespan, unit);
+   }
+
+   @Override
+   public void putForExternalRead(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
+      cache.putForExternalRead(key, value, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+   }
 
    @Override
    public void evict(K key) {

--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -581,7 +581,29 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
       putForExternalRead(key, value, null, null);
    }
 
+   @Override
+   public void putForExternalRead(K key, V value, long lifespan, TimeUnit lifespanUnit) {
+      putForExternalRead(key, value, lifespan, lifespanUnit, defaultMetadata.maxIdle(), MILLISECONDS);
+   }
+
+   @Override
+   public void putForExternalRead(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit idleTimeUnit) {
+      Metadata metadata = new EmbeddedMetadata.Builder()
+       .lifespan(lifespan, lifespanUnit)
+       .maxIdle(maxIdleTime, idleTimeUnit).build();
+      putForExternalRead(key, value, metadata);
+   }
+
+   @Override
+   public void putForExternalRead(K key, V value, Metadata metadata) {
+      putForExternalRead(key, value, metadata, null, null);
+   }
+
    final void putForExternalRead(K key, V value, EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
+      putForExternalRead(key, value, defaultMetadata, explicitFlags, explicitClassLoader);
+   }
+
+   final void putForExternalRead(K key, V value, Metadata metadata, EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
       Transaction ongoingTransaction = null;
       try {
          ongoingTransaction = suspendOngoingTransactionIfExists();
@@ -592,7 +614,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
          }
 
          // if the entry exists then this should be a no-op.
-         putIfAbsent(key, value, defaultMetadata, flags, explicitClassLoader);
+         putIfAbsent(key, value, metadata, flags, explicitClassLoader);
       } catch (Exception e) {
          if (log.isDebugEnabled()) log.debug("Caught exception while doing putForExternalRead()", e);
       }

--- a/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
@@ -135,6 +135,31 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
    }
 
    @Override
+   public void putForExternalRead(K key, V value, Metadata metadata) {
+      cacheImplementation.putForExternalRead(key, value, flags, classLoader.get());
+   }
+
+   @Override
+   public void putForExternalRead(K key, V value, long lifespan, TimeUnit unit) {
+      Metadata metadata = new EmbeddedMetadata.Builder()
+       .lifespan(lifespan, unit)
+       .maxIdle(cacheImplementation.defaultMetadata.maxIdle(), MILLISECONDS)
+       .build();
+
+      cacheImplementation.putForExternalRead(key, value, metadata, flags, classLoader.get());
+   }
+
+   @Override
+   public void putForExternalRead(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
+      Metadata metadata = new EmbeddedMetadata.Builder()
+       .lifespan(lifespan, lifespanUnit)
+       .maxIdle(maxIdle, maxIdleUnit)
+       .build();
+
+      cacheImplementation.putForExternalRead(key, value, metadata, flags, classLoader.get());
+   }
+
+   @Override
    public void evict(K key) {
       cacheImplementation.evict(key, flags, classLoader.get());
    }

--- a/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
+++ b/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
@@ -295,6 +295,24 @@ public final class SecureCacheImpl<K, V> implements SecureCache<K, V> {
    }
 
    @Override
+   public void putForExternalRead(K key, V value, Metadata metadata) {
+      authzManager.checkPermission(AuthorizationPermission.WRITE);
+      delegate.putForExternalRead(key, value);
+   }
+   
+   @Override
+   public void putForExternalRead(K key, V value, long lifespan, TimeUnit unit) {
+      authzManager.checkPermission(AuthorizationPermission.WRITE);
+      delegate.putForExternalRead(key, value);
+   }
+   
+   @Override
+   public void putForExternalRead(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
+      authzManager.checkPermission(AuthorizationPermission.WRITE);
+      delegate.putForExternalRead(key, value);
+   }
+
+   @Override
    public ComponentRegistry getComponentRegistry() {
       authzManager.checkPermission(AuthorizationPermission.ADMIN);
       return delegate.getComponentRegistry();


### PR DESCRIPTION
I'd like to be able to set metadata on cache entries that I use putForExternalRead on. I am using invalidation caches for caching data I load from a data store, so I can't use the standard put methods or risk invalidation after invalidation across my cluster. I have consider a Flags approach, however the putForExternalRead implementation does more than just flags; it also suspends the transaction.

The lack of metadata capability for putForExternalRead sticks out as different from the other methods. I've implemented metadata methods to match the other existing ones. I haven't put javadocs against them yet, but I will. I'd like to know if you like / approve the approach.
