### PR TITLE
ISPN-5180 Try standard serialization if unmarshalled entry still byte[]

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/marshall/MarshallerUtil.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/marshall/MarshallerUtil.java
@@ -6,7 +6,12 @@ import org.infinispan.client.hotrod.logging.LogFactory;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.Util;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamConstants;
 
 /**
  * @author Galder Zamarreño
@@ -21,10 +26,38 @@ public final class MarshallerUtil {
    public static <T> T bytes2obj(Marshaller marshaller, byte[] bytes) {
       if (bytes == null) return null;
       try {
-         return (T) marshaller.objectFromByteBuffer(bytes);
+         Object ret = marshaller.objectFromByteBuffer(bytes);
+
+         // No extra configuration is required for client when using compatibility mode,
+         // and no different marshaller should be required to deal with standard serialization.
+         // So, if the unmarshalled object is still a byte[], it could be a standard
+         // serialized object, so check for stream magic
+         if (ret instanceof byte[] && isJavaSerialized((byte[]) ret)) {
+            try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream((byte[]) ret))) {
+               return (T) ois.readObject();
+            } catch (Exception ee) {
+               if (log.isDebugEnabled())
+                  log.debugf("Standard deserialization not in use for %s", Util.printArray(bytes));
+            }
+         }
+
+         return (T) ret;
       } catch (Exception e) {
          throw log.unableToUnmarshallBytes(Util.toHexString(bytes), e);
       }
+   }
+
+   private static boolean isJavaSerialized(byte[] bytes) {
+      if (bytes.length > 2) {
+         short magic = (short) ((bytes[1] & 0xFF) + (bytes[0] << 8));
+         return magic == ObjectStreamConstants.STREAM_MAGIC;
+      }
+
+      return false;
+   }
+
+   static short getShort(byte[] b, int off) {
+      return (short) ((b[off + 1] & 0xFF) + (b[off] << 8));
    }
 
    public static byte[] obj2bytes(Marshaller marshaller, Object o, boolean isKey, int estimateKeySize, int estimateValueSize) {


### PR DESCRIPTION
It might not the ideal solution, but one that requires least amount of change.

Another alternative solutions might require HotRodTypeConverter to send back byte[] instances as-is, rather than trying to marshall them again (which is why you can still have a standard serialized object marshalled again with the marshaller).

Yet another alternative is to add a configuration flag in RemoteCacheManager to enable compatibility so that it works optimally when compatibility is enabled.

Yet, yet, another alternative is to have enforce that such use case requires a custom marshaller to be installed, but this shouldn't be required IMO to deal with Java standard serialization.