### PR TITLE
ISPN-5131 Created CacheStoreFactory

### DIFF
--- a/core/src/main/java/org/infinispan/factories/EmptyConstructorNamedCacheFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EmptyConstructorNamedCacheFactory.java
@@ -26,11 +26,13 @@ import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.marshall.core.MarshalledEntryFactory;
 import org.infinispan.marshall.core.MarshalledEntryFactoryImpl;
-import org.infinispan.notifications.cachelistener.cluster.ClusterCacheNotifier;
-import org.infinispan.persistence.manager.PersistenceManager;
-import org.infinispan.persistence.manager.PersistenceManagerImpl;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.notifications.cachelistener.CacheNotifierImpl;
+import org.infinispan.notifications.cachelistener.cluster.ClusterCacheNotifier;
+import org.infinispan.persistence.factory.CacheStoreFactoryRegistry;
+import org.infinispan.persistence.factory.DeployedCacheStoreFactory;
+import org.infinispan.persistence.manager.PersistenceManager;
+import org.infinispan.persistence.manager.PersistenceManagerImpl;
 import org.infinispan.statetransfer.CommitManager;
 import org.infinispan.statetransfer.StateTransferLock;
 import org.infinispan.statetransfer.StateTransferLockImpl;
@@ -64,7 +66,8 @@ import static org.infinispan.commons.util.Util.getInstance;
                               ClusteringDependentLogic.class, L1Manager.class, TransactionFactory.class, BackupSender.class,
                               TotalOrderManager.class, ByteBufferFactory.class, MarshalledEntryFactory.class,
                               RemoteValueRetrievedListener.class, InvocationContextFactory.class, CommitManager.class,
-                              XSiteStateTransferManager.class, XSiteStateConsumer.class, XSiteStateProvider.class})
+                              XSiteStateTransferManager.class, XSiteStateConsumer.class, XSiteStateProvider.class,
+                              CacheStoreFactoryRegistry.class, DeployedCacheStoreFactory.class})
 public class EmptyConstructorNamedCacheFactory extends AbstractNamedCacheComponentFactory implements AutoInstantiableFactory {
 
    @Override
@@ -136,6 +139,10 @@ public class EmptyConstructorNamedCacheFactory extends AbstractNamedCacheCompone
             return (T) new XSiteStateConsumerImpl();
          } else if (componentType.equals(XSiteStateProvider.class)) {
             return (T) new XSiteStateProviderImpl();
+         } else if (componentType.equals(CacheStoreFactoryRegistry.class)) {
+            return (T) new CacheStoreFactoryRegistry();
+         } else if (componentType.equals(DeployedCacheStoreFactory.class)) {
+            return (T) new DeployedCacheStoreFactory();
          }
       }
 

--- a/core/src/main/java/org/infinispan/persistence/factory/CacheStoreFactory.java
+++ b/core/src/main/java/org/infinispan/persistence/factory/CacheStoreFactory.java
@@ -1,0 +1,22 @@
+package org.infinispan.persistence.factory;
+
+import org.infinispan.configuration.cache.StoreConfiguration;
+
+/**
+ * Creates Cache Store instances.
+ *
+ * <i>Needs to be implemented when loading Cache Stores from custom locations (e.g. custom location on the disk).</i>
+ *
+ * @author Sebastian Laskawiec
+ * @since 7.2
+ */
+public interface CacheStoreFactory {
+
+   /**
+    * Returns new instance based on {@link org.infinispan.configuration.cache.StoreConfiguration}.
+    *
+    * @param storeConfiguration Configuration to be processed.
+    * @return Instance configured by the {@link org.infinispan.configuration.cache.StoreConfiguration}.
+    */
+   Object createInstance(StoreConfiguration storeConfiguration);
+}

--- a/core/src/main/java/org/infinispan/persistence/factory/CacheStoreFactoryRegistry.java
+++ b/core/src/main/java/org/infinispan/persistence/factory/CacheStoreFactoryRegistry.java
@@ -1,0 +1,64 @@
+package org.infinispan.persistence.factory;
+
+import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Registry for multiple {@link CacheStoreFactory} objects.
+ *
+ * @author Sebastian Laskawiec
+ * @since 7.2
+ */
+public class CacheStoreFactoryRegistry {
+
+   private static final Log log = LogFactory.getLog(CacheStoreFactoryRegistry.class);
+
+   private List<CacheStoreFactory> factories = new ArrayList<>();
+
+   public CacheStoreFactoryRegistry() {
+      factories.add(new LocalClassLoaderCacheStoreFactory());
+   }
+
+   @Inject
+   public void inject(DeployedCacheStoreFactory deployedCacheStoreFactory) {
+      addCacheStoreFactory(deployedCacheStoreFactory);
+   }
+
+   /**
+    * Creates new Object based on configuration.
+    *
+    * @param storeConfiguration Cache store configuration.
+    * @return Instance created based on the configuration.
+    * @throws org.infinispan.commons.CacheConfigurationException when the instance couldn't be created.
+    */
+   public Object createInstance(StoreConfiguration storeConfiguration) {
+      for(CacheStoreFactory factory : factories) {
+         Object instance = factory.createInstance(storeConfiguration);
+         if(instance != null) {
+            return instance;
+         }
+      }
+      throw log.unableToInstantiateClass(storeConfiguration);
+   }
+
+   /**
+    * Adds a new factory for processing.
+    *
+    * @param cacheStoreFactory Factory to be added.
+    */
+   public void addCacheStoreFactory(CacheStoreFactory cacheStoreFactory) {
+      factories.add(0, cacheStoreFactory);
+   }
+
+   /**
+    * Removes all factories associated to this registry.
+    */
+   public void clearFactories() {
+      factories.clear();
+   }
+}

