### PR TITLE
ISPN-5173 Allow subclasses of JGroupsTransport to override the initialization of the rpc dispatcher.

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -101,14 +101,14 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
    static final boolean trace = log.isTraceEnabled();
 
    protected boolean connectChannel = true, disconnectChannel = true, closeChannel = true;
-   private CommandAwareRpcDispatcher dispatcher;
+   protected CommandAwareRpcDispatcher dispatcher;
    protected TypedProperties props;
    protected StreamingMarshaller marshaller;
    protected ExecutorService asyncExecutor;
    protected CacheManagerNotifier notifier;
-   private GlobalComponentRegistry gcr;
+   protected GlobalComponentRegistry gcr;
    private TimeService timeService;
-   private InboundInvocationHandler globalHandler;
+   protected InboundInvocationHandler globalHandler;
 
    private boolean globalStatsEnabled;
    private MBeanServer mbeanServer;
@@ -347,6 +347,10 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
 
    private void initChannelAndRPCDispatcher() throws CacheException {
       initChannel();
+      initRPCDispatcher();
+   }
+
+   protected void initRPCDispatcher() {
       dispatcher = new CommandAwareRpcDispatcher(channel, this, asyncExecutor, gcr, globalHandler);
       MarshallerAdapter adapter = new MarshallerAdapter(marshaller);
       dispatcher.setRequestMarshaller(adapter);


### PR DESCRIPTION
This allows WildFly to override the marshaller used for request and response marshalling.  This is critical to working around https://issues.jboss.org/browse/JGRP-1905