### PR TITLE
ISPN-5202 maven.test.skip.exec replaced by skipTests

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -26,4 +26,14 @@
          </plugins>
       </pluginManagement>
    </build>
+
+   <profiles>
+      <profile>
+      <id>distribution</id>
+      <properties>
+         <skipTests>true</skipTests>
+      </properties>
+      </profile>
+   </profiles>
+
 </project>

--- a/integrationtests/all-embedded-it/pom.xml
+++ b/integrationtests/all-embedded-it/pom.xml
@@ -4,9 +4,8 @@
 
    <parent>
       <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-bom</artifactId>
+      <artifactId>infinispan-integrationtests-parent</artifactId>
       <version>7.2.0-SNAPSHOT</version>
-      <relativePath>../../bom/pom.xml</relativePath>
    </parent>
 
    <artifactId>infinispan-embedded-it</artifactId>

--- a/integrationtests/all-embedded-query-it/pom.xml
+++ b/integrationtests/all-embedded-query-it/pom.xml
@@ -4,9 +4,8 @@
 
    <parent>
       <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-bom</artifactId>
+      <artifactId>infinispan-integrationtests-parent</artifactId>
       <version>7.2.0-SNAPSHOT</version>
-      <relativePath>../../bom/pom.xml</relativePath>
    </parent>
 
    <artifactId>infinispan-embedded-query-it</artifactId>

--- a/integrationtests/all-remote-it/pom.xml
+++ b/integrationtests/all-remote-it/pom.xml
@@ -4,9 +4,8 @@
 
    <parent>
       <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-bom</artifactId>
+      <artifactId>infinispan-integrationtests-parent</artifactId>
       <version>7.2.0-SNAPSHOT</version>
-      <relativePath>../../bom/pom.xml</relativePath>
    </parent>
 
    <artifactId>infinispan-remote-it</artifactId>

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-bom</artifactId>
+        <version>7.2.0-SNAPSHOT</version>
+        <relativePath>../bom/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>infinispan-integrationtests-parent</artifactId>
+    <name>Infinispan Integration Tests Parent</name>
+    <description>Infinispan Integration Tests Parent</description>
+    <packaging>pom</packaging>
+
+    <profiles>
+        <profile>
+            <id>distribution</id>
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/jcache/pom.xml
+++ b/jcache/pom.xml
@@ -136,7 +136,6 @@
                   <goal>package</goal>
                </goals>
                <properties>
-                  <maven.test.skip.exec>${maven.test.skip.exec}</maven.test.skip.exec>
                   <skipTests>${skipTests}</skipTests>
                   <log4j.configuration>${log4j.configuration}</log4j.configuration>
                </properties>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1591,10 +1591,8 @@
          <properties>
             <skipTests>true</skipTests>
          </properties>
-
          <build>
             <plugins>
-               
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-dependency-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
       <module>server/integration</module>
       <module>as-modules/embedded</module>
       <module>as-modules/client</module>
+      <module>integrationtests</module>
       <module>integrationtests/as-integration-embedded</module>
       <module>integrationtests/as-integration-client</module>
       <module>integrationtests/as-lucene-directory</module>

--- a/server/integration/management/server-rhq-plugin/pom.xml
+++ b/server/integration/management/server-rhq-plugin/pom.xml
@@ -136,7 +136,7 @@
             <activeByDefault>false</activeByDefault>
          </activation>
          <properties>
-            <maven.test.skip.exec>true</maven.test.skip.exec>
+            <skipTests>true</skipTests>
          </properties>
          <build>
             <plugins>

--- a/server/integration/pom.xml
+++ b/server/integration/pom.xml
@@ -51,7 +51,7 @@
             <activeByDefault>false</activeByDefault>
          </activation>
          <properties>
-            <maven.test.skip.exec>true</maven.test.skip.exec>
+            <skipTests>true</skipTests>
          </properties>
          <build>
             <plugins>

--- a/server/integration/versions/pom.xml
+++ b/server/integration/versions/pom.xml
@@ -547,7 +547,7 @@
             <activeByDefault>false</activeByDefault>
          </activation>
          <properties>
-            <maven.test.skip.exec>true</maven.test.skip.exec>
+            <skipTests>true</skipTests>
          </properties>
       </profile>
    </profiles>


### PR DESCRIPTION
This pull request removed deprecated option: `maven.test.skip.exec` and replaces it with `skipTests`.

For more information please refer to: http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html

Jira: https://issues.jboss.org/browse/ISPN-5202