--- a/core/src/main/java/org/infinispan/persistence/factory/ConfigurationForClassExtractor.java
+++ b/core/src/main/java/org/infinispan/persistence/factory/ConfigurationForClassExtractor.java
@@ -1,0 +1,26 @@
+package org.infinispan.persistence.factory;
+
+import org.infinispan.commons.configuration.ConfigurationFor;
+import org.infinispan.configuration.cache.CustomStoreConfiguration;
+import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.util.logging.Log;
+
+class ConfigurationForClassExtractor {
+
+   static Class getClassBasedOnConfigurationAnnotation(StoreConfiguration cfg, Log logger) {
+      ConfigurationFor annotation = cfg.getClass().getAnnotation(ConfigurationFor.class);
+      Class classAnnotation = null;
+      if (annotation == null) {
+         if (cfg instanceof CustomStoreConfiguration) {
+            classAnnotation = ((CustomStoreConfiguration)cfg).customStoreClass();
+         }
+      } else {
+         classAnnotation = annotation.value();
+      }
+      if (classAnnotation == null) {
+         throw logger.loaderConfigurationDoesNotSpecifyLoaderClass(cfg.getClass().getName());
+      }
+      return classAnnotation;
+   }
+
+}

--- a/core/src/main/java/org/infinispan/persistence/factory/DeployedCacheStoreFactory.java
+++ b/core/src/main/java/org/infinispan/persistence/factory/DeployedCacheStoreFactory.java
@@ -1,0 +1,50 @@
+package org.infinispan.persistence.factory;
+
+import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.infinispan.persistence.factory.ConfigurationForClassExtractor.getClassBasedOnConfigurationAnnotation;
+
+/**
+ * Cache Store factory designed for deployed instances.
+ *
+ * @author Sebastian Laskawiec
+ * @since 7.2
+ */
+public class DeployedCacheStoreFactory implements CacheStoreFactory {
+
+   private static final Log log = LogFactory.getLog(DeployedCacheStoreFactory.class);
+
+   private Map<String, Object> instances = Collections.synchronizedMap(new HashMap<String, Object>());
+
+   @Override
+   public Object createInstance(StoreConfiguration cfg) {
+      String classNameBasedOnConfigurationAnnotation = getClassBasedOnConfigurationAnnotation(cfg, log).getName();
+      return instances.get(classNameBasedOnConfigurationAnnotation);
+   }
+
+   /**
+    * Adds deployed instance of a Cache Store.
+    *
+    * @param className Name of the deployed class. Use <code>myObject.getClass().getName();</code>
+    * @param instance Instance.
+    */
+   public void addInstance(String className, Object instance) {
+      instances.put(className, instance);
+   }
+
+   /**
+    * Removed deployed instance of a Cache Store.
+    *
+    * @param className Name of the deployed class.
+    */
+   public void removeInstance(String className) {
+      instances.remove(className);
+   }
+
+}

--- a/core/src/main/java/org/infinispan/persistence/factory/LocalClassLoaderCacheStoreFactory.java
+++ b/core/src/main/java/org/infinispan/persistence/factory/LocalClassLoaderCacheStoreFactory.java
@@ -1,0 +1,37 @@
+package org.infinispan.persistence.factory;
+
+import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * Default implementation, which uses Local class loader. No external class loading is allowed.
+ *
+ * @author Sebastian Laskawiec
+ * @since 7.2
+ */
+public class LocalClassLoaderCacheStoreFactory implements CacheStoreFactory {
+
+   private static final Log log = LogFactory.getLog(LocalClassLoaderCacheStoreFactory.class);
+
+   @Override
+   public Object createInstance(StoreConfiguration cfg) {
+      Class classBasedOnConfigurationAnnotation = ConfigurationForClassExtractor.getClassBasedOnConfigurationAnnotation(cfg, log);
+      try {
+         //getInstance is heavily used, so refactoring it might be risky. However we can safely catch
+         //and ignore the exception. Returning null is perfectly legal here.
+         Object instance = Util.getInstance(classBasedOnConfigurationAnnotation);
+         if(instance != null) {
+            return instance;
+         }
+      } catch (CacheConfigurationException unableToInstantiate) {
+         log.debugv("Could not instantiate class {0} using local classloader", classBasedOnConfigurationAnnotation.getName());
+      }
+      return null;
+   }
+
+
+
+}

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -8,6 +8,7 @@ import org.infinispan.commons.CacheException;
 import org.infinispan.commons.CacheListenerException;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.util.TypedProperties;
+import org.infinispan.configuration.cache.StoreConfiguration;
 import org.infinispan.jmx.JmxDomainConflictException;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.partitionhandling.AvailabilityException;
@@ -1225,4 +1226,6 @@ public interface Log extends BasicLogger {
    @Message(value = "Unable to invoke method %s on Object instance %s ", id = 331)
    void unableToInvokeListenerMethod(Method m, Object target, @Cause Throwable e);
 
+   @Message(value = "Unable to instantiate class for StoreConfiguration %s", id = 332)
+   CacheConfigurationException unableToInstantiateClass(StoreConfiguration storeConfiguration);
 }

