### PR TITLE
Don't override the finalName for some components

### DIFF
--- a/server/core/pom.xml
+++ b/server/core/pom.xml
@@ -26,7 +26,6 @@
    </dependencies>
 
    <build>
-      <finalName>infinispan</finalName>
       <sourceDirectory>src/main/scala</sourceDirectory>
       <testSourceDirectory>src/test/scala</testSourceDirectory>
 

--- a/server/hotrod/pom.xml
+++ b/server/hotrod/pom.xml
@@ -41,7 +41,6 @@
    </dependencies>
 
    <build>
-      <finalName>infinispan</finalName>
       <sourceDirectory>src/main/scala</sourceDirectory>
       <testSourceDirectory>src/test/scala</testSourceDirectory>
 

--- a/server/memcached/pom.xml
+++ b/server/memcached/pom.xml
@@ -33,7 +33,6 @@
    </dependencies>
 
    <build>
-      <finalName>infinispan</finalName>
       <sourceDirectory>src/main/scala</sourceDirectory>
       <testSourceDirectory>src/test/scala</testSourceDirectory>
 

--- a/server/rest/pom.xml
+++ b/server/rest/pom.xml
@@ -16,7 +16,6 @@
    </description>
 
    <build>
-      <finalName>infinispan</finalName>
       <sourceDirectory>src/main/scala</sourceDirectory>
       <testSourceDirectory>src/test/scala</testSourceDirectory>
 


### PR DESCRIPTION
Don't use finalName in some components to create homonym components
