### PR TITLE
ISPN-4950 Add ability to merge defaults into Metadata passed as param

### DIFF
--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -624,7 +624,8 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
 
    @Override
    public void putForExternalRead(K key, V value, Metadata metadata) {
-      putForExternalRead(key, value, metadata, null, null);
+      Metadata merged = applyDefaultMetadata(metadata);
+      putForExternalRead(key, value, merged, null, null);
    }
 
    final void putForExternalRead(K key, V value, EnumSet<Flag> explicitFlags, ClassLoader explicitClassLoader) {
@@ -1643,27 +1644,37 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
 
    @Override
    public V put(K key, V value, Metadata metadata) {
-      return put(key, value, metadata, null, null);
+      Metadata merged = applyDefaultMetadata(metadata);
+      return put(key, value, merged, null, null);
+   }
+
+   private Metadata applyDefaultMetadata(Metadata metadata) {
+      Metadata.Builder builder = metadata.builder();
+      return builder != null ? builder.merge(defaultMetadata).build() : metadata;
    }
 
    @Override
    public V replace(K key, V value, Metadata metadata) {
-      return replace(key, value, metadata, null, null);
+      Metadata merged = applyDefaultMetadata(metadata);
+      return replace(key, value, merged, null, null);
    }
 
    @Override
    public boolean replace(K key, V oldValue, V value, Metadata metadata) {
-      return replace(key, oldValue, value, metadata, null, null);
+      Metadata merged = applyDefaultMetadata(metadata);
+      return replace(key, oldValue, value, merged, null, null);
    }
 
    @Override
    public V putIfAbsent(K key, V value, Metadata metadata) {
-      return putIfAbsent(key, value, metadata, null, null);
+      Metadata merged = applyDefaultMetadata(metadata);
+      return putIfAbsent(key, value, merged, null, null);
    }
 
    @Override
    public NotifyingFuture<V> putAsync(K key, V value, Metadata metadata) {
-      return putAsync(key, value, metadata, null, null);
+      Metadata merged = applyDefaultMetadata(metadata);
+      return putAsync(key, value, merged, null, null);
    }
 
    private void associateImplicitTransactionWithCurrentThread(InvocationContext ctx) throws InvalidTransactionException, SystemException {

--- a/core/src/main/java/org/infinispan/metadata/EmbeddedMetadata.java
+++ b/core/src/main/java/org/infinispan/metadata/EmbeddedMetadata.java
@@ -73,9 +73,9 @@ public class EmbeddedMetadata implements Metadata {
 
    public static class Builder implements Metadata.Builder {
 
-      protected long lifespan = -1;
+      protected Long lifespan = null;
       protected TimeUnit lifespanUnit = TimeUnit.MILLISECONDS;
-      protected long maxIdle = -1;
+      protected Long maxIdle = null;
       protected TimeUnit maxIdleUnit = TimeUnit.MILLISECONDS;
       protected EntryVersion version;
 
@@ -111,13 +111,48 @@ public class EmbeddedMetadata implements Metadata {
 
       @Override
       public Metadata build() {
-         if (lifespan < 0 && maxIdle < 0)
-            return new EmbeddedMetadata(version);
-         else
+         boolean hasLifespan = hasLifespan();
+         boolean hasMaxIdle = hasMaxIdle();
+         if (hasLifespan && hasMaxIdle)
             return new EmbeddedExpirableMetadata(
-               lifespan, lifespanUnit, maxIdle, maxIdleUnit, version);
+                  lifespan, lifespanUnit, maxIdle, maxIdleUnit, version);
+         else if (hasLifespan)
+            return new EmbeddedLifespanExpirableMetadata(lifespan, lifespanUnit, version);
+         else if (hasMaxIdle)
+            return new EmbeddedMaxIdleExpirableMetadata(maxIdle, maxIdleUnit, version);
+         else
+            return new EmbeddedMetadata(version);
       }
 
+      protected boolean hasLifespan() {
+         return isExpirable(lifespan);
+      }
+
+      protected boolean hasMaxIdle() {
+         return isExpirable(maxIdle);
+      }
+
+      private boolean isExpirable(Long timeout) {
+         return timeout != null && timeout >= 0;
+      }
+
+      @Override
+      public Metadata.Builder merge(Metadata metadata) {
+         if (lifespan == null) { // if lifespan not set, apply default
+            lifespan = metadata.lifespan();
+            lifespanUnit = TimeUnit.MILLISECONDS;
+         }
+
+         if (maxIdle == null) { // if maxIdle not set, apply default
+            maxIdle = metadata.maxIdle();
+            maxIdleUnit = TimeUnit.MILLISECONDS;
+         }
+
+         if (version == null)
+            version = metadata.version();
+
+         return this;
+      }
    }
 
    private static class EmbeddedExpirableMetadata extends EmbeddedMetadata {
@@ -146,7 +181,7 @@ public class EmbeddedMetadata implements Metadata {
       @Override
       public Metadata.Builder builder() {
          return new EmbeddedMetadata.Builder()
-               .lifespan(lifespan).maxIdle(lifespan).version(version);
+               .lifespan(lifespan).maxIdle(maxIdle).version(version);
       }
 
       @Override
@@ -181,21 +216,112 @@ public class EmbeddedMetadata implements Metadata {
       }
    }
 
+   private static abstract class AbstractEmbeddedTimeoutMetadata extends EmbeddedMetadata {
+
+      protected final long timeout;
+
+      private AbstractEmbeddedTimeoutMetadata(
+            long timeout, TimeUnit timeoutUnit,
+            EntryVersion version) {
+         super(version);
+         this.timeout = timeoutUnit.toMillis(timeout);
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) return true;
+         if (o == null || getClass() != o.getClass()) return false;
+         if (!super.equals(o)) return false;
+
+         AbstractEmbeddedTimeoutMetadata that = (AbstractEmbeddedTimeoutMetadata) o;
+
+         if (timeout != that.timeout) return false;
+
+         return true;
+      }
+
+      @Override
+      public int hashCode() {
+         int result = super.hashCode();
+         result = 31 * result + (int) (timeout ^ (timeout >>> 32));
+         return result;
+      }
+   }
+
+   private static class EmbeddedLifespanExpirableMetadata extends AbstractEmbeddedTimeoutMetadata {
+
+      private EmbeddedLifespanExpirableMetadata(long lifespan, TimeUnit lifespanUnit, EntryVersion version) {
+         super(lifespan, lifespanUnit, version);
+      }
+
+      @Override
+      public long lifespan() {
+         return timeout;
+      }
+
+      @Override
+      public Metadata.Builder builder() {
+         return new EmbeddedMetadata.Builder()
+               .lifespan(timeout).version(version);
+      }
+
+      @Override
+      public String toString() {
+         return "EmbeddedLifespanExpirableMetadata{" +
+               "lifespan=" + timeout +
+               ", version=" + version +
+               '}';
+      }
+
+   }
+
+   private static class EmbeddedMaxIdleExpirableMetadata extends AbstractEmbeddedTimeoutMetadata {
+
+      private EmbeddedMaxIdleExpirableMetadata(long maxIdle, TimeUnit maxIdleUnit, EntryVersion version) {
+         super(maxIdle, maxIdleUnit, version);
+      }
+
+      @Override
+      public long maxIdle() {
+         return timeout;
+      }
+
+      @Override
+      public Metadata.Builder builder() {
+         return new EmbeddedMetadata.Builder()
+               .maxIdle(timeout).version(version);
+      }
+
+      @Override
+      public String toString() {
+         return "EmbeddedMaxIdleExpirableMetadata{" +
+               "maxIdle=" + timeout +
+               ", version=" + version +
+               '}';
+      }
+
+   }
+
    public static class Externalizer extends AbstractExternalizer<EmbeddedMetadata> {
 
       private static final int IMMORTAL = 0;
       private static final int EXPIRABLE = 1;
+      private static final int LIFESPAN_EXPIRABLE = 2;
+      private static final int MAXIDLE_EXPIRABLE = 3;
       private final IdentityIntMap<Class<?>> numbers = new IdentityIntMap<Class<?>>(2);
 
       public Externalizer() {
          numbers.put(EmbeddedMetadata.class, IMMORTAL);
          numbers.put(EmbeddedExpirableMetadata.class, EXPIRABLE);
+         numbers.put(EmbeddedLifespanExpirableMetadata.class, LIFESPAN_EXPIRABLE);
+         numbers.put(EmbeddedMaxIdleExpirableMetadata.class, MAXIDLE_EXPIRABLE);
       }
 
       @Override
       @SuppressWarnings("unchecked")
       public Set<Class<? extends EmbeddedMetadata>> getTypeClasses() {
-         return Util.asSet(EmbeddedMetadata.class, EmbeddedExpirableMetadata.class);
+         return Util.asSet(EmbeddedMetadata.class, EmbeddedExpirableMetadata.class,
+               EmbeddedLifespanExpirableMetadata.class, EmbeddedMaxIdleExpirableMetadata.class);
       }
 
       @Override
@@ -210,6 +336,12 @@ public class EmbeddedMetadata implements Metadata {
          switch (number) {
             case EXPIRABLE:
                output.writeLong(object.lifespan());
+               output.writeLong(object.maxIdle());
+               break;
+            case LIFESPAN_EXPIRABLE:
+               output.writeLong(object.lifespan());
+               break;
+            case MAXIDLE_EXPIRABLE:
                output.writeLong(object.maxIdle());
                break;
          }
@@ -231,6 +363,14 @@ public class EmbeddedMetadata implements Metadata {
                return new EmbeddedExpirableMetadata(
                      lifespan, TimeUnit.MILLISECONDS,
                      maxIdle, TimeUnit.MILLISECONDS, version);
+            case LIFESPAN_EXPIRABLE:
+               return new EmbeddedLifespanExpirableMetadata(
+                     input.readLong(), TimeUnit.MILLISECONDS,
+                     (EntryVersion) input.readObject());
+            case MAXIDLE_EXPIRABLE:
+               return new EmbeddedMaxIdleExpirableMetadata(
+                     input.readLong(), TimeUnit.MILLISECONDS,
+                     (EntryVersion) input.readObject());
             default:
                throw new IllegalStateException("Unknown metadata type " + number);
          }

--- a/core/src/main/java/org/infinispan/metadata/Metadata.java
+++ b/core/src/main/java/org/infinispan/metadata/Metadata.java
@@ -102,6 +102,13 @@ public interface Metadata {
        */
       Metadata build();
 
+      /**
+       * Merges the given metadata information into the given builder.
+       *
+       * @param metadata to merge into this builder
+       * @return a builder instance with the metadata applied
+       */
+      Builder merge(Metadata metadata);
    }
 
 }

--- a/core/src/test/java/org/infinispan/api/MetadataAPIDefaultExpiryTest.java
+++ b/core/src/test/java/org/infinispan/api/MetadataAPIDefaultExpiryTest.java
@@ -1,0 +1,96 @@
+package org.infinispan.api;
+
+import org.infinispan.commons.util.concurrent.NotifyingFuture;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.metadata.EmbeddedMetadata;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.infinispan.test.TestingUtil.*;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+
+@Test(groups = "functional", testName = "api.MetadataAPITest")
+public class MetadataAPIDefaultExpiryTest extends SingleCacheManagerTest {
+
+   public static final int EXPIRATION_TIMEOUT = 3000;
+   public static final int EVICTION_CHECK_TIMEOUT = 2000;
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.expiration().lifespan(EXPIRATION_TIMEOUT);
+      return TestCacheManagerFactory.createCacheManager(builder);
+   }
+
+   public void testDefaultLifespanPut() {
+      cache().put(1, "v1");
+      expectCachedThenExpired(1, "v1");
+      cache().getAdvancedCache().put(2, "v2", new EmbeddedMetadata.Builder().build());
+      expectCachedThenExpired(2, "v2");
+   }
+
+   public void testDefaultLifespanReplace() {
+      cache().put(1, "v1");
+      cache().replace(1, "v11");
+      expectCachedThenExpired(1, "v11");
+      cache().getAdvancedCache().put(2, "v2", new EmbeddedMetadata.Builder().build());
+      cache().getAdvancedCache().replace(2, "v22", new EmbeddedMetadata.Builder().build());
+      expectCachedThenExpired(2, "v22");
+   }
+
+   public void testDefaultLifespanReplaceWithOldValue() {
+      cache().put(1, "v1");
+      cache().replace(1, "v1", "v11");
+      expectCachedThenExpired(1, "v11");
+      cache().getAdvancedCache().put(2, "v2", new EmbeddedMetadata.Builder().build());
+      cache().getAdvancedCache().replace(2, "v2", "v22", new EmbeddedMetadata.Builder().build());
+      expectCachedThenExpired(2, "v22");
+   }
+
+   public void testDefaultLifespanPutIfAbsent() {
+      cache().putIfAbsent(1, "v1");
+      expectCachedThenExpired(1, "v1");
+      cache().getAdvancedCache().putIfAbsent(2, "v2", new EmbeddedMetadata.Builder().build());
+      expectCachedThenExpired(2, "v2");
+   }
+
+   public void testDefaultLifespanPutForExternalRead() {
+      cache().putForExternalRead(1, "v1");
+      expectCachedThenExpired(1, "v1");
+      cache().getAdvancedCache().putForExternalRead(2, "v2", new EmbeddedMetadata.Builder().build());
+      expectCachedThenExpired(2, "v2");
+   }
+
+   public void testDefaultLifespanPutAsync() throws Exception {
+      NotifyingFuture<Object> f = cache().putAsync(1, "v1");
+      f.get(10, TimeUnit.SECONDS);
+      expectCachedThenExpired(1, "v1");
+      f = cache().getAdvancedCache().putAsync(2, "v2", new EmbeddedMetadata.Builder().build());
+      f.get(10, TimeUnit.SECONDS);
+      expectCachedThenExpired(2, "v2");
+   }
+
+   private void expectCachedThenExpired(Integer key, String value) {
+      final long startTime = now();
+      final long expiration = EXPIRATION_TIMEOUT;
+      while (true) {
+         String v = this.<Integer, String>cache().get(key);
+         if (moreThanDurationElapsed(startTime, expiration))
+            break;
+         assertEquals(value, v);
+         sleepThread(100);
+      }
+
+      // Make sure that in the next X secs data is removed
+      while (!moreThanDurationElapsed(startTime, expiration + EVICTION_CHECK_TIMEOUT)) {
+         if (cache.get(key) == null) return;
+      }
+
+      assertNull(cache.get(key));
+   }
+}

--- a/core/src/test/java/org/infinispan/api/MetadataAPITest.java
+++ b/core/src/test/java/org/infinispan/api/MetadataAPITest.java
@@ -222,6 +222,11 @@ public class MetadataAPITest extends SingleCacheManagerTest {
       }
 
       @Override
+      public Builder merge(Metadata metadata) {
+         return this;
+      }
+
+      @Override
       public boolean equals(Object o) {
          if (this == o) return true;
          if (o == null || getClass() != o.getClass()) return false;

--- a/core/src/test/java/org/infinispan/metadata/InternalMetadataTest.java
+++ b/core/src/test/java/org/infinispan/metadata/InternalMetadataTest.java
@@ -124,6 +124,11 @@ public class InternalMetadataTest {
       }
 
       @Override
+      public Builder merge(Metadata metadata) {
+         return this;
+      }
+
+      @Override
       public boolean equals(Object o) {
          if (this == o) return true;
          if (o == null || getClass() != o.getClass()) return false;

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/metadata/MimeMetadataHelper.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/metadata/MimeMetadataHelper.java
@@ -4,6 +4,7 @@ import org.infinispan.marshall.core.MarshalledEntry;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.metadata.impl.InternalMetadataImpl;
 import org.infinispan.rest.MimeMetadata;
+import org.infinispan.rest.MimeMetadataBuilder;
 
 import java.util.concurrent.TimeUnit;
 
@@ -19,7 +20,9 @@ public class MimeMetadataHelper implements MetadataHelper {
 
    @Override
    public Metadata buildMetadata(String contentType, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
-      return MimeMetadata.apply(contentType, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+      MimeMetadataBuilder builder = new MimeMetadataBuilder();
+      builder.contentType(contentType).lifespan(lifespan, lifespanUnit).maxIdle(maxIdle, maxIdleUnit);
+      return builder.build();
    }
 
 }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/expiration/ExpirationIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/expiration/ExpirationIT.java
@@ -79,7 +79,9 @@ public class ExpirationIT {
         sleepForSecs(1);
         // k1 expired
         head(key1Path, HttpServletResponse.SC_NOT_FOUND);
-        get(key2Path, "v2");
+        // k2 should be expired too because without timeToLive/maxIdle parameters,
+        // the servers defaults are used.
+        head(key2Path, HttpServletResponse.SC_NOT_FOUND);
     }
 
     @Test

--- a/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedDecoder.scala
+++ b/server/memcached/src/main/scala/org/infinispan/server/memcached/MemcachedDecoder.scala
@@ -474,9 +474,13 @@ class MemcachedDecoder(memcachedCache: AdvancedCache[String, Array[Byte]], sched
    }
 
    override protected def buildMetadata(): Metadata = {
-      val version = generateVersion(cache)
-      MemcachedMetadata(params.flags, version,
-         toMillis(params.lifespan), MILLIS, defaultMaxIdleTime, MILLIS)
+      val metadata = new MemcachedMetadataBuilder
+      metadata.version(generateVersion(cache))
+      metadata.flags(params.flags)
+      if (params.lifespan > 0)
+         metadata.lifespan(toMillis(params.lifespan))
+
+      metadata.build()
    }
 
    private def logAndCreateErrorMessage(sb: StringBuilder, m: MemcachedException): StringBuilder = {

--- a/server/rest/src/main/scala/org/infinispan/rest/Server.scala
+++ b/server/rest/src/main/scala/org/infinispan/rest/Server.scala
@@ -423,17 +423,23 @@ class Server(@Context request: Request, @Context servletContext: ServletContext,
    }
 
    def createMetadata(cfg: Configuration, dataType: String, ttl: Long, idleTime: Long): Metadata = {
+      val metadata = new MimeMetadataBuilder
+      metadata.contentType(dataType)
       (ttl, idleTime) match {
-         case (0, 0) => MimeMetadata(dataType,
-            cfg.expiration().lifespan(), MILLIS,
-            cfg.expiration().maxIdle(), MILLIS)
+         case (0, 0) =>
+            metadata.lifespan(cfg.expiration().lifespan(), MILLIS)
+                  .maxIdle(cfg.expiration().maxIdle(), MILLIS)
          case (0, maxIdle) =>
-            MimeMetadata(dataType, cfg.expiration().lifespan(), MILLIS, maxIdle, SECS)
+            metadata.lifespan(cfg.expiration().lifespan(), MILLIS)
+                  .maxIdle(maxIdle, SECS)
          case (lifespan, 0) =>
-            MimeMetadata(dataType, lifespan, SECS, cfg.expiration().maxIdle(), MILLIS)
+            metadata.lifespan(lifespan, SECS)
+                  .maxIdle(cfg.expiration().maxIdle(), MILLIS)
          case (lifespan, maxIdle) =>
-            MimeMetadata(dataType, lifespan, SECS, maxIdle, SECS)
+            metadata.lifespan(lifespan, SECS)
+                  .maxIdle(maxIdle, SECS)
       }
+      metadata.build()
    }
 
    private def putOrReplace(cache: AdvancedCache[String, Array[Byte]],


### PR DESCRIPTION
- This is required in order to be able to apply default lifespan and max idle settings configured globally for the cache.
- To do so, a new method has been added to builder that allows a Metadata object to be merged with the builder instance.
- By making the default metadata builder implementation use objects for primitives, it can easily distinguish between those settings that have been set by the user versus the builder defaults.
