### PR TITLE
ISPN-4862 Don't use static resource fields to initialize the shared description resolver in the static initializer

### DIFF
--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanResourceDescriptionResolver.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanResourceDescriptionResolver.java
@@ -93,44 +93,44 @@ public class InfinispanResourceDescriptionResolver extends StandardResourceDescr
     static {
         sharedAttributeResolver = new HashMap<String, String>();
         // shared cache attributes
-        sharedAttributeResolver.put(CacheResource.BATCHING.getName(), "cache");
-        sharedAttributeResolver.put(CacheResource.CACHE_MODULE.getName(), "cache");
-        sharedAttributeResolver.put(CacheResource.INDEXING.getName(), "cache");
-        sharedAttributeResolver.put(CacheResource.INDEXING_AUTO_CONFIG.getName(), "cache");
-        sharedAttributeResolver.put(CacheResource.INDEXING_PROPERTIES.getName(), "cache");
-        sharedAttributeResolver.put(CacheResource.JNDI_NAME.getName(), "cache");
-        sharedAttributeResolver.put(CacheResource.NAME.getName(), "cache");
-        sharedAttributeResolver.put(CacheResource.START.getName(), "cache");
-        sharedAttributeResolver.put(CacheResource.STATISTICS.getName(), "cache");
+        sharedAttributeResolver.put(ModelKeys.BATCHING, "cache");
+        sharedAttributeResolver.put(ModelKeys.MODULE, "cache");
+        sharedAttributeResolver.put(ModelKeys.INDEXING, "cache");
+        sharedAttributeResolver.put(ModelKeys.AUTO_CONFIG, "cache");
+        sharedAttributeResolver.put(ModelKeys.INDEXING_PROPERTIES, "cache");
+        sharedAttributeResolver.put(ModelKeys.JNDI_NAME, "cache");
+        sharedAttributeResolver.put(ModelKeys.NAME, "cache");
+        sharedAttributeResolver.put(ModelKeys.START, "cache");
+        sharedAttributeResolver.put(ModelKeys.STATISTICS, "cache");
 
-        sharedAttributeResolver.put(ClusteredCacheResource.ASYNC_MARSHALLING.getName(), "clustered-cache");
-        sharedAttributeResolver.put(ClusteredCacheResource.MODE.getName(), "clustered-cache");
-        sharedAttributeResolver.put(ClusteredCacheResource.QUEUE_FLUSH_INTERVAL.getName(), "clustered-cache");
-        sharedAttributeResolver.put(ClusteredCacheResource.QUEUE_SIZE.getName(), "clustered-cache");
-        sharedAttributeResolver.put(ClusteredCacheResource.REMOTE_TIMEOUT.getName(), "clustered-cache");
+        sharedAttributeResolver.put(ModelKeys.ASYNC_MARSHALLING, "clustered-cache");
+        sharedAttributeResolver.put(ModelKeys.MODE, "clustered-cache");
+        sharedAttributeResolver.put(ModelKeys.QUEUE_FLUSH_INTERVAL, "clustered-cache");
+        sharedAttributeResolver.put(ModelKeys.QUEUE_SIZE, "clustered-cache");
+        sharedAttributeResolver.put(ModelKeys.REMOTE_TIMEOUT, "clustered-cache");
 
-        sharedAttributeResolver.put(BaseStoreResource.PROPERTIES.getName(), "loader");
+        sharedAttributeResolver.put(ModelKeys.PROPERTIES, "loader");
 
-        sharedAttributeResolver.put(BaseStoreResource.FETCH_STATE.getName(), "store");
-        sharedAttributeResolver.put(BaseStoreResource.PASSIVATION.getName(), "store");
-        sharedAttributeResolver.put(BaseStoreResource.PRELOAD.getName(), "store");
-        sharedAttributeResolver.put(BaseStoreResource.PURGE.getName(), "store");
-        sharedAttributeResolver.put(BaseStoreResource.READ_ONLY.getName(), "store");
-        sharedAttributeResolver.put(BaseStoreResource.SHARED.getName(), "store");
-        sharedAttributeResolver.put(BaseStoreResource.SINGLETON.getName(), "store");
-        sharedAttributeResolver.put(BaseStoreResource.PROPERTY.getName(), "store");
-        sharedAttributeResolver.put(BaseStoreResource.PROPERTIES.getName(), "store");
+        sharedAttributeResolver.put(ModelKeys.FETCH_STATE, "store");
+        sharedAttributeResolver.put(ModelKeys.PASSIVATION, "store");
+        sharedAttributeResolver.put(ModelKeys.PRELOAD, "store");
+        sharedAttributeResolver.put(ModelKeys.PURGE, "store");
+        sharedAttributeResolver.put(ModelKeys.READ_ONLY, "store");
+        sharedAttributeResolver.put(ModelKeys.SHARED, "store");
+        sharedAttributeResolver.put(ModelKeys.SINGLETON, "store");
+        sharedAttributeResolver.put(ModelKeys.PROPERTY, "store");
+        sharedAttributeResolver.put(ModelKeys.PROPERTIES, "store");
 
-        sharedAttributeResolver.put(BaseJDBCStoreResource.DATA_SOURCE.getName(), "jdbc-store");
-        sharedAttributeResolver.put(BaseJDBCStoreResource.DIALECT.getName(), "jdbc-store");
-        sharedAttributeResolver.put(BaseJDBCStoreResource.BATCH_SIZE.getName(), "jdbc-store");
-        sharedAttributeResolver.put(BaseJDBCStoreResource.FETCH_SIZE.getName(), "jdbc-store");
-        sharedAttributeResolver.put(BaseJDBCStoreResource.PREFIX.getName(), "jdbc-store");
-        sharedAttributeResolver.put(BaseJDBCStoreResource.ID_COLUMN.getName() + ".column", "jdbc-store");
-        sharedAttributeResolver.put(BaseJDBCStoreResource.DATA_COLUMN.getName() + ".column", "jdbc-store");
-        sharedAttributeResolver.put(BaseJDBCStoreResource.TIMESTAMP_COLUMN.getName() + ".column", "jdbc-store");
-        sharedAttributeResolver.put(BaseJDBCStoreResource.ENTRY_TABLE.getName() + "table", "jdbc-store");
-        sharedAttributeResolver.put(BaseJDBCStoreResource.BUCKET_TABLE.getName() + "table", "jdbc-store");
+        sharedAttributeResolver.put(ModelKeys.DATASOURCE, "jdbc-store");
+        sharedAttributeResolver.put(ModelKeys.DIALECT, "jdbc-store");
+        sharedAttributeResolver.put(ModelKeys.BATCH_SIZE, "jdbc-store");
+        sharedAttributeResolver.put(ModelKeys.FETCH_SIZE, "jdbc-store");
+        sharedAttributeResolver.put(ModelKeys.PREFIX, "jdbc-store");
+        sharedAttributeResolver.put(ModelKeys.ID_COLUMN + ".column", "jdbc-store");
+        sharedAttributeResolver.put(ModelKeys.DATA_COLUMN + ".column", "jdbc-store");
+        sharedAttributeResolver.put(ModelKeys.TIMESTAMP_COLUMN + ".column", "jdbc-store");
+        sharedAttributeResolver.put(ModelKeys.ENTRY_TABLE + "table", "jdbc-store");
+        sharedAttributeResolver.put(ModelKeys.BUCKET_TABLE + "table", "jdbc-store");
 
         // shared cache metrics
         sharedAttributeResolver.put(MetricKeys.AVERAGE_READ_TIME, "cache");


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4862

Don't use static resource fields to initialize the shared description resolver in the static initializer. This fixes an initialization race where some fields could be null