--- a/core/src/test/java/org/infinispan/persistence/factory/CacheStoreFactoryRegistryTest.java
+++ b/core/src/test/java/org/infinispan/persistence/factory/CacheStoreFactoryRegistryTest.java
@@ -1,0 +1,75 @@
+package org.infinispan.persistence.factory;
+
+import org.infinispan.commons.CacheException;
+import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.persistence.factory.configuration.MyCustomStoreConfiguration;
+import org.testng.annotations.Test;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import static org.testng.Assert.assertEquals;
+
+@Test(groups = "unit", testName = "persistence.CacheStoreFactoryRegistryTest")
+public class CacheStoreFactoryRegistryTest {
+
+   public void testIfNewlyAddedFactoryIsInvokedFirst() {
+      // given
+      final Object instanceReturnedByTheFactory = new Object();
+      StoreConfiguration doesNotMatter = null;
+
+      CacheStoreFactoryRegistry registry = new CacheStoreFactoryRegistry();
+      registry.addCacheStoreFactory(new CacheStoreFactory() {
+
+         @Override
+         public Object createInstance(StoreConfiguration storeConfiguration) {
+            return instanceReturnedByTheFactory;
+         }
+      });
+
+      // when
+      Object instance = registry.createInstance(doesNotMatter);
+
+      // then
+      assertEquals(instance, instanceReturnedByTheFactory);
+   }
+
+   public void testIfInstanceFromDifferentClassLoaderIsReturned() throws Exception {
+      // given
+      final Object instanceReturnedByTheFactory = loadWithCustomClassLoader(this.getClass().getName());
+      StoreConfiguration doesNotMatter = null;
+
+      CacheStoreFactoryRegistry registry = new CacheStoreFactoryRegistry();
+      registry.addCacheStoreFactory(new CacheStoreFactory() {
+
+         @Override
+         public Object createInstance(StoreConfiguration storeConfiguration) {
+            return instanceReturnedByTheFactory;
+         }
+      });
+
+      // when
+      Object instance = registry.createInstance(doesNotMatter);
+
+      // then
+      assertEquals(instance, instanceReturnedByTheFactory);
+   }
+
+   @Test(expectedExceptions = CacheException.class, expectedExceptionsMessageRegExp = "ISPN000332: Unable to instantiate class for StoreConfiguration org.infinispan.persistence.factory.configuration.MyCustomStoreConfiguration.*")
+   public void testIfACacheExceptionIfThrownWhenNoInstanceIfFound() throws Exception {
+      // given
+      StoreConfiguration configuration = new MyCustomStoreConfiguration();
+      CacheStoreFactoryRegistry registry = new CacheStoreFactoryRegistry();
+
+      // when
+      registry.clearFactories();
+      registry.createInstance(configuration);
+   }
+
+   private Object loadWithCustomClassLoader(String className) throws Exception {
+      URL thisClass = this.getClass().getResource(this.getClass().getSimpleName() + ".class");
+      ClassLoader customClassLoader = new URLClassLoader(new URL[] {thisClass});
+      Class<?> customInstanceFromDifferentClassLoader = customClassLoader.loadClass(className);
+      return customInstanceFromDifferentClassLoader.newInstance();
+   }
+}

--- a/core/src/test/java/org/infinispan/persistence/factory/DeployedCacheStoreFactoryTest.java
+++ b/core/src/test/java/org/infinispan/persistence/factory/DeployedCacheStoreFactoryTest.java
@@ -1,0 +1,41 @@
+package org.infinispan.persistence.factory;
+
+import org.infinispan.persistence.factory.configuration.MyCustomStore;
+import org.infinispan.persistence.factory.configuration.MyCustomStoreConfiguration;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNull;
+import static org.testng.AssertJUnit.assertEquals;
+
+@Test(groups = "unit", testName = "persistence.DeployedCacheStoreFactoryTest")
+public class DeployedCacheStoreFactoryTest {
+
+   @Test
+   public void testAddingInstance() throws Exception {
+      //given
+      MyCustomStore testedObject = new MyCustomStore();
+      DeployedCacheStoreFactory factory = new DeployedCacheStoreFactory();
+
+      //when
+      factory.addInstance(MyCustomStore.class.getName(), testedObject);
+      Object instance = factory.createInstance(new MyCustomStoreConfiguration());
+
+      //then
+      assertEquals(testedObject, instance);
+   }
+
+   @Test
+   public void testAddingAndRemovingInstance() throws Exception {
+      //given
+      MyCustomStore testedObject = new MyCustomStore();
+      DeployedCacheStoreFactory factory = new DeployedCacheStoreFactory();
+
+      //when
+      factory.addInstance(MyCustomStore.class.getName(), testedObject);
+      factory.removeInstance(MyCustomStore.class.getName());
+      Object instance = factory.createInstance(new MyCustomStoreConfiguration());
+
+      //then
+      assertNull(instance);
+   }
+}

--- a/core/src/test/java/org/infinispan/persistence/factory/configuration/MyCustomStore.java
+++ b/core/src/test/java/org/infinispan/persistence/factory/configuration/MyCustomStore.java
@@ -1,0 +1,59 @@
+package org.infinispan.persistence.factory.configuration;
+
+import org.infinispan.filter.KeyFilter;
+import org.infinispan.marshall.core.MarshalledEntry;
+import org.infinispan.persistence.spi.AdvancedLoadWriteStore;
+import org.infinispan.persistence.spi.InitializationContext;
+
+import java.util.concurrent.Executor;
+
+public class MyCustomStore implements AdvancedLoadWriteStore {
+
+   @Override
+   public void process(KeyFilter filter, CacheLoaderTask task, Executor executor, boolean fetchValue, boolean fetchMetadata) {
+   }
+
+   @Override
+   public int size() {
+      return 0;
+   }
+
+   @Override
+   public void clear() {
+   }
+
+   @Override
+   public void purge(Executor threadPool, PurgeListener listener) {
+   }
+
+   @Override
+   public void init(InitializationContext ctx) {
+   }
+
+   @Override
+   public void write(MarshalledEntry entry) {
+   }
+
+   @Override
+   public boolean delete(Object key) {
+      return false;
+   }
+
+   @Override
+   public MarshalledEntry load(Object key) {
+      return null;
+   }
+
+   @Override
+   public boolean contains(Object key) {
+      return false;
+   }
+
+   @Override
+   public void start() {
+   }
+
+   @Override
+   public void stop() {
+   }
+}

