### PR TITLE
ISPN-5300 CacheEventFilterAsKeyValueFilter must pass the value and metad...

### DIFF
--- a/core/src/main/java/org/infinispan/notifications/cachelistener/filter/CacheEventFilterAsKeyValueFilter.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/filter/CacheEventFilterAsKeyValueFilter.java
@@ -33,7 +33,7 @@ public class CacheEventFilterAsKeyValueFilter<K, V> implements KeyValueFilter<K,
 
    @Override
    public boolean accept(K key, V value, Metadata metadata) {
-      return filter.accept(key, value, metadata, null, null, CREATE_EVENT);
+      return filter.accept(key, null, null, value, metadata, CREATE_EVENT);
    }
 
    public static class Externalizer extends AbstractExternalizer<CacheEventFilterAsKeyValueFilter> {


### PR DESCRIPTION
...ata as 'new' to the underlying CacheEventFilter

This is for 7.1.x !

Jira: https://issues.jboss.org/browse/ISPN-5300