### PR TITLE
[6.0.x] ISPN-4969 Stopping a cache will stop all KeyAffinityServices created for other caches in the cache manager

### DIFF
--- a/core/src/main/java/org/infinispan/affinity/KeyAffinityServiceImpl.java
+++ b/core/src/main/java/org/infinispan/affinity/KeyAffinityServiceImpl.java
@@ -199,8 +199,10 @@ public class KeyAffinityServiceImpl<K> implements KeyAffinityService<K> {
    }
 
    public void handleCacheStopped(CacheStoppedEvent cse) {
-      log.tracef("Cache stopped, stopping the service: %s", cse);
-      stop();
+      if (this.cache.getName().equals(cse.getCacheName())) {
+         log.tracef("Cache stopped, stopping the service: %s", cse);
+         stop();
+      }
    }
 
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4969

This will require a 6.0.3.Final release for use by WildFly 8.2.
