### PR TITLE
ISPN-5232 Entry iterator returns entries created in current TX but does

### DIFF
--- a/core/src/main/java/org/infinispan/iteration/impl/TransactionAwareCloseableIterator.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/TransactionAwareCloseableIterator.java
@@ -87,8 +87,9 @@ public class TransactionAwareCloseableIterator<K, V, C> extends RemovableEntryIt
                   break;
                }
                
-            } else if ((returnedEntry = filterEntry(iteratedEntry)) != null) {
-               break;
+            } else {
+               // Filter and conversion were already done by the iterator
+               return (CacheEntry<K, C>) iteratedEntry;
             }
          }
       }

--- a/core/src/test/java/org/infinispan/iteration/BaseSetupEntryRetrieverTest.java
+++ b/core/src/test/java/org/infinispan/iteration/BaseSetupEntryRetrieverTest.java
@@ -88,7 +88,7 @@ public abstract class BaseSetupEntryRetrieverTest extends MultipleCacheManagersT
          if (value != null && value.length() > beginning + length) {
             return value.substring(beginning, beginning + length);
          } else {
-            return value;
+            throw new IllegalStateException("String should be longer than truncation size!  Possible double conversion performed!");
          }
       }
    }


### PR DESCRIPTION
not apply the filter/converter

* Fixed issue so entries returned from iterator are not filtered and
  converted twice

https://issues.jboss.org/browse/ISPN-5232