### PR TITLE
ISPN-5273 Add more test scenarios for HR event listeners

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterEventsTest.java
@@ -145,8 +145,11 @@ public class ClientClusterEventsTest extends MultiHotRodServersTest {
          statelessListener.expectNoEvents();
          failoverListener.expectNoEvents();
          statefulListener.expectUnorderedEvents(ClientEvent.Type.CLIENT_CACHE_ENTRY_CREATED, 1, 2);
+         c.put(3, "three");
+         statefulListener.expectUnorderedEvents(ClientEvent.Type.CLIENT_CACHE_ENTRY_CREATED, 3);
          c.remove(1);
          c.remove(2);
+         c.remove(3);
       } finally {
          killRemoteCacheManager(newClient);
       }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientCustomEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientCustomEventsTest.java
@@ -50,6 +50,24 @@ public class ClientCustomEventsTest extends SingleHotRodServerTest {
          }
       });
    }
+   
+   public void testTimeOrderedEvents() {
+      final StaticCustomEventLogListener eventListener = new StaticCustomEventLogListener();
+      withClientListener(eventListener, new RemoteCacheManagerCallable(remoteCacheManager) {
+         @Override
+         public void call() {
+            RemoteCache<Integer, String> cache = rcm.getCache();
+            eventListener.expectNoEvents();
+            cache.put(1, "one");
+            cache.replace(1, "newone");
+            cache.replace(1, "newnewone");
+            cache.replace(1, "newnewnewone");
+            cache.replace(1, "newnewnewnewone");
+            cache.replace(1, "newnewnewnewnewone");
+            eventListener.expectOrderedEventQueue(ClientEvent.Type.CLIENT_CACHE_ENTRY_MODIFIED);
+         }
+      });
+   }
 
    /**
     * Test that the HotRod server returns an error when a ClientListener is


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5273

* Verify listner continue recieveing events after failover
* Explicitly verify time ordering of recieved events
* Verify that events can contain custom fields