### PR TITLE
ISPN-4445 RHQ or CLI server -- cli.interpreter.ParseException in newly

### DIFF
--- a/core/src/test/resources/configs/unified/7.0.xml
+++ b/core/src/test/resources/configs/unified/7.0.xml
@@ -37,7 +37,7 @@
             </file-store>
          </persistence>
       </local-cache>
-      <invalidation-cache name="invalid" mode="ASYNC" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true" statistics="true">
+      <invalidation-cache name="invalid" mode="ASYNC" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="true" statistics="true">
          <locking acquire-timeout="30500" concurrency-level="2500" isolation="READ_UNCOMMITTED" striping="true"/>
          <transaction mode="BATCH" stop-timeout="60500"  locking="OPTIMISTIC"/>
          <eviction max-entries="20500" strategy="LRU"/>

--- a/core/src/test/resources/configs/unified/7.1.xml
+++ b/core/src/test/resources/configs/unified/7.1.xml
@@ -37,7 +37,7 @@
             </file-store>
          </persistence>
       </local-cache>
-      <invalidation-cache name="invalid" mode="ASYNC" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true" statistics="true">
+      <invalidation-cache name="invalid" mode="ASYNC" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="true" statistics="true">
          <locking acquire-timeout="30500" concurrency-level="2500" isolation="READ_UNCOMMITTED" striping="true"/>
          <transaction mode="BATCH" stop-timeout="60500"  locking="OPTIMISTIC"/>
          <eviction max-entries="20500" strategy="LRU"/>

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
@@ -206,7 +206,12 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
         // get model attributes
         ModelNode resolvedValue = null;
         final String jndiName = ((resolvedValue = CacheResource.JNDI_NAME.resolveModelAttribute(context, cacheModel)).isDefined()) ? resolvedValue.asString() : null;
