### PR TITLE
ISPN-4166 useSynchronization should be disabled by default

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ServerFailureRetrySingleOwnerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ServerFailureRetrySingleOwnerTest.java
@@ -35,7 +35,7 @@ public class ServerFailureRetrySingleOwnerTest extends AbstractRetryTest {
             getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
       builder.clustering().hash().numOwners(1).numSegments(1)
             .consistentHashFactory(new ControlledConsistentHashFactory(0))
-            .transaction().transactionMode(TransactionMode.TRANSACTIONAL);
+            .transaction().transactionMode(TransactionMode.TRANSACTIONAL).useSynchronization(true);
       return builder;
    }
 

--- a/core/src/main/java/org/infinispan/configuration/cache/RecoveryConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/RecoveryConfigurationBuilder.java
@@ -14,7 +14,7 @@ import static org.infinispan.configuration.cache.RecoveryConfiguration.DEFAULT_R
  */
 public class RecoveryConfigurationBuilder extends AbstractTransportConfigurationChildBuilder implements Builder<RecoveryConfiguration> {
 
-   boolean enabled = true;
+   boolean enabled = false;
    private String recoveryInfoCacheName = DEFAULT_RECOVERY_INFO_CACHE;
 
    RecoveryConfigurationBuilder(TransactionConfigurationBuilder builder) {

--- a/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
@@ -34,7 +34,7 @@ public class TransactionConfigurationBuilder extends AbstractConfigurationChildB
    private TransactionSynchronizationRegistryLookup transactionSynchronizationRegistryLookup;
    TransactionMode transactionMode = null;
    private boolean useEagerLocking = false;
-   private boolean useSynchronization = true;
+   private boolean useSynchronization = false;
    private final RecoveryConfigurationBuilder recovery;
    private boolean use1PcForAutoCommitTransactions = false;
    private long reaperWakeUpInterval = 30000;

--- a/core/src/test/java/org/infinispan/statetransfer/CommitTimeoutTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/CommitTimeoutTest.java
@@ -14,6 +14,7 @@ import org.infinispan.util.ControlledConsistentHashFactory;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.testng.annotations.Test;
 
+import javax.transaction.RollbackException;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -87,7 +88,11 @@ public class CommitTimeoutTest extends MultipleCacheManagersTest {
 
       tm(0).begin();
       cache(0).put(TEST_KEY, TX1_VALUE);
-      tm(0).commit();
+      try {
+         tm(0).commit();
+      } catch (RollbackException e) {
+         log.debugf("Commit timed out as expected", e);
+      }
 
       sequencer.advance("tx2:begin");
       LockManager lockManager1 = TestingUtil.extractLockManager(cache(1));

--- a/core/src/test/java/org/infinispan/tx/DefaultEnlistmentModeTest.java
+++ b/core/src/test/java/org/infinispan/tx/DefaultEnlistmentModeTest.java
@@ -15,7 +15,6 @@ import org.testng.annotations.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 @Test (groups = "functional", testName = "tx.DefaultEnlistmentModeTest")
 public class DefaultEnlistmentModeTest extends AbstractCacheTest {
@@ -32,7 +31,8 @@ public class DefaultEnlistmentModeTest extends AbstractCacheTest {
       builder.transaction().transactionMode(TransactionMode.TRANSACTIONAL);
       dcm = new DefaultCacheManager(getGlobalConfig(), builder.build());
       Cache<Object,Object> cache = dcm.getCache();
-      assertTrue(cache.getCacheConfiguration().transaction().useSynchronization());
+      assertFalse(cache.getCacheConfiguration().transaction().useSynchronization());
+      assertFalse(cache.getCacheConfiguration().transaction().recovery().enabled());
       cache.put("k", "v");
       assertEquals("v", cache.get("k"));
    }
@@ -45,7 +45,7 @@ public class DefaultEnlistmentModeTest extends AbstractCacheTest {
       dcm = new DefaultCacheManager(getGlobalConfig(), builder.build());
       Cache<Object,Object> cache = dcm.getCache();
       assertFalse(cache.getCacheConfiguration().transaction().useSynchronization());
-      assertTrue(cache.getCacheConfiguration().transaction().recovery().enabled());
+      assertFalse(cache.getCacheConfiguration().transaction().recovery().enabled());
       cache.put("k", "v");
       assertEquals("v", cache.get("k"));
    }

--- a/core/src/test/java/org/infinispan/tx/TxCompletionForRolledBackTxOptTest.java
+++ b/core/src/test/java/org/infinispan/tx/TxCompletionForRolledBackTxOptTest.java
@@ -38,7 +38,7 @@ public class TxCompletionForRolledBackTxOptTest extends MultipleCacheManagersTes
          tm(0).commit();
          fail();
       } catch (Throwable t) {
-         //expected
+         log.debugf("Got expected exception", t);
       }
 
       assertNotLocked(k1);
@@ -47,7 +47,7 @@ public class TxCompletionForRolledBackTxOptTest extends MultipleCacheManagersTes
       assertNull(cache(0).get(k2));
 
       assertEquals(cf.received(PrepareCommand.class), 1);
-      assertEquals(cf.received(RollbackCommand.class), 2);
+      assertEquals(cf.received(RollbackCommand.class), 1);
       assertEquals(cf.received(TxCompletionNotificationCommand.class), 0);
    }
 }

--- a/core/src/test/java/org/infinispan/tx/recovery/LocalRecoveryTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/LocalRecoveryTest.java
@@ -29,7 +29,7 @@ public class LocalRecoveryTest extends SingleCacheManagerTest {
             .transactionMode(TransactionMode.TRANSACTIONAL)
             .useSynchronization(false)
             .transactionManagerLookup(new RecoveryDummyTransactionManagerLookup())
-            .recovery();
+            .recovery().enable();
       return TestCacheManagerFactory.createCacheManager(cb);
    }
 

--- a/core/src/test/java/org/infinispan/tx/synchronisation/NoXaConfigTest.java
+++ b/core/src/test/java/org/infinispan/tx/synchronisation/NoXaConfigTest.java
@@ -6,6 +6,9 @@ import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
 /**
  * @author Mircea.Markus@jboss.com
  * @since 5.0
@@ -19,8 +22,8 @@ public class NoXaConfigTest extends SingleCacheManagerTest {
    }
 
    public void testConfig() {
-      assert cacheManager.getCache("syncEnabled").getCacheConfiguration().transaction().useSynchronization();
-      assert cacheManager.getCache("notSpecified").getCacheConfiguration().transaction().useSynchronization();
+      assertTrue(cacheManager.getCache("syncEnabled").getCacheConfiguration().transaction().useSynchronization());
+      assertFalse(cacheManager.getCache("notSpecified").getCacheConfiguration().transaction().useSynchronization());
 
       cacheManager.getCache("syncAndRecovery");
    }
@@ -29,6 +32,6 @@ public class NoXaConfigTest extends SingleCacheManagerTest {
       ConfigurationBuilder configuration = getDefaultStandaloneCacheConfig(true);
       configuration.transaction().useSynchronization(true);
       cacheManager.defineConfiguration("newCache", configuration.build());
-      assert cacheManager.getCache("newCache").getCacheConfiguration().transaction().useSynchronization();
+      assertTrue(cacheManager.getCache("newCache").getCacheConfiguration().transaction().useSynchronization());
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4166

Only the programmatic configuration is affected.
The default is now equivalent to NON_DURABLE_XA in the xml
configuration (i.e. recovery must be enabled explicitly).
