### PR TITLE
Ispn 4951 Entry Retriever iterator should rethrow caused exception

### DIFF
--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -31,6 +31,7 @@ import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.commands.tx.VersionedCommitCommand;
 import org.infinispan.commands.tx.VersionedPrepareCommand;
 import org.infinispan.commands.write.*;
+import org.infinispan.commons.CacheException;
 import org.infinispan.context.Flag;
 import org.infinispan.distexec.mapreduce.Mapper;
 import org.infinispan.distexec.mapreduce.Reducer;
@@ -50,6 +51,7 @@ import org.infinispan.xsite.statetransfer.XSiteStatePushCommand;
 import org.infinispan.xsite.statetransfer.XSiteStateTransferControlCommand;
 
 import javax.transaction.xa.Xid;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -448,12 +450,14 @@ public interface CommandsFactory {
     * @param inDoubtSegments The segements that are now in doubt meaning they must be retrieved again from another
     *                        node due to rehash
     * @param values The entries retrieved from the remote node
+    * @param e If an exception occurred while running the processing on the remote node
     * @param <K> The key type of the stored key
     * @param <C> The converted type after the value is applied from the converter
     * @return The EntryResponseCommand created
     */
    <K, C> EntryResponseCommand<K, C> buildEntryResponseCommand(UUID identifier, Set<Integer> completedSegments,
-                                                         Set<Integer> inDoubtSegments, Collection<CacheEntry<K, C>> values);
+                                                         Set<Integer> inDoubtSegments, Collection<CacheEntry<K, C>> values,
+                                                         CacheException e);
 
    /**
     * Builds {@link org.infinispan.commands.remote.GetKeysInGroupCommand} used to fetch all the keys belonging to a group.

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -48,6 +48,7 @@ import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.commons.CacheException;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.InternalEntryFactory;
@@ -617,11 +618,11 @@ public class CommandsFactoryImpl implements CommandsFactory {
    }
 
    @Override
-   public <K, C> EntryResponseCommand buildEntryResponseCommand(UUID identifier, Set<Integer> completedSegments,
+   public <K, C> EntryResponseCommand<K, C> buildEntryResponseCommand(UUID identifier, Set<Integer> completedSegments,
                                                                 Set<Integer> inDoubtSegments,
-                                                                Collection<CacheEntry<K, C>> values) {
-      return new EntryResponseCommand(cache.getCacheManager().getAddress(), cacheName, identifier, completedSegments,
-                                      inDoubtSegments, values);
+                                                                Collection<CacheEntry<K, C>> values, CacheException e) {
+      return new EntryResponseCommand<>(cache.getCacheManager().getAddress(), cacheName, identifier, completedSegments,
+                                      inDoubtSegments, values, e);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/iteration/impl/EntryRetriever.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/EntryRetriever.java
@@ -1,5 +1,6 @@
 package org.infinispan.iteration.impl;
 
+import org.infinispan.commons.CacheException;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
@@ -41,10 +42,11 @@ public interface EntryRetriever<K, V> {
     * @param completedSegments Which segments have been completed
     * @param inDoubtSegments Which segments are now in doubt due to a rehash
     * @param entries The entries retrieved
+    * @param e If an exception handled while processing the data on the remote node
     * @param <C> The type of entries values sent back
     */
    public <C> void receiveResponse(UUID identifier, Address origin, Set<Integer> completedSegments,
-                                   Set<Integer> inDoubtSegments, Collection<CacheEntry<K, C>> entries);
+                                   Set<Integer> inDoubtSegments, Collection<CacheEntry<K, C>> entries, CacheException e);
 
    /**
     * This is invoked locally on the node that requested the iteration process.  This method will return immediately

--- a/core/src/main/java/org/infinispan/iteration/impl/LocalEntryRetriever.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/LocalEntryRetriever.java
@@ -169,7 +169,7 @@ public class LocalEntryRetriever<K, V> implements EntryRetriever<K, V> {
 
    @Override
    public <C> void receiveResponse(UUID identifier, Address origin, Set<Integer> completedSegments, Set<Integer> inDoubtSegments,
-                                   Collection<CacheEntry<K, C>> entries) {
+                                   Collection<CacheEntry<K, C>> entries, CacheException e) {
       throw new UnsupportedOperationException();
    }
 
@@ -340,9 +340,9 @@ public class LocalEntryRetriever<K, V> implements EntryRetriever<K, V> {
 
                handler.handleBatch(true, queue);
                partitionListener.iterators.remove(iterator);
-            } catch (Throwable e) {
-               //todo [anistor] any exception happening during entry retrieval should stop the process and throw an exception to the requestor instead of timing out
-               log.exceptionProcessingEntryRetrievalValues(e);
+            } catch (Throwable t) {
+               CacheException e = log.exceptionProcessingEntryRetrievalValues(t);
+               iterator.close(e);
             }
          }
       });

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1104,13 +1104,11 @@ public interface Log extends BasicLogger {
    @Message(value = "Unable to acquire lock after %s for key %s and requestor %s. Lock is held by %s, while request came from %s", id = 299)
    TimeoutException unableToAcquireLock(String timeout, Object key, Object requestor, Object owner, Address origin);
 
-   @LogMessage(level = WARN)
    @Message(value = "There was an exception while processing retrieval of entry values", id = 300)
-   void exceptionProcessingEntryRetrievalValues(@Cause Throwable cause);
+   CacheException exceptionProcessingEntryRetrievalValues(@Cause Throwable cause);
 
-   @LogMessage(level = WARN)
    @Message(value = "Iterator response for identifier %s encountered unexpected exception", id = 301)
-   void exceptionProcessingIteratorResponse(UUID identifier, @Cause Throwable cause);
+   CacheException exceptionProcessingIteratorResponse(UUID identifier, @Cause Throwable cause);
 
    @LogMessage(level = WARN)
    @Message(value = "Issue when retrieving transactions from %s, response was %s", id = 302)

--- a/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverExceptionTest.java
+++ b/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverExceptionTest.java
@@ -1,0 +1,55 @@
+package org.infinispan.iteration;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.testng.AssertJUnit.fail;
+import static org.testng.AssertJUnit.assertNotNull;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.CacheException;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.container.DataContainer;
+import org.infinispan.filter.AcceptAllKeyValueFilter;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.Test;
+
+/**
+ * Test to verify entry retriever exception propagation behavior for a distributed cache.
+ *
+ * @author wburns
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "iteration.DistributedEntryRetrieverExceptionTest")
+public class DistributedEntryRetrieverExceptionTest extends BaseSetupEntryRetrieverTest {
+   public DistributedEntryRetrieverExceptionTest() {
+      super(false, CacheMode.DIST_SYNC);
+   }
+   
+   public void ensureDataContainerRemoteExceptionPropagated() {
+      Cache cache0 = cache(0, CACHE_NAME);
+      Cache cache1 = cache(1, CACHE_NAME);
+      // Extract real one to replace after
+      DataContainer dataContainer = TestingUtil.extractComponent(cache1, DataContainer.class);
+      try {
+         Throwable t = new AssertionError();
+         DataContainer mockContainer = when(mock(DataContainer.class).iterator()).thenThrow(t).getMock();
+         TestingUtil.replaceComponent(cache1, DataContainer.class, mockContainer, true);
+         
+         try {
+            cache0.getAdvancedCache().filterEntries(AcceptAllKeyValueFilter.getInstance()).iterator().hasNext();
+            fail("We should have gotten a CacheException");
+         } catch (CacheException e) {
+            Throwable cause = e;
+            while ((cause = cause.getCause()) != null) {
+               if (t.getClass().isInstance(cause)) {
+                  break;
+               }
+            }
+            assertNotNull("We should have found the throwable as a cause", cause);
+         }
+      } finally {
+         TestingUtil.replaceComponent(cache1, DataContainer.class, dataContainer, true);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverTest.java
+++ b/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.iteration;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.CacheException;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.container.DataContainer;
@@ -384,7 +385,7 @@ public class DistributedEntryRetrieverTest extends BaseClusteredEntryRetrieverTe
             }
          }
       }).when(mockRetriever).receiveResponse(any(UUID.class), any(Address.class), anySetOf(Integer.class),
-                                             anySetOf(Integer.class), anyCollection());
+                                             anySetOf(Integer.class), anyCollection(), any(CacheException.class));
       TestingUtil.replaceComponent(cache, EntryRetriever.class, mockRetriever, true);
       return rpc;
    }

--- a/core/src/test/java/org/infinispan/iteration/LocalEntryRetrieverExceptionTest.java
+++ b/core/src/test/java/org/infinispan/iteration/LocalEntryRetrieverExceptionTest.java
@@ -1,0 +1,54 @@
+package org.infinispan.iteration;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.testng.AssertJUnit.fail;
+import static org.testng.AssertJUnit.assertNotNull;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.CacheException;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.container.DataContainer;
+import org.infinispan.filter.AcceptAllKeyValueFilter;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.Test;
+
+/**
+ * Test to verify entry retriever exception propagation behavior for a local cache.
+ *
+ * @author wburns
+ * @since 7.0
+ */
+@Test(groups = "functional", testName = "iteration.LocalEntryRetrieverExceptionTest")
+public class LocalEntryRetrieverExceptionTest extends BaseSetupEntryRetrieverTest {
+   public LocalEntryRetrieverExceptionTest() {
+      super(false, CacheMode.LOCAL);
+   }
+   
+   public void ensureDataContainerExceptionPropagated() {
+      Cache cache = cache(0, CACHE_NAME);
+      // Extract real one to replace after
+      DataContainer dataContainer = TestingUtil.extractComponent(cache, DataContainer.class);
+      try {
+         Throwable t = new AssertionError();
+         DataContainer mockContainer = when(mock(DataContainer.class).iterator()).thenThrow(t).getMock();
+         TestingUtil.replaceComponent(cache, DataContainer.class, mockContainer, true);
+         
+         try {
+            cache.getAdvancedCache().filterEntries(AcceptAllKeyValueFilter.getInstance()).iterator().hasNext();
+            fail("We should have gotten a CacheException");
+         } catch (CacheException e) {
+            Throwable cause = e;
+            while ((cause = cause.getCause()) != null) {
+               if (cause == t) {
+                  break;
+               }
+            }
+            assertNotNull("We should have found the throwable as a cause", cause);
+         }
+      } finally {
+         TestingUtil.replaceComponent(cache, DataContainer.class, dataContainer, true);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/partitionhandling/EntryRetrieverDistPartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/EntryRetrieverDistPartitionHandlingTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.partitionhandling;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.CacheException;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
@@ -197,7 +198,7 @@ public class EntryRetrieverDistPartitionHandlingTest extends BasePartitionHandli
             }
          }
       }).when(mockRetriever).receiveResponse(any(UUID.class), any(Address.class), anySetOf(Integer.class),
-                                             anySetOf(Integer.class), anyCollectionOf(CacheEntry.class));
+                                             anySetOf(Integer.class), anyCollectionOf(CacheEntry.class), any(CacheException.class));
       TestingUtil.replaceComponent(cache, EntryRetriever.class, mockRetriever, true);
       return retriever;
    }

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -35,6 +35,7 @@ import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.commands.tx.VersionedCommitCommand;
 import org.infinispan.commands.tx.VersionedPrepareCommand;
 import org.infinispan.commands.write.*;