-        final ServiceController.Mode initialMode = StartMode.valueOf(CacheResource.START.resolveModelAttribute(context, cacheModel).asString()).getMode();
+        StartMode startMode = StartMode.valueOf(CacheResource.START.resolveModelAttribute(context, cacheModel).asString());
+        if (startMode != StartMode.EAGER) {
+           log.warnf("Ignoring start mode [%s] of cache service [%s], as EAGER is the only supported mode", startMode, cacheName);
+           startMode = StartMode.EAGER;
+        }
+        final ServiceController.Mode initialMode = startMode.getMode();
 
         final ModuleIdentifier moduleId = (resolvedValue = CacheResource.CACHE_MODULE.resolveModelAttribute(context, cacheModel)).isDefined() ? ModuleIdentifier.fromString(resolvedValue.asString()) : null;
 

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheResource.java
@@ -118,7 +118,7 @@ public class CacheResource extends SimpleResourceDefinition {
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setValidator(new EnumValidator<StartMode>(StartMode.class, true, false))
-                    .setDefaultValue(new ModelNode().set(StartMode.LAZY.name()))
+                    .setDefaultValue(new ModelNode().set(StartMode.EAGER.name()))
                     .build();
 
     static final SimpleAttributeDefinition STATISTICS =

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_7_1.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_7_1.java
@@ -8,9 +8,11 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
 
+import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
@@ -30,6 +32,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
  * @author Martin Gencur
  */
 public final class InfinispanSubsystemXMLReader_7_1 implements XMLElementReader<List<ModelNode>> {
+   private static final Logger log = Logger.getLogger(InfinispanSubsystemXMLReader_7_1.class);
 
     /**
      * {@inheritDoc}
@@ -330,6 +333,12 @@ public final class InfinispanSubsystemXMLReader_7_1 implements XMLElementReader<
             }
             case START: {
                 CacheResource.START.parseAndSetParameter(value, cache, reader);
+                if (!value.equalsIgnoreCase("EAGER")) {
+                   Location location = reader.getLocation();
+                   log.warnf("Ignoring start mode [%s] at [row,col] [%s, %s], as EAGER is the only supported mode", value, 
+                         location.getLineNumber(), location.getColumnNumber());
+                   cache.get(CacheResource.START.getName()).set("EAGER");
+                }
                 break;
             }
             case JNDI_NAME: {

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/JGroupsSubsystemInitialization.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/JGroupsSubsystemInitialization.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.clustering.infinispan.subsystem;
+
+import java.io.Serializable;
+
+import org.jboss.as.clustering.jgroups.subsystem.JGroupsExtension;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.RunningMode;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+
+/**
+ * Initializer for the JGroups subsystem.
+ * @author Paul Ferraro
+ * @author William Burns
+ */
+public class JGroupsSubsystemInitialization extends AdditionalInitialization implements Serializable {
+    private static final long serialVersionUID = -4433079373360352449L;
+    private final String module = "jgroups";
+    private final RunningMode mode;
+
+    public JGroupsSubsystemInitialization() {
+        this(RunningMode.ADMIN_ONLY);
+    }
+
+    public JGroupsSubsystemInitialization(RunningMode mode) {
+        this.mode = mode;
+    }
+
+    @Override
+    protected RunningMode getRunningMode() {
+        return this.mode;
+    }
+
+    @Override
+    protected void initializeExtraSubystemsAndModel(ExtensionRegistry registry, Resource root, ManagementResourceRegistration registration) {
+        new JGroupsExtension().initialize(registry.getExtensionContext(this.module, true));
+
+        Resource subsystem = Resource.Factory.create();
+        subsystem.getModel().get("default-stack").set("tcp");
+        root.registerChild(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, JGroupsExtension.SUBSYSTEM_NAME), subsystem);
+
+        Resource stack = Resource.Factory.create();
+        subsystem.registerChild(PathElement.pathElement("stack", "tcp"), stack);
+
+        Resource transport = Resource.Factory.create();
+        transport.getModel().get("type").set("TCP");
+        stack.registerChild(PathElement.pathElement(ModelKeys.TRANSPORT, ModelKeys.TRANSPORT_NAME), transport);
+    }
+}

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationSequencesTestCase.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationSequencesTestCase.java
@@ -26,7 +26,7 @@ public class OperationSequencesTestCase extends OperationTestCaseBase {
 
         // Parse and install the XML into the controller
         String subsystemXml = getSubsystemXml() ;
-        KernelServices servicesA = createKernelServicesBuilder(null).setSubsystemXml(subsystemXml).build();
+        KernelServices servicesA = createKernelServicesBuilder().setSubsystemXml(subsystemXml).build();
 
         ModelNode addContainerOp = getCacheContainerAddOperation("maximal2");
         ModelNode removeContainerOp = getCacheContainerRemoveOperation("maximal2");
@@ -52,6 +52,10 @@ public class OperationSequencesTestCase extends OperationTestCaseBase {
         // add the same local cache
         result = servicesA.executeOperation(addCacheOp);
         Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+
+        // remove the same local cache
+        result = servicesA.executeOperation(removeCacheOp);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
     }
 
     @Test
@@ -59,12 +63,11 @@ public class OperationSequencesTestCase extends OperationTestCaseBase {
 
         // Parse and install the XML into the controller
         String subsystemXml = getSubsystemXml() ;
-        KernelServices servicesA = createKernelServicesBuilder(null).setSubsystemXml(subsystemXml).build();
+        KernelServices servicesA = createKernelServicesBuilder().setSubsystemXml(subsystemXml).build();
 
         ModelNode addContainerOp = getCacheContainerAddOperation("maximal2");
         ModelNode removeContainerOp = getCacheContainerRemoveOperation("maximal2");
         ModelNode addCacheOp = getCacheAddOperation("maximal2", ModelKeys.LOCAL_CACHE, "fred");
-        ModelNode removeCacheOp = getCacheRemoveOperation("maximal2", ModelKeys.LOCAL_CACHE, "fred");
 
         // add a cache container
         ModelNode result = servicesA.executeOperation(addContainerOp);
@@ -84,52 +87,11 @@ public class OperationSequencesTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    @BMRule(name="Test remove rollback operation",
-            targetClass="org.jboss.as.clustering.infinispan.subsystem.CacheContainerRemove",
-            targetMethod="removeExistingCacheServices",
-            targetLocation="AT ENTRY",
-            action="$1.setRollbackOnly()")
-    public void testCacheContainerRemoveRollback() throws Exception {
-
-        // Parse and install the XML into the controller
-        String subsystemXml = getSubsystemXml() ;
-        KernelServices servicesA = createKernelServicesBuilder(null).setSubsystemXml(subsystemXml).build();
-
-        ModelNode addContainerOp = getCacheContainerAddOperation("maximal2");
-        ModelNode removeContainerOp = getCacheContainerRemoveOperation("maximal2");
-        ModelNode addCacheOp = getCacheAddOperation("maximal2", ModelKeys.LOCAL_CACHE, "fred");
-
-        // add a cache container
-        ModelNode result = servicesA.executeOperation(addContainerOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
-
-        // add a local cache
-        result = servicesA.executeOperation(addCacheOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
-
-        // remove the cache container
-        // the remove has OperationContext.setRollbackOnly() injected
-        // and so is expected to fail
-        result = servicesA.executeOperation(removeContainerOp);
-        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
-
-        // need to check that all services are correctly re-installed
-        ServiceName containerServiceName = EmbeddedCacheManagerService.getServiceName("maximal2");
-
-        ServiceName cacheConfigurationServiceName = CacheConfigurationService.getServiceName("maximal2", "fred");
-        ServiceName cacheServiceName = CacheService.getServiceName("maximal2", "fred");
-
-        Assert.assertNotNull("cache container service not installed", servicesA.getContainer().getService(containerServiceName));
-        Assert.assertNotNull("cache configuration service not installed", servicesA.getContainer().getService(cacheConfigurationServiceName));
-        Assert.assertNotNull("cache service not installed", servicesA.getContainer().getService(cacheServiceName));
-    }
-
-    @Test
     public void testLocalCacheAddRemoveAddSequence() throws Exception {
 
         // Parse and install the XML into the controller
         String subsystemXml = getSubsystemXml() ;
-        KernelServices servicesA = createKernelServicesBuilder(null).setSubsystemXml(subsystemXml).build();
+        KernelServices servicesA = createKernelServicesBuilder().setSubsystemXml(subsystemXml).build();
 
         ModelNode addOp = getCacheAddOperation("maximal", ModelKeys.LOCAL_CACHE, "fred");
         ModelNode removeOp = getCacheRemoveOperation("maximal", ModelKeys.LOCAL_CACHE, "fred");
@@ -152,7 +114,7 @@ public class OperationSequencesTestCase extends OperationTestCaseBase {
 
         // Parse and install the XML into the controller
         String subsystemXml = getSubsystemXml() ;
-        KernelServices servicesA = createKernelServicesBuilder(null).setSubsystemXml(subsystemXml).build();
+        KernelServices servicesA = createKernelServicesBuilder().setSubsystemXml(subsystemXml).build();
 
         ModelNode addOp = getCacheAddOperation("maximal", ModelKeys.LOCAL_CACHE, "fred");
         ModelNode removeOp = getCacheRemoveOperation("maximal", ModelKeys.LOCAL_CACHE, "fred");

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationTestCaseBase.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationTestCaseBase.java
@@ -8,18 +8,13 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
-import java.io.StringWriter;
-import java.net.URISyntaxException;
-import java.net.URL;
 
-import org.jboss.as.clustering.infinispan.InfinispanMessages;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.subsystem.test.AbstractSubsystemTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -34,6 +29,15 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
 
     public OperationTestCaseBase() {
         super(InfinispanExtension.SUBSYSTEM_NAME, new InfinispanExtension());
+    }
+
+    KernelServicesBuilder createKernelServicesBuilder() {
+       return this.createKernelServicesBuilder(this.createAdditionalInitialization());
+    
+    }
+
+    AdditionalInitialization createAdditionalInitialization() {
+       return new JGroupsSubsystemInitialization();
     }
 
     // cache container access

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer_1_3.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer_1_3.xml
@@ -37,7 +37,7 @@
             </file-store>
             <indexing index="LOCAL"/>
         </local-cache>
-        <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true">
+        <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer_1_4.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer_1_4.xml
@@ -45,7 +45,7 @@
                  -->
             </indexing>
         </local-cache>
-        <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true">
+        <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-test.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-test.xml
@@ -14,7 +14,7 @@
             </file-store>
             <indexing index="LOCAL" />
         </local-cache>
-        <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true">
+        <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_1_0.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_1_0.xml
@@ -13,7 +13,7 @@
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true" singleton="false"/>
         </local-cache>
-        <invalidation-cache name="invalid" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="LAZY">
+        <invalidation-cache name="invalid" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="EAGER">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000"/>
             <eviction max-entries="20000" strategy="LRU"/>

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_1_1.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_1_1.xml
@@ -11,7 +11,7 @@
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true" singleton="false"/>
         </local-cache>
-        <invalidation-cache name="invalid" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="LAZY">
+        <invalidation-cache name="invalid" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="EAGER">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_1_2.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_1_2.xml
@@ -13,7 +13,7 @@
                 <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
             </file-store>
         </local-cache>
-        <invalidation-cache name="invalid" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true">
+        <invalidation-cache name="invalid" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_1_3.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_1_3.xml
@@ -13,7 +13,7 @@
                 <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
             </file-store>
         </local-cache>
-        <invalidation-cache name="invalid" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true">
+        <invalidation-cache name="invalid" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_1_4.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_1_4.xml
@@ -38,7 +38,7 @@
             </file-store>
             <indexing index="LOCAL" />
         </local-cache>
-        <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true">
+        <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_5_2.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_5_2.xml
@@ -13,7 +13,7 @@
                 <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
             </file-store>
         </local-cache>
-        <invalidation-cache name="invalid" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true">
+        <invalidation-cache name="invalid" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_6_0.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_6_0.xml
@@ -37,7 +37,7 @@
             </rest-store>
             <indexing index="LOCAL" />
         </local-cache>
-        <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true"  statistics="true">
+        <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="true"  statistics="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_7_0.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_7_0.xml
@@ -37,7 +37,7 @@
             </rest-store>
             <indexing index="LOCAL" />
         </local-cache>
-        <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true"  statistics="true">
+        <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="true"  statistics="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_7_1.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_7_1.xml
@@ -37,7 +37,7 @@
             </rest-store>
             <indexing index="LOCAL" />
         </local-cache>
-        <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true"  statistics="true">
+        <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="true"  statistics="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>

--- a/server/integration/management/server-rhq-plugin/src/main/resources/META-INF/rhq-plugin.xml
+++ b/server/integration/management/server-rhq-plugin/src/main/resources/META-INF/rhq-plugin.xml
@@ -314,16 +314,9 @@
                 </c:list-property>
                 <c:simple-property name="jndi-name" required="false" type="string" readOnly="true"
                                    description="The jndi name to which to bind this cache container"/>
-                <c:simple-property name="start" required="false" type="string" readOnly="true" defaultValue="LAZY"
--                                   description="The cache container start mode, which can be EAGER (immediate start) or LAZY (on-demand start).">
--                   <c:property-options>
--                       <c:option value="EAGER"/>
--                   </c:property-options>
-                </c:simple-property>
-                <c:simple-property name="start" required="false" type="string" readOnly="true" defaultValue="LAZY"
-                                   description="The cache container start mode, which can be EAGER (immediate start) or LAZY (on-demand start).">
+                <c:simple-property name="start" required="false" type="string" readOnly="true" defaultValue="EAGER"
+                                   description="The cache container start mode, which can only be EAGER (immediate start).">
                     <c:property-options>
-                        <c:option value="LAZY"/>
                         <c:option value="EAGER"/>
                     </c:property-options>
                 </c:simple-property>
@@ -518,10 +511,9 @@
                             <c:option value="replicated-cache"/>
                         </c:property-options>
                     </c:simple-property>
-                    <c:simple-property name="start" required="false" type="string" readOnly="true" default="LAZY"
-                                       description="The cache start mode, which can be EAGER (immediate start) or LAZY (on-demand start).">
+                    <c:simple-property name="start" required="false" type="string" readOnly="true" default="EAGER"
+                                       description="The cache start mode, which can only be EAGER (immediate start).">
                         <c:property-options>
-                            <c:option value="LAZY"/>
                             <c:option value="EAGER"/>
                         </c:property-options>
                     </c:simple-property>


### PR DESCRIPTION
started cache for getting stats
- Changed so all cache services are EAGER always

https://issues.jboss.org/browse/ISPN-4445
