### PR TITLE
ISPN-5208 Avoid installing empty views and log WARN msgs

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/CustomEventLogListener.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/CustomEventLogListener.java
@@ -104,11 +104,11 @@ public abstract class CustomEventLogListener<E> {
    public static final class CustomEvent implements Serializable {
       final Integer key;
       final String value;
-      final Date timestamp;
+      final long timestamp;
       public CustomEvent(Integer key, String value) {
          this.key = key;
          this.value = value;
-         this.timestamp = new Date(System.currentTimeMillis());
+         this.timestamp = System.nanoTime();
       }
 
       @Override
@@ -163,7 +163,8 @@ public abstract class CustomEventLogListener<E> {
       }
       
       private void expectTimeOrdered(CustomEvent before, CustomEvent after) {
-         assertTrue(before.timestamp.before(after.timestamp));
+         assertTrue("Before timestamp=" + before.timestamp + ", after timestamp=" + after.timestamp,
+            before.timestamp < after.timestamp);
       }
    }
 

--- a/server/core/src/main/scala/org/infinispan/server/core/logging/JavaLog.java
+++ b/server/core/src/main/scala/org/infinispan/server/core/logging/JavaLog.java
@@ -2,6 +2,7 @@ package org.infinispan.server.core.logging;
 
 import io.netty.channel.Channel;
 import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.distribution.ch.ConsistentHash;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -83,4 +84,16 @@ public interface JavaLog extends org.infinispan.util.logging.Log {
 
    @Message(value = "Cannot configure custom KeyStore and/or TrustStore when specifying a SSLContext", id = 5018)
    CacheConfigurationException xorSSLContext();
+
+   @LogMessage(level = WARN)
+   @Message(value = "No members for new topology after applying consistent hash %s filtering into base topology %s", id = 5019)
+   void noMembersInHashTopology(ConsistentHash ch, String topologyMap);
+
+   @LogMessage(level = WARN)
+   @Message(value = "No members in new topology", id = 5020)
+   void noMembersInTopology();
+
+   @LogMessage(level = WARN)
+   @Message(value = "Server endpoint topology is empty, and cluster members are %s", id = 5021)
+   void serverEndpointTopologyEmpty(String clusterMembers);
 }

--- a/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
@@ -1,6 +1,8 @@
 package org.infinispan.server.core.logging
 
 import java.net.SocketAddress
+import org.infinispan.distribution.ch.ConsistentHash
+import org.infinispan.remoting.transport.Address
 import org.infinispan.util.logging.LogFactory
 import io.netty.channel.Channel
 
@@ -74,4 +76,12 @@ trait Log {
 
    def logErrorBeforeReadingRequest(t: Throwable) =
       log.errorBeforeReadingRequest(t)
+
+   def logNoMembersInHashTopology(ch: ConsistentHash, topology: String) =
+      log.noMembersInHashTopology(ch, topology)
+
+   def logNoMembersInTopology() =  log.noMembersInTopology()
+
+   def logServerEndpointTopologyEmpty(clusterMembers: String) =
+      log.serverEndpointTopologyEmpty(clusterMembers)
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Encoder2x.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Encoder2x.scala
@@ -73,13 +73,19 @@ object Encoder2x extends AbstractVersionedEncoder with Constants with Log {
    }
 
    private def writeTopologyUpdate(t: TopologyAwareResponse, buffer: ByteBuf) {
-      trace("Write topology change response header %s", t)
-      buffer.writeByte(1) // Topology changed
-      writeUnsignedInt(t.topologyId, buffer)
-      writeUnsignedInt(t.serverEndpointsMap.size, buffer)
-      for (address <- t.serverEndpointsMap.values) {
-         writeString(address.host, buffer)
-         writeUnsignedShort(address.port, buffer)
+      val topologyMap = t.serverEndpointsMap
+      if (topologyMap.isEmpty) {
+         logNoMembersInTopology()
+         buffer.writeByte(0) // Topology not changed
+      } else {
+         trace("Write topology change response header %s", t)
+         buffer.writeByte(1) // Topology changed
+         writeUnsignedInt(t.topologyId, buffer)
+         writeUnsignedInt(topologyMap.size, buffer)
+         for (address <- topologyMap.values) {
+            writeString(address.host, buffer)
+            writeUnsignedShort(address.port, buffer)
+         }
       }
    }
 
@@ -90,43 +96,49 @@ object Encoder2x extends AbstractVersionedEncoder with Constants with Log {
    }
 
    private def writeHashTopologyUpdate(h: HashDistAware20Response, cache: Cache, buf: ByteBuf) {
-      trace("Write hash distribution change response header %s", h)
-      buf.writeByte(1) // Topology changed
-      writeUnsignedInt(h.topologyId, buf) // Topology ID
-
-      if (isTraceEnabled) trace(s"Topology cache contains: ${h.serverEndpointsMap}")
-
-      // Calculate members
+      // Calculate members first, in case there are no members
       val ch = SecurityActions.getCacheDistributionManager(cache).getReadConsistentHash
       val members = h.serverEndpointsMap.filter { case (addr, serverAddr) =>
          ch.getMembers.contains(addr)
       }
 
-      if (isTraceEnabled) trace(s"After read consistent hash filter, members are: $members")
-
-      // Write members
-      var indexCount = -1
-      writeUnsignedInt(members.size, buf)
-      val indexedMembers = members.map { case (addr, serverAddr) =>
-         writeString(serverAddr.host, buf)
-         writeUnsignedShort(serverAddr.port, buf)
-         indexCount += 1
-         addr -> indexCount // easier indexing
+      if (isTraceEnabled) {
+         trace(s"Topology cache contains: ${h.serverEndpointsMap}")
+         trace(s"After read consistent hash filter, members are: $members")
       }
 
-      // Write segment information
-      val numSegments = ch.getNumSegments
-      buf.writeByte(h.hashFunction) // Hash function
-      writeUnsignedInt(numSegments, buf)
+      if (members.isEmpty) {
+         logNoMembersInHashTopology(ch, h.serverEndpointsMap.toString())
+         buf.writeByte(0) // Topology not changed
+      } else {
+         trace("Write hash distribution change response header %s", h)
+         buf.writeByte(1) // Topology changed
+         writeUnsignedInt(h.topologyId, buf) // Topology ID
 
-      for (segmentId <- 0 until numSegments) {
-         val owners = ch.locateOwnersForSegment(segmentId).filter(members.contains)
-         val numOwnersToSend = Math.min(2, owners.size())
-         buf.writeByte(numOwnersToSend)
-         owners.take(numOwnersToSend).foreach { ownerAddr =>
-            indexedMembers.get(ownerAddr) match {
-               case Some(index) => writeUnsignedInt(index, buf)
-               case None => // Do not add to indexes
+         // Write members
+         var indexCount = -1
+         writeUnsignedInt(members.size, buf)
+         val indexedMembers = members.map { case (addr, serverAddr) =>
+            writeString(serverAddr.host, buf)
+            writeUnsignedShort(serverAddr.port, buf)
+            indexCount += 1
+            addr -> indexCount // easier indexing
+         }
+
+         // Write segment information
+         val numSegments = ch.getNumSegments
+         buf.writeByte(h.hashFunction) // Hash function
+         writeUnsignedInt(numSegments, buf)
+
+         for (segmentId <- 0 until numSegments) {
+            val owners = ch.locateOwnersForSegment(segmentId).filter(members.contains)
+            val numOwnersToSend = Math.min(2, owners.size)
+            buf.writeByte(numOwnersToSend)
+            owners.take(numOwnersToSend).foreach { ownerAddr =>
+               indexedMembers.get(ownerAddr) match {
+                  case Some(index) => writeUnsignedInt(index, buf)
+                  case None => // Do not add to indexes
+               }
             }
          }
       }
@@ -169,6 +181,7 @@ object Encoder2x extends AbstractVersionedEncoder with Constants with Log {
       // the topology cache is updated.
       val cacheMembers = rpcManager.getMembers
       val serverEndpoints = addressCache.toMap
+
       var topologyId = currentTopologyId
       if (!serverEndpoints.keySet.containsAll(cacheMembers)) {
          // At least one cache member is missing from the topology cache


### PR DESCRIPTION
* Do not install empty topologies in clients.
* If empty topologies are discovered, log WARN messages with further debugging information.
* Custom event test fails due to timestamp precision issue with date/milliseconds time, use nano time instead.

https://issues.jboss.org/browse/ISPN-5208

Please leave the JIRA open after integrating this PR.