### PR TITLE
ISPN-4795 Force return previous WARN message only for write operations

### DIFF
--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
@@ -489,8 +489,12 @@ object Decoder2x extends AbstractVersionedDecoder with ServerConstants with Log 
             case _ =>
          }
       } else {
-         if (!isTransactional)
-            warnForceReturnPreviousNonTransactional(h.op.toString)
+         h.op match {
+            case PutRequest | RemoveRequest | PutIfAbsentRequest | ReplaceRequest
+                 | ReplaceIfUnmodifiedRequest | RemoveIfUnmodifiedRequest if !isTransactional =>
+               warnForceReturnPreviousNonTransactional(h.op.toString)
+            case _ => // no-op
+         }
       }
       optCache
    }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/logging/Log.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/logging/Log.scala
@@ -14,6 +14,9 @@ trait Log extends org.infinispan.server.core.logging.Log {
 
    private[hotrod] lazy val log: JavaLog = LogFactory.getLog(getClass, classOf[JavaLog])
 
+   @volatile private var warnConditionalLogged = false
+   @volatile private var warnForceReturnPreviousLogged = false
+
    def logViewNullWhileDetectingCrashedMember = log.viewNullWhileDetectingCrashedMember
 
    def logUnableToUpdateView = log.unableToUpdateView
@@ -22,9 +25,19 @@ trait Log extends org.infinispan.server.core.logging.Log {
 
    def unexpectedEvent(e: Event[_, _]) = log.unexpectedEvent(e)
 
-   def warnConditionalOperationNonTransactional(op: String) = log.warnConditionalOperationNonTransactional(op)
+   def warnConditionalOperationNonTransactional(op: String) = {
+      if (!warnConditionalLogged) {
+         log.warnConditionalOperationNonTransactional(op)
+         warnConditionalLogged = true
+      }
+   }
 
-   def warnForceReturnPreviousNonTransactional(op: String) = log.warnForceReturnPreviousNonTransactional(op)
+   def warnForceReturnPreviousNonTransactional(op: String) = {
+      if (!warnForceReturnPreviousLogged) {
+         log.warnForceReturnPreviousNonTransactional(op)
+         warnForceReturnPreviousLogged = true
+      }
+   }
 
    def warnMarshallerAlreadySet(existingMarshaller: Marshaller, newMarshaller: Marshaller) =
       log.warnMarshallerAlreadySet(existingMarshaller, newMarshaller)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4795

* Tweaked warning message printing logic for per-operation warn messages so that they are only printed once instead of repeatedly.