### PR TITLE
ISPN-4867 Reset server marshaller when undeployed

### DIFF
--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ClientListenerRegistry.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ClientListenerRegistry.scala
@@ -50,7 +50,7 @@ class ClientListenerRegistry(configuration: HotRodServerConfiguration) extends L
    def getMarshaller(maybeMarshaller: Option[Marshaller]): Option[Marshaller] = {
       (marshaller, maybeMarshaller) match {
          case (None, None) => defaultMashaller
-         case (Some(m), None) => marshaller
+         case (Some(m), None) => defaultMashaller
          case (None, Some(m)) => maybeMarshaller
          case (Some(m), Some(mm)) =>
             warnMarshallerAlreadySet(m, mm)

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/MarshallerExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/MarshallerExtensionProcessor.java
@@ -64,7 +64,8 @@ public class MarshallerExtensionProcessor extends AbstractServerExtensionProcess
 
         @Override
         public void stop(StopContext context) {
-            // No-op
+           ROOT_LOGGER.debugf("Stopped marshaller service with marshaller = %s", marshaller);
+           extensionManager.getValue().setMarshaller(null);
         }
 
         @Override

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodCustomMarshallerEventIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodCustomMarshallerEventIT.java
@@ -60,7 +60,7 @@ public class HotRodCustomMarshallerEventIT {
     @InfinispanResource("container1")
     RemoteInfinispanServer server1;
 
-    @Deployment(testable = false, name = "filter-converter-1")
+    @Deployment(testable = false, name = "marshaller")
     @TargetsContainer("container1")
     @OverProtocol("jmx-as7")
     public static Archive<?> deploy1() {
@@ -126,6 +126,9 @@ public class HotRodCustomMarshallerEventIT {
             remoteCache.remove(new Id(1));
             ClientCacheEntryRemovedEvent<Id> removed = eventListener.pollEvent();
             assertEquals(new Id(1), removed.getKey());
+            remoteCache.remove(new Id(2));
+            removed = eventListener.pollEvent();
+            assertEquals(new Id(2), removed.getKey());
         } finally {
             remoteCache.removeClientListener(eventListener);
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4867
- Marshaller needs to be reset when undeployed to avoid CNFE exceptions in tests running after.
- If passing null marshaller, reset the default marshaller for remote event marshalling.
