### PR TITLE
ISPN-4027 Disable TxCleanupService for non-tx cache

### DIFF
--- a/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
@@ -125,8 +125,9 @@ public class TransactionTable {
          clustered = true;
       }
 
+      boolean transactional = configuration.transaction().transactionMode().isTransactional();
       boolean totalOrder = configuration.transaction().transactionProtocol().isTotalOrder();
-      if (clustered && !totalOrder) {
+      if (clustered && transactional && !totalOrder) {
          completedTransactionsInfo = new CompletedTransactionsInfo();
 
          // Periodically run a task to cleanup the transaction table from completed transactions.


### PR DESCRIPTION
The TxCleanupService is only needed when TxIntercepter is enabled and it's not needed for no-tx cache.