--- a/core/src/test/java/org/infinispan/persistence/factory/configuration/MyCustomStoreConfiguration.java
+++ b/core/src/test/java/org/infinispan/persistence/factory/configuration/MyCustomStoreConfiguration.java
@@ -1,0 +1,52 @@
+package org.infinispan.persistence.factory.configuration;
+
+import org.infinispan.commons.configuration.ConfigurationFor;
+import org.infinispan.configuration.cache.AsyncStoreConfiguration;
+import org.infinispan.configuration.cache.SingletonStoreConfiguration;
+import org.infinispan.configuration.cache.StoreConfiguration;
+
+import java.util.Properties;
+
+@ConfigurationFor(MyCustomStore.class)
+public class MyCustomStoreConfiguration implements StoreConfiguration {
+
+   @Override
+   public AsyncStoreConfiguration async() {
+      return null;
+   }
+
+   @Override
+   public SingletonStoreConfiguration singletonStore() {
+      return null;
+   }
+
+   @Override
+   public boolean purgeOnStartup() {
+      return false;
+   }
+
+   @Override
+   public boolean fetchPersistentState() {
+      return false;
+   }
+
+   @Override
+   public boolean ignoreModifications() {
+      return false;
+   }
+
+   @Override
+   public boolean preload() {
+      return false;
+   }
+
+   @Override
+   public boolean shared() {
+      return false;
+   }
+
+   @Override
+   public Properties properties() {
+      return null;
+   }
+}

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
@@ -3,6 +3,7 @@ package org.infinispan.server.hotrod
 import logging.Log
 import org.infinispan.commons.marshall.Marshaller
 import org.infinispan.notifications.cachelistener.filter.{CacheEventConverterFactory, CacheEventFilterFactory}
+import org.infinispan.persistence.factory.DeployedCacheStoreFactory
 import scala.collection.JavaConversions._
 import org.infinispan.manager.EmbeddedCacheManager
 import org.infinispan.server.core.{QueryFacade, AbstractProtocolServer}
@@ -247,7 +248,19 @@ class HotRodServer extends AbstractProtocolServer("HotRod") with Log {
       clientListenerRegistry.setEventMarshaller(Option(marshaller))
    }
 
