### PR TITLE
ISPN-4945 Remote removed events should not be fired when not removed

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientEventsTest.java
@@ -57,6 +57,8 @@ public class ClientEventsTest extends SingleHotRodServerTest {
          public void call() {
             RemoteCache<Integer, String> cache = rcm.getCache();
             eventListener.expectNoEvents();
+            cache.remove(1);
+            eventListener.expectNoEvents();
             cache.put(1, "one");
             eventListener.expectOnlyCreatedEvent(1, cache());
             cache.remove(1);

--- a/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
@@ -175,6 +175,13 @@ provide information on the affected key, and the version of the entry. This
 version can be used to invoke conditional operations on the server, such as
 `replaceWithVersion` or `removeWithVersion`.
 
+`ClientCacheEntryRemovedEvent` events are only sent when the remove operation
+succeeds. In other words, if a remove operation is invoked but no entry is
+found or no entry should be removed, no event is generated. Users interested
+in removed events, even when no entry was removed, can develop event
+customization logic to generate such events. More information can be found
+in the link:$$#_customizing_client_events_contents$$[customizing client events section].
+
 All `ClientCacheEntryCreatedEvent`, `ClientCacheEntryModifiedEvent` and
 `ClientCacheEntryRemovedEvent` event instances also provide a `boolean isCommandRetried()`
 method that will return true if the write command that caused this had to be retried

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedHotRodTest.java
@@ -187,6 +187,8 @@ public class EmbeddedHotRodTest extends AbstractInfinispanTest {
       remote.addClientListener(eventListener);
       try {
          eventListener.expectNoEvents();
+         remote.remove(1);
+         eventListener.expectNoEvents();
          remote.put(1, "one");
          assertEquals("one", embedded.get(1));
          eventListener.expectOnlyCreatedEvent(1, embedded);

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/HotRodCustomEventsTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/HotRodCustomEventsTest.scala
@@ -29,6 +29,8 @@ class HotRodCustomEventsTest extends HotRodSingleNodeTest {
       withClientListener(converterFactory = Some(("static-converter-factory", List.empty))) { () =>
          eventListener.expectNoEvents()
          val key = k(m)
+         client.remove(key)
+         eventListener.expectNoEvents()
          val keyLength = key.length.toByte
          val value = v(m)
          val valueLength = value.length.toByte

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/HotRodEventsTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/HotRodEventsTest.scala
@@ -39,6 +39,8 @@ class HotRodEventsTest extends HotRodSingleNodeTest {
       withClientListener() { () =>
          eventListener.expectNoEvents()
          val key = k(m)
+         client.remove(key)
+         eventListener.expectNoEvents()
          client.put(key, 0, 0, v(m))
          eventListener.expectOnlyCreatedEvent(key)
          client.remove(key)

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/HotRodFilterEventsTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/event/HotRodFilterEventsTest.scala
@@ -30,6 +30,8 @@ class HotRodFilterEventsTest extends HotRodSingleNodeTest {
       withClientListener(filterFactory = Some(("static-filter-factory", List.empty))) { () =>
          eventListener.expectNoEvents()
          val key = k(m)
+         client.remove(key)
+         eventListener.expectNoEvents()
          client.put(key, 0, 0, v(m))
          eventListener.expectNoEvents()
          client.put(acceptedKey, 0, 0, v(m))


### PR DESCRIPTION
- A NPE was being thrown when using remote events, with a remove entry event listener, and removing a non-existing entry.
- No remote removed events are thrown when nothing is removed. This can be changed by the user with custom events.
