### PR TITLE
ISPN-4491 Cluster Listener Event Batching

### DIFF
--- a/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
+++ b/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
@@ -1,5 +1,13 @@
 package org.infinispan.marshall.core;
 
+import static org.infinispan.factories.KnownComponentNames.GLOBAL_MARSHALLER;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+
 import org.infinispan.atomic.DeltaCompositeKey;
 import org.infinispan.atomic.impl.AtomicHashMap;
 import org.infinispan.atomic.impl.AtomicHashMapDelta;
@@ -71,6 +79,7 @@ import org.infinispan.notifications.cachelistener.cluster.ClusterEvent;
 import org.infinispan.notifications.cachelistener.cluster.ClusterEventCallable;
 import org.infinispan.notifications.cachelistener.cluster.ClusterListenerRemoveCallable;
 import org.infinispan.notifications.cachelistener.cluster.ClusterListenerReplicateCallable;
+import org.infinispan.notifications.cachelistener.cluster.MultiClusterEventCallable;
 import org.infinispan.notifications.cachelistener.filter.CacheEventConverterAsConverter;
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilterAsKeyValueFilter;
 import org.infinispan.notifications.cachelistener.filter.ConverterAsCacheEventConverter;
@@ -103,14 +112,6 @@ import org.infinispan.xsite.statetransfer.XSiteState;
 import org.jboss.marshalling.Marshaller;
 import org.jboss.marshalling.ObjectTable;
 import org.jboss.marshalling.Unmarshaller;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.WeakHashMap;
