### PR TITLE
ISPN-5295 Remote cache entries with sub-second lifetime never expire

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -599,8 +599,15 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
       return new MetadataValueImpl<V>(value.getCreated(), value.getLifespan(), value.getLastUsed(), value.getMaxIdle(), value.getVersion(), valueObj);
    }
 
-   private int toSeconds(long duration, TimeUnit timeUnit) {
-      return (int) timeUnit.toSeconds(duration);
+   protected static int toSeconds(long duration, TimeUnit timeUnit) {
+      int seconds = (int) timeUnit.toSeconds(duration);
+      long inverseDuration = timeUnit.convert(seconds, TimeUnit.SECONDS);
+
+      if (duration > inverseDuration) {
+         //Round up.
+         seconds++;
+      }
+      return seconds;
    }
 
    private void assertRemoteCacheManagerIsStarted() {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/RemoteCacheImplTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/RemoteCacheImplTest.java
@@ -1,0 +1,26 @@
+package org.infinispan.client.hotrod.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.Test;
+
+@Test (testName = "client.hotrod.RemoteCacheImplTest", groups = "unit" )
+public class RemoteCacheImplTest {
+   @Test
+   public void testSubsecondConversion() {
+      assertEquals(0, RemoteCacheImpl.toSeconds(0, TimeUnit.MILLISECONDS));
+      assertEquals(1, RemoteCacheImpl.toSeconds(1, TimeUnit.MILLISECONDS));
+      assertEquals(1, RemoteCacheImpl.toSeconds(999, TimeUnit.MILLISECONDS));
+      assertEquals(1, RemoteCacheImpl.toSeconds(1000, TimeUnit.MILLISECONDS));
+   }
+
+   @Test
+   public void testFractionOfSecondConversion() {
+      assertEquals(2, RemoteCacheImpl.toSeconds(1001, TimeUnit.MILLISECONDS));
+      assertEquals(2, RemoteCacheImpl.toSeconds(1999, TimeUnit.MILLISECONDS));
+      assertEquals(2, RemoteCacheImpl.toSeconds(2000, TimeUnit.MILLISECONDS));
+      assertEquals(3, RemoteCacheImpl.toSeconds(2001, TimeUnit.MILLISECONDS));
+   }
+}


### PR DESCRIPTION
Fix for https://issues.jboss.org/browse/ISPN-5295

Fixes:
* specifying a subsecond lifespan/maxidle no longer make the entry immortal
* when converting lifespan/maxidle with timeunit < second round the specified duration up to a full second to avoid entry expiration _before_ the specified duration