### PR TITLE
ISPN-4939 Always include the clean goal as part of the lifecycle of the uberjar builds to avoid stale data

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -20,6 +20,20 @@
          <plugins>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-clean-plugin</artifactId>
+               <version>2.6.1</version>
+               <executions>
+                  <execution>
+                     <id>mrproper</id>
+                     <phase>initialize</phase>
+                     <goals>
+                        <goal>clean</goal>
+                     </goals>
+                  </execution>
+               </executions>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-shade-plugin</artifactId>
                <version>2.3</version>
             </plugin>

--- a/bin/generateJmxDocs.sh
+++ b/bin/generateJmxDocs.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-mvn install -Dmaven.test.skip.exec=true -Pjmxdoc
-

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -377,7 +377,7 @@ class DryRunUploader(DryRun):
 
 def maven_build_distribution(version):
   """Builds the distribution in the current working dir"""
-  mvn_commands = [["clean"], ["install", "-Pjmxdoc"],["install", "-Pgenerate-schema-doc"], ["deploy", "-Pdistribution,extras"]]
+  mvn_commands = [["clean"], ["install"], ["deploy", "-Pdistribution"]]
     
   for c in mvn_commands:
     c.append("-Dmaven.test.skip.exec=true")

--- a/documentation/src/main/asciidoc/contributing/chapter-3-Building_Infinispan.adoc
+++ b/documentation/src/main/asciidoc/contributing/chapter-3-Building_Infinispan.adoc
@@ -104,7 +104,6 @@ TIP: Maven places it's output in `target/`
 | `mvn install -DskipTests` |Installs the artifacts in your local repo for use by other projects/modules, including inter-module dependencies within the same project.
 | `mvn install -P distribution` | In addition to install, will also use Maven's assembly plugin to build ZIP files for distribution (in target/distribution ). Contents of various distribution are controlled by the files in src/main/resources/assemblies . 
 | `mvn deploy` |Builds and deploy the project to the JBoss snapshots repository.
-| `mvn -Pgenerate-schema-doc install -DskipTests -pl core` |Builds the configuration reference HTML file, often followed up with `firefox core/target/xsd_doc`
 | `mvn install -P-extras` |Avoids the extras profile disables the enforce plugin, generation of source jars and OSGI bundleconstruction, hence making builds run faster. Clearly, this option should not be used when making a release or publishing a snapshot.
 |===============
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1058,7 +1058,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-clean-plugin</artifactId>
-               <version>2.5</version>
+               <version>2.6.1</version>
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4939
ISPN-4939 Always include the clean goal as part of the lifecycle of the uberjar builds to avoid stale data
Remove references to old unused profiles in the documentation and the release script

Applies cleanly to both master and 7.0.x
