### PR TITLE
[ISPN-4645] Many XSD default values do not match the defaults from the

### DIFF
--- a/server/integration/build/src/main/resources/docs/schema/jboss-infinispan-core_7_0.xsd
+++ b/server/integration/build/src/main/resources/docs/schema/jboss-infinispan-core_7_0.xsd
@@ -1199,9 +1199,9 @@
                 <xs:documentation>The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="chunk-size" type="xs:integer" default="10000">
+        <xs:attribute name="chunk-size" type="xs:integer" default="512">
             <xs:annotation>
-                <xs:documentation>The size, in bytes, in which to batch the transfer of cache entries.</xs:documentation>
+                <xs:documentation>The number of cache entries to batch in each transfer.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="await-initial-transfer" type="xs:boolean" default="true">


### PR DESCRIPTION
corresponding configuration builder

Updated core XSD for state transfer chunk size property default value
