### PR TITLE
ISPN-3982 TransactionTable leaks memory when JTS is activated

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/equivalence/IdentityEquivalence.java
+++ b/commons/src/main/java/org/infinispan/commons/equivalence/IdentityEquivalence.java
@@ -1,0 +1,37 @@
+package org.infinispan.commons.equivalence;
+
+/**
+ * {@link org.infinispan.commons.equivalence.Equivalence} implementation that uses the {@link
+ * java.lang.System#identityHashCode(Object)} as hash code function.
+ *
+ * @author Pedro Ruivo
+ * @since 7.1
+ */
+public class IdentityEquivalence<T> implements Equivalence<T> {
+
+   @Override
+   public int hashCode(Object obj) {
+      return System.identityHashCode(obj);
+   }
+
+   @Override
+   public boolean equals(T obj, Object otherObj) {
+      return obj != null ? obj.equals(otherObj) : otherObj == null;
+   }
+
+   @Override
+   public String toString(Object obj) {
+      return String.valueOf(obj);
+   }
+
+   @Override
+   public boolean isComparable(Object obj) {
+      return obj instanceof Comparable;
+   }
+
+   @Override
+   public int compare(T obj, T otherObj) {
+      //noinspection unchecked
+      return ((Comparable<T>) obj).compareTo(otherObj);
+   }
+}

--- a/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
@@ -7,6 +7,7 @@ import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.equivalence.AnyEquivalence;
+import org.infinispan.commons.equivalence.IdentityEquivalence;
 import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.commons.util.InfinispanCollections;
 import org.infinispan.commons.util.Util;
@@ -116,7 +117,11 @@ public class TransactionTable {
    @SuppressWarnings("unused")
    public void start() {
       final int concurrencyLevel = configuration.locking().concurrencyLevel();
-      localTransactions = CollectionFactory.makeConcurrentMap(concurrencyLevel, 0.75f, concurrencyLevel);
+      //use the IdentityEquivalence because some Transaction implementation does not have a stable hash code function
+      //and it can cause some leaks in the concurrent map.
+      localTransactions = CollectionFactory.makeConcurrentMap(concurrencyLevel, 0.75f, concurrencyLevel,
+                                                              new IdentityEquivalence<Transaction>(),
+                                                              AnyEquivalence.getInstance());
       globalToLocalTransactions = CollectionFactory.makeConcurrentMap(concurrencyLevel, 0.75f, concurrencyLevel);
       if (configuration.clustering().cacheMode().isClustered()) {
          minTopologyRecalculationLock = new ReentrantLock();


### PR DESCRIPTION
- Some implementation has an unstable hash code. Use instead the identityHashCode()

https://issues.jboss.org/browse/ISPN-3982
