### PR TITLE
ISPN-4878 StateTransferSuppressIT always fails: the protobuf metadata

### DIFF
--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/ProtobufMetadataManager.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/ProtobufMetadataManager.java
@@ -103,7 +103,7 @@ public class ProtobufMetadataManager implements ProtobufMetadataManagerMBean {
             .transaction().lockingMode(LockingMode.PESSIMISTIC).syncCommitPhase(true).syncRollbackPhase(true)
             .locking().isolationLevel(IsolationLevel.READ_COMMITTED).useLockStriping(false)
             .clustering().cacheMode(cacheMode).sync()
-            .stateTransfer().fetchInMemoryState(true)
+            .stateTransfer().fetchInMemoryState(true).awaitInitialTransfer(false)
             .compatibility().enable().marshaller(new CompatibilityProtoStreamMarshaller())
             .customInterceptors().addInterceptor()
             .interceptor(new ProtobufMetadataManagerInterceptor()).after(PessimisticLockingInterceptor.class);


### PR DESCRIPTION
cache can't start with state transfer suspended

Disable awaitInitialTransfer in the ___protobuf_metadata configuration.

https://issues.jboss.org/browse/ISPN-4878

@anistor I considered disabling awaitInitialTransfer only for the test with a custom ___protobuf_metadata configuration, but custom interceptors are not allowed in the server configuration. The tests seem to pass, so I guess it's OK to make it the default.
