### PR TITLE
ISPN-5104 Infinite loop in TransactionAwareCloseableIterator when

### DIFF
--- a/core/src/test/java/org/infinispan/api/CacheAPITest.java
+++ b/core/src/test/java/org/infinispan/api/CacheAPITest.java
@@ -12,9 +12,12 @@ import org.testng.annotations.Test;
 import javax.transaction.NotSupportedException;
 import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
+
 import java.lang.reflect.Method;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import static org.infinispan.test.TestingUtil.v;
@@ -74,13 +77,16 @@ public abstract class CacheAPITest extends APINonTxTest {
       assert cache.values().contains(value);
 
       TestingUtil.getTransactionManager(cache).begin();
-      cache.put(key, value2);
-      assert cache.get(key).equals(value2);
-      size = 1;
-      assert size == cache.size() && size == cache.keySet().size() && size == cache.values().size() && size == cache.entrySet().size();
-      assert cache.keySet().contains(key);
-      assert cache.values().contains(value2);
-      TestingUtil.getTransactionManager(cache).rollback();
+      try {
+         cache.put(key, value2);
+         assert cache.get(key).equals(value2);
+         size = 1;
+         assert size == cache.size() && size == cache.keySet().size() && size == cache.values().size() && size == cache.entrySet().size();
+         assert cache.keySet().contains(key);
+         assert cache.values().contains(value2);
+      } finally {
+         TestingUtil.getTransactionManager(cache).rollback();
+      }
 
       assert cache.get(key).equals(value);
       size = 1;
@@ -100,11 +106,14 @@ public abstract class CacheAPITest extends APINonTxTest {
       assert cache.values().contains(value);
 
       TestingUtil.getTransactionManager(cache).begin();
-      cache.remove(key);
-      assert cache.get(key) == null;
-      size = 0;
-      assert size == cache.size() && size == cache.keySet().size() && size == cache.values().size() && size == cache.entrySet().size();
-      TestingUtil.getTransactionManager(cache).rollback();
+      try {
+         cache.remove(key);
+         assert cache.get(key) == null;
+         size = 0;
+         assert size == cache.size() && size == cache.keySet().size() && size == cache.values().size() && size == cache.entrySet().size();
+      } finally {
+         TestingUtil.getTransactionManager(cache).rollback();
+      }
 
       assert cache.get(key).equals(value);
       size = 1;
@@ -126,21 +135,25 @@ public abstract class CacheAPITest extends APINonTxTest {
 
       final TransactionManager transactionManager = cache.getAdvancedCache().getTransactionManager();
       transactionManager.begin();
-      log.trace("Here is where it begins: " + transactionManager.getTransaction());
-
-      cache.size();
-
-      cache.clear();
-      assert cache.get(key) == null;
-      size = 0;
-      assert size == cache.size() && size == cache.keySet().size() && size == cache.values().size() && size == cache.entrySet().size();
-      TestingUtil.getTransactionManager(cache).rollback();
-
+      try {
+         log.trace("Here is where it begins: " + transactionManager.getTransaction());
+   
+         cache.size();
+   
+         cache.clear();
+         assert cache.get(key) == null;
+         size = 0;
+         assert size == cache.size() && size == cache.keySet().size() && size == cache.values().size() && size == cache.entrySet().size();
+      } finally {
+         transactionManager.rollback();
+      }
+   
       assert cache.get(key).equals(value);
       size = 1;
       assert size == cache.size() && size == cache.keySet().size() && size == cache.values().size() && size == cache.entrySet().size();
       assert cache.keySet().contains(key);
       assert cache.values().contains(value);
+     
    }
 
    public void testEntrySetEqualityInTx(Method m) throws Exception {
@@ -166,8 +179,39 @@ public abstract class CacheAPITest extends APINonTxTest {
          Set entries = cache.entrySet();
          assertEquals(allEntriesIn.entrySet(), entries);
       } finally {
-         tm.commit();
+         tm.rollback();
       }
+   }
+
+   public void testEntrySetIterationInTx(Method m) throws Exception {
+      Map<Integer, String> dataIn = new HashMap<Integer, String>();
+      dataIn.put(1, v(m, 1));
+      dataIn.put(2, v(m, 2));
+
+      cache.putAll(dataIn);
+
+      Map<Object, Object> foundValues = new HashMap<>();
+      TransactionManager tm = cache.getAdvancedCache().getTransactionManager();
+      tm.begin();
+      try {
+         Set<Entry<Object, Object>> entries = cache.entrySet();
+
+         Iterator<Entry<Object, Object>> itr = entries.iterator();
+
+         // Add an entry within tx
+         cache.put(3, v(m, 3));
+
+         while (itr.hasNext()) {
+            Entry<Object, Object> entry = itr.next();
+            foundValues.put(entry.getKey(), entry.getValue());
+         }
+      } finally {
+         tm.rollback();
+      }
+      assertEquals(3, foundValues.size());
+      assertEquals(v(m, 1), foundValues.get(1));
+      assertEquals(v(m, 2), foundValues.get(2));
+      assertEquals(v(m, 3), foundValues.get(3));
    }
 
    public void testRollbackAfterPut() throws Exception {
@@ -181,17 +225,20 @@ public abstract class CacheAPITest extends APINonTxTest {
       assert cache.values().contains(value);
 
       TestingUtil.getTransactionManager(cache).begin();
-      cache.put(key2, value2);
-      assert cache.get(key2).equals(value2);
-      assert cache.keySet().contains(key2);
-      size = 2;
-      log.trace(cache.size());
-      assert size == cache.size();
-      assert size == cache.keySet().size();
-      assert size == cache.values().size();
-      assert size == cache.entrySet().size();
-      assert cache.values().contains(value2);
-      TestingUtil.getTransactionManager(cache).rollback();
+      try {
+         cache.put(key2, value2);
+         assert cache.get(key2).equals(value2);
+         assert cache.keySet().contains(key2);
+         size = 2;
+         log.trace(cache.size());
+         assert size == cache.size();
+         assert size == cache.keySet().size();
+         assert size == cache.values().size();
+         assert size == cache.entrySet().size();
+         assert cache.values().contains(value2);
+      } finally {
+         TestingUtil.getTransactionManager(cache).rollback();
+      }
 
       assert cache.get(key).equals(value);
       size = 1;
@@ -216,10 +263,13 @@ public abstract class CacheAPITest extends APINonTxTest {
       assert cache.get(key).equals(old_value);
 
       TestingUtil.getTransactionManager(cache).begin();
-      assert cache.remove(key).equals(old_value);
-      assert cache.get(key) == null;
-//      assertEquals(cache.putIfAbsent(key, new_value), null);
-      TestingUtil.getTransactionManager(cache).rollback();
+      try {
+         assert cache.remove(key).equals(old_value);
+         assert cache.get(key) == null;
+   //      assertEquals(cache.putIfAbsent(key, new_value), null);
+      } finally {
+         TestingUtil.getTransactionManager(cache).rollback();
+      }
 
       assertEquals(old_value, cache.get(key));
    }


### PR DESCRIPTION
iterating through cache

Fixed issue where entry was repeated if added to context after
starting a transaction

https://issues.jboss.org/browse/ISPN-5104
