### PR TITLE
ISPN-5166, ISPN-5158, and ISPN-5197

### DIFF
--- a/core/src/main/java/org/infinispan/topology/CacheTopologyControlCommand.java
+++ b/core/src/main/java/org/infinispan/topology/CacheTopologyControlCommand.java
@@ -170,7 +170,7 @@ public class CacheTopologyControlCommand implements ReplicableCommand {
          // coordinator to member
          case CH_UPDATE:
             localTopologyManager.handleTopologyUpdate(cacheName, new CacheTopology(topologyId, rebalanceId, currentCH,
-                  pendingCH, actualMembers), availabilityMode, viewId);
+                  pendingCH, actualMembers), availabilityMode, viewId, sender);
             return null;
          case STABLE_TOPOLOGY_UPDATE:
             localTopologyManager.handleStableTopologyUpdate(cacheName, new CacheTopology(topologyId, rebalanceId,
@@ -178,7 +178,7 @@ public class CacheTopologyControlCommand implements ReplicableCommand {
             return null;
          case REBALANCE_START:
             localTopologyManager.handleRebalance(cacheName, new CacheTopology(topologyId, rebalanceId, currentCH,
-                  pendingCH, actualMembers), viewId);
+                  pendingCH, actualMembers), viewId, sender);
             return null;
          case GET_STATUS:
             return localTopologyManager.handleStatusRequest(viewId);

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManager.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManager.java
@@ -1,11 +1,10 @@
 package org.infinispan.topology;
 
-import java.util.Map;
-
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.partitionhandling.AvailabilityMode;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
+import org.infinispan.remoting.transport.Address;
 
 /**
  * Runs on every node and handles the communication with the {@link ClusterTopologyManager}.
@@ -50,7 +49,8 @@ public interface LocalTopologyManager {
    /**
     * Updates the current and/or pending consistent hash, without transferring any state.
     */
-   void handleTopologyUpdate(String cacheName, CacheTopology cacheTopology, AvailabilityMode availabilityMode, int viewId) throws InterruptedException;
+   void handleTopologyUpdate(String cacheName, CacheTopology cacheTopology, AvailabilityMode availabilityMode,
+                             int viewId, Address sender) throws InterruptedException;
 
    /**
     * Update the stable cache topology.
@@ -62,7 +62,7 @@ public interface LocalTopologyManager {
    /**
     * Performs the state transfer.
     */
-   void handleRebalance(String cacheName, CacheTopology cacheTopology, int viewId) throws InterruptedException;
+   void handleRebalance(String cacheName, CacheTopology cacheTopology, int viewId, Address sender) throws InterruptedException;
 
    /**
     * @return the current topology for a cache.

--- a/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
@@ -196,7 +196,7 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
    @Stop
    @SuppressWarnings("unused")
    private void stop() {
-
+      cacheManagerNotifier.removeListener(this);
       if (executorService != null)
          executorService.shutdownNow();
 

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareTransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareTransactionTable.java
@@ -116,6 +116,8 @@ public class RecoveryAwareTransactionTable extends XaTransactionTable {
 
    @Override
    public void failureCompletingTransaction(Transaction tx) {
+      // TODO Change the Transaction parameter to LocalTransaction to avoid the reverse lookup and the
+      // NullPointerException when called from RecoveryManagerImpl.forceTransactionCompletion
       RecoveryAwareLocalTransaction localTx = (RecoveryAwareLocalTransaction) getLocalTransaction(tx);
       if (localTx == null)
          throw new CacheException(String.format("Local transaction for transaction (%s) not found", tx));

--- a/core/src/main/java/org/infinispan/util/AbstractControlledLocalTopologyManager.java
+++ b/core/src/main/java/org/infinispan/util/AbstractControlledLocalTopologyManager.java
@@ -4,6 +4,7 @@ import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.partitionhandling.AvailabilityMode;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
+import org.infinispan.remoting.transport.Address;
 import org.infinispan.topology.CacheJoinInfo;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.topology.CacheTopologyHandler;
@@ -49,15 +50,17 @@ public abstract class AbstractControlledLocalTopologyManager implements LocalTop
    }
 
    @Override
-   public final void handleTopologyUpdate(String cacheName, CacheTopology cacheTopology, AvailabilityMode availabilityMode, int viewId) throws InterruptedException {
+   public final void handleTopologyUpdate(String cacheName, CacheTopology cacheTopology,
+         AvailabilityMode availabilityMode, int viewId, Address sender) throws InterruptedException {
       beforeHandleTopologyUpdate(cacheName, cacheTopology, viewId);
-      delegate.handleTopologyUpdate(cacheName, cacheTopology, availabilityMode, viewId);
+      delegate.handleTopologyUpdate(cacheName, cacheTopology, availabilityMode, viewId, sender);
    }
 
    @Override
-   public final void handleRebalance(String cacheName, CacheTopology cacheTopology, int viewId) throws InterruptedException {
+   public final void handleRebalance(String cacheName, CacheTopology cacheTopology, int viewId, Address sender)
+         throws InterruptedException {
       beforeHandleRebalance(cacheName, cacheTopology, viewId);
-      delegate.handleRebalance(cacheName, cacheTopology, viewId);
+      delegate.handleRebalance(cacheName, cacheTopology, viewId, sender);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -36,10 +36,10 @@ import javax.management.MBeanRegistrationException;
 import javax.management.ObjectName;
 import javax.naming.NamingException;
 import javax.transaction.Synchronization;
+import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAException;
 import javax.xml.namespace.QName;
-
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -52,7 +52,12 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
-import static org.jboss.logging.Logger.Level.*;
+import static org.jboss.logging.Logger.Level.DEBUG;
+import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.FATAL;
+import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.TRACE;
+import static org.jboss.logging.Logger.Level.WARN;
 
 /**
  * Infinispan's log abstraction layer on top of JBoss Logging.
@@ -1220,9 +1225,11 @@ public interface Log extends BasicLogger {
    @LogMessage(level = WARN)
    @Message(value = "Distributed task failed at %s. The task is failing over to be executed at %s", id = 330)
    void distributedTaskFailover(Address failedAtAddress, Address failoverTarget, @Cause Exception e);
-   
+
    @LogMessage(level = WARN)
    @Message(value = "Unable to invoke method %s on Object instance %s ", id = 331)
    void unableToInvokeListenerMethod(Method m, Object target, @Cause Throwable e);
 
+   @Message(value = "Remote transaction %s rolled back because originator is no longer in the cluster", id = 332)
+   CacheException orphanTransactionRolledBack(GlobalTransaction gtx);
 }

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxBackupOwnerBecomingPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxBackupOwnerBecomingPrimaryOwnerTest.java
@@ -236,7 +236,7 @@ public class NonTxBackupOwnerBecomingPrimaryOwnerTest extends MultipleCacheManag
             return invocation.callRealMethod();
          }
       }).when(spyLtm).handleTopologyUpdate(eq(CacheContainer.DEFAULT_CACHE_NAME), any(CacheTopology.class),
-            any(AvailabilityMode.class), anyInt());
+            any(AvailabilityMode.class), anyInt(), any(Address.class));
       TestingUtil.extractGlobalComponentRegistry(manager).registerComponent(spyLtm, LocalTopologyManager.class);
    }
 }

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxPrimaryOwnerBecomingNonOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxPrimaryOwnerBecomingNonOwnerTest.java
@@ -232,7 +232,7 @@ public class NonTxPrimaryOwnerBecomingNonOwnerTest extends MultipleCacheManagers
             return invocation.callRealMethod();
          }
       }).when(spyLtm).handleTopologyUpdate(eq(CacheContainer.DEFAULT_CACHE_NAME), any(CacheTopology.class),
-            any(AvailabilityMode.class), anyInt());
+            any(AvailabilityMode.class), anyInt(), any(Address.class));
       TestingUtil.extractGlobalComponentRegistry(manager).registerComponent(spyLtm, LocalTopologyManager.class);
    }
 }

--- a/core/src/test/java/org/infinispan/statetransfer/ClusterTopologyManagerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ClusterTopologyManagerTest.java
@@ -307,7 +307,8 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
             }
             return invocation.callRealMethod();
          }
-      }).when(spyLocalTopologyManager).handleRebalance(eq(CACHE_NAME), any(CacheTopology.class), anyInt());
+      }).when(spyLocalTopologyManager).handleRebalance(eq(CACHE_NAME), any(CacheTopology.class), anyInt(),
+            any(Address.class));
       TestingUtil.replaceComponent(manager, LocalTopologyManager.class, spyLocalTopologyManager, true);
    }
 
@@ -339,7 +340,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
             return invocation.callRealMethod();
          }
       }).when(spyLocalTopologyManager2).handleTopologyUpdate(eq(CACHE_NAME), any(CacheTopology.class),
-            any(AvailabilityMode.class), anyInt());
+            any(AvailabilityMode.class), anyInt(), any(Address.class));
       doAnswer(new Answer<Object>() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -350,7 +351,8 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
             }
             return invocation.callRealMethod();
          }
-      }).when(spyLocalTopologyManager2).handleRebalance(eq(CACHE_NAME), any(CacheTopology.class), anyInt());
+      }).when(spyLocalTopologyManager2).handleRebalance(eq(CACHE_NAME), any(CacheTopology.class), anyInt(),
+            any(Address.class));
       TestingUtil.replaceComponent(manager(1), LocalTopologyManager.class, spyLocalTopologyManager2, true);
 
       // Node 1 (the coordinator) dies. Node 2 becomes coordinator and tries to call GET_STATUS
@@ -410,7 +412,7 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
             return invocation.callRealMethod();
          }
       }).when(spyLocalTopologyManager2).handleTopologyUpdate(eq(CACHE_NAME), any(CacheTopology.class),
-            any(AvailabilityMode.class), anyInt());
+            any(AvailabilityMode.class), anyInt(), any(Address.class));
       doAnswer(new Answer<Object>() {
          @Override
          public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -421,7 +423,8 @@ public class ClusterTopologyManagerTest extends MultipleCacheManagersTest {
             }
             return invocation.callRealMethod();
          }
-      }).when(spyLocalTopologyManager2).handleRebalance(eq(CACHE_NAME), any(CacheTopology.class), anyInt());
+      }).when(spyLocalTopologyManager2).handleRebalance(eq(CACHE_NAME), any(CacheTopology.class), anyInt(),
+            any(Address.class));
       TestingUtil.replaceComponent(manager(1), LocalTopologyManager.class, spyLocalTopologyManager2, true);
 
       // Node 1 (the coordinator) dies. Node 2 becomes coordinator and tries to call GET_STATUS


### PR DESCRIPTION
ISPN-5158 Transaction rolled back but returns successful response
https://issues.jboss.org/browse/ISPN-5158

ISPN-5166 During ST, previously removed entry was revived
https://issues.jboss.org/browse/ISPN-5166
Ignore any topologies sent by the old coordinator after receiving the
GET_STATUS command from the new coordinator.

ISPN-5197 JGroupsTransport.getViewId() returns too soon
https://issues.jboss.org/browse/ISPN-5166
