### PR TITLE
ISPN-5072 MapExternalizer no longer needs to extend

### DIFF
--- a/core/src/main/java/org/infinispan/marshall/exts/MapExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/MapExternalizer.java
@@ -3,7 +3,6 @@ package org.infinispan.marshall.exts;
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.equivalence.EquivalentHashMap;
 import org.infinispan.commons.marshall.AbstractExternalizer;
-import org.infinispan.commons.marshall.InstanceReusingAdvancedExternalizer;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.util.FastCopyHashMap;
 import org.infinispan.commons.util.Util;
@@ -25,7 +24,7 @@ import java.util.TreeMap;
  * @author Galder Zamarreño
  * @since 4.0
  */
-public class MapExternalizer extends InstanceReusingAdvancedExternalizer<Map> {
+public class MapExternalizer extends AbstractExternalizer<Map> {
    private static final int HASHMAP = 0;
    private static final int TREEMAP = 1;
    private static final int FASTCOPYHASHMAP = 2;
@@ -40,7 +39,7 @@ public class MapExternalizer extends InstanceReusingAdvancedExternalizer<Map> {
    }
 
    @Override
-   public void doWriteObject(ObjectOutput output, Map map) throws IOException {
+   public void writeObject(ObjectOutput output, Map map) throws IOException {
       int number = numbers.get(map.getClass(), -1);
       output.write(number);
       switch (number) {
@@ -60,7 +59,7 @@ public class MapExternalizer extends InstanceReusingAdvancedExternalizer<Map> {
    }
 
    @Override
-   public Map doReadObject(ObjectInput input) throws IOException, ClassNotFoundException {
+   public Map readObject(ObjectInput input) throws IOException, ClassNotFoundException {
       int magicNumber = input.readUnsignedByte();
       Map subject = null;
       switch (magicNumber) {

--- a/core/src/main/java/org/infinispan/topology/ManagerStatusResponse.java
+++ b/core/src/main/java/org/infinispan/topology/ManagerStatusResponse.java
@@ -1,6 +1,6 @@
 package org.infinispan.topology;
 
-import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.marshall.InstanceReusingAdvancedExternalizer;
 import org.infinispan.marshall.core.Ids;
 
 import java.io.IOException;
@@ -40,15 +40,15 @@ public class ManagerStatusResponse implements Serializable {
             '}';
    }
 
-   public static class Externalizer extends AbstractExternalizer<ManagerStatusResponse> {
+   public static class Externalizer extends InstanceReusingAdvancedExternalizer<ManagerStatusResponse> {
       @Override
-      public void writeObject(ObjectOutput output, ManagerStatusResponse cacheStatusResponse) throws IOException {
+      public void doWriteObject(ObjectOutput output, ManagerStatusResponse cacheStatusResponse) throws IOException {
          output.writeObject(cacheStatusResponse.caches);
          output.writeBoolean(cacheStatusResponse.rebalancingEnabled);
       }
 
       @Override
-      public ManagerStatusResponse readObject(ObjectInput unmarshaller) throws IOException, ClassNotFoundException {
+      public ManagerStatusResponse doReadObject(ObjectInput unmarshaller) throws IOException, ClassNotFoundException {
          Map<String, CacheStatusResponse> caches = (Map<String, CacheStatusResponse>) unmarshaller.readObject();
          boolean rebalancingEnabled = unmarshaller.readBoolean();
          return new ManagerStatusResponse(caches, rebalancingEnabled);


### PR DESCRIPTION
InstanceReusingAdvancedExternalizer
- Changed which class extends Reusing Externalizer

https://issues.jboss.org/browse/ISPN-5072
