### PR TITLE
ISPN-5099 Failed random failure of MultipleCacheManagersTest

### DIFF
--- a/core/src/test/java/org/infinispan/api/ConditionalOperationPrimaryOwnerFailTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationPrimaryOwnerFailTest.java
@@ -22,6 +22,8 @@ import org.mockito.stubbing.Answer;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.infinispan.test.TestingUtil.extractComponent;
 import static org.infinispan.test.TestingUtil.replaceField;
@@ -80,7 +82,7 @@ public class ConditionalOperationPrimaryOwnerFailTest extends MultipleCacheManag
                                                any(InternalCacheEntry.class), anyBoolean(),
                                                any(FlagAffectedCommand.class), anyBoolean());
 
-      fork(new Runnable() {
+      Future<?> killMemberResult = fork(new Runnable() {
          @Override
          public void run() {
             killMember(1);
@@ -92,6 +94,7 @@ public class ConditionalOperationPrimaryOwnerFailTest extends MultipleCacheManag
       futureBackupOwnerCache.put(key, FINAL_VALUE);
 
       latch1.countDown();
+      killMemberResult.get(30, TimeUnit.SECONDS);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -26,8 +26,10 @@ import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 
 /**
@@ -57,7 +59,7 @@ import java.util.List;
  */
 public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
 
-   protected List<EmbeddedCacheManager> cacheManagers = new ArrayList<EmbeddedCacheManager>();
+   protected List<EmbeddedCacheManager> cacheManagers = new ArrayList<>();
    protected IdentityHashMap<Cache<?, ?>, ReplListener> listeners = new IdentityHashMap<Cache<?, ?>, ReplListener>();
 
    @BeforeClass(alwaysRun = true)


### PR DESCRIPTION
Hi!

Please take a look at proposed solution for https://issues.jboss.org/browse/ISPN-5099.

Since the `ConcurrentModificationException` happened during clean up - the easiest way to fix this is to use `CopyOnWriteArrayList`.