### PR TITLE
ISPN-4990 Run all security tests by default and in one maven profile

### DIFF
--- a/server/integration/testsuite/pom.xml
+++ b/server/integration/testsuite/pom.xml
@@ -283,7 +283,7 @@
         <suite.manual.include>**/*.java</suite.manual.include>
         <suite.manual.exclude.groups>
             org.infinispan.server.test.category.ClientLocal,org.infinispan.server.test.category.ClientClustered,org.infinispan.server.test.category.RollingUpgrades,org.infinispan.server.test.category.RollingUpgradesDist,org.infinispan.server.test.category.Unstable,org.infinispan.server.test.category.Osgi,
-            org.infinispan.server.test.category.Security, org.infinispan.server.test.category.Queries
+            org.infinispan.server.test.category.Queries
         </suite.manual.exclude.groups>
         <suite.client.local.config>testsuite/standalone-default-local.xml</suite.client.local.config>
         <suite.client.dist.config>testsuite/clustered-default-dist.xml</suite.client.dist.config>
@@ -1055,19 +1055,7 @@
                 <suite.client.dist.phase>none</suite.client.dist.phase>
                 <suite.client.repl.phase>none</suite.client.repl.phase>
                 <suite.security.phase>integration-test</suite.security.phase>
-                <suite.security.arquillian>suite-security</suite.security.arquillian>
-            </properties>
-        </profile>
-        <profile>
-            <id>suite.security.manual</id>
-            <properties>
-                <suite.manual.phase>none</suite.manual.phase>
-                <suite.queries.phase>none</suite.queries.phase>
-                <suite.client.local.phase>none</suite.client.local.phase>
-                <suite.client.dist.phase>none</suite.client.dist.phase>
-                <suite.client.repl.phase>none</suite.client.repl.phase>
-                <suite.security.phase>integration-test</suite.security.phase>
-                <suite.security.arquillian>suite-security-manual</suite.security.arquillian>
+                <suite.security.arquillian>suite-manual</suite.security.arquillian>
             </properties>
         </profile>
         <profile>

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/security/HotRodDigestMd5AuthLocalIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/security/HotRodDigestMd5AuthLocalIT.java
@@ -2,6 +2,8 @@ package org.infinispan.server.test.client.hotrod.security;
 
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServer;
+import org.infinispan.arquillian.core.RunningServer;
+import org.infinispan.arquillian.core.WithRunningServer;
 import org.infinispan.server.test.category.Security;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.experimental.categories.Category;
@@ -16,6 +18,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @Category({ Security.class })
+@WithRunningServer({@RunningServer(name="hotrodAuth")})
 public class HotRodDigestMd5AuthLocalIT extends HotRodSaslAuthTestBase {
 
    @InfinispanResource("hotrodAuth")

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/security/HotRodPlainAuthLocalIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/security/HotRodPlainAuthLocalIT.java
@@ -2,6 +2,8 @@ package org.infinispan.server.test.client.hotrod.security;
 
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServer;
+import org.infinispan.arquillian.core.RunningServer;
+import org.infinispan.arquillian.core.WithRunningServer;
 import org.infinispan.server.test.category.Security;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.experimental.categories.Category;
@@ -16,6 +18,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @Category({ Security.class })
+@WithRunningServer({@RunningServer(name="hotrodAuth")})
 public class HotRodPlainAuthLocalIT extends HotRodSaslAuthTestBase {
 
    @InfinispanResource("hotrodAuth")

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/security/jgroups/encrypt/EncryptProtocolIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/security/jgroups/encrypt/EncryptProtocolIT.java
@@ -10,14 +10,13 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import javax.management.ObjectName;
-
 import org.apache.commons.io.FileUtils;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServers;
 import org.infinispan.arquillian.core.RunningServer;
 import org.infinispan.arquillian.core.WithRunningServer;
 import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
+import org.infinispan.server.test.category.Security;
 import org.infinispan.server.test.client.memcached.MemcachedClient;
 import org.infinispan.server.test.util.RemoteInfinispanMBeans;
 import org.jboss.arquillian.container.test.api.ContainerController;
@@ -25,6 +24,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -40,6 +40,7 @@ import org.junit.runner.RunWith;
  * @author Martin Gencur
  */
 @RunWith(Arquillian.class)
