### PR TITLE
ISPN-5131 Deployable Cache Stores implementation

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/PersistenceConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/PersistenceConfigurationBuilder.java
@@ -2,15 +2,15 @@ package org.infinispan.configuration.cache;
 
 import static org.infinispan.configuration.cache.PersistenceConfiguration.PASSIVATION;
 
+import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.ConfigurationUtils;
+import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.global.GlobalConfiguration;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.infinispan.commons.CacheConfigurationException;
-import org.infinispan.commons.configuration.Builder;
-import org.infinispan.commons.configuration.ConfigurationUtils;
-import org.infinispan.commons.configuration.attributes.AttributeSet;
-import org.infinispan.configuration.global.GlobalConfiguration;
 /**
  * Configuration for cache stores.
  *
@@ -131,15 +131,20 @@ public class PersistenceConfigurationBuilder extends AbstractConfigurationChildB
       this.attributes.read(template.attributes());
       clearStores();
       for (StoreConfiguration c : template.stores()) {
-         Class<? extends StoreConfigurationBuilder<?, ?>> builderClass = (Class<? extends StoreConfigurationBuilder<?, ?>>) ConfigurationUtils.builderForNonStrict(c);
-         if (builderClass == null) {
-            builderClass = CustomStoreConfigurationBuilder.class;
-         }
+         Class<? extends StoreConfigurationBuilder<?, ?>> builderClass = getBuilderClass(c);
          StoreConfigurationBuilder builder =  this.addStore(builderClass);
          builder.read(c);
       }
 
       return this;
+   }
+
+   private Class<? extends StoreConfigurationBuilder<?, ?>> getBuilderClass(StoreConfiguration c) {
+      Class<? extends StoreConfigurationBuilder<?, ?>> builderClass = (Class<? extends StoreConfigurationBuilder<?, ?>>) ConfigurationUtils.builderForNonStrict(c);
+      if (builderClass == null) {
+         builderClass = CustomStoreConfigurationBuilder.class;
+      }
+      return builderClass;
    }
 
    public List<StoreConfigurationBuilder<?, ?>> stores() {

--- a/core/src/main/java/org/infinispan/configuration/cache/PersistenceConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/PersistenceConfigurationBuilder.java
@@ -1,15 +1,16 @@
 package org.infinispan.configuration.cache;
 
-import static org.infinispan.configuration.cache.PersistenceConfiguration.PASSIVATION;
-
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.ConfigurationUtils;
-import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.configuration.global.GlobalConfiguration;
+
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.infinispan.configuration.cache.PersistenceConfiguration.PASSIVATION;
 
 /**
  * Configuration for cache stores.

--- a/core/src/main/java/org/infinispan/factories/CacheStoreFactoryRegistryFactory.java
+++ b/core/src/main/java/org/infinispan/factories/CacheStoreFactoryRegistryFactory.java
@@ -1,0 +1,13 @@
+package org.infinispan.factories;
+
+import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.persistence.factory.CacheStoreFactoryRegistry;
+
+@DefaultFactoryFor(classes = CacheStoreFactoryRegistry.class)
+public class CacheStoreFactoryRegistryFactory extends AbstractNamedCacheComponentFactory implements AutoInstantiableFactory {
+   @Override
+   @SuppressWarnings("unchecked")
+   public <T> T construct(Class<T> componentType) {
+      return (T) new CacheStoreFactoryRegistry();
+   }
+}

--- a/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
@@ -1,19 +1,6 @@
 package org.infinispan.factories;
 
-import java.lang.ref.WeakReference;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
-import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
-
 import net.jcip.annotations.ThreadSafe;
-
 import org.infinispan.Version;
 import org.infinispan.commands.module.ModuleCommandFactory;
 import org.infinispan.commands.module.ModuleCommandInitializer;
@@ -32,6 +19,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.manager.EmbeddedCacheManagerStartupException;
 import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifier;
 import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifierImpl;
+import org.infinispan.persistence.factory.CacheStoreFactoryRegistry;
 import org.infinispan.registry.ClusterRegistry;
 import org.infinispan.registry.impl.ClusterRegistryImpl;
 import org.infinispan.remoting.transport.Transport;
@@ -41,6 +29,17 @@ import org.infinispan.util.ModuleProperties;
 import org.infinispan.util.TimeService;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * A global component registry where shared components are stored.
@@ -110,6 +109,7 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
          registerComponent(new CacheManagerJmxRegistration(), CacheManagerJmxRegistration.class);
          registerComponent(new CacheManagerNotifierImpl(), CacheManagerNotifier.class);
          registerComponent(new ClusterRegistryImpl(), ClusterRegistry.class);
+         registerComponent(new CacheStoreFactoryRegistry(), CacheStoreFactoryRegistry.class);
 
          moduleProperties.loadModuleCommandHandlers(configuredClassLoader);
          Map<Byte, ModuleCommandFactory> factories = moduleProperties.moduleCommandFactories();

--- a/core/src/main/java/org/infinispan/persistence/factory/CacheStoreFactory.java
+++ b/core/src/main/java/org/infinispan/persistence/factory/CacheStoreFactory.java
@@ -1,0 +1,24 @@
+package org.infinispan.persistence.factory;
+
+import org.infinispan.configuration.cache.StoreConfiguration;
+
+/**
+ * Creates Cache Store instances.
+ *
+ * <i>Needs to be implemented when loading Cache Stores from custom locations (e.g. custom location on the disk).</i>
+ *
+ * @author Sebastian Laskawiec
+ * @since 7.2
+ */
+public interface CacheStoreFactory {
+
+   /**
+    * Returns new instance based on {@link org.infinispan.configuration.cache.StoreConfiguration}.
+    *
+    * @param storeConfiguration Configuration to be processed.
+    * @return Instance configured by the {@link org.infinispan.configuration.cache.StoreConfiguration}.
+    */
+   <T> T createInstance(StoreConfiguration storeConfiguration);
+
+   StoreConfiguration processConfiguration(StoreConfiguration storeConfiguration);
+}

--- a/core/src/main/java/org/infinispan/persistence/factory/CacheStoreFactoryRegistry.java
+++ b/core/src/main/java/org/infinispan/persistence/factory/CacheStoreFactoryRegistry.java
@@ -1,0 +1,68 @@
+package org.infinispan.persistence.factory;
+
+import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Registry for multiple {@link CacheStoreFactory} objects.
+ *
+ * @author Sebastian Laskawiec
+ * @since 7.2
+ */
+public class CacheStoreFactoryRegistry {
+
+   private static final Log log = LogFactory.getLog(CacheStoreFactoryRegistry.class);
+
+   private List<CacheStoreFactory> factories = new ArrayList<>();
+
+   public CacheStoreFactoryRegistry() {
+      factories.add(new LocalClassLoaderCacheStoreFactory());
+   }
+
+   /**
+    * Creates new Object based on configuration.
+    *
+    * @param storeConfiguration Cache store configuration.
+    * @return Instance created based on the configuration.
+    * @throws org.infinispan.commons.CacheConfigurationException when the instance couldn't be created.
+    */
+   public Object createInstance(StoreConfiguration storeConfiguration) {
+      for(CacheStoreFactory factory : factories) {
+         Object instance = factory.createInstance(storeConfiguration);
+         if(instance != null) {
+            return instance;
+         }
+      }
+      throw log.unableToInstantiateClass(storeConfiguration.getClass());
+   }
+
+   public StoreConfiguration processStoreConfiguration(StoreConfiguration storeConfiguration) {
+      for(CacheStoreFactory factory : factories) {
+         StoreConfiguration processedConfiguration = factory.processConfiguration(storeConfiguration);
+         if(processedConfiguration != null) {
+            return processedConfiguration;
+         }
+      }
+      return storeConfiguration;
+   }
+
+   /**
+    * Adds a new factory for processing.
+    *
+    * @param cacheStoreFactory Factory to be added.
+    */
+   public void addCacheStoreFactory(CacheStoreFactory cacheStoreFactory) {
+      factories.add(0, cacheStoreFactory);
+   }
+
+   /**
+    * Removes all factories associated to this registry.
+    */
+   public void clearFactories() {
+      factories.clear();
+   }
+}

--- a/core/src/main/java/org/infinispan/persistence/factory/CacheStoreFactoryRegistry.java
+++ b/core/src/main/java/org/infinispan/persistence/factory/CacheStoreFactoryRegistry.java
@@ -1,6 +1,8 @@
 package org.infinispan.persistence.factory;
 
 import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -13,6 +15,7 @@ import java.util.List;
  * @author Sebastian Laskawiec
  * @since 7.2
  */