-   override def stop: Unit = {
+   def addCacheStore(name: String, instance: Object): Unit = {
+      knownCacheRegistries
+         .mapValues(registry => registry.getComponent(classOf[DeployedCacheStoreFactory]))
+         .foreach(value => value._2.addInstance(name, instance))
+   }
+
+   def removeCacheStore(name: String): Unit = {
+      knownCacheRegistries
+         .mapValues(registry => registry.getComponent(classOf[DeployedCacheStoreFactory]))
+         .foreach(value => value._2.removeInstance(name))
+   }
+
+  override def stop: Unit = {
       if (clientListenerRegistry != null) clientListenerRegistry.stop()
       super.stop
    }

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDeployableCacheStoreTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDeployableCacheStoreTest.scala
@@ -1,0 +1,60 @@
+package org.infinispan.server.hotrod
+
+import java.lang.reflect.Method
+import java.util.Properties
+
+import org.infinispan.commons.configuration.ConfigurationFor
+import org.infinispan.configuration.cache.{AsyncStoreConfiguration, SingletonStoreConfiguration, StoreConfiguration}
+import org.infinispan.manager.EmbeddedCacheManager
+import org.infinispan.persistence.factory.DeployedCacheStoreFactory
+import org.infinispan.server.hotrod.OperationStatus._
+import org.infinispan.server.hotrod.test.HotRodTestingUtil._
+import org.mockito.Mockito
+import org.testng.AssertJUnit._
+import org.testng.annotations.Test
+
+/**
+ * Tests if adding Deplyable Cache Stores works properly in Hotrod server.
+ *
+ * <i>For more detailed tests refer to: {@link org.infinispan.persistence.factory.DeployedCacheStoreFactoryTest}</i>
+ *
+ * @author Sebastian Laskawiec
+ * @since 7.2
+ */
+@Test(groups = Array("functional"), testName = "server.hotrod.HotRodDeployableCacheStoreTest")
+class HotRodDeployableCacheStoreTest extends HotRodSingleNodeTest {
+   override def createStartHotRodServer(cacheManager: EmbeddedCacheManager) = startHotRodServer(cacheManager, cacheName)
+
+   @ConfigurationFor(classOf[Object])
+   object configuration extends StoreConfiguration {
+
+      override def async(): AsyncStoreConfiguration = ???
+
+      override def fetchPersistentState(): Boolean = ???
+
+      override def singletonStore(): SingletonStoreConfiguration = ???
+
+      override def shared(): Boolean = ???
+
+      override def properties(): Properties = ???
+
+      override def purgeOnStartup(): Boolean = ???
+
+      override def preload(): Boolean = ???
+
+      override def ignoreModifications(): Boolean = ???
+   }
+
+   def testAddingNewDeployableCacheStoreToHotrodServer(m: Method) {
+      // given
+      val testedObject = new Object
+      val deployedCacheStoreFactory = hotRodServer.getCacheRegistry(this.cacheName).getComponent(classOf[DeployedCacheStoreFactory])
+
+      // when
+      hotRodServer.addCacheStore(testedObject.getClass.getName, testedObject)
+      val createdInstance = deployedCacheStoreFactory.createInstance(configuration)
+
+      //then
+      assertEquals(testedObject, createdInstance)
+   }
+}

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/Constants.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/Constants.java
@@ -42,6 +42,12 @@ public class Constants {
    public static final int INSTALL_FILTER_FACTORY = 0x1801;
    public static final int INSTALL_CONVERTER_FACTORY = 0x1802;
    public static final int INSTALL_MARSHALLER = 0x1803;
+   public static final int INSTALL_CACHE_LOADER = 0x1804;
+   public static final int INSTALL_CACHE_WRITER = 0x1805;
+   public static final int INSTALL_ADVANCED_CACHE_LOADER = 0x1806;
+   public static final int INSTALL_ADVANCED_CACHE_WRITER = 0x1807;
+   public static final int INSTALL_EXTERNAL_STORE = 0x1808;
+   public static final int INSTALL_ADVANCED_LOAD_WRITE_STORE = 0x1809;
    public static final int DEPENDENCIES = 0x1C01;
 
    public static String VERSION = Constants.class.getPackage().getImplementationVersion();

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/EndpointLogger.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/EndpointLogger.java
@@ -160,8 +160,8 @@ public interface EndpointLogger extends BasicLogger {
    void cannotInstantiateClass(String clazz, Throwable reason);
 
    @LogMessage(level = WARN)
-   @Message(id = 10026, value = "No @NamedFactory annotation found in class: %s")
-   void noFactoryName(String clazz);
+   @Message(id = 10026, value = "Could not find annotation %s in class: %s")
+   void noFactoryName(String annotation, String clazz);
 
    @Message(id = 10027, value = "Service not started")
    IllegalStateException serviceNotStarted();

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/AbstractCacheStoreExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/AbstractCacheStoreExtensionProcessor.java
@@ -1,0 +1,52 @@
+package org.infinispan.server.endpoint.deployments;
+
+import org.infinispan.server.endpoint.Constants;
+import org.infinispan.server.endpoint.subsystem.ExtensionManagerService;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.value.InjectedValue;
+
+import static org.infinispan.server.endpoint.EndpointLogger.ROOT_LOGGER;
+
+public abstract class AbstractCacheStoreExtensionProcessor<T> extends AbstractServerExtensionProcessor<T> {
+
+   private final ServiceName extensionManagerServiceName;
+
+   protected AbstractCacheStoreExtensionProcessor(ServiceName extensionManagerServiceName) {
+      this.extensionManagerServiceName = extensionManagerServiceName;
+   }
+
+   @Override
+   public final void installService(DeploymentPhaseContext ctx, String serviceName, T instance) {
+      AbstractExtensionManagerService<T> service = createService(serviceName, instance);
+      ServiceName extensionServiceName = Constants.DATAGRID.append(service.getServiceTypeName(), serviceName.replaceAll("\\.", "_"));
+      ServiceBuilder<T> serviceBuilder = ctx.getServiceTarget().addService(extensionServiceName, service);
+      serviceBuilder.setInitialMode(ServiceController.Mode.ACTIVE)
+            .addDependency(extensionManagerServiceName, ExtensionManagerService.class, service.getExtensionManager());
+      serviceBuilder.install();
+   }
+
+   public abstract AbstractExtensionManagerService<T> createService(String serviceName, T instance);
+
+   protected static abstract class AbstractExtensionManagerService<T> implements Service<T> {
+
+      protected final T extension;
+      protected final String serviceName;
+      protected final InjectedValue<ExtensionManagerService> extensionManager = new InjectedValue<>();
+
+      protected AbstractExtensionManagerService(String serviceName, T extension) {
+         assert extension != null : ROOT_LOGGER.nullVar(getServiceTypeName());
+         this.extension = extension;
+         this.serviceName = serviceName;
+      }
+
+      public InjectedValue<ExtensionManagerService> getExtensionManager() {
+         return extensionManager;
+      }
+
+      public abstract String getServiceTypeName();
+   }
+}

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/AbstractNamedFactoryExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/AbstractNamedFactoryExtensionProcessor.java
@@ -34,7 +34,7 @@ public abstract class AbstractNamedFactoryExtensionProcessor<T> extends Abstract
         CompositeIndex index = ctx.getDeploymentUnit().getAttachment(Attachments.COMPOSITE_ANNOTATION_INDEX);
         List<AnnotationInstance> annotations = index.getAnnotations(NAMED_FACTORY);
         if (annotations.isEmpty())
-            ROOT_LOGGER.noFactoryName(getServiceClass().getName());
+            ROOT_LOGGER.noFactoryName(NAMED_FACTORY.local(), getServiceClass().getName());
         else {
             for (AnnotationInstance annotation : annotations) {
                 AnnotationTarget annotationTarget = annotation.target();

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/AdvancedCacheLoaderExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/AdvancedCacheLoaderExtensionProcessor.java
@@ -1,0 +1,54 @@
+package org.infinispan.server.endpoint.deployments;
+
+import org.infinispan.persistence.spi.AdvancedCacheLoader;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+
+import static org.infinispan.server.endpoint.EndpointLogger.ROOT_LOGGER;
+
+public final class AdvancedCacheLoaderExtensionProcessor extends AbstractCacheStoreExtensionProcessor<AdvancedCacheLoader> {
+
+   public AdvancedCacheLoaderExtensionProcessor(ServiceName extensionManagerServiceName) {
+      super(extensionManagerServiceName);
+   }
+
+   @Override
+   public AbstractExtensionManagerService<AdvancedCacheLoader> createService(String serviceName, AdvancedCacheLoader instance) {
+      return new AdvancedCacheLoaderService(serviceName, instance);
+   }
+
+   @Override
+   public Class<AdvancedCacheLoader> getServiceClass() {
+      return AdvancedCacheLoader.class;
+   }
+
+   private static class AdvancedCacheLoaderService extends AbstractExtensionManagerService<AdvancedCacheLoader> {
+      private AdvancedCacheLoaderService(String serviceName, AdvancedCacheLoader AdvancedCacheLoader) {
+         super(serviceName, AdvancedCacheLoader);
+      }
+
+      @Override
+      public void start(StartContext context) {
+         ROOT_LOGGER.debugf("Started AdvancedCacheLoader service with name = %s", serviceName);
+         extensionManager.getValue().addCacheStore(serviceName, extension);
+      }
+
+      @Override
+      public void stop(StopContext context) {
+         ROOT_LOGGER.debugf("Stopped AdvancedCacheLoader service with name = %s", serviceName);
+         extensionManager.getValue().removeCacheStore(serviceName);
+      }
+
+      @Override
+      public AdvancedCacheLoader getValue() {
+         return extension;
+      }
+
+      @Override
+      public String getServiceTypeName() {
+         return "AdvancedCacheLoader-service";
+      }
+   }
+
+}

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/AdvancedCacheWriterExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/AdvancedCacheWriterExtensionProcessor.java
@@ -1,0 +1,54 @@
+package org.infinispan.server.endpoint.deployments;
+
+import org.infinispan.persistence.spi.AdvancedCacheWriter;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+
+import static org.infinispan.server.endpoint.EndpointLogger.ROOT_LOGGER;
+
+public final class AdvancedCacheWriterExtensionProcessor extends AbstractCacheStoreExtensionProcessor<AdvancedCacheWriter> {
+
+   public AdvancedCacheWriterExtensionProcessor(ServiceName extensionManagerServiceName) {
+      super(extensionManagerServiceName);
+   }
+
+   @Override
+   public AbstractExtensionManagerService<AdvancedCacheWriter> createService(String serviceName, AdvancedCacheWriter instance) {
+      return new AdvancedCacheWriterService(serviceName, instance);
+   }
+
+   @Override
+   public Class<AdvancedCacheWriter> getServiceClass() {
+      return AdvancedCacheWriter.class;
+   }
+
+   private static class AdvancedCacheWriterService extends AbstractExtensionManagerService<AdvancedCacheWriter> {
+      private AdvancedCacheWriterService(String serviceName, AdvancedCacheWriter AdvancedCacheWriter) {
+         super(serviceName, AdvancedCacheWriter);
+      }
+
+      @Override
+      public void start(StartContext context) {
+         ROOT_LOGGER.debugf("Started AdvancedCacheWriter service with name = %s", serviceName);
+         extensionManager.getValue().addCacheStore(serviceName, extension);
+      }
+
+      @Override
+      public void stop(StopContext context) {
+         ROOT_LOGGER.debugf("Stopped AdvancedCacheWriter service with name = %s", serviceName);
+         extensionManager.getValue().removeCacheStore(serviceName);
+      }
+
+      @Override
+      public AdvancedCacheWriter getValue() {
+         return extension;
+      }
+
+      @Override
+      public String getServiceTypeName() {
+         return "AdvancedCacheWriter-service";
+      }
+   }
+
+}

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/AdvancedLoadWriteStoreExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/AdvancedLoadWriteStoreExtensionProcessor.java
@@ -1,0 +1,54 @@
+package org.infinispan.server.endpoint.deployments;
+
+import org.infinispan.persistence.spi.AdvancedLoadWriteStore;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+
+import static org.infinispan.server.endpoint.EndpointLogger.ROOT_LOGGER;
+
+public final class AdvancedLoadWriteStoreExtensionProcessor extends AbstractCacheStoreExtensionProcessor<AdvancedLoadWriteStore> {
+
+   public AdvancedLoadWriteStoreExtensionProcessor(ServiceName extensionManagerServiceName) {
+      super(extensionManagerServiceName);
+   }
+
+   @Override
+   public AbstractExtensionManagerService<AdvancedLoadWriteStore> createService(String serviceName, AdvancedLoadWriteStore instance) {
+      return new AdvancedCacheLoaderService(serviceName, instance);
+   }
+
+   @Override
+   public Class<AdvancedLoadWriteStore> getServiceClass() {
+      return AdvancedLoadWriteStore.class;
+   }
+
+   private static class AdvancedCacheLoaderService extends AbstractExtensionManagerService<AdvancedLoadWriteStore> {
+      private AdvancedCacheLoaderService(String serviceName, AdvancedLoadWriteStore AdvancedLoadWriteStore) {
+         super(serviceName, AdvancedLoadWriteStore);
+      }
+
+      @Override
+      public void start(StartContext context) {
+         ROOT_LOGGER.debugf("Started AdvancedLoadWriteStore service with name = %s", serviceName);
+         extensionManager.getValue().addCacheStore(serviceName, extension);
+      }
+
+      @Override
+      public void stop(StopContext context) {
+         ROOT_LOGGER.debugf("Stopped AdvancedLoadWriteStore service with name = %s", serviceName);
+         extensionManager.getValue().removeCacheStore(serviceName);
+      }
+
+      @Override
+      public AdvancedLoadWriteStore getValue() {
+         return extension;
+      }
+
+      @Override
+      public String getServiceTypeName() {
+         return "AdvancedLoadWriteStore-service";
+      }
+   }
+
+}

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/CacheLoaderExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/CacheLoaderExtensionProcessor.java
@@ -1,0 +1,54 @@
+package org.infinispan.server.endpoint.deployments;
+
+import org.infinispan.persistence.spi.CacheLoader;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+
+import static org.infinispan.server.endpoint.EndpointLogger.ROOT_LOGGER;
+
+public final class CacheLoaderExtensionProcessor extends AbstractCacheStoreExtensionProcessor<CacheLoader> {
+
+   public CacheLoaderExtensionProcessor(ServiceName extensionManagerServiceName) {
+      super(extensionManagerServiceName);
+   }
+
+   @Override
+   public AbstractExtensionManagerService<CacheLoader> createService(String serviceName, CacheLoader instance) {
+      return new CacheLoaderService(serviceName, instance);
+   }
+
+   @Override
+   public Class<CacheLoader> getServiceClass() {
+      return CacheLoader.class;
+   }
+
+   private static class CacheLoaderService extends AbstractExtensionManagerService<CacheLoader> {
+      private CacheLoaderService(String serviceName, CacheLoader cacheLoader) {
+         super(serviceName, cacheLoader);
+      }
+
+      @Override
+      public void start(StartContext context) {
+         ROOT_LOGGER.debugf("Started CacheLoader service with name = %s", serviceName);
+         extensionManager.getValue().addCacheStore(serviceName, extension);
+      }
+
+      @Override
+      public void stop(StopContext context) {
+         ROOT_LOGGER.debugf("Stopped CacheLoader service with name = %s", serviceName);
+         extensionManager.getValue().removeCacheStore(serviceName);
+      }
+
+      @Override
+      public CacheLoader getValue() {
+         return extension;
+      }
+
+      @Override
+      public String getServiceTypeName() {
+         return "CacheLoader-service";
+      }
+   }
+
+}

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/CacheWriterExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/CacheWriterExtensionProcessor.java
@@ -1,0 +1,54 @@
+package org.infinispan.server.endpoint.deployments;
+
+import org.infinispan.persistence.spi.CacheWriter;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+
+import static org.infinispan.server.endpoint.EndpointLogger.ROOT_LOGGER;
+
+public final class CacheWriterExtensionProcessor extends AbstractCacheStoreExtensionProcessor<CacheWriter> {
+
+   public CacheWriterExtensionProcessor(ServiceName extensionManagerServiceName) {
+      super(extensionManagerServiceName);
+   }
+
+   @Override
+   public AbstractExtensionManagerService<CacheWriter> createService(String serviceName, CacheWriter instance) {
+      return new CacheWriterService(serviceName, instance);
+   }
+
+   @Override
+   public Class<CacheWriter> getServiceClass() {
+      return CacheWriter.class;
+   }
+
+   private static class CacheWriterService extends AbstractExtensionManagerService<CacheWriter> {
+      private CacheWriterService(String serviceName, CacheWriter CacheWriter) {
+         super(serviceName, CacheWriter);
+      }
+
+      @Override
+      public void start(StartContext context) {
+         ROOT_LOGGER.debugf("Started CacheWriter service with name = %s", serviceName);
+         extensionManager.getValue().addCacheStore(serviceName, extension);
+      }
+
+      @Override
+      public void stop(StopContext context) {
+         ROOT_LOGGER.debugf("Stopped CacheWriter service with name = %s", serviceName);
+         extensionManager.getValue().removeCacheStore(serviceName);
+      }
+
+      @Override
+      public CacheWriter getValue() {
+         return extension;
+      }
+
+      @Override
+      public String getServiceTypeName() {
+         return "CacheWriter-service";
+      }
+   }
+
+}

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/ExternalStoreExtensionProcessor.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/deployments/ExternalStoreExtensionProcessor.java
@@ -1,0 +1,54 @@
+package org.infinispan.server.endpoint.deployments;
+
+import org.infinispan.persistence.spi.ExternalStore;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+
+import static org.infinispan.server.endpoint.EndpointLogger.ROOT_LOGGER;
+
+public final class ExternalStoreExtensionProcessor extends AbstractCacheStoreExtensionProcessor<ExternalStore> {
+
+   public ExternalStoreExtensionProcessor(ServiceName extensionManagerServiceName) {
+      super(extensionManagerServiceName);
+   }
+
+   @Override
+   public AbstractExtensionManagerService<ExternalStore> createService(String serviceName, ExternalStore instance) {
+      return new ExternalStoreService(serviceName, instance);
+   }
+
+   @Override
+   public Class<ExternalStore> getServiceClass() {
+      return ExternalStore.class;
+   }
+
+   private static class ExternalStoreService extends AbstractExtensionManagerService<ExternalStore> {
+      private ExternalStoreService(String serviceName, ExternalStore ExternalStore) {
+         super(serviceName, ExternalStore);
+      }
+
+      @Override
+      public void start(StartContext context) {
+         ROOT_LOGGER.debugf("Started ExternalStore service with name = %s", serviceName);
+         extensionManager.getValue().addCacheStore(serviceName, extension);
+      }
+
+      @Override
+      public void stop(StopContext context) {
+         ROOT_LOGGER.debugf("Stopped ExternalStore service with name = %s", serviceName);
+         extensionManager.getValue().removeCacheStore(serviceName);
+      }
+
+      @Override
+      public ExternalStore getValue() {
+         return extension;
+      }
+
+      @Override
+      public String getServiceTypeName() {
+         return "ExternalStore-service";
+      }
+   }
+
+}

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/EndpointSubsystemAdd.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/EndpointSubsystemAdd.java
@@ -19,10 +19,7 @@
 package org.infinispan.server.endpoint.subsystem;
 
 import org.infinispan.server.endpoint.Constants;
-import org.infinispan.server.endpoint.deployments.ConverterFactoryExtensionProcessor;
-import org.infinispan.server.endpoint.deployments.FilterFactoryExtensionProcessor;
-import org.infinispan.server.endpoint.deployments.MarshallerExtensionProcessor;
-import org.infinispan.server.endpoint.deployments.ServerExtensionDependenciesProcessor;
+import org.infinispan.server.endpoint.deployments.*;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -80,15 +77,47 @@ class EndpointSubsystemAdd extends AbstractAddStepHandler {
 
         ctx.addStep(new AbstractDeploymentChainStep() {
             protected void execute(DeploymentProcessorTarget processorTarget) {
-            processorTarget.addDeploymentProcessor(Constants.SUBSYSTEM_NAME,
-                Phase.INSTALL, Constants.INSTALL_FILTER_FACTORY, new FilterFactoryExtensionProcessor(serviceName));
-            processorTarget.addDeploymentProcessor(Constants.SUBSYSTEM_NAME,
-                Phase.INSTALL, Constants.INSTALL_CONVERTER_FACTORY, new ConverterFactoryExtensionProcessor(serviceName));
-            processorTarget.addDeploymentProcessor(Constants.SUBSYSTEM_NAME,
-                Phase.INSTALL, Constants.INSTALL_MARSHALLER, new MarshallerExtensionProcessor(serviceName));
-            processorTarget.addDeploymentProcessor(Constants.SUBSYSTEM_NAME,
-                Phase.DEPENDENCIES, Constants.DEPENDENCIES, new ServerExtensionDependenciesProcessor());
+               addFilterFactory(processorTarget);
+               addConverterFactory(processorTarget);
+               addMarshaller(processorTarget);
+               addCacheStore(processorTarget);
+               addDependencies(processorTarget);
             }
+
+           private void addDependencies(DeploymentProcessorTarget processorTarget) {
+              processorTarget.addDeploymentProcessor(Constants.SUBSYSTEM_NAME,
+                  Phase.DEPENDENCIES, Constants.DEPENDENCIES, new ServerExtensionDependenciesProcessor());
+           }
+
+           private void addCacheStore(DeploymentProcessorTarget processorTarget) {
+              processorTarget.addDeploymentProcessor(Constants.SUBSYSTEM_NAME,
+               Phase.INSTALL, Constants.INSTALL_CACHE_LOADER, new CacheLoaderExtensionProcessor(serviceName));
+              processorTarget.addDeploymentProcessor(Constants.SUBSYSTEM_NAME,
+                  Phase.INSTALL, Constants.INSTALL_CACHE_WRITER, new CacheWriterExtensionProcessor(serviceName));
+              processorTarget.addDeploymentProcessor(Constants.SUBSYSTEM_NAME,
+                  Phase.INSTALL, Constants.INSTALL_ADVANCED_CACHE_LOADER, new AdvancedCacheLoaderExtensionProcessor(serviceName));
+              processorTarget.addDeploymentProcessor(Constants.SUBSYSTEM_NAME,
+                  Phase.INSTALL, Constants.INSTALL_ADVANCED_CACHE_WRITER, new AdvancedCacheWriterExtensionProcessor(serviceName));
+              processorTarget.addDeploymentProcessor(Constants.SUBSYSTEM_NAME,
+                  Phase.INSTALL, Constants.INSTALL_EXTERNAL_STORE, new ExternalStoreExtensionProcessor(serviceName));
+              processorTarget.addDeploymentProcessor(Constants.SUBSYSTEM_NAME,
+                  Phase.INSTALL, Constants.INSTALL_ADVANCED_LOAD_WRITE_STORE, new AdvancedLoadWriteStoreExtensionProcessor(serviceName));
+           }
+
+           private void addMarshaller(DeploymentProcessorTarget processorTarget) {
+              processorTarget.addDeploymentProcessor(Constants.SUBSYSTEM_NAME,
+               Phase.INSTALL, Constants.INSTALL_MARSHALLER, new MarshallerExtensionProcessor(serviceName));
+           }
+
+           private void addConverterFactory(DeploymentProcessorTarget processorTarget) {
+              processorTarget.addDeploymentProcessor(Constants.SUBSYSTEM_NAME,
+               Phase.INSTALL, Constants.INSTALL_CONVERTER_FACTORY, new ConverterFactoryExtensionProcessor(serviceName));
+           }
+
+           private void addFilterFactory(DeploymentProcessorTarget processorTarget) {
+              processorTarget.addDeploymentProcessor(Constants.SUBSYSTEM_NAME,
+                  Phase.INSTALL, Constants.INSTALL_FILTER_FACTORY, new FilterFactoryExtensionProcessor(serviceName));
+           }
         }, OperationContext.Stage.RUNTIME);
 
         builder.install();

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/ExtensionManagerService.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/ExtensionManagerService.java
@@ -21,6 +21,7 @@ public class ExtensionManagerService implements Service<ExtensionManagerService>
     private final List<HotRodServer> servers = new ArrayList<>();
     private final Map<String, CacheEventFilterFactory> filterFactories = new HashMap<>();
     private final Map<String, CacheEventConverterFactory> converterFactories = new HashMap<>();
+    private final Map<String, Object> cacheStores = new HashMap<>();
 
     @Override
     public void start(StartContext context) throws StartException {
@@ -120,4 +121,27 @@ public class ExtensionManagerService implements Service<ExtensionManagerService>
         return this;
     }
 
+    public void removeCacheStore(String className) {
+        synchronized (cacheStores) {
+            cacheStores.remove(className);
+        }
+
+        synchronized (servers) {
+            for (HotRodServer server : servers) {
+                server.removeCacheStore(className);
+            }
+        }
+    }
+
+    public void addCacheStore(String className, Object extension) {
+        synchronized (cacheStores) {
+            cacheStores.put(className, extension);
+        }
+
+        synchronized (servers) {
+            for (HotRodServer server : servers) {
+                server.addCacheStore(className, extension);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Hey!

Please take a look at proposed implementation of https://issues.jboss.org/browse/ISPN-5131. 

Implementation highlights:
* Refactoring in PersistenceManagerImpl - now it uses CacheStoreFactoryRegistry
* CacheStoreFactoryRegistry added to DI
* Logic of converting StoreConfiguration to an instance moved to ConfigurationForClassExtractor
* Added extensions to Hotrod server
* Deployable Filters and Converters were used as a template: https://github.com/infinispan/infinispan/pull/2782

Thanks!
Sebastian