+@Category({ Security.class })
 public class EncryptProtocolIT {
 
     @InfinispanResource

--- a/server/integration/testsuite/src/test/resources/arquillian.xml
+++ b/server/integration/testsuite/src/test/resources/arquillian.xml
@@ -656,6 +656,173 @@
                 <property name="waitForPorts">11311 11322 8180</property>
             </configuration>
         </container>
+                <container qualifier="hotrodAuthClustered" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="managementAddress">${node0.ip}</property>
+                <property name="serverConfig">testsuite/hotrod-auth-clustered.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                </property>
+                <property name="managementPort">9990</property>
+                <property name="waitForPorts">11211 11222 8080</property>
+            </configuration>
+        </container>
+        <container qualifier="hotrodAuthClustered-2" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server2.dist}</property>
+                <property name="managementAddress">${node1.ip}</property>
+                <property name="serverConfig">testsuite/hotrod-auth-clustered.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djboss.socket.binding.port-offset=100
+                </property>
+                <property name="managementPort">10090</property>
+                <property name="waitForPorts">11311 11322 8180</property>
+            </configuration>
+        </container>
+        <container qualifier="hotrodAuthKrb" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="managementAddress">${node0.ip}</property>
+                <property name="serverConfig">testsuite/hotrod-auth-krb.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                </property>
+                <property name="managementPort">9990</property>
+                <property name="waitForPorts">11211 11222 8080</property>
+            </configuration>
+        </container>
+        <container qualifier="hotrodAuthQop" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="managementAddress">${node0.ip}</property>
+                <property name="serverConfig">testsuite/hotrod-auth-qop.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                </property>
+                <property name="managementPort">9990</property>
+                <property name="waitForPorts">11211 11222 8080</property>
+            </configuration>
+        </container>
+        <container qualifier="hotrodAuthLdap" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="managementAddress">${node0.ip}</property>
+                <property name="serverConfig">testsuite/hotrod-auth-ldap.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                </property>
+                <property name="managementPort">9990</property>
+                <property name="waitForPorts">11211 11222 8080</property>
+            </configuration>
+        </container>
+        <container qualifier="hotrodAuthLdapOverSsl" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="managementAddress">${node0.ip}</property>
+                <property name="serverConfig">testsuite/hotrod-auth-ldap-ssl.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                </property>
+                <property name="managementPort">9990</property>
+                <property name="waitForPorts">11211 11222 8080</property>
+            </configuration>
+        </container>
+        <container qualifier="hotrodAuthzLdap" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="managementAddress">${node0.ip}</property>
+                <property name="serverConfig">testsuite/hotrod-authz-ldap.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                </property>
+                <property name="managementPort">9990</property>
+                <property name="waitForPorts">11211 11222 8080</property>
+            </configuration>
+        </container>
+        <container qualifier="clustered-sasl-md5-1" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="managementAddress">${node0.ip}</property>
+                <property name="managementPort">9990</property>
+                <property name="serverConfig">testsuite/clustered-with-sasl-md5-0.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip} -Dsasl.username=test -Dsasl.password=heslo -Dsasl.realm=testRealm
+                </property>
+                <property name="waitForPorts">11211 11222 8080</property>
+            </configuration>
+        </container>
+        <container qualifier="clustered-sasl-md5-2" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server2.dist}</property>
+                <property name="managementAddress">${node1.ip}</property>
+                <property name="managementPort">10090</property>
+                <property name="serverConfig">testsuite/clustered-with-sasl-md5-1.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip} -Dsasl.username=test -Dsasl.password=heslo -Dsasl.realm=testRealm
+                    -Djboss.socket.binding.port-offset=100
+                </property>
+                <property name="waitForPorts">11311 11322 8180</property>
+            </configuration>
+        </container>
+        <container qualifier="clustered-sasl-krb-1" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="managementAddress">${node0.ip}</property>
+                <property name="managementPort">9990</property>
+                <property name="serverConfig">testsuite/clustered-with-sasl-krb-0.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                </property>
+                <property name="waitForPorts">11211 11222 8080</property>
+            </configuration>
+        </container>
+        <container qualifier="clustered-sasl-krb-2" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server2.dist}</property>
+                <property name="managementAddress">${node1.ip}</property>
+                <property name="managementPort">10090</property>
+                <property name="serverConfig">testsuite/clustered-with-sasl-krb-1.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100
+                </property>
+                <property name="waitForPorts">11311 11322 8180</property>
+            </configuration>
+        </container>
+        <container qualifier="another-clustered-sasl-md5-2" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server2.dist}</property>
+                <property name="managementAddress">${node1.ip}</property>
+                <property name="managementPort">10090</property>
+                <property name="serverConfig">testsuite/clustered-with-sasl-md5-1.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=another_node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip} -Dsasl.username=test -Dsasl.password=heslo -Dsasl.realm=testRealm
+                    -Djboss.socket.binding.port-offset=100
+                </property>
+                <property name="waitForPorts">11311 11322 8180</property>
+            </configuration>
+        </container>
+        <container qualifier="hotrodAuth" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="managementAddress">${node0.ip}</property>
+                <property name="serverConfig">testsuite/hotrod-auth.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                </property>
+                <property name="managementPort">9990</property>
+                <property name="waitForPorts">11211 11222 8080</property>
+            </configuration>
+        </container>
     </group>
 
     <group qualifier="queries">