-
-import static org.infinispan.factories.KnownComponentNames.GLOBAL_MARSHALLER;
 
 /**
  * The externalizer table maintains information necessary to be able to map a particular type with the corresponding
@@ -337,6 +338,7 @@ public class ExternalizerTable implements ObjectTable {
       addInternalExternalizer(new NullValueConverter.Externalizer());
       addInternalExternalizer(new AcceptAllKeyValueFilter.Externalizer());
       addInternalExternalizer(new ManagerStatusResponse.Externalizer());
+      addInternalExternalizer(new MultiClusterEventCallable.Externalizer());
    }
 
    void addInternalExternalizer(AdvancedExternalizer<?> ext) {

--- a/core/src/main/java/org/infinispan/marshall/core/Ids.java
+++ b/core/src/main/java/org/infinispan/marshall/core/Ids.java
@@ -136,4 +136,5 @@ public interface Ids extends org.infinispan.commons.marshall.Ids {
    int NULL_VALUE_CONVERTER = 139;
    int ACCEPT_ALL_KEY_VALUE_FILTER = 140;
    int MANAGER_STATUS_RESPONSE = 141;
+   int MULTI_CLUSTER_EVENT_CALLABLE = 142;
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheEntryListenerInvocation.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheEntryListenerInvocation.java
@@ -1,14 +1,12 @@
 package org.infinispan.notifications.cachelistener;
 
-import org.infinispan.filter.Converter;
-import org.infinispan.filter.KeyValueFilter;
+import java.util.UUID;
+
+import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
+import org.infinispan.notifications.cachelistener.event.Event;
 import org.infinispan.notifications.cachelistener.filter.CacheEventConverter;
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilter;
 import org.infinispan.notifications.impl.ListenerInvocation;
-import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
-import org.infinispan.notifications.cachelistener.event.Event;
-
-import java.util.UUID;
 
 /**
  * Additional listener methods specific to caches.
@@ -22,6 +20,8 @@ public interface CacheEntryListenerInvocation<K, V> extends ListenerInvocation<E
    void invokeNoChecks(CacheEntryEvent<K, V> event, boolean skipQueue, boolean skipConverter);
 
    boolean isClustered();
+
+   boolean isSync();
 
    UUID getIdentifier();
 

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterEventManager.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterEventManager.java
@@ -1,0 +1,30 @@
+package org.infinispan.notifications.cachelistener.cluster;
+
+import java.util.Collection;
+import java.util.UUID;
+
+import org.infinispan.commons.CacheException;
+import org.infinispan.remoting.transport.Address;
+
+public interface ClusterEventManager<K, V> {
+   /**
+    * Adds additional cluster events that need to be sent remotely for an event originating locally.
+    * These events are not sent at time of registering but rather after the {@link ClusterEventManager#sendEvents()} is invoked.
+    * These events are gathered on a per thread basis and batched to reduce number of RPCs required. 
+    * @param target The target node this event was meant for
+    * @param identifier The cluster listener that is identified for these events
+    * @param events The events that were generated
+    * @param sync Whether these events need to be sent synchronously or not
+    */
+   public void addEvents(Address target, UUID identifier, Collection<ClusterEvent<K, V>> events, boolean sync);
+   
+   /**
+    * Sends all previously added events on this thread
+    */
+   public void sendEvents() throws CacheException;
+   
+   /**
+    * Drops and ignores all previously added events on this thread.
+    */
+   public void dropEvents();
+}

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterEventManagerFactory.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterEventManagerFactory.java
@@ -1,0 +1,31 @@
+package org.infinispan.notifications.cachelistener.cluster;
+
+import org.infinispan.Cache;
+import org.infinispan.factories.AbstractNamedCacheComponentFactory;
+import org.infinispan.factories.AutoInstantiableFactory;
+import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.notifications.cachelistener.cluster.impl.BatchingClusterEventManagerImpl;
+
+/**
+ * Constructs the data container
+ * 
+ * @author William Burns
+ * @since 7.1
+ */
+@DefaultFactoryFor(classes = ClusterEventManager.class)
+public class ClusterEventManagerFactory extends AbstractNamedCacheComponentFactory implements
+         AutoInstantiableFactory {
+   public Cache<?, ?> cache;
+   
+   @Inject
+   public void injectCache(Cache<?, ?> cache) {
+      this.cache = cache;
+   }
+
+   @Override
+   @SuppressWarnings("unchecked")
+   public <T> T construct(Class<T> componentType) {
+      return (T) new BatchingClusterEventManagerImpl(cache);
+   }
+}

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/MultiClusterEventCallable.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/MultiClusterEventCallable.java
@@ -1,0 +1,83 @@
+package org.infinispan.notifications.cachelistener.cluster;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.util.Util;
+import org.infinispan.distexec.DistributedCallable;
+import org.infinispan.marshall.core.Ids;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * This DistributedCallable is used to invoke a raised notification on the cluster listener that registered to listen
+ * for this event.
+ *
+ * @author wburns
+ * @since 7.0
+ */
+public class MultiClusterEventCallable<K, V> implements DistributedCallable<K, V, Void> {
+
+   private static final Log log = LogFactory.getLog(MultiClusterEventCallable.class);
+
+   private transient ClusterCacheNotifier<K, V> clusterCacheNotifier;
+
+   private final Map<UUID, Collection<ClusterEvent<K, V>>> multiEvents;
+
+   public MultiClusterEventCallable(Map<UUID, Collection<ClusterEvent<K, V>>> events) {
+      this.multiEvents = events;
+   }
+
+   @Override
+   public Void call() throws Exception {
+      if (log.isTraceEnabled()) {
+         log.tracef("Received multiple cluster event(s) %s", multiEvents);
+      }
+      for (Entry<UUID, Collection<ClusterEvent<K, V>>> entry : multiEvents.entrySet()) {
+         UUID identifier = entry.getKey();
+         Collection<ClusterEvent<K, V>> events = entry.getValue();
+         clusterCacheNotifier.notifyClusterListeners(events, identifier);
+      }
+      return null;
+   }
+
+   @Override
+   public void setEnvironment(Cache<K, V> cache, Set<K> inputKeys) {
+      this.clusterCacheNotifier = cache.getAdvancedCache().getComponentRegistry().getComponent(ClusterCacheNotifier.class);
+      for (Collection<? extends ClusterEvent<K, V>> events : multiEvents.values()) {
+         for (ClusterEvent<K, V> event : events) {
+            event.cache = cache;
+         }
+      }
+   }
+
+   public static class Externalizer extends AbstractExternalizer<MultiClusterEventCallable> {
+      @Override
+      public Set<Class<? extends MultiClusterEventCallable>> getTypeClasses() {
+         return Util.<Class<? extends MultiClusterEventCallable>>asSet(MultiClusterEventCallable.class);
+      }
+
+      @Override
+      public void writeObject(ObjectOutput output, MultiClusterEventCallable object) throws IOException {
+         output.writeObject(object.multiEvents);
+      }
+
+      @Override
+      public MultiClusterEventCallable readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+         return new MultiClusterEventCallable((Map<UUID, Collection<? extends ClusterEvent>>)input.readObject());
+      }
+
+      @Override
+      public Integer getId() {
+         return Ids.MULTI_CLUSTER_EVENT_CALLABLE;
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/impl/BatchingClusterEventManagerImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/impl/BatchingClusterEventManagerImpl.java
@@ -1,0 +1,128 @@
+package org.infinispan.notifications.cachelistener.cluster.impl;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.CacheException;
+import org.infinispan.distexec.DistributedExecutionCompletionService;
+import org.infinispan.distexec.DistributedExecutorService;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.notifications.cachelistener.cluster.ClusterEvent;
+import org.infinispan.notifications.cachelistener.cluster.ClusterEventCallable;
+import org.infinispan.notifications.cachelistener.cluster.ClusterEventManager;
+import org.infinispan.notifications.cachelistener.cluster.MultiClusterEventCallable;
+import org.infinispan.remoting.transport.Address;
+
+public class BatchingClusterEventManagerImpl<K, V> implements ClusterEventManager<K, V>{
+   private final Cache<K, V> cache;
+   
+   private DistributedExecutorService distExecService;
+   
+   private final ThreadLocal<EventContext<K, V>> localContext = new ThreadLocal<>();
+   
+   public BatchingClusterEventManagerImpl(Cache<K, V> cache) {
+      this.cache = cache;
+   }
+   
+   @Start
+   public void start() {
+      distExecService = SecurityActions.getDefaultExecutorService(cache);
+   }
+   
+   @Override
+   public void addEvents(Address target, UUID identifier, Collection<ClusterEvent<K, V>> events, boolean sync) {
+      EventContext<K, V> ctx = localContext.get();
+      if (ctx == null) {
+         ctx = new UnicastEventContext<K, V>();
+         localContext.set(ctx);
+      }
+      ctx.addTargets(target, identifier, events, sync);
+   }
+
+   @Override
+   public void sendEvents() {
+      EventContext<K, V> ctx = localContext.get();
+      if (ctx != null) {
+         ctx.sendToTargets(distExecService);
+         localContext.remove();
+      }
+   }
+   
+   @Override
+   public void dropEvents() {
+      localContext.remove();
+   }
+   
+   private static interface EventContext<K, V> {
+      public void addTargets(Address address, UUID identifier, Collection<ClusterEvent<K, V>> events, boolean sync);
+      
+      public void sendToTargets(DistributedExecutorService service);
+   }
+   
+   protected static class UnicastEventContext<K, V> implements EventContext<K, V> {
+      protected final Map<Address, TargetEvents<K, V>> targets = new HashMap<>();
+
+      @Override
+      public void addTargets(Address address, UUID identifier, Collection<ClusterEvent<K, V>> events, boolean sync) {
+         TargetEvents<K, V> targetEvents = targets.get(address);
+         if (targetEvents == null) {
+            targetEvents = new TargetEvents<>();
+            targets.put(address, targetEvents);
+         }
+         
+         Map<UUID, Collection<ClusterEvent<K, V>>> listenerEvents = targetEvents.events;
+         // This shouldn't be set before, so do put instead of doing get then put
+         Collection<ClusterEvent<K, V>> prevEvents = listenerEvents.put(identifier, events);
+         if (prevEvents != null) {
+            // If we have multiple events to the same node for the same uuid condense them.  This shouldn't really happen...
+            events.addAll(prevEvents);
+         }
+         if (sync) {
+            targetEvents.sync = true;
+         }
+      }
+      
+      @Override
+      public void sendToTargets(DistributedExecutorService service) {
+         DistributedExecutionCompletionService<Void> completion = new DistributedExecutionCompletionService<Void>(service);
+         int syncCount = 0;
+         for (Entry<Address, TargetEvents<K, V>> entry : targets.entrySet()) {
+            TargetEvents<K, V> value = entry.getValue();
+            if (value.events.size() > 1) {
+               if (value.sync) {
+                  completion.submit(entry.getKey(), new MultiClusterEventCallable<>(value.events));
+                  syncCount++;
+               } else {
+                  service.submit(entry.getKey(), new MultiClusterEventCallable<>(value.events));
+               }
+            } else if (value.events.size() == 1){
+               Entry<UUID, Collection<ClusterEvent<K, V>>> entryValue = value.events.entrySet().iterator().next();
+               if (value.sync) {
+                  completion.submit(entry.getKey(), new ClusterEventCallable<K, V>(entryValue.getKey(), entryValue.getValue()));
+                  syncCount++;
+               } else {
+                  service.submit(entry.getKey(), new ClusterEventCallable<K, V>(entryValue.getKey(), entryValue.getValue()));
+               }
+            }
+         }
+         
+         try {
+            for (int i = 0; i < syncCount; ++i) {
+               completion.take();
+            }
+         }
+         catch (InterruptedException e) {
+            throw new CacheException("Interrupted while waiting for event notifications to complete.", e);
+         }
+      }
+   }
+   
+   private static class TargetEvents<K, V> {
+      final Map<UUID, Collection<ClusterEvent<K, V>>> events = new HashMap<>();
+      boolean sync = false;
+   }
+}

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/impl/SecurityActions.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/impl/SecurityActions.java
@@ -1,0 +1,33 @@
+package org.infinispan.notifications.cachelistener.cluster.impl;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import org.infinispan.Cache;
+import org.infinispan.distexec.DefaultExecutorService;
+import org.infinispan.security.Security;
+import org.infinispan.security.actions.GetDefaultExecutorServiceAction;
+
+/**
+ * SecurityActions for the org.infinispan.notifications.cachelistener.cluster package.
+ *
+ * Do not move. Do not change class and method visibility to avoid being called from other
+ * {@link java.security.CodeSource}s, thus granting privilege escalation to external code.
+ *
+ * @author Tristan Tarrant
+ * @since 7.1
+ */
+final class SecurityActions {
+   private static <T> T doPrivileged(PrivilegedAction<T> action) {
+      if (System.getSecurityManager() != null) {
+         return AccessController.doPrivileged(action);
+      } else {
+         return Security.doPrivileged(action);
+      }
+   }
+
+   static DefaultExecutorService getDefaultExecutorService(final Cache<?, ?> cache) {
+      GetDefaultExecutorServiceAction action = new GetDefaultExecutorServiceAction(cache);
+      return doPrivileged(action);
+   }
+}

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/BaseCacheNotifierImplInitialTransferTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/BaseCacheNotifierImplInitialTransferTest.java
@@ -26,6 +26,7 @@ import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
+import org.infinispan.notifications.cachelistener.cluster.ClusterEventManager;
 import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
 import org.infinispan.notifications.cachelistener.event.Event;
 import org.infinispan.notifications.cachelistener.filter.CacheEventConverter;
@@ -128,7 +129,8 @@ public abstract class BaseCacheNotifierImplInitialTransferTest extends AbstractI
       when(mockCache.getAdvancedCache().getComponentRegistry().getComponent(any(Class.class))).then(answer);
       when(mockCache.getAdvancedCache().getComponentRegistry().getComponent(any(Class.class), anyString())).then(answer);
       n.injectDependencies(mockCache, new ClusteringDependentLogic.LocalLogic(), null, config,
-                           mock(DistributionManager.class), retriever, new InternalEntryFactoryImpl());
+                           mock(DistributionManager.class), retriever, new InternalEntryFactoryImpl(), 
+                           mock(ClusterEventManager.class));
       n.start();
       ctx = new NonTxInvocationContext(AnyEquivalence.getInstance());
    }

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
@@ -11,6 +11,7 @@ import org.infinispan.distribution.DistributionManager;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.iteration.impl.EntryRetriever;
 import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.notifications.cachelistener.cluster.ClusterEventManager;
 import org.infinispan.notifications.cachelistener.event.*;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
