### PR TITLE
ISPN-5024 Generate META-INF and blueprint services automatically

### DIFF
--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -129,8 +129,21 @@
          <artifactId>slf4j-jdk14</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.kohsuke.metainf-services</groupId>
+         <artifactId>metainf-services</artifactId>
+         <optional>true</optional>
+      </dependency>
    </dependencies>
    <build>
+      <resources>
+         <resource>
+            <directory>${project.basedir}/src/main/resources</directory>
+         </resource>
+         <resource>
+            <directory>${project.build.outputDirectory}</directory>
+         </resource>
+      </resources>
       <plugins>
          
          <plugin>
@@ -142,6 +155,10 @@
                <parallel>none</parallel>
                <groups>${defaultTestGroup}</groups>
             </configuration>
+         </plugin>
+         <plugin>
+            <groupId>org.scala-tools</groupId>
+            <artifactId>maven-scala-plugin</artifactId>
          </plugin>
          <plugin>
             <groupId>org.apache.felix</groupId>

--- a/cdi/src/main/java/org/infinispan/cdi/CDIDistributedTaskLifecycle.java
+++ b/cdi/src/main/java/org/infinispan/cdi/CDIDistributedTaskLifecycle.java
@@ -10,7 +10,9 @@ import javax.enterprise.inject.spi.InjectionTarget;
 import org.infinispan.Cache;
 import org.infinispan.cdi.util.BeanManagerProvider;
 import org.infinispan.distexec.spi.DistributedTaskLifecycle;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices
 public class CDIDistributedTaskLifecycle implements
          DistributedTaskLifecycle {
 

--- a/cdi/src/main/java/org/infinispan/cdi/CDIMapReduceTaskLifecycle.java
+++ b/cdi/src/main/java/org/infinispan/cdi/CDIMapReduceTaskLifecycle.java
@@ -10,8 +10,9 @@ import org.infinispan.cdi.util.BeanManagerProvider;
 import org.infinispan.distexec.mapreduce.Mapper;
 import org.infinispan.distexec.mapreduce.Reducer;
 import org.infinispan.distexec.mapreduce.spi.MapReduceTaskLifecycle;
+import org.kohsuke.MetaInfServices;
 
-
+@MetaInfServices
 public class CDIMapReduceTaskLifecycle implements MapReduceTaskLifecycle {
   
    @Override

--- a/cdi/src/main/java/org/infinispan/cdi/InfinispanExtension.java
+++ b/cdi/src/main/java/org/infinispan/cdi/InfinispanExtension.java
@@ -12,6 +12,7 @@ import org.infinispan.cdi.util.defaultbean.DefaultBeanHolder;
 import org.infinispan.cdi.util.defaultbean.Installed;
 import org.infinispan.cdi.util.logging.Log;
 import org.infinispan.commons.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 /**
  * The Infinispan CDI extension class.
@@ -19,6 +20,8 @@ import org.infinispan.commons.logging.LogFactory;
  * @author Pete Muir
  * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
  */
+
+@MetaInfServices
 public class InfinispanExtension implements Extension {
    private static final Log log = LogFactory.getLog(InfinispanExtension.class, Log.class);
    private final InfinispanExtensionEmbedded embeddedExtension;

--- a/cdi/src/main/java/org/infinispan/cdi/util/BeanManagerProvider.java
+++ b/cdi/src/main/java/org/infinispan/cdi/util/BeanManagerProvider.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
-
+import org.kohsuke.MetaInfServices;
 
 
 /**
@@ -41,6 +41,7 @@ import java.util.logging.Logger;
  * This is the only way to guarantee to get the right
  * BeanManager in more complex Container scenarios.</p>
  */
+@MetaInfServices
 public class BeanManagerProvider implements Extension
 {
     private static final Logger  LOG = Logger.getLogger(BeanManagerProvider.class.getName());

--- a/cdi/src/main/java/org/infinispan/cdi/util/defaultbean/DefaultBeanExtension.java
+++ b/cdi/src/main/java/org/infinispan/cdi/util/defaultbean/DefaultBeanExtension.java
@@ -39,6 +39,7 @@ import org.infinispan.cdi.util.Synthetic;
 import org.infinispan.cdi.util.annotatedtypebuilder.AnnotatedTypeBuilder;
 import org.infinispan.cdi.util.logging.Log;
 import org.infinispan.commons.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 /**
  * Registers beans annotated @DefaultBean
@@ -54,6 +55,8 @@ import org.infinispan.commons.logging.LogFactory;
  *
  * @author Stuart Douglas
  */
+
+@MetaInfServices
 public class DefaultBeanExtension implements Extension {
 
     private static final String QUALIFIER_NAMEPSACE = "org.infinispan.cdi.defaultbean";

--- a/cdi/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/cdi/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,3 +1,0 @@
-org.infinispan.cdi.InfinispanExtension
-org.infinispan.cdi.util.defaultbean.DefaultBeanExtension
-org.infinispan.cdi.util.BeanManagerProvider

--- a/cdi/src/main/resources/META-INF/services/org.infinispan.distexec.mapreduce.spi.MapReduceTaskLifecycle
+++ b/cdi/src/main/resources/META-INF/services/org.infinispan.distexec.mapreduce.spi.MapReduceTaskLifecycle
@@ -1,1 +1,0 @@
-org.infinispan.cdi.CDIMapReduceTaskLifecycle

--- a/cdi/src/main/resources/META-INF/services/org.infinispan.distexec.spi.DistributedTaskLifecycle
+++ b/cdi/src/main/resources/META-INF/services/org.infinispan.distexec.spi.DistributedTaskLifecycle
@@ -1,1 +1,0 @@
-org.infinispan.cdi.CDIDistributedTaskLifecycle

--- a/cdi/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/cdi/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,19 +4,6 @@
             xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <bean id="infinispanExtension" class="org.infinispan.cdi.InfinispanExtension"/>
-  <service ref="infinispanExtension" interface="javax.enterprise.inject.spi.Extension"/>
+${services}
 
-  <bean id="defaultBeanExtension" class="org.infinispan.cdi.util.defaultbean.DefaultBeanExtension"/>
-  <service ref="defaultBeanExtension" interface="javax.enterprise.inject.spi.Extension"/>
-
-  <bean id="beanManagerProvider" class="org.infinispan.cdi.util.BeanManagerProvider"/>
-  <service ref="beanManagerProvider" interface="javax.enterprise.inject.spi.Extension"/>
-
-  <bean id="cdiMapReduceTaskLifecycle" class="org.infinispan.cdi.CDIMapReduceTaskLifecycle"/>
-  <service ref="cdiMapReduceTaskLifecycle" interface="org.infinispan.distexec.mapreduce.spi.MapReduceTaskLifecycle"/>
-
-  <bean id="cdiDistributedTaskLifecycle" class="org.infinispan.cdi.CDIDistributedTaskLifecycle"/>
-  <service ref="cdiDistributedTaskLifecycle" interface="org.infinispan.distexec.spi.DistributedTaskLifecycle"/>
-  
 </blueprint>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -92,6 +92,12 @@
          <artifactId>howl</artifactId>
          <scope>test</scope>
       </dependency>
+
+      <dependency>
+         <groupId>org.kohsuke.metainf-services</groupId>
+         <artifactId>metainf-services</artifactId>
+         <optional>true</optional>
+      </dependency>
       
    </dependencies>
 
@@ -113,6 +119,9 @@
             <excludes>
                <exclude>features.xml</exclude>
             </excludes>
+         </resource>
+         <resource>
+            <directory>${project.build.outputDirectory}</directory>
          </resource>
       </resources>
       <pluginManagement>
@@ -177,6 +186,10 @@
          </plugins>
       </pluginManagement>
       <plugins>
+         <plugin>
+            <groupId>org.scala-tools</groupId>
+            <artifactId>maven-scala-plugin</artifactId>
+         </plugin>
          <plugin>
             <groupId>org.jboss.maven.plugins</groupId>
             <artifactId>maven-injection-plugin</artifactId>

--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser70.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser70.java
@@ -40,6 +40,7 @@ import org.infinispan.transaction.lookup.TransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -60,6 +61,7 @@ import static org.infinispan.factories.KnownComponentNames.*;
  * @author Galder Zamarreño
  * @since 7.0
  */
+@MetaInfServices
 @Namespaces({
       @Namespace(uri = "urn:infinispan:config:7.0", root = "infinispan")
 })

--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser71.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser71.java
@@ -40,6 +40,7 @@ import org.infinispan.transaction.lookup.TransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -60,6 +61,7 @@ import static org.infinispan.factories.KnownComponentNames.*;
  * @author Galder Zamarreño
  * @since 7.1
  */
+@MetaInfServices
 @Namespaces({
       @Namespace(uri = "urn:infinispan:config:7.1", root = "infinispan"),
       @Namespace(root = "infinispan")

--- a/core/src/main/java/org/infinispan/distexec/mapreduce/spi/DefaultMapReduceTaskLifecycle.java
+++ b/core/src/main/java/org/infinispan/distexec/mapreduce/spi/DefaultMapReduceTaskLifecycle.java
@@ -3,7 +3,9 @@ package org.infinispan.distexec.mapreduce.spi;
 import org.infinispan.Cache;
 import org.infinispan.distexec.mapreduce.Mapper;
 import org.infinispan.distexec.mapreduce.Reducer;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices
 public class DefaultMapReduceTaskLifecycle implements MapReduceTaskLifecycle {
 
    @Override

--- a/core/src/main/java/org/infinispan/distexec/spi/DefaultDistributedTaskLifecycle.java
+++ b/core/src/main/java/org/infinispan/distexec/spi/DefaultDistributedTaskLifecycle.java
@@ -3,7 +3,9 @@ package org.infinispan.distexec.spi;
 import java.util.concurrent.Callable;
 
 import org.infinispan.Cache;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices
 public class DefaultDistributedTaskLifecycle implements DistributedTaskLifecycle {
 
    @Override

--- a/core/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
+++ b/core/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
@@ -1,2 +1,0 @@
-org.infinispan.configuration.parsing.Parser71
-org.infinispan.configuration.parsing.Parser70

--- a/core/src/main/resources/META-INF/services/org.infinispan.distexec.mapreduce.spi.MapReduceTaskLifecycle
+++ b/core/src/main/resources/META-INF/services/org.infinispan.distexec.mapreduce.spi.MapReduceTaskLifecycle
@@ -1,1 +1,0 @@
-org.infinispan.distexec.mapreduce.spi.DefaultMapReduceTaskLifecycle

--- a/core/src/main/resources/META-INF/services/org.infinispan.distexec.spi.DistributedTaskLifecycle
+++ b/core/src/main/resources/META-INF/services/org.infinispan.distexec.spi.DistributedTaskLifecycle
@@ -1,1 +1,0 @@
-org.infinispan.distexec.spi.DefaultDistributedTaskLifecycle

--- a/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/core/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,13 +4,6 @@
             xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <bean id="parser70" class="org.infinispan.configuration.parsing.Parser70"/>
-  <service ref="parser70" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
+${services}
 
-  <bean id="defaultMapReduceTaskLifecycle" class="org.infinispan.distexec.mapreduce.spi.DefaultMapReduceTaskLifecycle"/>
-  <service ref="defaultMapReduceTaskLifecycle" interface="org.infinispan.distexec.mapreduce.spi.MapReduceTaskLifecycle"/>
-
-  <bean id="defaultDistributedTaskLifecycle" class="org.infinispan.distexec.spi.DefaultDistributedTaskLifecycle"/>
-  <service ref="defaultDistributedTaskLifecycle" interface="org.infinispan.distexec.spi.DistributedTaskLifecycle"/>
-  
 </blueprint>

--- a/jcache/pom.xml
+++ b/jcache/pom.xml
@@ -52,6 +52,12 @@
          <scope>test</scope>
       </dependency>
 
+      <dependency>
+         <groupId>org.kohsuke.metainf-services</groupId>
+         <artifactId>metainf-services</artifactId>
+         <optional>true</optional>
+      </dependency>
+
    </dependencies>
 
    <repositories>
@@ -70,6 +76,14 @@
    </repositories>
 
    <build>
+      <resources>
+         <resource>
+            <directory>${basedir}/src/main/resources</directory>
+         </resource>
+         <resource>
+            <directory>${project.build.outputDirectory}</directory>
+         </resource>
+      </resources>
       <plugins>
          <plugin>
             <groupId>org.apache.felix</groupId>
@@ -83,7 +97,6 @@
             </configuration>
          </plugin>
 
-         
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
@@ -93,6 +106,24 @@
             </configuration>
          </plugin>
 
+         <plugin>
+            <groupId>org.scala-tools</groupId>
+            <artifactId>maven-scala-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>default</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>compile</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>test-compile</id>
+                  <phase>none</phase>
+               </execution>
+            </executions>
+         </plugin>
          
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -111,11 +142,8 @@
                   <goal>package</goal>
                </goals>
                <properties>
-                  
                   <maven.test.skip.exec>${maven.test.skip.exec}</maven.test.skip.exec>
                   <skipTests>${skipTests}</skipTests>
-                  
-                  
                   <log4j.configuration>${log4j.configuration}</log4j.configuration>
                </properties>
             </configuration>
@@ -167,6 +195,28 @@
                <scope>test</scope>
             </dependency>
          </dependencies>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.scala-tools</groupId>
+                  <artifactId>maven-scala-plugin</artifactId>
+                  <executions>
+                     <execution>
+                        <id>default</id>
+                        <phase>none</phase>
+                     </execution>
+                     <execution>
+                        <id>compile</id>
+                        <phase>none</phase>
+                     </execution>
+                     <execution>
+                        <id>test-compile</id>
+                        <phase>none</phase>
+                     </execution>
+                  </executions>
+               </plugin>
+            </plugins>
+         </build>
       </profile>
       <profile>
          <id>smoke</id>

--- a/jcache/src/main/java/org/infinispan/jcache/JCachingProvider.java
+++ b/jcache/src/main/java/org/infinispan/jcache/JCachingProvider.java
@@ -2,6 +2,7 @@ package org.infinispan.jcache;
 
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 import javax.cache.CacheManager;
 import javax.cache.configuration.OptionalFeature;
@@ -19,6 +20,7 @@ import java.util.WeakHashMap;
  * @author Galder Zamarreño
  * @since 5.3
  */
+@MetaInfServices
 @SuppressWarnings("unused")
 public class JCachingProvider implements CachingProvider {
 

--- a/jcache/src/main/java/org/infinispan/jcache/annotation/AnnotationInjectExtension.java
+++ b/jcache/src/main/java/org/infinispan/jcache/annotation/AnnotationInjectExtension.java
@@ -7,6 +7,7 @@ import javax.cache.annotation.CacheResult;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.enterprise.inject.spi.Extension;
+import org.kohsuke.MetaInfServices;
 
 /**
  * CDI extension to register additional interceptor bindings
@@ -15,6 +16,7 @@ import javax.enterprise.inject.spi.Extension;
  * @author Pete Muir
  * @since 5.3
  */
+@MetaInfServices
 public class AnnotationInjectExtension implements Extension {
 
    void registerInterceptorBindings(@Observes BeforeBeanDiscovery event) {

--- a/jcache/src/main/resources/META-INF/services/javax.cache.spi.CachingProvider
+++ b/jcache/src/main/resources/META-INF/services/javax.cache.spi.CachingProvider
@@ -1,1 +1,0 @@
-org.infinispan.jcache.JCachingProvider

--- a/jcache/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/jcache/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,1 +1,0 @@
-org.infinispan.jcache.annotation.AnnotationInjectExtension

--- a/jcache/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/jcache/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,10 +4,6 @@
             xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <bean id="jCachingProvider" class="org.infinispan.jcache.JCachingProvider"/>
-  <service ref="jCachingProvider" interface="javax.cache.spi.CachingProvider"/>
+${services}
 
-  <bean id="annotationInjectExtension" class="org.infinispan.jcache.annotation.AnnotationInjectExtension"/>
-  <service ref="annotationInjectExtension" interface="javax.enterprise.inject.spi.Extension"/>
-  
 </blueprint>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -176,6 +176,7 @@
       <version.maven.scala>2.15.2</version.maven.scala>
       <version.maven.surefire>2.17</version.maven.surefire>
       <version.maven.invoker>1.8</version.maven.invoker>
+      <version.metainf-services>1.5</version.metainf-services>
       <version.jacoco>0.5.10.201208310627</version.jacoco>
       <version.asm>3.3.1</version.asm>
       <version.pax.url>2.2.0</version.pax.url>
@@ -954,6 +955,12 @@
               <artifactId>guava</artifactId>
               <version>${version.guava}</version>
           </dependency>
+          <dependency>
+              <groupId>org.kohsuke.metainf-services</groupId>
+              <artifactId>metainf-services</artifactId>
+              <version>${version.metainf-services}</version>
+              <optional>true</optional>
+          </dependency>
       </dependencies>
    </dependencyManagement>
    <dependencies>
@@ -1224,6 +1231,7 @@
                               <goals>
                                  <goal>testCompile</goal>
                                  <goal>compile</goal>
+                                 <goal>script</goal>
                               </goals>
                            </pluginExecutionFilter>
                            <action>
@@ -1325,6 +1333,41 @@
                       <goals>
                          <goal>compile</goal>
                       </goals>
+                   </execution>
+                   <execution>
+                      <id>generate-blueprint</id>
+                      <phase>prepare-package</phase>
+                      <goals>
+                         <goal>script</goal>
+                      </goals>
+                      <configuration>
+                         <keepGeneratedScript>true</keepGeneratedScript>
+                         <!-- Expose all services from META-INF/services to target OSGI-INF/blueprint/blueprint.xml -->
+                         <script>
+                           <![CDATA[
+                             import scala.io.Source
+                             import java.io.{File, PrintWriter}
+                             val serviceDir = new File(project.getBuild().getOutputDirectory() + "/META-INF/services")
+                             if (serviceDir.exists && serviceDir.listFiles.length != 0) {
+                                val services =
+                                   for (file <- serviceDir.listFiles; line <- Source.fromFile(file).getLines())
+                                   yield {
+                                          val beanName = line.substring(line.lastIndexOf(".") + 1).toLowerCase
+                                          "<bean id=\"" + beanName + "\" class=\"" + line + "\"/>" + "\n" +
+                                          "<service ref=\"" + beanName + "\" interface=\"" + file.getName + "\"/>\n"
+                                         }
+                                val targetBlueprint = new File(project.getBuild().getOutputDirectory() + "/OSGI-INF/blueprint/blueprint.xml")
+                                val input = Source.fromFile(targetBlueprint).getLines.mkString("\n")
+                                val output = new PrintWriter(targetBlueprint)
+                                try {
+                                   output.println(input.replace("${services}", services.toArray.mkString("\n")))
+                                } finally {
+                                   output.close
+                                }
+                             }
+                           ]]>
+                         </script>
+                      </configuration>
                    </execution>
                 </executions>
                 <configuration>

--- a/persistence/cli/pom.xml
+++ b/persistence/cli/pom.xml
@@ -23,16 +23,46 @@
          <groupId>org.codehaus.jackson</groupId>
          <artifactId>jackson-mapper-asl</artifactId>
       </dependency>
-
       <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-cli-interpreter</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.kohsuke.metainf-services</groupId>
+         <artifactId>metainf-services</artifactId>
+         <optional>true</optional>
+      </dependency>
    </dependencies>
 
    <build>
+      <resources>
+         <resource>
+            <directory>${project.basedir}/src/main/resources</directory>
+         </resource>
+         <resource>
+            <directory>${project.build.outputDirectory}</directory>
+         </resource>
+      </resources>
       <plugins>
+         <plugin>
+            <groupId>org.scala-tools</groupId>
+            <artifactId>maven-scala-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>default</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>compile</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>test-compile</id>
+                  <phase>none</phase>
+               </execution>
+            </executions>
+         </plugin>
          <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>
@@ -49,7 +79,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-               
                <argLine>
                   -Dcom.sun.management.jmxremote=true
                   -Djava.rmi.server.hostname=localhost

--- a/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/CLInterfaceLoaderConfigurationParser70.java
+++ b/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/CLInterfaceLoaderConfigurationParser70.java
@@ -9,6 +9,7 @@ import org.infinispan.configuration.parsing.Namespaces;
 import org.infinispan.configuration.parsing.ParseUtils;
 import org.infinispan.configuration.parsing.Parser70;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
+import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -20,6 +21,7 @@ import static org.infinispan.commons.util.StringPropertyReplacer.replaceProperti
  * @author Galder Zamarreño
  * @since 7.0
  */
+@MetaInfServices
 @Namespaces({
       @Namespace(uri = "urn:infinispan:config:store:cli:7.0", root = "cli-loader"),
 })

--- a/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/CLInterfaceLoaderConfigurationParser71.java
+++ b/persistence/cli/src/main/java/org/infinispan/persistence/cli/configuration/CLInterfaceLoaderConfigurationParser71.java
@@ -9,6 +9,7 @@ import org.infinispan.configuration.parsing.Namespaces;
 import org.infinispan.configuration.parsing.ParseUtils;
 import org.infinispan.configuration.parsing.Parser71;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
+import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -20,6 +21,7 @@ import static org.infinispan.commons.util.StringPropertyReplacer.replaceProperti
  * @author Galder Zamarreño
  * @since 7.1
  */
+@MetaInfServices
 @Namespaces({
       @Namespace(uri = "urn:infinispan:config:store:cli:7.1", root = "cli-loader"),
       @Namespace(root = "cli-loader")

--- a/persistence/cli/src/main/java/org/infinispan/persistence/cli/upgrade/CLInterfaceTargetMigrator.java
+++ b/persistence/cli/src/main/java/org/infinispan/persistence/cli/upgrade/CLInterfaceTargetMigrator.java
@@ -12,6 +12,7 @@ import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.upgrade.TargetMigrator;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -27,6 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author Galder Zamarreño
  * @since // TODO
  */
+@MetaInfServices
 public class CLInterfaceTargetMigrator implements TargetMigrator {
 
    private static final Log log = LogFactory.getLog(CLInterfaceTargetMigrator.class);

--- a/persistence/cli/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
+++ b/persistence/cli/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
@@ -1,2 +1,0 @@
-org.infinispan.persistence.cli.configuration.CLInterfaceLoaderConfigurationParser71
-org.infinispan.persistence.cli.configuration.CLInterfaceLoaderConfigurationParser70

--- a/persistence/cli/src/main/resources/META-INF/services/org.infinispan.upgrade.TargetMigrator
+++ b/persistence/cli/src/main/resources/META-INF/services/org.infinispan.upgrade.TargetMigrator
@@ -1,1 +1,0 @@
-org.infinispan.persistence.cli.upgrade.CLInterfaceTargetMigrator

--- a/persistence/cli/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/persistence/cli/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,12 +4,6 @@
             xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <bean id="clInterfaceLoaderConfigurationParser71" class="org.infinispan.persistence.cli.configuration.CLInterfaceLoaderConfigurationParser71"/>
-  <service ref="clInterfaceLoaderConfigurationParser71" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
-  <bean id="clInterfaceLoaderConfigurationParser70" class="org.infinispan.persistence.cli.configuration.CLInterfaceLoaderConfigurationParser70"/>
-  <service ref="clInterfaceLoaderConfigurationParser70" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
-
-  <bean id="clInterfaceTargetMigrator" class="org.infinispan.persistence.cli.upgrade.CLInterfaceTargetMigrator"/>
-  <service ref="clInterfaceTargetMigrator" interface="org.infinispan.upgrade.TargetMigrator"/>
+${services}
   
 </blueprint>

--- a/persistence/jdbc/pom.xml
+++ b/persistence/jdbc/pom.xml
@@ -26,11 +26,16 @@
          <scope>test</scope>
       </dependency>
 
-      
       <dependency>
          <groupId>mysql</groupId>
          <artifactId>mysql-connector-java</artifactId>
          <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.kohsuke.metainf-services</groupId>
+         <artifactId>metainf-services</artifactId>
+         <optional>true</optional>
       </dependency>
    </dependencies>
 
@@ -53,8 +58,29 @@
                <exclude>features.xml</exclude>
             </excludes>
          </resource>
+         <resource>
+            <directory>${project.build.outputDirectory}</directory>
+         </resource>
       </resources>
       <plugins>
+         <plugin>
+            <groupId>org.scala-tools</groupId>
+            <artifactId>maven-scala-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>default</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>compile</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>test-compile</id>
+                  <phase>none</phase>
+               </execution>
+            </executions>
+         </plugin>
          <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/JdbcStoreConfigurationParser70.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/JdbcStoreConfigurationParser70.java
@@ -10,6 +10,7 @@ import org.infinispan.configuration.parsing.ParseUtils;
 import org.infinispan.configuration.parsing.Parser70;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
 import org.infinispan.persistence.jdbc.DatabaseType;
+import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -22,6 +23,7 @@ import static org.infinispan.commons.util.StringPropertyReplacer.replaceProperti
  * @author Galder Zamarreño
  * @since 7.0
  */
+@MetaInfServices
 @Namespaces({
     @Namespace(uri = "urn:infinispan:config:store:jdbc:7.0", root = "string-keyed-jdbc-store"),
     @Namespace(uri = "urn:infinispan:config:store:jdbc:7.0", root = "binary-keyed-jdbc-store"),

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/JdbcStoreConfigurationParser71.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/configuration/JdbcStoreConfigurationParser71.java
@@ -10,6 +10,7 @@ import org.infinispan.configuration.parsing.ParseUtils;
 import org.infinispan.configuration.parsing.Parser71;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
 import org.infinispan.persistence.jdbc.DatabaseType;
+import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -22,6 +23,7 @@ import static org.infinispan.commons.util.StringPropertyReplacer.replaceProperti
  * @author Galder Zamarreño
  * @since 7.1
  */
+@MetaInfServices
 @Namespaces({
     @Namespace(uri = "urn:infinispan:config:store:jdbc:7.1", root = "string-keyed-jdbc-store"),
     @Namespace(root = "string-keyed-jdbc-store"),

--- a/persistence/jdbc/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
+++ b/persistence/jdbc/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
@@ -1,2 +1,0 @@
-org.infinispan.persistence.jdbc.configuration.JdbcStoreConfigurationParser71
-org.infinispan.persistence.jdbc.configuration.JdbcStoreConfigurationParser70

--- a/persistence/jdbc/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/persistence/jdbc/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,9 +4,6 @@
             xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <bean id="jdbcStoreConfigurationParser71" class="org.infinispan.persistence.jdbc.configuration.JdbcStoreConfigurationParser71"/>
-  <service ref="jdbcStoreConfigurationParser71" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
-  <bean id="jdbcStoreConfigurationParser70" class="org.infinispan.persistence.jdbc.configuration.JdbcStoreConfigurationParser70"/>
-  <service ref="jdbcStoreConfigurationParser70" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
+${services}
   
 </blueprint>

--- a/persistence/jpa/pom.xml
+++ b/persistence/jpa/pom.xml
@@ -32,8 +32,29 @@
                <exclude>features.xml</exclude>
             </excludes>
          </resource>
+         <resource>
+            <directory>${project.build.outputDirectory}</directory>
+         </resource>
       </resources>
       <plugins>
+         <plugin>
+            <groupId>org.scala-tools</groupId>
+            <artifactId>maven-scala-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>default</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>compile</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>test-compile</id>
+                  <phase>none</phase>
+               </execution>
+            </executions>
+         </plugin>
          <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>
@@ -113,6 +134,11 @@
          <groupId>org.osgi</groupId>
          <artifactId>org.osgi.compendium</artifactId>
          <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.kohsuke.metainf-services</groupId>
+         <artifactId>metainf-services</artifactId>
+         <optional>true</optional>
       </dependency>
    </dependencies>
 

--- a/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/configuration/JpaStoreConfigurationParser70.java
+++ b/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/configuration/JpaStoreConfigurationParser70.java
@@ -9,6 +9,7 @@ import org.infinispan.configuration.parsing.Namespaces;
 import org.infinispan.configuration.parsing.ParseUtils;
 import org.infinispan.configuration.parsing.Parser70;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
+import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -16,6 +17,7 @@ import javax.xml.stream.XMLStreamException;
 /**
  * @author Galder Zamarreño
  */
+@MetaInfServices
 @Namespaces({
       @Namespace(uri = "urn:infinispan:config:store:jpa:7.0", root = "jpa-store"),
 })

--- a/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/configuration/JpaStoreConfigurationParser71.java
+++ b/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/configuration/JpaStoreConfigurationParser71.java
@@ -9,6 +9,7 @@ import org.infinispan.configuration.parsing.Namespaces;
 import org.infinispan.configuration.parsing.ParseUtils;
 import org.infinispan.configuration.parsing.Parser71;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
+import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -16,6 +17,7 @@ import javax.xml.stream.XMLStreamException;
 /**
  * @author Galder Zamarreño
  */
+@MetaInfServices
 @Namespaces({
       @Namespace(uri = "urn:infinispan:config:store:jpa:7.1", root = "jpa-store"),
       @Namespace(root = "jpa-store")

--- a/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/impl/JpaStoreLifecycleManager.java
+++ b/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/impl/JpaStoreLifecycleManager.java
@@ -3,7 +3,9 @@ package org.infinispan.persistence.jpa.impl;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.lifecycle.AbstractModuleLifecycle;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices(org.infinispan.lifecycle.ModuleLifecycle.class)
 public class JpaStoreLifecycleManager extends AbstractModuleLifecycle {
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalConfiguration) {

--- a/persistence/jpa/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
+++ b/persistence/jpa/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
@@ -1,2 +1,0 @@
-org.infinispan.persistence.jpa.configuration.JpaStoreConfigurationParser71
-org.infinispan.persistence.jpa.configuration.JpaStoreConfigurationParser70

--- a/persistence/jpa/src/main/resources/META-INF/services/org.infinispan.lifecycle.ModuleLifecycle
+++ b/persistence/jpa/src/main/resources/META-INF/services/org.infinispan.lifecycle.ModuleLifecycle
@@ -1,1 +1,0 @@
-org.infinispan.persistence.jpa.impl.JpaStoreLifecycleManager

--- a/persistence/jpa/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/persistence/jpa/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -3,12 +3,7 @@
 <blueprint  default-activation="eager" 
             xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <bean id="jpaStoreConfigurationParser71" class="org.infinispan.persistence.jpa.configuration.JpaStoreConfigurationParser71"/>
-  <service ref="jpaStoreConfigurationParser71" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
-  <bean id="jpaStoreConfigurationParser70" class="org.infinispan.persistence.jpa.configuration.JpaStoreConfigurationParser70"/>
-  <service ref="jpaStoreConfigurationParser70" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
 
-  <bean id="jpaStoreLifecycleManager" class="org.infinispan.persistence.jpa.impl.JpaStoreLifecycleManager"/>
-  <service ref="jpaStoreLifecycleManager" interface="org.infinispan.lifecycle.ModuleLifecycle"/>
+${services}
   
 </blueprint>

--- a/persistence/leveldb/pom.xml
+++ b/persistence/leveldb/pom.xml
@@ -21,6 +21,11 @@
          <groupId>org.iq80.leveldb</groupId>
          <artifactId>leveldb</artifactId>
       </dependency>
+      <dependency>
+         <groupId>org.kohsuke.metainf-services</groupId>
+         <artifactId>metainf-services</artifactId>
+         <optional>true</optional>
+      </dependency>
    </dependencies>
 
    <build>
@@ -42,8 +47,29 @@
                <exclude>features.xml</exclude>
            </excludes>
          </resource>
+         <resource>
+            <directory>${project.build.outputDirectory}</directory>
+         </resource>
       </resources>
       <plugins>
+         <plugin>
+            <groupId>org.scala-tools</groupId>
+            <artifactId>maven-scala-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>default</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>compile</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>test-compile</id>
+                  <phase>none</phase>
+               </execution>
+            </executions>
+         </plugin>
          <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>

--- a/persistence/leveldb/src/main/java/org/infinispan/persistence/leveldb/configuration/LevelDBStoreConfigurationParser70.java
+++ b/persistence/leveldb/src/main/java/org/infinispan/persistence/leveldb/configuration/LevelDBStoreConfigurationParser70.java
@@ -11,6 +11,7 @@ import org.infinispan.configuration.parsing.Parser70;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -20,6 +21,7 @@ import javax.xml.stream.XMLStreamException;
  * @author <a href="mailto:rtsang@redhat.com">Ray Tsang</a>
  *
  */
+@MetaInfServices
 @Namespaces({
       @Namespace(uri = "urn:infinispan:config:store:leveldb:7.0", root = "leveldb-store"),
 })

--- a/persistence/leveldb/src/main/java/org/infinispan/persistence/leveldb/configuration/LevelDBStoreConfigurationParser71.java
+++ b/persistence/leveldb/src/main/java/org/infinispan/persistence/leveldb/configuration/LevelDBStoreConfigurationParser71.java
@@ -11,6 +11,7 @@ import org.infinispan.configuration.parsing.Parser71;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -20,6 +21,7 @@ import javax.xml.stream.XMLStreamException;
  * @author <a href="mailto:rtsang@redhat.com">Ray Tsang</a>
  *
  */
+@MetaInfServices
 @Namespaces({
       @Namespace(uri = "urn:infinispan:config:store:leveldb:7.1", root = "leveldb-store"),
       @Namespace(root = "leveldb-store")

--- a/persistence/leveldb/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
+++ b/persistence/leveldb/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
@@ -1,2 +1,0 @@
-org.infinispan.persistence.leveldb.configuration.LevelDBStoreConfigurationParser71
-org.infinispan.persistence.leveldb.configuration.LevelDBStoreConfigurationParser70

--- a/persistence/leveldb/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/persistence/leveldb/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,9 +4,6 @@
             xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <bean id="levelDBStoreConfigurationParser71" class="org.infinispan.persistence.leveldb.configuration.LevelDBStoreConfigurationParser71"/>
-  <service ref="levelDBStoreConfigurationParser71" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
-  <bean id="levelDBStoreConfigurationParser70" class="org.infinispan.persistence.leveldb.configuration.LevelDBStoreConfigurationParser70"/>
-  <service ref="levelDBStoreConfigurationParser70" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
+${services}
   
 </blueprint>

--- a/persistence/remote/pom.xml
+++ b/persistence/remote/pom.xml
@@ -38,6 +38,11 @@
          <type>test-jar</type>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.kohsuke.metainf-services</groupId>
+         <artifactId>metainf-services</artifactId>
+         <optional>true</optional>
+      </dependency>
    </dependencies>
 
    <build>
@@ -59,8 +64,29 @@
                <exclude>features.xml</exclude>
             </excludes>
          </resource>
+         <resource>
+            <directory>${project.build.outputDirectory}</directory>
+         </resource>
       </resources>
       <plugins>
+         <plugin>
+            <groupId>org.scala-tools</groupId>
+            <artifactId>maven-scala-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>default</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>compile</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>test-compile</id>
+                  <phase>none</phase>
+               </execution>
+            </executions>
+         </plugin>
          <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfigurationParser70.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfigurationParser70.java
@@ -13,6 +13,7 @@ import org.infinispan.configuration.parsing.Parser70;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
 import org.infinispan.persistence.remote.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -25,6 +26,7 @@ import static org.infinispan.commons.util.StringPropertyReplacer.replaceProperti
  * @author Galder Zamarreño
  * @since 7.0
  */
+@MetaInfServices
 @Namespaces({
    @Namespace(uri = "urn:infinispan:config:store:remote:7.0", root = "remote-store"),
 })

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfigurationParser71.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfigurationParser71.java
@@ -13,6 +13,7 @@ import org.infinispan.configuration.parsing.Parser71;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
 import org.infinispan.persistence.remote.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -25,6 +26,7 @@ import static org.infinispan.commons.util.StringPropertyReplacer.replaceProperti
  * @author Galder Zamarreño
  * @since 7.1
  */
+@MetaInfServices
 @Namespaces({
    @Namespace(uri = "urn:infinispan:config:store:remote:7.1", root = "remote-store"),
    @Namespace(root = "remote-store")

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/upgrade/HotRodTargetMigrator.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/upgrade/HotRodTargetMigrator.java
@@ -18,7 +18,9 @@ import org.infinispan.persistence.remote.configuration.RemoteStoreConfiguration;
 import org.infinispan.persistence.remote.logging.Log;
 import org.infinispan.upgrade.TargetMigrator;
 import org.infinispan.util.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices
 public class HotRodTargetMigrator implements TargetMigrator {
    private static final String MIGRATION_MANAGER_HOT_ROD_KNOWN_KEYS = "___MigrationManager_HotRod_KnownKeys___";
 

--- a/persistence/remote/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
+++ b/persistence/remote/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
@@ -1,2 +1,0 @@
-org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationParser71
-org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationParser70

--- a/persistence/remote/src/main/resources/META-INF/services/org.infinispan.upgrade.TargetMigrator
+++ b/persistence/remote/src/main/resources/META-INF/services/org.infinispan.upgrade.TargetMigrator
@@ -1,1 +1,0 @@
-org.infinispan.persistence.remote.upgrade.HotRodTargetMigrator

--- a/persistence/remote/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/persistence/remote/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,12 +4,6 @@
             xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <bean id="remoteStoreConfigurationParser71" class="org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationParser71"/>
-  <service ref="remoteStoreConfigurationParser71" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
-  <bean id="remoteStoreConfigurationParser70" class="org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationParser70"/>
-  <service ref="remoteStoreConfigurationParser70" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
-
-  <bean id="hotRodTargetMigrator" class="org.infinispan.persistence.remote.upgrade.HotRodTargetMigrator"/>
-  <service ref="hotRodTargetMigrator" interface="org.infinispan.upgrade.TargetMigrator"/>
+${services}
   
 </blueprint>

--- a/persistence/rest/pom.xml
+++ b/persistence/rest/pom.xml
@@ -43,10 +43,41 @@
          <artifactId>commons-httpclient</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.kohsuke.metainf-services</groupId>
+         <artifactId>metainf-services</artifactId>
+         <optional>true</optional>
+      </dependency>
    </dependencies>
 
    <build>
+      <resources>
+         <resource>
+            <directory>${project.basedir}/src/main/resources</directory>
+         </resource>
+         <resource>
+            <directory>${project.build.outputDirectory}</directory>
+         </resource>
+      </resources>
       <plugins>
+         <plugin>
+            <groupId>org.scala-tools</groupId>
+            <artifactId>maven-scala-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>default</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>compile</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>test-compile</id>
+                  <phase>none</phase>
+               </execution>
+            </executions>
+         </plugin>
          <plugin>
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>jetty-maven-plugin</artifactId>

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/RestStoreConfigurationParser70.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/RestStoreConfigurationParser70.java
@@ -11,6 +11,7 @@ import org.infinispan.configuration.parsing.Parser70;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
 import org.infinispan.persistence.rest.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -23,6 +24,7 @@ import static org.infinispan.commons.util.StringPropertyReplacer.replaceProperti
  * @author Galder Zamarreño
  * @since 7.0
  */
+@MetaInfServices
 @Namespaces({
    @Namespace(uri = "urn:infinispan:config:store:rest:7.0", root = "rest-store"),
 })

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/RestStoreConfigurationParser71.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/RestStoreConfigurationParser71.java
@@ -11,6 +11,7 @@ import org.infinispan.configuration.parsing.Parser71;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
 import org.infinispan.persistence.rest.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -23,6 +24,7 @@ import static org.infinispan.commons.util.StringPropertyReplacer.replaceProperti
  * @author Galder Zamarreño
  * @since 7.1
  */
+@MetaInfServices
 @Namespaces({
    @Namespace(uri = "urn:infinispan:config:store:rest:7.1", root = "rest-store"),
    @Namespace(root = "rest-store")

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/upgrade/RestTargetMigrator.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/upgrade/RestTargetMigrator.java
@@ -11,6 +11,7 @@ import org.infinispan.persistence.PersistenceUtil;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.upgrade.TargetMigrator;
 import org.infinispan.util.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -18,6 +19,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@MetaInfServices
 public class RestTargetMigrator implements TargetMigrator {
    private static final Log log = LogFactory.getLog(RestTargetMigrator.class, Log.class);
 

--- a/persistence/rest/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
+++ b/persistence/rest/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
@@ -1,2 +1,0 @@
-org.infinispan.persistence.rest.configuration.RestStoreConfigurationParser71
-org.infinispan.persistence.rest.configuration.RestStoreConfigurationParser70

--- a/persistence/rest/src/main/resources/META-INF/services/org.infinispan.upgrade.TargetMigrator
+++ b/persistence/rest/src/main/resources/META-INF/services/org.infinispan.upgrade.TargetMigrator
@@ -1,1 +1,0 @@
-org.infinispan.persistence.rest.upgrade.RestTargetMigrator

--- a/persistence/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/persistence/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,12 +4,6 @@
             xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <bean id="restStoreConfigurationParser71" class="org.infinispan.persistence.rest.configuration.RestStoreConfigurationParser71"/>
-  <service ref="restStoreConfigurationParser71" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
-  <bean id="restStoreConfigurationParser70" class="org.infinispan.persistence.rest.configuration.RestStoreConfigurationParser70"/>
-  <service ref="restStoreConfigurationParser70" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
-
-  <bean id="restTargetMigrator" class="org.infinispan.persistence.rest.upgrade.RestTargetMigrator"/>
-  <service ref="restTargetMigrator" interface="org.infinispan.upgrade.TargetMigrator"/>
+${services}
   
 </blueprint>

--- a/persistence/soft-index/pom.xml
+++ b/persistence/soft-index/pom.xml
@@ -18,10 +18,41 @@
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-core</artifactId>
       </dependency>
+      <dependency>
+         <groupId>org.kohsuke.metainf-services</groupId>
+         <artifactId>metainf-services</artifactId>
+         <optional>true</optional>
+      </dependency>
    </dependencies>
 
    <build>
+      <resources>
+         <resource>
+            <directory>${project.basedir}/src/main/resources</directory>
+         </resource>
+         <resource>
+            <directory>${project.build.outputDirectory}</directory>
+         </resource>
+      </resources>
       <plugins>
+         <plugin>
+            <groupId>org.scala-tools</groupId>
+            <artifactId>maven-scala-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>default</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>compile</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>test-compile</id>
+                  <phase>none</phase>
+               </execution>
+            </executions>
+         </plugin>
          <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/SoftIndexFileStoreConfigurationParser70.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/SoftIndexFileStoreConfigurationParser70.java
@@ -13,12 +13,14 @@ import org.infinispan.configuration.parsing.Namespaces;
 import org.infinispan.configuration.parsing.ParseUtils;
 import org.infinispan.configuration.parsing.Parser70;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
+import org.kohsuke.MetaInfServices;
 
 /**
  *
  * @author Radim Vansa
  *
  */
+@MetaInfServices
 @Namespaces({
       @Namespace(uri = "urn:infinispan:config:soft-index:7.0",
                  root = SoftIndexFileStoreConfigurationParser70.ROOT_ELEMENT),

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/SoftIndexFileStoreConfigurationParser71.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/configuration/SoftIndexFileStoreConfigurationParser71.java
@@ -13,12 +13,14 @@ import org.infinispan.configuration.parsing.Namespaces;
 import org.infinispan.configuration.parsing.ParseUtils;
 import org.infinispan.configuration.parsing.Parser71;
 import org.infinispan.configuration.parsing.XMLExtendedStreamReader;
+import org.kohsuke.MetaInfServices;
 
 /**
  *
  * @author Radim Vansa
  *
  */
+@MetaInfServices
 @Namespaces({
       @Namespace(uri = "urn:infinispan:config:store:soft-index:7.1",
                  root = SoftIndexFileStoreConfigurationParser71.ROOT_ELEMENT),

--- a/persistence/soft-index/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
+++ b/persistence/soft-index/src/main/resources/META-INF/services/org.infinispan.configuration.parsing.ConfigurationParser
@@ -1,2 +1,0 @@
-org.infinispan.persistence.sifs.configuration.SoftIndexFileStoreConfigurationParser71
-org.infinispan.persistence.sifs.configuration.SoftIndexFileStoreConfigurationParser70

--- a/persistence/soft-index/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/persistence/soft-index/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,7 +4,6 @@
             xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <bean id="softIndexFileStoreConfigurationParser71" class="org.infinispan.persistence.sifs.configuration.SoftIndexFileStoreConfigurationParser71"/>
-  <service ref="softIndexFileStoreConfigurationParser71" interface="org.infinispan.configuration.parsing.ConfigurationParser"/>
+${services}
 
 </blueprint>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -97,10 +97,42 @@
            <scope>test</scope>
        </dependency>
 
+       <dependency>
+           <groupId>org.kohsuke.metainf-services</groupId>
+           <artifactId>metainf-services</artifactId>
+           <optional>true</optional>
+       </dependency>
+
    </dependencies>
 
    <build>
+      <resources>
+         <resource>
+            <directory>${project.basedir}/src/main/resources</directory>
+         </resource>
+         <resource>
+            <directory>${project.build.outputDirectory}</directory>
+         </resource>
+      </resources>
       <plugins>
+         <plugin>
+            <groupId>org.scala-tools</groupId>
+            <artifactId>maven-scala-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>default</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>compile</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>test-compile</id>
+                  <phase>none</phase>
+               </execution>
+            </executions>
+         </plugin>
          <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -59,6 +59,7 @@ import org.infinispan.query.logging.Log;
 import org.infinispan.query.spi.ProgrammaticSearchMappingProvider;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.util.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 import java.util.Set;
 
@@ -73,6 +74,7 @@ import static org.infinispan.query.impl.IndexPropertyInspector.*;
  *
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
  */
+@MetaInfServices(org.infinispan.lifecycle.ModuleLifecycle.class)
 public class LifecycleManager extends AbstractModuleLifecycle {
 
    private static final Log log = LogFactory.getLog(LifecycleManager.class, Log.class);

--- a/query/src/main/java/org/infinispan/query/impl/QueryMetadataFileFinder.java
+++ b/query/src/main/java/org/infinispan/query/impl/QueryMetadataFileFinder.java
@@ -1,7 +1,9 @@
 package org.infinispan.query.impl;
 
 import org.infinispan.factories.components.ModuleMetadataFileFinder;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices
 public class QueryMetadataFileFinder implements ModuleMetadataFileFinder {
    @Override
    public String getMetadataFilename() {

--- a/query/src/main/java/org/infinispan/query/impl/QueryModuleCommandExtensions.java
+++ b/query/src/main/java/org/infinispan/query/impl/QueryModuleCommandExtensions.java
@@ -3,7 +3,9 @@ package org.infinispan.query.impl;
 import org.infinispan.commands.module.ExtendedModuleCommandFactory;
 import org.infinispan.commands.module.ModuleCommandInitializer;
 import org.infinispan.commands.module.ModuleCommandExtensions;
+import org.kohsuke.MetaInfServices;
 
+@MetaInfServices
 public class QueryModuleCommandExtensions implements ModuleCommandExtensions {
 
    @Override

--- a/query/src/main/java/org/infinispan/query/impl/massindex/MapReduceInitializer.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/MapReduceInitializer.java
@@ -4,12 +4,14 @@ import org.infinispan.Cache;
 import org.infinispan.distexec.mapreduce.Mapper;
 import org.infinispan.distexec.mapreduce.Reducer;
 import org.infinispan.distexec.mapreduce.spi.MapReduceTaskLifecycle;
+import org.kohsuke.MetaInfServices;
 
 /**
  * Initializes the custom Map Reduce tasks we use to rebuild indexes
  *  
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2012 Red Hat Inc.
  */
+@MetaInfServices
 public class MapReduceInitializer implements MapReduceTaskLifecycle {
 
    @Override

--- a/query/src/main/resources/META-INF/services/org.infinispan.commands.module.ModuleCommandExtensions
+++ b/query/src/main/resources/META-INF/services/org.infinispan.commands.module.ModuleCommandExtensions
@@ -1,1 +1,0 @@
-org.infinispan.query.impl.QueryModuleCommandExtensions

--- a/query/src/main/resources/META-INF/services/org.infinispan.distexec.mapreduce.spi.MapReduceTaskLifecycle
+++ b/query/src/main/resources/META-INF/services/org.infinispan.distexec.mapreduce.spi.MapReduceTaskLifecycle
@@ -1,1 +1,0 @@
-org.infinispan.query.impl.massindex.MapReduceInitializer

--- a/query/src/main/resources/META-INF/services/org.infinispan.factories.components.ModuleMetadataFileFinder
+++ b/query/src/main/resources/META-INF/services/org.infinispan.factories.components.ModuleMetadataFileFinder
@@ -1,1 +1,0 @@
-org.infinispan.query.impl.QueryMetadataFileFinder

--- a/query/src/main/resources/META-INF/services/org.infinispan.lifecycle.ModuleLifecycle
+++ b/query/src/main/resources/META-INF/services/org.infinispan.lifecycle.ModuleLifecycle
@@ -1,1 +1,0 @@
-org.infinispan.query.impl.LifecycleManager

--- a/query/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/query/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,16 +4,6 @@
             xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <bean id="queryModuleCommandExtensions" class="org.infinispan.query.impl.QueryModuleCommandExtensions"/>
-  <service ref="queryModuleCommandExtensions" interface="org.infinispan.commands.module.ModuleCommandExtensions"/>
-
-  <bean id="mapReduceInitializer" class="org.infinispan.query.impl.massindex.MapReduceInitializer"/>
-  <service ref="mapReduceInitializer" interface="org.infinispan.distexec.mapreduce.spi.MapReduceTaskLifecycle"/>
-
-  <bean id="queryMetadataFileFinder" class="org.infinispan.query.impl.QueryMetadataFileFinder"/>
-  <service ref="queryMetadataFileFinder" interface="org.infinispan.factories.components.ModuleMetadataFileFinder"/>
-
-  <bean id="lifecycleManager" class="org.infinispan.query.impl.LifecycleManager"/>
-  <service ref="lifecycleManager" interface="org.infinispan.lifecycle.ModuleLifecycle"/>
+${services}
   
 </blueprint>

--- a/remote-query/remote-query-server/pom.xml
+++ b/remote-query/remote-query-server/pom.xml
@@ -50,10 +50,42 @@
          <type>test-jar</type>
          <scope>test</scope>
       </dependency>
+
+      <dependency>
+         <groupId>org.kohsuke.metainf-services</groupId>
+         <artifactId>metainf-services</artifactId>
+         <optional>true</optional>
+      </dependency>
    </dependencies>
 
    <build>
+      <resources>
+         <resource>
+            <directory>${project.basedir}/src/main/resources</directory>
+         </resource>
+         <resource>
+            <directory>${project.build.outputDirectory}</directory>
+         </resource>
+      </resources>
       <plugins>
+         <plugin>
+            <groupId>org.scala-tools</groupId>
+            <artifactId>maven-scala-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>default</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>compile</id>
+                  <phase>none</phase>
+               </execution>
+               <execution>
+                  <id>test-compile</id>
+                  <phase>none</phase>
+               </execution>
+            </executions>
+         </plugin>
          <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/LifecycleManager.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/LifecycleManager.java
@@ -25,6 +25,7 @@ import org.infinispan.query.remote.indexing.ProtobufValueWrapper;
 import org.infinispan.query.remote.indexing.RemoteValueWrapperInterceptor;
 import org.infinispan.query.remote.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.kohsuke.MetaInfServices;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -34,6 +35,7 @@ import java.util.Map;
  * @author anistor@redhat.com
  * @since 6.0
  */
+@MetaInfServices(org.infinispan.lifecycle.ModuleLifecycle.class)
 public class LifecycleManager extends AbstractModuleLifecycle {
 
    private static final Log log = LogFactory.getLog(LifecycleManager.class, Log.class);

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/ProgrammaticSearchMappingProviderImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/ProgrammaticSearchMappingProviderImpl.java
@@ -8,11 +8,13 @@ import org.infinispan.Cache;
 import org.infinispan.query.remote.indexing.ProtobufValueWrapper;
 import org.infinispan.query.remote.indexing.ProtobufValueWrapperFieldBridge;
 import org.infinispan.query.spi.ProgrammaticSearchMappingProvider;
+import org.kohsuke.MetaInfServices;
 
 /**
  * @author anistor@redhat.com
  * @since 6.0
  */
+@MetaInfServices
 public class ProgrammaticSearchMappingProviderImpl implements ProgrammaticSearchMappingProvider {
 
    @Override

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/QueryFacadeImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/QueryFacadeImpl.java
@@ -36,6 +36,7 @@ import org.infinispan.query.remote.indexing.IndexingMetadata;
 import org.infinispan.query.remote.indexing.ProtobufValueWrapper;
 import org.infinispan.server.core.QueryFacade;
 import org.infinispan.util.KeyValuePair;
+import org.kohsuke.MetaInfServices;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -47,6 +48,7 @@ import java.util.List;
  * @author anistor@redhat.com
  * @since 6.0
  */
+@MetaInfServices
 public class QueryFacadeImpl implements QueryFacade {
 
    /**

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/RemoteQueryMetadataFileFinder.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/RemoteQueryMetadataFileFinder.java
@@ -1,11 +1,13 @@
 package org.infinispan.query.remote;
 
 import org.infinispan.factories.components.ModuleMetadataFileFinder;
+import org.kohsuke.MetaInfServices;
 
 /**
  * @author anistor@redhat.com
  * @since 6.0
  */
+@MetaInfServices
 public class RemoteQueryMetadataFileFinder implements ModuleMetadataFileFinder {
 
    @Override

--- a/remote-query/remote-query-server/src/main/resources/META-INF/services/org.infinispan.factories.components.ModuleMetadataFileFinder
+++ b/remote-query/remote-query-server/src/main/resources/META-INF/services/org.infinispan.factories.components.ModuleMetadataFileFinder
@@ -1,1 +1,0 @@
-org.infinispan.query.remote.RemoteQueryMetadataFileFinder

--- a/remote-query/remote-query-server/src/main/resources/META-INF/services/org.infinispan.lifecycle.ModuleLifecycle
+++ b/remote-query/remote-query-server/src/main/resources/META-INF/services/org.infinispan.lifecycle.ModuleLifecycle
@@ -1,1 +1,0 @@
-org.infinispan.query.remote.LifecycleManager

--- a/remote-query/remote-query-server/src/main/resources/META-INF/services/org.infinispan.query.spi.ProgrammaticSearchMappingProvider
+++ b/remote-query/remote-query-server/src/main/resources/META-INF/services/org.infinispan.query.spi.ProgrammaticSearchMappingProvider
@@ -1,1 +1,0 @@
-org.infinispan.query.remote.ProgrammaticSearchMappingProviderImpl

--- a/remote-query/remote-query-server/src/main/resources/META-INF/services/org.infinispan.server.core.QueryFacade
+++ b/remote-query/remote-query-server/src/main/resources/META-INF/services/org.infinispan.server.core.QueryFacade
@@ -1,1 +1,0 @@
-org.infinispan.query.remote.QueryFacadeImpl

--- a/remote-query/remote-query-server/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/remote-query/remote-query-server/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -4,16 +4,6 @@
             xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-  <bean id="remoteQueryMetadataFileFinder" class="org.infinispan.query.remote.RemoteQueryMetadataFileFinder"/>
-  <service ref="remoteQueryMetadataFileFinder" interface="org.infinispan.factories.components.ModuleMetadataFileFinder"/>
-
-  <bean id="lifecycleManager" class="org.infinispan.query.remote.LifecycleManager"/>
-  <service ref="lifecycleManager" interface="org.infinispan.lifecycle.ModuleLifecycle"/>
-
-  <bean id="programmaticSearchMappingProviderImpl" class="org.infinispan.query.remote.ProgrammaticSearchMappingProviderImpl"/>
-  <service ref="programmaticSearchMappingProviderImpl" interface="org.infinispan.query.spi.ProgrammaticSearchMappingProvider"/>
-
-  <bean id="queryFacadeImpl" class="org.infinispan.query.remote.QueryFacadeImpl"/>
-  <service ref="queryFacadeImpl" interface="org.infinispan.server.core.QueryFacade"/>
+${services}
   
 </blueprint>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5024

META-INF/services and OSGI-INF/blueprint/blueprint.xml are generated automatically. I did this for all modules where it is likely that there will be new parsers added in the future. And several more modules. Though, there are still modules that use the old approach - static META-INF and blueprint files.

We can convert the rest later if that's desirable. Let me know.

Thanks
Martin