@@ -933,177 +1100,6 @@
                 </property>
                 <property name="managementPort">10290</property>
                 <property name="waitForPorts">11511 11522 8380</property>
-            </configuration>
-        </container>
-    </group>
-    <group qualifier="suite-security">
-        <container qualifier="hotrodAuth" mode="suite">
-            <configuration>
-                <property name="javaHome">${server.jvm}</property>
-                <property name="jbossHome">${server1.dist}</property>
-                <property name="managementAddress">${node0.ip}</property>
-                <property name="serverConfig">testsuite/hotrod-auth.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
-                </property>
-                <property name="managementPort">9990</property>
-                <property name="waitForPorts">11211 11222 8080</property>
-            </configuration>
-        </container>
-    </group>
-    <group qualifier="suite-security-manual">
-        <container qualifier="hotrodAuthClustered" mode="manual">
-            <configuration>
-                <property name="javaHome">${server.jvm}</property>
-                <property name="jbossHome">${server1.dist}</property>
-                <property name="managementAddress">${node0.ip}</property>
-                <property name="serverConfig">testsuite/hotrod-auth-clustered.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
-                </property>
-                <property name="managementPort">9990</property>
-                <property name="waitForPorts">11211 11222 8080</property>
-            </configuration>
-        </container>
-        <container qualifier="hotrodAuthClustered-2" mode="manual">
-            <configuration>
-                <property name="javaHome">${server.jvm}</property>
-                <property name="jbossHome">${server2.dist}</property>
-                <property name="managementAddress">${node1.ip}</property>
-                <property name="serverConfig">testsuite/hotrod-auth-clustered.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djboss.socket.binding.port-offset=100
-                </property>
-                <property name="managementPort">10090</property>
-                <property name="waitForPorts">11311 11322 8180</property>
-            </configuration>
-        </container>
-        <container qualifier="hotrodAuthKrb" mode="manual">
-            <configuration>
-                <property name="javaHome">${server.jvm}</property>
-                <property name="jbossHome">${server1.dist}</property>
-                <property name="managementAddress">${node0.ip}</property>
-                <property name="serverConfig">testsuite/hotrod-auth-krb.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
-                </property>
-                <property name="managementPort">9990</property>
-                <property name="waitForPorts">11211 11222 8080</property>
-            </configuration>
-        </container>
-        <container qualifier="hotrodAuthQop" mode="manual">
-            <configuration>
-                <property name="javaHome">${server.jvm}</property>
-                <property name="jbossHome">${server1.dist}</property>
-                <property name="managementAddress">${node0.ip}</property>
-                <property name="serverConfig">testsuite/hotrod-auth-qop.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
-                </property>
-                <property name="managementPort">9990</property>
-                <property name="waitForPorts">11211 11222 8080</property>
-            </configuration>
-        </container>
-        <container qualifier="hotrodAuthLdap" mode="manual">
-            <configuration>
-                <property name="javaHome">${server.jvm}</property>
-                <property name="jbossHome">${server1.dist}</property>
-                <property name="managementAddress">${node0.ip}</property>
-                <property name="serverConfig">testsuite/hotrod-auth-ldap.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
-                </property>
-                <property name="managementPort">9990</property>
-                <property name="waitForPorts">11211 11222 8080</property>
-            </configuration>
-        </container>
-        <container qualifier="hotrodAuthLdapOverSsl" mode="manual">
-            <configuration>
-                <property name="javaHome">${server.jvm}</property>
-                <property name="jbossHome">${server1.dist}</property>
-                <property name="managementAddress">${node0.ip}</property>
-                <property name="serverConfig">testsuite/hotrod-auth-ldap-ssl.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
-                </property>
-                <property name="managementPort">9990</property>
-                <property name="waitForPorts">11211 11222 8080</property>
-            </configuration>
-        </container>
-        <container qualifier="hotrodAuthzLdap" mode="manual">
-            <configuration>
-                <property name="javaHome">${server.jvm}</property>
-                <property name="jbossHome">${server1.dist}</property>
-                <property name="managementAddress">${node0.ip}</property>
-                <property name="serverConfig">testsuite/hotrod-authz-ldap.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
-                </property>
-                <property name="managementPort">9990</property>
-                <property name="waitForPorts">11211 11222 8080</property>
-            </configuration>
-        </container>
-        <container qualifier="clustered-sasl-md5-1" mode="manual">
-            <configuration>
-                <property name="javaHome">${server.jvm}</property>
-                <property name="jbossHome">${server1.dist}</property>
-                <property name="managementAddress">${node0.ip}</property>
-                <property name="managementPort">9990</property>
-                <property name="serverConfig">testsuite/clustered-with-sasl-md5-0.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip} -Dsasl.username=test -Dsasl.password=heslo -Dsasl.realm=testRealm
-                </property>
-                <property name="waitForPorts">11211 11222 8080</property>
-            </configuration>
-        </container>
-        <container qualifier="clustered-sasl-md5-2" mode="manual">
-            <configuration>
-                <property name="javaHome">${server.jvm}</property>
-                <property name="jbossHome">${server2.dist}</property>
-                <property name="managementAddress">${node1.ip}</property>
-                <property name="managementPort">10090</property>
-                <property name="serverConfig">testsuite/clustered-with-sasl-md5-1.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip} -Dsasl.username=test -Dsasl.password=heslo -Dsasl.realm=testRealm
-                    -Djboss.socket.binding.port-offset=100
-                </property>
-                <property name="waitForPorts">11311 11322 8180</property>
-            </configuration>
-        </container>
-        <container qualifier="clustered-sasl-krb-1" mode="manual">
-            <configuration>
-                <property name="javaHome">${server.jvm}</property>
-                <property name="jbossHome">${server1.dist}</property>
-                <property name="managementAddress">${node0.ip}</property>
-                <property name="managementPort">9990</property>
-                <property name="serverConfig">testsuite/clustered-with-sasl-krb-0.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                </property>
-                <property name="waitForPorts">11211 11222 8080</property>
-            </configuration>
-        </container>
-        <container qualifier="clustered-sasl-krb-2" mode="manual">
-            <configuration>
-                <property name="javaHome">${server.jvm}</property>
-                <property name="jbossHome">${server2.dist}</property>
-                <property name="managementAddress">${node1.ip}</property>
-                <property name="managementPort">10090</property>
-                <property name="serverConfig">testsuite/clustered-with-sasl-krb-1.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
-                </property>
-                <property name="waitForPorts">11311 11322 8180</property>
-            </configuration>
-        </container>
-        <container qualifier="another-clustered-sasl-md5-2" mode="manual">
-            <configuration>
-                <property name="javaHome">${server.jvm}</property>
-                <property name="jbossHome">${server2.dist}</property>
-                <property name="managementAddress">${node1.ip}</property>
-                <property name="managementPort">10090</property>
-                <property name="serverConfig">testsuite/clustered-with-sasl-md5-1.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=another_node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip} -Dsasl.username=test -Dsasl.password=heslo -Dsasl.realm=testRealm
-                    -Djboss.socket.binding.port-offset=100
-                </property>
-                <property name="waitForPorts">11311 11322 8180</property>
             </configuration>
         </container>
     </group>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4990

* all security tests are now executed by default
* all security tests are no consolidated under one maven profile and can be executed separately via `mvn clean verify -pl server/integration/testsuite/ -Psuite.security`