### PR TITLE
ISPN-5057 CDI dependency missing from infinispan-remote uberjar

### DIFF
--- a/all/remote/pom.xml
+++ b/all/remote/pom.xml
@@ -46,6 +46,18 @@
       </dependency>
 
       <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-cdi</artifactId>
+         <optional>true</optional>
+         <exclusions>
+            <exclusion>
+               <groupId>org.infinispan</groupId>
+               <artifactId>infinispan-core</artifactId>
+            </exclusion>
+         </exclusions>
+      </dependency>
+
+      <dependency>
          <groupId>org.jboss.marshalling</groupId>
          <artifactId>jboss-marshalling-osgi</artifactId>
          <optional>true</optional>
@@ -185,6 +197,8 @@
                         </Export-Package>
                         <Import-Package>
                            !infinispan.*,
+                           !org.infinispan.*,
+                           !javax.*,
                            !sun.misc,
                            !sun.reflect,
                            !net.jcip.annotations,


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5057

I removed the dependency with an earlier commit. Sorry for this. Adding back and fixing imports for OSGi. Btw, CDI integration is not supposed to work in OSGi.
