### PR TITLE
ISPN-5103 Inefficient index updates cause high cost merges and increase ...

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -72,7 +72,7 @@
       <version.gnu.getopt>1.0.13</version.gnu.getopt>
       <version.hibernate.javax.persistence>1.0.0.Final</version.hibernate.javax.persistence>
       <version.hibernate.core>4.3.6.Final</version.hibernate.core>
-      <version.hibernate.search>5.0.0.Final</version.hibernate.search>
+      <version.hibernate.search>5.0.1.Final</version.hibernate.search>
       <version.javax.cache>1.0.0</version.javax.cache>
       <version.cdi>1.0-SP4</version.cdi>
       <version.jboss.marshalling>1.4.4.Final</version.jboss.marshalling>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -146,7 +146,7 @@
       <version.leveldb>0.7</version.leveldb>
       <version.leveldbjni>1.7</version.leveldbjni>
       <version.log4j>1.2.16</version.log4j>
-      <version.lucene>4.10.2</version.lucene>
+      <version.lucene>4.10.3</version.lucene>
       <version.mc4j>1.2.6</version.mc4j>
       <version.milyn.smooks>1.2.2</version.milyn.smooks>
       <version.mockito>1.9.5</version.mockito>

--- a/query/src/main/java/org/infinispan/query/backend/SearchableCacheConfiguration.java
+++ b/query/src/main/java/org/infinispan/query/backend/SearchableCacheConfiguration.java
@@ -76,6 +76,11 @@ public class SearchableCacheConfiguration extends SearchConfigurationBase implem
    }
 
    @Override
+   public boolean isDeleteByTermEnforced() {
+      return true;
+   }
+
+   @Override
    public Iterator<Class<?>> getClassMappings() {
       return classes.values().iterator();
    }

--- a/query/src/test/java/org/infinispan/query/backend/MultipleEntitiesTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/MultipleEntitiesTest.java
@@ -1,0 +1,103 @@
+package org.infinispan.query.backend;
+
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.backend.impl.lucene.LuceneBackendQueueProcessor;
+import org.hibernate.search.backend.impl.lucene.LuceneBackendResources;
+import org.hibernate.search.backend.impl.lucene.works.ByTermUpdateWorkDelegate;
+import org.hibernate.search.backend.impl.lucene.works.LuceneWorkVisitor;
+import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
+import org.hibernate.search.spi.SearchIntegrator;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.Index;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.query.CacheQuery;
+import org.infinispan.query.Search;
+import org.infinispan.query.SearchManager;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+import java.util.Date;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test for multiple entities types in the same cache sharing the same index
+ *
+ * @author gustavonalle
+ * @since 7.1
+ */
+public class MultipleEntitiesTest extends SingleCacheManagerTest {
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      ConfigurationBuilder cfg = getDefaultStandaloneCacheConfig(false);
+      cfg.indexing().index(Index.ALL)
+            .addProperty("default.directory_provider", "ram")
+            .addProperty("error_handler", "org.infinispan.query.helper.StaticTestingErrorHandler");
+      return TestCacheManagerFactory.createCacheManager(cfg);
+   }
+
+   @Test
+   public void testIndexAndQuery() throws Exception {
+      SearchManager searchManager = Search.getSearchManager(cache);
+
+      cache.put(123405, new Bond(new Date(System.currentTimeMillis()), 450L));
+      assertEfficientIndexingUsed(searchManager.getSearchFactory(), Bond.class);
+
+      cache.put(123502, new Debenture("GB", 116d));
+      assertEfficientIndexingUsed(searchManager.getSearchFactory(), Debenture.class);
+
+      cache.put(223456, new Bond(new Date(System.currentTimeMillis()), 550L));
+      assertEfficientIndexingUsed(searchManager.getSearchFactory(), Bond.class);
+
+      CacheQuery query = searchManager.getQuery(new MatchAllDocsQuery(), Bond.class, Debenture.class);
+      assertEquals(query.list().size(), 3);
+
+      CacheQuery queryBond = searchManager.getQuery(new MatchAllDocsQuery(), Bond.class);
+      assertEquals(queryBond.getResultSize(), 2);
+
+      CacheQuery queryDeb = searchManager.getQuery(new MatchAllDocsQuery(), Debenture.class);
+      assertEquals(queryDeb.getResultSize(), 1);
+   }
+
+   private void assertEfficientIndexingUsed(SearchIntegrator searchIntegrator, Class<?> clazz) {
+      DirectoryBasedIndexManager im = (DirectoryBasedIndexManager) searchIntegrator.getIndexBinding(clazz).getIndexManagers()[0];
+      LuceneBackendQueueProcessor bqp = (LuceneBackendQueueProcessor) im.getBackendQueueProcessor();
+      LuceneBackendResources indexResources = bqp.getIndexResources();
+      LuceneWorkVisitor visitor = indexResources.getVisitor();
+      assertTrue(TestingUtil.extractField(visitor, "updateDelegate") instanceof ByTermUpdateWorkDelegate);
+   }
+}
+
+@Indexed(index = "instruments")
+class Bond {
+   @Field
+   Date maturity;
+   @Field
+   Long price;
+
+   public Bond(Date maturity, Long price) {
+      this.maturity = maturity;
+      this.price = price;
+   }
+}
+
+@Indexed(index = "instruments")
+class Debenture {
+
+   @Field
+   String issuer;
+
+   @Field
+   Double rate;
+
+   public Debenture(String issuer, Double rate) {
+      this.issuer = issuer;
+      this.rate = rate;
+   }
+}

