### PR TITLE
ISPN-4444 After state transfer, a node is able to read keys it no longer...

### DIFF
--- a/core/src/main/java/org/infinispan/container/DefaultDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/DefaultDataContainer.java
@@ -20,6 +20,7 @@ import org.infinispan.factories.annotations.Inject;
 import org.infinispan.filter.KeyFilter;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.filter.KeyValueFilter;
+import org.infinispan.metadata.impl.L1Metadata;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.util.CoreImmutables;
 import org.infinispan.util.TimeService;
@@ -162,12 +163,19 @@ public class DefaultDataContainer<K, V> implements DataContainer<K, V> {
 
    @Override
    public void put(K k, V v, Metadata metadata) {
+      boolean l1Entry = false;
+      if (metadata instanceof L1Metadata) {
+         metadata = ((L1Metadata) metadata).metadata();
+         l1Entry = true;
+      }
       InternalCacheEntry<K, V> e = entries.get(k);
 
       if (trace) {
          log.tracef("Creating new ICE for writing. Existing=%s, metadata=%s, new value=%s", e, metadata, v);
       }
-      if (e != null) {
+      if (l1Entry) {
+         e = entryFactory.createL1(k, v, metadata);
+      } else if (e != null) {
          e = entryFactory.update(e, v, metadata);
       } else {
          // this is a brand-new entry

--- a/core/src/main/java/org/infinispan/container/InternalEntryFactory.java
+++ b/core/src/main/java/org/infinispan/container/InternalEntryFactory.java
@@ -143,4 +143,14 @@ public interface InternalEntryFactory {
     * @param <V> The value type for the entry
     */
    <K, V> CacheEntry<K, V> copy(CacheEntry<K, V> cacheEntry);
+
+   /**
+    * Creates a L1 entry.
+    *
+    * @param <K> The key type for the entry
+    * @param <V> The value type for the entry
+    * @param key
+    *@param value @return a new {@link org.infinispan.container.entries.InternalCacheEntry}
+    */
+   <K, V> InternalCacheEntry<K, V> createL1(K key, V value, Metadata metadata);
 }

--- a/core/src/main/java/org/infinispan/container/InternalEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/InternalEntryFactoryImpl.java
@@ -1,18 +1,9 @@
 package org.infinispan.container;
 
+import org.infinispan.container.entries.*;
+import org.infinispan.container.entries.metadata.L1MetadataInternalCacheEntry;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.metadata.Metadata;
-import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.container.entries.ImmortalCacheEntry;
-import org.infinispan.container.entries.ImmortalCacheValue;
-import org.infinispan.container.entries.InternalCacheEntry;
-import org.infinispan.container.entries.InternalCacheValue;
-import org.infinispan.container.entries.MortalCacheEntry;
-import org.infinispan.container.entries.MortalCacheValue;
-import org.infinispan.container.entries.TransientCacheEntry;
-import org.infinispan.container.entries.TransientCacheValue;
-import org.infinispan.container.entries.TransientMortalCacheEntry;
-import org.infinispan.container.entries.TransientMortalCacheValue;
 import org.infinispan.container.entries.metadata.MetadataImmortalCacheEntry;
 import org.infinispan.container.entries.metadata.MetadataImmortalCacheValue;
 import org.infinispan.container.entries.metadata.MetadataMortalCacheEntry;
@@ -23,7 +14,6 @@ import org.infinispan.container.entries.metadata.MetadataTransientMortalCacheEnt
 import org.infinispan.container.entries.metadata.MetadataTransientMortalCacheValue;
 import org.infinispan.container.versioning.EntryVersion;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.util.CoreImmutables;
 import org.infinispan.util.TimeService;
 
 /**
@@ -173,6 +163,15 @@ public class InternalEntryFactoryImpl implements InternalEntryFactory {
    public CacheEntry copy(CacheEntry cacheEntry) {
       synchronized (cacheEntry) {
          return cacheEntry.clone();
+      }
+   }
+
+   @Override
+   public <K, V> InternalCacheEntry createL1(K key, V value, Metadata metadata) {
+      if (!isStoreMetadata(metadata)) {
+         return new L1InternalCacheEntry(key, value, metadata.lifespan(), timeService.wallClockTime());
+      } else {
+         return new L1MetadataInternalCacheEntry(key, value, metadata, timeService.wallClockTime());
       }
    }
 

--- a/core/src/main/java/org/infinispan/container/entries/AbstractInternalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/AbstractInternalCacheEntry.java
@@ -126,6 +126,11 @@ public abstract class AbstractInternalCacheEntry implements InternalCacheEntry {
    }
 
    @Override
+   public boolean isL1Entry() {
+      return false;
+   }
+
+   @Override
    public String toString() {
       return getClass().getSimpleName() + "{" +
             "key=" + key +

--- a/core/src/main/java/org/infinispan/container/entries/InternalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/InternalCacheEntry.java
@@ -75,6 +75,11 @@ public interface InternalCacheEntry<K, V> extends CacheEntry<K, V>, Cloneable {
    void reincarnate(long now);
 
    /**
+    * @return {@code true} if the entry is a L1 entry.
+    */
+   boolean isL1Entry();
+
+   /**
     * Creates a representation of this entry as an {@link org.infinispan.container.entries.InternalCacheValue}. The main
     * purpose of this is to provide a representation that does <i>not</i> have a reference to the key. This is useful in
     * situations where the key is already known or stored elsewhere, making serialization and deserialization more

--- a/core/src/main/java/org/infinispan/container/entries/L1InternalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/L1InternalCacheEntry.java
@@ -1,0 +1,19 @@
+package org.infinispan.container.entries;
+
+/**
+ * A {@link org.infinispan.container.entries.InternalCacheEntry} implementation to store a L1 entry.
+ *
+ * @author Pedro Ruivo
+ * @since 7.1
+ */
+public class L1InternalCacheEntry extends MortalCacheEntry {
+
+   public L1InternalCacheEntry(Object key, Object value, long lifespan, long created) {
+      super(key, value, lifespan, created);
+   }
+
+   @Override
+   public boolean isL1Entry() {
+      return true;
+   }
+}

--- a/core/src/main/java/org/infinispan/container/entries/metadata/L1MetadataInternalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/metadata/L1MetadataInternalCacheEntry.java
@@ -1,0 +1,21 @@
+package org.infinispan.container.entries.metadata;
+
+import org.infinispan.metadata.Metadata;
+
+/**
+ * A {@link org.infinispan.container.entries.InternalCacheEntry} implementation to store a L1 entry.
+ *
+ * @author Pedro Ruivo
+ * @since 7.1
+ */
+public class L1MetadataInternalCacheEntry extends MetadataMortalCacheEntry {
+
+   public L1MetadataInternalCacheEntry(Object key, Object value, Metadata metadata, long created) {
+      super(key, value, metadata, created);
+   }
+
+   @Override
+   public boolean isL1Entry() {
+      return true;
+   }
+}

--- a/core/src/main/java/org/infinispan/interceptors/ClusteringInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/ClusteringInterceptor.java
@@ -78,7 +78,18 @@ public abstract class ClusteringInterceptor extends BaseRpcInterceptor {
 
    protected boolean isValueAvailableLocally(ConsistentHash consistentHash, Object key) {
       final boolean isLocal = consistentHash.isKeyLocalToNode(rpcManager.getAddress(), key);
-      return isLocal || (isL1Enabled && dataContainer.containsKey(key));
+      final InternalCacheEntry ice = dataContainer.get(key);
+      return isLocal || (isL1Enabled && ice != null && ice.isL1Entry());
+   }
+
+   protected InternalCacheEntry fetchValueLocallyIfAvailable(ConsistentHash consistentHash, Object key) {
+      if (consistentHash.isKeyLocalToNode(rpcManager.getAddress(), key)) {
+         return dataContainer.get(key);
+      } else if (isL1Enabled) {
+         InternalCacheEntry entry = dataContainer.get(key);
+         return entry != null && entry.isL1Entry() ? entry : null;
+      }
+      return null;
    }
 
    /**

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1WriteSynchronizer.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1WriteSynchronizer.java
@@ -1,6 +1,7 @@
 package org.infinispan.interceptors.distribution;
 
 import org.infinispan.container.DataContainer;
+import org.infinispan.metadata.impl.L1Metadata;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.metadata.Metadata;
@@ -25,12 +26,13 @@ public class L1WriteSynchronizer {
    private final L1WriteSync sync = new L1WriteSync();
 
    private final long l1Lifespan;
-   private final DataContainer dc;
+   private final DataContainer<Object, Object> dc;
    private final StateTransferLock stateTransferLock;
    private final ClusteringDependentLogic cdl;
 
    public L1WriteSynchronizer(DataContainer dc, long l1Lifespan, StateTransferLock stateTransferLock,
                               ClusteringDependentLogic cdl) {
+      //noinspection unchecked
       this.dc = dc;
       this.l1Lifespan = l1Lifespan;
       this.stateTransferLock = stateTransferLock;
@@ -182,7 +184,7 @@ public class L1WriteSynchronizer {
                      // lifespan/maxIdle settings and send them a modification
                      Metadata newMetadata = ice.getMetadata().builder()
                            .lifespan(lifespan).maxIdle(-1).build();
-                     dc.put(key, ice.getValue(), newMetadata);
+                     dc.put(key, ice.getValue(), new L1Metadata(newMetadata));
                   } else {
                      log.tracef("Data container contained value after rehash for key %s", key);
                   }

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -285,7 +285,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
 
    private Object localGet(InvocationContext ctx, Object key, boolean isWrite,
          FlagAffectedCommand command, boolean isGetCacheEntry) throws Throwable {
-      InternalCacheEntry ice = dataContainer.get(key);
+      InternalCacheEntry ice = fetchValueLocallyIfAvailable(dm.getReadConsistentHash(), key);
       if (ice != null) {
          if (isWrite && isPessimisticCache && ctx.isInTxScope()) {
             ((TxInvocationContext) ctx).addAffectedKey(key);

--- a/core/src/main/java/org/infinispan/metadata/impl/L1Metadata.java
+++ b/core/src/main/java/org/infinispan/metadata/impl/L1Metadata.java
@@ -1,0 +1,45 @@
+package org.infinispan.metadata.impl;
+
+import org.infinispan.container.versioning.EntryVersion;
+import org.infinispan.metadata.Metadata;
+
+/**
+ * {@link org.infinispan.metadata.Metadata} implementation that must be passed to the {@link
+ * org.infinispan.container.DataContainer#put(Object, Object, org.infinispan.metadata.Metadata)} when the entry to store
+ * is a L1 entry.
+ *
+ * @author Pedro Ruivo
+ * @since 7.1
+ */
+public class L1Metadata implements Metadata {
+
+   private final Metadata metadata;
+
+   public L1Metadata(Metadata metadata) {
+      this.metadata = metadata;
+   }
+
+   @Override
+   public long lifespan() {
+      return metadata.lifespan();
+   }
+
+   @Override
+   public long maxIdle() {
+      return metadata.maxIdle();
+   }
+
+   @Override
+   public EntryVersion version() {
+      return metadata.version();
+   }
+
+   @Override
+   public Metadata.Builder builder() {
+      return metadata.builder();
+   }
+
+   public Metadata metadata() {
+      return metadata;
+   }
+}

--- a/core/src/main/java/org/infinispan/util/CoreImmutables.java
+++ b/core/src/main/java/org/infinispan/util/CoreImmutables.java
@@ -4,7 +4,6 @@ import static org.infinispan.commons.util.Util.toStr;
 
 import org.infinispan.commons.util.Immutables;
 import org.infinispan.container.DataContainer;
-import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.InternalCacheValue;
 import org.infinispan.metadata.Metadata;
@@ -139,6 +138,11 @@ public class CoreImmutables extends Immutables {
       @Override
       public void reincarnate(long now) {
          throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public boolean isL1Entry() {
+         return entry.isL1Entry();
       }
 
       @Override

--- a/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
@@ -8,7 +8,9 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.ImmortalCacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.entries.L1InternalCacheEntry;
 import org.infinispan.container.entries.MortalCacheEntry;
+import org.infinispan.container.entries.metadata.MetadataMortalCacheEntry;
 import org.infinispan.distribution.group.Grouper;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.interceptors.InterceptorChain;
@@ -160,7 +162,7 @@ public abstract class BaseDistFunctionalTest<K, V> extends MultipleCacheManagers
             assert ice instanceof ImmortalCacheEntry : "Fail on owner cache " + addressOf(c) + ": dc.get(" + key + ") returned " + safeType(ice);
          } else {
             if (allowL1) {
-               assert ice == null || ice instanceof MortalCacheEntry : "Fail on non-owner cache " + addressOf(c) + ": dc.get(" + key + ") returned " + safeType(ice);
+               assert ice == null || ice instanceof L1InternalCacheEntry : "Fail on non-owner cache " + addressOf(c) + ": dc.get(" + key + ") returned " + safeType(ice);
             } else {
                assert ice == null : "Fail on non-owner cache " + addressOf(c) + ": dc.get(" + key + ") returned " + ice + "!";
             }

--- a/core/src/test/java/org/infinispan/statetransfer/TxReadAfterLosingOwnershipTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/TxReadAfterLosingOwnershipTest.java
@@ -33,11 +33,19 @@ public class TxReadAfterLosingOwnershipTest extends MultipleCacheManagersTest {
 
 
    public void testOwnershipLostWithPut() throws Exception {
-      doOwnershipLostTest(Operation.PUT);
+      doOwnershipLostTest(Operation.PUT, false);
    }
 
    public void testOwnershipLostWithRemove() throws Exception {
-      doOwnershipLostTest(Operation.REMOVE);
+      doOwnershipLostTest(Operation.REMOVE, false);
+   }
+
+   public void testOwnershipLostWithPutOnOwner() throws Exception {
+      doOwnershipLostTest(Operation.PUT, true);
+   }
+
+   public void testOwnershipLostWithRemoveOnOwner() throws Exception {
+      doOwnershipLostTest(Operation.REMOVE, true);
    }
 
    @Override
@@ -62,7 +70,7 @@ public class TxReadAfterLosingOwnershipTest extends MultipleCacheManagersTest {
       return false;
    }
 
-   private void doOwnershipLostTest(Operation operation) throws ExecutionException, InterruptedException {
+   private void doOwnershipLostTest(Operation operation, boolean onOwner) throws ExecutionException, InterruptedException {
       log.debug("Initialize cache");
       cache(0).put("key", "value0");
       assertCachesKeyValue("key", "value0");
@@ -86,8 +94,8 @@ public class TxReadAfterLosingOwnershipTest extends MultipleCacheManagersTest {
       listener.notifier.await();
 
       log.debug("Set a new value");
-      //we change the value in the old owner
-      operation.update(cache(1));
+      //we change the value in the old owner if onOwner is false
+      operation.update(onOwner ? cache(0) : cache(1));
 
       //we check the value in the primary owner and old owner (cache(2) has not started yet)
       assertCachesKeyValue("key", operation.finalValue(), cache(0), cache(1));


### PR DESCRIPTION
... owns from its data container
- mark the keys stored as L1
- this avoid read the keys that are going to be invalidated during the ST

https://issues.jboss.org/browse/ISPN-4444
