### PR TITLE
ISPN-4994 MultiHotRodServerIspnDirReplQueryTest fails

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultiHotRodServerIspnDirReplQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultiHotRodServerIspnDirReplQueryTest.java
@@ -22,11 +22,9 @@ public class MultiHotRodServerIspnDirReplQueryTest extends MultiHotRodServerIspn
       createHotRodServers(2, defaultConfiguration);
 
       ConfigurationBuilder builder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false));
-      builder.indexing().index(Index.LOCAL)
-            .addProperty("default.directory_provider", "infinispan")
-            .addProperty("default.exclusive_index_use", "false")
-            //.addProperty("default.indexmanager", "org.infinispan.query.indexmanager.InfinispanIndexManager")
-            .addProperty("lucene_version", "LUCENE_CURRENT");
+      builder.indexing()
+            .index(Index.LOCAL)
+            .addProperty("default.indexmanager", "org.infinispan.query.indexmanager.InfinispanIndexManager");
 
       for (EmbeddedCacheManager cm : cacheManagers) {
          cm.defineConfiguration(TEST_CACHE, builder.build());


### PR DESCRIPTION
Wait on lucene dir caches to start before the test.