### PR TITLE
ISPN-5271 Usage of filter composition in DistributedEntryRetriever.sendRequest prevents dependency injection to filter and converter

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterEventsTest.java
@@ -8,7 +8,6 @@ import org.infinispan.client.hotrod.event.CustomEventLogListener.StaticConverter
 import org.infinispan.client.hotrod.event.CustomEventLogListener.StaticCustomEventLogListener;
 import org.infinispan.client.hotrod.event.EventLogListener.StaticFilteredEventLogListener;
 import org.infinispan.client.hotrod.event.EventLogListener.StaticCacheEventFilterFactory;
-import org.infinispan.client.hotrod.impl.transport.tcp.FailoverRequestBalancingStrategy;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
 import org.infinispan.client.hotrod.test.RemoteCacheManagerCallable;
@@ -17,10 +16,8 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
-import org.infinispan.test.TestingUtil;
 import org.testng.annotations.Test;
 
-import java.net.InetSocketAddress;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.*;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerWithFilterAndProtobufTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerWithFilterAndProtobufTest.java
@@ -1,0 +1,150 @@
+package org.infinispan.client.hotrod.event;
+
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
+import org.infinispan.client.hotrod.annotation.ClientListener;
+import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
+import org.infinispan.client.hotrod.query.testdomain.protobuf.UserPB;
+import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.MarshallerRegistration;
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.metadata.Metadata;
+import org.infinispan.notifications.cachelistener.filter.CacheEventFilter;
+import org.infinispan.notifications.cachelistener.filter.CacheEventFilterFactory;
+import org.infinispan.notifications.cachelistener.filter.EventType;
+import org.infinispan.notifications.cachelistener.filter.NamedFactory;
+import org.infinispan.query.dsl.embedded.testdomain.User;
+import org.infinispan.query.remote.client.ProtobufMetadataManagerConstants;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+
+/**
+ * A simple remote listener test with filter and protobuf marshalling. This test uses unmarshalled key/value in events.
+ *
+ * @author anistor@redhat.com
+ * @since 7.2
+ */
+@Test(groups = "functional", testName = "client.hotrod.event.ClientListenerWithFilterAndProtobufTest")
+public class ClientListenerWithFilterAndProtobufTest extends MultiHotRodServersTest {
+
+   private final int NUM_NODES = 2;
+
+   private RemoteCache<Object, Object> remoteCache;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder cfgBuilder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
+      createHotRodServers(NUM_NODES, cfgBuilder);
+      waitForClusterToForm();
+
+      for (int i = 0; i < NUM_NODES; i++) {
+         server(i).addCacheEventFilterFactory("custom-filter-factory", new CustomCacheEventFilterFactory());
+
+         // WARNING! This is not the actual instance used at runtime. A new instance is created instead, so all state is lost unless it is re-created in the constructor!
+         ProtoStreamMarshaller marshaller = new CustomProtoStreamMarshaller();
+
+         server(i).setEventMarshaller(marshaller);
+      }
+
+      //initialize server-side serialization context
+      RemoteCache<String, String> metadataCache = client(0).getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
+      metadataCache.put("sample_bank_account/bank.proto", Util.read(Util.getResourceAsStream("/sample_bank_account/bank.proto", getClass().getClassLoader())));
+      assertFalse(metadataCache.containsKey(ProtobufMetadataManagerConstants.ERRORS_KEY_SUFFIX));
+
+      //initialize client-side serialization context
+      MarshallerRegistration.registerMarshallers(ProtoStreamMarshaller.getSerializationContext(client(0)));
+
+      remoteCache = client(0).getCache();
+   }
+
+   @Override
+   protected org.infinispan.client.hotrod.configuration.ConfigurationBuilder createHotRodClientConfigurationBuilder(int serverPort) {
+      return super.createHotRodClientConfigurationBuilder(serverPort)
+            .marshaller(new ProtoStreamMarshaller());
+   }
+
+   public void testEventFilter() throws Exception {
+      Object[] filterFactoryParams = new Object[]{"string_key_1", "user_1"};
+      ClientEntryListener listener = new ClientEntryListener();
+      remoteCache.addClientListener(listener, filterFactoryParams, null);
+
+      User user1 = new UserPB();
+      user1.setId(1);
+      user1.setName("John");
+      user1.setSurname("Doe");
+      user1.setGender(User.Gender.MALE);
+      user1.setAge(22);
+
+      remoteCache.put("string_key_1", "string value 1");
+      remoteCache.put("string_key_2", "string value 2");
+      remoteCache.put("user_1", user1);
+
+      assertEquals(3, remoteCache.keySet().size());
+      assertEquals(2, listener.createEvents.size());
+      assertEquals("string_key_1", listener.createEvents.get(0).getKey());
+      assertEquals("user_1", listener.createEvents.get(1).getKey());
+   }
+
+   @ClientListener(filterFactoryName = "custom-filter-factory")
+   public static class ClientEntryListener {
+
+      public List<ClientCacheEntryCreatedEvent> createEvents = new ArrayList<>();
+
+      @ClientCacheEntryCreated
+      @SuppressWarnings("unused")
+      public void handleClientCacheEntryCreatedEvent(ClientCacheEntryCreatedEvent event) {
+         createEvents.add(event);
+      }
+   }
+
+   @NamedFactory(name = "custom-filter-factory")
+   public static class CustomCacheEventFilterFactory implements CacheEventFilterFactory {
+
+      @Override
+      public CacheEventFilter<String, Object> getFilter(Object[] params) {
+         String firstParam = (String) params[0];
+         String secondParam = (String) params[1];
+         return new CustomEventFilter(firstParam, secondParam);
+      }
+   }
+
+   public static class CustomEventFilter implements CacheEventFilter<String, Object>, Serializable {
+
+      private String firstParam;
+      private String secondParam;
+
+      public CustomEventFilter(String firstParam, String secondParam) {
+         this.firstParam = firstParam;
+         this.secondParam = secondParam;
+      }
+
+      @Override
+      public boolean accept(String key, Object oldValue, Metadata oldMetadata, Object newValue, Metadata newMetadata, EventType eventType) {
+         // this filter accepts only the two keys it received as params
+         return firstParam.equals(key) || secondParam.equals(key);
+      }
+   }
+
+   /**
+    * We use a custom implementation just to get the chance to register our protobuf entity marshallers in the
+    * constructor.
+    */
+   public static class CustomProtoStreamMarshaller extends ProtoStreamMarshaller {
+
+      public CustomProtoStreamMarshaller() throws IOException {
+         MarshallerRegistration.registerMarshallers(getSerializationContext());
+      }
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerWithFilterAndRawProtobufTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerWithFilterAndRawProtobufTest.java
@@ -1,0 +1,159 @@
+package org.infinispan.client.hotrod.event;
+
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
+import org.infinispan.client.hotrod.annotation.ClientListener;
+import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
+import org.infinispan.client.hotrod.query.testdomain.protobuf.UserPB;
+import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.MarshallerRegistration;
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.metadata.Metadata;
+import org.infinispan.notifications.cachelistener.filter.CacheEventFilter;
+import org.infinispan.notifications.cachelistener.filter.CacheEventFilterFactory;
+import org.infinispan.notifications.cachelistener.filter.EventType;
+import org.infinispan.notifications.cachelistener.filter.NamedFactory;
+import org.infinispan.query.dsl.embedded.testdomain.User;
+import org.infinispan.query.remote.client.ProtobufMetadataManagerConstants;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+
+/**
+ * A simple remote listener test with filter and protobuf marshalling. This test uses raw key/value in events.
+ *
+ * @author anistor@redhat.com
+ * @since 7.2
+ */
+@Test(groups = "functional", testName = "client.hotrod.event.ClientListenerWithFilterAndRawProtobufTest")
+public class ClientListenerWithFilterAndRawProtobufTest extends MultiHotRodServersTest {
+
+   private final int NUM_NODES = 2;
+
+   private RemoteCache<Object, Object> remoteCache;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder cfgBuilder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
+      createHotRodServers(NUM_NODES, cfgBuilder);
+      waitForClusterToForm();
+
+      for (int i = 0; i < NUM_NODES; i++) {
+         server(i).addCacheEventFilterFactory("custom-filter-factory", new CustomCacheEventFilterFactory());
+      }
+
+      //initialize server-side serialization context
+      RemoteCache<String, String> metadataCache = client(0).getCache(ProtobufMetadataManagerConstants.PROTOBUF_METADATA_CACHE_NAME);
+      metadataCache.put("sample_bank_account/bank.proto", Util.read(Util.getResourceAsStream("/sample_bank_account/bank.proto", getClass().getClassLoader())));
+      assertFalse(metadataCache.containsKey(ProtobufMetadataManagerConstants.ERRORS_KEY_SUFFIX));
+
+      //initialize client-side serialization context
+      MarshallerRegistration.registerMarshallers(ProtoStreamMarshaller.getSerializationContext(client(0)));
+
+      remoteCache = client(0).getCache();
+   }
+
+   @Override
+   protected org.infinispan.client.hotrod.configuration.ConfigurationBuilder createHotRodClientConfigurationBuilder(int serverPort) {
+      return super.createHotRodClientConfigurationBuilder(serverPort)
+            .marshaller(new ProtoStreamMarshaller());
+   }
+
+   public void testEventFilter() throws Exception {
+      Object[] filterFactoryParams = new Object[]{"string_key_1", "user_1"};
+      ClientEntryListener listener = new ClientEntryListener();
+      remoteCache.addClientListener(listener, filterFactoryParams, null);
+
+      User user1 = new UserPB();
+      user1.setId(1);
+      user1.setName("John");
+      user1.setSurname("Doe");
+      user1.setGender(User.Gender.MALE);
+      user1.setAge(22);
+
+      remoteCache.put("string_key_1", "string value 1");
+      remoteCache.put("string_key_2", "string value 2");
+      remoteCache.put("user_1", user1);
+
+      assertEquals(3, remoteCache.keySet().size());
+      assertEquals(2, listener.createEvents.size());
+      assertEquals("string_key_1", listener.createEvents.get(0).getKey());
+      assertEquals("user_1", listener.createEvents.get(1).getKey());
+   }
+
+   @ClientListener(filterFactoryName = "custom-filter-factory", useRawData = true)
+   public static class ClientEntryListener {
+
+      public List<ClientCacheEntryCreatedEvent> createEvents = new ArrayList<>();
+
+      @ClientCacheEntryCreated
+      @SuppressWarnings("unused")
+      public void handleClientCacheEntryCreatedEvent(ClientCacheEntryCreatedEvent event) {
+         createEvents.add(event);
+      }
+   }
+
+   @NamedFactory(name = "custom-filter-factory")
+   public static class CustomCacheEventFilterFactory implements CacheEventFilterFactory {
+
+      private final ProtoStreamMarshaller marshaller = new ProtoStreamMarshaller();
+
+      @Override
+      public CacheEventFilter<byte[], byte[]> getFilter(Object[] params) {
+         String firstParam;
+         String secondParam;
+         try {
+            firstParam = (String) marshaller.objectFromByteBuffer((byte[]) params[0]);
+            secondParam = (String) marshaller.objectFromByteBuffer((byte[]) params[1]);
+         } catch (IOException e) {
+            throw new RuntimeException(e);
+         } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+         }
+         return new CustomEventFilter(firstParam, secondParam);
+      }
+   }
+
+   public static class CustomEventFilter implements CacheEventFilter<byte[], byte[]>, Serializable {
+
+      private transient ProtoStreamMarshaller marshaller;
+      private String firstParam;
+      private String secondParam;
+
+      public CustomEventFilter(String firstParam, String secondParam) {
+         this.firstParam = firstParam;
+         this.secondParam = secondParam;
+      }
+
+      private ProtoStreamMarshaller getMarshaller() {
+         if (marshaller == null) {
+            marshaller = new ProtoStreamMarshaller();
+         }
+         return marshaller;
+      }
+
+      @Override
+      public boolean accept(byte[] key, byte[] oldValue, Metadata oldMetadata, byte[] newValue, Metadata newMetadata, EventType eventType) {
+         try {
+            String stringKey = (String) getMarshaller().objectFromByteBuffer(key);
+            // this filter accepts only the two keys it received as params
+            return firstParam.equals(stringKey) || secondParam.equals(stringKey);
+         } catch (IOException e) {
+            throw new RuntimeException(e);
+         } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+         }
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -1,12 +1,10 @@
 package org.infinispan.commands;
 
-import org.infinispan.Cache;
 import org.infinispan.commands.read.EntryRetrievalCommand;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.commands.remote.GetKeysInGroupCommand;
 import org.infinispan.iteration.impl.EntryRequestCommand;
 import org.infinispan.iteration.impl.EntryResponseCommand;
-import org.infinispan.iteration.impl.EntryRetriever;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.atomic.Delta;
 import org.infinispan.commands.control.LockControlCommand;
@@ -446,7 +444,7 @@ public interface CommandsFactory {
     * @param <C> The converted type after the value is applied from the converter
     * @return the EntryRequestCommand created
     */
-   <K, V, C> EntryRequestCommand<K, V, C> buildEntryRequestCommand(UUID identifier, Set<Integer> segments,
+   <K, V, C> EntryRequestCommand<K, V, C> buildEntryRequestCommand(UUID identifier, Set<Integer> segments, Set<K> keysToFilter,
                                                 KeyValueFilter<? super K, ? super V> filter,
                                                 Converter<? super K, ? super V, C> converter, Set<Flag> flags);
 

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -610,11 +610,12 @@ public class CommandsFactoryImpl implements CommandsFactory {
 
    @Override
    public <K, V, C> EntryRequestCommand<K, V, C> buildEntryRequestCommand(UUID identifier, Set<Integer> segments,
+                                                                    Set<K> keysToFilter,
                                                                     KeyValueFilter<? super K, ? super V> filter,
                                                                     Converter<? super K, ? super V, C> converter,
                                                                     Set<Flag> flags) {
       return new EntryRequestCommand<K, V, C>(cacheName, identifier, cache.getCacheManager().getAddress(), segments,
-                                              filter, converter, flags);
+                                              keysToFilter, filter, converter, flags);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/filter/AcceptAllKeyValueFilter.java
+++ b/core/src/main/java/org/infinispan/filter/AcceptAllKeyValueFilter.java
@@ -5,10 +5,8 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.marshall.core.Ids;
 import org.infinispan.metadata.Metadata;
 
-import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.io.Serializable;
 import java.util.Set;
 
 /**
@@ -20,7 +18,7 @@ import java.util.Set;
  * @author wburns
  * @since 7.0
  */
-public class AcceptAllKeyValueFilter implements KeyValueFilter<Object, Object>, Serializable {
+public class AcceptAllKeyValueFilter implements KeyValueFilter<Object, Object> {
 
    private AcceptAllKeyValueFilter() { }
 
@@ -44,11 +42,11 @@ public class AcceptAllKeyValueFilter implements KeyValueFilter<Object, Object>, 
       }
 
       @Override
-      public void writeObject(ObjectOutput output, AcceptAllKeyValueFilter object) throws IOException {
+      public void writeObject(ObjectOutput output, AcceptAllKeyValueFilter object) {
       }
 
       @Override
-      public AcceptAllKeyValueFilter readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+      public AcceptAllKeyValueFilter readObject(ObjectInput input) {
          return AcceptAllKeyValueFilter.getInstance();
       }
 

--- a/core/src/main/java/org/infinispan/filter/CompositeKeyFilter.java
+++ b/core/src/main/java/org/infinispan/filter/CompositeKeyFilter.java
@@ -7,7 +7,7 @@ package org.infinispan.filter;
  * @since 6.0
  */
 public class CompositeKeyFilter<K> implements KeyFilter<K> {
-   private KeyFilter<? super K>[] filters;
+   private final KeyFilter<? super K>[] filters;
 
    public CompositeKeyFilter(KeyFilter<? super K>... filters) {
       this.filters = filters;

--- a/core/src/main/java/org/infinispan/filter/CompositeKeyValueFilter.java
+++ b/core/src/main/java/org/infinispan/filter/CompositeKeyValueFilter.java
@@ -17,7 +17,7 @@ import java.util.Set;
  * @since 7.0
  */
 public class CompositeKeyValueFilter<K, V> implements KeyValueFilter<K, V> {
-   KeyValueFilter<? super K, ? super V> filters[];
+   private final KeyValueFilter<? super K, ? super V> filters[];
 
    public CompositeKeyValueFilter(KeyValueFilter<? super K, ? super V>... filters) {
       this.filters = filters;

--- a/core/src/main/java/org/infinispan/filter/KeyFilter.java
+++ b/core/src/main/java/org/infinispan/filter/KeyFilter.java
@@ -13,12 +13,20 @@ import net.jcip.annotations.ThreadSafe;
  */
 @ThreadSafe
 public interface KeyFilter<K> {
-   public static final KeyFilter LOAD_ALL_FILTER = new KeyFilter() {
+
+   KeyFilter ACCEPT_ALL_FILTER = new KeyFilter() {
       @Override
       public boolean accept(Object key) {
          return true;
       }
    };
+
+   //TODO remove this in 8.0
+   /**
+    * @deprecated Use {@code ACCEPT_ALL_FILTER} instead
+    */
+   KeyFilter LOAD_ALL_FILTER = ACCEPT_ALL_FILTER;
+
    /**
     * @param key key to test
     * @return true if the given key is accepted by this filter.

--- a/core/src/main/java/org/infinispan/filter/NullValueConverter.java
+++ b/core/src/main/java/org/infinispan/filter/NullValueConverter.java
@@ -5,10 +5,8 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.marshall.core.Ids;
 import org.infinispan.metadata.Metadata;
 
-import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.io.Serializable;
 import java.util.Set;
 
 /**
@@ -18,7 +16,7 @@ import java.util.Set;
  * @author wburns
  * @since 7.0
  */
-public class NullValueConverter implements Converter<Object, Object, Void>, Serializable {
+public class NullValueConverter implements Converter<Object, Object, Void> {
 
    private NullValueConverter() { }
 
@@ -42,11 +40,11 @@ public class NullValueConverter implements Converter<Object, Object, Void>, Seri
       }
 
       @Override
-      public void writeObject(ObjectOutput output, NullValueConverter object) throws IOException {
+      public void writeObject(ObjectOutput output, NullValueConverter object) {
       }
 
       @Override
-      public NullValueConverter readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+      public NullValueConverter readObject(ObjectInput input) {
          return NullValueConverter.getInstance();
       }
 

--- a/core/src/main/java/org/infinispan/iteration/EntryIterable.java
+++ b/core/src/main/java/org/infinispan/iteration/EntryIterable.java
@@ -4,7 +4,6 @@ import org.infinispan.commons.util.CloseableIterable;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.filter.Converter;
 
-import java.util.Map;
 
 /**
  * A {@link java.lang.Iterable} instance that allows the user to iterate over the entries in the cache.  This

--- a/core/src/main/java/org/infinispan/iteration/impl/EntryIterableImpl.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/EntryIterableImpl.java
@@ -9,7 +9,6 @@ import org.infinispan.filter.KeyValueFilter;
 import org.infinispan.iteration.EntryIterable;
 
 import java.util.EnumSet;
-import java.util.Map;
 
 /**
  * This is an implementation that allows for creating new EntryIterable instances by supplying a new converter.

--- a/core/src/main/java/org/infinispan/iteration/impl/EntryRequestCommand.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/EntryRequestCommand.java
@@ -23,6 +23,7 @@ public class EntryRequestCommand<K, V, C> extends BaseRpcCommand implements Topo
 
    private UUID identifier;
    private Set<Integer> segments;
+   private Set<K> keysToFilter;
    private KeyValueFilter<? super K, ? super V> filter;
    private Converter<? super K, ? super V, C> converter;
    private Set<Flag> flags;
@@ -39,13 +40,14 @@ public class EntryRequestCommand<K, V, C> extends BaseRpcCommand implements Topo
       super(cacheName);
    }
 
-   public EntryRequestCommand(String cacheName, UUID identifier, Address origin, Set<Integer> segments,
+   public EntryRequestCommand(String cacheName, UUID identifier, Address origin, Set<Integer> segments, Set<K> keysToFilter,
                               KeyValueFilter<? super K, ? super V> filter, Converter<? super K, ? super V, C> converter,
                               Set<Flag> flags) {
       super(cacheName);
       setOrigin(origin);
       this.identifier = identifier;
       this.segments = segments;
+      this.keysToFilter = keysToFilter;
       this.filter = filter;
       this.converter = converter;
       this.flags = flags;
@@ -58,7 +60,7 @@ public class EntryRequestCommand<K, V, C> extends BaseRpcCommand implements Topo
 
    @Override
    public Object perform(InvocationContext ctx) throws Throwable {
-      entryRetrieverManager.startRetrievingValues(identifier, getOrigin(), segments, filter, converter, flags);
+      entryRetrieverManager.startRetrievingValues(identifier, getOrigin(), segments, keysToFilter, filter, converter, flags);
       return null;
    }
 
@@ -69,7 +71,7 @@ public class EntryRequestCommand<K, V, C> extends BaseRpcCommand implements Topo
 
    @Override
    public Object[] getParameters() {
-      return new Object[]{identifier, getOrigin(), segments, filter, converter, topologyId, flags};
+      return new Object[]{identifier, getOrigin(), segments, keysToFilter, filter, converter, topologyId, flags};
    }
 
    @Override
@@ -78,6 +80,7 @@ public class EntryRequestCommand<K, V, C> extends BaseRpcCommand implements Topo
       identifier = (UUID) parameters[i++];
       setOrigin((Address) parameters[i++]);
       segments = (Set<Integer>) parameters[i++];
+      keysToFilter = (Set<K>) parameters[i++];
       filter = (KeyValueFilter<? super K, ? super V>) parameters[i++];
       converter = (Converter<? super K, ? super V, C>) parameters[i++];
       topologyId = (Integer) parameters[i++];
@@ -104,6 +107,7 @@ public class EntryRequestCommand<K, V, C> extends BaseRpcCommand implements Topo
       return "EntryRequestCommand{" +
             "identifier=" + identifier +
             ", segments=" + segments +
+            ", keysToFilter=" + keysToFilter +
             ", filter=" + filter +
             ", converter=" + converter +
             ", topologyId=" + topologyId +

--- a/core/src/main/java/org/infinispan/iteration/impl/EntryRetriever.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/EntryRetriever.java
@@ -24,11 +24,12 @@ public interface EntryRetriever<K, V> {
     * @param identifier The unique identifier of the iteration request
     * @param origin The node that sent the iteration request
     * @param segments The segments this node wants
+    * @param keysToFilter The keys to filter out (can be {@code null})
     * @param filter The filter to be applied to determine if a value should be used
     * @param converter The converter to run on the values retrieved before returning
     * @param <C> The resulting type of the Converter
     */
-   public <C> void startRetrievingValues(UUID identifier, Address origin, Set<Integer> segments,
+   public <C> void startRetrievingValues(UUID identifier, Address origin, Set<Integer> segments, Set<K> keysToFilter,
                                         KeyValueFilter<? super K, ? super V> filter,
                                         Converter<? super K, ? super V, C> converter,
                                         Set<Flag> flagss);

--- a/core/src/main/java/org/infinispan/iteration/impl/LocalEntryRetriever.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/LocalEntryRetriever.java
@@ -151,7 +151,7 @@ public class LocalEntryRetriever<K, V> implements EntryRetriever<K, V> {
    }
 
    @Override
-   public <C> void startRetrievingValues(UUID identifier, Address origin, Set<Integer> segments,
+   public <C> void startRetrievingValues(UUID identifier, Address origin, Set<Integer> segments, Set<K> keysToFilter,
                                             KeyValueFilter<? super K, ? super V> filter,
                                             Converter<? super K, ? super V, C> converter, Set<Flag> flags) {
       throw new UnsupportedOperationException();

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/filter/CacheEventConverterAsConverter.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/filter/CacheEventConverterAsConverter.java
@@ -3,7 +3,6 @@ package org.infinispan.notifications.cachelistener.filter;
 import org.infinispan.commons.marshall.AbstractExternalizer;
 import org.infinispan.commons.util.Util;
 import org.infinispan.filter.Converter;
-import org.infinispan.filter.KeyFilterAsKeyValueFilter;
 import org.infinispan.marshall.core.Ids;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.notifications.cachelistener.event.Event;
@@ -11,7 +10,6 @@ import org.infinispan.notifications.cachelistener.event.Event;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.io.Serializable;
 import java.util.Set;
 
 /**

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/filter/CacheEventFilterAsKeyValueFilter.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/filter/CacheEventFilterAsKeyValueFilter.java
@@ -10,7 +10,6 @@ import org.infinispan.notifications.cachelistener.event.Event;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.io.Serializable;
 import java.util.Set;
 
 /**
@@ -22,7 +21,7 @@ import java.util.Set;
  * @author wburns
  * @since 7.0
  */
-public class CacheEventFilterAsKeyValueFilter<K, V> implements KeyValueFilter<K, V>, Serializable {
+public class CacheEventFilterAsKeyValueFilter<K, V> implements KeyValueFilter<K, V> {
    private static final EventType CREATE_EVENT = new EventType(false, false, Event.Type.CACHE_ENTRY_CREATED);
 
    private final CacheEventFilter<K, V> filter;

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/filter/ConverterAsCacheEventConverter.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/filter/ConverterAsCacheEventConverter.java
@@ -9,7 +9,6 @@ import org.infinispan.metadata.Metadata;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.io.Serializable;
 import java.util.Set;
 
 /**
@@ -18,7 +17,7 @@ import java.util.Set;
  * @author wburns
  * @since 7.0
  */
-public class ConverterAsCacheEventConverter<K, V, C> implements CacheEventConverter<K, V, C>, Serializable {
+public class ConverterAsCacheEventConverter<K, V, C> implements CacheEventConverter<K, V, C> {
    private final Converter<K, V, C> converter;
 
    public ConverterAsCacheEventConverter(Converter<K, V, C> converter) {

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/filter/KeyFilterAsCacheEventFilter.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/filter/KeyFilterAsCacheEventFilter.java
@@ -9,7 +9,6 @@ import org.infinispan.metadata.Metadata;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.io.Serializable;
 import java.util.Set;
 
 /**
@@ -18,7 +17,7 @@ import java.util.Set;
  * @author wburns
  * @since 7.0
  */
-public class KeyFilterAsCacheEventFilter<K> implements CacheEventFilter<K, Object>, Serializable {
+public class KeyFilterAsCacheEventFilter<K> implements CacheEventFilter<K, Object> {
    private final KeyFilter<? super K> filter;
 
    public KeyFilterAsCacheEventFilter(KeyFilter<? super K> filter) {

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/filter/KeyValueFilterAsCacheEventFilter.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/filter/KeyValueFilterAsCacheEventFilter.java
@@ -9,7 +9,6 @@ import org.infinispan.metadata.Metadata;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.io.Serializable;
 import java.util.Set;
 
 /**
@@ -18,7 +17,7 @@ import java.util.Set;
  * @author wburns
  * @since 7.0
  */
-public class KeyValueFilterAsCacheEventFilter<K, V> implements CacheEventFilter<K, V>, Serializable {
+public class KeyValueFilterAsCacheEventFilter<K, V> implements CacheEventFilter<K, V> {
    private final KeyValueFilter<? super K, ? super V> filter;
 
    public KeyValueFilterAsCacheEventFilter(KeyValueFilter<? super K, ? super V> filter) {

--- a/core/src/main/java/org/infinispan/persistence/PersistenceUtil.java
+++ b/core/src/main/java/org/infinispan/persistence/PersistenceUtil.java
@@ -32,7 +32,7 @@ public class PersistenceUtil {
    private static Log log = LogFactory.getLog(PersistenceUtil.class);
 
    public static KeyFilter notNull(KeyFilter filter) {
-      return filter == null ? KeyFilter.LOAD_ALL_FILTER : filter;
+      return filter == null ? KeyFilter.ACCEPT_ALL_FILTER : filter;
    }
 
    public static <K, V> int count(AdvancedCacheLoader<K, V> acl, KeyFilter<? super K> filter) {

--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -893,7 +893,7 @@ public class StateConsumerImpl implements StateConsumer {
       // Keys that we used to own, and need to be removed from the data container AND the cache stores
       final ConcurrentHashSet<Object> keysToRemove = new ConcurrentHashSet<Object>();
 
-      dataContainer.executeTask(KeyFilter.LOAD_ALL_FILTER, new ParallelIterableMap.KeyValueAction<Object, InternalCacheEntry<Object, Object>>() {
+      dataContainer.executeTask(KeyFilter.ACCEPT_ALL_FILTER, new ParallelIterableMap.KeyValueAction<Object, InternalCacheEntry<Object, Object>>() {
          @Override
          public void apply(Object o, InternalCacheEntry<Object, Object> ice) {
             Object key = ice.getKey();

--- a/core/src/test/java/org/infinispan/distribution/groups/BaseGetGroupKeysTest.java
+++ b/core/src/test/java/org/infinispan/distribution/groups/BaseGetGroupKeysTest.java
@@ -109,7 +109,7 @@ public abstract class BaseGetGroupKeysTest extends BaseUtilGroupTest {
 
       final AtomicReference<GroupKey> keyToActivate = new AtomicReference<>(null);
       PersistenceManager persistenceManager = TestingUtil.extractComponent(extractTargetCache(testCache), PersistenceManager.class);
-      persistenceManager.processOnAllStores(KeyFilter.LOAD_ALL_FILTER, new AdvancedCacheLoader.CacheLoaderTask() {
+      persistenceManager.processOnAllStores(KeyFilter.ACCEPT_ALL_FILTER, new AdvancedCacheLoader.CacheLoaderTask() {
          @Override
          public void processEntry(MarshalledEntry marshalledEntry, AdvancedCacheLoader.TaskContext taskContext) throws InterruptedException {
             keyToActivate.compareAndSet(null, (GroupKey) marshalledEntry.getKey());

--- a/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverTest.java
+++ b/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverTest.java
@@ -140,7 +140,7 @@ public class DistributedEntryRetrieverTest extends BaseClusteredEntryRetrieverTe
       Future<Void> future = fork(new Callable<Void>() {
          @Override
          public Void call() throws Exception {
-            Iterator<CacheEntry<Object, String>> iter = retriever.retrieveEntries(null, null, null, null);
+            Iterator<CacheEntry<Object, String>> iter = retriever.retrieveEntries(new NoOpFilterConverterWithDependencies<Object, String>(), null, null, null);
             while (iter.hasNext()) {
                Map.Entry<Object, String> entry = iter.next();
                returnQueue.add(entry);

--- a/core/src/test/java/org/infinispan/iteration/NoOpFilterConverterWithDependencies.java
+++ b/core/src/test/java/org/infinispan/iteration/NoOpFilterConverterWithDependencies.java
@@ -1,0 +1,30 @@
+package org.infinispan.iteration;
+
+import org.infinispan.Cache;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.filter.AbstractKeyValueFilterConverter;
+import org.infinispan.metadata.Metadata;
+
+import java.io.Serializable;
+
+/**
+ * @author anistor@redhat.com
+ * @since 7.2
+ */
+public class NoOpFilterConverterWithDependencies<K, V> extends AbstractKeyValueFilterConverter<K, V, V> implements Serializable {
+
+   private transient Cache cache;
+
+   @Inject
+   protected void injectDependencies(Cache cache) {
+      this.cache = cache;
+   }
+
+   @Override
+   public V filterAndConvert(K key, V value, Metadata metadata) {
+      if (cache == null) {
+         throw new IllegalStateException("Dependencies were not injected");
+      }
+      return value;
+   }
+}

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -362,8 +362,8 @@ public class ControlledCommandFactory implements CommandsFactory {
    }
 
    @Override
-   public <K, V, C> EntryRequestCommand<K, V, C> buildEntryRequestCommand(UUID identifier, Set<Integer> segments, KeyValueFilter<? super K, ? super V> filter, Converter<? super K, ? super V, C> converter, Set<Flag> flags) {
-      return actual.buildEntryRequestCommand(identifier, segments, filter, converter, flags);
+   public <K, V, C> EntryRequestCommand<K, V, C> buildEntryRequestCommand(UUID identifier, Set<Integer> segments, Set<K> keysToFilter, KeyValueFilter<? super K, ? super V> filter, Converter<? super K, ? super V, C> converter, Set<Flag> flags) {
+      return actual.buildEntryRequestCommand(identifier, segments, keysToFilter, filter, converter, flags);
    }
 
    @Override


### PR DESCRIPTION
This is for 7.1.x !

Jira: https://issues.jboss.org/browse/ISPN-5271
        https://issues.jboss.org/browse/ISPN-5277
        https://issues.jboss.org/browse/ISPN-5279