### PR TITLE
ISPN-5153 CacheEntryInvalidatedEvent is not raised

### DIFF
--- a/core/src/main/java/org/infinispan/commands/write/EvictCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/EvictCommand.java
@@ -38,11 +38,17 @@ public class EvictCommand extends RemoveCommand implements LocalCommand {
    }
 
    @Override
-   public void notify(InvocationContext ctx, Object value, Metadata previousMetadata) {
-      /**
-       * We don't notify in pre for evictions - the notification is done in
-       * {@link org.infinispan.interceptors.locking.ClusteringDependentLogic.AbstractClusteringDependentLogic#notifyCommitEntry(boolean, boolean, boolean, org.infinispan.container.entries.CacheEntry, org.infinispan.context.InvocationContext, org.infinispan.commands.FlagAffectedCommand, org.infinispan.container.entries.InternalCacheEntry)}
-        */
+   public void notify(InvocationContext ctx, Object value, Metadata previousMetadata, 
+         boolean isPre) {
+      // Eviction has no notion of pre/post event since 4.2.0.ALPHA4.
+      // EvictionManagerImpl.onEntryEviction() triggers both pre and post events
+      // with non-null values, so we should do the same here as an ugly workaround.
+      if (!isPre) {
+         if (log.isTraceEnabled())
+            log.tracef("Notify eviction listeners for key=%", key);
+
+         notifier.notifyCacheEntryEvicted(key, value, ctx, this);
+      }
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/write/InvalidateCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/InvalidateCommand.java
@@ -5,6 +5,7 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.metadata.Metadata;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -68,6 +69,12 @@ public class InvalidateCommand extends RemoveCommand {
    protected void invalidate(InvocationContext ctx, Object keyToInvalidate) throws Throwable {
       key = keyToInvalidate; // so that the superclass can see it
       super.perform(ctx);
+   }
+
+   @Override
+   public void notify(InvocationContext ctx, Object removedValue, Metadata removedMetadata,
+         boolean isPre) {
+      notifier.notifyCacheEntryInvalidated(key, removedValue, isPre, ctx, this);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/write/RemoveCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/RemoveCommand.java
@@ -93,8 +93,8 @@ public class RemoveCommand extends AbstractDataWriteCommand {
       return performRemove(e, ctx);
    }
 
-   protected void notify(InvocationContext ctx, Object removedValue, Metadata removedMetadata) {
-      notifier.notifyCacheEntryRemoved(key, removedValue, removedMetadata, true, ctx, this);
+   public void notify(InvocationContext ctx, Object removedValue, Metadata removedMetadata, boolean isPre) {
+      notifier.notifyCacheEntryRemoved(key, removedValue, removedMetadata, isPre, ctx, this);
    }
 
    @Override
@@ -205,7 +205,7 @@ public class RemoveCommand extends AbstractDataWriteCommand {
 
    private Object performRemove(CacheEntry e, InvocationContext ctx) {
       final Object removedValue = e.getValue();
-      notify(ctx, removedValue, e.getMetadata());
+      notify(ctx, removedValue, e.getMetadata(), true);
 
       e.setRemoved(true);
       e.setValid(false);

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
@@ -402,15 +402,11 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
    }
 
    @Override
-   public void notifyCacheEntryInvalidated(final K key, V value, final boolean pre,
-         InvocationContext ctx, FlagAffectedCommand command) {
+   public void notifyCacheEntryInvalidated(final K key, V value, 
+         final boolean pre, InvocationContext ctx, FlagAffectedCommand command) {
       if (isNotificationAllowed(command, cacheEntryInvalidatedListeners)) {
-         final boolean originLocal = ctx.isOriginLocal();
          EventImpl<K, V> e = EventImpl.createEvent(cache, CACHE_ENTRY_INVALIDATED);
-         e.setOriginLocal(originLocal);
-         e.setPre(pre);
-         e.setKey(key);
-         e.setValue(value);
+         configureEvent(e, key, value, pre, ctx, command, value, null);
          setTx(ctx, e);
          boolean isLocalNodePrimaryOwner = clusteringDependentLogic.localNodeIsPrimaryOwner(key);
          for (CacheEntryListenerInvocation<K, V> listener : cacheEntryInvalidatedListeners) listener.invoke(e, isLocalNodePrimaryOwner);

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/event/CacheEntryInvalidatedEvent.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/event/CacheEntryInvalidatedEvent.java
@@ -2,13 +2,16 @@ package org.infinispan.notifications.cachelistener.event;
 
 /**
  * Notifies a listener of an invalidation event.
+ * <p>
+ * Eviction has no notion of pre/post event since 4.2.0.ALPHA4.  This event is only
+ * raised once after the eviction has occurred with the pre event flag being false.
  *
  * @author Manik Surtani
  * @since 4.0
  */
 public interface CacheEntryInvalidatedEvent<K, V> extends CacheEntryEvent<K, V> {
    /**
-    * Retrieves the value of the entry being activated.
+    * Retrieves the value of the entry being invalidated.
     *
     * @return the value of the invalidated entry
     */

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierInvalidationTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierInvalidationTest.java
@@ -1,0 +1,97 @@
+package org.infinispan.notifications.cachelistener;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryInvalidated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryPassivated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryVisited;
+import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryInvalidatedEvent;
+import org.infinispan.notifications.cachelistener.event.Event.Type;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.testng.annotations.Test;
+
+/**
+ * Simple test class that tests to make sure invalidation events are raised on remote 
+ * nodes
+ *
+ * @author wburns
+ * @since 4.0
+ */
+@Test(groups = "functional", testName = "notifications.cachelistener.CacheNotifierInvalidationTest")
+public class CacheNotifierInvalidationTest extends MultipleCacheManagersTest {
+   protected final String CACHE_NAME = getClass().getName();
+   protected ConfigurationBuilder builderUsed;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      builderUsed = new ConfigurationBuilder();
+      builderUsed.clustering().cacheMode(CacheMode.INVALIDATION_SYNC);
+      createClusteredCaches(3, CACHE_NAME, builderUsed);
+   }
+
+   @Listener
+   private static class AllCacheEntryListener {
+      private final List<CacheEntryEvent> events = Collections.synchronizedList(
+            new ArrayList<CacheEntryEvent>());
+
+      @CacheEntryVisited
+      @CacheEntryActivated
+      @CacheEntryModified
+      @CacheEntryRemoved
+      @CacheEntryCreated
+      @CacheEntryInvalidated
+      @CacheEntryPassivated
+      public void listenEvent(CacheEntryEvent event) {
+         events.add(event);
+      }
+   }
+
+   /**
+    * Basic test to ensure that a remote node's is notified of invalidation
+    */
+   @Test
+   public void testRemoteNodeValueInvalidated() {
+      String key = "key";
+      String value = "value";
+      Cache<String, String> cache0 = cache(0, CACHE_NAME);
+      cache0.put(key, value);
+
+      AllCacheEntryListener listener = new AllCacheEntryListener();
+      cache0.addListener(listener);
+
+      String value2 = "value2";
+      // Now update the key which will invalidate cache0's key
+      cache(1, CACHE_NAME).put(key, value2);
+
+      assertEquals(2, listener.events.size());
+
+      CacheEntryEvent event = listener.events.get(0);
+      assertEquals(Type.CACHE_ENTRY_INVALIDATED, event.getType());
+      assertEquals(key, event.getKey());
+      assertEquals(value, event.getValue());
+      assertTrue(event.isPre());
+      assertFalse(event.isOriginLocal());
+      
+      event = listener.events.get(1);
+      assertEquals(Type.CACHE_ENTRY_INVALIDATED, event.getType());
+      assertEquals(key, event.getKey());
+      assertEquals(value, event.getValue());
+      assertFalse(event.isPre());
+      assertFalse(event.isOriginLocal());
+   }
+}


### PR DESCRIPTION
* Added back in invalidation event
* Fixed issue where remove events were being sent as post event
** Affected Invalidation Events
** Affected Eviction Events

https://issues.jboss.org/browse/ISPN-5153