### PR TITLE
ISPN-5208 Avoid installing empty views and log WARN msgs

### DIFF
--- a/server/core/src/main/scala/org/infinispan/server/core/logging/JavaLog.java
+++ b/server/core/src/main/scala/org/infinispan/server/core/logging/JavaLog.java
@@ -2,6 +2,7 @@ package org.infinispan.server.core.logging;
 
 import io.netty.channel.Channel;
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.distribution.ch.ConsistentHash;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -83,4 +84,16 @@ public interface JavaLog extends org.infinispan.util.logging.Log {
 
    @Message(value = "Cannot configure custom KeyStore and/or TrustStore when specifying a SSLContext", id = 5018)
    CacheConfigurationException xorSSLContext();
+
+   @LogMessage(level = WARN)
+   @Message(value = "No members for new topology after applying consistent hash %s filtering into base topology %s", id = 5019)
+   void noMembersInHashTopology(ConsistentHash ch, String topologyMap);
+
+   @LogMessage(level = WARN)
+   @Message(value = "No members in new topology", id = 5020)
+   void noMembersInTopology();
+
+   @LogMessage(level = WARN)
+   @Message(value = "Server endpoint topology is empty, and cluster members are %s", id = 5021)
+   void serverEndpointTopologyEmpty(String clusterMembers);
 }

--- a/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
@@ -1,6 +1,8 @@
 package org.infinispan.server.core.logging
 
 import java.net.SocketAddress
+import org.infinispan.distribution.ch.ConsistentHash
+import org.infinispan.remoting.transport.Address
 import org.infinispan.util.logging.LogFactory
 import io.netty.channel.Channel
 
@@ -74,4 +76,12 @@ trait Log {
 
    def logErrorBeforeReadingRequest(t: Throwable) =
       log.errorBeforeReadingRequest(t)
+
+   def logNoMembersInHashTopology(ch: ConsistentHash, topology: String) =
+      log.noMembersInHashTopology(ch, topology)
+
+   def logNoMembersInTopology() =  log.noMembersInTopology()
+
+   def logServerEndpointTopologyEmpty(clusterMembers: String) =
+      log.serverEndpointTopologyEmpty(clusterMembers)
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5208

Seems like server topologies sent to clients are sometimes empty. Avoid such scenario and log some WARN messages when that happens so that we can find out more about the cause.

Please leave the JIRA open after integrating this PR.