### PR TITLE
ISPN-5232 Entry iterator returns entries created in current TX but does

### DIFF
--- a/core/src/main/java/org/infinispan/commands/read/EntryRetrievalCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/EntryRetrievalCommand.java
@@ -45,4 +45,8 @@ public class EntryRetrievalCommand<K, V> extends AbstractLocalCommand implements
       return new EntryIterableImpl<>(retriever, filter, flags != null ? EnumSet.copyOf(flags) :
             EnumSet.noneOf(Flag.class), cache);
    }
+
+   public KeyValueFilter<K, V> getFilter() {
+      return filter;
+   }
 }

--- a/core/src/main/java/org/infinispan/interceptors/TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/TxInterceptor.java
@@ -325,7 +325,8 @@ public class TxInterceptor extends CommandInterceptor implements JmxStatisticsEx
       // command and the iterator itself does not place read values into the context.
       EntryIterable iterable = (EntryIterable) super.visitEntryRetrievalCommand(ctx, command);
       if (ctx.isInTxScope()) {
-         return new TransactionAwareEntryIterable(iterable, (TxInvocationContext<LocalTransaction>) ctx, cache);
+         return new TransactionAwareEntryIterable(iterable, command.getFilter(), 
+               (TxInvocationContext<LocalTransaction>) ctx, cache);
       } else {
          return iterable;
       }

--- a/core/src/main/java/org/infinispan/iteration/impl/RemovableEntryIterator.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/RemovableEntryIterator.java
@@ -13,15 +13,15 @@ import java.util.NoSuchElementException;
  * @author wburns
  * @since 7.0
  */
