### PR TITLE
ISPN-4979 CacheStatusResponse map uses too much memory

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHashV2.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHashV2.java
@@ -11,6 +11,6 @@ import org.infinispan.commons.hash.MurmurHash3;
  */
 public class ConsistentHashV2 extends ConsistentHashV1 {
    public ConsistentHashV2() {
-      hash = new MurmurHash3();
+      hash = MurmurHash3.getInstance();
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/SegmentConsistentHash.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/SegmentConsistentHash.java
@@ -13,7 +13,7 @@ import java.util.Set;
  */
 public final class SegmentConsistentHash implements ConsistentHash {
 
-   private final Hash hash = new MurmurHash3();
+   private final Hash hash = MurmurHash3.getInstance();
    private SocketAddress[][] segmentOwners;
    private int segmentSize;
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashPerformanceTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashPerformanceTest.java
@@ -71,6 +71,6 @@ public class ConsistentHashPerformanceTest {
 
 
       dch.init(map, 2, 10024);
-      dch.setHash(new MurmurHash3());
+      dch.setHash(MurmurHash3.getInstance());
    }
 }

--- a/commons/src/main/java/org/infinispan/commons/hash/MurmurHash3.java
+++ b/commons/src/main/java/org/infinispan/commons/hash/MurmurHash3.java
@@ -28,6 +28,15 @@ import java.util.Set;
 @ThreadSafe
 @Immutable
 public class MurmurHash3 implements Hash {
+   private final static MurmurHash3 instance = new MurmurHash3();
+   
+   public static MurmurHash3 getInstance() {
+      return instance;
+   }
+   
+   private MurmurHash3() {
+   }
+   
    private static final Charset UTF8 = Charset.forName("UTF-8");
 
    static class State {
@@ -412,7 +421,7 @@ public class MurmurHash3 implements Hash {
 
       @Override
       public MurmurHash3 readObject(ObjectInput input) {
-         return new MurmurHash3();
+         return instance;
       }
 
       @Override

--- a/commons/src/main/java/org/infinispan/commons/marshall/InstanceReusingAdvancedExternalizer.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/InstanceReusingAdvancedExternalizer.java
@@ -1,0 +1,138 @@
+package org.infinispan.commons.marshall;
+
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.marshalling.util.IdentityIntMap;
+
+/**
+ * An advanced externalizer that when implemented will allow for child instances that also extend this class to use object
+ * instances instead of serializing a brand new object.
+ * @author wburns
+ * @since 7.1
+ */
+public abstract class InstanceReusingAdvancedExternalizer<T> extends AbstractExternalizer<T> {
+   static class ReusableData {
+      IdentityIntMap<Object> map = new IdentityIntMap<>();
+      int offset;
+   }
+   private static ThreadLocal<ReusableData> cachedWriteObjects = new ThreadLocal<ReusableData>();
+   private static ThreadLocal<List<Object>> cachedReadObjects = new ThreadLocal<List<Object>>();
+   
+   private static final int ID_NO_REPEAT                 = 0x01;
+   private static final int ID_REPEAT_OBJECT_NEAR        = 0x02;
+   private static final int ID_REPEAT_OBJECT_NEARISH     = 0x03;
+   private static final int ID_REPEAT_OBJECT_FAR         = 0x04;
+   
+   public InstanceReusingAdvancedExternalizer() {
+      this(true);
+   }
+   
+   public InstanceReusingAdvancedExternalizer(boolean hasChildren) {
+      this.hasChildren = hasChildren;
+   }
+   
+   /**
+    * This boolean controls whether or not it makes sense to actually create the context or not.  In the case of
+    * classes that don't expect to have children that support this they shouldn't do the creation
+    */
+   private final boolean hasChildren;
+   
+   @Override
+   public final void writeObject(ObjectOutput output, T object) throws IOException {
+      ReusableData data = cachedWriteObjects.get();
+      boolean shouldRemove;
+      if (hasChildren && data == null) {
+         data = new ReusableData();
+         cachedWriteObjects.set(data);
+         shouldRemove = true;
+      } else {
+         shouldRemove = false;
+      }
+      try {
+         int id;
+         if (data != null && (id = data.map.get(object, -1)) != -1) {
+            final int diff = id - data.offset;
+            if (diff >= -256) {
+                output.write(ID_REPEAT_OBJECT_NEAR);
+                output.write(diff);
+            } else if (diff >= -65536) {
+                output.write(ID_REPEAT_OBJECT_NEARISH);
+                output.writeShort(diff);
+            } else {
+                output.write(ID_REPEAT_OBJECT_FAR);
+                output.writeInt(id);
+            }
+         } else {
+            output.write(ID_NO_REPEAT);
+            doWriteObject(output, object);
+            // Set this before writing object in case of circular dependencies
+            if (data != null) {
+               data.map.put(object, data.offset++);
+            }
+         }
+      } finally {
+         if (shouldRemove) {
+            cachedWriteObjects.remove();
+         }
+      }
+   }
+   
+   public abstract void doWriteObject(ObjectOutput output, T object) throws IOException;
+   
+   @Override
+   public final T readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+      List<Object> data = cachedReadObjects.get();
+      boolean shouldRemove;
+      if (hasChildren && data == null) {
+         data = new ArrayList<>();
+         cachedReadObjects.set(data);
+         shouldRemove = true;
+      } else {
+         shouldRemove = false;
+      }
+      try {
+         int type = input.read();
+         switch (type) {
+         case ID_NO_REPEAT:
+            T object = doReadObject(input);
+            if (data != null) {
+               data.add(object);
+            }
+            return object;
+         case ID_REPEAT_OBJECT_NEAR:
+            int offset = input.read() | 0xffffff00;
+            return getFromCache(data, offset + data.size());
+         case ID_REPEAT_OBJECT_NEARISH:
+            offset = input.readShort() | 0xffff0000;
+            return getFromCache(data, offset + data.size());
+         case ID_REPEAT_OBJECT_FAR:
+            return getFromCache(data, input.readInt());
+         default:
+            throw new IllegalStateException("Unexpected byte encountered" + type);
+         }
+      } finally {
+         if (shouldRemove) {
+            cachedReadObjects.remove();
+         }
+      }
+   }
+   
+   private T getFromCache(List<Object> data, int index) throws InvalidObjectException {
+      try {
+         Object obj = data.get(index);
+         if (obj != null) {
+            return (T) obj;
+         }
+     } catch (IndexOutOfBoundsException e) {
+     }
+     throw new InvalidObjectException("Attempt to read a backreference for " + getClass() + " with an invalid ID (absolute " 
+           + index + ")");
+   }
+   
+   public abstract T doReadObject(ObjectInput input) throws IOException, ClassNotFoundException;
+}

--- a/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
@@ -52,7 +52,7 @@ public class PrepareCommand extends AbstractTransactionBoundaryCommand {
    private static final Object[] EMPTY_ARRAY = new Object[0];
    private static final Comparator<Object> KEY_COMPARATOR = new Comparator<Object>() {
 
-      private final Hash hash = new MurmurHash3();
+      private final Hash hash = MurmurHash3.getInstance();
 
       @Override
       public int compare(Object o1, Object o2) {

--- a/core/src/main/java/org/infinispan/configuration/cache/HashConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/HashConfigurationBuilder.java
@@ -19,7 +19,7 @@ public class HashConfigurationBuilder extends AbstractClusteringConfigurationChi
    private static final Log log = LogFactory.getLog(HashConfigurationBuilder.class);
 
    private ConsistentHashFactory consistentHashFactory;
-   private Hash hash = new MurmurHash3();
+   private Hash hash = MurmurHash3.getInstance();
    private int numOwners = 2;
    // With the default consistent hash factory, this default gives us an even spread for clusters
    // up to 6 members and the difference between nodes stays under 20% up to 12 members.

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/DefaultConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/DefaultConsistentHash.java
@@ -16,6 +16,7 @@ import net.jcip.annotations.Immutable;
 
 import org.infinispan.commons.hash.Hash;
 import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.marshall.InstanceReusingAdvancedExternalizer;
 import org.infinispan.commons.util.Immutables;
 import org.infinispan.commons.util.Util;
 import org.infinispan.distribution.ch.ConsistentHash;
@@ -314,10 +315,10 @@ public class DefaultConsistentHash implements ConsistentHash {
       return capacityFactors;
    }
 
-   public static class Externalizer extends AbstractExternalizer<DefaultConsistentHash> {
+   public static class Externalizer extends InstanceReusingAdvancedExternalizer<DefaultConsistentHash> {
 
       @Override
-      public void writeObject(ObjectOutput output, DefaultConsistentHash ch) throws IOException {
+      public void doWriteObject(ObjectOutput output, DefaultConsistentHash ch) throws IOException {
          output.writeInt(ch.numSegments);
          output.writeInt(ch.numOwners);
          output.writeObject(ch.members);
@@ -328,7 +329,7 @@ public class DefaultConsistentHash implements ConsistentHash {
 
       @Override
       @SuppressWarnings("unchecked")
-      public DefaultConsistentHash readObject(ObjectInput unmarshaller) throws IOException, ClassNotFoundException {
+      public DefaultConsistentHash doReadObject(ObjectInput unmarshaller) throws IOException, ClassNotFoundException {
          int numSegments = unmarshaller.readInt();
          int numOwners = unmarshaller.readInt();
          List<Address> members = (List<Address>) unmarshaller.readObject();

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/DefaultConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/DefaultConsistentHashFactory.java
@@ -591,6 +591,16 @@ public class DefaultConsistentHashFactory implements ConsistentHashFactory<Defau
       }
    }
 
+   @Override
+   public boolean equals(Object other) {
+      return other != null && other.getClass() == getClass();
+   }
+
+   @Override
+   public int hashCode() {
+      return 3853;
+   }
+
    public static class Externalizer extends AbstractExternalizer<DefaultConsistentHashFactory> {
 
       @Override

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHashFactory.java
@@ -148,6 +148,16 @@ public class ReplicatedConsistentHashFactory implements ConsistentHashFactory<Re
       return new ReplicatedConsistentHash(ch1.getHashFunction(), unionMembers, primaryOwners);
    }
 
+   @Override
+   public boolean equals(Object other) {
+      return other != null && other.getClass() == getClass();
+   }
+
+   @Override
+   public int hashCode() {
+      return -6053;
+   }
+
    public static class Externalizer extends AbstractExternalizer<ReplicatedConsistentHashFactory> {
 
       @Override

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/SyncConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/SyncConsistentHashFactory.java
@@ -327,6 +327,16 @@ public class SyncConsistentHashFactory implements ConsistentHashFactory<DefaultC
       }
    }
 
+   @Override
+   public boolean equals(Object other) {
+      return other != null && other.getClass() == getClass();
+   }
+
+   @Override
+   public int hashCode() {
+      return -10007;
+   }
+
    public static class Externalizer extends AbstractExternalizer<SyncConsistentHashFactory> {
 
       @Override

--- a/core/src/main/java/org/infinispan/marshall/exts/MapExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/MapExternalizer.java
@@ -3,6 +3,7 @@ package org.infinispan.marshall.exts;
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.equivalence.EquivalentHashMap;
 import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.marshall.InstanceReusingAdvancedExternalizer;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.util.FastCopyHashMap;
 import org.infinispan.commons.util.Util;
@@ -24,7 +25,7 @@ import java.util.TreeMap;
  * @author Galder Zamarreño
  * @since 4.0
  */
-public class MapExternalizer extends AbstractExternalizer<Map> {
+public class MapExternalizer extends InstanceReusingAdvancedExternalizer<Map> {
    private static final int HASHMAP = 0;
    private static final int TREEMAP = 1;
    private static final int FASTCOPYHASHMAP = 2;
@@ -39,7 +40,7 @@ public class MapExternalizer extends AbstractExternalizer<Map> {
    }
 
    @Override
-   public void writeObject(ObjectOutput output, Map map) throws IOException {
+   public void doWriteObject(ObjectOutput output, Map map) throws IOException {
       int number = numbers.get(map.getClass(), -1);
       output.write(number);
       switch (number) {
@@ -59,7 +60,7 @@ public class MapExternalizer extends AbstractExternalizer<Map> {
    }
 
    @Override
-   public Map readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+   public Map doReadObject(ObjectInput input) throws IOException, ClassNotFoundException {
       int magicNumber = input.readUnsignedByte();
       Map subject = null;
       switch (magicNumber) {

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsAddress.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsAddress.java
@@ -5,7 +5,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
 
-import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.marshall.InstanceReusingAdvancedExternalizer;
 import org.infinispan.commons.util.Util;
 import org.infinispan.marshall.core.Ids;
 import org.infinispan.remoting.transport.Address;
@@ -58,9 +58,14 @@ public class JGroupsAddress implements Address {
       return address.compareTo(oa.address);
    }
 
-   public static final class Externalizer extends AbstractExternalizer<JGroupsAddress> {
+   public static final class Externalizer extends InstanceReusingAdvancedExternalizer<JGroupsAddress> {
+      
+      public Externalizer() {
+         super(false);
+      }
+      
       @Override
-      public void writeObject(ObjectOutput output, JGroupsAddress address) throws IOException {
+      public void doWriteObject(ObjectOutput output, JGroupsAddress address) throws IOException {
          try {
             org.jgroups.util.Util.writeAddress(address.address, output);
          } catch (Exception e) {
@@ -69,7 +74,7 @@ public class JGroupsAddress implements Address {
       }
 
       @Override
-      public JGroupsAddress readObject(ObjectInput unmarshaller) throws IOException, ClassNotFoundException {
+      public JGroupsAddress doReadObject(ObjectInput unmarshaller) throws IOException, ClassNotFoundException {
          try {
             org.jgroups.Address address = org.jgroups.util.Util.readAddress(unmarshaller);
             return new JGroupsAddress(address);

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTopologyAwareAddress.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTopologyAwareAddress.java
@@ -1,6 +1,7 @@
 package org.infinispan.remoting.transport.jgroups;
 
 import org.infinispan.commons.marshall.AdvancedExternalizer;
+import org.infinispan.commons.marshall.InstanceReusingAdvancedExternalizer;
 import org.infinispan.marshall.core.Ids;
 import org.infinispan.remoting.transport.TopologyAwareAddress;
 import org.jgroups.util.ExtendedUUID;
@@ -68,9 +69,14 @@ public class JGroupsTopologyAwareAddress extends JGroupsAddress implements Topol
       return getMachineId() == null ? addr.getMachineId() == null : getMachineId().equals(addr.getMachineId());
    }
 
-   public static final class Externalizer implements AdvancedExternalizer<JGroupsTopologyAwareAddress> {
+   public static final class Externalizer extends InstanceReusingAdvancedExternalizer<JGroupsTopologyAwareAddress> {
+      
+      public Externalizer() {
+         super(false);
+      }
+      
       @Override
-      public void writeObject(ObjectOutput output, JGroupsTopologyAwareAddress address) throws IOException {
+      public void doWriteObject(ObjectOutput output, JGroupsTopologyAwareAddress address) throws IOException {
          try {
             org.jgroups.util.Util.writeAddress(address.address, output);
          } catch (Exception e) {
@@ -79,7 +85,7 @@ public class JGroupsTopologyAwareAddress extends JGroupsAddress implements Topol
       }
 
       @Override
-      public JGroupsTopologyAwareAddress readObject(ObjectInput unmarshaller) throws IOException, ClassNotFoundException {
+      public JGroupsTopologyAwareAddress doReadObject(ObjectInput unmarshaller) throws IOException, ClassNotFoundException {
          try {
             ExtendedUUID jgroupsAddress = (ExtendedUUID) org.jgroups.util.Util.readAddress(unmarshaller);
             return new JGroupsTopologyAwareAddress(jgroupsAddress);

--- a/core/src/main/java/org/infinispan/topology/CacheJoinInfo.java
+++ b/core/src/main/java/org/infinispan/topology/CacheJoinInfo.java
@@ -75,6 +75,55 @@ public class CacheJoinInfo {
    }
 
    @Override
+   public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + Float.floatToIntBits(capacityFactor);
+      result = prime * result + ((consistentHashFactory == null) ? 0 : consistentHashFactory.hashCode());
+      result = prime * result + (distributed ? 1231 : 1237);
+      result = prime * result + ((hashFunction == null) ? 0 : hashFunction.hashCode());
+      result = prime * result + numOwners;
+      result = prime * result + numSegments;
+      result = prime * result + (int) (timeout ^ (timeout >>> 32));
+      result = prime * result + (totalOrder ? 1231 : 1237);
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+      CacheJoinInfo other = (CacheJoinInfo) obj;
+      if (Float.floatToIntBits(capacityFactor) != Float.floatToIntBits(other.capacityFactor))
+         return false;
+      if (consistentHashFactory == null) {
+         if (other.consistentHashFactory != null)
+            return false;
+      } else if (!consistentHashFactory.equals(other.consistentHashFactory))
+         return false;
+      if (distributed != other.distributed)
+         return false;
+      if (hashFunction == null) {
+         if (other.hashFunction != null)
+            return false;
+      } else if (!hashFunction.equals(other.hashFunction))
+         return false;
+      if (numOwners != other.numOwners)
+         return false;
+      if (numSegments != other.numSegments)
+         return false;
+      if (timeout != other.timeout)
+         return false;
+      if (totalOrder != other.totalOrder)
+         return false;
+      return true;
+   }
+
+   @Override
    public String toString() {
       return "CacheJoinInfo{" +
             "consistentHashFactory=" + consistentHashFactory +

--- a/core/src/main/java/org/infinispan/topology/CacheTopology.java
+++ b/core/src/main/java/org/infinispan/topology/CacheTopology.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.marshall.InstanceReusingAdvancedExternalizer;
 import org.infinispan.commons.util.InfinispanCollections;
 import org.infinispan.marshall.core.Ids;
 import org.infinispan.remoting.transport.Address;
@@ -162,9 +163,9 @@ public class CacheTopology {
    }
 
 
-   public static class Externalizer extends AbstractExternalizer<CacheTopology> {
+   public static class Externalizer extends InstanceReusingAdvancedExternalizer<CacheTopology> {
       @Override
-      public void writeObject(ObjectOutput output, CacheTopology cacheTopology) throws IOException {
+      public void doWriteObject(ObjectOutput output, CacheTopology cacheTopology) throws IOException {
          output.writeInt(cacheTopology.topologyId);
          output.writeInt(cacheTopology.rebalanceId);
          output.writeObject(cacheTopology.currentCH);
@@ -173,7 +174,7 @@ public class CacheTopology {
       }
 
       @Override
-      public CacheTopology readObject(ObjectInput unmarshaller) throws IOException, ClassNotFoundException {
+      public CacheTopology doReadObject(ObjectInput unmarshaller) throws IOException, ClassNotFoundException {
          int topologyId = unmarshaller.readInt();
          int rebalanceId = unmarshaller.readInt();
          ConsistentHash currentCH = (ConsistentHash) unmarshaller.readObject();

--- a/core/src/test/java/org/infinispan/distribution/ConsistentHashPerfTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ConsistentHashPerfTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.distribution;
 
+import org.infinispan.commons.hash.MurmurHash3;
 import org.infinispan.commons.util.Util;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.distribution.ch.impl.DefaultConsistentHashFactory;
@@ -33,7 +34,7 @@ public class ConsistentHashPerfTest extends AbstractInfinispanTest {
    private ConsistentHash createNewConsistentHash(List<Address> servers) {
       try {
          // TODO Revisit after we have replaced the CH with the CHFactory in the configuration
-         return new DefaultConsistentHashFactory().create(new org.infinispan.commons.hash.MurmurHash3(), 2, 10,
+         return new DefaultConsistentHashFactory().create(MurmurHash3.getInstance(), 2, 10,
                servers, null);
       } catch (RuntimeException re) {
          throw re;

--- a/core/src/test/java/org/infinispan/distribution/HashFunctionComparisonTest.java
+++ b/core/src/test/java/org/infinispan/distribution/HashFunctionComparisonTest.java
@@ -327,7 +327,7 @@ class MurmurHash2Compat extends HashFunction {
 }
 
 class MurmurHash3 extends HashFunction {
-   org.infinispan.commons.hash.MurmurHash3 h = new org.infinispan.commons.hash.MurmurHash3();
+   org.infinispan.commons.hash.MurmurHash3 h = org.infinispan.commons.hash.MurmurHash3.getInstance();
    public String functionName() {
       return "MurmurHash3";
    }

--- a/core/src/test/java/org/infinispan/distribution/ch/DefaultConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/DefaultConsistentHashFactoryTest.java
@@ -48,7 +48,7 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
       float[][] capacityFactors = {null, {1}, {2}, {1, 100}, {2, 0, 1}};
 
       ConsistentHashFactory <DefaultConsistentHash> chf = createConsistentHashFactory();
-      Hash hashFunction = new MurmurHash3();
+      Hash hashFunction = MurmurHash3.getInstance();
 
       for (int nn : numNodes) {
          List<Address> nodes = new ArrayList<Address>(nn);
@@ -362,7 +362,7 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
       TestAddress C = new TestAddress(2, "C");
       TestAddress D = new TestAddress(3, "D");
 
-      DefaultConsistentHash ch1 = chf.create(new MurmurHash3(), 2, 60, Arrays.<Address>asList(A), null);
+      DefaultConsistentHash ch1 = chf.create(MurmurHash3.getInstance(), 2, 60, Arrays.<Address>asList(A), null);
       //System.out.println(ch1);
 
       DefaultConsistentHash ch2 = chf.updateMembers(ch1, Arrays.<Address>asList(A, B), null);

--- a/core/src/test/java/org/infinispan/distribution/ch/ReplicatedConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/ReplicatedConsistentHashFactoryTest.java
@@ -38,7 +38,7 @@ public class ReplicatedConsistentHashFactoryTest {
       List<Address> c = Arrays.asList(C);
 
       for (int segments : testSegments) {
-         ReplicatedConsistentHash ch = factory.create(new MurmurHash3(), 0, segments, a, null);
+         ReplicatedConsistentHash ch = factory.create(MurmurHash3.getInstance(), 0, segments, a, null);
          checkDistribution(ch);
 
          ch = factory.updateMembers(ch, ab, null);

--- a/core/src/test/java/org/infinispan/distribution/ch/SyncConsistentHashFactoryKeyDistributionTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/SyncConsistentHashFactoryKeyDistributionTest.java
@@ -59,7 +59,7 @@ public class SyncConsistentHashFactoryKeyDistributionTest extends AbstractInfini
    public static final double[] PERCENTILES = { .999 };
 
    protected DefaultConsistentHash createConsistentHash(int numSegments, int numOwners, List<Address> members) {
-      MurmurHash3 hash = new MurmurHash3();
+      MurmurHash3 hash = MurmurHash3.getInstance();
       ConsistentHashFactory<DefaultConsistentHash> chf = new SyncConsistentHashFactory();
       DefaultConsistentHash ch = chf.create(hash, numOwners, numSegments, members, null);
       return ch;

--- a/core/src/test/java/org/infinispan/distribution/ch/TopologyAwareSyncConsistentHashFactoryKeyDistributionTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/TopologyAwareSyncConsistentHashFactoryKeyDistributionTest.java
@@ -1,27 +1,16 @@
 package org.infinispan.distribution.ch;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.infinispan.commons.hash.MurmurHash3;
 import org.infinispan.distribution.ch.impl.DefaultConsistentHash;
-import org.infinispan.distribution.ch.impl.OwnershipStatistics;
-import org.infinispan.distribution.ch.impl.SyncConsistentHashFactory;
 import org.infinispan.distribution.ch.impl.TopologyAwareSyncConsistentHashFactory;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.jgroups.JGroupsTopologyAwareAddress;
-import org.infinispan.test.AbstractInfinispanTest;
 import org.jgroups.util.ExtendedUUID;
 import org.jgroups.util.TopologyUUID;
-import org.jgroups.util.UUID;
 import org.testng.annotations.Test;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-
-import static java.lang.Math.sqrt;
-import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Tests the uniformity of the SyncConsistentHashFactory algorithm, which is very similar to the 5.1
@@ -47,7 +36,7 @@ public class TopologyAwareSyncConsistentHashFactoryKeyDistributionTest extends S
 
    @Override
    protected DefaultConsistentHash createConsistentHash(int numSegments, int numOwners, List<Address> members) {
-      MurmurHash3 hash = new MurmurHash3();
+      MurmurHash3 hash = MurmurHash3.getInstance();
       ConsistentHashFactory<DefaultConsistentHash> chf = new TopologyAwareSyncConsistentHashFactory();
       DefaultConsistentHash ch = chf.create(hash, numOwners, numSegments, members, null);
       return ch;

--- a/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/topologyaware/TopologyAwareConsistentHashFactoryTest.java
@@ -324,13 +324,13 @@ public class TopologyAwareConsistentHashFactoryTest extends AbstractInfinispanTe
    }
 
    private void assertAllLocationsWithRebalance(int numOwners) {
-      ch = chf.create(new MurmurHash3(), numOwners, numSegments, chMembers, capacityFactors);
+      ch = chf.create(MurmurHash3.getInstance(), numOwners, numSegments, chMembers, capacityFactors);
 
       List<Address> membersWithLoad = computeNodesWithLoad(chMembers);
       assertAllLocations(numOwners, membersWithLoad);
       assertDistribution(numOwners, membersWithLoad);
 
-      ch = chf.create(new MurmurHash3(), numOwners, numSegments, chMembers.subList(0, 1), capacityFactors);
+      ch = chf.create(MurmurHash3.getInstance(), numOwners, numSegments, chMembers.subList(0, 1), capacityFactors);
       assertAllLocations(numOwners, chMembers.subList(0, 1));
 
       for (int i = 2; i <= chMembers.size(); i++) {
@@ -497,7 +497,7 @@ public class TopologyAwareConsistentHashFactoryTest extends AbstractInfinispanTe
    }
 
    protected void updateConsistentHash(int numOwners) {
-      ch = chf.create(new MurmurHash3(), numOwners, numSegments, chMembers, null);
+      ch = chf.create(MurmurHash3.getInstance(), numOwners, numSegments, chMembers, null);
       log.debugf("Created CH with numOwners %d, members %s", numOwners, chMembers);
    }
 }

--- a/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
@@ -306,12 +306,12 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
       oldAddresses.add(a1);
       oldAddresses.add(a2);
       DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
-      DefaultConsistentHash oldCh = chf.create(new MurmurHash3(), 2, 3, oldAddresses, null);
+      DefaultConsistentHash oldCh = chf.create(MurmurHash3.getInstance(), 2, 3, oldAddresses, null);
       List<Address> newAddresses = new ArrayList<Address>();
       newAddresses.add(a1);
       newAddresses.add(a2);
       newAddresses.add(a3);
-      DefaultConsistentHash newCh = chf.create(new MurmurHash3(), 2, 3, newAddresses, null);
+      DefaultConsistentHash newCh = chf.create(MurmurHash3.getInstance(), 2, 3, newAddresses, null);
       StateRequestCommand c14 = new StateRequestCommand(cacheName, StateRequestCommand.Type.START_STATE_TRANSFER, a1, 99, null);
       byte[] bytes = marshaller.objectToByteBuffer(c14);
       marshaller.objectFromByteBuffer(bytes);

--- a/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
@@ -115,7 +115,7 @@ public class StateConsumerTest extends AbstractInfinispanTest {
 
       // create CHes
       DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
-      DefaultConsistentHash ch1 = chf.create(new MurmurHash3(), 2, 40, members1, null);
+      DefaultConsistentHash ch1 = chf.create(MurmurHash3.getInstance(), 2, 40, members1, null);
       final DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2, null);
       DefaultConsistentHash ch3 = chf.rebalance(ch2);
       DefaultConsistentHash ch23 = chf.union(ch2, ch3);

--- a/core/src/test/java/org/infinispan/statetransfer/StateProviderTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateProviderTest.java
@@ -132,7 +132,7 @@ public class StateProviderTest {
 
       // create CHes
       DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
-      DefaultConsistentHash ch1 = chf.create(new MurmurHash3(), 2, numSegments, members1, null);
+      DefaultConsistentHash ch1 = chf.create(MurmurHash3.getInstance(), 2, numSegments, members1, null);
       DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2, null);
 
       // create dependencies
@@ -220,7 +220,7 @@ public class StateProviderTest {
 
       // create CHes
       DefaultConsistentHashFactory chf = new DefaultConsistentHashFactory();
-      DefaultConsistentHash ch1 = chf.create(new MurmurHash3(), 2, numSegments, members1, null);
+      DefaultConsistentHash ch1 = chf.create(MurmurHash3.getInstance(), 2, numSegments, members1, null);
       //todo [anistor] it seems that address 6 is not used for un-owned segments
       DefaultConsistentHash ch2 = chf.updateMembers(ch1, members2, null);
 

--- a/core/src/test/java/org/infinispan/tx/lockreordering/DistLockReorderingTest.java
+++ b/core/src/test/java/org/infinispan/tx/lockreordering/DistLockReorderingTest.java
@@ -35,7 +35,7 @@ public class DistLockReorderingTest extends MultipleCacheManagersTest {
    void buildKeys() {
       int node = (int) (System.nanoTime() % 2);
       /** this is what's used for inducing ordering */
-      MurmurHash3 hashFunction = new MurmurHash3();
+      MurmurHash3 hashFunction = MurmurHash3.getInstance();
       keys = new ArrayList<Integer>(2);
       final Object firstKey = getKeyForCache(node);
       keys.add(firstKey);

--- a/core/src/test/java/org/infinispan/util/HashFunctionTest.java
+++ b/core/src/test/java/org/infinispan/util/HashFunctionTest.java
@@ -19,7 +19,7 @@ public class HashFunctionTest extends AbstractInfinispanTest {
    }
 
    public void testMurmurHash3Consistency() {
-      testHashConsistency(new MurmurHash3());
+      testHashConsistency(MurmurHash3.getInstance());
    }
 
    private void testHashConsistency(Hash hash) {

--- a/server/rest/src/main/scala/org/infinispan/rest/Server.scala
+++ b/server/rest/src/main/scala/org/infinispan/rest/Server.scala
@@ -517,7 +517,7 @@ class Server(@Context request: Request, @Context servletContext: ServletContext,
          "Preconditions were not implemented yet for PUT, POST, and DELETE methods.").build()
    }
 
-   val hashFunc = new MurmurHash3()
+   val hashFunc = MurmurHash3.getInstance
 
    private def calcETAG[K, V](entry: InternalCacheEntry[K, V], meta: MimeMetadata): EntityTag =
       new EntityTag(meta.contentType + hashFunc.hash(entry.getValue))


### PR DESCRIPTION
- Added in way to cache various instances in the serialization context

https://issues.jboss.org/browse/ISPN-4979
