### PR TITLE
ISPN-4942 Make uber jars compatible with OSGi

### DIFF
--- a/all/embedded/pom.xml
+++ b/all/embedded/pom.xml
@@ -10,7 +10,7 @@
    </parent>
 
    <artifactId>infinispan-embedded</artifactId>
-   <packaging>jar</packaging>
+   <packaging>bundle</packaging>
    <name>Infinispan Embedded</name>
    <description>Infinispan Embedded All-in-One module</description>
 
@@ -98,15 +98,46 @@
          <artifactId>hibernate-jpa-2.1-api</artifactId>
          <scope>provided</scope>
       </dependency>
+
+      <dependency>
+         <groupId>org.osgi</groupId>
+         <artifactId>org.osgi.core</artifactId>
+         <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.osgi</groupId>
+         <artifactId>org.osgi.compendium</artifactId>
+         <scope>provided</scope>
+      </dependency>
    </dependencies>
 
    <build>
+      <finalName>${project.artifactId}-${project.version}</finalName>
+      <resources>
+         <resource>
+            <directory>${project.basedir}/src/main/resources</directory>
+            <filtering>true</filtering>
+            <includes>
+               <include>features.xml</include>
+               <include>OSGI-INF/blueprint/blueprint.xml</include>
+            </includes>
+         </resource>
+         <resource>
+            <directory>${project.basedir}/target/classes</directory>
+            <filtering>false</filtering>
+            <includes>
+               <include>**/*</include>
+            </includes>
+         </resource>
+      </resources>
       <plugins>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
             <executions>
                <execution>
+                  <id>none-default</id>
                   <phase>package</phase>
                   <goals>
                      <goal>shade</goal>
@@ -127,6 +158,7 @@
                            <exclude>javax.inject:javax.inject:jar:</exclude>
                            <exclude>org.osgi:org.osgi.core:jar:</exclude>
                            <exclude>org.osgi:org.osgi.compendium:jar:</exclude>
+                           <exclude>com.google.code.findbugs:jsr305:jar:</exclude>
                         </excludes>
                      </artifactSet>
                      <filters>
@@ -163,7 +195,6 @@
                         </transformer>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                            <resources>
-                              <resource>blueprint.xml</resource>
                               <resource>features.xml</resource>
                            </resources>
                         </transformer>
@@ -173,7 +204,149 @@
                </execution>
             </executions>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>unpack</id>
+                  <phase>package</phase>
+                  <goals>
+                     <goal>unpack</goal>
+                  </goals>
+                  <configuration>
+                     <artifactItems>
+                        <artifactItem>
+                           <groupId>${project.groupId}</groupId>
+                           <artifactId>${project.artifactId}</artifactId>
+                           <version>${project.version}</version>
+                           <type>jar</type>
+                           <overWrite>true</overWrite>
+                        </artifactItem>
+                     </artifactItems>
+                     <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <executions>
+               <execution>
+               <id>bundle-package</id>
+               <phase>package</phase>
+               <goals>
+                  <goal>bundle</goal>
+               </goals>
+               <configuration>
+                  <excludeDependencies>*</excludeDependencies>
+                  <instructions>
+                     <!-- Define packages from dependencies, exported further by current bundle -->
+                     <_exportcontents>
+                        org.infinispan.*,
+                        org.jboss.marshalling.*;version=${version.jboss.marshalling},
+                        org.jgroups.*;version=${version.jgroups},
+                     </_exportcontents>
+                     <Import-Package>
+                        !com.mchange.v2.c3p0,
+                        !com.sun.jmx.mbeanserver,
+                        !javax.cache.*,
+                        !javax.enterprise.*,
+                        !javax.inject.*,
+                        !javax.interceptor.*,
+                        !javax.persistence.*,
+                        !net.jcip.annotations,
+                        !org.apache.logging.*,
+                        !org.hibernate.*,
+                        !org.infinispan.*,
+                        !org.infinispan.client.*,
+                        !org.jgroups.*,
+                        !org.jboss.logmanager,
+                        !org.jboss.modules,
+                        !org.iq80.snappy,
+                        !org.jboss.marshalling.*,
+                        !org.xerial.snappy,
+                        !sun.misc,
+                        !sun.reflect,
+                        !sun.nio.ch,
+                        *
+                     </Import-Package>
+                     <DynamicImport-Package>*</DynamicImport-Package>
+                  </instructions>
+               </configuration>
+            </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>attach-artifacts</id>
+                  <phase>package</phase>
+                  <goals>
+                     <goal>attach-artifact</goal>
+                  </goals>
+                  <configuration>
+                     <artifacts>
+                        <artifact>
+                           <file>target/classes/features.xml</file>
+                           <type>xml</type>
+                           <classifier>features</classifier>
+                        </artifact>
+                     </artifacts>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>attach-sources</id>
+                  <phase>none</phase>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>build-test-jar</id>
+                  <phase>none</phase>
+               </execution>
+            </executions>
+         </plugin>
       </plugins>
+      <pluginManagement>
+         <plugins>
+            <plugin>
+               <groupId>org.eclipse.m2e</groupId>
+               <artifactId>lifecycle-mapping</artifactId>
+               <version>1.0.0</version>
+               <configuration>
+                  <lifecycleMappingMetadata>
+                     <pluginExecutions>
+                        <pluginExecution>
+                           <pluginExecutionFilter>
+                              <groupId>org.apache.felix</groupId>
+                              <artifactId>maven-bundle-plugin</artifactId>
+                              <versionRange>[2.4.0,)</versionRange>
+                              <goals>
+                                 <goal>cleanVersions</goal>
+                              </goals>
+                           </pluginExecutionFilter>
+                           <action>
+                              <ignore />
+                           </action>
+                        </pluginExecution>
+                     </pluginExecutions>
+                  </lifecycleMappingMetadata>
+               </configuration>
+            </plugin>
+         </plugins>
+      </pluginManagement>
    </build>
 
 </project>

--- a/all/embedded/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/all/embedded/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<blueprint  default-activation="eager" 
+            xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <bean id="parser71" class="org.infinispan.configuration.parsing.Parser71"/>
+    <service ref="parser71" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
+
+    <bean id="defaultMapReduceTaskLifecycle" class="org.infinispan.distexec.mapreduce.spi.DefaultMapReduceTaskLifecycle"/>
+    <service ref="defaultMapReduceTaskLifecycle" interface="org.infinispan.distexec.mapreduce.spi.MapReduceTaskLifecycle"/>
+
+    <bean id="defaultDistributedTaskLifecycle" class="org.infinispan.distexec.spi.DefaultDistributedTaskLifecycle"/>
+    <service ref="defaultDistributedTaskLifecycle" interface="org.infinispan.distexec.spi.DistributedTaskLifecycle"/>
+
+    <bean id="jdbcStoreConfigurationParser71" class="org.infinispan.persistence.jdbc.configuration.JdbcStoreConfigurationParser71"/>
+    <service ref="jdbcStoreConfigurationParser71" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
+
+    <bean id="levelDBStoreConfigurationParser71" class="org.infinispan.persistence.leveldb.configuration.LevelDBStoreConfigurationParser71"/>
+    <service ref="levelDBStoreConfigurationParser71" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
+
+    <bean id="remoteStoreConfigurationParser71" class="org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationParser71"/>
+    <service ref="remoteStoreConfigurationParser71" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
+
+    <bean id="hotRodTargetMigrator" class="org.infinispan.persistence.remote.upgrade.HotRodTargetMigrator"/>
+    <service ref="hotRodTargetMigrator" interface="org.infinispan.upgrade.TargetMigrator"/>
+
+    <bean id="clInterfaceLoaderConfigurationParser71" class="org.infinispan.persistence.cli.configuration.CLInterfaceLoaderConfigurationParser71"/>
+    <service ref="clInterfaceLoaderConfigurationParser71" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
+
+    <bean id="clInterfaceTargetMigrator" class="org.infinispan.persistence.cli.upgrade.CLInterfaceTargetMigrator"/>
+    <service ref="clInterfaceTargetMigrator" interface="org.infinispan.upgrade.TargetMigrator"/>
+  
+</blueprint>

--- a/all/embedded/src/main/resources/features.xml
+++ b/all/embedded/src/main/resources/features.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="infinispan-embedded-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
+   <feature name="infinispan-embedded" version="${project.version}">
+      <feature>transaction</feature>
+      <bundle>mvn:org.infinispan/infinispan-embedded/${project.version}</bundle>
+   </feature>
+   <!-- c3p0 dependencies required only when using PooledConnectionFactory with JDBC cache store -->
+   <feature name="c3p0" version="${project.version}">
+      <bundle>wrap:mvn:com.mchange/c3p0/${version.c3p0}$DynamicImport-Package=*</bundle>
+      <bundle>wrap:mvn:com.mchange/mchange-commons-java/${version.c3p0_dep.mchange-commons-java}</bundle>
+   </feature>
+   <!-- Hibernate dependencies required only when using JPACacheStore -->
+   <feature name="hibernate" version="${project.version}">
+      <feature>jndi</feature>
+      <!-- hibernate -->
+      <bundle>mvn:org.hibernate/hibernate-core/${version.hibernate.core}</bundle>
+      <bundle>mvn:org.hibernate/hibernate-entitymanager/${version.hibernate.entitymanager}</bundle>
+      <bundle>mvn:org.hibernate/hibernate-osgi/${version.hibernate.osgi}</bundle>
+      <bundle>mvn:org.hibernate.javax.persistence/hibernate-jpa-2.1-api/${version.hibernate.javax.persistence}</bundle>
+      <!-- hibernate's dependencies -->
+      <bundle>mvn:org.jboss.logging/jboss-logging/${version.jboss.logging}</bundle>
+      <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.antlr/${version.hibernate_dep.antlr}</bundle>
+      <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/${version.hibernate_dep.dom4j}</bundle>
+      <bundle>mvn:com.fasterxml/classmate/${version.hibernate_dep.classmate}</bundle>
+      <bundle>mvn:org.javassist/javassist/${version.hibernate_dep.javaassist}</bundle>
+      <bundle>wrap:mvn:org.hibernate.common/hibernate-commons-annotations/${version.hibernate_dep.hibernate-commons-annotations}</bundle>
+      <bundle>wrap:mvn:org.jboss/jandex/${version.hibernate_dep.jandex}</bundle>
+   </feature>
+</features>

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -3,9 +3,9 @@
    <modelVersion>4.0.0</modelVersion>
    <parent>
       <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-bom</artifactId>
+      <artifactId>infinispan-parent</artifactId>
       <version>7.1.0-SNAPSHOT</version>
-      <relativePath>../bom/pom.xml</relativePath>
+      <relativePath>../parent/pom.xml</relativePath>
    </parent>
    <artifactId>infinispan-all-parent</artifactId>
    <name>Parent pom for uberjar modules</name>

--- a/all/remote/pom.xml
+++ b/all/remote/pom.xml
@@ -44,18 +44,6 @@
       </dependency>
 
       <dependency>
-         <groupId>org.infinispan</groupId>
-         <artifactId>infinispan-cdi</artifactId>
-         <optional>true</optional>
-         <exclusions>
-            <exclusion>
-               <groupId>org.infinispan</groupId>
-               <artifactId>infinispan-core</artifactId>
-            </exclusion>
-         </exclusions>
-      </dependency>
-
-      <dependency>
          <groupId>org.jboss.marshalling</groupId>
          <artifactId>jboss-marshalling-osgi</artifactId>
          <optional>true</optional>
@@ -63,10 +51,23 @@
    </dependencies>
 
    <build>
-      <pluginManagement>
-         <plugins>
-         </plugins>
-      </pluginManagement>
+      <finalName>${project.artifactId}-${project.version}</finalName>
+      <resources>
+         <resource>
+            <directory>${project.basedir}/src/main/resources</directory>
+            <filtering>true</filtering>
+            <includes>
+               <include>features.xml</include>
+            </includes>
+         </resource>
+         <resource>
+            <directory>${project.basedir}/target/classes</directory>
+            <filtering>false</filtering>
+            <includes>
+               <include>**/*</include>
+            </includes>
+         </resource>
+      </resources>
       <plugins>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -126,7 +127,137 @@
                </execution>
             </executions>
          </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>unpack</id>
