### PR TITLE
ISPN-5298 HotRod millisecond precision for lifespan/maxidle

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
@@ -51,13 +51,14 @@ public class ConfigurationProperties {
    public static final int DEFAULT_SO_TIMEOUT = 60000;
    public static final int DEFAULT_CONNECT_TIMEOUT = 60000;
    public static final int DEFAULT_MAX_RETRIES = 10;
+   public static final String PROTOCOL_VERSION_22 = "2.2";
    public static final String PROTOCOL_VERSION_21 = "2.1";
    public static final String PROTOCOL_VERSION_20 = "2.0";
    public static final String PROTOCOL_VERSION_13 = "1.3";
    public static final String PROTOCOL_VERSION_12 = "1.2";
    public static final String PROTOCOL_VERSION_11 = "1.1";
    public static final String PROTOCOL_VERSION_10 = "1.0";
-   public static final String DEFAULT_PROTOCOL_VERSION = PROTOCOL_VERSION_21;
+   public static final String DEFAULT_PROTOCOL_VERSION = PROTOCOL_VERSION_22;
 
    private final TypedProperties props;
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -112,7 +112,10 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    @Override
    public boolean replaceWithVersion(K key, V newValue, long version, int lifespanSeconds, int maxIdleTimeSeconds) {
       assertRemoteCacheManagerIsStarted();
-      ReplaceIfUnmodifiedOperation op = operationsFactory.newReplaceIfUnmodifiedOperation(obj2bytes(key, true), obj2bytes(newValue, false), lifespanSeconds, maxIdleTimeSeconds, version);
+      long maxIdleNanos = toNanoseconds(maxIdleTimeSeconds, TimeUnit.SECONDS);
+      long lifespanNanos = toNanoseconds(lifespanSeconds, TimeUnit.SECONDS);
+
+      ReplaceIfUnmodifiedOperation op = operationsFactory.newReplaceIfUnmodifiedOperation(obj2bytes(key, true), obj2bytes(newValue, false), lifespanNanos, maxIdleNanos, version);
       VersionedOperationResponse response = op.execute();
       return response.getCode().isUpdated();
    }
@@ -227,13 +230,14 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    @Override
    public V put(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
       assertRemoteCacheManagerIsStarted();
-      int lifespanSecs = toSeconds(lifespan, lifespanUnit);
-      int maxIdleSecs = toSeconds(maxIdleTime, maxIdleTimeUnit);
+      long lifespanNanos = toNanoseconds(lifespan, lifespanUnit);
+      long maxIdleNanos = toNanoseconds(maxIdleTime, maxIdleTimeUnit);
+
       applyDefaultExpirationFlags(lifespan, maxIdleTime);
       if (log.isTraceEnabled()) {
-         log.tracef("About to add (K,V): (%s, %s) lifespanSecs:%d, maxIdleSecs:%d", key, value, lifespanSecs, maxIdleSecs);
+         log.tracef("About to add (K,V): (%s, %s) lifespanSecs:%d, maxIdleSecs:%d", key, value, toSeconds(lifespan, lifespanUnit), toSeconds(maxIdleTime, maxIdleTimeUnit));
       }
-      PutOperation op = operationsFactory.newPutKeyValueOperation(obj2bytes(key, true), obj2bytes(value, false), lifespanSecs, maxIdleSecs);
+      PutOperation op = operationsFactory.newPutKeyValueOperation(obj2bytes(key, true), obj2bytes(value, false), lifespanNanos, maxIdleNanos);
       byte[] result = op.execute();
       return MarshallerUtil.bytes2obj(marshaller, result);
    }
@@ -242,10 +246,10 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    @Override
    public V putIfAbsent(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
       assertRemoteCacheManagerIsStarted();
-      int lifespanSecs = toSeconds(lifespan, lifespanUnit);
-      int maxIdleSecs = toSeconds(maxIdleTime, maxIdleTimeUnit);
+      long lifespanNanos = toNanoseconds(lifespan, lifespanUnit);
+      long maxIdleNanos = toNanoseconds(maxIdleTime, maxIdleTimeUnit);
       applyDefaultExpirationFlags(lifespan, maxIdleTime);
-      PutIfAbsentOperation op = operationsFactory.newPutIfAbsentOperation(obj2bytes(key, true), obj2bytes(value, false), lifespanSecs, maxIdleSecs);
+      PutIfAbsentOperation op = operationsFactory.newPutIfAbsentOperation(obj2bytes(key, true), obj2bytes(value, false), lifespanNanos, maxIdleNanos);
       byte[] bytes = op.execute();
       return MarshallerUtil.bytes2obj(marshaller, bytes);
    }
@@ -253,10 +257,10 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    @Override
    public V replace(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
       assertRemoteCacheManagerIsStarted();
-      int lifespanSecs = toSeconds(lifespan, lifespanUnit);
-      int maxIdleSecs = toSeconds(maxIdleTime, maxIdleTimeUnit);
+      long lifespanNanos = toNanoseconds(lifespan, lifespanUnit);
+      long maxIdleNanos = toNanoseconds(maxIdleTime, maxIdleTimeUnit);
       applyDefaultExpirationFlags(lifespan, maxIdleTime);
-      ReplaceOperation op = operationsFactory.newReplaceOperation(obj2bytes(key, true), obj2bytes(value, false), lifespanSecs, maxIdleSecs);
+      ReplaceOperation op = operationsFactory.newReplaceOperation(obj2bytes(key, true), obj2bytes(value, false), lifespanNanos, maxIdleNanos);
       byte[] bytes = op.execute();
       return MarshallerUtil.bytes2obj(marshaller, bytes);
    }
@@ -599,8 +603,12 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
       return new MetadataValueImpl<V>(value.getCreated(), value.getLifespan(), value.getLastUsed(), value.getMaxIdle(), value.getVersion(), valueObj);
    }
 
