### PR TITLE
JavaDoc: multiline code examples are mangled

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -263,13 +263,13 @@ public class RemoteCacheManager implements BasicCacheContainer {
     * Retrieves the configuration currently in use. The configuration object is immutable. If you wish to change configuration,
     * you should use the following pattern:
     *
-    * <code>
+    * <pre><code>
     * ConfigurationBuilder builder = new ConfigurationBuilder();
     * builder.read(remoteCacheManager.getConfiguration());
     * // modify builder
     * remoteCacheManager.stop();
     * remoteCacheManager = new RemoteCacheManager(builder.build());
-    * </code>
+    * </code></pre>
     *
     * @since 5.3
     * @return The configuration of this RemoteCacheManager
@@ -283,12 +283,13 @@ public class RemoteCacheManager implements BasicCacheContainer {
     * retrieved will not affect an already-running RemoteCacheManager.  If you wish to make changes to an already-running
     * RemoteCacheManager, you should use the following pattern:
     *
-    * <code>
+    * <pre><code>
     * Properties p = remoteCacheManager.getProperties();
     * // update properties
     * remoteCacheManager.stop();
     * remoteCacheManager = new RemoteCacheManager(p);
-    * </code>
+    * </code></pre>
+    *
     * @return a clone of the properties used to configure this RemoteCacheManager
     * @since 4.2
     */

--- a/commons/src/main/java/org/infinispan/commons/util/concurrent/NotifyingFutureImpl.java
+++ b/commons/src/main/java/org/infinispan/commons/util/concurrent/NotifyingFutureImpl.java
@@ -10,8 +10,12 @@ import java.util.concurrent.TimeUnit;
  * <p/>
  * Typical usage:
  * <p/>
- * <code> Object retval = .... // do some work here NotifyingFuture nf = new NotifyingFutureImpl();
- * rpcManager.broadcastRpcCommandInFuture(nf, command); return nf; </code>
+ * <pre><code>
+ * Object retval = ... // do some work here
+ * NotifyingFuture nf = new NotifyingFutureImpl();
+ * rpcManager.broadcastRpcCommandInFuture(nf, command);
+ * return nf;
+ * </code></pre>
  *
  * @author Manik Surtani
  * @since 4.0

--- a/core/src/main/java/org/infinispan/affinity/KeyAffinityService.java
+++ b/core/src/main/java/org/infinispan/affinity/KeyAffinityService.java
@@ -9,8 +9,8 @@ import org.infinispan.remoting.transport.Address;
  * <p/>
  * Sample usage:
  * <p/>
- * <code>
- *    Cache&gt;String,Long&lt; cache = getDistributedCache();
+ * <pre><code>
+ *    Cache&lt;String, Long&gt; cache = getDistributedCache();
  *    KeyAffinityService&lt;String&gt; service = KeyAffinityServiceFactory.newKeyAffinityService(cache, 100);
  *    ...
  *    String sessionId = sessionObject.getId();
@@ -18,7 +18,7 @@ import org.infinispan.remoting.transport.Address;
  *
  *    //this will reside on the same node in the cluster
  *    cache.put(newCollocatedSession, someInfo);
- * </code>
+ * </code></pre>
  * <p/>
  * Uniqueness: the service does not guarantee that the generated keys are unique. It relies on an
  * {@link org.infinispan.affinity.KeyGenerator} for obtaining and distributing the generated keys. If key uniqueness is

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -92,7 +92,7 @@ import org.infinispan.util.logging.LogFactory;
  * within its scope are properly stopped as well.
  * <p/>
  * Sample usage:
- * <code>
+ * <pre><code>
  *    CacheManager manager = CacheManager.getInstance("my-config-file.xml");
  *    Cache&lt;String, Person&gt; entityCache = manager.getCache("myEntityCache");
  *    entityCache.put("aPerson", new Person());
@@ -101,7 +101,7 @@ import org.infinispan.util.logging.LogFactory;
  *    confBuilder.clustering().cacheMode(CacheMode.REPL_SYNC);
  *    manager.defineConfiguration("myReplicatedCache", confBuilder.build());
  *    Cache&lt;String, String&gt; replicatedCache = manager.getCache("myReplicatedCache");
- * </code>
+ * </code></pre>
  *
  * @author Manik Surtani
  * @author Galder Zamarreño


### PR DESCRIPTION
Maybe its unintuitive, but <code> actually needs <pre> to maintain multiline block formatting, otherwise it gets mangled like this

http://docs.jboss.org/infinispan/7.0/apidocs/org/infinispan/affinity/KeyAffinityService.html
