### PR TITLE
ISPN-5137 Transaction from new topology rolled back (but succeeds on

### DIFF
--- a/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
@@ -146,7 +146,9 @@ public class InterceptorChainFactory extends AbstractNamedCacheComponentFactory 
          } else {
             interceptorChain.appendInterceptor(createInterceptor(new StateTransferInterceptor(), StateTransferInterceptor.class), false);
          }
-         interceptorChain.appendInterceptor(createInterceptor(new TransactionSynchronizerInterceptor(), TransactionSynchronizerInterceptor.class), false);
+         if (configuration.transaction().transactionMode().isTransactional()) {
+            interceptorChain.appendInterceptor(createInterceptor(new TransactionSynchronizerInterceptor(), TransactionSynchronizerInterceptor.class), false);
+         }
       }
 
       // The partition handling must run every time the state transfer interceptor retries a command (in non-transactional caches)

--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -374,7 +374,7 @@ public class StateConsumerImpl implements StateConsumer {
          // Need to do it now, after we have applied any transactions from other nodes,
          // and after notifyTransactionDataReceived - otherwise the RollbackCommands would block.
          if (transactionTable != null) {
-            transactionTable.cleanupLeaverTransactions(cacheTopology);
+            transactionTable.cleanupLeaverTransactions(rpcManager.getTransport().getMembers());
          }
 
          // Any data for segments we do not own should be removed from data container and cache store

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -257,7 +257,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
          if (newCacheTopology.getRebalanceId() != oldCacheTopology.getRebalanceId()) {
             // The currentCH changed, we need to install a "reset" topology with the new currentCH first
             CacheTopology resetTopology = new CacheTopology(newCacheTopology.getTopologyId() - 1,
-                  newCacheTopology.getRebalanceId() - 1, newCacheTopology.getCurrentCH(), null, null);
+                  newCacheTopology.getRebalanceId() - 1, newCacheTopology.getCurrentCH(), null, newCacheTopology.getActualMembers());
             log.debugf("Installing fake cache topology %s for cache %s", resetTopology, cacheName);
             handler.updateConsistentHash(resetTopology);
          }

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareTransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareTransactionTable.java
@@ -2,7 +2,7 @@ package org.infinispan.transaction.xa.recovery;
 
 import org.infinispan.commons.CacheException;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.topology.CacheTopology;
+import org.infinispan.remoting.transport.Address;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
@@ -13,7 +13,6 @@ import org.infinispan.util.logging.LogFactory;
 
 import javax.transaction.Transaction;
 import javax.transaction.xa.Xid;
