### PR TITLE
ISPN-5190 DefaultExecutorService throws ISE if constructed with ManagedExecutorService

### DIFF
--- a/core/src/main/java/org/infinispan/distexec/DefaultExecutorService.java
+++ b/core/src/main/java/org/infinispan/distexec/DefaultExecutorService.java
@@ -161,7 +161,7 @@ public class DefaultExecutorService extends AbstractExecutorService implements D
          throw new IllegalArgumentException("Can not use null cache for DefaultExecutorService");
       else if (localExecutorService == null)
          throw new IllegalArgumentException("Can not use null instance of ExecutorService");
-      else if (localExecutorService.isShutdown())
+      else if (takeExecutorOwnership && localExecutorService.isShutdown())
          throw new IllegalArgumentException("Can not use an instance of ExecutorService which is shutdown");
       ensureAccessPermissions(masterCacheNode.getAdvancedCache());
       ensureProperCacheState(masterCacheNode.getAdvancedCache());


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5190