### PR TITLE
ISPN-4673 Split-brain: get() returns null when all owners are removed from view

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/InfinispanCollections.java
+++ b/commons/src/main/java/org/infinispan/commons/util/InfinispanCollections.java
@@ -305,4 +305,11 @@ public class InfinispanCollections {
       return EMPTY_LIST;
    }
 
+   public static final <T> boolean containsAny(Collection<T> haystack, Collection<T> needle) {
+      for (T element : needle) {
+         if (haystack.contains(element))
+            return true;
+      }
+      return false;
+   }
 }

--- a/core/src/main/java/org/infinispan/partionhandling/impl/PartitionHandlingInterceptor.java
+++ b/core/src/main/java/org/infinispan/partionhandling/impl/PartitionHandlingInterceptor.java
@@ -7,16 +7,25 @@ import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
+import org.infinispan.commons.util.InfinispanCollections;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.interceptors.base.CommandInterceptor;
+import org.infinispan.interceptors.locking.ClusteringDependentLogic;
+import org.infinispan.remoting.RpcException;
+import org.infinispan.remoting.transport.Transport;
 
 public class PartitionHandlingInterceptor extends CommandInterceptor {
 
    PartitionHandlingManager partitionHandlingManager;
+   private Transport transport;
+   private ClusteringDependentLogic cdl;
 
-   @Inject void init(PartitionHandlingManager partitionHandlingManager) {
+   @Inject
+   void init(PartitionHandlingManager partitionHandlingManager, Transport transport, ClusteringDependentLogic cdl) {
       this.partitionHandlingManager = partitionHandlingManager;
+      this.transport = transport;
+      this.cdl = cdl;
    }
 
    @Override
@@ -58,8 +67,33 @@ public class PartitionHandlingInterceptor extends CommandInterceptor {
 
    @Override
    public Object visitGetKeyValueCommand(InvocationContext ctx, GetKeyValueCommand command) throws Throwable {
-      partitionHandlingManager.checkRead(command.getKey());
-      return super.visitGetKeyValueCommand(ctx, command);
+      Object key = command.getKey();
+      Object result;
+      try {
+         result = super.visitGetKeyValueCommand(ctx, command);
+      } catch (RpcException e) {
+         // We must have received an AvailabilityException from one of the owners.
+         // There is no way to verify the cause here, but there isn't any other way to get an invalid get response.
+         throw getLog().degradedModeKeyUnavailable(key);
+      }
+
+      // We do the availability check after the read, because the cache may have entered degraded mode
+      // while we were reading from a remote node.
+      partitionHandlingManager.checkRead(key);
+
+      // If all owners left and we still haven't received the availability update yet, we could return
+      // an incorrect null value. So we need a special check for null results.
+      if (result == null) {
+         // Unlike in PartitionHandlingManager.checkRead(), here we ignore the availability status
+         // and we only fail the operation if _all_ owners have left the cluster.
+         // TODO Move this to the availability strategy when implementing ISPN-4624
+         if (!InfinispanCollections.containsAny(transport.getMembers(), cdl.getOwners(key))) {
+            throw getLog().degradedModeKeyUnavailable(key);
+         }
+      }
+
+      // TODO We can still return a stale value if the other partition stayed active without us and we haven't entered degraded mode yet.
+      return result;
    }
 
 }

--- a/core/src/main/java/org/infinispan/partionhandling/impl/PreferAvailabilityStrategy.java
+++ b/core/src/main/java/org/infinispan/partionhandling/impl/PreferAvailabilityStrategy.java
@@ -1,5 +1,6 @@
 package org.infinispan.partionhandling.impl;
 
+import org.infinispan.commons.util.InfinispanCollections;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.topology.CacheStatusResponse;
@@ -145,17 +146,10 @@ public class PreferAvailabilityStrategy implements AvailabilityStrategy {
 
    private boolean isDataLost(ConsistentHash currentCH, List<Address> newMembers) {
       for (int i = 0; i < currentCH.getNumSegments(); i++) {
-         if (!containsAny(newMembers, currentCH.locateOwnersForSegment(i)))
+         if (!InfinispanCollections.containsAny(newMembers, currentCH.locateOwnersForSegment(i)))
             return true;
       }
       return false;
    }
 
-   private boolean containsAny(List<Address> newMembers, List<Address> owners) {
-      for (Address owner : owners) {
-         if (newMembers.contains(owner))
-            return true;
-      }
-      return false;
-   }
 }

--- a/core/src/main/java/org/infinispan/partionhandling/impl/PreferConsistencyStrategy.java
+++ b/core/src/main/java/org/infinispan/partionhandling/impl/PreferConsistencyStrategy.java
@@ -1,5 +1,6 @@
 package org.infinispan.partionhandling.impl;
 
+import org.infinispan.commons.util.InfinispanCollections;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.partionhandling.AvailabilityMode;
 import org.infinispan.remoting.transport.Address;
@@ -228,15 +229,7 @@ public class PreferConsistencyStrategy implements AvailabilityStrategy {
 
    private boolean isDataLost(ConsistentHash currentCH, List<Address> newMembers) {
       for (int i = 0; i < currentCH.getNumSegments(); i++) {
-         if (!containsAny(newMembers, currentCH.locateOwnersForSegment(i)))
-            return true;
-      }
-      return false;
-   }
-
-   private boolean containsAny(List<Address> newMembers, List<Address> owners) {
-      for (Address owner : owners) {
-         if (newMembers.contains(owner))
+         if (!InfinispanCollections.containsAny(newMembers, currentCH.locateOwnersForSegment(i)))
             return true;
       }
       return false;

--- a/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
@@ -105,7 +105,6 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
          disableDiscovery();
          installNewView();
          assertPartitionFormed();
-         assertDegradedMode();
          log.trace("New views installed");
       }
 
@@ -256,16 +255,9 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
          }
       }
 
-      private void assertDegradedMode() {
+      public void assertDegradedMode() {
          if (partitionHandling) {
-            for (final Cache c : cachesInThisPartition()) {
-               eventually(new Condition() {
-                  @Override
-                  public boolean isSatisfied() throws Exception {
-                     return partitionHandlingManager(c.getAdvancedCache()).getAvailabilityMode() == AvailabilityMode.DEGRADED_MODE;
-                  }
-               });
-            }
+            assertAvailabilityMode(AvailabilityMode.DEGRADED_MODE);
          }
       }
 
@@ -282,12 +274,12 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
          }
       }
 
