### PR TITLE
ISPN-5089 Store divisors in a temporary variable to avoid java.lang.ArithmeticException: / by zero

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/CacheMgmtInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheMgmtInterceptor.java
@@ -287,9 +287,10 @@ public class CacheMgmtInterceptor extends JmxStatsCommandInterceptor {
    )
    @SuppressWarnings("unused")
    public double getReadWriteRatio() {
-      if (stores.sum() == 0)
+      long sum = stores.sum();
+      if (sum == 0)
          return 0;
-      return (((double) (hits.sum() + misses.sum()) / (double) stores.sum()));
+      return (((double) (hits.sum() + misses.sum()) / (double) sum));
    }
 
    @ManagedAttribute(
@@ -314,9 +315,10 @@ public class CacheMgmtInterceptor extends JmxStatsCommandInterceptor {
    )
    @SuppressWarnings("unused")
    public long getAverageWriteTime() {
-      if (stores.sum() == 0)
+      long sum = stores.sum();
+      if (sum == 0)
          return 0;
-      return (storeTimes.sum()) / stores.sum();
+      return (storeTimes.sum()) / sum;
    }
 
    @ManagedAttribute(


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5089