@@ -51,7 +52,8 @@ public class CacheNotifierImplTest extends AbstractInfinispanTest {
       when(mockCache.getAdvancedCache().getComponentRegistry().getComponent(any(Class.class))).then(answer);
       when(mockCache.getAdvancedCache().getComponentRegistry().getComponent(any(Class.class), anyString())).then(answer);
       n.injectDependencies(mockCache, new ClusteringDependentLogic.LocalLogic(), null, config,
-                           mock(DistributionManager.class), mock(EntryRetriever.class), mock(InternalEntryFactory.class));
+                           mock(DistributionManager.class), mock(EntryRetriever.class), mock(InternalEntryFactory.class),
+                           mock(ClusterEventManager.class));
       cl = new CacheListener();
       n.start();
       n.addListener(cl);

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/KeyFilterTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/KeyFilterTest.java
@@ -11,6 +11,7 @@ import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.iteration.impl.EntryRetriever;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.filter.KeyFilter;
+import org.infinispan.notifications.cachelistener.cluster.ClusterEventManager;
 import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
 import org.infinispan.notifications.cachelistener.event.Event;
 import org.infinispan.test.AbstractInfinispanTest;
@@ -51,7 +52,8 @@ public class KeyFilterTest extends AbstractInfinispanTest {
       when(mockCache.getAdvancedCache().getComponentRegistry().getComponent(any(Class.class))).then(answer);
       when(mockCache.getAdvancedCache().getComponentRegistry().getComponent(any(Class.class), anyString())).then(answer);
       n.injectDependencies(mockCache, new ClusteringDependentLogic.LocalLogic(), null, config,
-                           mock(DistributionManager.class), mock(EntryRetriever.class), mock(InternalEntryFactory.class));
+                           mock(DistributionManager.class), mock(EntryRetriever.class), mock(InternalEntryFactory.class), 
+                           mock(ClusterEventManager.class));
       cl = new CacheListener();
       n.start();
       n.addListener(cl, kf);

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/ListenerRegistrationTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/ListenerRegistrationTest.java
@@ -11,6 +11,7 @@ import org.infinispan.notifications.IncorrectListenerException;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryVisited;
+import org.infinispan.notifications.cachelistener.cluster.ClusterEventManager;
 import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
 import org.infinispan.notifications.cachelistener.event.Event;
 import org.infinispan.test.AbstractInfinispanTest;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.*;
