### PR TITLE
Correct state-transfer timeout default value in server xsd

### DIFF
--- a/server/integration/build/src/main/resources/docs/schema/jboss-infinispan-core_7_0.xsd
+++ b/server/integration/build/src/main/resources/docs/schema/jboss-infinispan-core_7_0.xsd
@@ -1194,7 +1194,7 @@
                 <xs:documentation>If enabled, this will cause the cache to ask neighboring caches for state when it starts up, so the cache starts 'warm', although it will impact startup time.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="timeout" type="xs:long" default="60000">
+        <xs:attribute name="timeout" type="xs:long" default="240000">
             <xs:annotation>
                 <xs:documentation>The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.</xs:documentation>
             </xs:annotation>

--- a/server/integration/build/src/main/resources/docs/schema/jboss-infinispan-core_7_1.xsd
+++ b/server/integration/build/src/main/resources/docs/schema/jboss-infinispan-core_7_1.xsd
@@ -1194,7 +1194,7 @@
                 <xs:documentation>If enabled, this will cause the cache to ask neighboring caches for state when it starts up, so the cache starts 'warm', although it will impact startup time.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="timeout" type="xs:long" default="60000">
+        <xs:attribute name="timeout" type="xs:long" default="240000">
             <xs:annotation>
                 <xs:documentation>The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.</xs:documentation>
             </xs:annotation>


### PR DESCRIPTION
As changed in 67e188b4f32a0639f5a0978c665f01597f0a41ac, which updated the default value in `org.jboss.as.clustering.infinispan.subsystem.StateTransferResource.java` from 60000 to 240000 to match the default state transfer timeout in Infinispan core.

Again, I'm not sure if you'd prefer an ISPN for this sort of change. Please advise and I'll create one.