-
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -40,8 +39,8 @@ public class RecoveryAwareTransactionTable extends XaTransactionTable {
 
    /**
     * Marks the transaction as prepared. If at a further point the originator fails, the transaction is removed form the
-    * "normal" transactions collection and moved into the cache that holds in-doubt transactions. See {@link
-    * #cleanupLeaverTransactions(org.infinispan.topology.CacheTopology)}
+    * "normal" transactions collection and moved into the cache that holds in-doubt transactions.
+    * See {@link #cleanupLeaverTransactions(java.util.List)}
     */
    @Override
    public void remoteTransactionPrepared(GlobalTransaction gtx) {
@@ -64,27 +63,21 @@ public class RecoveryAwareTransactionTable extends XaTransactionTable {
    /**
     * First moves the prepared transactions originated on the leavers into the recovery cache and then cleans up the
     * transactions that are not yet prepared.
-    * @param cacheTopology
+    * @param members The list of cluster members
     */
    @Override
-   public void cleanupLeaverTransactions(CacheTopology cacheTopology) {
-      // We only care about transactions originated before this topology update
-      if (getMinTopologyId() >= cacheTopology.getTopologyId())
-         return;
-
+   public void cleanupLeaverTransactions(List<Address> members) {
       Iterator<RemoteTransaction> it = getRemoteTransactions().iterator();
       while (it.hasNext()) {
          RecoveryAwareRemoteTransaction recTx = (RecoveryAwareRemoteTransaction) it.next();
-         if (recTx.getTopologyId() < cacheTopology.getTopologyId()) {
-            recTx.computeOrphan(cacheTopology.getMembers());
-            if (recTx.isInDoubt()) {
-               recoveryManager.registerInDoubtTransaction(recTx);
-               it.remove();
-            }
+         recTx.computeOrphan(members);
+         if (recTx.isInDoubt()) {
+            recoveryManager.registerInDoubtTransaction(recTx);
+            it.remove();
          }
       }
       //this cleans up the transactions that are not yet prepared
-      super.cleanupLeaverTransactions(cacheTopology);
+      super.cleanupLeaverTransactions(members);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/statetransfer/OrphanTransactionsCleanupTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/OrphanTransactionsCleanupTest.java
@@ -1,0 +1,84 @@
+package org.infinispan.statetransfer;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.topology.LocalTopologyManager;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.impl.TransactionTable;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.testng.annotations.Test;
+
+import javax.transaction.Transaction;
+import java.util.Arrays;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+@Test(groups = "functional", testName = "statetransfer.OrphanTransactionsCleanupTest")
+public class OrphanTransactionsCleanupTest extends MultipleCacheManagersTest {
+   private static final Log log = LogFactory.getLog(OrphanTransactionsCleanupTest.class);
+
+   protected ConfigurationBuilder configurationBuilder;
+
+   public OrphanTransactionsCleanupTest() {
+      cleanup = CleanupPhase.AFTER_METHOD;
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      configurationBuilder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
+      configurationBuilder.transaction().lockingMode(LockingMode.PESSIMISTIC);
+      configurationBuilder.clustering().stateTransfer().awaitInitialTransfer(false);
+
+      addClusterEnabledCacheManager(configurationBuilder);
+      addClusterEnabledCacheManager(configurationBuilder);
+      waitForClusterToForm();
+   }
+
+   public void testJoinerTransactionSurvives() throws Exception {
+      Cache<Object, Object> c0 = manager(0).getCache();
+      Cache<Object, Object> c1 = manager(1).getCache();
+      final TransactionTable tt0 = TestingUtil.extractComponent(c0, TransactionTable.class);
+
+      // Disable rebalancing so that the joiner is not included in the CH
+      LocalTopologyManager ltm0 = TestingUtil.extractGlobalComponent(manager(0), LocalTopologyManager.class);
+      ltm0.setRebalancingEnabled(false);
+
+      // Add a new node
+      addClusterEnabledCacheManager(configurationBuilder);
+      Cache<Object, Object> c2 = manager(2).getCache();
+
+      // Start a transaction from c2, but don't commit yet
+      tm(2).begin();
+      c2.put("key1", "value1");
+      assertEquals(1, tt0.getRemoteGlobalTransaction().size());
+      Transaction tx2 = tm(2).suspend();
+
+      // Start another transaction from c1, also without committing it
+      tm(1).begin();
+      c1.put("key2", "value2");
+      assertEquals(2, tt0.getRemoteGlobalTransaction().size());
+      Transaction tx1 = tm(1).suspend();
+
+      // Kill node 1 to trigger the orphan transaction cleanup
+      manager(1).stop();
+      TestingUtil.blockUntilViewsReceived(60000, false, c0, c2);
+      // Cache 2 should not be in the CH yet
+      TestingUtil.waitForRehashToComplete(c0);
+
+      assertEquals(Arrays.asList(address(0)), c0.getAdvancedCache().getDistributionManager().getConsistentHash().getMembers());
+      eventually(new Condition() {
+         @Override
+         public boolean isSatisfied() throws Exception {
+            return tt0.getRemoteTransactions().size() == 1;
+         }
+      });
+
+      // Committing the tx on c2 should succeed
+      tm(2).resume(tx2);
+      tm(2).commit();
+   }
+}

--- a/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
@@ -1,7 +1,5 @@
 package org.infinispan.tx;
 
-import javax.transaction.xa.XAException;
-import javax.transaction.xa.XAResource;
 import org.infinispan.Cache;
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commons.equivalence.AnyEquivalence;
@@ -24,6 +22,8 @@ import org.infinispan.transaction.xa.XaTransactionTable;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
 import java.util.UUID;
 
 import static org.mockito.Mockito.mock;
@@ -50,7 +50,7 @@ public class TransactionXaAdapterTmIntegrationTest {
       configuration = new ConfigurationBuilder().build();
       txTable = new XaTransactionTable();
       txTable.initialize(null, configuration, null, null, null, null,
-            null, null, null, null, mockCache, null);
+            null, null, null, null, mockCache, null, null);
       txTable.start();
       txTable.startXidMapping();
       TransactionFactory gtf = new TransactionFactory();


### PR DESCRIPTION
originator)

https://issues.jboss.org/browse/ISPN-5137

Check if a node left the cluster using the JGroups view members instead
of the cache topology members.
Run the check both on topology changes and on JGroups view changes.