+                  <phase>package</phase>
+                  <goals>
+                     <goal>unpack</goal>
+                  </goals>
+                  <configuration>
+                     <artifactItems>
+                        <artifactItem>
+                           <groupId>${project.groupId}</groupId>
+                           <artifactId>${project.artifactId}</artifactId>
+                           <version>${project.version}</version>
+                           <type>jar</type>
+                           <overWrite>true</overWrite>
+                        </artifactItem>
+                     </artifactItems>
+                     <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>bundle-package</id>
+                  <phase>package</phase>
+                  <goals>
+                     <goal>bundle</goal>
+                  </goals>
+                  <configuration>
+                     <excludeDependencies>*</excludeDependencies>
+                     <instructions>
+                        <!-- Define packages from dependencies, exported further by current bundle -->
+                        <_exportcontents>
+                           org.infinispan.client.hotrod.*,
+                           org.infinispan.commons.*,
+                           org.infinispan.query.*,
+                           org.infinispan.protostream;version=${version.protostream}
+                        </_exportcontents>
+                        <Export-Package>
+                           !${project.groupId}.*.logging
+                        </Export-Package>
+                        <Import-Package>
+                           !sun.misc,
+                           !sun.reflect,
+                           !net.jcip.annotations,
+                           !org.jboss.logmanager,
+                           !org.jboss.modules,
+                           *
+                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                     </instructions>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>attach-artifacts</id>
+                  <phase>package</phase>
+                  <goals>
+                     <goal>attach-artifact</goal>
+                  </goals>
+                  <configuration>
+                     <artifacts>
+                        <artifact>
+                           <file>target/classes/features.xml</file>
+                           <type>xml</type>
+                           <classifier>features</classifier>
+                        </artifact>
+                     </artifacts>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>attach-sources</id>
+                  <phase>none</phase>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>build-test-jar</id>
+                  <phase>none</phase>
+               </execution>
+            </executions>
+         </plugin>
       </plugins>