+
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -32,7 +34,8 @@ public class ListenerRegistrationTest extends AbstractInfinispanTest {
       Configuration config = mock(Configuration.class, RETURNS_DEEP_STUBS);
       when(config.clustering().cacheMode()).thenReturn(CacheMode.LOCAL);
       notifier.injectDependencies(mockCache, new ClusteringDependentLogic.LocalLogic(), null, config,
-                           mock(DistributionManager.class), mock(EntryRetriever.class), new InternalEntryFactoryImpl());
+                           mock(DistributionManager.class), mock(EntryRetriever.class), new InternalEntryFactoryImpl(),
+                           mock(ClusterEventManager.class));
       return notifier;
    }
 

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
@@ -18,6 +18,7 @@ import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.iteration.impl.EntryRetriever;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.metadata.Metadata;
+import org.infinispan.notifications.cachelistener.cluster.ClusterEventManager;
 import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
 import org.infinispan.notifications.cachelistener.event.Event;
 import org.infinispan.remoting.transport.Address;
@@ -59,7 +60,7 @@ public class OnlyPrimaryOwnerTest {
       when(mockCache.getAdvancedCache().getComponentRegistry().getComponent(any(Class.class))).then(answer);
       when(mockCache.getAdvancedCache().getComponentRegistry().getComponent(any(Class.class), anyString())).then(answer);
       n.injectDependencies(mockCache, cdl, null, config, mock(DistributionManager.class), mock(EntryRetriever.class),
-                           mock(InternalEntryFactory.class));
+                           mock(InternalEntryFactory.class), mock(ClusterEventManager.class));
       cl = new PrimaryOwnerCacheListener();
       n.start();
       n.addListener(cl);

--- a/server/integration/management/server-rhq-plugin/src/main/resources/META-INF/rhq-plugin.xml
+++ b/server/integration/management/server-rhq-plugin/src/main/resources/META-INF/rhq-plugin.xml
@@ -315,6 +315,12 @@
                 <c:simple-property name="jndi-name" required="false" type="string" readOnly="true"
                                    description="The jndi name to which to bind this cache container"/>
                 <c:simple-property name="start" required="false" type="string" readOnly="true" defaultValue="LAZY"
+-                                   description="The cache container start mode, which can be EAGER (immediate start) or LAZY (on-demand start).">
+-                   <c:property-options>
+-                       <c:option value="EAGER"/>
+-                   </c:property-options>
+                </c:simple-property>
+                <c:simple-property name="start" required="false" type="string" readOnly="true" defaultValue="LAZY"
                                    description="The cache container start mode, which can be EAGER (immediate start) or LAZY (on-demand start).">
                     <c:property-options>
                         <c:option value="LAZY"/>


### PR DESCRIPTION
- Batch events destined from the same node for the same modifiation
- Send events concurrently to multiple nodes
- Async now is done from the owner node instead of listener node

https://issues.jboss.org/browse/ISPN-4491
