### PR TITLE
ISPN-5150 In testing, near cache events should fire after event

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -573,7 +573,7 @@ public class RemoteCacheManager implements BasicCacheContainer {
          asyncExecutorService = executorFactory.getExecutor(configuration.asyncExecutorFactory().properties());
       }
 
-      listenerNotifier = new ClientListenerNotifier(asyncExecutorService, codec, marshaller);
+      listenerNotifier = ClientListenerNotifier.create(codec, marshaller);
       transportFactory.start(codec, configuration, defaultCacheTopologyId, listenerNotifier);
 
       synchronized (cacheName2RemoteCache) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/MockNearCacheService.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/MockNearCacheService.java
@@ -45,20 +45,20 @@ public class MockNearCacheService<K, V> extends NearCacheService<K, V> {
 
       @Override
       public void put(K key, VersionedValue<V> value) {
-         events.add(new MockPutEvent<K, V>(key, value));
          delegate.put(key, value);
+         events.add(new MockPutEvent<K, V>(key, value));
       }
 
       @Override
       public void putIfAbsent(K key, VersionedValue<V> value) {
-         events.add(new MockPutIfAbsentEvent<K, V>(key, value));
          delegate.putIfAbsent(key, value);
+         events.add(new MockPutIfAbsentEvent<K, V>(key, value));
       }
 
       @Override
       public void remove(K key) {
-         events.add(new MockRemoveEvent<>(key));
          delegate.remove(key);
+         events.add(new MockRemoveEvent<>(key));
       }
 
       @Override
@@ -70,8 +70,8 @@ public class MockNearCacheService<K, V> extends NearCacheService<K, V> {
 
       @Override
       public void clear() {
-         events.add(new MockClearEvent());
          delegate.clear();
+         events.add(new MockClearEvent());
       }
    }
 


### PR DESCRIPTION
* Before this fix, events were being fired before the near cache had been updated, and as a result of that, client code was making working on assumptions that might not have yet been applied in a multi threaded environment.
* Instead of using the Hot Rod async thread pool for client listeners, created a simple cached pool where each thread is associated with a client listener, and the thread name is adjusted when the client listener starts.
* Added multiple TRACE log messages to help debugging.