+      <pluginManagement>
+         <plugins>
+            <plugin>
+               <groupId>org.eclipse.m2e</groupId>
+               <artifactId>lifecycle-mapping</artifactId>
+               <version>1.0.0</version>
+               <configuration>
+                  <lifecycleMappingMetadata>
+                     <pluginExecutions>
+                        <pluginExecution>
+                           <pluginExecutionFilter>
+                              <groupId>org.apache.felix</groupId>
+                              <artifactId>maven-bundle-plugin</artifactId>
+                              <versionRange>[2.4.0,)</versionRange>
+                              <goals>
+                                 <goal>cleanVersions</goal>
+                              </goals>
+                           </pluginExecutionFilter>
+                           <action>
+                              <ignore />
+                           </action>
+                        </pluginExecution>
+                     </pluginExecutions>
+                  </lifecycleMappingMetadata>
+               </configuration>
+            </plugin>
+         </plugins>
+      </pluginManagement>
    </build>
 
 </project>

--- a/all/remote/src/main/resources/features.xml
+++ b/all/remote/src/main/resources/features.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="infinispan-remote-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
+   <feature name="infinispan-remote" version="${project.version}">
+      <bundle>mvn:org.infinispan/infinispan-remote/${project.version}</bundle>
+   </feature>
+</features>