-public class RemovableEntryIterator<K, C> implements CloseableIterator<CacheEntry<K, C>> {
-   protected final CloseableIterator<CacheEntry<K, C>> realIterator;
-   protected final Cache<K, ?> cache;
+public class RemovableEntryIterator<K, V, C> implements CloseableIterator<CacheEntry<K, C>> {
+   protected final CloseableIterator<CacheEntry<K, V>> realIterator;
+   protected final Cache<K, V> cache;
 
    protected CacheEntry<K, C> previousValue;
    protected CacheEntry<K, C> currentValue;
 
-   public RemovableEntryIterator(CloseableIterator<CacheEntry<K, C>> realIterator,
-                                            Cache<K, ?> cache, boolean initIterator) {
+   public RemovableEntryIterator(CloseableIterator<CacheEntry<K, V>> realIterator,
+                                            Cache<K, V> cache, boolean initIterator) {
       this.realIterator = realIterator;
       this.cache = cache;
       if (initIterator) {
@@ -31,7 +31,7 @@ public class RemovableEntryIterator<K, C> implements CloseableIterator<CacheEntr
 
    protected CacheEntry<K, C> getNextFromIterator() {
       if (realIterator.hasNext()) {
-         return realIterator.next();
+         return (CacheEntry<K, C>) realIterator.next();
       } else {
          return null;
       }

--- a/core/src/main/java/org/infinispan/iteration/impl/TransactionAwareCloseableIterator.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/TransactionAwareCloseableIterator.java
@@ -2,8 +2,15 @@ package org.infinispan.iteration.impl;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.container.EntryFactory;
+import org.infinispan.container.InternalEntryFactory;
 import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.filter.Converter;
+import org.infinispan.filter.KeyValueFilter;
+import org.infinispan.filter.KeyValueFilterConverter;
+import org.infinispan.marshall.core.MarshalledValue;
 import org.infinispan.transaction.impl.LocalTransaction;
 
 import java.util.ArrayList;
@@ -19,45 +26,71 @@ import java.util.Set;
  * @author wburns
  * @since 7.0
  */
-public class TransactionAwareCloseableIterator<K, C> extends RemovableEntryIterator<K, C> {
+public class TransactionAwareCloseableIterator<K, V, C> extends RemovableEntryIterator<K, V, C> {
    private final TxInvocationContext<LocalTransaction> ctx;
    // We store all the not yet seen context entries here.  We rely on the fact that the cache entry reference is updated
    // if a change occurs in between iterations to see updates.
    private final List<CacheEntry> contextEntries;
    private final Set<Object> seenContextKeys = new HashSet<>();
+   private final KeyValueFilter<? super K, ? super V> filter;
+   private final Converter<? super K, ? super V, ? extends C> converter;
+   private final InternalEntryFactory entryFactory;
 
-   public TransactionAwareCloseableIterator(CloseableIterator<CacheEntry<K, C>> realIterator,
-                                            TxInvocationContext<LocalTransaction> ctx, Cache<K, ?> cache) {
+   public TransactionAwareCloseableIterator(CloseableIterator<CacheEntry<K, V>> realIterator,
+         KeyValueFilter<? super K, ? super V> filter,
+         Converter<? super K, ? super V, ? extends C> converter, 
+         TxInvocationContext<LocalTransaction> ctx, Cache<K, V> cache) {
       super(realIterator, cache, false);
       this.ctx = ctx;
+      this.filter = filter;
+      this.converter = checkForKeyValueFilterConverter(filter, converter);
+      this.entryFactory = cache.getAdvancedCache().getComponentRegistry().getComponent(
+            InternalEntryFactory.class);
       contextEntries = new ArrayList<>(ctx.getLookedUpEntries().values());
       currentValue = getNextFromIterator();
    }
 
+   protected CacheEntry<K, V> filterEntry(CacheEntry<K, V> entry) {
+      if (converter == null && filter instanceof KeyValueFilterConverter) {
+         K key = entry.getKey();
+         C converted = ((KeyValueFilterConverter<K, V, C>)filter).filterAndConvert(
+               key, entry.getValue(), entry.getMetadata());
+         if (converted != null) {
+            entry = entryFactory.create(entry);
+            entry.setValue((V) converted);
+            return entry;
+         }
+      } else if (filter == null || 
+            filter.accept(entry.getKey(), entry.getValue(), entry.getMetadata())) {
+         return entry;
+      }
+      return null;
+   }
+
    @Override
    protected CacheEntry<K, C> getNextFromIterator() {
-      CacheEntry<K, C> returnedEntry = null;
+      CacheEntry<K, V> returnedEntry = null;
       // We first have to exhaust all of our context entries
-      CacheEntry<K, C> entry;
-      while (!contextEntries.isEmpty() && (entry = contextEntries.remove(0)) != null) {
+      CacheEntry<K, V> entry;
+      while (returnedEntry == null && !contextEntries.isEmpty() && 
+            (entry = contextEntries.remove(0)) != null) {
          seenContextKeys.add(entry.getKey());
          if (!ctx.isEntryRemovedInContext(entry.getKey())) {
-            returnedEntry = entry;
+            returnedEntry = filterEntry(entry);
          }
       }
       if (returnedEntry == null) {
          while (realIterator.hasNext()) {
-            CacheEntry<K, C> iteratedEntry = realIterator.next();
+            CacheEntry<K, V> iteratedEntry = realIterator.next();
             CacheEntry contextEntry;
             // If the value was in the context then we ignore the stored value since we use the context value
             if ((contextEntry = ctx.lookupEntry(iteratedEntry.getKey())) != null) {
-               if (seenContextKeys.add(contextEntry.getKey()) && !contextEntry.isRemoved()) {
-                  returnedEntry = contextEntry;
+               if (seenContextKeys.add(contextEntry.getKey()) && !contextEntry.isRemoved() && 
+                     (returnedEntry = filterEntry(contextEntry)) != null) {
                   break;
                }
                
-            } else {
-               returnedEntry = iteratedEntry;
+            } else if ((returnedEntry = filterEntry(iteratedEntry)) != null) {
                break;
             }
          }
@@ -75,6 +108,31 @@ public class TransactionAwareCloseableIterator<K, C> extends RemovableEntryItera
             }
          }
       }
-      return returnedEntry;
+      if (returnedEntry != null && converter != null) {
+         C newValue = converter.convert(returnedEntry.getKey(), returnedEntry.getValue(),
+               returnedEntry.getMetadata());
+         returnedEntry = entryFactory.create(returnedEntry);
+         returnedEntry.setValue((V) newValue);
+      }
+      return (CacheEntry<K, C>) returnedEntry;
+   }
+
+   protected <C> Converter<? super K, ? super V, ? extends C> checkForKeyValueFilterConverter(
+         KeyValueFilter<? super K, ? super V> filter, Converter<? super K, ? super V, ? extends C> converter) {
+      Converter<? super K, ? super V, ? extends C> usedConverter;
+      if (filter == converter && filter instanceof KeyValueFilterConverter) {
+         // If we were supplied an efficient KeyValueFilterConverter don't use a converter!
+         usedConverter = null;
+      } else {
+         usedConverter = converter;
+      }
+      return usedConverter;
+   }
+
+   protected static <T> T unwrapMarshalledvalue(T value) {
+      if (value instanceof MarshalledValue) {
+         return (T) ((MarshalledValue) value).get();
+      }
+      return value;
    }
 }

--- a/core/src/main/java/org/infinispan/iteration/impl/TransactionAwareEntryIterable.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/TransactionAwareEntryIterable.java
@@ -5,6 +5,7 @@ import org.infinispan.commons.util.CloseableIterable;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.filter.Converter;
+import org.infinispan.filter.KeyValueFilter;
 import org.infinispan.iteration.EntryIterable;
 import org.infinispan.transaction.impl.LocalTransaction;
 
@@ -14,17 +15,19 @@ import org.infinispan.transaction.impl.LocalTransaction;
  * @author wburns
  * @since 7.0
  */
-public class TransactionAwareEntryIterable<K, V> extends TransactionAwareCloseableIterable<K, V> implements EntryIterable<K, V> {
+public class TransactionAwareEntryIterable<K, V> extends TransactionAwareCloseableIterable<K, V, V> implements EntryIterable<K, V> {
    private final EntryIterable<K, V> entryIterable;
 
-   public TransactionAwareEntryIterable(EntryIterable<K, V> entryIterable, TxInvocationContext<LocalTransaction> ctx,
+   public TransactionAwareEntryIterable(EntryIterable<K, V> entryIterable, 
+         KeyValueFilter<? super K, ? super V> filter, TxInvocationContext<LocalTransaction> ctx,
                                         Cache<K, V> cache) {
-      super(entryIterable, ctx, cache);
+      super(entryIterable, filter, null, ctx, cache);
       this.entryIterable = entryIterable;
    }
 
    @Override
    public <C> CloseableIterable<CacheEntry<K, C>> converter(Converter<? super K, ? super V, ? extends C> converter) {
-      return new TransactionAwareCloseableIterable<>(entryIterable.converter(converter), ctx, cache);
+      return new TransactionAwareCloseableIterable<>(entryIterable.converter(converter),
+            filter, converter, ctx, cache);
    }
 }

--- a/core/src/test/java/org/infinispan/iteration/BaseClusteredEntryRetrieverTest.java
+++ b/core/src/test/java/org/infinispan/iteration/BaseClusteredEntryRetrieverTest.java
@@ -4,7 +4,6 @@ import org.infinispan.Cache;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.container.entries.TransientMortalCacheEntry;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.filter.CollectionKeyFilter;
 import org.infinispan.filter.KeyFilterAsKeyValueFilter;
@@ -12,12 +11,9 @@ import org.infinispan.iteration.impl.EntryRetriever;
 import org.testng.annotations.Test;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.assertEquals;
 

--- a/core/src/test/java/org/infinispan/iteration/BaseSetupEntryRetrieverTest.java
+++ b/core/src/test/java/org/infinispan/iteration/BaseSetupEntryRetrieverTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.iteration;
 
-import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.entries.CacheEntry;

--- a/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverTest.java
+++ b/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverTest.java
@@ -56,7 +56,11 @@ import static org.testng.AssertJUnit.*;
 @Test(groups = {"functional", "smoke"}, testName = "iteration.DistributedEntryRetrieverTest")
 public class DistributedEntryRetrieverTest extends BaseClusteredEntryRetrieverTest {
    public DistributedEntryRetrieverTest() {
-      super(false, CacheMode.DIST_SYNC);
+      this(false);
+   }
+
+   public DistributedEntryRetrieverTest(boolean tx) {
+      super(tx, CacheMode.DIST_SYNC);
       // This is needed since we kill nodes
       cleanup = CleanupPhase.AFTER_METHOD;
    }

--- a/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverTxTest.java
+++ b/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverTxTest.java
@@ -1,0 +1,132 @@
+package org.infinispan.iteration;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.filter.AcceptAllKeyValueFilter;
+import org.infinispan.filter.CollectionKeyFilter;
+import org.infinispan.filter.CompositeKeyValueFilterConverter;
+import org.infinispan.filter.KeyFilterAsKeyValueFilter;
+import org.infinispan.filter.KeyValueFilterConverter;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.Test;
+
+/**
+ * Test to verify distributed entry behavior when in a tx
+ *
+ * @author wburns
+ * @since 7.0
+ */
+@Test(groups = {"functional", "smoke"}, testName = "iteration.DistributedEntryRetrieverTxTest")
+public class DistributedEntryRetrieverTxTest extends DistributedEntryRetrieverTest {
+   public DistributedEntryRetrieverTxTest() {
+      super(true);
+   }
+
+   public void testFilterWithExistingTransaction() throws NotSupportedException,
+         SystemException, SecurityException, IllegalStateException, RollbackException,
+         HeuristicMixedException, HeuristicRollbackException {
+      Map<Object, String> values = putValueInEachCache(3);
+
+      Cache<Object, String> cache = cache(0, CACHE_NAME);
+      TransactionManager tm = TestingUtil.extractComponent(cache,
+            TransactionManager.class);
+      tm.begin();
+      try {
+         Object key = "filtered-key";
+         cache.put(key, "filtered-value");
+
+         CloseableIterator<CacheEntry<Object, String>> iterator = 
+               cache.getAdvancedCache().filterEntries(
+                     new KeyFilterAsKeyValueFilter<>(new CollectionKeyFilter<>(Collections.singleton(key)))).iterator();
+         Map<Object, String> results = mapFromIterator(iterator);
+         assertEquals(values, results);
+      } finally {
+         tm.rollback();
+      }
+   }
+
+   @Test
+   public void testConverterWithExistingTransaction() throws NotSupportedException, SystemException {
+      Map<Object, String> values = putValuesInCache();
+
+      Cache<Object, String> cache = cache(0, CACHE_NAME);
+      TransactionManager tm = TestingUtil.extractComponent(cache,
+            TransactionManager.class);
+      tm.begin();
+      try {
+         Object key = "converted-key";
+         String value = "converted-value";
+         values.put(key, value);
+         cache.put(key, "converted-value");
+         
+         try (EntryIterable<Object, String> iterable = cache.getAdvancedCache().filterEntries(AcceptAllKeyValueFilter.getInstance())) {
+            Map<Object, String> results = mapFromIterable(iterable.converter(new StringTruncator(2, 5)));
+
+            assertEquals(values.size(), results.size());
+            for (Map.Entry<Object, String> entry : values.entrySet()) {
+               assertEquals(entry.getValue().substring(2, 7), results.get(entry.getKey()));
+            }
+         }
+      } finally {
+         tm.rollback();
+      }
+   }
+
+   @Test
+   public void testKeyFilterConverterWithExistingTransaction() throws NotSupportedException, SystemException {
+      Map<Object, String> values = putValuesInCache();
+
+
+      Cache<Object, String> cache = cache(0, CACHE_NAME);
+      TransactionManager tm = TestingUtil.extractComponent(cache,
+            TransactionManager.class);
+      tm.begin();
+      try {
+         Iterator<Map.Entry<Object, String>> iter = values.entrySet().iterator();
+         Map.Entry<Object, String> extraEntry = iter.next();
+         while (iter.hasNext()) {
+            iter.next();
+            iter.remove();
+         }
+         
+         Object key = "converted-key";
+         String value = "converted-value";
+         values.put(key, value);
+         cache.put(key, "converted-value");
+
+         Collection<Object> acceptedKeys = new ArrayList<>();
+         acceptedKeys.add(key);
+         acceptedKeys.add(extraEntry.getKey());
+         
+         KeyValueFilterConverter<Object, String, String> filterConverter = 
+               new CompositeKeyValueFilterConverter<Object, String, String>(
+                     new KeyFilterAsKeyValueFilter<>(new CollectionKeyFilter<>(acceptedKeys, true)),
+                     new StringTruncator(2, 5));
+         try (EntryIterable<Object, String> iterable = cache.getAdvancedCache().filterEntries(filterConverter)) {
+            Map<Object, String> results = mapFromIterable(iterable.converter(filterConverter));
+            assertEquals(values.size(), results.size());
+            for (Map.Entry<Object, String> entry : values.entrySet()) {
+               assertEquals(entry.getValue().substring(2, 7), results.get(entry.getKey()));
+            }
+         }
+      } finally {
+         tm.rollback();
+      }
+   }
+}


### PR DESCRIPTION
not apply the filter/converter

* Transaction context values now check filter/converter
* Fixed issue when multiple context values were present we only chose 1

https://issues.jboss.org/browse/ISPN-5232