### PR TITLE
ISPN-4836 Change entrySet, keySet and values to be backing maps

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/CloseableIterable.java
+++ b/commons/src/main/java/org/infinispan/commons/util/CloseableIterable.java
@@ -12,4 +12,7 @@ package org.infinispan.commons.util;
 public interface CloseableIterable<E> extends AutoCloseable, Iterable<E> {
    @Override
    void close();
+
+   @Override
+   CloseableIterator<E> iterator();
 }

--- a/commons/src/main/java/org/infinispan/commons/util/CloseableIteratorCollection.java
+++ b/commons/src/main/java/org/infinispan/commons/util/CloseableIteratorCollection.java
@@ -1,0 +1,17 @@
+package org.infinispan.commons.util;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * A collection that defines an iterator method that returns a {@link CloseableIterator}
+ * instead of a non closeable one.  This is needed so that iterators can be properly cleaned up.  All other
+ * methods will internally clean up any iterators created and don't have other side effects.
+ *
+ * @author wburns
+ * @since 7.0
+ */
+public interface CloseableIteratorCollection<E> extends Collection<E> {
+   @Override
+   CloseableIterator<E> iterator();
+}

--- a/commons/src/main/java/org/infinispan/commons/util/CloseableIteratorSet.java
+++ b/commons/src/main/java/org/infinispan/commons/util/CloseableIteratorSet.java
@@ -1,0 +1,14 @@
+package org.infinispan.commons.util;
+
+import java.util.Set;
+
+/**
+ * A set that defines an iterator method that returns a {@link org.infinispan.commons.util.CloseableIterator}
+ * instead of a non closeable one.  This is needed so that iterators can be properly cleaned up.  All other
+ * methods will internally clean up any iterators created and don't have other side effects.
+ *
+ * @author wburns
+ * @since 7.0
+ */
+public interface CloseableIteratorSet<E> extends Set<E>, CloseableIteratorCollection<E> {
+}

--- a/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingCache.java
@@ -2,6 +2,8 @@ package org.infinispan.cache.impl;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
+import org.infinispan.commons.util.CloseableIteratorCollection;
+import org.infinispan.commons.util.CloseableIteratorSet;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.filter.Converter;
@@ -298,17 +300,17 @@ public abstract class AbstractDelegatingCache<K, V> implements Cache<K, V> {
    }
 
    @Override
