### PR TITLE
[ISPN-4645] Many XSD default values do not match the defaults from the

### DIFF
--- a/core/src/main/resources/schema/infinispan-config-7.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-7.0.xsd
@@ -1275,9 +1275,9 @@
         <xs:documentation>The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="chunk-size" type="xs:integer" default="10000">
+    <xs:attribute name="chunk-size" type="xs:integer" default="512">
       <xs:annotation>
-        <xs:documentation>The size, in bytes, in which to batch the transfer of cache entries.</xs:documentation>
+        <xs:documentation>The number of cache entries to batch in each transfer.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="await-initial-transfer" type="xs:boolean" default="true">

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StateTransferResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StateTransferResource.java
@@ -59,7 +59,7 @@ public class StateTransferResource extends SimpleResourceDefinition {
                     .setXmlName(Attribute.CHUNK_SIZE.getLocalName())
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setDefaultValue(new ModelNode().set(10000))
+                    .setDefaultValue(new ModelNode().set(512))
                     .build();
 
     // enabled (used in state transfer, rehashing)


### PR DESCRIPTION
corresponding configuration builder

https://issues.jboss.org/browse/ISPN-4645

Updated XSD and server code for state transfer chunk size property
default value