-      protected void assertKeysNotAvailable(Object ... keys) {
+      protected void assertKeysNotAvailableForRead(Object... keys) {
          for (Object k : keys)
-            assertKeyNotAvailable(k);
+            assertKeyNotAvailableForRead(k);
       }
 
-      protected void assertKeyNotAvailable(Object key) {
+      protected void assertKeyNotAvailableForRead(Object key) {
          for (Cache c : cachesInThisPartition()) {
             try {
                c.get(key);
@@ -322,7 +314,7 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
          }
       }
 
-      public void expectPartitionState(final AvailabilityMode state) {
+      public void assertAvailabilityMode(final AvailabilityMode state) {
          for (final Cache c : cachesInThisPartition()) {
             eventually(new Condition() {
                @Override

--- a/core/src/test/java/org/infinispan/partitionhandling/DelayedAvailabilityUpdateTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/DelayedAvailabilityUpdateTest.java
@@ -1,0 +1,110 @@
+package org.infinispan.partitionhandling;
+
+import org.infinispan.Cache;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.partionhandling.AvailabilityException;
+import org.infinispan.partionhandling.AvailabilityMode;
+import org.infinispan.test.concurrent.StateSequencer;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.topology.LocalTopologyManager;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.testng.annotations.Test;
+
+import static org.infinispan.test.concurrent.StateSequencerUtil.advanceOnGlobalComponentMethod;
+import static org.infinispan.test.concurrent.StateSequencerUtil.matchMethodCall;
+import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.fail;
+
+@Test(groups = "functional", testName = "partitionhandling.DelayedAvailabilityUpdateTest")
+@CleanupAfterMethod
+public class DelayedAvailabilityUpdateTest extends BasePartitionHandlingTest {
+   private static final Log log = LogFactory.getLog(DelayedAvailabilityUpdateTest.class);
+
+   public void testDelayedAvailabilityUpdate0() throws Exception {
+      testDelayedAvailabilityUpdate(new PartitionDescriptor(0, 1), new PartitionDescriptor(2, 3));
+   }
+
+   public void testDelayedAvailabilityUpdate1() throws Exception {
+      testDelayedAvailabilityUpdate(new PartitionDescriptor(0, 2), new PartitionDescriptor(1, 3));
+   }
+
+   public void testDelayedAvailabilityUpdate2() throws Exception {
+      testDelayedAvailabilityUpdate(new PartitionDescriptor(0, 3), new PartitionDescriptor(1, 2));
+   }
+
+   public void testDelayedAvailabilityUpdate3() throws Exception {
+      testDelayedAvailabilityUpdate(new PartitionDescriptor(1, 2), new PartitionDescriptor(0, 3));
+   }
+
+   public void testDelayedAvailabilityUpdate4() throws Exception {
+      testDelayedAvailabilityUpdate(new PartitionDescriptor(1, 3), new PartitionDescriptor(0, 2));
+   }
+
+   public void testDelayedAvailabilityUpdate5() throws Exception {
+      testDelayedAvailabilityUpdate(new PartitionDescriptor(2, 3), new PartitionDescriptor(0, 1));
+   }
+
+
+   private void testDelayedAvailabilityUpdate(PartitionDescriptor p0, PartitionDescriptor p1) throws Exception {
+      Object k0Existing = new MagicKey("k0Existing", cache(p0.node(0)), cache(p0.node(1)));
+      Object k1Existing = new MagicKey("k1Existing", cache(p0.node(1)), cache(p1.node(0)));
+      Object k2Existing = new MagicKey("k2Existing", cache(p1.node(0)), cache(p1.node(1)));
+      Object k3Existing = new MagicKey("k3Existing", cache(p1.node(1)), cache(p0.node(0)));
+      Object k0Missing = new MagicKey("k0Missing", cache(p0.node(0)), cache(p0.node(1)));
+      Object k1Missing = new MagicKey("k1Missing", cache(p0.node(1)), cache(p1.node(0)));
+      Object k2Missing = new MagicKey("k2Missing", cache(p1.node(0)), cache(p1.node(1)));
+      Object k3Missing = new MagicKey("k3Missing", cache(p1.node(1)), cache(p0.node(0)));
+
+      Cache<Object, Object> cacheP0N0 = cache(p0.node(0));
+      cacheP0N0.put(k0Existing, "v0");
+      cacheP0N0.put(k1Existing, "v1");
+      cacheP0N0.put(k2Existing, "v2");
+      cacheP0N0.put(k3Existing, "v3");
+
+      StateSequencer ss = new StateSequencer();
+      ss.logicalThread("main", "main:block_availability_update_p0n0", "main:after_availability_update_p0n1",
+            "main:check_availability", "main:resume_availability_update_p0n0");
+
+      log.debugf("Delaying the availability mode update on node %s", address(p0.node(0)));
+      advanceOnGlobalComponentMethod(ss, manager(p0.node(0)), LocalTopologyManager.class,
+            matchMethodCall("handleTopologyUpdate").withParam(2, AvailabilityMode.DEGRADED_MODE).build())
+            .before("main:block_availability_update_p0n0", "main:resume_availability_update_p0n0");
+      advanceOnGlobalComponentMethod(ss, manager(p0.node(1)), LocalTopologyManager.class,
+            matchMethodCall("handleTopologyUpdate").withParam(2, AvailabilityMode.DEGRADED_MODE).build())
+            .after("main:after_availability_update_p0n1");
+
+      splitCluster(p0.getNodes(), p1.getNodes());
+
+      ss.enter("main:check_availability");
+      assertEquals(AvailabilityMode.AVAILABLE, partitionHandlingManager(p0.node(0)).getAvailabilityMode());
+
+      // The availability didn't change on p0.node0, check that keys owned by p1 are not accessible
+      partition(0).assertKeyAvailableForRead(k0Existing, "v0");
+      partition(0).assertKeysNotAvailableForRead(k1Existing, k2Existing);
+      // k3 is an exception, since p0.node0 is a backup owner it returns the local value
+      assertPartiallyAvailable(p0, k3Existing, "v3");
+
+      partition(0).assertKeyAvailableForRead(k0Missing, null);
+      partition(0).assertKeysNotAvailableForRead(k1Missing, k2Missing);
+      // k3 is an exception, since p0.node0 is a backup owner it returns the local value
+      assertPartiallyAvailable(p0, k3Missing, null);
+
+      // Allow the partition handling manager on p0.node0 to update the availability mode
+      ss.exit("main:check_availability");
+
+      partition(0).assertDegradedMode();
+      partition(1).assertDegradedMode();
+   }
+
+   private void assertPartiallyAvailable(PartitionDescriptor p0, Object k3Existing, Object value) {
+      assertEquals(value, cache(p0.node(0)).get(k3Existing));
+      try {
+         cache(p0.node(1)).get(k3Existing);
+         fail("Should have failed, cache " + cache(p0.node(1)) + " is in degraded mode");
+      } catch (AvailabilityException e) {
+         // Expected
+      }
+   }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4673
- If get returns null, check that at least one owner is in the cluster.
- Replace RpcException with AvailabilityException if there are no valid
  answers.
