### PR TITLE
ISPN-4445 RHQ or CLI server -- cli.interpreter.ParseException in newly

### DIFF
--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
@@ -206,7 +206,12 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
         // get model attributes
         ModelNode resolvedValue = null;
         final String jndiName = ((resolvedValue = CacheResource.JNDI_NAME.resolveModelAttribute(context, cacheModel)).isDefined()) ? resolvedValue.asString() : null;
-        final ServiceController.Mode initialMode = StartMode.valueOf(CacheResource.START.resolveModelAttribute(context, cacheModel).asString()).getMode();
+        StartMode startMode = StartMode.valueOf(CacheResource.START.resolveModelAttribute(context, cacheModel).asString());
+        if (startMode != StartMode.EAGER) {
+           log.warnf("Ignoring start mode [%s] of cache service [%s], as EAGER is the only supported mode", startMode, cacheName);
+           startMode = StartMode.EAGER;
+        }
+        final ServiceController.Mode initialMode = startMode.getMode();
 
         final ModuleIdentifier moduleId = (resolvedValue = CacheResource.CACHE_MODULE.resolveModelAttribute(context, cacheModel)).isDefined() ? ModuleIdentifier.fromString(resolvedValue.asString()) : null;
 

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheResource.java
@@ -118,7 +118,7 @@ public class CacheResource extends SimpleResourceDefinition {
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setValidator(new EnumValidator<StartMode>(StartMode.class, true, false))
-                    .setDefaultValue(new ModelNode().set(StartMode.LAZY.name()))
+                    .setDefaultValue(new ModelNode().set(StartMode.EAGER.name()))
                     .build();
 
     static final SimpleAttributeDefinition STATISTICS =

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_7_1.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_7_1.java
@@ -8,9 +8,11 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
 
+import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
@@ -30,6 +32,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
  * @author Martin Gencur
  */
 public final class InfinispanSubsystemXMLReader_7_1 implements XMLElementReader<List<ModelNode>> {
+   private static final Logger log = Logger.getLogger(InfinispanSubsystemXMLReader_7_1.class);
 
     /**
      * {@inheritDoc}
@@ -330,6 +333,12 @@ public final class InfinispanSubsystemXMLReader_7_1 implements XMLElementReader<
             }
             case START: {
                 CacheResource.START.parseAndSetParameter(value, cache, reader);
+                if (!value.equalsIgnoreCase("EAGER")) {
+                   Location location = reader.getLocation();
+                   log.warnf("Ignoring start mode [%s] at [row,col] [%s, %s], as EAGER is the only supported mode", value, 
+                         location.getLineNumber(), location.getColumnNumber());
+                   cache.get(CacheResource.START.getName()).set("EAGER");
+                }
                 break;
             }
             case JNDI_NAME: {

--- a/server/integration/management/server-rhq-plugin/src/main/resources/META-INF/rhq-plugin.xml
+++ b/server/integration/management/server-rhq-plugin/src/main/resources/META-INF/rhq-plugin.xml
@@ -314,10 +314,9 @@
                 </c:list-property>
                 <c:simple-property name="jndi-name" required="false" type="string" readOnly="true"
                                    description="The jndi name to which to bind this cache container"/>
-                <c:simple-property name="start" required="false" type="string" readOnly="true" defaultValue="LAZY"
-                                   description="The cache container start mode, which can be EAGER (immediate start) or LAZY (on-demand start).">
+                <c:simple-property name="start" required="false" type="string" readOnly="true" defaultValue="EAGER"
+                                   description="The cache container start mode, which can only be EAGER (immediate start).">
                     <c:property-options>
-                        <c:option value="LAZY"/>
                         <c:option value="EAGER"/>
                     </c:property-options>
                 </c:simple-property>


### PR DESCRIPTION
started cache for getting stats
- Changed so all cache services are EAGER always

https://issues.jboss.org/browse/ISPN-4445