+@Scope(Scopes.GLOBAL)
 public class CacheStoreFactoryRegistry {
 
    private static final Log log = LogFactory.getLog(CacheStoreFactoryRegistry.class);

--- a/core/src/main/java/org/infinispan/persistence/factory/ConfigurationForClassExtractor.java
+++ b/core/src/main/java/org/infinispan/persistence/factory/ConfigurationForClassExtractor.java
@@ -1,0 +1,26 @@
+package org.infinispan.persistence.factory;
+
+import org.infinispan.commons.configuration.ConfigurationFor;
+import org.infinispan.configuration.cache.CustomStoreConfiguration;
+import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.util.logging.Log;
+
+public class ConfigurationForClassExtractor {
+
+   public static Class getClassBasedOnConfigurationAnnotation(StoreConfiguration cfg, Log logger) {
+      ConfigurationFor annotation = cfg.getClass().getAnnotation(ConfigurationFor.class);
+      Class classAnnotation = null;
+      if (annotation == null) {
+         if (cfg instanceof CustomStoreConfiguration) {
+            classAnnotation = ((CustomStoreConfiguration)cfg).customStoreClass();
+         }
+      } else {
+         classAnnotation = annotation.value();
+      }
+      if (classAnnotation == null) {
+         throw logger.loaderConfigurationDoesNotSpecifyLoaderClass(cfg.getClass().getName());
+      }
+      return classAnnotation;
+   }
+
+}

--- a/core/src/main/java/org/infinispan/persistence/factory/LocalClassLoaderCacheStoreFactory.java
+++ b/core/src/main/java/org/infinispan/persistence/factory/LocalClassLoaderCacheStoreFactory.java
@@ -1,0 +1,40 @@
+package org.infinispan.persistence.factory;
+
+import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * Default implementation, which uses Local class loader. No external class loading is allowed.
+ *
+ * @author Sebastian Laskawiec
+ * @since 7.2
+ */
+public class LocalClassLoaderCacheStoreFactory implements CacheStoreFactory {
+
+   private static final Log log = LogFactory.getLog(LocalClassLoaderCacheStoreFactory.class);
+
+   @Override
+   public <T> T createInstance(StoreConfiguration cfg) {
+      Class classBasedOnConfigurationAnnotation = ConfigurationForClassExtractor.getClassBasedOnConfigurationAnnotation(cfg, log);
+      try {
+         //getInstance is heavily used, so refactoring it might be risky. However we can safely catch
+         //and ignore the exception. Returning null is perfectly legal here.
+         Object instance = Util.getInstance(classBasedOnConfigurationAnnotation);
+         if(instance != null) {
+            return (T) instance;
+         }
+      } catch (CacheConfigurationException unableToInstantiate) {
+         log.debugv("Could not instantiate class {0} using local classloader", classBasedOnConfigurationAnnotation.getName());
+      }
+      return null;
+   }
+
+   @Override
+   public StoreConfiguration processConfiguration(StoreConfiguration storeConfiguration) {
+      return null;
+   }
+
+}

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -96,7 +96,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
    public void inject(AdvancedCache<Object, Object> cache, @ComponentName(CACHE_MARSHALLER) StreamingMarshaller marshaller,
                       Configuration configuration, TransactionManager transactionManager,
                       TimeService timeService, @ComponentName(PERSISTENCE_EXECUTOR) ExecutorService persistenceExecutor,
-                      ByteBufferFactory byteBufferFactory, MarshalledEntryFactory marshalledEntryFactory) {
+                      ByteBufferFactory byteBufferFactory, MarshalledEntryFactory marshalledEntryFactory, CacheStoreFactoryRegistry cacheStoreFactoryRegistry) {
       this.cache = cache;
       this.m = marshaller;
       this.configuration = configuration;
@@ -105,7 +105,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
       this.persistenceExecutor = persistenceExecutor;
       this.byteBufferFactory = byteBufferFactory;
       this.marshalledEntryFactory = marshalledEntryFactory;
-      this.cacheStoreFactoryRegistry = cache.getComponentRegistry().getGlobalComponentRegistry().getComponent(CacheStoreFactoryRegistry.class);
+      this.cacheStoreFactoryRegistry = cacheStoreFactoryRegistry;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -2,12 +2,10 @@ package org.infinispan.persistence.manager;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.commons.CacheException;
-import org.infinispan.commons.configuration.ConfigurationFor;
 import org.infinispan.commons.io.ByteBufferFactory;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.Configuration;
-import org.infinispan.configuration.cache.CustomStoreConfiguration;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.configuration.cache.StoreConfiguration;
 import org.infinispan.container.entries.ImmortalCacheEntry;
@@ -34,6 +32,7 @@ import org.infinispan.persistence.async.AdvancedAsyncCacheWriter;
 import org.infinispan.persistence.async.AsyncCacheLoader;
 import org.infinispan.persistence.async.AsyncCacheWriter;
 import org.infinispan.persistence.async.State;
+import org.infinispan.persistence.factory.CacheStoreFactoryRegistry;
 import org.infinispan.persistence.spi.AdvancedCacheLoader;
 import org.infinispan.persistence.spi.AdvancedCacheWriter;
 import org.infinispan.persistence.spi.CacheLoader;
@@ -51,7 +50,6 @@ import org.infinispan.util.logging.LogFactory;
 
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
-
 import java.util.*;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -83,6 +81,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
    private final ReadWriteLock storesMutex = new ReentrantReadWriteLock();
    private final Map<Object, StoreConfiguration> configMap = new HashMap<>();
 
+   private CacheStoreFactoryRegistry cacheStoreFactoryRegistry;
 
    /**
     * making it volatile as it might change after @Start, so it needs the visibility.
@@ -106,6 +105,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
       this.persistenceExecutor = persistenceExecutor;
       this.byteBufferFactory = byteBufferFactory;
       this.marshalledEntryFactory = marshalledEntryFactory;
+      this.cacheStoreFactoryRegistry = cache.getComponentRegistry().getGlobalComponentRegistry().getComponent(CacheStoreFactoryRegistry.class);
    }
 
    @Override
@@ -509,66 +509,92 @@ public class PersistenceManagerImpl implements PersistenceManager {
 
    private void createLoadersAndWriters() {
       for (StoreConfiguration cfg : configuration.persistence().stores()) {
-         ConfigurationFor annotation = cfg.getClass().getAnnotation(ConfigurationFor.class);
-         Class classAnnotation = null;
-         if (annotation == null) {
-            if (cfg instanceof CustomStoreConfiguration) {
-               classAnnotation = ((CustomStoreConfiguration)cfg).customStoreClass();
-            }
-         } else {
-            classAnnotation = annotation.value();
-         }
-         if (classAnnotation == null) {
-            throw log.loaderConfigurationDoesNotSpecifyLoaderClass(cfg.getClass().getName());
-         }
-         Object instance = Util.getInstance(classAnnotation);
-         CacheWriter writer = instance instanceof CacheWriter ? (CacheWriter) instance : null;
-         CacheLoader loader = instance instanceof CacheLoader ? (CacheLoader) instance : null;
+         Object bareInstance = cacheStoreFactoryRegistry.createInstance(cfg);
 
+         StoreConfiguration processedConfiguration = cacheStoreFactoryRegistry.processStoreConfiguration(cfg);
 
-         if (cfg.ignoreModifications())
-            writer = null;
+         CacheWriter writer = createCacheWriter(bareInstance);
+         CacheLoader loader = createCacheLoader(bareInstance);
 
-         if (cfg.singletonStore().enabled() && writer != null) {
-            writer = (writer instanceof AdvancedCacheWriter) ?
-                  new AdvancedSingletonCacheWriter(writer, cfg.singletonStore()) :
-                  new SingletonCacheWriter(writer, cfg.singletonStore());
-         }
+         writer = postProcessWriter(processedConfiguration, writer);
+         loader = postProcessReader(processedConfiguration, writer, loader);
 
-         if (cfg.async().enabled() && writer != null) {
-            writer = createAsyncWriter(writer);
-            if (loader != null) {
-               AtomicReference<State> state = ((AsyncCacheWriter) writer).getState();
-               loader = (loader instanceof AdvancedCacheLoader) ?
-                     new AdvancedAsyncCacheLoader(loader, state) : new AsyncCacheLoader(loader, state);
-            }
-         }
-
-         InitializationContextImpl ctx = new InitializationContextImpl(cfg, cache, m, timeService, byteBufferFactory,
+         InitializationContextImpl ctx = new InitializationContextImpl(processedConfiguration, cache, m, timeService, byteBufferFactory,
                                                                        marshalledEntryFactory);
-         if (loader != null) {
-            if (loader instanceof DelegatingCacheLoader)
-               loader.init(ctx);
-            loaders.add(loader);
-            configMap.put(loader, cfg);
-         }
-         if (writer != null) {
-            if (writer instanceof DelegatingCacheWriter)
-               writer.init(ctx);
-            writers.add(writer);
-            configMap.put(writer, cfg);
-         }
-
-         //the delegates only propagate init if the underlaying object is a delegate as well.
-         // we do this in order to assure the init is only invoked once
-         if (instance instanceof CacheWriter) {
-            ((CacheWriter) instance).init(ctx);
-         } else {
-            ((CacheLoader)instance).init(ctx);
-         }
+         initializeLoader(processedConfiguration, loader, ctx);
+         initializeWriter(processedConfiguration, writer, ctx);
+         initializeBareInstance(bareInstance, ctx);
       }
    }
 
+   private CacheLoader postProcessReader(StoreConfiguration cfg, CacheWriter writer, CacheLoader loader) {
+      if(cfg.async().enabled() && loader != null && writer != null) {
+         loader = createAsyncLoader(loader, (AsyncCacheWriter) writer);
+      }
+      return loader;
+   }
+
+   private CacheWriter postProcessWriter(StoreConfiguration cfg, CacheWriter writer) {
+      if (writer != null) {
+         if(cfg.ignoreModifications()) {
+            writer = null;
+         } else if (cfg.singletonStore().enabled()) {
+            writer = createSingletonWriter(cfg, writer);
+         } else if (cfg.async().enabled()) {
+            writer = createAsyncWriter(writer);
+         }
+      }
+      return writer;
+   }
+
+   private CacheLoader createAsyncLoader(CacheLoader loader, AsyncCacheWriter asyncWriter) {
+      AtomicReference<State> state = asyncWriter.getState();
+      loader = (loader instanceof AdvancedCacheLoader) ?
+            new AdvancedAsyncCacheLoader(loader, state) : new AsyncCacheLoader(loader, state);
+      return loader;
+   }
+
+   private SingletonCacheWriter createSingletonWriter(StoreConfiguration cfg, CacheWriter writer) {
+      return (writer instanceof AdvancedCacheWriter) ?
+            new AdvancedSingletonCacheWriter(writer, cfg.singletonStore()) :
+            new SingletonCacheWriter(writer, cfg.singletonStore());
+   }
+
+   private void initializeWriter(StoreConfiguration cfg, CacheWriter writer, InitializationContextImpl ctx) {
+      if (writer != null) {
+         if (writer instanceof DelegatingCacheWriter)
+            writer.init(ctx);
+         writers.add(writer);
+         configMap.put(writer, cfg);
+      }
+   }
+
+   private void initializeLoader(StoreConfiguration cfg, CacheLoader loader, InitializationContextImpl ctx) {
+      if (loader != null) {
+         if (loader instanceof DelegatingCacheLoader)
+            loader.init(ctx);
+         loaders.add(loader);
+         configMap.put(loader, cfg);
+      }
+   }
+
+   private void initializeBareInstance(Object instance, InitializationContextImpl ctx) {
+      // the delegates only propagate init if the underlaying object is a delegate as well.
+      // we do this in order to assure the init is only invoked once
+      if (instance instanceof CacheWriter) {
+         ((CacheWriter) instance).init(ctx);
+      } else {
+         ((CacheLoader) instance).init(ctx);
+      }
+   }
+
+   private CacheLoader createCacheLoader(Object instance) {
+      return instance instanceof CacheLoader ? (CacheLoader) instance : null;
+   }
+
+   private CacheWriter createCacheWriter(Object instance) {
+      return instance instanceof CacheWriter ? (CacheWriter) instance : null;
+   }
 
    protected AsyncCacheWriter createAsyncWriter(CacheWriter writer) {
       return (writer instanceof AdvancedCacheWriter) ?

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1299,4 +1299,7 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Use of the replication queue is only allowed with an ASYNCHRONOUS cluster mode.", id = 353)
    CacheConfigurationException replicationQueueOnlyForAsyncCaches();
+
+   @Message(value = "Unable to instantiate loader/writer instance for StoreConfiguration %s", id = 354)
+   CacheConfigurationException unableToInstantiateClass(Class<?> storeConfigurationClass);
 }

--- a/core/src/test/java/org/infinispan/persistence/factory/CacheStoreFactoryRegistryTest.java
+++ b/core/src/test/java/org/infinispan/persistence/factory/CacheStoreFactoryRegistryTest.java
@@ -1,0 +1,129 @@
+package org.infinispan.persistence.factory;
+
+import org.infinispan.commons.CacheException;
+import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfiguration;
+import org.testng.annotations.Test;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import static org.testng.Assert.assertEquals;
+
+@Test(groups = "unit", testName = "persistence.CacheStoreFactoryRegistryTest")
+public class CacheStoreFactoryRegistryTest {
+
+   public void testIfNewlyAddedFactoryIsInvokedFirst() {
+      // given
+      final Object instanceReturnedByTheFactory = new Object();
+      StoreConfiguration doesNotMatter = null;
+
+      CacheStoreFactoryRegistry registry = new CacheStoreFactoryRegistry();
+      registry.addCacheStoreFactory(new CacheStoreFactory() {
+
+         @Override
+         public <T> T createInstance(StoreConfiguration storeConfiguration) {
+            return (T) instanceReturnedByTheFactory;
+         }
+
+         @Override
+         public StoreConfiguration processConfiguration(StoreConfiguration storeConfiguration) {
+            return null;
+         }
+      });
+
+      // when
+      Object instance = registry.createInstance(doesNotMatter);
+
+      // then
+      assertEquals(instance, instanceReturnedByTheFactory);
+   }
+
+   public void testIfInstanceFromDifferentClassLoaderIsReturned() throws Exception {
+      // given
+      final Object instanceReturnedByTheFactory = loadWithCustomClassLoader(this.getClass().getName());
+      StoreConfiguration doesNotMatter = null;
+
+      CacheStoreFactoryRegistry registry = new CacheStoreFactoryRegistry();
+      registry.addCacheStoreFactory(new CacheStoreFactory() {
+
+         @Override
+         public <T> T createInstance(StoreConfiguration storeConfiguration) {
+            return (T) instanceReturnedByTheFactory;
+         }
+
+         @Override
+         public StoreConfiguration processConfiguration(StoreConfiguration storeConfiguration) {
+            return null;
+         }
+      });
+
+      // when
+      Object instance = registry.createInstance(doesNotMatter);
+
+      // then
+      assertEquals(instance, instanceReturnedByTheFactory);
+   }
+
+   @Test(expectedExceptions = CacheException.class, expectedExceptionsMessageRegExp = "ISPN000\\d{3}: Unable to instantiate loader/writer instance for StoreConfiguration class .*.DummyInMemoryStoreConfiguration")
+   public void testIfACacheExceptionIfThrownWhenNoInstanceIfFound() throws Exception {
+      // given
+      StoreConfiguration configuration = createDummyConfiguration();
+      CacheStoreFactoryRegistry registry = new CacheStoreFactoryRegistry();
+
+      // when
+      registry.clearFactories();
+      registry.createInstance(configuration);
+   }
+
+   @Test
+   public void testProcessingConfigurationWithoutCustomFactories () throws Exception {
+      // given
+      StoreConfiguration configuration = createDummyConfiguration();
+      CacheStoreFactoryRegistry registry = new CacheStoreFactoryRegistry();
+
+      //when
+      StoreConfiguration processedConfiguration = registry.processStoreConfiguration(configuration);
+
+      //than
+      assertEquals(configuration, processedConfiguration);
+   }
+
+   @Test
+   public void testCustomFactoryProcessesConfigurationFirst() throws Exception {
+      // given
+      final StoreConfiguration configuration = createDummyConfiguration();
+      final StoreConfiguration enhancedConfiguration = createDummyConfiguration();
+
+      CacheStoreFactoryRegistry registry = new CacheStoreFactoryRegistry();
+      registry.addCacheStoreFactory(new CacheStoreFactory() {
+
+         @Override
+         public <T> T createInstance(StoreConfiguration storeConfiguration) {
+            throw new AssertionError("Should not be called");
+         }
+
+         @Override
+         public StoreConfiguration processConfiguration(StoreConfiguration storeConfiguration) {
+            return enhancedConfiguration;
+         }
+      });
+
+      // when
+      StoreConfiguration returnedConfiguration = registry.processStoreConfiguration(configuration);
+
+      // then
+      assertEquals(enhancedConfiguration, returnedConfiguration);
+   }
+
+   private DummyInMemoryStoreConfiguration createDummyConfiguration() {
+      return new DummyInMemoryStoreConfiguration(false, false, false, null, null, false, false, null, false, false, "test", null);
+   }
+
+   private Object loadWithCustomClassLoader(String className) throws Exception {
+      URL thisClass = this.getClass().getResource(this.getClass().getSimpleName() + ".class");
+      ClassLoader customClassLoader = new URLClassLoader(new URL[] {thisClass});
+      Class<?> customInstanceFromDifferentClassLoader = customClassLoader.loadClass(className);
+      return customInstanceFromDifferentClassLoader.newInstance();
+   }
+}

--- a/core/src/test/java/org/infinispan/persistence/factory/CacheStoreFactoryRegistryTest.java
+++ b/core/src/test/java/org/infinispan/persistence/factory/CacheStoreFactoryRegistryTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.persistence.factory;
 
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.configuration.cache.StoreConfiguration;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfiguration;
 import org.testng.annotations.Test;
@@ -117,7 +118,8 @@ public class CacheStoreFactoryRegistryTest {
    }
 
    private DummyInMemoryStoreConfiguration createDummyConfiguration() {
-      return new DummyInMemoryStoreConfiguration(false, false, false, null, null, false, false, null, false, false, "test", null);
+      AttributeSet protectedAttributesSet = DummyInMemoryStoreConfiguration.attributeDefinitionSet().protect();
+      return new DummyInMemoryStoreConfiguration(protectedAttributesSet, null, null);
    }
 
    private Object loadWithCustomClassLoader(String className) throws Exception {

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/InfinispanLogger.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/InfinispanLogger.java
@@ -22,15 +22,15 @@
 
 package org.jboss.as.clustering.infinispan;
 
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
 import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
-
-import org.jboss.logging.BasicLogger;
-import org.jboss.logging.annotations.LogMessage;
-import org.jboss.logging.Logger;
-import org.jboss.logging.annotations.Message;
-import org.jboss.logging.annotations.MessageLogger;
 
 /**
  * InfinispanLogger
@@ -108,4 +108,24 @@ public interface InfinispanLogger extends BasicLogger {
     @Message(id = 10286, value = "Attribute 'virtual-nodes' has been deprecated and has no effect.")
     void virtualNodesAttributeDeprecated();
 
+   /**
+    * Logs an info message about installing implementation service.
+    */
+    @LogMessage(level = INFO)
+    @Message(id = 10287, value = "Registering Deployed Cache Store service for store '%s'")
+    void installDeployedCacheStore(String implementationClassName);
+
+   /**
+    * Logs debug message when starting Deployed Cache service.
+    */
+    @LogMessage(level = DEBUG)
+    @Message(id = 10288, value = "Started Deployed Cache service for implementation '%s'")
+    void deployedStoreStarted(String className);
+
+   /**
+    * Logs debug message when stopping Deployed Cache service.
+    */
+    @LogMessage(level = DEBUG)
+    @Message(id = 10289, value = "Stopped Deployed Cache service for implementation '%s'")
+    void deployedStoreStopped(String className);
 }

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/InfinispanMessages.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/InfinispanMessages.java
@@ -22,19 +22,19 @@
 
 package org.jboss.as.clustering.infinispan;
 
-import java.net.UnknownHostException;
-import java.util.Properties;
-
 import org.infinispan.configuration.cache.CacheMode;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
 import org.jboss.as.network.OutboundSocketBinding;
+import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
-import org.jboss.logging.Messages;
 import org.jboss.msc.inject.InjectionException;
 import org.jboss.msc.service.StartException;
+
+import java.net.UnknownHostException;
+import java.util.Properties;
 
 /**
  * InfinispanMessages
@@ -263,4 +263,10 @@ public interface InfinispanMessages {
     */
    @Message(id = 11005, value = "Parameter %s must be of type %s")
    IllegalArgumentException invalidParameterType(String name, String requiredType);
+
+   /**
+    * Error message thrown when Subsystem can't instantiate given class.
+    */
+   @Message(id = 11006, value = "Could not instantiate class %s")
+   IllegalStateException unableToInstantiateClass(String className);
 }

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/configuration/DeployedStoreConfiguration.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/configuration/DeployedStoreConfiguration.java
@@ -1,0 +1,43 @@
+package org.jboss.as.clustering.infinispan.cs.configuration;
+
+import org.infinispan.commons.configuration.BuiltBy;
+import org.infinispan.configuration.cache.*;
+
+import java.util.Properties;
+
+/**
+ * Configuration which operates only on class names instead of class objects.
+ *
+ * @author Sebastian Laskawiec
+ * @since 7.2
+ */
+@BuiltBy(DeployedStoreConfigurationBuilder.class)
+public class DeployedStoreConfiguration extends AbstractStoreConfiguration {
+
+   private PersistenceConfigurationBuilder persistenceConfigurationBuilder;
+   private String customStoreClassName;
+
+   public DeployedStoreConfiguration(boolean purgeOnStartup, boolean fetchPersistentState, boolean ignoreModifications,
+                                     AsyncStoreConfiguration async, SingletonStoreConfiguration singletonStore, boolean preload,
+                                     boolean shared, Properties properties, PersistenceConfigurationBuilder persistenceConfigurationBuilder, String customStoreClassName) {
+      super(purgeOnStartup, fetchPersistentState, ignoreModifications, async, singletonStore, preload, shared, properties);
+      this.persistenceConfigurationBuilder = persistenceConfigurationBuilder;
+      this.customStoreClassName = customStoreClassName;
+   }
+
+   public PersistenceConfigurationBuilder getPersistenceConfigurationBuilder() {
+      return persistenceConfigurationBuilder;
+   }
+
+   public void setPersistenceConfigurationBuilder(PersistenceConfigurationBuilder persistenceConfigurationBuilder) {
+      this.persistenceConfigurationBuilder = persistenceConfigurationBuilder;
+   }
+
+   public String getCustomStoreClassName() {
+      return customStoreClassName;
+   }
+
+   public void setCustomStoreClassName(String customStoreClassName) {
+      this.customStoreClassName = customStoreClassName;
+   }
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/configuration/DeployedStoreConfigurationBuilder.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/configuration/DeployedStoreConfigurationBuilder.java
@@ -1,0 +1,46 @@
+package org.jboss.as.clustering.infinispan.cs.configuration;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.cache.AbstractStoreConfigurationBuilder;
+import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+
+/**
+ * StoreConfigurationBuilder used for stores/loaders that don't have a configuration builder
+ *
+ * @author Sebastian Laskawiec
+ * @since 7.2
+ */
+public class DeployedStoreConfigurationBuilder extends AbstractStoreConfigurationBuilder<DeployedStoreConfiguration, DeployedStoreConfigurationBuilder> {
+
+   private PersistenceConfigurationBuilder persistenceConfigurationBuilder;
+   private String customStoreClassName;
+
+   public DeployedStoreConfigurationBuilder(PersistenceConfigurationBuilder builder) {
+      super(builder);
+      this.persistenceConfigurationBuilder = builder;
+   }
+
+   @Override
+   public DeployedStoreConfiguration create() {
+      return new DeployedStoreConfiguration(purgeOnStartup, fetchPersistentState, ignoreModifications,
+              async.create(), singletonStore.create(), preload, shared, properties, persistenceConfigurationBuilder, customStoreClassName);
+   }
+
+   @Override
+   public Builder<?> read(DeployedStoreConfiguration template) {
+      super.read(template);
+      this.persistenceConfigurationBuilder = template.getPersistenceConfigurationBuilder();
+      this.customStoreClassName = template.getCustomStoreClassName();
+      return this;
+   }
+
+   @Override
+   public DeployedStoreConfigurationBuilder self() {
+      return this;
+   }
+
+   public DeployedStoreConfigurationBuilder customStoreClassName(String customStoreClassName) {
+      this.customStoreClassName = customStoreClassName;
+      return this;
+   }
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/AbstractCacheStoreExtensionProcessor.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/AbstractCacheStoreExtensionProcessor.java
@@ -1,0 +1,92 @@
+package org.jboss.as.clustering.infinispan.cs.deployment;
+
+import org.jboss.as.clustering.infinispan.InfinispanLogger;
+import org.jboss.as.clustering.infinispan.InfinispanMessages;
+import org.jboss.as.clustering.infinispan.cs.factory.DeployedCacheStoreFactory;
+import org.jboss.as.clustering.infinispan.cs.factory.DeployedCacheStoreFactoryService;
+import org.jboss.as.server.deployment.*;
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleClassLoader;
+import org.jboss.msc.service.*;
+import org.jboss.msc.value.InjectedValue;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+public abstract class AbstractCacheStoreExtensionProcessor<T> implements DeploymentUnitProcessor {
+
+   @Override
+   public void deploy(DeploymentPhaseContext ctx) throws DeploymentUnitProcessingException {
+      DeploymentUnit deploymentUnit = ctx.getDeploymentUnit();
+      Module module = deploymentUnit.getAttachment(Attachments.MODULE);
+      ServicesAttachment servicesAttachment = deploymentUnit.getAttachment(Attachments.SERVICES);
+      if (module != null && servicesAttachment != null)
+         addServices(ctx, servicesAttachment, module);
+   }
+
+   @Override
+   public void undeploy(DeploymentUnit deploymentUnit) {
+      // Deploy only adds services, so no need to do anything here
+      // since these services are automatically removed.
+   }
+
+   private void addServices(DeploymentPhaseContext ctx, ServicesAttachment servicesAttachment, Module module) {
+      Class<T> serviceClass = getServiceClass();
+      List<String> implementationNames = servicesAttachment.getServiceImplementations(serviceClass.getName());
+      ModuleClassLoader classLoader = module.getClassLoader();
+      for (String serviceClassName : implementationNames) {
+         try {
+            Class<? extends T> clazz = classLoader.loadClass(serviceClassName).asSubclass(serviceClass);
+            Constructor<? extends T> ctor = clazz.getConstructor();
+            T instance = ctor.newInstance();
+            installService(ctx, serviceClassName, instance);
+         } catch (Exception e) {
+            InfinispanMessages.MESSAGES.unableToInstantiateClass(serviceClassName);
+         }
+      }
+   }
+
+   public final void installService(DeploymentPhaseContext ctx, String implementationClassName, T instance) {
+      AbstractExtensionManagerService<T> service = createService(implementationClassName, instance);
+      ServiceName extensionServiceName = ServiceName.JBOSS.append(service.getServiceTypeName(), implementationClassName.replaceAll("\\.", "_"));
+      InfinispanLogger.ROOT_LOGGER.installDeployedCacheStore(implementationClassName);
+      ServiceBuilder<T> serviceBuilder = ctx.getServiceTarget().addService(extensionServiceName, service);
+      serviceBuilder.setInitialMode(ServiceController.Mode.ACTIVE);
+      serviceBuilder.addDependency(DeployedCacheStoreFactoryService.SERVICE_NAME, DeployedCacheStoreFactory.class, service.getDeployedCacheStoreFactory());
+      serviceBuilder.install();
+   }
+
+   public abstract Class<T> getServiceClass();
+
+   public abstract AbstractExtensionManagerService<T> createService(String serviceName, T instance);
+
+   protected static abstract class AbstractExtensionManagerService<T> implements Service<T> {
+
+      protected final T extension;
+      protected final String className;
+      protected InjectedValue<DeployedCacheStoreFactory> deployedCacheStoreFactory = new InjectedValue<>();
+
+      protected AbstractExtensionManagerService(String className, T extension) {
+         this.extension = extension;
+         this.className = className;
+      }
+
+      @Override
+      public void start(StartContext context) {
+         InfinispanLogger.ROOT_LOGGER.deployedStoreStarted(className);
+         deployedCacheStoreFactory.getValue().addInstance(extension);
+      }
+
+      @Override
+      public void stop(StopContext context) {
+         InfinispanLogger.ROOT_LOGGER.deployedStoreStopped(className);
+         deployedCacheStoreFactory.getValue().removeInstance(extension);
+      }
+
+      public InjectedValue<DeployedCacheStoreFactory> getDeployedCacheStoreFactory() {
+         return deployedCacheStoreFactory;
+      }
+
+      public abstract String getServiceTypeName();
+   }
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/AdvancedCacheLoaderExtensionProcessor.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/AdvancedCacheLoaderExtensionProcessor.java
@@ -1,0 +1,33 @@
+package org.jboss.as.clustering.infinispan.cs.deployment;
+
+import org.infinispan.persistence.spi.AdvancedCacheLoader;
+
+public final class AdvancedCacheLoaderExtensionProcessor extends AbstractCacheStoreExtensionProcessor<AdvancedCacheLoader> {
+
+   @Override
+   public AdvancedCacheLoaderService createService(String serviceName, AdvancedCacheLoader instance) {
+      return new AdvancedCacheLoaderService(serviceName, instance);
+   }
+
+   @Override
+   public Class<AdvancedCacheLoader> getServiceClass() {
+      return AdvancedCacheLoader.class;
+   }
+
+   private static class AdvancedCacheLoaderService extends AbstractExtensionManagerService<AdvancedCacheLoader> {
+      private AdvancedCacheLoaderService(String serviceName, AdvancedCacheLoader AdvancedCacheLoader) {
+         super(serviceName, AdvancedCacheLoader);
+      }
+
+      @Override
+      public AdvancedCacheLoader getValue() {
+         return extension;
+      }
+
+      @Override
+      public String getServiceTypeName() {
+         return "AdvancedCacheLoader-service";
+      }
+   }
+
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/AdvancedCacheWriterExtensionProcessor.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/AdvancedCacheWriterExtensionProcessor.java
@@ -1,0 +1,33 @@
+package org.jboss.as.clustering.infinispan.cs.deployment;
+
+import org.infinispan.persistence.spi.AdvancedCacheWriter;
+
+public final class AdvancedCacheWriterExtensionProcessor extends AbstractCacheStoreExtensionProcessor<AdvancedCacheWriter> {
+
+   @Override
+   public AdvancedCacheWriterService createService(String serviceName, AdvancedCacheWriter instance) {
+      return new AdvancedCacheWriterService(serviceName, instance);
+   }
+
+   @Override
+   public Class<AdvancedCacheWriter> getServiceClass() {
+      return AdvancedCacheWriter.class;
+   }
+
+   private static class AdvancedCacheWriterService extends AbstractExtensionManagerService<AdvancedCacheWriter> {
+      private AdvancedCacheWriterService(String serviceName, AdvancedCacheWriter AdvancedCacheWriter) {
+         super(serviceName, AdvancedCacheWriter);
+      }
+
+      @Override
+      public AdvancedCacheWriter getValue() {
+         return extension;
+      }
+
+      @Override
+      public String getServiceTypeName() {
+         return "AdvancedCacheWriter-service";
+      }
+   }
+
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/AdvancedLoadWriteStoreExtensionProcessor.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/AdvancedLoadWriteStoreExtensionProcessor.java
@@ -1,0 +1,33 @@
+package org.jboss.as.clustering.infinispan.cs.deployment;
+
+import org.infinispan.persistence.spi.AdvancedLoadWriteStore;
+
+public final class AdvancedLoadWriteStoreExtensionProcessor extends AbstractCacheStoreExtensionProcessor<AdvancedLoadWriteStore> {
+
+   @Override
+   public AdvancedCacheLoaderService createService(String serviceName, AdvancedLoadWriteStore instance) {
+      return new AdvancedCacheLoaderService(serviceName, instance);
+   }
+
+   @Override
+   public Class<AdvancedLoadWriteStore> getServiceClass() {
+      return AdvancedLoadWriteStore.class;
+   }
+
+   private static class AdvancedCacheLoaderService extends AbstractExtensionManagerService<AdvancedLoadWriteStore> {
+      private AdvancedCacheLoaderService(String serviceName, AdvancedLoadWriteStore AdvancedLoadWriteStore) {
+         super(serviceName, AdvancedLoadWriteStore);
+      }
+
+      @Override
+      public AdvancedLoadWriteStore getValue() {
+         return extension;
+      }
+
+      @Override
+      public String getServiceTypeName() {
+         return "AdvancedLoadWriteStore-service";
+      }
+   }
+
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/CacheLoaderExtensionProcessor.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/CacheLoaderExtensionProcessor.java
@@ -1,0 +1,33 @@
+package org.jboss.as.clustering.infinispan.cs.deployment;
+
+import org.infinispan.persistence.spi.CacheLoader;
+
+public final class CacheLoaderExtensionProcessor extends AbstractCacheStoreExtensionProcessor<CacheLoader> {
+
+   @Override
+   public CacheLoaderService createService(String serviceName, CacheLoader instance) {
+      return new CacheLoaderService(serviceName, instance);
+   }
+
+   @Override
+   public Class<CacheLoader> getServiceClass() {
+      return CacheLoader.class;
+   }
+
+   private static class CacheLoaderService extends AbstractExtensionManagerService<CacheLoader> {
+      private CacheLoaderService(String serviceName, CacheLoader cacheLoader) {
+         super(serviceName, cacheLoader);
+      }
+
+      @Override
+      public CacheLoader getValue() {
+         return extension;
+      }
+
+      @Override
+      public String getServiceTypeName() {
+         return "CacheLoader-service";
+      }
+   }
+
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/CacheWriterExtensionProcessor.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/CacheWriterExtensionProcessor.java
@@ -1,0 +1,33 @@
+package org.jboss.as.clustering.infinispan.cs.deployment;
+
+import org.infinispan.persistence.spi.CacheWriter;
+
+public final class CacheWriterExtensionProcessor extends AbstractCacheStoreExtensionProcessor<CacheWriter> {
+
+   @Override
+   public CacheWriterService createService(String serviceName, CacheWriter instance) {
+      return new CacheWriterService(serviceName, instance);
+   }
+
+   @Override
+   public Class<CacheWriter> getServiceClass() {
+      return CacheWriter.class;
+   }
+
+   private static class CacheWriterService extends AbstractExtensionManagerService<CacheWriter> {
+      private CacheWriterService(String serviceName, CacheWriter CacheWriter) {
+         super(serviceName, CacheWriter);
+      }
+
+      @Override
+      public CacheWriter getValue() {
+         return extension;
+      }
+
+      @Override
+      public String getServiceTypeName() {
+         return "CacheWriter-service";
+      }
+   }
+
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/ExternalStoreExtensionProcessor.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/ExternalStoreExtensionProcessor.java
@@ -1,0 +1,33 @@
+package org.jboss.as.clustering.infinispan.cs.deployment;
+
+import org.infinispan.persistence.spi.ExternalStore;
+
+public final class ExternalStoreExtensionProcessor extends AbstractCacheStoreExtensionProcessor<ExternalStore> {
+
+   @Override
+   public ExternalStoreService createService(String serviceName, ExternalStore instance) {
+      return new ExternalStoreService(serviceName, instance);
+   }
+
+   @Override
+   public Class<ExternalStore> getServiceClass() {
+      return ExternalStore.class;
+   }
+
+   private static class ExternalStoreService extends AbstractExtensionManagerService<ExternalStore> {
+      private ExternalStoreService(String serviceName, ExternalStore ExternalStore) {
+         super(serviceName, ExternalStore);
+      }
+
+      @Override
+      public ExternalStore getValue() {
+         return extension;
+      }
+
+      @Override
+      public String getServiceTypeName() {
+         return "ExternalStore-service";
+      }
+   }
+
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/ServerExtensionDependenciesProcessor.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/deployment/ServerExtensionDependenciesProcessor.java
@@ -1,0 +1,89 @@
+package org.jboss.as.clustering.infinispan.cs.deployment;
+
+import org.infinispan.persistence.spi.AdvancedCacheLoader;
+import org.infinispan.persistence.spi.AdvancedCacheWriter;
+import org.infinispan.persistence.spi.AdvancedLoadWriteStore;
+import org.infinispan.persistence.spi.CacheLoader;
+import org.infinispan.persistence.spi.CacheWriter;
+import org.infinispan.persistence.spi.ExternalStore;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.ServicesAttachment;
+import org.jboss.as.server.deployment.module.ModuleDependency;
+import org.jboss.as.server.deployment.module.ModuleSpecification;
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+
+/**
+ * Adds dependency from deployed module to Infinispan core.
+ *
+ * @author Sebastian Laskawiec
+ * @since 7.2
+ */
+public class ServerExtensionDependenciesProcessor implements DeploymentUnitProcessor {
+
+   private static final ModuleIdentifier API = ModuleIdentifier.create("org.infinispan");
+
+   @Override
+   public void deploy(DeploymentPhaseContext ctx) throws DeploymentUnitProcessingException {
+      if (hasInfinispanExtensions(ctx)) {
+         DeploymentUnit deploymentUnit = ctx.getDeploymentUnit();
+         ModuleSpecification moduleSpec = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
+         ModuleLoader moduleLoader = Module.getBootModuleLoader();
+         moduleSpec.addSystemDependency(new ModuleDependency(moduleLoader, API, false, false, false, false));
+      }
+   }
+
+   private boolean hasInfinispanExtensions(DeploymentPhaseContext ctx) {
+      DeploymentUnit deploymentUnit = ctx.getDeploymentUnit();
+      ServicesAttachment sa = deploymentUnit.getAttachment(Attachments.SERVICES);
+      if (sa != null) {
+         return hasDeployableCache(sa);
+      }
+      return false;
+   }
+
+   @Override
+   public void undeploy(DeploymentUnit context) {
+      // No-op
+   }
+
+
+   private boolean hasDeployableCache(ServicesAttachment sa) {
+      return hasAdvancedCacheLoaders(sa) || hasAdvancedCacheWriters(sa) || hasAdvancedLoadWriteStores(sa) ||
+            hasCacheLoader(sa) || hasCacheWriter(sa) || hasExternalStores(sa);
+   }
+
+   private boolean hasAdvancedCacheLoaders(ServicesAttachment servicesAttachment) {
+      return hasExtension(servicesAttachment, AdvancedCacheLoader.class);
+   }
+
+   private boolean hasAdvancedCacheWriters(ServicesAttachment servicesAttachment) {
+      return hasExtension(servicesAttachment, AdvancedCacheWriter.class);
+   }
+
+   private boolean hasAdvancedLoadWriteStores(ServicesAttachment servicesAttachment) {
+      return hasExtension(servicesAttachment, AdvancedLoadWriteStore.class);
+   }
+
+   private boolean hasCacheLoader(ServicesAttachment servicesAttachment) {
+      return hasExtension(servicesAttachment, CacheLoader.class);
+   }
+
+   private boolean hasCacheWriter(ServicesAttachment servicesAttachment) {
+      return hasExtension(servicesAttachment, CacheWriter.class);
+   }
+
+   private boolean hasExternalStores(ServicesAttachment servicesAttachment) {
+      return hasExtension(servicesAttachment, ExternalStore.class);
+   }
+
+   private boolean hasExtension(ServicesAttachment servicesAttachment, Class<?> extensionClass) {
+      return !servicesAttachment.getServiceImplementations(extensionClass.getName()).isEmpty();
+   }
+
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/factory/DeployedCacheStoreFactory.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/factory/DeployedCacheStoreFactory.java
@@ -1,0 +1,66 @@
+package org.jboss.as.clustering.infinispan.cs.factory;
+
+import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.configuration.cache.StoreConfigurationBuilder;
+import org.infinispan.persistence.factory.CacheStoreFactory;
+import org.jboss.as.clustering.infinispan.cs.configuration.DeployedStoreConfiguration;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Cache Store factory designed for deployed instances.
+ *
+ * @author Sebastian Laskawiec
+ * @since 7.2
+ */
+public class DeployedCacheStoreFactory implements CacheStoreFactory {
+
+   private Map<String, DeployedCacheStoreMetadata> deployedCacheStores = Collections.synchronizedMap(new HashMap<String, DeployedCacheStoreMetadata>());
+
+   @Override
+   public <T> T createInstance(StoreConfiguration cfg) {
+      if(cfg instanceof DeployedStoreConfiguration) {
+         DeployedStoreConfiguration deployedConfiguration = (DeployedStoreConfiguration) cfg;
+         DeployedCacheStoreMetadata deployedCacheStoreMetadata = deployedCacheStores.get(deployedConfiguration.getCustomStoreClassName());
+         return (T) deployedCacheStoreMetadata.getLoaderWriterRawInstance();
+      }
+      return null;
+   }
+
+   @Override
+   public StoreConfiguration processConfiguration(StoreConfiguration storeConfiguration) {
+      if(storeConfiguration instanceof DeployedStoreConfiguration) {
+         DeployedStoreConfiguration deployedConfiguration = (DeployedStoreConfiguration) storeConfiguration;
+         PersistenceConfigurationBuilder replacedBuilder = deployedConfiguration.getPersistenceConfigurationBuilder();
+         DeployedCacheStoreMetadata deployedCacheStoreMetadata = deployedCacheStores.get(deployedConfiguration.getCustomStoreClassName());
+
+         if(deployedCacheStoreMetadata == null) {
+            throw new IllegalStateException("Could not find Deployed Cache metadata for " + deployedConfiguration.getCustomStoreClassName());
+         }
+
+         StoreConfigurationBuilder replacedStoreBuilder = replacedBuilder.addStore(deployedCacheStoreMetadata.getStoreBuilderClass());
+         replacedStoreBuilder.fetchPersistentState(deployedConfiguration.fetchPersistentState());
+         replacedStoreBuilder.ignoreModifications(deployedConfiguration.ignoreModifications());
+         replacedStoreBuilder.preload(deployedConfiguration.preload());
+         replacedStoreBuilder.purgeOnStartup(deployedConfiguration.purgeOnStartup());
+         replacedStoreBuilder.shared(deployedConfiguration.shared());
+         replacedStoreBuilder.withProperties(deployedConfiguration.properties());
+         StoreConfiguration replacedConfiguration = (StoreConfiguration) replacedStoreBuilder.create();
+
+         return replacedConfiguration;
+      }
+      return null;
+   }
+
+   public void addInstance(Object instance) {
+      DeployedCacheStoreMetadata deployedCacheStoreMetadata = DeployedCacheStoreMetadata.fromDeployedStoreInstance(instance);
+      deployedCacheStores.put(deployedCacheStoreMetadata.getDeployedCacheClassName(), deployedCacheStoreMetadata);
+   }
+
+   public void removeInstance(Object instance) {
+      deployedCacheStores.remove(instance.getClass().getName());
+   }
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/factory/DeployedCacheStoreFactoryService.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/factory/DeployedCacheStoreFactoryService.java
@@ -1,0 +1,32 @@
+package org.jboss.as.clustering.infinispan.cs.factory;
+
+import org.infinispan.persistence.factory.CacheStoreFactory;
+import org.jboss.as.clustering.infinispan.InfinispanLogger;
+import org.jboss.msc.service.*;
+
+/**
+ * Service wrapper for {@link org.jboss.as.clustering.infinispan.cs.factory.DeployedCacheStoreFactory}.
+ *
+ * @author Sebastian Laskawiec
+ */
+public class DeployedCacheStoreFactoryService implements Service<CacheStoreFactory> {
+
+   public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("DeployedCacheStoreFactoryService");
+
+   private final DeployedCacheStoreFactory internalImplementation = new DeployedCacheStoreFactory();
+
+   @Override
+   public void start(StartContext context) throws StartException {
+      InfinispanLogger.ROOT_LOGGER.debugf("Starting DeployedCacheStoreFactoryService " + internalImplementation);
+   }
+
+   @Override
+   public void stop(StopContext context) {
+      InfinispanLogger.ROOT_LOGGER.debugf("Stopping DeployedCacheStoreFactoryService " + internalImplementation);
+   }
+
+   @Override
+   public DeployedCacheStoreFactory getValue() throws IllegalStateException, IllegalArgumentException {
+      return internalImplementation;
+   }
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/factory/DeployedCacheStoreMetadata.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/cs/factory/DeployedCacheStoreMetadata.java
@@ -1,0 +1,81 @@
+package org.jboss.as.clustering.infinispan.cs.factory;
+
+import org.infinispan.commons.configuration.BuiltBy;
+import org.infinispan.commons.configuration.ConfiguredBy;
+import org.infinispan.configuration.cache.CustomStoreConfiguration;
+import org.infinispan.configuration.cache.CustomStoreConfigurationBuilder;
+import org.infinispan.configuration.cache.StoreConfiguration;
+import org.infinispan.configuration.cache.StoreConfigurationBuilder;
+
+/**
+ * Metadata for deployed Cache Store
+ *
+ * @author Sebastian Laskawiec
+ * @since 7.2
+ */
+public class DeployedCacheStoreMetadata {
+
+   private String loaderWriterInstanceName;
+   private Object loaderWriterRawInstance;
+   private Class<? extends StoreConfiguration> storeConfigurationClass;
+   private Class<? extends StoreConfigurationBuilder> storeBuilderClass;
+
+   public DeployedCacheStoreMetadata(Object loaderWriterRawInstance) {
+      this.loaderWriterRawInstance = loaderWriterRawInstance;
+      this.loaderWriterInstanceName = loaderWriterRawInstance.getClass().getName();
+   }
+
+   public static DeployedCacheStoreMetadata fromDeployedStoreInstance(Object loaderWriterRawInstance) {
+      DeployedCacheStoreMetadata ret = new DeployedCacheStoreMetadata(loaderWriterRawInstance);
+      ret.initializeConfigurationData();
+      return ret;
+   }
+
+   private void initializeConfigurationData() {
+      ConfiguredBy configuredBy = loaderWriterRawInstance.getClass().getAnnotation(ConfiguredBy.class);
+      if (configuredBy != null) {
+         if (configuredBy.value() == null) {
+            throw new IllegalArgumentException("Cache Store's configuration class is incorrect");
+         }
+         this.storeConfigurationClass = (Class<? extends StoreConfiguration>) configuredBy.value();
+         BuiltBy builtBy = storeConfigurationClass.getAnnotation(BuiltBy.class);
+         if (builtBy != null) {
+            if (builtBy.value() == null) {
+               throw new IllegalArgumentException("Cache Store's configuration builder class is incorrect");
+            }
+            this.storeBuilderClass = builtBy.value().asSubclass(StoreConfigurationBuilder.class);
+         } else {
+            this.storeBuilderClass = CustomStoreConfigurationBuilder.class;
+         }
+      } else {
+         this.storeConfigurationClass = CustomStoreConfiguration.class;
+         this.storeBuilderClass = CustomStoreConfigurationBuilder.class;
+      }
+   }
+
+   public String getDeployedCacheClassName() {
+      return loaderWriterInstanceName;
+   }
+
+   public Object getLoaderWriterRawInstance() {
+      return loaderWriterRawInstance;
+   }
+
+   public Class<? extends StoreConfiguration> getStoreConfigurationClass() {
+      return storeConfigurationClass;
+   }
+
+   public Class<? extends StoreConfigurationBuilder> getStoreBuilderClass() {
+      return storeBuilderClass;
+   }
+
+   @Override
+   public String toString() {
+      return "DeployedCacheStoreMetadata{" +
+            "loaderWriterInstanceName='" + loaderWriterInstanceName + '\'' +
+            ", loaderWriterRawInstance=" + loaderWriterRawInstance +
+            ", storeConfigurationClass=" + storeConfigurationClass +
+            ", storeBuilderClass=" + storeBuilderClass +
+            '}';
+   }
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheService.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheService.java
@@ -22,11 +22,11 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import javax.transaction.xa.XAResource;
-
 import org.infinispan.Cache;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.persistence.factory.CacheStoreFactory;
+import org.infinispan.persistence.factory.CacheStoreFactoryRegistry;
 import org.infinispan.server.infinispan.SecurityActions;
 import org.jboss.logging.Logger;
 import org.jboss.msc.service.Service;
@@ -35,6 +35,8 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StopContext;
 import org.jboss.tm.XAResourceRecovery;
 import org.jboss.tm.XAResourceRecoveryRegistry;
+
+import javax.transaction.xa.XAResource;
 
 /**
  * @author Paul Ferraro
@@ -56,6 +58,7 @@ public class CacheService<K, V> implements Service<Cache<K, V>> {
     public interface Dependencies {
         EmbeddedCacheManager getCacheContainer();
         XAResourceRecoveryRegistry getRecoveryRegistry();
+        CacheStoreFactory getDeployedCacheStoreFactory();
     }
 
     public CacheService(String name, Dependencies dependencies) {
@@ -76,7 +79,10 @@ public class CacheService<K, V> implements Service<Cache<K, V>> {
     public void start(StartContext context) {
         EmbeddedCacheManager container = this.dependencies.getCacheContainer();
 
-        this.cache = SecurityActions.startCache(container, this.name);
+       CacheStoreFactoryRegistry cacheStoreFactoryRegistry = container.getGlobalComponentRegistry().getComponent(CacheStoreFactoryRegistry.class);
+       cacheStoreFactoryRegistry.addCacheStoreFactory(this.dependencies.getDeployedCacheStoreFactory());
+
+       this.cache = SecurityActions.startCache(container, this.name);
 
         XAResourceRecoveryRegistry recoveryRegistry = this.dependencies.getRecoveryRegistry();
         if (recoveryRegistry != null) {

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemAdd.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemAdd.java
@@ -22,45 +22,78 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import static org.jboss.as.clustering.infinispan.InfinispanLogger.ROOT_LOGGER;
-
-import java.util.List;
-
+import org.jboss.as.clustering.infinispan.cs.deployment.AdvancedCacheLoaderExtensionProcessor;
+import org.jboss.as.clustering.infinispan.cs.deployment.AdvancedCacheWriterExtensionProcessor;
+import org.jboss.as.clustering.infinispan.cs.deployment.AdvancedLoadWriteStoreExtensionProcessor;
+import org.jboss.as.clustering.infinispan.cs.deployment.CacheLoaderExtensionProcessor;
+import org.jboss.as.clustering.infinispan.cs.deployment.CacheWriterExtensionProcessor;
+import org.jboss.as.clustering.infinispan.cs.deployment.ExternalStoreExtensionProcessor;
+import org.jboss.as.clustering.infinispan.cs.deployment.ServerExtensionDependenciesProcessor;
+import org.jboss.as.clustering.infinispan.cs.factory.DeployedCacheStoreFactoryService;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.server.AbstractDeploymentChainStep;
+import org.jboss.as.server.DeploymentProcessorTarget;
+import org.jboss.as.server.deployment.Phase;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
+
+import java.util.List;
+
+import static org.jboss.as.clustering.infinispan.InfinispanLogger.ROOT_LOGGER;
 
 /**
  * @author Paul Ferraro
  */
 public class InfinispanSubsystemAdd extends AbstractAddStepHandler {
 
-    public static final InfinispanSubsystemAdd INSTANCE = new InfinispanSubsystemAdd();
+   public static final InfinispanSubsystemAdd INSTANCE = new InfinispanSubsystemAdd();
+   private static final int POST_MODULE_PRIORITY = 0x1300;
+   private static final int DEPENDENCIES_PRIORITY_PRIORITY = 0x1300;
 
-    static ModelNode createOperation(ModelNode address, ModelNode existing) throws OperationFailedException {
-        ModelNode operation = Util.getEmptyOperation(ModelDescriptionConstants.ADD, address);
-        populate(existing, operation);
-        return operation;
-    }
+   private static final String INFINISPAN_SUBSYSTEM_NAME = "infinispan";
 
-    private static void populate(ModelNode source, ModelNode target) throws OperationFailedException {
-        target.get(ModelKeys.CACHE_CONTAINER).setEmptyObject();
-    }
+   static ModelNode createOperation(ModelNode address, ModelNode existing) throws OperationFailedException {
+      ModelNode operation = Util.getEmptyOperation(ModelDescriptionConstants.ADD, address);
+      populate(existing, operation);
+      return operation;
+   }
 
-    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
-        populate(operation, model);
-    }
+   private static void populate(ModelNode source, ModelNode target) throws OperationFailedException {
+      target.get(ModelKeys.CACHE_CONTAINER).setEmptyObject();
+   }
 
-    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
-        ROOT_LOGGER.activatingSubsystem();
-    }
+   protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
+      populate(operation, model);
+   }
 
-    protected boolean requiresRuntimeVerification() {
-        return false;
-    }
+   protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
+      ROOT_LOGGER.activatingSubsystem();
+      addDeployableCacheStoresProcessors(context);
+   }
+
+   private void addDeployableCacheStoresProcessors(OperationContext context) {
+      context.addStep(new AbstractDeploymentChainStep() {
+         protected void execute(DeploymentProcessorTarget processorTarget) {
+            int basePriority = POST_MODULE_PRIORITY;
+            processorTarget.addDeploymentProcessor(INFINISPAN_SUBSYSTEM_NAME, Phase.POST_MODULE, ++basePriority, new AdvancedCacheLoaderExtensionProcessor());
+            processorTarget.addDeploymentProcessor(INFINISPAN_SUBSYSTEM_NAME, Phase.POST_MODULE, ++basePriority, new AdvancedCacheWriterExtensionProcessor());
+            processorTarget.addDeploymentProcessor(INFINISPAN_SUBSYSTEM_NAME, Phase.POST_MODULE, ++basePriority, new AdvancedLoadWriteStoreExtensionProcessor());
+            processorTarget.addDeploymentProcessor(INFINISPAN_SUBSYSTEM_NAME, Phase.POST_MODULE, ++basePriority, new CacheLoaderExtensionProcessor());
+            processorTarget.addDeploymentProcessor(INFINISPAN_SUBSYSTEM_NAME, Phase.POST_MODULE, ++basePriority, new CacheWriterExtensionProcessor());
+            processorTarget.addDeploymentProcessor(INFINISPAN_SUBSYSTEM_NAME, Phase.POST_MODULE, ++basePriority, new ExternalStoreExtensionProcessor());
+            processorTarget.addDeploymentProcessor(INFINISPAN_SUBSYSTEM_NAME, Phase.DEPENDENCIES, DEPENDENCIES_PRIORITY_PRIORITY, new ServerExtensionDependenciesProcessor());
+         }
+      }, OperationContext.Stage.RUNTIME);
+
+      context.getServiceTarget().addService(DeployedCacheStoreFactoryService.SERVICE_NAME, new DeployedCacheStoreFactoryService()).install();
+   }
+
+   protected boolean requiresRuntimeVerification() {
+      return false;
+   }
 }

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/CustomStoreConfigurationBuilder.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/CustomStoreConfigurationBuilder.java
@@ -1,0 +1,196 @@
+package org.jboss.as.clustering.infinispan.cs.factory;
+
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.commons.configuration.Self;
+import org.infinispan.configuration.cache.AsyncStoreConfigurationBuilder;
+import org.infinispan.configuration.cache.ClusteringConfigurationBuilder;
+import org.infinispan.configuration.cache.CompatibilityModeConfigurationBuilder;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.CustomInterceptorsConfigurationBuilder;
+import org.infinispan.configuration.cache.DataContainerConfigurationBuilder;
+import org.infinispan.configuration.cache.DeadlockDetectionConfigurationBuilder;
+import org.infinispan.configuration.cache.EvictionConfigurationBuilder;
+import org.infinispan.configuration.cache.ExpirationConfigurationBuilder;
+import org.infinispan.configuration.cache.IndexingConfigurationBuilder;
+import org.infinispan.configuration.cache.InvocationBatchingConfigurationBuilder;
+import org.infinispan.configuration.cache.JMXStatisticsConfigurationBuilder;
+import org.infinispan.configuration.cache.LockingConfigurationBuilder;
+import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+import org.infinispan.configuration.cache.SecurityConfigurationBuilder;
+import org.infinispan.configuration.cache.SingletonStoreConfigurationBuilder;
+import org.infinispan.configuration.cache.SitesConfigurationBuilder;
+import org.infinispan.configuration.cache.StoreAsBinaryConfigurationBuilder;
+import org.infinispan.configuration.cache.StoreConfigurationBuilder;
+import org.infinispan.configuration.cache.TransactionConfigurationBuilder;
+import org.infinispan.configuration.cache.UnsafeConfigurationBuilder;
+import org.infinispan.configuration.cache.VersioningConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfiguration;
+
+import java.util.Properties;
+
+public class CustomStoreConfigurationBuilder implements StoreConfigurationBuilder {
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public Object create() {
+      return null;
+   }
+
+   @Override
+   public Builder<?> read(Object template) {
+      return null;
+   }
+
+   @Override
+   public AsyncStoreConfigurationBuilder async() {
+      return null;
+   }
+
+   @Override
+   public SingletonStoreConfigurationBuilder singleton() {
+      return null;
+   }
+
+   @Override
+   public Object fetchPersistentState(boolean b) {
+      return null;
+   }
+
+   @Override
+   public Object ignoreModifications(boolean b) {
+      return null;
+   }
+
+   @Override
+   public Object purgeOnStartup(boolean b) {
+      return null;
+   }
+
+   @Override
+   public Object preload(boolean b) {
+      return null;
+   }
+
+   @Override
+   public Object shared(boolean b) {
+      return null;
+   }
+
+   @Override
+   public Object addProperty(String key, String value) {
+      return null;
+   }
+
+   @Override
+   public Object withProperties(Properties p) {
+      return null;
+   }
+
+   @Override
+   public ClusteringConfigurationBuilder clustering() {
+      return null;
+   }
+
+   @Override
+   public CustomInterceptorsConfigurationBuilder customInterceptors() {
+      return null;
+   }
+
+   @Override
+   public DataContainerConfigurationBuilder dataContainer() {
+      return null;
+   }
+
+   @Override
+   public DeadlockDetectionConfigurationBuilder deadlockDetection() {
+      return null;
+   }
+
+   @Override
+   public EvictionConfigurationBuilder eviction() {
+      return null;
+   }
+
+   @Override
+   public ExpirationConfigurationBuilder expiration() {
+      return null;
+   }
+
+   @Override
+   public IndexingConfigurationBuilder indexing() {
+      return null;
+   }
+
+   @Override
+   public InvocationBatchingConfigurationBuilder invocationBatching() {
+      return null;
+   }
+
+   @Override
+   public JMXStatisticsConfigurationBuilder jmxStatistics() {
+      return null;
+   }
+
+   @Override
+   public PersistenceConfigurationBuilder persistence() {
+      return null;
+   }
+
+   @Override
+   public LockingConfigurationBuilder locking() {
+      return null;
+   }
+
+   @Override
+   public SecurityConfigurationBuilder security() {
+      return null;
+   }
+
+   @Override
+   public StoreAsBinaryConfigurationBuilder storeAsBinary() {
+      return null;
+   }
+
+   @Override
+   public TransactionConfigurationBuilder transaction() {
+      return null;
+   }
+
+   @Override
+   public VersioningConfigurationBuilder versioning() {
+      return null;
+   }
+
+   @Override
+   public UnsafeConfigurationBuilder unsafe() {
+      return null;
+   }
+
+   @Override
+   public SitesConfigurationBuilder sites() {
+      return null;
+   }
+
+   @Override
+   public CompatibilityModeConfigurationBuilder compatibility() {
+      return null;
+   }
+
+   @Override
+   public void validate(GlobalConfiguration globalConfig) {
+   }
+
+   @Override
+   public Configuration build() {
+      return null;
+   }
+
+   @Override
+   public Self self() {
+      return null;
+   }
+}

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/CustomStoreConfigurationWithBuilder.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/CustomStoreConfigurationWithBuilder.java
@@ -1,0 +1,53 @@
+package org.jboss.as.clustering.infinispan.cs.factory;
+
+import org.infinispan.commons.configuration.BuiltBy;
+import org.infinispan.configuration.cache.AsyncStoreConfiguration;
+import org.infinispan.configuration.cache.SingletonStoreConfiguration;
+import org.infinispan.configuration.cache.StoreConfiguration;
+
+import java.util.Properties;
+
+@BuiltBy(CustomStoreConfigurationBuilder.class)
+public class CustomStoreConfigurationWithBuilder implements StoreConfiguration {
+
+   @Override
+   public AsyncStoreConfiguration async() {
+      return null;
+   }
+
+   @Override
+   public SingletonStoreConfiguration singletonStore() {
+      return null;
+   }
+
+   @Override
+   public boolean purgeOnStartup() {
+      return false;
+   }
+
+   @Override
+   public boolean fetchPersistentState() {
+      return false;
+   }
+
+   @Override
+   public boolean ignoreModifications() {
+      return false;
+   }
+
+   @Override
+   public boolean preload() {
+      return false;
+   }
+
+   @Override
+   public boolean shared() {
+      return false;
+   }
+
+   @Override
+   public Properties properties() {
+      return null;
+   }
+
+}

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/CustomStoreConfigurationWithoutBuilder.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/CustomStoreConfigurationWithoutBuilder.java
@@ -1,0 +1,51 @@
+package org.jboss.as.clustering.infinispan.cs.factory;
+
+import org.infinispan.configuration.cache.AsyncStoreConfiguration;
+import org.infinispan.configuration.cache.SingletonStoreConfiguration;
+import org.infinispan.configuration.cache.StoreConfiguration;
+
+import java.util.Properties;
+
+public class CustomStoreConfigurationWithoutBuilder implements StoreConfiguration {
+
+   @Override
+   public AsyncStoreConfiguration async() {
+      return null;
+   }
+
+   @Override
+   public SingletonStoreConfiguration singletonStore() {
+      return null;
+   }
+
+   @Override
+   public boolean purgeOnStartup() {
+      return false;
+   }
+
+   @Override
+   public boolean fetchPersistentState() {
+      return false;
+   }
+
+   @Override
+   public boolean ignoreModifications() {
+      return false;
+   }
+
+   @Override
+   public boolean preload() {
+      return false;
+   }
+
+   @Override
+   public boolean shared() {
+      return false;
+   }
+
+   @Override
+   public Properties properties() {
+      return null;
+   }
+
+}

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/CustomStoreWithConfiguration.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/CustomStoreWithConfiguration.java
@@ -1,0 +1,44 @@
+package org.jboss.as.clustering.infinispan.cs.factory;
+
+import org.infinispan.commons.configuration.ConfiguredBy;
+import org.infinispan.filter.KeyFilter;
+import org.infinispan.marshall.core.MarshalledEntry;
+import org.infinispan.persistence.spi.AdvancedCacheLoader;
+import org.infinispan.persistence.spi.InitializationContext;
+
+import java.util.concurrent.Executor;
+
+@ConfiguredBy(CustomStoreConfigurationWithoutBuilder.class)
+public class CustomStoreWithConfiguration implements AdvancedCacheLoader<Object,Object> {
+
+   @Override
+   public void process(KeyFilter<? super Object> filter, CacheLoaderTask<Object, Object> task, Executor executor, boolean fetchValue, boolean fetchMetadata) {
+   }
+
+   @Override
+   public int size() {
+      return 0;
+   }
+
+   @Override
+   public void init(InitializationContext ctx) {
+   }
+
+   @Override
+   public MarshalledEntry<Object, Object> load(Object key) {
+      return null;
+   }
+
+   @Override
+   public boolean contains(Object key) {
+      return false;
+   }
+
+   @Override
+   public void start() {
+   }
+
+   @Override
+   public void stop() {
+   }
+}

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/CustomStoreWithConfigurationAndBuilder.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/CustomStoreWithConfigurationAndBuilder.java
@@ -1,0 +1,44 @@
+package org.jboss.as.clustering.infinispan.cs.factory;
+
+import org.infinispan.commons.configuration.ConfiguredBy;
+import org.infinispan.filter.KeyFilter;
+import org.infinispan.marshall.core.MarshalledEntry;
+import org.infinispan.persistence.spi.AdvancedCacheLoader;
+import org.infinispan.persistence.spi.InitializationContext;
+
+import java.util.concurrent.Executor;
+
+@ConfiguredBy(CustomStoreConfigurationWithBuilder.class)
+public class CustomStoreWithConfigurationAndBuilder implements AdvancedCacheLoader<Object,Object> {
+
+   @Override
+   public void process(KeyFilter<? super Object> filter, CacheLoaderTask<Object, Object> task, Executor executor, boolean fetchValue, boolean fetchMetadata) {
+   }
+
+   @Override
+   public int size() {
+      return 0;
+   }
+
+   @Override
+   public void init(InitializationContext ctx) {
+   }
+
+   @Override
+   public MarshalledEntry<Object, Object> load(Object key) {
+      return null;
+   }
+
+   @Override
+   public boolean contains(Object key) {
+      return false;
+   }
+
+   @Override
+   public void start() {
+   }
+
+   @Override
+   public void stop() {
+   }
+}

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/CustomStoreWithoutConfiguration.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/CustomStoreWithoutConfiguration.java
@@ -1,0 +1,42 @@
+package org.jboss.as.clustering.infinispan.cs.factory;
+
+import org.infinispan.filter.KeyFilter;
+import org.infinispan.marshall.core.MarshalledEntry;
+import org.infinispan.persistence.spi.AdvancedCacheLoader;
+import org.infinispan.persistence.spi.InitializationContext;
+
+import java.util.concurrent.Executor;
+
+public class CustomStoreWithoutConfiguration implements AdvancedCacheLoader<Object,Object> {
+
+   @Override
+   public void process(KeyFilter<? super Object> filter, CacheLoaderTask<Object, Object> task, Executor executor, boolean fetchValue, boolean fetchMetadata) {
+   }
+
+   @Override
+   public int size() {
+      return 0;
+   }
+
+   @Override
+   public void init(InitializationContext ctx) {
+   }
+
+   @Override
+   public MarshalledEntry<Object, Object> load(Object key) {
+      return null;
+   }
+
+   @Override
+   public boolean contains(Object key) {
+      return false;
+   }
+
+   @Override
+   public void start() {
+   }
+
+   @Override
+   public void stop() {
+   }
+}

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/DeployedCacheStoreMetadataTest.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/DeployedCacheStoreMetadataTest.java
@@ -1,0 +1,51 @@
+package org.jboss.as.clustering.infinispan.cs.factory;
+
+import org.infinispan.configuration.cache.CustomStoreConfiguration;
+import org.infinispan.configuration.cache.CustomStoreConfigurationBuilder;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DeployedCacheStoreMetadataTest {
+
+   @Test
+   public void testImportingMetadataWithLoaderWriterClassOnly() throws Exception {
+      //given
+      Object loaderWriterRawInstance = new CustomStoreWithoutConfiguration();
+
+      //when
+      DeployedCacheStoreMetadata deployedCacheStoreMetadata = DeployedCacheStoreMetadata.fromDeployedStoreInstance(loaderWriterRawInstance);
+
+      //then
+      assertEquals(CustomStoreConfiguration.class, deployedCacheStoreMetadata.getStoreConfigurationClass());
+      assertEquals(CustomStoreConfigurationBuilder.class, deployedCacheStoreMetadata.getStoreBuilderClass());
+      assertEquals(loaderWriterRawInstance, deployedCacheStoreMetadata.getLoaderWriterRawInstance());
+      assertEquals(loaderWriterRawInstance.getClass().getName(), deployedCacheStoreMetadata.getDeployedCacheClassName());
+   }
+
+   @Test
+   public void testImportingMetadataWithLoaderWriterWithConfiguration() throws Exception {
+      //given
+      Object loaderWriterRawInstance = new CustomStoreWithConfiguration();
+
+      //when
+      DeployedCacheStoreMetadata deployedCacheStoreMetadata = DeployedCacheStoreMetadata.fromDeployedStoreInstance(loaderWriterRawInstance);
+
+      //then
+      assertEquals(CustomStoreConfigurationWithoutBuilder.class, deployedCacheStoreMetadata.getStoreConfigurationClass());
+      assertEquals(CustomStoreConfigurationBuilder.class, deployedCacheStoreMetadata.getStoreBuilderClass());
+   }
+
+   @Test
+   public void testImportingMetadataWithLoaderWriterWithConfigurationAndBuilder() throws Exception {
+      //given
+      Object loaderWriterRawInstance = new CustomStoreWithConfigurationAndBuilder();
+
+      //when
+      DeployedCacheStoreMetadata deployedCacheStoreMetadata = DeployedCacheStoreMetadata.fromDeployedStoreInstance(loaderWriterRawInstance);
+
+      //then
+      assertEquals(CustomStoreConfigurationWithBuilder.class, deployedCacheStoreMetadata.getStoreConfigurationClass());
+      assertEquals(org.jboss.as.clustering.infinispan.cs.factory.CustomStoreConfigurationBuilder.class, deployedCacheStoreMetadata.getStoreBuilderClass());
+   }
+}

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/MyCustomStore.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/MyCustomStore.java
@@ -1,0 +1,59 @@
+package org.jboss.as.clustering.infinispan.cs.factory;
+
+import org.infinispan.filter.KeyFilter;
+import org.infinispan.marshall.core.MarshalledEntry;
+import org.infinispan.persistence.spi.AdvancedLoadWriteStore;
+import org.infinispan.persistence.spi.InitializationContext;
+
+import java.util.concurrent.Executor;
+
+public class MyCustomStore implements AdvancedLoadWriteStore {
+
+   @Override
+   public void process(KeyFilter filter, CacheLoaderTask task, Executor executor, boolean fetchValue, boolean fetchMetadata) {
+   }
+
+   @Override
+   public int size() {
+      return 0;
+   }
+
+   @Override
+   public void clear() {
+   }
+
+   @Override
+   public void purge(Executor threadPool, PurgeListener listener) {
+   }
+
+   @Override
+   public void init(InitializationContext ctx) {
+   }
+
+   @Override
+   public void write(MarshalledEntry entry) {
+   }
+
+   @Override
+   public boolean delete(Object key) {
+      return false;
+   }
+
+   @Override
+   public MarshalledEntry load(Object key) {
+      return null;
+   }
+
+   @Override
+   public boolean contains(Object key) {
+      return false;
+   }
+
+   @Override
+   public void start() {
+   }
+
+   @Override
+   public void stop() {
+   }
+}

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/MyCustomStoreConfiguration.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/MyCustomStoreConfiguration.java
@@ -1,0 +1,52 @@
+package org.jboss.as.clustering.infinispan.cs.factory;
+
+import org.infinispan.commons.configuration.ConfigurationFor;
+import org.infinispan.configuration.cache.AsyncStoreConfiguration;
+import org.infinispan.configuration.cache.SingletonStoreConfiguration;
+import org.infinispan.configuration.cache.StoreConfiguration;
+
+import java.util.Properties;
+
+@ConfigurationFor(MyCustomStore.class)
+public class MyCustomStoreConfiguration implements StoreConfiguration {
+
+   @Override
+   public AsyncStoreConfiguration async() {
+      return null;
+   }
+
+   @Override
+   public SingletonStoreConfiguration singletonStore() {
+      return null;
+   }
+
+   @Override
+   public boolean purgeOnStartup() {
+      return false;
+   }
+
+   @Override
+   public boolean fetchPersistentState() {
+      return false;
+   }
+
+   @Override
+   public boolean ignoreModifications() {
+      return false;
+   }
+
+   @Override
+   public boolean preload() {
+      return false;
+   }
+
+   @Override
+   public boolean shared() {
+      return false;
+   }
+
+   @Override
+   public Properties properties() {
+      return null;
+   }
+}

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/cs/custom/CustomCacheStoreIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/cs/custom/CustomCacheStoreIT.java
@@ -1,18 +1,5 @@
 package org.infinispan.server.test.cs.custom;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
-import java.util.zip.ZipOutputStream;
-
-import javax.management.ObjectName;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServer;
 import org.infinispan.arquillian.core.RunningServer;
@@ -20,107 +7,67 @@ import org.infinispan.arquillian.core.WithRunningServer;
 import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.persistence.cluster.MyCustomCacheStore;
+import org.infinispan.persistence.spi.ExternalStore;
 import org.infinispan.server.test.category.CacheStore;
 import org.infinispan.server.test.util.ITestUtils;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.management.ObjectName;
+import java.io.File;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 /**
- * Tests custom cache store configuration. Store classes are copied into infinispan-core jar before the server is started.
+ * Tests Deployeable Cache Stores which are placed into server deployments directory.
  *
  * @author <a href="mailto:jmarkos@redhat.com">Jakub Markos</a>
- *
+ * @author Sebastian Laskawiec
  */
 @RunWith(Arquillian.class)
 @Category({CacheStore.class})
 public class CustomCacheStoreIT {
 
-    @InfinispanResource("standalone-customcs")
-    RemoteInfinispanServer server;
+   @InfinispanResource("standalone-customcs")
+   RemoteInfinispanServer server;
 
-    final int managementPort = 9990;
-    final String cacheLoaderMBean = "jboss.infinispan:type=Cache,name=\"default(local)\",manager=\"local\",component=CacheLoader";
+   final int managementPort = 9990;
+   final String cacheLoaderMBean = "jboss.infinispan:type=Cache,name=\"default(local)\",manager=\"local\",component=CacheLoader";
 
-    @BeforeClass
-    public static void before() {
-        // need to put the brno loader classes into ispn core jar, so ispn can see them
-        String serverDir = System.getProperty("server1.dist");
-        File ispnCoreJarDir = new File(serverDir + "/modules/system/layers/base/org/infinispan/main/");
-        FileFilter ispnCoreJarFilter = new WildcardFileFilter("infinispan-core*.jar");
-        File ispnCoreJar = ispnCoreJarDir.listFiles(ispnCoreJarFilter)[0];
+   @BeforeClass
+   public static void before() throws Exception {
+      String serverDir = System.getProperty("server1.dist");
 
-        String customLoaderClassesDir = System.getProperty("basedir") + "/target/test-classes/org/infinispan/persistence/cluster/";
-        File[] csClasses = {new File(customLoaderClassesDir + "MyCustomCacheStore.class"),
-                            new File(customLoaderClassesDir + "MyCustomCacheStoreConfiguration.class"),
-                            new File(customLoaderClassesDir + "MyCustomCacheStoreConfigurationBuilder.class")};
-        addFilesToZip(ispnCoreJar, csClasses, "org/infinispan/persistence/cluster/");
-    }
+      JavaArchive deployedCacheStore = ShrinkWrap.create(JavaArchive.class);
+      deployedCacheStore.addPackage(MyCustomCacheStore.class.getPackage());
+      deployedCacheStore.addAsServiceProvider(ExternalStore.class, MyCustomCacheStore.class);
 
-    @Test
-    @WithRunningServer({@RunningServer(name = "standalone-customcs")})
-    public void test() throws Exception {
-        RemoteCacheManager rcm = ITestUtils.createCacheManager(server);
-        RemoteCache<String, String> rc = rcm.getCache();
-        assertNull(rc.get("key1"));
-        rc.put("key1", "value1");
-        assertEquals("value1", rc.get("key1"));
-        // check via jmx that MyCustomCacheStore is indeed used
-        MBeanServerConnectionProvider provider = new MBeanServerConnectionProvider(server.getHotrodEndpoint().getInetAddress().getHostName(), managementPort);
-        assertEquals("[org.infinispan.persistence.cluster.MyCustomCacheStore]", getAttribute(provider, cacheLoaderMBean, "stores"));
-    }
+      deployedCacheStore.as(ZipExporter.class).exportTo(
+            new File(serverDir, "/standalone/deployments/custom-store.jar"), true);
+   }
 
-    private String getAttribute(MBeanServerConnectionProvider provider, String mbean, String attr) throws Exception {
-        return provider.getConnection().getAttribute(new ObjectName(mbean), attr).toString();
-    }
+   @Test
+   @WithRunningServer({@RunningServer(name = "standalone-customcs")})
+   public void testIfDeployedCacheContainsProperValues() throws Exception {
+      RemoteCacheManager rcm = ITestUtils.createCacheManager(server);
+      RemoteCache<String, String> rc = rcm.getCache();
+      assertNull(rc.get("key1"));
+      rc.put("key1", "value1");
+      assertEquals("value1", rc.get("key1"));
+      // check via jmx that MyCustomCacheStore is indeed used
+      MBeanServerConnectionProvider provider = new MBeanServerConnectionProvider(server.getHotrodEndpoint().getInetAddress().getHostName(), managementPort);
+      assertEquals("[org.infinispan.persistence.cluster.MyCustomCacheStore]", getAttribute(provider, cacheLoaderMBean, "stores"));
+   }
 
-    /*
-    * Credit goes to user577732 - http://stackoverflow.com/a/9305091/2064880 (slightly modified)
-    */
-    public static void addFilesToZip(File source, File[] files, String path){
-        try{
-            File tmpZip = new File(source.getAbsolutePath()+".tmp");
-            FileUtils.copyFile(source, tmpZip);
-
-            byte[] buffer = new byte[4096];
-            ZipInputStream zin = new ZipInputStream(new FileInputStream(tmpZip));
-            ZipOutputStream out = new ZipOutputStream(new FileOutputStream(source));
-            for(int i = 0; i < files.length; i++){
-                InputStream in = new FileInputStream(files[i]);
-                out.putNextEntry(new ZipEntry(path + files[i].getName()));
-                for(int read = in.read(buffer); read > -1; read = in.read(buffer)){
-                    out.write(buffer, 0, read);
-                }
-                out.closeEntry();
-                in.close();
-            }
-            for(ZipEntry ze = zin.getNextEntry(); ze != null; ze = zin.getNextEntry()){
-                if(!zipEntryMatch(ze.getName(), files, path)){
-                    out.putNextEntry(ze);
-                    for(int read = zin.read(buffer); read > -1; read = zin.read(buffer)){
-                        out.write(buffer, 0, read);
-                    }
-                    out.closeEntry();
-                }
-            }
-            out.close();
-            tmpZip.delete();
-        }catch(Exception e){
-            e.printStackTrace();
-        }
-    }
-
-   public static boolean zipEntryMatch(String zeName, File[] files, String path){
-        for(int i = 0; i < files.length; i++){
-            if((path + files[i].getName()).equals(zeName)){
-                return true;
-            }
-        }
-        return false;
-    }
+   private String getAttribute(MBeanServerConnectionProvider provider, String mbean, String attr) throws Exception {
+      return provider.getConnection().getAttribute(new ObjectName(mbean), attr).toString();
+   }
 }


### PR DESCRIPTION
Hey!

Please take a look at proposed implementation of https://issues.jboss.org/browse/ISPN-5131

Key features:
* Introduced `CacheStoreFactory` and `CacheStoreFactoryRegistry` in order to control Cache Stores instantiation in pluggable fashion
* Added processors for all kind of Custom Cache Stores in Infinispan subsystem
* Added `DeployedStoreConfiguration` and `DeployedStoreConfigurationBuilder` to allow lazy instantiation of Custom Stores

How it works?
* At first we create add `DeployedCacheStoreFactory` to `CacheStoreFactoryRegistry`. From that point on, each time `PersistenceManagerImpl` wants to create a new Cache Loader/Writer - it also scans deployed stores.
* In `POST_MODULE` phase we discover Deployed Cache Stores (it happens before installing main Infinispan services) and add them to `DeployedCacheStoreFactory`. From that point `PersistenceManagerImpl` will be able to "see" them.
* Finally we use `DeployedStoreConfiguration` and `DeployedStoreConfigurationBuilder` to delay initialization of Deployed Cache Stores (because their classes might not be initialized yet).

Thanks!