### PR TITLE
ISPN-5283 HotRod client should try to recover from full shutdowns

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
@@ -227,7 +227,7 @@ public class Codec10 implements Codec {
          localLog.newTopology(transport.getRemoteSocketAddress(), newTopologyId,
                socketAddresses.size(), socketAddresses);
       }
-      transport.getTransportFactory().updateServers(socketAddresses, cacheName);
+      transport.getTransportFactory().updateServers(socketAddresses, cacheName, false);
       if (hashFunctionVersion == 0) {
          localLog.trace("Not using a consistent hash function (hash function version == 0).");
       } else {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
@@ -387,7 +387,7 @@ public class Codec20 implements Codec, HotRodConstants {
          localLog.newTopology(transport.getRemoteSocketAddress(), newTopologyId,
                addresses.length, new HashSet<SocketAddress>(addressList));
       }
-      transport.getTransportFactory().updateServers(addressList, cacheName);
+      transport.getTransportFactory().updateServers(addressList, cacheName, false);
       if (hashFunctionVersion == 0) {
          if (trace)
             localLog.trace("Not using a consistent hash function (hash function version == 0).");

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
@@ -28,7 +28,7 @@ public interface TransportFactory {
 
    void start(Codec codec, Configuration configuration, AtomicInteger topologyId, ClientListenerNotifier listenerNotifier);
 
-   void updateServers(Collection<SocketAddress> newServers, byte[] cacheName);
+   void updateServers(Collection<SocketAddress> newServers, byte[] cacheName, boolean quiet);
 
    void destroy();
 
@@ -57,4 +57,6 @@ public interface TransportFactory {
    void invalidateTransport(SocketAddress serverAddress, Transport transport);
 
    SSLContext getSSLContext();
+
+   void reset(byte[] cacheName);
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AsymmetricRoutingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AsymmetricRoutingTest.java
@@ -81,7 +81,7 @@ public class AsymmetricRoutingTest extends HitsAwareCacheManagersTest {
       cm.defineConfiguration(DIST_ONE_CACHE_NAME, distOneBuilder.build());
       cm.defineConfiguration(DIST_TWO_CACHE_NAME, distTwoBuilder.build());
       HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cm);
-      hrServ2CacheManager.put(new InetSocketAddress(server.getHost(), server.getPort()), cm);
+      addr2hrServer.put(new InetSocketAddress(server.getHost(), server.getPort()), server);
       return server;
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CSAIntegrationTest.java
@@ -63,11 +63,11 @@ public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
       addClusterEnabledCacheManager(builder);
 
       hotRodServer1 = HotRodClientTestingUtil.startHotRodServer(manager(0));
-      hrServ2CacheManager.put(new InetSocketAddress(hotRodServer1.getHost(), hotRodServer1.getPort()), manager(0));
+      addr2hrServer.put(new InetSocketAddress(hotRodServer1.getHost(), hotRodServer1.getPort()), hotRodServer1);
       hotRodServer2 = HotRodClientTestingUtil.startHotRodServer(manager(1));
-      hrServ2CacheManager.put(new InetSocketAddress(hotRodServer2.getHost(), hotRodServer2.getPort()), manager(1));
+      addr2hrServer.put(new InetSocketAddress(hotRodServer2.getHost(), hotRodServer2.getPort()), hotRodServer2);
       hotRodServer3 = HotRodClientTestingUtil.startHotRodServer(manager(2));
-      hrServ2CacheManager.put(new InetSocketAddress(hotRodServer3.getHost(), hotRodServer3.getPort()), manager(2));
+      addr2hrServer.put(new InetSocketAddress(hotRodServer3.getHost(), hotRodServer3.getPort()), hotRodServer3);
 
       assert manager(0).getCache() != null;
       assert manager(1).getCache() != null;
@@ -124,8 +124,8 @@ public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
          byte[] key = generateKey(i);
          TcpTransport transport = (TcpTransport) tcpConnectionFactory.getTransport(key, null, RemoteCacheManager.cacheNameBytes());
          SocketAddress serverAddress = transport.getServerAddress();
-         CacheContainer cacheContainer = hrServ2CacheManager.get(serverAddress);
-         assertNotNull("For server address " + serverAddress + " found " + cacheContainer + ". Map is: " + hrServ2CacheManager, cacheContainer);
+         CacheContainer cacheContainer = addr2hrServer.get(serverAddress).getCacheManager();
+         assertNotNull("For server address " + serverAddress + " found " + cacheContainer + ". Map is: " + addr2hrServer, cacheContainer);
          DistributionManager distributionManager = cacheContainer.getCache().getAdvancedCache().getDistributionManager();
          Address clusterAddress = cacheContainer.getCache().getAdvancedCache().getRpcManager().getAddress();
 
@@ -149,7 +149,7 @@ public class CSAIntegrationTest extends HitsAwareCacheManagersTest {
          String keyStr = new String(key);
          remoteCache.put(keyStr, "value");
          TcpTransport transport = (TcpTransport) tcpConnectionFactory.getTransport(marshall(keyStr), null, RemoteCacheManager.cacheNameBytes());
-         assertHotRodEquals(hrServ2CacheManager.get(transport.getServerAddress()), keyStr, "value");
+         assertHotRodEquals(addr2hrServer.get(transport.getServerAddress()).getCacheManager(), keyStr, "value");
          tcpConnectionFactory.releaseTransport(transport);
       }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HitsAwareCacheManagersTest.java
@@ -1,20 +1,32 @@
 package org.infinispan.client.hotrod;
 
 import org.infinispan.Cache;
+import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.commands.VisitableCommand;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.interceptors.base.CommandInterceptor;
+import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
+import org.infinispan.server.hotrod.test.HotRodTestingUtil;
 import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 import org.testng.annotations.BeforeMethod;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
+import static org.infinispan.test.TestingUtil.*;
 
 /**
  * @author Mircea.Markus@jboss.com
@@ -22,14 +34,79 @@ import java.util.Map;
  */
 public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTest {
 
-   protected Map<SocketAddress, EmbeddedCacheManager> hrServ2CacheManager = new HashMap<SocketAddress, EmbeddedCacheManager>();
-   protected Map<SocketAddress, HotRodServer> addr2hrServer = new HashMap<SocketAddress, HotRodServer>();
+   protected Map<SocketAddress, HotRodServer> addr2hrServer = new LinkedHashMap<SocketAddress, HotRodServer>();
+   protected List<RemoteCacheManager> clients = new ArrayList<RemoteCacheManager>();
+
+   protected void createHotRodServers(int num, ConfigurationBuilder defaultBuilder) {
+      // Start Hot Rod servers
+      for (int i = 0; i < num; i++) addHotRodServer(defaultBuilder);
+      // Verify that default caches should be started
+      for (int i = 0; i < num; i++) assert manager(i).getCache() != null;
+      // Block until views have been received
+      blockUntilViewReceived(manager(0).getCache(), num);
+      // Verify that caches running
+      for (int i = 0; i < num; i++) {
+         blockUntilCacheStatusAchieved(
+            manager(i).getCache(), ComponentStatus.RUNNING, 10000);
+      }
+
+      // Add hits tracking interceptors
+      addInterceptors();
+
+      for (int i = 0; i < num; i++) {
+         clients.add(createClient());
+      }
+   }
+
+   protected RemoteCacheManager client(int i) {
+      return clients.get(i);
+   }
+
+   protected RemoteCacheManager createClient() {
+      return new RemoteCacheManager(createHotRodClientConfigurationBuilder(
+         addr2hrServer.values().iterator().next().getPort()).build());
+   }
+
+   protected org.infinispan.client.hotrod.configuration.ConfigurationBuilder createHotRodClientConfigurationBuilder(int serverPort) {
+      org.infinispan.client.hotrod.configuration.ConfigurationBuilder clientBuilder = new org.infinispan.client.hotrod.configuration.ConfigurationBuilder();
+      clientBuilder.addServer()
+         .host("localhost")
+         .port(serverPort)
+         .pingOnStartup(false);
+      return clientBuilder;
+   }
+
+   protected HotRodServer addHotRodServer(ConfigurationBuilder builder) {
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder);
+      HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cm);
+      InetSocketAddress addr = new InetSocketAddress(server.getHost(), server.getPort());
+      addr2hrServer.put(addr, server);
+      return server;
+   }
+
+   protected HotRodServer addHotRodServer(ConfigurationBuilder builder, int port) {
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder);
+      HotRodServer server = HotRodTestingUtil.startHotRodServer(
+         cm, port, new HotRodServerConfigurationBuilder());
+      InetSocketAddress addr = new InetSocketAddress(server.getHost(), server.getPort());
+      addr2hrServer.put(addr, server);
+      return server;
+   }
+
+   protected void killServer() {
+      Iterator<HotRodServer> it = addr2hrServer.values().iterator();
+      HotRodServer server = it.next();
+      EmbeddedCacheManager cm = server.getCacheManager();
+      it.remove();
+      killServers(server);
+      killCacheManagers(cm);
+      cacheManagers.remove(cm);
+   }
 
    @Override
    @BeforeMethod(alwaysRun=true)
    public void createBeforeMethod() throws Throwable {
       if (cleanupAfterMethod()) {
-         hrServ2CacheManager.clear();
          addr2hrServer.clear();
       }
       super.createBeforeMethod();
@@ -55,13 +132,13 @@ public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTe
    }
 
    protected void assertServerHit(SocketAddress serverAddress, String cacheName, int expectedHits) {
-      CacheContainer cacheContainer = hrServ2CacheManager.get(serverAddress);
+      CacheContainer cacheContainer = addr2hrServer.get(serverAddress).getCacheManager();
       HitCountInterceptor interceptor = getHitCountInterceptor(namedCache(cacheName, cacheContainer));
       assert interceptor.getHits() == expectedHits :
             "Expected " + expectedHits + " hit(s) for " + serverAddress + " but received " + interceptor.getHits();
-      for (CacheContainer cm : hrServ2CacheManager.values()) {
-         if (cm != cacheContainer) {
-            interceptor = getHitCountInterceptor(namedCache(cacheName, cm));
+      for (HotRodServer server : addr2hrServer.values()) {
+         if (server.getCacheManager() != cacheContainer) {
+            interceptor = getHitCountInterceptor(namedCache(cacheName, server.getCacheManager()));
             assert interceptor.getHits() == 0 :
                   "Expected 0 hits in " + serverAddress + " but got " + interceptor.getHits();
          }
@@ -73,8 +150,8 @@ public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTe
    }
 
    protected void assertNoHits() {
-      for (CacheContainer cm : hrServ2CacheManager.values()) {
-         HitCountInterceptor interceptor = getHitCountInterceptor(cm.getCache());
+      for (HotRodServer server : addr2hrServer.values()) {
+         HitCountInterceptor interceptor = getHitCountInterceptor(server.getCacheManager().getCache());
          assert interceptor.getHits() == 0 : "Expected 0 hits but got " + interceptor.getHits();
       }
    }
@@ -113,12 +190,14 @@ public abstract class HitsAwareCacheManagersTest extends MultipleCacheManagersTe
     * @since 4.1
     */
    public static class HitCountInterceptor extends CommandInterceptor{
+      private static final Log log = LogFactory.getLog(HitCountInterceptor.class);
 
       private volatile int invocationCount;
 
       @Override
       protected Object handleDefault(InvocationContext ctx, VisitableCommand command) throws Throwable {
          if (ctx.isOriginLocal()) {
+            log.infof("Increment hit count after being visited by %s", command);
             invocationCount ++;
          }
          return super.handleDefault(ctx, command);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SocketTimeoutErrorTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SocketTimeoutErrorTest.java
@@ -98,6 +98,7 @@ public class SocketTimeoutErrorTest extends SingleCacheManagerTest {
       public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) throws Throwable {
          if (unmarshall(command.getKey()).equals("FailFailFail")) {
             Thread.sleep(6000);
+            return null;
          }
 
          return super.visitPutKeyValueCommand(ctx, command);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/AbstractRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/AbstractRetryTest.java
@@ -56,16 +56,16 @@ public abstract class AbstractRetryTest extends HitsAwareCacheManagersTest {
       registerCacheManager(cm3);
 
       hotRodServer1 = HotRodClientTestingUtil.startHotRodServer(manager(0));
-      hrServ2CacheManager.put(getAddress(hotRodServer1), cm1);
+      addr2hrServer.put(getAddress(hotRodServer1), hotRodServer1);
       hotRodServer2 = HotRodClientTestingUtil.startHotRodServer(manager(1));
-      hrServ2CacheManager.put(getAddress(hotRodServer2), cm2);
+      addr2hrServer.put(getAddress(hotRodServer2), hotRodServer2);
       hotRodServer3 = HotRodClientTestingUtil.startHotRodServer(manager(2));
-      hrServ2CacheManager.put(getAddress(hotRodServer3), cm3);
+      addr2hrServer.put(getAddress(hotRodServer3), hotRodServer3);
 
       waitForClusterToForm();
 
       Properties clientConfig = new Properties();
-      clientConfig.put("infinispan.client.hotrod.server_list", "localhost:" + hotRodServer2.getPort());
+      clientConfig.put("infinispan.client.hotrod.server_list", "localhost:" + hotRodServer1.getPort());
       clientConfig.put("infinispan.client.hotrod.force_return_values", "true");
       clientConfig.put("infinispan.client.hotrod.connect_timeout", "5");
       clientConfig.put("maxActive",1); //this ensures that only one server is active at a time
@@ -93,7 +93,7 @@ public abstract class AbstractRetryTest extends HitsAwareCacheManagersTest {
 
    protected AdvancedCache<?, ?> nextCacheToHit() {
       SocketAddress expectedServer = strategy.getServers()[strategy.getNextPosition()];
-      return hrServ2CacheManager.get(expectedServer).getCache().getAdvancedCache();
+      return addr2hrServer.get(expectedServer).getCacheManager().getCache().getAdvancedCache();
    }
 
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/CompleteShutdownReplRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/CompleteShutdownReplRetryTest.java
@@ -1,0 +1,55 @@
+package org.infinispan.client.hotrod.retry;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.exceptions.TransportException;
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.testng.annotations.Test;
+
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.fail;
+
+@Test(groups = "functional", testName = "client.hotrod.retry.CompleteShutdownRetryTest")
+public class CompleteShutdownReplRetryTest extends MultiHotRodServersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      // Empty
+   }
+
+   public void testRetryAfterCompleteShutdown() {
+      ConfigurationBuilder builder = hotRodCacheConfiguration(
+         getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false));
+      createHotRodServers(3, builder);
+      try {
+         int initialServerPort = server(0).getPort();
+
+         assertClusterSize("Cluster should be formed", 3);
+
+         RemoteCache<Integer, String> client = client(0).getCache();
+         client.put(1, "one");
+         assertEquals("one", client.get(1));
+
+         killServer(0);
+         assertEquals("one", client.get(1));
+         killServer(0);
+         assertEquals("one", client.get(1));
+         killServer(0);
+         try {
+            assertEquals("one", client.get(1));
+            fail("Should have thrown exception");
+         } catch (TransportException e) {
+            // Ignore, expected
+         }
+
+         addHotRodServer(builder, initialServerPort);
+         client.put(1, "one");
+         assertEquals("one", client.get(1));
+      } finally {
+         destroy();
+      }
+   }
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/RetryOnFailureUnitTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/RetryOnFailureUnitTest.java
@@ -61,7 +61,8 @@ public class RetryOnFailureUnitTest {
          //ignore
       }
       if (failOnTransport) {
-         assertEquals("Wrong getTransport() invocation.", maxRetry + 1, mockOperation.transportInvocationCount.get());
+         // Number of retries doubles as a result of dealing with complete shutdown recoveries
+         assertEquals("Wrong getTransport() invocation.", (maxRetry + 1) * 2, mockOperation.transportInvocationCount.get());
          assertEquals("Wrong execute() invocation.", 0, mockOperation.executeInvocationCount.get());
       } else {
          assertEquals("Wrong getTransport() invocation.", maxRetry + 1, mockOperation.transportInvocationCount.get());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
@@ -5,6 +5,8 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
+import org.infinispan.server.hotrod.test.HotRodTestingUtil;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -12,8 +14,10 @@ import org.testng.annotations.AfterMethod;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.test.TestingUtil.blockUntilCacheStatusAchieved;
 import static org.infinispan.test.TestingUtil.blockUntilViewReceived;
+import static org.infinispan.test.TestingUtil.killCacheManagers;
 
 /**
  * Base test class for Hot Rod tests.
@@ -83,8 +87,24 @@ public abstract class MultiHotRodServersTest extends MultipleCacheManagersTest {
       return server;
    }
 
+   protected HotRodServer addHotRodServer(ConfigurationBuilder builder, int port) {
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder);
+      HotRodServer server = HotRodTestingUtil.startHotRodServer(
+         cm, port, new HotRodServerConfigurationBuilder());
+      servers.add(server);
+      return server;
+   }
+
    protected HotRodServer server(int i) {
       return servers.get(i);
+   }
+
+   protected void killServer(int i) {
+      HotRodServer server = servers.get(i);
+      killServers(server);
+      servers.remove(i);
+      killCacheManagers(cacheManagers.get(i));
+      cacheManagers.remove(i);
    }
 
    protected RemoteCacheManager client(int i) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5283

Includes the fix explained in https://issues.jboss.org/browse/ISPN-5282.

This PR is related to #3300. Clients need to reset their topology ID when trying to recover from a full shutdown so that they can receive new topology information.