### PR TITLE
ISPN-5062 Cross site state transfer - incorrect status of push operation

### DIFF
--- a/core/src/main/java/org/infinispan/xsite/XSiteAdminOperations.java
+++ b/core/src/main/java/org/infinispan/xsite/XSiteAdminOperations.java
@@ -256,7 +256,7 @@ public class XSiteAdminOperations {
       Map<String, String> map = new HashMap<String, String>();
       try {
          for (String siteName : getRunningStateTransfer()) {
-            map.put(siteName, "SENDING");
+            map.put(siteName, XSiteStateTransferManager.STATUS_SENDING);
          }
          map.putAll(stateTransferManager.getClusterStatus());
          return map;

--- a/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateTransferManager.java
+++ b/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateTransferManager.java
@@ -15,6 +15,7 @@ public interface XSiteStateTransferManager {
 
    public static final String STATUS_OK = "OK";
    public static final String STATUS_ERROR = "ERROR";
+   public static final String STATUS_SENDING = "SENDING";
    public static final String STATUS_CANCELED = "CANCELED";
 
    /**

--- a/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateTransferManagerImpl.java
@@ -131,6 +131,9 @@ public class XSiteStateTransferManagerImpl implements XSiteStateTransferManager 
          throw new Exception(format("X-Site state transfer to '%s' already started!", siteName));
       }
 
+      //clear the previous status
+      status.remove(siteName);
+
       try {
          controlStateTransferOnRemoteSite(xSiteBackup, StateTransferControl.START_RECEIVE, null);
          if (!stateTransferManager.isStateTransferInProgress()) {


### PR DESCRIPTION
- clear the state before starting the state tansfer.

https://issues.jboss.org/browse/ISPN-5062