--- a/integrationtests/osgi/pom.xml
+++ b/integrationtests/osgi/pom.xml
@@ -66,6 +66,11 @@
          <scope>test</scope>
       </dependency>
       <dependency>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>infinispan-embedded</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+      <dependency>
          <groupId>org.hibernate</groupId>
          <artifactId>hibernate-core</artifactId>
          <scope>test</scope>
@@ -249,7 +254,6 @@
                </properties>
             </configuration>
             <executions>
-               
                <execution>
                   <id>default-test</id>
                   <phase>test</phase>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1665,7 +1665,6 @@
          </activation>
          <build>
             <plugins>
-               
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-source-plugin</artifactId>

--- a/server/integration/testsuite/pom.xml
+++ b/server/integration/testsuite/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>infinispan-commons</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-remote</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>net.jcip</groupId>
             <artifactId>jcip-annotations</artifactId>
         </dependency>

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/osgi/RemoteCacheOsgiIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/osgi/RemoteCacheOsgiIT.java
@@ -37,6 +37,7 @@ import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.osgi.framework.Bundle;
 
+import java.io.File;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
@@ -71,12 +72,12 @@ public class RemoteCacheOsgiIT extends KarafTestSupport {
       return new Option[] {
             KarafDistributionOption
                   .karafDistributionConfiguration()
+                  .unpackDirectory(new File("target/pax"))
                   .frameworkUrl(
                         maven().groupId("org.apache.karaf").artifactId("apache-karaf").type("zip")
                               .version(KARAF_VERSION)).karafVersion(KARAF_VERSION),
-            //install HotRod client feature ("feature" is a set of bundles, all the bundles are installed at once)
-            KarafDistributionOption.features(maven().groupId("org.infinispan").artifactId("infinispan-client-hotrod")
-                  .type("xml").classifier("features").versionAsInProject(), "hotrod-client-with-query"),
+            KarafDistributionOption.features(maven().groupId("org.infinispan").artifactId("infinispan-remote")
+                                                   .type("xml").classifier("features").versionAsInProject(), "infinispan-remote"),
             KarafDistributionOption.features(new RawUrlReference("file:///" + RESOURCES_DIR.replace("\\", "/")
                   + "/test-features.xml"), "query-sample-domain"),
             KarafDistributionOption.editConfigurationFileExtend("etc/jre.properties", "jre-1.7", "sun.misc"),

--- a/server/integration/testsuite/src/test/resources/test-features.xml
+++ b/server/integration/testsuite/src/test/resources/test-features.xml
@@ -3,5 +3,10 @@
     <feature name="query-sample-domain" version="${project.version}">
         <bundle>mvn:org.infinispan.protostream/sample-domain-implementation/${version.org.infinispan.protostream}</bundle>
         <bundle>mvn:org.infinispan.protostream/sample-domain-definition/${version.org.infinispan.protostream}</bundle>
+        <!-- protobuf-java and protoparser packages are required by sample-domain-implementation
+             and sample-domain-definition. These packages are also included in infinispan-remote uber-jar
+             but are NOT exported further so we need to install them separately, just for the tests. -->
+        <bundle>mvn:com.google.protobuf/protobuf-java/${version.protobuf}</bundle>
+        <bundle>wrap:mvn:com.squareup/protoparser/${version.org.infinispan.protostream}</bundle>
     </feature>
 </features>

--- a/server/integration/versions/pom.xml
+++ b/server/integration/versions/pom.xml
@@ -39,6 +39,7 @@
       <version.org.xerial.snappy>1.0.5</version.org.xerial.snappy>
       <version.xml.maven.plugin>1.0</version.xml.maven.plugin>
       <version.org.infinispan.protostream>2.0.2.Final</version.org.infinispan.protostream>
+      <version.protobuf>2.6.0</version.protobuf>
       <version.http.client>4.3</version.http.client>
       <version.org.picketbox>4.0.17.SP2</version.org.picketbox>
       <version.xpp3>1.1.4c</version.xpp3>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4942

All existing tests for OSGi are passing with these changes.

We could possibly remove the features file for infinispan-remote completely because the jar can be installed directly.