-   private int toSeconds(long duration, TimeUnit timeUnit) {
+   private static int toSeconds(long duration, TimeUnit timeUnit) {
       return (int) timeUnit.toSeconds(duration);
+   }
+
+   private static long toNanoseconds(long duration, TimeUnit timeUnit) {
+      return (int) timeUnit.toNanos(duration);
    }
 
    private void assertRemoteCacheManagerIsStarted() {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AbstractKeyOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AbstractKeyOperation.java
@@ -5,10 +5,12 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import net.jcip.annotations.Immutable;
+
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.impl.VersionedOperationResponse;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.impl.protocol.HeaderParams;
+import org.infinispan.client.hotrod.impl.protocol.InternalFlag;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 import org.infinispan.commons.logging.BasicLogFactory;
@@ -29,8 +31,13 @@ public abstract class AbstractKeyOperation<T> extends RetryOnFailureOperation<T>
    protected final byte[] key;
 
    protected AbstractKeyOperation(Codec codec, TransportFactory transportFactory,
-            byte[] key, byte[] cacheName, AtomicInteger topologyId, Flag[] flags) {
-      super(codec, transportFactory, cacheName, topologyId, flags);
+         byte[] key, byte[] cacheName, AtomicInteger topologyId, Flag[] flags) {
+      this(codec, transportFactory, key, cacheName, topologyId, flags, null);
+   }
+
+   protected AbstractKeyOperation(Codec codec, TransportFactory transportFactory,
+            byte[] key, byte[] cacheName, AtomicInteger topologyId, Flag[] flags, InternalFlag[] internalFlags) {
+      super(codec, transportFactory, cacheName, topologyId, flags, internalFlags);
       this.key = key;
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AbstractKeyValueOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AbstractKeyValueOperation.java
@@ -1,12 +1,15 @@
 package org.infinispan.client.hotrod.impl.operations;
 
 import net.jcip.annotations.Immutable;
+
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.impl.protocol.HeaderParams;
+import org.infinispan.client.hotrod.impl.protocol.InternalFlag;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -17,16 +20,18 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @Immutable
 public abstract class AbstractKeyValueOperation<T> extends AbstractKeyOperation<T> {
+   private static final long NANOS_IN_SEC = TimeUnit.NANOSECONDS.convert(1, TimeUnit.SECONDS);
 
    protected final byte[] value;
 
-   protected final int lifespan;
+   protected final long lifespan;
 
-   protected final int maxIdle;
+   protected final long maxIdle;
 
    protected AbstractKeyValueOperation(Codec codec, TransportFactory transportFactory, byte[] key, byte[] cacheName,
-                                       AtomicInteger topologyId, Flag[] flags, byte[] value, int lifespan, int maxIdle) {
-      super(codec, transportFactory, key, cacheName, topologyId, flags);
+                                       AtomicInteger topologyId, Flag[] flags, byte[] value,
+                                       long lifespan, long maxIdle) {
+      super(codec, transportFactory, key, cacheName, topologyId, flags, internalFlags(lifespan, maxIdle));
       this.value = value;
       this.lifespan = lifespan;
       this.maxIdle = maxIdle;
@@ -39,8 +44,7 @@ public abstract class AbstractKeyValueOperation<T> extends AbstractKeyOperation<
 
       // 2) write key and value
       transport.writeArray(key);
-      transport.writeVInt(lifespan);
-      transport.writeVInt(maxIdle);
+      codec.writeExpirationParams(transport, lifespan, maxIdle, internalFlags);
       transport.writeArray(value);
       transport.flush();
 
@@ -48,5 +52,13 @@ public abstract class AbstractKeyValueOperation<T> extends AbstractKeyOperation<
 
       //return status (not error status for sure)
       return readHeaderAndValidate(transport, params);
+   }
+
+   private static InternalFlag[] internalFlags(long lifespan, long maxIdle) {
+      if ((lifespan % NANOS_IN_SEC != 0) || (maxIdle % NANOS_IN_SEC != 0)) {
+         return new InternalFlag[] {InternalFlag.NANO_DURATIONS};
+      } else {
+         return null;
+      }
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/HotRodOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/HotRodOperation.java
@@ -8,6 +8,7 @@ import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.impl.protocol.HeaderParams;
 import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
+import org.infinispan.client.hotrod.impl.protocol.InternalFlag;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 
 /**
@@ -22,6 +23,7 @@ import org.infinispan.client.hotrod.impl.transport.Transport;
 public abstract class HotRodOperation implements HotRodConstants {
 
    protected final Flag[] flags;
+   protected final InternalFlag[] internalFlags;
 
    public final byte[] cacheName;
 
@@ -33,7 +35,12 @@ public abstract class HotRodOperation implements HotRodConstants {
    private static final byte XA_TX = 1;
 
    protected HotRodOperation(Codec codec, Flag[] flags, byte[] cacheName, AtomicInteger topologyId) {
+      this(codec, flags, null, cacheName, topologyId);
+   }
+
+   protected HotRodOperation(Codec codec, Flag[] flags, InternalFlag[] internalFlags, byte[] cacheName, AtomicInteger topologyId) {
       this.flags = flags;
+      this.internalFlags = internalFlags;
       this.cacheName = cacheName;
       this.topologyId = topologyId;
       this.codec = codec;
@@ -43,7 +50,8 @@ public abstract class HotRodOperation implements HotRodConstants {
 
    protected final HeaderParams writeHeader(Transport transport, short operationCode) {
       HeaderParams params = new HeaderParams()
-            .opCode(operationCode).cacheName(cacheName).flags(flags)
+            .opCode(operationCode).cacheName(cacheName)
+            .flags(flags).internalFlags(internalFlags)
             .clientIntel(CLIENT_INTELLIGENCE_HASH_DISTRIBUTION_AWARE)
             .topologyId(topologyId).txMarker(NO_TX);
       return codec.writeHeader(transport, params);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
@@ -1,5 +1,10 @@
 package org.infinispan.client.hotrod.impl.operations;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import net.jcip.annotations.Immutable;
 
 import org.infinispan.client.hotrod.Flag;
@@ -10,16 +15,6 @@ import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.impl.query.RemoteQuery;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
-import org.infinispan.commons.util.InfinispanCollections;
-
-import java.net.SocketAddress;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Factory for {@link org.infinispan.client.hotrod.impl.operations.HotRodOperation} objects.
@@ -81,10 +76,10 @@ public class OperationsFactory implements HotRodConstants {
    }
 
    public ReplaceIfUnmodifiedOperation newReplaceIfUnmodifiedOperation(byte[] key,
-            byte[] value, int lifespanSeconds, int maxIdleTimeSeconds, long version) {
+            byte[] value, long lifespan, long maxIdle, long version) {
       return new ReplaceIfUnmodifiedOperation(
             codec, transportFactory, key, cacheNameBytes, topologyId, flags(),
-            value, lifespanSeconds, maxIdleTimeSeconds, version);
+            value, lifespan, maxIdle, version);
    }
 
    public GetWithVersionOperation newGetWithVersionOperation(byte[] key) {
@@ -103,24 +98,24 @@ public class OperationsFactory implements HotRodConstants {
    }
 
    public PutOperation newPutKeyValueOperation(byte[] key, byte[] value,
-            int lifespanSecs, int maxIdleSecs) {
+            long lifespan, long maxIdle) {
       return new PutOperation(
             codec, transportFactory, key, cacheNameBytes, topologyId, flags(),
-            value, lifespanSecs, maxIdleSecs);
+            value, lifespan, maxIdle);
    }
 
    public PutIfAbsentOperation newPutIfAbsentOperation(byte[] key, byte[] value,
-            int lifespanSecs, int maxIdleSecs) {
+            long lifespan, long maxIdle) {
       return new PutIfAbsentOperation(
             codec, transportFactory, key, cacheNameBytes, topologyId, flags(),
-            value, lifespanSecs, maxIdleSecs);
+            value, lifespan, maxIdle);
    }
 
    public ReplaceOperation newReplaceOperation(byte[] key, byte[] values,
-            int lifespanSecs, int maxIdleSecs) {
+            long lifespan, long maxIdle) {
       return new ReplaceOperation(
             codec, transportFactory, key, cacheNameBytes, topologyId, flags(),
-            values, lifespanSecs, maxIdleSecs);
+            values, lifespan, maxIdle);
    }
 
    public ContainsKeyOperation newContainsKeyOperation(byte[] key) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutIfAbsentOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutIfAbsentOperation.java
@@ -6,6 +6,7 @@ import net.jcip.annotations.Immutable;
 
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
+import org.infinispan.client.hotrod.impl.protocol.InternalFlag;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 import org.infinispan.commons.logging.BasicLogFactory;
@@ -26,7 +27,7 @@ public class PutIfAbsentOperation extends AbstractKeyValueOperation<byte[]> {
 
    public PutIfAbsentOperation(Codec codec, TransportFactory transportFactory,
                                byte[] key, byte[] cacheName, AtomicInteger topologyId,
-                               Flag[] flags, byte[] value, int lifespan, int maxIdle) {
+                               Flag[] flags, byte[] value, long lifespan, long maxIdle) {
       super(codec, transportFactory, key, cacheName, topologyId, flags, value, lifespan, maxIdle);
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutOperation.java
@@ -21,7 +21,7 @@ public class PutOperation extends AbstractKeyValueOperation<byte[]> {
 
    public PutOperation(Codec codec, TransportFactory transportFactory,
                        byte[] key, byte[] cacheName, AtomicInteger topologyId,
-                       Flag[] flags, byte[] value, int lifespan, int maxIdle) {
+                       Flag[] flags, byte[] value, long lifespan, long maxIdle) {
       super(codec, transportFactory, key, cacheName, topologyId, flags, value, lifespan, maxIdle);
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceIfUnmodifiedOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceIfUnmodifiedOperation.java
@@ -4,6 +4,7 @@ import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.impl.VersionedOperationResponse;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.impl.protocol.HeaderParams;
+import org.infinispan.client.hotrod.impl.protocol.InternalFlag;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 
@@ -20,8 +21,8 @@ public class ReplaceIfUnmodifiedOperation extends AbstractKeyValueOperation<Vers
    private final long version;
 
    public ReplaceIfUnmodifiedOperation(Codec codec, TransportFactory transportFactory, byte[] key, byte[] cacheName,
-                                       AtomicInteger topologyId, Flag[] flags, byte[] value, int lifespan,
-                                       int maxIdle, long version) {
+                                       AtomicInteger topologyId, Flag[] flags, byte[] value,
+                                       long lifespan, long maxIdle, long version) {
       super(codec, transportFactory, key, cacheName, topologyId, flags, value, lifespan, maxIdle);
       this.version = version;
    }
@@ -33,8 +34,7 @@ public class ReplaceIfUnmodifiedOperation extends AbstractKeyValueOperation<Vers
 
       //2) write message body
       transport.writeArray(key);
-      transport.writeVInt(lifespan);
-      transport.writeVInt(maxIdle);
+      codec.writeExpirationParams(transport, lifespan, maxIdle, internalFlags);
       transport.writeLong(version);
       transport.writeArray(value);
       transport.flush();

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceOperation.java
@@ -1,8 +1,10 @@
 package org.infinispan.client.hotrod.impl.operations;
 
 import net.jcip.annotations.Immutable;
+
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
+import org.infinispan.client.hotrod.impl.protocol.InternalFlag;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 
@@ -20,7 +22,7 @@ public class ReplaceOperation extends AbstractKeyValueOperation<byte[]> {
 
    public ReplaceOperation(Codec codec, TransportFactory transportFactory,
             byte[] key, byte[] cacheName, AtomicInteger topologyId,
-            Flag[] flags, byte[] value, int lifespan, int maxIdle) {
+            Flag[] flags, byte[] value, long lifespan, long maxIdle) {
       super(codec, transportFactory, key, cacheName, topologyId, flags, value, lifespan, maxIdle);
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
@@ -1,12 +1,14 @@
 package org.infinispan.client.hotrod.impl.operations;
 
 import net.jcip.annotations.Immutable;
+
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.client.hotrod.exceptions.RemoteIllegalLifecycleStateException;
 import org.infinispan.client.hotrod.exceptions.RemoteNodeSuspectException;
 import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
+import org.infinispan.client.hotrod.impl.protocol.InternalFlag;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 import org.infinispan.client.hotrod.logging.Log;
@@ -33,8 +35,14 @@ public abstract class RetryOnFailureOperation<T> extends HotRodOperation {
    protected final TransportFactory transportFactory;
 
    protected RetryOnFailureOperation(Codec codec, TransportFactory transportFactory,
-            byte[] cacheName, AtomicInteger topologyId, Flag[] flags) {
-      super(codec, flags, cacheName, topologyId);
+         byte[] cacheName, AtomicInteger topologyId, Flag[] flags) {
+      super(codec, flags, null, cacheName, topologyId);
+      this.transportFactory = transportFactory;
+   }
+
+   protected RetryOnFailureOperation(Codec codec, TransportFactory transportFactory,
+            byte[] cacheName, AtomicInteger topologyId, Flag[] flags, InternalFlag[] internalFlags) {
+      super(codec, flags, internalFlags, cacheName, topologyId);
       this.transportFactory = transportFactory;
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
@@ -29,6 +29,11 @@ public interface Codec {
          byte[][] filterFactoryParams, byte[][] converterFactoryParams);
 
    /**
+    * Write lifespan/maxidle parameters.
+    */
+   void writeExpirationParams(Transport transport, long lifespanNanos, long maxIdleNanos, InternalFlag[] internalFlags);
+
+   /**
     * Reads a response header from the transport and returns the status
     * of the response.
     */

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -45,6 +46,12 @@ public class Codec10 implements Codec {
    public void writeClientListenerParams(Transport transport, ClientListener clientListener,
          byte[][] filterFactoryParams, byte[][] converterFactoryParams) {
       // No-op
+   }
+
+   @Override
+   public void writeExpirationParams(Transport transport, long lifespanNanos, long maxIdleNanos, InternalFlag[] internalFlags) {
+      transport.writeVInt((int) TimeUnit.SECONDS.convert(lifespanNanos, TimeUnit.NANOSECONDS));
+      transport.writeVInt((int) TimeUnit.SECONDS.convert(maxIdleNanos, TimeUnit.NANOSECONDS));
    }
 
    protected HeaderParams writeHeader(

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec12.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec12.java
@@ -29,7 +29,7 @@ public class Codec12 extends Codec11 {
       transport.writeByte(params.opCode);
       transport.writeArray(params.cacheName);
 
-      int joinedFlags = HeaderParams.joinFlags(params.flags);
+      int joinedFlags = HeaderParams.joinFlags(params.flags, params.internalFlags);
       transport.writeVInt(joinedFlags);
       transport.writeByte(params.clientIntel);
       transport.writeVInt(params.topologyId.get());

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
@@ -24,6 +24,7 @@ import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -56,6 +57,12 @@ public class Codec20 implements Codec, HotRodConstants {
       writeNamedFactory(transport, clientListener.converterFactoryName(), converterFactoryParams);
    }
 
+   @Override
+   public void writeExpirationParams(Transport transport, long lifespanNanos, long maxIdleNanos, InternalFlag[] internalFlags) {
+      transport.writeVInt((int) TimeUnit.SECONDS.convert(lifespanNanos, TimeUnit.NANOSECONDS));
+      transport.writeVInt((int) TimeUnit.SECONDS.convert(maxIdleNanos, TimeUnit.NANOSECONDS));
+   }
+
    private void writeNamedFactory(Transport transport, String factoryName, byte[][] params) {
       transport.writeString(factoryName);
       if (!factoryName.isEmpty()) {
@@ -77,7 +84,7 @@ public class Codec20 implements Codec, HotRodConstants {
       transport.writeByte(version);
       transport.writeByte(params.opCode);
       transport.writeArray(params.cacheName);
-      int joinedFlags = HeaderParams.joinFlags(params.flags);
+      int joinedFlags = HeaderParams.joinFlags(params.flags, params.internalFlags);
       transport.writeVInt(joinedFlags);
       transport.writeByte(params.clientIntel);
       transport.writeVInt(params.topologyId.get());

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec22.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec22.java
@@ -1,0 +1,34 @@
+package org.infinispan.client.hotrod.impl.protocol;
+
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.client.hotrod.impl.transport.Transport;
+
+public class Codec22 extends Codec21 {
+   @Override
+   public HeaderParams writeHeader(Transport transport, HeaderParams params) {
+      return writeHeader(transport, params, HotRodConstants.VERSION_22);
+   }
+
+   @Override
+   public void writeExpirationParams(Transport transport, long lifespanNanos, long maxIdleNanos, InternalFlag[] internalFlags) {
+      if (!hasFlag(internalFlags, InternalFlag.NANO_DURATIONS)) {
+         lifespanNanos = TimeUnit.SECONDS.convert(lifespanNanos, TimeUnit.NANOSECONDS);
+         maxIdleNanos = TimeUnit.SECONDS.convert(maxIdleNanos, TimeUnit.NANOSECONDS);
+      }
+      transport.writeVLong(lifespanNanos);
+      transport.writeVLong(maxIdleNanos);
+   }
+
+   private boolean hasFlag(InternalFlag[] internalFlags, InternalFlag flag) {
+      if (internalFlags == null) {
+         return false;
+      }
+      for (InternalFlag internalFlag : internalFlags) {
+         if (internalFlag == flag) {
+            return true;
+         }
+      }
+      return false;
+   }
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/CodecFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/CodecFactory.java
@@ -20,6 +20,7 @@ public class CodecFactory {
    private static final Codec CODEC_13 = new Codec13();
    private static final Codec CODEC_20 = new Codec20();
    private static final Codec CODEC_21 = new Codec21();
+   private static final Codec CODEC_22 = new Codec22();
 
    static {
       codecMap = new HashMap<String, Codec>();
@@ -29,6 +30,7 @@ public class CodecFactory {
       codecMap.put(PROTOCOL_VERSION_13, CODEC_13);
       codecMap.put(PROTOCOL_VERSION_20, CODEC_20);
       codecMap.put(PROTOCOL_VERSION_21, CODEC_21);
+      codecMap.put(PROTOCOL_VERSION_22, CODEC_22);
    }
 
    public static Codec getCodec(String version) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HeaderParams.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HeaderParams.java
@@ -16,6 +16,7 @@ public class HeaderParams {
    short opRespCode;
    byte[] cacheName;
    Flag[] flags;
+   InternalFlag[] internalFlags;
    byte clientIntel;
    byte txMarker;
    AtomicInteger topologyId;
@@ -34,6 +35,11 @@ public class HeaderParams {
 
    public HeaderParams flags(Flag[] flags) {
       this.flags = flags;
+      return this;
+   }
+
+   public HeaderParams internalFlags(InternalFlag[] internalFlags) {
+      this.internalFlags = internalFlags;
       return this;
    }
 
@@ -108,11 +114,16 @@ public class HeaderParams {
       }
    }
 
-   static int joinFlags(Flag[] flags) {
+   static int joinFlags(Flag[] flags, InternalFlag[] internalFlags) {
       int flagInt = 0;
       if (flags != null) {
          for (Flag flag : flags)
             flagInt = flag.getFlagInt() | flagInt;
+      }
+      if (internalFlags != null) {
+         for (InternalFlag internalFlag : internalFlags) {
+            flagInt = internalFlag.getFlagInt() | flagInt;
+         }
       }
       return flagInt;
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HotRodConstants.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HotRodConstants.java
@@ -19,6 +19,7 @@ public interface HotRodConstants {
    static final byte VERSION_13 = 13;
    static final byte VERSION_20 = 20;
    static final byte VERSION_21 = 21;
+   static final byte VERSION_22 = 22;
 
    //requests
    static final byte PUT_REQUEST = 0x01;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/InternalFlag.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/InternalFlag.java
@@ -1,0 +1,22 @@
+package org.infinispan.client.hotrod.impl.protocol;
+
+/**
+ * Flags which are internal to the protocol and shouldn't be exposed to users.
+ */
+public enum InternalFlag {
+   /**
+    * Indicates that lifespan and maxidle represent nanoseconds instead of seconds.
+    */
+   NANO_DURATIONS(0x0020);
+
+   private int flagInt;
+
+   InternalFlag(int flagInt) {
+      this.flagInt = flagInt;
+   }
+
+   public int getFlagInt() {
+      return flagInt;
+   }
+
+}

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/CacheDecodeContext.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/CacheDecodeContext.scala
@@ -31,7 +31,7 @@ class CacheDecodeContext(server: HotRodServer) extends ServerConstants with Log 
    type BytesResponse = Bytes => Response
 
    val isTrace = isTraceEnabled
-   val SecondsInAMonth = 60 * 60 * 24 * 30
+   val MillisInAMonth = 60 * 60 * 24 * 30 * 1000
 
    var isError = false
    var decoder: AbstractVersionedDecoder = _
@@ -256,18 +256,19 @@ class CacheDecodeContext(server: HotRodServer) extends ServerConstants with Log 
     * Otherwise it's just considered number of seconds from
     * now and it's returned in milliseconds unit.
     */
-   protected def toMillis(lifespan: Int): Long = {
-      if (lifespan > SecondsInAMonth) {
-         val unixTimeExpiry = TimeUnit.SECONDS.toMillis(lifespan) - System.currentTimeMillis
+   protected def toMillis(nanosDuration: Long): Long = {
+      val millis = TimeUnit.NANOSECONDS.toMillis(nanosDuration)
+      if (millis > MillisInAMonth) {
+         val unixTimeExpiry = millis - System.currentTimeMillis
          if (unixTimeExpiry < 0) 0 else unixTimeExpiry
       } else {
-         TimeUnit.SECONDS.toMillis(lifespan)
+         millis
       }
    }
 
 }
 
-class RequestParameters(val valueLength: Int, val lifespan: Int, val maxIdle: Int, val streamVersion: Long) {
+class RequestParameters(val valueLength: Int, val lifespan: Long, val maxIdle: Long, val streamVersion: Long) {
    override def toString = {
       new StringBuilder().append("RequestParameters").append("{")
       .append("valueLength=").append(valueLength)

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Constants.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Constants.scala
@@ -16,6 +16,7 @@ trait Constants {
    val VERSION_13: Byte = 13
    val VERSION_20: Byte = 20
    val VERSION_21: Byte = 21
+   val VERSION_22: Byte = 22
    val DEFAULT_CONSISTENT_HASH_VERSION_1x: Byte = 2
    val DEFAULT_CONSISTENT_HASH_VERSION: Byte = 3
 

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder10.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder10.scala
@@ -18,6 +18,7 @@ import org.infinispan.container.versioning.NumericVersion
 import io.netty.buffer.ByteBuf
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.Channel
+import java.util.concurrent.TimeUnit
 
 /**
  * HotRod protocol decoder specific for specification version 1.0.
@@ -105,14 +106,14 @@ object Decoder10 extends AbstractVersionedDecoder with ServerConstants with Log 
       (h.flag & f.id) == f.id
    }
 
-   private def readLifespanOrMaxIdle(buffer: ByteBuf, useDefault: Boolean): Int = {
+   private def readLifespanOrMaxIdle(buffer: ByteBuf, useDefault: Boolean): Long = {
       val stream = readUnsignedInt(buffer)
       if (stream <= 0) {
          if (useDefault)
             EXPIRATION_DEFAULT
          else
             EXPIRATION_NONE
-      } else stream
+      } else TimeUnit.SECONDS.toNanos(stream)
    }
 
    override def createSuccessResponse(header: HotRodHeader, prev: Array[Byte]): Response =

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
@@ -162,7 +162,7 @@ extends ReplayingDecoder[HotRodDecoderState](DECODE_HEADER) with StatsChannelHan
       try {
          val decoder = version match {
             case VERSION_10 | VERSION_11 | VERSION_12 | VERSION_13 => Decoder10
-            case VERSION_20 | VERSION_21 => Decoder2x
+            case VERSION_20 | VERSION_21 | VERSION_22  => Decoder2x
             case _ => throw new UnknownVersionException("Unknown version:" + version, version, messageId)
          }
          val endOfOp = decoder.readHeader(buffer, version, messageId, header)

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
@@ -31,7 +31,7 @@ class HotRodEncoder(cacheManager: EmbeddedCacheManager, server: HotRodServer)
          case r: Response =>
             val encoder = getEncoder(r.version)
             r.version match {
-               case VERSION_10 | VERSION_11 | VERSION_12 | VERSION_13 | VERSION_20 | VERSION_21 =>
+               case VERSION_10 | VERSION_11 | VERSION_12 | VERSION_13 | VERSION_20 | VERSION_21 | VERSION_22 =>
                   encoder.writeHeader(r, buf, addressCache, server)
                // if error before reading version, don't send any topology changes
                // cos the encoding might vary from one version to the other
@@ -57,7 +57,7 @@ class HotRodEncoder(cacheManager: EmbeddedCacheManager, server: HotRodServer)
          case VERSION_11 => Encoders.Encoder11
          case VERSION_12 => Encoders.Encoder12
          case VERSION_13 => Encoders.Encoder13
-         case VERSION_20 | VERSION_21 => Encoder2x
+         case VERSION_20 | VERSION_21 | VERSION_22 => Encoder2x
          case 0 => Encoder2x
       }
    }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ProtocolFlag.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ProtocolFlag.scala
@@ -11,4 +11,5 @@ object ProtocolFlag extends Enumeration {
    val DefaultMaxIdle = Value(0x04)
    val SkipCacheLoader = Value(0x08)
    val SkipIndexing = Value(0x10)
+   val NanoExpiration = Value(0x20)
 }


### PR DESCRIPTION
Preview, don't integrate yet.

https://issues.jboss.org/browse/ISPN-5298

New protocol version 2.2 with new flags in the request header indicating if lifespan/maxidle values should be interpreted as nanosecond durations.