### PR TITLE
ISPN-4884 Deployment scanner is neeeded to deploy filter/converters...

### DIFF
--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-auth.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-auth.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem supplement="auth">configuration/examples/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem supplement="auth">configuration/examples/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-ccl-clustered.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-ccl-clustered.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem supplement="clustered">configuration/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/examples/subsystems/datasources.xml</subsystem>
       <subsystem supplement="ccl-clustered">configuration/examples/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-compatibility-mode.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-compatibility-mode.xml
@@ -26,6 +26,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem supplement="compatibility-mode">configuration/examples/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem supplement="compatibility-mode">configuration/examples/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-fcs-local.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-fcs-local.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem>configuration/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem supplement="fcs-local">configuration/examples/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-hotrod-multiple.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-hotrod-multiple.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem supplement="hotrod-multiple">configuration/examples/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem>configuration/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-hotrod-rolling-upgrade.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-hotrod-rolling-upgrade.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem supplement="hotrod-rolling-upgrade">configuration/examples/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem supplement="hotrod-rolling-upgrade">configuration/examples/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-hotrod-ssl.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-hotrod-ssl.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem supplement="hotrod-ssl">configuration/examples/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem>configuration/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-jdbc-clustered.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-jdbc-clustered.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem supplement="clustered">configuration/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/examples/subsystems/datasources.xml</subsystem>
       <subsystem supplement="jdbc-clustered">configuration/examples/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-leveldb-cs-local.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-leveldb-cs-local.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem>configuration/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem supplement="leveldb-cs-local">configuration/examples/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-node-auth.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-node-auth.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem supplement="clustered">configuration/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem supplement="clustered">configuration/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-rcs-local.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-rcs-local.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem>configuration/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem supplement="rcs-local">configuration/examples/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-rest-rolling-upgrade.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-rest-rolling-upgrade.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem supplement="rest-rolling-upgrade">configuration/examples/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem supplement="rest-rolling-upgrade">configuration/examples/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-storage-only.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-storage-only.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem>configuration/examples/subsystems/datasources.xml</subsystem>
       <subsystem supplement="clustered">configuration/subsystems/infinispan.xml</subsystem>
       <subsystem>configuration/subsystems/io.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-topology.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-topology.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem supplement="clustered">configuration/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem supplement="clustered">configuration/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-two-nodes.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-two-nodes.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem supplement="clustered">configuration/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem supplement="clustered">configuration/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/examples/subsystems-xsite.xml
+++ b/server/integration/build/src/main/resources/configuration/examples/subsystems-xsite.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem supplement="clustered">configuration/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/examples/subsystems/datasources.xml</subsystem>
       <subsystem supplement="xsite">configuration/examples/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/standalone/subsystems-clustered.xml
+++ b/server/integration/build/src/main/resources/configuration/standalone/subsystems-clustered.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem supplement="clustered">configuration/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem supplement="clustered">configuration/subsystems/infinispan.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/standalone/subsystems.xml
+++ b/server/integration/build/src/main/resources/configuration/standalone/subsystems.xml
@@ -3,6 +3,7 @@
 <config>
    <subsystems>
       <subsystem>configuration/subsystems/logging.xml</subsystem>
+      <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem>configuration/subsystems/endpoint.xml</subsystem>
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem>configuration/subsystems/io.xml</subsystem>

--- a/server/integration/build/src/main/resources/configuration/subsystems/deployment-scanner.xml
+++ b/server/integration/build/src/main/resources/configuration/subsystems/deployment-scanner.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
+<config>
+   <extension-module>org.jboss.as.deployment-scanner</extension-module>
+   <subsystem xmlns="urn:jboss:domain:deployment-scanner:2.0">
+      <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000"
+                       runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
+   </subsystem>
+</config>


### PR DESCRIPTION
- Without the deployment scanner, is not possible to deploy filter, converter and marshaller instances for enhanced Hot Rod remote events.
