### PR TITLE
Use FrameworkUtil to retrive the osgi bundle and FileLookup to retrieve ...

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/OsgiClassLoader.java
+++ b/commons/src/main/java/org/infinispan/commons/util/OsgiClassLoader.java
@@ -13,6 +13,7 @@ import java.util.NoSuchElementException;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleReference;
+import org.osgi.framework.FrameworkUtil;
 
 /**
  * @author Brett Meyer
@@ -47,8 +48,7 @@ public class OsgiClassLoader extends ClassLoader {
       super(null);
 
       if (Util.isOSGiContext()) {
-         final BundleContext bundleContext = ((BundleReference) OsgiClassLoader.class.getClassLoader()).getBundle()
-               .getBundleContext();
+         final BundleContext bundleContext = FrameworkUtil.getBundle(OsgiClassLoader.class).getBundleContext();
          Bundle[] foundBundles = bundleContext.getBundles();
          bundles = new ArrayList<WeakReference<Bundle>>(foundBundles.length);
          for (Bundle foundBundle : foundBundles) {

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -19,6 +19,10 @@
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-core</artifactId>
       </dependency>
+       <dependency>
+           <groupId>org.infinispan</groupId>
+           <artifactId>infinispan-commons</artifactId>
+       </dependency>
       <dependency>
          <groupId>org.osgi</groupId>
          <artifactId>org.osgi.core</artifactId>

--- a/osgi/src/main/java/org/infinispan/osgi/InfinispanEmbeddedServiceFactory.java
+++ b/osgi/src/main/java/org/infinispan/osgi/InfinispanEmbeddedServiceFactory.java
@@ -11,6 +11,7 @@ import java.util.Set;
 
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.commons.util.FileLookup;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.ConfigurationException;
@@ -49,7 +50,7 @@ public class InfinispanEmbeddedServiceFactory implements ManagedServiceFactory {
         }
 
         try {
-            URL configURL = this.getClass().getClassLoader().getResource(config);
+            URL configURL = new FileLookup().lookupFileLocation(config, Thread.currentThread().getContextClassLoader());
             if (configURL == null) {
                 throw new ConfigurationException(PROP_CONFIG, String.format("Failed to find the specified config '%s'.", config));
             }


### PR DESCRIPTION
Sometimes ((BundleReference) OsgiClassLoader.class.getClassLoader()).getBundle()
returns null. To fix that use FrameworkUtil to retrive the osgi bundle [1]

Use FileLookup to find the resources on OSGI classpath as files for InfinispanEmbeddedServiceFactory are loaded by other bundles and not accessible using its class loader.

[1] http://grepcode.com/file/repo1.maven.org/maven2/org.osgi/org.osgi.core/4.2.0/org/osgi/framework/FrameworkUtil.java#FrameworkUtil.getBundle%28java.lang.Class%29