+import org.infinispan.commons.CacheException;
 import org.infinispan.context.Flag;
 import org.infinispan.distexec.mapreduce.Mapper;
 import org.infinispan.distexec.mapreduce.Reducer;
@@ -58,6 +59,7 @@ import org.infinispan.xsite.statetransfer.XSiteStatePushCommand;
 import org.infinispan.xsite.statetransfer.XSiteStateTransferControlCommand;
 
 import javax.transaction.xa.Xid;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -364,9 +366,10 @@ public class ControlledCommandFactory implements CommandsFactory {
    }
 
    @Override
-   public <K, C> EntryResponseCommand buildEntryResponseCommand(UUID identifier, Set<Integer> completedSegments,
-                                                                Set<Integer> inDoubtSegments, Collection<CacheEntry<K, C>> values) {
-      return actual.buildEntryResponseCommand(identifier, completedSegments, inDoubtSegments, values);
+   public <K, C> EntryResponseCommand<K, C> buildEntryResponseCommand(UUID identifier, Set<Integer> completedSegments,
+                                                                Set<Integer> inDoubtSegments, Collection<CacheEntry<K, C>> values,
+                                                                CacheException e) {
+      return actual.buildEntryResponseCommand(identifier, completedSegments, inDoubtSegments, values, e);
    }
 
    @Override


### PR DESCRIPTION
- Pass along any local throwable to iterator
- If remote node receives throwable propagate that as a response

https://issues.jboss.org/browse/ISPN-4951