--- a/server/integration/versions/pom.xml
+++ b/server/integration/versions/pom.xml
@@ -39,7 +39,7 @@
       <version.org.xerial.snappy>1.0.5</version.org.xerial.snappy>
       <version.antrun.maven.plugin>1.8</version.antrun.maven.plugin>
       <version.xml.maven.plugin>1.0</version.xml.maven.plugin>
-      <version.org.infinispan.protostream>3.0.0.Alpha5</version.org.infinispan.protostream>
+      <version.org.infinispan.protostream>3.0.0.Alpha2</version.org.infinispan.protostream>
       <version.protobuf>2.6.0</version.protobuf>
       <version.http.client>4.3</version.http.client>
       <version.org.picketbox>4.0.17.SP2</version.org.picketbox>
@@ -50,7 +50,7 @@
       <version.javax.inject>1</version.javax.inject>
       <version.h2.database>1.3.173</version.h2.database>
       <version.resteasy>3.0.8.Final</version.resteasy>
-      <version.lucene>4.10.2</version.lucene>
+      <version.lucene>4.10.3</version.lucene>
       <relocations />
 
    </properties>

--- a/server/integration/versions/pom.xml
+++ b/server/integration/versions/pom.xml
@@ -39,7 +39,7 @@
       <version.org.xerial.snappy>1.0.5</version.org.xerial.snappy>
       <version.antrun.maven.plugin>1.8</version.antrun.maven.plugin>
       <version.xml.maven.plugin>1.0</version.xml.maven.plugin>
-      <version.org.infinispan.protostream>3.0.0.Alpha2</version.org.infinispan.protostream>
+      <version.org.infinispan.protostream>3.0.0.Alpha5</version.org.infinispan.protostream>
       <version.protobuf>2.6.0</version.protobuf>
       <version.http.client>4.3</version.http.client>
       <version.org.picketbox>4.0.17.SP2</version.org.picketbox>


### PR DESCRIPTION
...overall latency

https://issues.jboss.org/browse/ISPN-5103

[DO NOT INTEGRATE YET]
With a single entity, efficient indexing is used since ```isIndexMetadataComplete``` is being enforced
After a new entity type is indexed, the search engine falls back to ```'safe'``` indexing.

Depends on https://hibernate.atlassian.net/browse/HSEARCH-1767