### PR TITLE
ISPN-5228 ISPN-5229 Cleanup of redundant code

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/base/CommandInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/base/CommandInterceptor.java
@@ -3,7 +3,7 @@ package org.infinispan.interceptors.base;
 import org.infinispan.Cache;
 import org.infinispan.cache.impl.CacheImpl;
 import org.infinispan.commands.AbstractVisitor;
-import org.infinispan.commands.FlagAffectedCommand;
+import org.infinispan.commands.LocalFlagAffectedCommand;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.Visitor;
 import org.infinispan.commands.read.GetKeyValueCommand;
@@ -111,7 +111,7 @@ public abstract class CommandInterceptor extends AbstractVisitor {
       return invokeNextInterceptor(ctx, command);
    }
 
-   protected final long getLockAcquisitionTimeout(FlagAffectedCommand command, boolean skipLocking) {
+   protected final long getLockAcquisitionTimeout(LocalFlagAffectedCommand command, boolean skipLocking) {
       if (!skipLocking)
          return command.hasFlag(Flag.ZERO_LOCK_ACQUISITION_TIMEOUT) ?
                0 : cacheConfiguration.locking().lockAcquisitionTimeout();
@@ -119,7 +119,7 @@ public abstract class CommandInterceptor extends AbstractVisitor {
       return -1;
    }
 
-   protected final boolean hasSkipLocking(FlagAffectedCommand command) {
+   protected final boolean hasSkipLocking(LocalFlagAffectedCommand command) {
       return command.hasFlag(Flag.SKIP_LOCKING);
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/locking/NonTransactionalLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/NonTransactionalLockingInterceptor.java
@@ -1,13 +1,10 @@
 package org.infinispan.interceptors.locking;
 
 import org.infinispan.InvalidCacheUsageException;
-import org.infinispan.commands.read.AbstractDataCommand;
-import org.infinispan.commands.read.GetCacheEntryCommand;
-import org.infinispan.commands.read.GetKeyValueCommand;
+import org.infinispan.commands.DataCommand;
 import org.infinispan.commands.write.ClearCommand;
+import org.infinispan.commands.write.DataWriteCommand;
 import org.infinispan.commands.write.PutMapCommand;
-import org.infinispan.commands.write.RemoveCommand;
-import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -28,21 +25,19 @@ public class NonTransactionalLockingInterceptor extends AbstractLockingIntercept
    }
 
    @Override
-   public final Object visitGetKeyValueCommand(InvocationContext ctx, GetKeyValueCommand command) throws Throwable {
-      return visitDataReadCommand(ctx, command);
-   }
-   @Override
-   public final Object visitGetCacheEntryCommand(InvocationContext ctx, GetCacheEntryCommand command) throws Throwable {
-      return visitDataReadCommand(ctx, command);
-   }
-
-   private Object visitDataReadCommand(InvocationContext ctx, AbstractDataCommand command) throws Throwable {
+   protected final Object visitDataReadCommand(InvocationContext ctx, DataCommand command) throws Throwable {
       assertNonTransactional(ctx);
       try {
          return invokeNextInterceptor(ctx, command);
       } finally {
          lockManager.unlockAll(ctx);//possibly needed because of L1 locks being acquired
       }
+   }
+
+   @Override
+   protected Object visitDataWriteCommand(InvocationContext ctx, DataWriteCommand command) throws Throwable {
+      assertNonTransactional(ctx);
+      return visitNonTxDataWriteCommand(ctx, command);
    }
 
    @Override
@@ -74,37 +69,6 @@ public class NonTransactionalLockingInterceptor extends AbstractLockingIntercept
                   lockKey(ctx, key, lockTimeout, skipLocking);
             }
          }
-         return invokeNextInterceptor(ctx, command);
-      } catch (Throwable te) {
-         throw cleanLocksAndRethrow(ctx, te);
-      }
-      finally {
-         lockManager.unlockAll(ctx);
-      }
-   }
-
-   @Override
-   public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
-      assertNonTransactional(ctx);
-      try {
-         if (!shouldLock(command.getKey(), command))
-            return invokeNextInterceptor(ctx, command);
-         lockKey(ctx, command);
-         return invokeNextInterceptor(ctx, command);
-      } catch (Throwable te) {
-         throw cleanLocksAndRethrow(ctx, te);
-      } finally {
-         lockManager.unlockAll(ctx);
-      }
-   }
-
-   @Override
-   public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) throws Throwable {
-      assertNonTransactional(ctx);
-      try {
-         if (!shouldLock(command.getKey(), command))
-            return invokeNextInterceptor(ctx, command);
-         lockKey(ctx, command);
          return invokeNextInterceptor(ctx, command);
       } catch (Throwable te) {
          throw cleanLocksAndRethrow(ctx, te);

--- a/core/src/test/java/org/infinispan/jmx/CacheLoaderAndCacheWriterInterceptorMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheLoaderAndCacheWriterInterceptorMBeanTest.java
@@ -1,22 +1,23 @@
 package org.infinispan.jmx;
 
+import static org.infinispan.test.TestingUtil.checkMBeanOperationParameterNaming;
+import static org.infinispan.test.TestingUtil.getCacheObjectName;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.Flag;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.core.MarshalledEntryImpl;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.persistence.spi.AdvancedLoadWriteStore;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
-
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
-
-import static org.infinispan.test.TestingUtil.*;
 
 /**
  * Tests the jmx functionality from CacheLoaderInterceptor and CacheWriterInterceptor.
@@ -70,73 +71,73 @@ public class CacheLoaderAndCacheWriterInterceptorMBeanTest extends SingleCacheMa
    public void testPutKeyValue() throws Exception {
       assertStoreAccess(0, 0, 0);
       cache.put("key", "value");
-      assertStoreAccess(0, 0, 1);
+      assertStoreAccess(0, 1, 1);
       cache.put("key", "value2");
-      assertStoreAccess(0, 0, 2);
+      assertStoreAccess(0, 1, 2);
 
       store.write(new MarshalledEntryImpl("a", "b", null, marshaller()));
       cache.put("a", "c");
-      assertStoreAccess(1, 0, 3);
+      assertStoreAccess(1, 1, 3);
       assert store.load("a").getValue().equals("c");
    }
 
    public void testGetValue() throws Exception {
       assertStoreAccess(0, 0, 0);
       cache.put("key", "value");
-      assertStoreAccess(0, 0, 1);
+      assertStoreAccess(0, 1, 1);
 
       assert cache.get("key").equals("value");
-      assertStoreAccess(0, 0, 1);
+      assertStoreAccess(0, 1, 1);
 
       store.write(new MarshalledEntryImpl("a", "b", null, marshaller()));
       assert cache.get("a").equals("b");
-      assertStoreAccess(1, 0, 1);
+      assertStoreAccess(1, 1, 1);
 
       assert cache.get("no_such_key") == null;
-      assertStoreAccess(1, 1, 1);
+      assertStoreAccess(1, 2, 1);
    }
 
    public void testRemoveValue() throws Exception {
       assertStoreAccess(0, 0, 0);
       cache.put("key", "value");
-      assertStoreAccess(0, 0, 1);
+      assertStoreAccess(0, 1, 1);
 
       assert cache.get("key").equals("value");
-      assertStoreAccess(0, 0, 1);
+      assertStoreAccess(0, 1, 1);
 
       assert cache.remove("key").equals("value");
-      assertStoreAccess(0, 0, 1);
+      assertStoreAccess(0, 1, 1);
 
       cache.remove("no_such_key");
-      assertStoreAccess(0, 1, 1);
+      assertStoreAccess(0, 2, 1);
 
       store.write(new MarshalledEntryImpl("a", "b", null, marshaller()));
       assert cache.remove("a").equals("b");
-      assertStoreAccess(1, 1, 1);
+      assertStoreAccess(1, 2, 1);
    }
 
    public void testReplaceCommand() throws Exception {
       assertStoreAccess(0, 0, 0);
       cache.put("key", "value");
-      assertStoreAccess(0, 0, 1);
+      assertStoreAccess(0, 1, 1);
 
       assert cache.replace("key", "value2").equals("value");
-      assertStoreAccess(0, 0, 2);
+      assertStoreAccess(0, 1, 2);
 
       store.write(new MarshalledEntryImpl("a", "b", null, marshaller()));
       assert cache.replace("a", "c").equals("b");
-      assertStoreAccess(1, 0, 3);
+      assertStoreAccess(1, 1, 3);
 
       assert cache.replace("no_such_key", "c") == null;
-      assertStoreAccess(1, 1, 3);
+      assertStoreAccess(1, 2, 3);
    }
 
    public void testFlagMissNotCounted() throws Exception {
       assertStoreAccess(0, 0, 0);
       cache.put("key", "value");
-      assertStoreAccess(0, 0, 1);
+      assertStoreAccess(0, 1, 1);
       cache.getAdvancedCache().withFlags(Flag.SKIP_CACHE_LOAD).get("no_such_key");
-      assertStoreAccess(0, 0, 1);
+      assertStoreAccess(0, 1, 1);
    }
 
    private void assertStoreAccess(int loadsCount, int missesCount, int storeCount) throws Exception {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5228
https://issues.jboss.org/browse/ISPN-5229

Implementation of many visitX commands was almost copy-paste - this PR unites them.
Main focus is on *LockingInterceptor, and a bit on CacheLoaderInterceptor.