### PR TITLE
[6.x] ISPN-3982 TransactionTable leaks memory when JTS is activated

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/equivalence/IdentityEquivalence.java
+++ b/commons/src/main/java/org/infinispan/commons/equivalence/IdentityEquivalence.java
@@ -1,0 +1,37 @@
+package org.infinispan.commons.equivalence;
+
+/**
+ * {@link org.infinispan.commons.equivalence.Equivalence} implementation that uses the {@link
+ * java.lang.System#identityHashCode(Object)} as hash code function.
+ *
+ * @author Pedro Ruivo
+ * @since 6.0
+ */
+public class IdentityEquivalence<T> implements Equivalence<T> {
+
+   @Override
+   public int hashCode(Object obj) {
+      return System.identityHashCode(obj);
+   }
+
+   @Override
+   public boolean equals(T obj, Object otherObj) {
+      return obj != null ? obj.equals(otherObj) : otherObj == null;
+   }
+
+   @Override
+   public String toString(Object obj) {
+      return String.valueOf(obj);
+   }
+
+   @Override
+   public boolean isComparable(Object obj) {
+      return obj instanceof Comparable;
+   }
+
+   @Override
+   public int compare(T obj, T otherObj) {
+      //noinspection unchecked
+      return ((Comparable<T>) obj).compareTo(otherObj);
+   }
+}


### PR DESCRIPTION
- Some implementation has an unstable hash code. Use instead the identityHashCode()

https://issues.jboss.org/browse/ISPN-3982