-   public Set<K> keySet() {
+   public CloseableIteratorSet<K> keySet() {
       return cache.keySet();
    }
 
    @Override
-   public Set<Entry<K, V>> entrySet() {
+   public CloseableIteratorSet<Entry<K, V>> entrySet() {
       return cache.entrySet();
    }
 
    @Override
-   public Collection<V> values() {
+   public CloseableIteratorCollection<V> values() {
       return cache.values();
    }
 

--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -1,31 +1,5 @@
 package org.infinispan.cache.impl;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.infinispan.context.Flag.*;
-import static org.infinispan.context.InvocationContextFactory.UNBOUNDED;
-import static org.infinispan.factories.KnownComponentNames.ASYNC_TRANSPORT_EXECUTOR;
-import static org.infinispan.factories.KnownComponentNames.CACHE_MARSHALLER;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-
-import javax.transaction.InvalidTransactionException;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionManager;
-import javax.transaction.xa.XAResource;
-
 import org.infinispan.AdvancedCache;
 import org.infinispan.Version;
 import org.infinispan.atomic.Delta;
@@ -33,6 +7,7 @@ import org.infinispan.batch.BatchContainer;
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.control.LockControlCommand;
+import org.infinispan.commands.read.EntryRetrievalCommand;
 import org.infinispan.commands.read.EntrySetCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.read.KeySetCommand;
@@ -51,6 +26,9 @@ import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.util.CloseableIterable;
+import org.infinispan.commons.util.CloseableIteratorCollection;
+import org.infinispan.commons.util.CloseableIteratorSet;
 import org.infinispan.commons.util.Util;
 import org.infinispan.commons.util.concurrent.AbstractInProcessNotifyingFuture;
 import org.infinispan.commons.util.concurrent.NotifyingFuture;
@@ -71,10 +49,13 @@ import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.SurvivesRestarts;
+import org.infinispan.filter.AcceptAllKeyValueFilter;
+import org.infinispan.filter.KeyFilter;
+import org.infinispan.filter.KeyValueFilter;
+import org.infinispan.filter.NullValueConverter;
 import org.infinispan.interceptors.InterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.iteration.EntryIterable;
-import org.infinispan.iteration.impl.EntryIterableImpl;
 import org.infinispan.iteration.impl.EntryRetriever;
 import org.infinispan.jmx.annotations.DataType;
 import org.infinispan.jmx.annotations.DisplayType;
@@ -85,8 +66,6 @@ import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.metadata.Metadata;
-import org.infinispan.filter.KeyFilter;
-import org.infinispan.filter.KeyValueFilter;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.notifications.cachelistener.filter.CacheEventConverter;
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilter;
@@ -103,6 +82,31 @@ import org.infinispan.transaction.xa.recovery.RecoveryManager;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+
+import javax.transaction.InvalidTransactionException;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import javax.transaction.xa.XAResource;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.infinispan.context.Flag.*;
+import static org.infinispan.context.InvocationContextFactory.UNBOUNDED;
+import static org.infinispan.factories.KnownComponentNames.ASYNC_TRANSPORT_EXECUTOR;
+import static org.infinispan.factories.KnownComponentNames.CACHE_MARSHALLER;
 
 /**
  * @author Mircea.Markus@jboss.com
@@ -358,11 +362,14 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
 
    @Override
    public final boolean isEmpty() {
-      return size() == 0;
+      return isEmpty(null, null);
    }
 
    final boolean isEmpty(EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
-      return size(explicitFlags, explicitClassLoader) == 0;
+      try (CloseableIterable<CacheEntry<K, Void>> iterable = filterEntries(AcceptAllKeyValueFilter.getInstance(),
+            explicitFlags, explicitClassLoader).converter(NullValueConverter.getInstance())) {
+         return !iterable.iterator().hasNext();
+      }
    }
 
    @Override
@@ -380,7 +387,20 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
 
    @Override
    public final boolean containsValue(Object value) {
-      throw new UnsupportedOperationException("Not supported");
+      return containsValue(value, null, null);
+   }
+
+   final boolean containsValue(Object value, EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
+      assertValueNotNull(value);
+      try (CloseableIterable<CacheEntry<K, V>> iterable = filterEntries(AcceptAllKeyValueFilter.getInstance(),
+                                                                           explicitFlags, explicitClassLoader)) {
+         for (CacheEntry<K, V> entry : iterable) {
+            if (value.equals(entry.getValue())) {
+               return true;
+            }
+         }
+      }
+      return false;
    }
 
    @Override
@@ -411,15 +431,15 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
 
    @Override
    public EntryIterable<K, V> filterEntries(KeyValueFilter<? super K, ? super V> filter) {
-      return filterEntries(filter, null);
+      return filterEntries(filter, null, null);
    }
 
-   protected EntryIterable<K, V> filterEntries(KeyValueFilter<? super K, ? super V> filter, EnumSet<Flag> explicitFlags) {
-      // We need to copy the flag set since it is possible to modify the flags after retrieving the
-      // EntryIterable and we don't want it to effect that.
-
-      return new EntryIterableImpl<K, V>(entryRetriever, filter, explicitFlags != null ? EnumSet.copyOf(explicitFlags) :
-            EnumSet.noneOf(Flag.class));
+   protected EntryIterable<K, V> filterEntries(KeyValueFilter<? super K, ? super V> filter, EnumSet<Flag> explicitFlags,
+                                               ClassLoader explicitClassLoader) {
+      // We need a read invocation context as the remove is done with its own context
+      InvocationContext ctx = getInvocationContextForRead(explicitClassLoader, UNBOUNDED);
+      EntryRetrievalCommand<K, V> command = commandsFactory.buildEntryRetrievalCommand(explicitFlags, filter);
+      return (EntryIterable<K, V>) invoker.invoke(ctx, command);
    }
 
    @Override
@@ -543,39 +563,39 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    }
 
    @Override
-   public Set<K> keySet() {
+   public CloseableIteratorSet<K> keySet() {
       return keySet(null, null);
    }
 
    @SuppressWarnings("unchecked")
-   Set<K> keySet(EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
+   CloseableIteratorSet<K> keySet(EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
       InvocationContext ctx = getInvocationContextForRead(explicitClassLoader, UNBOUNDED);
       KeySetCommand command = commandsFactory.buildKeySetCommand(explicitFlags);
-      return (Set<K>) invoker.invoke(ctx, command);
+      return (CloseableIteratorSet<K>) invoker.invoke(ctx, command);
    }
 
    @Override
-   public Collection<V> values() {
+   public CloseableIteratorCollection<V> values() {
       return values(null, null);
    }
 
    @SuppressWarnings("unchecked")
-   Collection<V> values(EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
+   CloseableIteratorCollection<V> values(EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
       InvocationContext ctx = getInvocationContextForRead(explicitClassLoader, UNBOUNDED);
       ValuesCommand command = commandsFactory.buildValuesCommand(explicitFlags);
-      return (Collection<V>) invoker.invoke(ctx, command);
+      return (CloseableIteratorCollection<V>) invoker.invoke(ctx, command);
    }
 
    @Override
-   public Set<Map.Entry<K, V>> entrySet() {
+   public CloseableIteratorSet<Map.Entry<K, V>> entrySet() {
       return entrySet(null, null);
    }
 
    @SuppressWarnings("unchecked")
-   Set<Map.Entry<K, V>> entrySet(EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
+   CloseableIteratorSet<Map.Entry<K, V>> entrySet(EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
       InvocationContext ctx = getInvocationContextForRead(explicitClassLoader, UNBOUNDED);
       EntrySetCommand command = commandsFactory.buildEntrySetCommand(explicitFlags);
-      return (Set<Map.Entry<K, V>>) invoker.invoke(ctx, command);
+      return (CloseableIteratorSet<Map.Entry<K, V>>) invoker.invoke(ctx, command);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
@@ -12,6 +12,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.AdvancedCache;
+import org.infinispan.commons.util.CloseableIteratorCollection;
+import org.infinispan.commons.util.CloseableIteratorSet;
 import org.infinispan.commons.util.concurrent.NotifyingFuture;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
@@ -421,7 +423,7 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
    }
 
    @Override
-   public Set<K> keySet() {
+   public CloseableIteratorSet<K> keySet() {
       return cacheImplementation.keySet(flags, classLoader.get());
    }
 
@@ -436,12 +438,12 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
    }
 
    @Override
-   public Collection<V> values() {
+   public CloseableIteratorCollection<V> values() {
       return cacheImplementation.values(flags, classLoader.get());
    }
 
    @Override
-   public Set<Entry<K, V>> entrySet() {
+   public CloseableIteratorSet<Entry<K, V>> entrySet() {
       return cacheImplementation.entrySet(flags, classLoader.get());
    }
 
@@ -513,6 +515,6 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
 
    @Override
    public EntryIterable<K, V> filterEntries(KeyValueFilter<? super K, ? super V> filter) {
-      return cacheImplementation.filterEntries(filter, flags);
+      return cacheImplementation.filterEntries(filter, flags, classLoader.get());
    }
 }

--- a/core/src/main/java/org/infinispan/commands/AbstractVisitor.java
+++ b/core/src/main/java/org/infinispan/commands/AbstractVisitor.java
@@ -2,6 +2,7 @@ package org.infinispan.commands;
 
 import org.infinispan.commands.control.LockControlCommand;
 import org.infinispan.commands.read.DistributedExecuteCommand;
+import org.infinispan.commands.read.EntryRetrievalCommand;
 import org.infinispan.commands.read.EntrySetCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.read.KeySetCommand;
@@ -14,6 +15,7 @@ import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.commands.write.*;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.iteration.EntryIterable;
 
 import java.util.Collection;
 
@@ -87,6 +89,11 @@ public abstract class AbstractVisitor implements Visitor {
 
    @Override
    public Object visitEntrySetCommand(InvocationContext ctx, EntrySetCommand command) throws Throwable {
+      return handleDefault(ctx, command);
+   }
+
+   @Override
+   public Object visitEntryRetrievalCommand(InvocationContext ctx, EntryRetrievalCommand command) throws Throwable {
       return handleDefault(ctx, command);
    }
 

--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -1,9 +1,12 @@
 package org.infinispan.commands;
 
+import org.infinispan.Cache;
+import org.infinispan.commands.read.EntryRetrievalCommand;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.commands.remote.GetKeysInGroupCommand;
 import org.infinispan.iteration.impl.EntryRequestCommand;
 import org.infinispan.iteration.impl.EntryResponseCommand;
+import org.infinispan.iteration.impl.EntryRetriever;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.atomic.Delta;
 import org.infinispan.commands.control.LockControlCommand;
@@ -157,6 +160,14 @@ public interface CommandsFactory {
     * @return a EntrySetCommand
     */
    EntrySetCommand buildEntrySetCommand(Set<Flag> flags);
+
+   /**
+    * Builds a EntryRetrievalCommand
+    * @param flags Command flags provided by cache
+    * @param filter The filter used for the iteration process
+    * @return a EntryRetrievalCommand
+    */
+   EntryRetrievalCommand buildEntryRetrievalCommand(Set<Flag> flags, KeyValueFilter filter);
 
    /**
     * Builds a PutMapCommand

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -1,6 +1,7 @@
 package org.infinispan.commands;
 
 import org.infinispan.Cache;
+import org.infinispan.commands.read.EntryRetrievalCommand;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.commands.remote.GetKeysInGroupCommand;
 import org.infinispan.context.InvocationContextFactory;
@@ -226,17 +227,22 @@ public class CommandsFactoryImpl implements CommandsFactory {
 
    @Override
    public KeySetCommand buildKeySetCommand(Set<Flag> flags) {
-      return new KeySetCommand(dataContainer, flags);
+      return new KeySetCommand(cache, flags);
    }
 
    @Override
    public ValuesCommand buildValuesCommand(Set<Flag> flags) {
-      return new ValuesCommand(dataContainer, timeService, flags);
+      return new ValuesCommand(cache, flags);
    }
 
    @Override
    public EntrySetCommand buildEntrySetCommand(Set<Flag> flags) {
-      return new EntrySetCommand(dataContainer, entryFactory, timeService, flags);
+      return new EntrySetCommand(cache, flags);
+   }
+
+   @Override
+   public EntryRetrievalCommand buildEntryRetrievalCommand(Set<Flag> flags, KeyValueFilter filter) {
+      return new EntryRetrievalCommand(filter, entryRetriever, flags, cache);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/Visitor.java
+++ b/core/src/main/java/org/infinispan/commands/Visitor.java
@@ -2,6 +2,7 @@ package org.infinispan.commands;
 
 import org.infinispan.commands.control.LockControlCommand;
 import org.infinispan.commands.read.DistributedExecuteCommand;
+import org.infinispan.commands.read.EntryRetrievalCommand;
 import org.infinispan.commands.read.EntrySetCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.read.KeySetCommand;
@@ -14,6 +15,7 @@ import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.commands.write.*;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.iteration.EntryIterable;
 
 /**
  * @author Mircea.Markus@jboss.com
@@ -49,6 +51,8 @@ public interface Visitor {
    Object visitValuesCommand(InvocationContext ctx, ValuesCommand command) throws Throwable;
 
    Object visitEntrySetCommand(InvocationContext ctx, EntrySetCommand command) throws Throwable;
+
+   Object visitEntryRetrievalCommand(InvocationContext ctx, EntryRetrievalCommand command) throws Throwable;
 
    // tx commands
 

--- a/core/src/main/java/org/infinispan/commands/read/AbstractCloseableIteratorCollection.java
+++ b/core/src/main/java/org/infinispan/commands/read/AbstractCloseableIteratorCollection.java
@@ -1,0 +1,159 @@
+package org.infinispan.commands.read;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.util.CloseableIteratorCollection;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.container.entries.CacheEntry;
+
+import java.util.AbstractCollection;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * Abstract collection that uses an underlying Cache instance to do various operations.  This is useful for a backing
+ * collection such as entrySet, keySet or values from the Map interface.  Implementors only need to implement individual
+ * methods such as {@link Collection#contains(Object)}, {@link Collection#remove(Object)} and
+ * {@link org.infinispan.commons.util.CloseableIteratorCollection#iterator()}.  The {@link Collection#add(Object)} by default will throw an
+ * {@link java.lang.UnsupportedOperationException}.
+ *
+ * @author wburns
+ * @since 7.0
+ */
+public abstract class AbstractCloseableIteratorCollection<O, K, V> extends AbstractCollection<O> implements CloseableIteratorCollection<O> {
+   protected final Cache<K, V> cache;
+
+   public AbstractCloseableIteratorCollection(Cache<K, V> cache) {
+      this.cache = cache;
+   }
+
+   public static interface IteratorConverter {
+      Object forEntry(CacheEntry entry);
+   }
+
+   @Override
+   public abstract CloseableIterator<O> iterator();
+
+   @Override
+   public abstract boolean contains(Object o);
+
+   @Override
+   public abstract boolean remove(Object o);
+
+   @Override
+   public int size() {
+      return cache.size();
+   }
+
+   @Override
+   public boolean isEmpty() {
+      return cache.isEmpty();
+   }
+
+   // Copied from AbstractCollection since we need to close iterator
+   @Override
+   public Object[] toArray() {
+      // Estimate size of array; be prepared to see more or fewer elements
+      Object[] r = new Object[size()];
+      try (CloseableIterator<O> it = iterator()) {
+         for (int i = 0; i < r.length; i++) {
+            if (! it.hasNext()) // fewer elements than expected
+               return Arrays.copyOf(r, i);
+            r[i] = it.next();
+         }
+         return it.hasNext() ? finishToArray(r, it) : r;
+      }
+   }
+
+   // Copied from AbstractCollection since we need to close iterator
+   @Override
+   public <T> T[] toArray(T[] a) {
+      // Estimate size of array; be prepared to see more or fewer elements
+      int size = size();
+      T[] r = a.length >= size ? a :
+            (T[])java.lang.reflect.Array
+                  .newInstance(a.getClass().getComponentType(), size);
+      try (CloseableIterator<O> it = iterator()) {
+         for (int i = 0; i < r.length; i++) {
+            if (! it.hasNext()) { // fewer elements than expected
+               if (a == r) {
+                  r[i] = null; // null-terminate
+               } else if (a.length < i) {
+                  return Arrays.copyOf(r, i);
+               } else {
+                  System.arraycopy(r, 0, a, 0, i);
+                  if (a.length > i) {
+                     a[i] = null;
+                  }
+               }
+               return a;
+            }
+            r[i] = (T)it.next();
+         }
+         // more elements than expected
+         return it.hasNext() ? finishToArray(r, it) : r;
+      }
+   }
+
+   @Override
+   public boolean removeAll(Collection<?> c) {
+      boolean modified = false;
+      for (Object o : c) {
+         if (remove(o)) {
+            modified = true;
+         }
+      }
+      return modified;
+   }
+
+   // Copied from AbstractCollection since we need to close iterator
+   @Override
+   public boolean retainAll(Collection<?> c) {
+      boolean modified = false;
+      try (CloseableIterator<O> it = iterator()) {
+         while (it.hasNext()) {
+            if (!c.contains(it.next())) {
+               it.remove();
+               modified = true;
+            }
+         }
+         return modified;
+      }
+   }
+
+   @Override
+   public void clear() {
+      cache.clear();
+   }
+
+   // Copied from AbstractCollection to support toArray methods
+   @SuppressWarnings("unchecked")
+   private static <T> T[] finishToArray(T[] r, Iterator<?> it) {
+      int i = r.length;
+      while (it.hasNext()) {
+         int cap = r.length;
+         if (i == cap) {
+            int newCap = cap + (cap >> 1) + 1;
+            // overflow-conscious code
+            if (newCap - MAX_ARRAY_SIZE > 0)
+               newCap = hugeCapacity(cap + 1);
+            r = Arrays.copyOf(r, newCap);
+         }
+         r[i++] = (T)it.next();
+      }
+      // trim if overallocated
+      return (i == r.length) ? r : Arrays.copyOf(r, i);
+   }
+
+   // Copied from AbstractCollection to support toArray methods
+   private static int hugeCapacity(int minCapacity) {
+      if (minCapacity < 0) // overflow
+         throw new OutOfMemoryError
+               ("Required array size too large");
+      return (minCapacity > MAX_ARRAY_SIZE) ?
+            Integer.MAX_VALUE :
+            MAX_ARRAY_SIZE;
+   }
+
+   private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+}

--- a/core/src/main/java/org/infinispan/commands/read/EntryRetrievalCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/EntryRetrievalCommand.java
@@ -1,0 +1,48 @@
+package org.infinispan.commands.read;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.VisitableCommand;
+import org.infinispan.commands.Visitor;
+import org.infinispan.context.Flag;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.filter.KeyValueFilter;
+import org.infinispan.iteration.EntryIterable;
+import org.infinispan.iteration.impl.EntryIterableImpl;
+import org.infinispan.iteration.impl.EntryRetriever;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Command that returns an iterable instance that can be used to produce iterators that work over the entire
+ * cache.
+ *
+ * @author wburns
+ * @since 7.0
+ */
+public class EntryRetrievalCommand<K, V> extends AbstractLocalCommand implements VisitableCommand {
+   private final KeyValueFilter<K, V> filter;
+   private final EntryRetriever<K, V> retriever;
+   private final Cache<K, V> cache;
+
+   public EntryRetrievalCommand(KeyValueFilter<K, V> filter, EntryRetriever<K, V> retriever, Set<Flag> flags,
+                                Cache<K, V> cache) {
+      setFlags(flags);
+      this.filter = filter;
+      this.retriever = retriever;
+      this.cache = cache;
+   }
+
+   @Override
+   public Object acceptVisitor(InvocationContext ctx, Visitor visitor) throws Throwable {
+      return visitor.visitEntryRetrievalCommand(ctx, this);
+   }
+
+   @Override
+   public EntryIterable<K, V> perform(InvocationContext ctx) throws Throwable {
+      // We need to copy the flag set since it is possible to modify the flags after retrieving the
+      // EntryIterable and we don't want it to effect that.
+      return new EntryIterableImpl<>(retriever, filter, flags != null ? EnumSet.copyOf(flags) :
+            EnumSet.noneOf(Flag.class), cache);
+   }
+}

--- a/core/src/main/java/org/infinispan/commands/read/KeySetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/KeySetCommand.java
@@ -1,17 +1,16 @@
 package org.infinispan.commands.read;
 
+import org.infinispan.Cache;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.Visitor;
-import org.infinispan.container.DataContainer;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.CloseableIteratorSet;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.filter.AcceptAllKeyValueFilter;
+import org.infinispan.filter.NullValueConverter;
 
-import java.util.AbstractSet;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
 
 /**
@@ -20,14 +19,19 @@ import java.util.Set;
  * @author Galder Zamarreño
  * @author Mircea.Markus@jboss.com
  * @author <a href="http://gleamynode.net/">Trustin Lee</a>
+ * @author William Burns
  * @since 4.0
  */
-public class KeySetCommand extends AbstractLocalCommand implements VisitableCommand {
-   private final DataContainer container;
+public class KeySetCommand<K, V> extends AbstractLocalCommand implements VisitableCommand {
+   private final Cache<K, V> cache;
 
-   public KeySetCommand(DataContainer container, Set<Flag> flags) {
+   public KeySetCommand(Cache<K, V> cache, Set<Flag> flags) {
       setFlags(flags);
-      this.container = container;
+      if (flags != null) {
+         this.cache = cache.getAdvancedCache().withFlags(flags.toArray(new Flag[flags.size()]));
+      } else {
+         this.cache = cache;
+      }
    }
 
    @Override
@@ -36,275 +40,66 @@ public class KeySetCommand extends AbstractLocalCommand implements VisitableComm
    }
 
    @Override
-   public Set<Object> perform(InvocationContext ctx) throws Throwable {
-      Set<Object> objects = container.keySet();
-      if (ctx.getLookedUpEntries().isEmpty()) {
-         return new ExpiredFilteredKeySet(objects, container);
-      }
-
-      return new FilteredKeySet(objects, ctx.getLookedUpEntries(), container);
+   public Set<K> perform(InvocationContext ctx) throws Throwable {
+      return new BackingKeySet<>(cache);
    }
 
    @Override
    public String toString() {
       return "KeySetCommand{" +
-            "set=" + container.size() + " elements" +
+            "cache=" + cache.getName() +
             '}';
    }
 
-   private static class FilteredKeySet extends AbstractSet<Object> {
-      final Set<Object> keySet;
-      final Map<Object, CacheEntry> lookedUpEntries;
-      final DataContainer container;
+   private static class BackingKeySet<K, V> extends AbstractCloseableIteratorCollection<K, K, V> implements CloseableIteratorSet<K> {
 
-      FilteredKeySet(Set<Object> keySet, Map<Object, CacheEntry> lookedUpEntries, DataContainer container) {
-         this.keySet = keySet;
-         this.lookedUpEntries = lookedUpEntries;
-         this.container = container;
+      public BackingKeySet(Cache<K, V> cache) {
+         super(cache);
       }
 
       @Override
-      public int size() {
-         int size = keySet.size();
-         // First, removed any expired keys
-         for (Object k : keySet) {
-            // Given the key set, a key won't be contained if it's expired
-            if (!container.containsKey(k))
-               size--;
-         }
-         // Update according to keys added or removed in tx
-         for (CacheEntry e: lookedUpEntries.values()) {
-            if (container.containsKey(e.getKey())) {
-               if (e.isRemoved()) {
-                  size --;
-               }
-            } else if (!e.isRemoved()) {
-               size ++;
-            }
-         }
-         return Math.max(size, 0);
+      public CloseableIterator<K> iterator() {
+         return new EntryToKeyIterator(cache.getAdvancedCache().filterEntries(AcceptAllKeyValueFilter.getInstance())
+                                             .converter(NullValueConverter.getInstance()).iterator());
       }
 
       @Override
       public boolean contains(Object o) {
-         CacheEntry e = lookedUpEntries.get(o);
-         if (e != null) {
-            return !e.isRemoved();
-         }
-         return keySet.contains(o);
-      }
-
-      @Override
-      public Iterator<Object> iterator() {
-         return new Itr();
-      }
-
-      @Override
-      public boolean add(Object e) {
-         throw new UnsupportedOperationException();
+         return cache.containsKey(o);
       }
 
       @Override
       public boolean remove(Object o) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean addAll(Collection<?> c) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean retainAll(Collection<?> c) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean removeAll(Collection<?> c) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public void clear() {
-         throw new UnsupportedOperationException();
-      }
-
-      private class Itr implements Iterator<Object> {
-
-         private final Iterator<CacheEntry> it1 = lookedUpEntries.values().iterator();
-         private final Iterator<Object> it2 = keySet.iterator();
-         private boolean atIt1 = true;
-         private Object next;
-
-         Itr() {
-            fetchNext();
-         }
-
-         private void fetchNext() {
-            if (atIt1) {
-               boolean found = false;
-               while (it1.hasNext()) {
-                  CacheEntry e = it1.next();
-                  if (!e.isRemoved()) {
-                     next = e.getKey();
-                     found = true;
-                     break;
-                  }
-               }
-
-               if (!found) {
-                  atIt1 = false;
-               }
-            }
-
-            if (!atIt1) {
-               boolean found = false;
-               while (it2.hasNext()) {
-                  Object k = it2.next();
-                  if (!lookedUpEntries.containsKey(k)) {
-                     next = k;
-                     found = true;
-                     break;
-                  }
-               }
-
-               if (!found) {
-                  next = null;
-               }
-            }
-         }
-
-         @Override
-         public boolean hasNext() {
-            if (next == null) {
-               fetchNext();
-            }
-            return next != null;
-         }
-
-         @Override
-         public Object next() {
-            if (next == null) {
-               fetchNext();
-            }
-
-            if (next == null) {
-               throw new NoSuchElementException();
-            }
-
-            Object ret = next;
-            next = null;
-            return ret;
-         }
-
-         @Override
-         public void remove() {
-            throw new UnsupportedOperationException();
-         }
+         return cache.remove(o) != null;
       }
    }
 
-   public static class ExpiredFilteredKeySet extends AbstractSet<Object> {
-      final Set<Object> keySet;
-      final DataContainer container;
+   private static class EntryToKeyIterator<K> implements CloseableIterator<K> {
 
-      public ExpiredFilteredKeySet(Set<Object> keySet, DataContainer container) {
-         this.keySet = keySet;
-         this.container = container;
+      private final CloseableIterator<CacheEntry<K, Void>> iterator;
+
+      public EntryToKeyIterator(CloseableIterator<CacheEntry<K, Void>> iterator) {
+         this.iterator = iterator;
       }
 
       @Override
-      public boolean add(Object e) {
-         throw new UnsupportedOperationException();
+      public boolean hasNext() {
+         return iterator.hasNext();
       }
 
       @Override
-      public boolean remove(Object o) {
-         throw new UnsupportedOperationException();
+      public K next() {
+         return iterator.next().getKey();
       }
 
       @Override
-      public boolean addAll(Collection<?> c) {
-         throw new UnsupportedOperationException();
+      public void remove() {
+         iterator.remove();
       }
 
       @Override
-      public boolean retainAll(Collection<?> c) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean removeAll(Collection<?> c) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public void clear() {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public Iterator<Object> iterator() {
-         return new Itr();
-      }
-
-      @Override
-      public int size() {
-         // Size cannot be cached because even if the set is immutable,
-         // over time, the expired entries could grow hence reducing the size
-         int s = keySet.size();
-         for (Object k : keySet) {
-            // Given the key set, a key won't be contained if it's expired
-            if (!container.containsKey(k))
-               s--;
-         }
-         return s;
-      }
-
-      private class Itr implements Iterator<Object> {
-
-         private final Iterator<Object> it = keySet.iterator();
-         private Object next;
-
-         private Itr() {
-            fetchNext();
-         }
-
-         private void fetchNext() {
-            while (it.hasNext()) {
-               Object k = it.next();
-               if (container.containsKey(k)) {
-                  next = k;
-                  break;
-               }
-            }
-         }
-
-         @Override
-         public boolean hasNext() {
-            if (next == null)
-               fetchNext();
-
-            return next != null;
-         }
-
-         @Override
-         public Object next() {
-            if (next == null)
-               fetchNext();
-
-            if (next == null)
-               throw new NoSuchElementException();
-
-            Object ret = next;
-            next = null;
-            return ret;
-         }
-
-         @Override
-         public void remove() {
-            throw new UnsupportedOperationException();
-         }
+      public void close() {
+         iterator.close();
       }
    }
 }

--- a/core/src/main/java/org/infinispan/commands/read/SizeCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/SizeCommand.java
@@ -49,10 +49,10 @@ public class SizeCommand extends AbstractLocalCommand implements VisitableComman
             if (value != null) {
                keys.add(entry.getKey());
                if (!value.isRemoved()) {
-                  size++;
+                  if (size++ == Integer.MAX_VALUE) {return Integer.MAX_VALUE;}
                }
             } else {
-               size++;
+               if (size++ == Integer.MAX_VALUE) {return Integer.MAX_VALUE;}
             }
          }
       }
@@ -60,7 +60,7 @@ public class SizeCommand extends AbstractLocalCommand implements VisitableComman
       // We can only add context entries if we didn't see it in iterator and it isn't removed
       for (Map.Entry<Object, CacheEntry> entry : contextEntries.entrySet()) {
          if (!keys.contains(entry.getKey()) && !entry.getValue().isRemoved()) {
-            size++;
+            if (size++ == Integer.MAX_VALUE) { return Integer.MAX_VALUE; }
          }
       }
 

--- a/core/src/main/java/org/infinispan/commands/read/ValuesCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/ValuesCommand.java
@@ -1,20 +1,16 @@
 package org.infinispan.commands.read;
 
+import org.infinispan.Cache;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.Visitor;
-import org.infinispan.container.DataContainer;
+import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.util.TimeService;
+import org.infinispan.filter.AcceptAllKeyValueFilter;
 
-import java.util.AbstractCollection;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Set;
 
 /**
@@ -23,16 +19,19 @@ import java.util.Set;
  * @author Galder Zamarreño
  * @author Mircea.Markus@jboss.com
  * @author <a href="http://gleamynode.net/">Trustin Lee</a>
+ * @author William Burns
  * @since 4.0
  */
-public class ValuesCommand extends AbstractLocalCommand implements VisitableCommand {
-   private final DataContainer container;
-   private final TimeService timeService;
+public class ValuesCommand<K, V> extends AbstractLocalCommand implements VisitableCommand {
+   private final Cache<K, V> cache;
 
-   public ValuesCommand(DataContainer container, TimeService timeService, Set<Flag> flags) {
+   public ValuesCommand(Cache<K, V> cache, Set<Flag> flags) {
       setFlags(flags);
-      this.container = container;
-      this.timeService = timeService;
+      if (flags != null) {
+         this.cache = cache.getAdvancedCache().withFlags(flags.toArray(new Flag[flags.size()]));
+      } else {
+         this.cache = cache;
+      }
    }
 
    @Override
@@ -41,317 +40,98 @@ public class ValuesCommand extends AbstractLocalCommand implements VisitableComm
    }
 
    @Override
-   public Collection<Object> perform(InvocationContext ctx) throws Throwable {
-      if (ctx.getLookedUpEntries().isEmpty()) {
-         return new ExpiredFilteredValues(container.entrySet(), timeService);
-      }
-
-      return new FilteredValues(container, ctx.getLookedUpEntries(), timeService);
+   public Collection<V> perform(InvocationContext ctx) throws Throwable {
+      return new BackingValuesCollection<>(cache);
    }
 
    @Override
    public String toString() {
       return "ValuesCommand{" +
-            "values=" + container.size() + " elements" +
+            "cache=" + cache.getName() +
             '}';
    }
 
-   private static class FilteredValues extends AbstractCollection<Object> {
-      final DataContainer<Object, Object> container;
-      final Set<InternalCacheEntry> entrySet;
-      final Map<Object, CacheEntry> lookedUpEntries;
-      final TimeService timeService;
+   private static class BackingValuesCollection<K, V> extends AbstractCloseableIteratorCollection<V, K, V> {
 
-      FilteredValues(DataContainer container, Map<Object, CacheEntry> lookedUpEntries, TimeService timeService) {
-         this.container = container;
-         entrySet = container.entrySet();
-         this.lookedUpEntries = lookedUpEntries;
-         this.timeService = timeService;
+      public BackingValuesCollection(Cache<K, V> cache) {
+         super(cache);
       }
 
       @Override
-      public int size() {
-         long currentTimeMillis = 0;
-         Set<Object> validKeys = new HashSet<Object>();
-         // First, removed any expired ones
-         for (InternalCacheEntry e: entrySet) {
-            if (e.canExpire()) {
-               if (currentTimeMillis == 0)
-                  currentTimeMillis = timeService.wallClockTime();
-               if (!e.isExpired(currentTimeMillis)) {
-                  validKeys.add(e.getKey());
-               }
-            } else {
-               validKeys.add(e.getKey());
-            }
-         }
-
-         int size = validKeys.size();
-         // Update according to entries added or removed in tx
-         for (CacheEntry e: lookedUpEntries.values()) {
-            if (validKeys.contains(e.getKey())) {
-               if (e.isRemoved()) {
-                  size --;
-               }
-            } else if (!e.isRemoved()) {
-               size ++;
-            }
-         }
-         return Math.max(size, 0);
+      public CloseableIterator<V> iterator() {
+         return new EntryToValueIterator(cache.getAdvancedCache().filterEntries(AcceptAllKeyValueFilter.getInstance()).iterator());
       }
 
       @Override
       public boolean contains(Object o) {
-         for (CacheEntry e: lookedUpEntries.values()) {
-            // A value can repeat, so only return true if we find one, not just whether or not it was removed
-            if (o.equals(e.getValue()) && !e.isRemoved()) {
-               return true;
-            }
+         // We don't support null values
+         if (o == null) {
+            throw new NullPointerException();
          }
-
-         for (Map.Entry<Object, Object> entry : container) {
-            Object value = entry.getValue();
-            // If we find the key looked up in the lookedUpEntries at this point it means that entry was removed
-            // however the value could be on another key so keep looking
-            if (o.equals(value) && !lookedUpEntries.containsKey(entry.getKey())) {
-               return true;
-            }
+         try (CloseableIterator<V> it = iterator()) {
+            while (it.hasNext())
+               if (o.equals(it.next()))
+                  return true;
+            return false;
          }
-         return false;
       }
 
       @Override
-      public Iterator<Object> iterator() {
-         return new Itr();
-      }
-
-      @Override
-      public boolean add(Object e) {
-         throw new UnsupportedOperationException();
+      public boolean containsAll(Collection<?> c) {
+         // The AbstractCollection implementation calls contains for each element.  Instead we want to call the iterator
+         // only once so we have a special implementation.
+         if (c.size() > 0) {
+            Set<?> set = new HashSet<>(c);
+            try (CloseableIterator<V> it = iterator()) {
+               while (!set.isEmpty() && it.hasNext()) {
+                  set.remove(it.next());
+               }
+            }
+            return set.isEmpty();
+         }
+         return true;
       }
 
       @Override
       public boolean remove(Object o) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean addAll(Collection<?> c) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean retainAll(Collection<?> c) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean removeAll(Collection<?> c) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public void clear() {
-         throw new UnsupportedOperationException();
-      }
-
-      private class Itr implements Iterator<Object> {
-
-         private final Iterator<CacheEntry> it1 = lookedUpEntries.values().iterator();
-         private final Iterator<InternalCacheEntry> it2 = entrySet.iterator();
-         private boolean atIt1 = true;
-         private Object next;
-
-         Itr() {
-            fetchNext();
-         }
-
-         private void fetchNext() {
-            if (atIt1) {
-               boolean found = false;
-               while (it1.hasNext()) {
-                  CacheEntry e = it1.next();
-                  if (!e.isRemoved()) {
-                     next = e.getValue();
-                     found = true;
-                     break;
-                  }
-               }
-
-               if (!found) {
-                  atIt1 = false;
-               }
-            }
-
-            if (!atIt1) {
-               boolean found = false;
-               long currentTimeMillis = 0;
-               while (it2.hasNext()) {
-                  InternalCacheEntry ice = it2.next();
-                  Object key = ice.getKey();
-                  if (ice.canExpire()) {
-                     if (currentTimeMillis == 0)
-                        currentTimeMillis = timeService.wallClockTime();
-                     if (ice.isExpired(currentTimeMillis))
-                        continue;
-                  }
-
-                  if (!lookedUpEntries.containsKey(key)) {
-                     next = ice.getValue();
-                     found = true;
-                     break;
-                  }
-               }
-
-               if (!found) {
-                  next = null;
-               }
-            }
-         }
-
-         @Override
-         public boolean hasNext() {
-            if (next == null) {
-               fetchNext();
-            }
-            return next != null;
-         }
-
-         @Override
-         public Object next() {
-            if (next == null) {
-               fetchNext();
-            }
-
-            if (next == null) {
-               throw new NoSuchElementException();
-            }
-
-            Object ret = next;
-            next = null;
-            return ret;
-         }
-
-         @Override
-         public void remove() {
-            throw new UnsupportedOperationException();
-         }
-      }
-   }
-
-   public static class ExpiredFilteredValues extends AbstractCollection<Object> {
-      final Set<InternalCacheEntry> entrySet;
-      final TimeService timeService;
-
-      public ExpiredFilteredValues(Set<InternalCacheEntry> entrySet, TimeService timeService) {
-         this.entrySet = entrySet;
-         this.timeService = timeService;
-      }
-
-      @Override
-      public Iterator<Object> iterator() {
-         return new Itr();
-      }
-
-      @Override
-      public boolean add(Object e) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean remove(Object o) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean addAll(Collection<?> c) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean retainAll(Collection<?> c) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public boolean removeAll(Collection<?> c) {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public void clear() {
-         throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public int size() {
-         // Use entry set as a way to calculate the number of values.
-         int s = entrySet.size();
-         long currentTimeMillis = 0;
-         for (InternalCacheEntry e: entrySet) {
-            if (e.canExpire()) {
-               if (currentTimeMillis==0)
-                  currentTimeMillis = timeService.wallClockTime();
-               if (e.isExpired(currentTimeMillis))
-                  s--;
-            }
-         }
-         return s;
-      }
-
-      private class Itr implements Iterator<Object> {
-
-         private final Iterator<InternalCacheEntry> it = entrySet.iterator();
-         private Object next;
-
-         private Itr() {
-            fetchNext();
-         }
-
-         private void fetchNext() {
-            long currentTimeMillis = 0;
+         try (CloseableIterator<V> it = iterator()) {
             while (it.hasNext()) {
-               InternalCacheEntry e = it.next();
-               final boolean canExpire = e.canExpire();
-               if (canExpire && currentTimeMillis == 0) {
-                  currentTimeMillis = timeService.wallClockTime();
-               }
-               if (!canExpire) {
-                  next = e.getValue();
-                  break;
-               } else if (!e.isExpired(currentTimeMillis)) {
-                  next = e.getValue();
-                  break;
+               if (o.equals(it.next())) {
+                  it.remove();
+                  return true;
                }
             }
-         }
-
-         @Override
-         public boolean hasNext() {
-            if (next == null)
-               fetchNext();
-
-            return next != null;
-         }
-
-         @Override
-         public Object next() {
-            if (next == null)
-               fetchNext();
-
-            if (next == null)
-               throw new NoSuchElementException();
-
-            Object ret = next;
-            next = null;
-            return ret;
-         }
-
-         @Override
-         public void remove() {
-            throw new UnsupportedOperationException();
+            return false;
          }
       }
    }
 
+   private static class EntryToValueIterator<V> implements CloseableIterator<V> {
+
+      private final CloseableIterator<CacheEntry<?, V>> iterator;
+
+      public EntryToValueIterator(CloseableIterator<CacheEntry<?, V>> iterator) {
+         this.iterator = iterator;
+      }
+
+      @Override
+      public boolean hasNext() {
+         return iterator.hasNext();
+      }
+
+      @Override
+      public V next() {
+         return iterator.next().getValue();
+      }
+
+      @Override
+      public void remove() {
+         iterator.remove();
+      }
+
+      @Override
+      public void close() {
+         iterator.close();
+      }
+   }
 }

--- a/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
@@ -129,6 +129,6 @@ public interface CacheEntry<K, V> extends Cloneable, Map.Entry<K, V>, MetadataAw
     */
    boolean undelete(boolean doUndelete);
 
-   public CacheEntry clone();
+   public CacheEntry<K, V> clone();
 
 }

--- a/core/src/main/java/org/infinispan/container/entries/ForwardingCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ForwardingCacheEntry.java
@@ -1,0 +1,164 @@
+package org.infinispan.container.entries;
+
+import org.infinispan.container.DataContainer;
+import org.infinispan.metadata.Metadata;
+
+/**
+ * A class designed to forward all method invocations for a CacheEntry to the provided delegate.  This
+ * class is useful to extend when you want to only modify
+ *
+ * @author wburns
+ * @since 7.0
+ */
+public abstract class ForwardingCacheEntry<K, V> implements CacheEntry<K, V> {
+   protected abstract CacheEntry<K, V> delegate();
+
+   @Override
+   public boolean isNull() {
+      return delegate().isNull();
+   }
+
+   @Override
+   public boolean isChanged() {
+      return delegate().isChanged();
+   }
+
+   @Override
+   public boolean isCreated() {
+      return delegate().isCreated();
+   }
+
+   @Override
+   public boolean isRemoved() {
+      return delegate().isRemoved();
+   }
+
+   @Override
+   public boolean isEvicted() {
+      return delegate().isEvicted();
+   }
+
+   @Override
+   public boolean isValid() {
+      return delegate().isValid();
+   }
+
+   @Override
+   public boolean isLoaded() {
+      return delegate().isLoaded();
+   }
+
+   @Override
+   public K getKey() {
+      return delegate().getKey();
+   }
+
+   @Override
+   public V getValue() {
+      return delegate().getValue();
+   }
+
+   @Override
+   public long getLifespan() {
+      return delegate().getLifespan();
+   }
+
+   @Override
+   public long getMaxIdle() {
+      return delegate().getMaxIdle();
+   }
+
+   @Override
+   public boolean skipLookup() {
+      return delegate().skipLookup();
+   }
+
+   @Override
+   public V setValue(V value) {
+      return delegate().setValue(value);
+   }
+
+   @Override
+   public void commit(DataContainer container, Metadata metadata) {
+      delegate().commit(container, metadata);
+   }
+
+   @Override
+   public void rollback() {
+      delegate().rollback();
+   }
+
+   @Override
+   public void setChanged(boolean changed) {
+      delegate().setChanged(changed);
+   }
+
+   @Override
+   public void setCreated(boolean created) {
+      delegate().setCreated(created);
+   }
+
+   @Override
+   public void setRemoved(boolean removed) {
+      delegate().setRemoved(removed);
+   }
+
+   @Override
+   public void setEvicted(boolean evicted) {
+      delegate().setEvicted(evicted);
+   }
+
+   @Override
+   public void setValid(boolean valid) {
+      delegate().setValid(valid);
+   }
+
+   @Override
+   public void setLoaded(boolean loaded) {
+      delegate().setLoaded(loaded);
+   }
+
+   @Override
+   public void setSkipLookup(boolean skipLookup) {
+      delegate().setSkipLookup(skipLookup);
+   }
+
+   @Override
+   public boolean undelete(boolean doUndelete) {
+      return delegate().undelete(doUndelete);
+   }
+
+   @Override
+   public CacheEntry<K, V> clone() {
+      return delegate().clone();
+   }
+
+   @Override
+   public Metadata getMetadata() {
+      return delegate().getMetadata();
+   }
+
+   @Override
+   public void setMetadata(Metadata metadata) {
+      delegate().setMetadata(metadata);
+   }
+
+   @Override
+   public String toString() {
+      return delegate().toString();
+   }
+
+   // We already break equals contract in several places when comparing all the various CacheEntry
+   // types as the same ones
+   @Override
+   public boolean equals(Object obj) {
+      return delegate().equals(obj);
+   }
+
+   // We already break hashcode contract in several places when comparing all the various CacheEntry
+   // types as the same ones
+   @Override
+   public int hashCode() {
+      return delegate().hashCode();
+   }
+}

--- a/core/src/main/java/org/infinispan/interceptors/MarshalledValueInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/MarshalledValueInterceptor.java
@@ -166,62 +166,6 @@ public class MarshalledValueInterceptor extends CommandInterceptor {
    }
 
    @Override
-   @SuppressWarnings("unchecked")
-   public Object visitKeySetCommand(InvocationContext ctx, KeySetCommand command) throws Throwable {
-      Set<Object> keys = (Set<Object>) invokeNextInterceptor(ctx, command);
-      if (wrapKeys) {
-         Set<Object> copy = new HashSet<Object>(keys.size());
-         for (Object key : keys) {
-            if (key instanceof MarshalledValue) {
-               key = ((MarshalledValue) key).get();
-            }
-            copy.add(key);
-         }
-         return Immutables.immutableSetWrap(copy);
-      } else {
-         return Immutables.immutableSetWrap(keys);
-      }
-   }
-
-   @Override
-   @SuppressWarnings("unchecked")
-   public Object visitValuesCommand(InvocationContext ctx, ValuesCommand command) throws Throwable {
-      Collection<Object> values = (Collection<Object>) invokeNextInterceptor(ctx, command);
-      if (wrapValues) {
-         Collection<Object> copy = new ArrayList<Object>();
-         for (Object value : values) {
-            if (value instanceof MarshalledValue) {
-               value = ((MarshalledValue) value).get();
-            }
-            copy.add(value);
-         }
-         return Immutables.immutableCollectionWrap(copy);
-      } else {
-         return Immutables.immutableCollectionWrap(values);
-      }
-   }
-
-   @Override
-   @SuppressWarnings("unchecked")
-   public Object visitEntrySetCommand(InvocationContext ctx, EntrySetCommand command) throws Throwable {
-      Set<InternalCacheEntry> entries = (Set<InternalCacheEntry>) invokeNextInterceptor(ctx, command);
-      Set<InternalCacheEntry> copy = new HashSet<InternalCacheEntry>(entries.size());
-      for (InternalCacheEntry entry : entries) {
-         Object key = entry.getKey();
-         Object value = entry.getValue();
-         if (key instanceof MarshalledValue) {
-            key = ((MarshalledValue) key).get();
-         }
-         if (value instanceof MarshalledValue) {
-            value = ((MarshalledValue) value).get();
-         }
-         InternalCacheEntry newEntry = CoreImmutables.immutableInternalCacheEntry(entryFactory.create(key, value, entry));
-         copy.add(newEntry);
-      }
-      return Immutables.immutableSetWrap(copy);
-   }
-
-   @Override
    public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) throws Throwable {
       MarshalledValue key, newValue, oldValue;
       if (wrapKeys && !isTypeExcluded(command.getKey().getClass())) {

--- a/core/src/main/java/org/infinispan/iteration/impl/EntryIterableImpl.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/EntryIterableImpl.java
@@ -1,5 +1,6 @@
 package org.infinispan.iteration.impl;
 
+import org.infinispan.Cache;
 import org.infinispan.commons.util.CloseableIterable;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
@@ -18,12 +19,12 @@ import java.util.Map;
  */
 public class EntryIterableImpl<K, V> extends TrackingEntryIterable<K, V, V> implements EntryIterable<K, V> {
    public EntryIterableImpl(EntryRetriever<K, V> entryRetriver, KeyValueFilter<? super K, ? super V> filter,
-                            EnumSet<Flag> flags) {
-      super(entryRetriver, filter, null, flags);
+                            EnumSet<Flag> flags, Cache<K, V> cache) {
+      super(entryRetriver, filter, null, flags, cache);
    }
 
    @Override
    public <C> CloseableIterable<CacheEntry<K, C>> converter(Converter<? super K, ? super V, ? extends C> converter) {
-      return new TrackingEntryIterable<>(entryRetriever, filter, converter, flags);
+      return new TrackingEntryIterable<>(entryRetriever, filter, converter, flags, cache);
    }
 }

--- a/core/src/main/java/org/infinispan/iteration/impl/RemovableEntryIterator.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/RemovableEntryIterator.java
@@ -1,0 +1,71 @@
+package org.infinispan.iteration.impl;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.container.entries.CacheEntry;
+
+import java.util.NoSuchElementException;
+
+/**
+ * A CloseableIterator implementation that allows for a CloseableIterator that doesn't allow remove operations to
+ * implement remove by delegating the call to the provided cache to remove the previously read value.
+ *
+ * @author wburns
+ * @since 7.0
+ */
+public class RemovableEntryIterator<K, C> implements CloseableIterator<CacheEntry<K, C>> {
+   protected final CloseableIterator<CacheEntry<K, C>> realIterator;
+   protected final Cache<K, ?> cache;
+
+   protected CacheEntry<K, C> previousValue;
+   protected CacheEntry<K, C> currentValue;
+
+   public RemovableEntryIterator(CloseableIterator<CacheEntry<K, C>> realIterator,
+                                            Cache<K, ?> cache, boolean initIterator) {
+      this.realIterator = realIterator;
+      this.cache = cache;
+      if (initIterator) {
+         currentValue = getNextFromIterator();
+      }
+   }
+
+   protected CacheEntry<K, C> getNextFromIterator() {
+      if (realIterator.hasNext()) {
+         return realIterator.next();
+      } else {
+         return null;
+      }
+   }
+
+   @Override
+   public boolean hasNext() {
+      return currentValue != null;
+   }
+
+   @Override
+   public CacheEntry<K, C> next() {
+      if (currentValue == null) {
+         throw new NoSuchElementException();
+      }
+      previousValue = currentValue;
+      // Set the current value to the next one if there is one
+      currentValue = getNextFromIterator();
+      return previousValue;
+   }
+
+   @Override
+   public void remove() {
+      if (previousValue == null) {
+         throw new IllegalStateException();
+      }
+      cache.remove(previousValue.getKey());
+      previousValue = null;
+   }
+
+   @Override
+   public void close() {
+      currentValue = null;
+      previousValue = null;
+      realIterator.close();
+   }
+}

--- a/core/src/main/java/org/infinispan/iteration/impl/TrackingEntryIterable.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/TrackingEntryIterable.java
@@ -1,5 +1,6 @@
 package org.infinispan.iteration.impl;
 
+import org.infinispan.Cache;
 import org.infinispan.commons.util.CloseableIterable;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.container.entries.CacheEntry;
@@ -9,7 +10,6 @@ import org.infinispan.filter.KeyValueFilter;
 import org.infinispan.util.concurrent.ConcurrentHashSet;
 
 import java.util.EnumSet;
-import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -25,12 +25,15 @@ public class TrackingEntryIterable<K, V, C> implements CloseableIterable<CacheEn
    protected final KeyValueFilter<? super K, ? super V> filter;
    protected final Converter<? super K, ? super V, ? extends C> converter;
    protected final EnumSet<Flag> flags;
+   protected final Cache<K, V> cache;
+
    protected final AtomicBoolean closed = new AtomicBoolean(false);
    protected final Set<CloseableIterator<CacheEntry<K, C>>> iterators =
          new ConcurrentHashSet<>();
 
    public TrackingEntryIterable(EntryRetriever<K, V> retriever, KeyValueFilter<? super K, ? super V> filter,
-                                 Converter<? super K, ? super V, ? extends C> converter, EnumSet<Flag> flags) {
+                                 Converter<? super K, ? super V, ? extends C> converter, EnumSet<Flag> flags,
+                                 Cache<K, V> cache) {
       if (retriever == null) {
          throw new NullPointerException("Retriever cannot be null!");
       }
@@ -41,6 +44,7 @@ public class TrackingEntryIterable<K, V, C> implements CloseableIterable<CacheEn
       this.filter = filter;
       this.converter = converter;
       this.flags = flags;
+      this.cache = cache;
    }
 
    @Override
@@ -52,10 +56,11 @@ public class TrackingEntryIterable<K, V, C> implements CloseableIterable<CacheEn
    }
 
    @Override
-   public Iterator<CacheEntry<K, C>> iterator() {
+   public CloseableIterator<CacheEntry<K, C>> iterator() {
       if (closed.get()) {
          throw new IllegalStateException("Iterable has been closed - cannot be reused");
       }
+      // TODO: when an iterator is closed we should remove it from the set - this isn't critical yet though
       CloseableIterator<CacheEntry<K, C>> iterator = entryRetriever.retrieveEntries(filter, converter, flags, null);
       iterators.add(iterator);
       // Note we have to check if we were closed afterwards just in case if a concurrent close occurred.
@@ -64,6 +69,6 @@ public class TrackingEntryIterable<K, V, C> implements CloseableIterable<CacheEn
          iterator.close();
          throw new IllegalStateException("Iterable has been closed - cannot be reused");
       }
-      return iterator;
+      return new RemovableEntryIterator(iterator, cache, true);
    }
 }

--- a/core/src/main/java/org/infinispan/iteration/impl/TransactionAwareCloseableIterable.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/TransactionAwareCloseableIterable.java
@@ -1,0 +1,38 @@
+package org.infinispan.iteration.impl;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.util.CloseableIterable;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.transaction.impl.LocalTransaction;
+
+/**
+ * CloseableIterable implementation that will enhance another CloseableIterable to use the provided context values in the
+ * iteration process properly.  That is context values will take precendence over values found from the iterator.
+ *
+ * @author wburns
+ * @since 7.0
+ */
+public class TransactionAwareCloseableIterable<K, C> implements CloseableIterable<CacheEntry<K, C>> {
+   protected final CloseableIterable<CacheEntry<K, C>>  iterable;
+   protected final TxInvocationContext<LocalTransaction> ctx;
+   protected final Cache<K, ?> cache;
+
+   public TransactionAwareCloseableIterable(CloseableIterable<CacheEntry<K, C>> iterable,
+                                            TxInvocationContext<LocalTransaction> ctx, Cache<K, ?> cache) {
+      this.iterable = iterable;
+      this.ctx = ctx;
+      this.cache = cache;
+   }
+
+   @Override
+   public void close() {
+      iterable.close();
+   }
+
+   @Override
+   public CloseableIterator<CacheEntry<K, C>> iterator() {
+      return new TransactionAwareCloseableIterator(iterable.iterator(), ctx, cache);
+   }
+}

--- a/core/src/main/java/org/infinispan/iteration/impl/TransactionAwareCloseableIterator.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/TransactionAwareCloseableIterator.java
@@ -1,0 +1,79 @@
+package org.infinispan.iteration.impl;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.transaction.impl.LocalTransaction;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Class that provides transactional support so that the iterator will use the values in the context if they exist.
+ * This will keep track of seen values from the transactional context and if the transactional context is updated while
+ * iterating on this iterator it will see those updates unless the changed value was already seen by the iterator.
+ *
+ * @author wburns
+ * @since 7.0
+ */
+public class TransactionAwareCloseableIterator<K, C> extends RemovableEntryIterator<K, C> {
+   private final TxInvocationContext<LocalTransaction> ctx;
+   // We store all the not yet seen context entries here.  We rely on the fact that the cache entry reference is updated
+   // if a change occurs in between iterations to see updates.
+   private final List<CacheEntry> contextEntries;
+   private final Set<Object> seenContextKeys = new HashSet<>();
+
+   public TransactionAwareCloseableIterator(CloseableIterator<CacheEntry<K, C>> realIterator,
+                                            TxInvocationContext<LocalTransaction> ctx, Cache<K, ?> cache) {
+      super(realIterator, cache, false);
+      this.ctx = ctx;
+      contextEntries = new ArrayList<>(ctx.getLookedUpEntries().values());
+      currentValue = getNextFromIterator();
+   }
+
+   @Override
+   protected CacheEntry<K, C> getNextFromIterator() {
+      CacheEntry<K, C> returnedEntry = null;
+      // We first have to exhaust all of our context entries
+      CacheEntry<K, C> entry;
+      while (!contextEntries.isEmpty() && (entry = contextEntries.remove(0)) != null) {
+         seenContextKeys.add(entry.getKey());
+         if (!ctx.isEntryRemovedInContext(entry.getKey())) {
+            returnedEntry = entry;
+         }
+      }
+      if (returnedEntry == null) {
+         while (realIterator.hasNext()) {
+            CacheEntry<K, C> iteratedEntry = realIterator.next();
+            CacheEntry contextEntry;
+            // If the value was in the context then we ignore it since we use the context value
+            if ((contextEntry = ctx.lookupEntry(iteratedEntry.getKey())) == null) {
+               returnedEntry = iteratedEntry;
+               break;
+            } else {
+               if (seenContextKeys.add(contextEntry.getKey()) && !contextEntry.isRemoved()) {
+                  returnedEntry = contextEntry;
+                  break;
+               }
+            }
+         }
+      }
+
+      if (returnedEntry == null) {
+         // We do a last check to make sure no additional values were added to our context while iterating
+         for (CacheEntry lookedUpEntry : ctx.getLookedUpEntries().values()) {
+            if (!seenContextKeys.contains(lookedUpEntry.getKey())) {
+               if (returnedEntry == null) {
+                  returnedEntry = lookedUpEntry;
+               } else {
+                  contextEntries.add(lookedUpEntry);
+               }
+            }
+         }
+      }
+      return returnedEntry;
+   }
+}

--- a/core/src/main/java/org/infinispan/iteration/impl/TransactionAwareEntryIterable.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/TransactionAwareEntryIterable.java
@@ -1,0 +1,30 @@
+package org.infinispan.iteration.impl;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.util.CloseableIterable;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.filter.Converter;
+import org.infinispan.iteration.EntryIterable;
+import org.infinispan.transaction.impl.LocalTransaction;
+
+/**
+ * {@inheritDoc}
+ *
+ * @author wburns
+ * @since 7.0
+ */
+public class TransactionAwareEntryIterable<K, V> extends TransactionAwareCloseableIterable<K, V> implements EntryIterable<K, V> {
+   private final EntryIterable<K, V> entryIterable;
+
+   public TransactionAwareEntryIterable(EntryIterable<K, V> entryIterable, TxInvocationContext<LocalTransaction> ctx,
+                                        Cache<K, V> cache) {
+      super(entryIterable, ctx, cache);
+      this.entryIterable = entryIterable;
+   }
+
+   @Override
+   public <C> CloseableIterable<CacheEntry<K, C>> converter(Converter<? super K, ? super V, ? extends C> converter) {
+      return new TransactionAwareCloseableIterable<>(entryIterable.converter(converter), ctx, cache);
+   }
+}

--- a/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
+++ b/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
@@ -3,7 +3,9 @@
  import org.infinispan.AdvancedCache;
 import org.infinispan.atomic.Delta;
 import org.infinispan.batch.BatchContainer;
-import org.infinispan.commons.util.concurrent.NotifyingFuture;
+ import org.infinispan.commons.util.CloseableIteratorCollection;
+ import org.infinispan.commons.util.CloseableIteratorSet;
+ import org.infinispan.commons.util.concurrent.NotifyingFuture;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.CacheEntry;
@@ -488,7 +490,7 @@ public final class SecureCacheImpl<K, V> implements SecureCache<K, V> {
    }
 
    @Override
-   public Set<K> keySet() {
+   public CloseableIteratorSet<K> keySet() {
       authzManager.checkPermission(AuthorizationPermission.BULK_READ);
       return delegate.keySet();
    }
@@ -535,7 +537,7 @@ public final class SecureCacheImpl<K, V> implements SecureCache<K, V> {
    }
 
    @Override
-   public Collection<V> values() {
+   public CloseableIteratorCollection<V> values() {
       authzManager.checkPermission(AuthorizationPermission.BULK_READ);
       return delegate.values();
    }
@@ -553,7 +555,7 @@ public final class SecureCacheImpl<K, V> implements SecureCache<K, V> {
    }
 
    @Override
-   public Set<java.util.Map.Entry<K, V>> entrySet() {
+   public CloseableIteratorSet<Entry<K, V>> entrySet() {
       authzManager.checkPermission(AuthorizationPermission.BULK_READ);
       return delegate.entrySet();
    }

--- a/core/src/test/java/org/infinispan/api/APINonTxTest.java
+++ b/core/src/test/java/org/infinispan/api/APINonTxTest.java
@@ -2,6 +2,7 @@ package org.infinispan.api;
 
 import org.infinispan.commons.util.ObjectDuplicator;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.entries.ImmortalCacheEntry;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -133,7 +134,7 @@ public class APINonTxTest extends SingleCacheManagerTest {
       assert cache.entrySet().isEmpty();
    }
 
-   public void testImmutabilityOfKeyValueEntryCollections() {
+   public void testUnsupportedKeyValueCollectionOperations() {
       final String key1 = "1", value1 = "one", key2 = "2", value2 = "two", key3 = "3", value3 = "three";
       Map<String, String> m = new HashMap<String, String>();
       m.put(key1, value1);
@@ -143,8 +144,8 @@ public class APINonTxTest extends SingleCacheManagerTest {
 
       Set<Object> keys = cache.keySet();
       Collection<Object> values = cache.values();
-      Set<Map.Entry<Object, Object>> entries = cache.entrySet();
-      Collection[] collections = new Collection[]{keys, values, entries};
+      Collection[] collections = new Collection[]{keys, values};
+
       Object newObj = new Object();
       List newObjCol = new ArrayList();
       newObjCol.add(newObj);
@@ -162,39 +163,237 @@ public class APINonTxTest extends SingleCacheManagerTest {
             assert false : "Should have thrown a UnsupportedOperationException";
          } catch (UnsupportedOperationException uoe) {
          }
-
-         try {
-            col.clear();
-            assert false : "Should have thrown a UnsupportedOperationException";
-         } catch (UnsupportedOperationException uoe) {
-         }
-
-         try {
-            col.remove(key1);
-            assert false : "Should have thrown a UnsupportedOperationException";
-         } catch (UnsupportedOperationException uoe) {
-         }
-
-         try {
-            col.removeAll(newObjCol);
-            assert false : "Should have thrown a UnsupportedOperationException";
-         } catch (UnsupportedOperationException uoe) {
-         }
-
-         try {
-            col.retainAll(newObjCol);
-            assert false : "Should have thrown a UnsupportedOperationException";
-         } catch (UnsupportedOperationException uoe) {
-         }
       }
+   }
+
+   public void testAddMethodsForEntryCollection() {
+      final String key1 = "1", value1 = "one", key2 = "2", value2 = "two", key3 = "3", value3 = "three";
+      Map<String, String> m = new HashMap<String, String>();
+      m.put(key1, value1);
+      m.put(key2, value2);
+      m.put(key3, value3);
+      cache.putAll(m);
+
+      Set<Map.Entry<Object, Object>> entries = cache.entrySet();
+
+      Map.Entry entry = new ImmortalCacheEntry("4", "four");
+      entries.add(entry);
+
+      assertEquals(4, cache.size());
+
+      List<Map.Entry<Object, Object>> entryCollection = new ArrayList<>(2);
+
+      entryCollection.add(new ImmortalCacheEntry("5", "five"));
+      entryCollection.add(new ImmortalCacheEntry("6", "six"));
+
+      entries.addAll(entryCollection);
+
+      assertEquals(6, cache.size());
+   }
+
+   public void testRemoveMethodOfKeyValueEntryCollections() {
+      final String key1 = "1", value1 = "one", key2 = "2", value2 = "two", key3 = "3", value3 = "three";
+      Map<String, String> m = new HashMap<String, String>();
+      m.put(key1, value1);
+      m.put(key2, value2);
+      m.put(key3, value3);
+      cache.putAll(m);
+
+      Set<Object> keys = cache.keySet();
+      keys.remove(key1);
+
+      assertEquals(2, cache.size());
+
+      Collection<Object> values = cache.values();
+      values.remove(value2);
+
+      assertEquals(1, cache.size());
+
+      Set<Map.Entry<Object, Object>> entries = cache.entrySet();
+      entries.remove(new ImmortalCacheEntry(key3, value3));
+
+      assertEquals(0, cache.size());
+   }
+
+   public void testClearMethodOfKeyCollection() {
+      final String key1 = "1", value1 = "one", key2 = "2", value2 = "two", key3 = "3", value3 = "three";
+      Map<String, String> m = new HashMap<String, String>();
+      m.put(key1, value1);
+      m.put(key2, value2);
+      m.put(key3, value3);
+      cache.putAll(m);
+
+      Set<Object> keys = cache.keySet();
+      keys.clear();
+
+      assertEquals(0, cache.size());
+   }
+
+   public void testClearMethodOfValuesCollection() {
+      final String key1 = "1", value1 = "one", key2 = "2", value2 = "two", key3 = "3", value3 = "three";
+      Map<String, String> m = new HashMap<String, String>();
+      m.put(key1, value1);
+      m.put(key2, value2);
+      m.put(key3, value3);
+      cache.putAll(m);
+
+      Collection<Object> values = cache.values();
+      values.clear();
+
+      assertEquals(0, cache.size());
+   }
+
+   public void testClearMethodOfEntryCollection() {
+      final String key1 = "1", value1 = "one", key2 = "2", value2 = "two", key3 = "3", value3 = "three";
+      Map<String, String> m = new HashMap<String, String>();
+      m.put(key1, value1);
+      m.put(key2, value2);
+      m.put(key3, value3);
+      cache.putAll(m);
+
+      Set<Map.Entry<Object, Object>> entries = cache.entrySet();
+      entries.clear();
+
+      assertEquals(0, cache.size());
+   }
+
+   public void testRemoveAllMethodOfKeyCollection() {
+      final String key1 = "1", value1 = "one", key2 = "2", value2 = "two", key3 = "3", value3 = "three";
+      Map<String, String> m = new HashMap<String, String>();
+      m.put(key1, value1);
+      m.put(key2, value2);
+      m.put(key3, value3);
+      cache.putAll(m);
+
+      List<String> keyCollection = new ArrayList<>(2);
+
+      keyCollection.add(key2);
+      keyCollection.add(key3);
+
+      Collection<Object> keys = cache.keySet();
+      keys.removeAll(keyCollection);
+
+      assertEquals(1, cache.size());
+   }
+
+   public void testRemoveAllMethodOfValuesCollection() {
+      final String key1 = "1", value1 = "one", key2 = "2", value2 = "two", key3 = "3", value3 = "three";
+      Map<String, String> m = new HashMap<String, String>();
+      m.put(key1, value1);
+      m.put(key2, value2);
+      m.put(key3, value3);
+      cache.putAll(m);
+
+      List<String> valueCollection = new ArrayList<>(2);
+
+      valueCollection.add(value1);
+      valueCollection.add(value2);
+
+      Collection<Object> values = cache.values();
+      values.removeAll(valueCollection);
+
+      assertEquals(1, cache.size());
+   }
+
+   public void testRemoveAllMethodOfEntryCollection() {
+      final String key1 = "1", value1 = "one", key2 = "2", value2 = "two", key3 = "3", value3 = "three";
+      Map<String, String> m = new HashMap<String, String>();
+      m.put(key1, value1);
+      m.put(key2, value2);
+      m.put(key3, value3);
+      cache.putAll(m);
+
+      List<Map.Entry> entryCollection = new ArrayList<>(2);
+
+      entryCollection.add(new ImmortalCacheEntry(key1, value1));
+      entryCollection.add(new ImmortalCacheEntry(key3, value3));
+
+      Set<Map.Entry<Object, Object>> entries = cache.entrySet();
+      entries.removeAll(entryCollection);
+
+      assertEquals(1, cache.size());
+   }
+
+   public void testRetainAllMethodOfKeyCollection() {
+      final String key1 = "1", value1 = "one", key2 = "2", value2 = "two", key3 = "3", value3 = "three";
+      Map<String, String> m = new HashMap<String, String>();
+      m.put(key1, value1);
+      m.put(key2, value2);
+      m.put(key3, value3);
+      cache.putAll(m);
+
+      List<String> keyCollection = new ArrayList<>(2);
+
+      keyCollection.add(key2);
+      keyCollection.add(key3);
+      keyCollection.add("6");
+
+      Collection<Object> keys = cache.keySet();
+      keys.retainAll(keyCollection);
+
+      assertEquals(2, cache.size());
+   }
+
+   public void testRetainAllMethodOfValuesCollection() {
+      final String key1 = "1", value1 = "one", key2 = "2", value2 = "two", key3 = "3", value3 = "three";
+      Map<String, String> m = new HashMap<String, String>();
+      m.put(key1, value1);
+      m.put(key2, value2);
+      m.put(key3, value3);
+      cache.putAll(m);
+
+      List<String> valueCollection = new ArrayList<>(2);
+
+      valueCollection.add(value1);
+      valueCollection.add(value2);
+      valueCollection.add("5");
+
+      Collection<Object> values = cache.values();
+      values.retainAll(valueCollection);
+
+      assertEquals(2, cache.size());
+   }
+
+   public void testRetainAllMethodOfEntryCollection() {
+      final String key1 = "1", value1 = "one", key2 = "2", value2 = "two", key3 = "3", value3 = "three";
+      Map<String, String> m = new HashMap<String, String>();
+      m.put(key1, value1);
+      m.put(key2, value2);
+      m.put(key3, value3);
+      cache.putAll(m);
+
+      List<Map.Entry> entryCollection = new ArrayList<>(3);
+
+      entryCollection.add(new ImmortalCacheEntry(key1, value1));
+      entryCollection.add(new ImmortalCacheEntry(key3, value3));
+      entryCollection.add(new ImmortalCacheEntry("4", "5"));
+
+      Set<Map.Entry<Object, Object>> entries = cache.entrySet();
+      entries.retainAll(entryCollection);
+
+      assertEquals(2, cache.size());
+   }
+
+   public void testEntrySetValueFromEntryCollections() {
+      final String key1 = "1", value1 = "one", key2 = "2", value2 = "two", key3 = "3", value3 = "three";
+      Map<String, String> m = new HashMap<String, String>();
+      m.put(key1, value1);
+      m.put(key2, value2);
+      m.put(key3, value3);
+      cache.putAll(m);
+
+      Set<Map.Entry<Object, Object>> entries = cache.entrySet();
+      Object newObj = new Object();
 
       for (Map.Entry entry : entries) {
-         try {
-            entry.setValue(newObj);
-            assert false : "Should have thrown a UnsupportedOperationException";
-         } catch (UnsupportedOperationException uoe) {
-         }
+         entry.setValue(newObj);
       }
+
+      assertEquals(3, cache.size());
+
+      assertEquals(newObj, cache.get(key1));
+      assertEquals(newObj, cache.get(key2));
+      assertEquals(newObj, cache.get(key3));
    }
 
    public void testKeyValueEntryCollections() {

--- a/core/src/test/java/org/infinispan/distribution/DistSyncFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncFuncTest.java
@@ -6,6 +6,7 @@ import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commons.util.ObjectDuplicator;
+import org.infinispan.context.Flag;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.TestingUtil;
 import org.testng.annotations.Test;
@@ -229,15 +230,15 @@ public class DistSyncFuncTest extends BaseDistFunctionalTest<Object, String> {
          Set expKeyEntries = ObjectDuplicator.duplicateSet(expKeys);
          Collection expValueEntries = ObjectDuplicator.duplicateCollection(expValues);
 
-         Set keys = c.keySet();
+         Set keys = c.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).keySet();
          for (Object key : keys) assert expKeys.remove(key);
          assert expKeys.isEmpty() : "Did not see keys " + expKeys + " in iterator!";
 
-         Collection values = c.values();
+         Collection values = c.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).values();
          for (Object value : values) assert expValues.remove(value);
          assert expValues.isEmpty() : "Did not see keys " + expValues + " in iterator!";
 
-         Set<Map.Entry> entries = c.entrySet();
+         Set<Map.Entry> entries = c.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).entrySet();
          for (Map.Entry entry : entries) {
             assert expKeyEntries.remove(entry.getKey());
             assert expValueEntries.remove(entry.getValue());

--- a/core/src/test/java/org/infinispan/statetransfer/BaseOperationsDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/BaseOperationsDuringStateTransferTest.java
@@ -372,7 +372,7 @@ public abstract class BaseOperationsDuringStateTransferTest extends MultipleCach
       log.info("Added a new node");
 
       // state transfer is blocked, no keys should be present on node B yet
-      assertTrue(cache(1).keySet().isEmpty());
+      assertTrue(cache(1).getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).keySet().isEmpty());
 
       // wait for state transfer on node B to progress to the point where data segments are about to be applied
       if (!applyStateStartedLatch.await(15, TimeUnit.SECONDS)) {
@@ -380,7 +380,7 @@ public abstract class BaseOperationsDuringStateTransferTest extends MultipleCach
       }
 
       // state transfer is blocked, no keys should be present on node B yet
-      assertTrue(cache(1).keySet().isEmpty());
+      assertTrue(cache(1).getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).keySet().isEmpty());
 
       // initiate a GET
       Future<Object> getFuture = fork(new Callable<Object>() {
@@ -402,7 +402,7 @@ public abstract class BaseOperationsDuringStateTransferTest extends MultipleCach
       // wait for state transfer to end
       TestingUtil.waitForRehashToComplete(cache(0), cache(1));
 
-      assertEquals(1, cache(1).keySet().size());
+      assertEquals(1, cache(1).getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).keySet().size());
 
       // allow GET to continue
       getKeyProceedLatch.countDown();

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -2,6 +2,7 @@ package org.infinispan.util.mocks;
 
 import org.infinispan.Cache;
 import org.infinispan.commands.VisitableCommand;
+import org.infinispan.commands.read.EntryRetrievalCommand;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.commands.remote.GetKeysInGroupCommand;
 import org.infinispan.iteration.impl.EntryRequestCommand;
@@ -183,6 +184,11 @@ public class ControlledCommandFactory implements CommandsFactory {
    @Override
    public EntrySetCommand buildEntrySetCommand(Set<Flag> flags) {
       return actual.buildEntrySetCommand(flags);
+   }
+
+   @Override
+   public EntryRetrievalCommand buildEntryRetrievalCommand(Set<Flag> flags, KeyValueFilter filter) {
+      return actual.buildEntryRetrievalCommand(flags, filter);
    }
 
    @Override

--- a/documentation/src/main/asciidoc/user_guide/chapter-53-Using_the_Cache_API.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-53-Using_the_Cache_API.adoc
@@ -7,10 +7,17 @@ The Cache interface exposes simple methods for adding, retrieving and removing e
 
 NOTE: For simple usage, using the Cache API should be no different from using the JDK Map API, and hence migrating from simple in-memory caches based on a Map to Infinispan's Cache should be trivial.
 
-==== Limitations of Certain Map Methods
-Certain methods exposed in Map have certain limitations when used with Infinispan, such as link:$$http://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/Cache.html#size%28%29$$[size()] , link:$$http://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/Cache.html#values%28%29$$[values()] , link:$$http://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/Cache.html#keySet%28%29$$[keySet()] and link:$$http://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/Cache.html#entrySet%28%29$$[entrySet()] .  Specifically, these methods are _unreliable_ and only provide a best-effort guess.  They do not acquire locks, either local or global, and concurrent modifications, additions and removals will not be considered in the result of any of these calls.  Further, they only operate on the local node, and as such, do not give you a global(cluster) view of the state.
+==== Performance Concerns of Certain Map Methods
+Certain methods exposed in Map have certain performance consequences when used with Infinispan, such as 
+link:$$http://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/Cache.html#size%28%29$$[size()] , 
+link:$$http://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/Cache.html#values%28%29$$[values()] , 
+link:$$http://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/Cache.html#keySet%28%29$$[keySet()] and 
+link:$$http://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/Cache.html#entrySet%28%29$$[entrySet()] .  
+Specific methods on the `keySet`, `values` and `entrySet` are fine for use please see their Javadoc for further details.
 
 Attempting to perform these operations globally would have large performance impact as well as become a scalability bottleneck.  As such, these methods should only be used for informational or debugging purposes only.
+
+It should be noted that using certain flags with the link:$$http://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/AdvancedCache.html#withFlags%28org.infinispan.context.Flag...%29$$[withFlags] method can mitigate some of these concerns, please check each method's documentation for more details.
 
 ==== Mortal and Immortal Data
 Further to simply storing entries, Infinispan's cache API allows you to attach mortality information to data.  For example, simply using link:$$http://docs.oracle.com/javase/6/docs/api/java/util/Map.html#put%28K,%20V%29$$[put(key, value)] would create an _immortal_ entry, i.e., an entry that lives in the cache forever, until it is removed (or evicted from memory to prevent running out of memory).  If, however, you put data in the cache using link:$$http://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/Cache.html#put%28K,%20V,%20long,%20java.util.concurrent.TimeUnit%29$$[put(key, value, lifespan, timeunit)] , this creates a _mortal_ entry, i.e., an entry that has a fixed lifespan and expires after that lifespan.
@@ -80,11 +87,15 @@ advancedCache.withFlags(Flag.CACHE_MODE_LOCAL, Flag.SKIP_LOCKING)
 
 ==== Entry Retrieval
 
-Bulk Map methods are not fully implemented for distributed caches (only uses local contents) as can be seen from their javadocs link:$$https://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/Cache.html#entrySet()$$[entrySet], link:$$https://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/Cache.html#values()$$[values], link:$$https://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/Cache.html#keySet()$$[keySet], and link:$$https://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/Cache.html#size()$$[size]
+It is possible to retrieve all of the entries stored in a given cache, irrespective of its clustering configuration.
+These entries are only retrieved through an iterator where each value is only returned one at a time.
+This is done because of the possible memory constraints of pulling all the values into a single node at the same time.
 
-This is done because of the possible memory constraints of pulling all the values into a single node.  It may desireable to still access all data and Infinispan allows this but through a different interface.
-
-An `EntryIterable` is available by invoking the link:$$https://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/AdvancedCache.html#filterEntries(org.infinispan.filter.KeyValueFilter)$$[filterEntries] method on `AdvancedCache`.  Note you are required to provide a `KeyValueFilter`, this is to make sure users realize this can be an expensive operation and by filtering entries on the remote side will allow the operation to perform faster and more efficiently.  This allows you to iterate over the contents in the cache in a memory sensitive way so out of memory errors should not occur.  The size of contents held in memory by the iterator while being processed currently is limited by the state transfer chunk size configuration value.
+An `EntryIterable` is available by invoking the 
+link:$$https://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/AdvancedCache.html#filterEntries(org.infinispan.filter.KeyValueFilter)$$[filterEntries]
+method on `AdvancedCache`.  Note you are required to provide a `KeyValueFilter`, this is to make sure users realize this can be an expensive operation and by filtering entries on the remote side will allow the operation to perform faster and more efficiently.
+This allows you to iterate over the contents in the cache in a memory sensitive way so out of memory errors should not occur.
+The size of contents held in memory by the iterator while being processed currently is limited by the state transfer chunk size configuration value.
 
 Once the `EntryIterable` is retrieved, invocation of the iterator method will immediately start retrieving entries.  Note each invocation of the iterator method will start a brand new entry request thus allowing the `Iterable` to be reused.
 
@@ -100,9 +111,16 @@ try (EntryIterable<Object, Object> iterable = advancedCache.filterEntries(filter
 }
 ----
 
-NOTE: The iterators produced do not obey the current transaction if there is one and thus will always retrieve the most current committed values from the cache.
+===== Transactional Aware
+The iterators produced will obey the current transaction if there is one when they are generated.  Note the transaction they use is the one that is found to be in the thread when `filterEntries` is first invoked.  Thus you should only access this iterator from the same thread or else undefind behavior may occur.
 
-NOTE: Also the remove method is not supported on the iterators and will throw an `UnsupportedOperationException` if invoked.
+Since we cannot put all entries into the local transaction any entries retrieved using the iterator are not added to the transaction context.  This means that the iterator will behave always in a way similar to a Read Committed isolation level even if Repeatable Read is enabled for example.  If an entry was previously put in the context it will use this value, including if it was removed, in which case it will not be returned from the iterator.
+
+
+===== Iterator remove
+We also do support the remove operation on the iterator.  In a non transactional cache this will immediately remove the key from the cache.  In a transactional cache this will instead be added to the existing transaction context if there is one otherwise an implicit transaction will be generated for it.
+
+===== Value conversion
 
 While the provided filter can be used to efficiently reduce what entries are returned to the local node, there is also the possibility of providing an optional link:$$https://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/filter/Converter.html$$[Converter] which will convert the provided value to another object or even type, which is done on the remote side.  This is useful to reduce payload size when you may want only a partial view of the object or even an object that is created from it.
 

--- a/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/BaseProtoStreamMarshaller.java
+++ b/remote-query/remote-query-client/src/main/java/org/infinispan/query/remote/client/BaseProtoStreamMarshaller.java
@@ -26,6 +26,11 @@ public abstract class BaseProtoStreamMarshaller extends AbstractMarshaller {
 
    @Override
    public boolean isMarshallable(Object o) {
+      // Protostream can handle all of these type as well
+      if (o instanceof String || o instanceof Long || o instanceof Integer || o instanceof Double || o instanceof Float
+            || o instanceof Boolean || o instanceof byte[]) {
+         return true;
+      }
       return getSerializationContext().canMarshall(o.getClass());
    }
 

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ClientListenerRegistry.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ClientListenerRegistry.scala
@@ -253,7 +253,7 @@ class ClientListenerRegistry(configuration: HotRodServerConfiguration) extends L
             // In compatibility mode, version could be null if stored via embedded
             val version = event.getMetadata.version()
             val dataVersion = if (version == null) 0 else version.asInstanceOf[NumericVersion].getVersion
-            delegate.sendEvent(key, value, dataVersion, event)
+            delegate.sendEvent(key.asInstanceOf[Array[Byte]], value.asInstanceOf[Array[Byte]], dataVersion, event)
          } else {
             log.debug("Channel disconnected, remove event sender listener")
             event.getCache.removeListener(this)

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodTypeConverter.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodTypeConverter.scala
@@ -21,9 +21,9 @@ class HotRodTypeConverter extends TypeConverter[AnyRef, AnyRef, AnyRef, AnyRef] 
 
    override def boxValue(value: AnyRef): AnyRef = unmarshall(value)
 
-   override def unboxKey(target: AnyRef): Array[Byte] = marshall(target)
+   override def unboxKey(target: AnyRef): AnyRef = marshall(target)
 
-   override def unboxValue(target: AnyRef): Array[Byte] = marshall(target)
+   override def unboxValue(target: AnyRef): AnyRef = marshall(target)
 
    override def supportsInvocation(flag: Flag): Boolean =
       if (flag == Flag.OPERATION_HOTROD) true else false
@@ -40,8 +40,9 @@ class HotRodTypeConverter extends TypeConverter[AnyRef, AnyRef, AnyRef, AnyRef] 
       }
    }
 
-   private def marshall(source: AnyRef): Array[Byte] =
-      if (source != null) marshaller.objectToByteBuffer(source) else null
+   private def marshall(source: AnyRef): AnyRef = {
+      if (source != null) { if (marshaller.isMarshallable(source)) marshaller.objectToByteBuffer(source) else source } else null
+   }
 
 }
 


### PR DESCRIPTION
- Collections now fall back to calling cache or using entry iterator
- Reworked entry iterator to use a visitable command
  *\* Allows for compatibility support
  *\* Also easier detection of transactions
