### PR TITLE
ISPN-5314 Increase worker thread pool in SocketTimeoutException tests

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
@@ -58,6 +58,9 @@ public abstract class RetryOnFailureOperation<T> extends HotRodOperation {
             // Invalidate transport since this exception means that this
             // instance is no longer usable and should be destroyed.
             if (transport != null) {
+               if (log.isTraceEnabled())
+                  log.tracef("Invalidating transport %s as a result of transport exception", transport);
+
                transportFactory.invalidateTransport(
                      te.getServerAddress(), transport);
             }
@@ -85,7 +88,7 @@ public abstract class RetryOnFailureOperation<T> extends HotRodOperation {
       String message = "Exception encountered. Retry %d out of %d";
       if (i >= transportFactory.getMaxRetries() || transportFactory.getMaxRetries() < 0) {
          if (!triedCompleteRestart) {
-            log.debug("Cluster might have completely shut down, try resetting transport layer and topology id");
+            log.debug("Cluster might have completely shut down, try resetting transport layer and topology id", e);
             transportFactory.reset(cacheName);
             triedCompleteRestart = true;
             return -1; // reset retry count

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EventSocketTimeoutTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EventSocketTimeoutTest.java
@@ -2,15 +2,16 @@ package org.infinispan.client.hotrod.event;
 
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
-import org.infinispan.client.hotrod.SocketTimeoutErrorTest;
 import org.infinispan.client.hotrod.SocketTimeoutErrorTest.TimeoutInducingInterceptor;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
+import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.client.hotrod.test.RemoteCacheManagerCallable;
 import org.infinispan.client.hotrod.test.SingleHotRodServerTest;
-import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.interceptors.EntryWrappingInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -30,6 +31,13 @@ public class EventSocketTimeoutTest extends SingleHotRodServerTest {
       builder.customInterceptors().addInterceptor().interceptor(
          new TimeoutInducingInterceptor()).after(EntryWrappingInterceptor.class);
       return TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration(builder));
+   }
+
+   @Override
+   protected HotRodServer createHotRodServer() {
+      HotRodServerConfigurationBuilder builder = new HotRodServerConfigurationBuilder();
+      builder.workerThreads(6); // TODO: Remove workerThreads configuration when ISPN-5083 implemented
+      return HotRodClientTestingUtil.startHotRodServer(cacheManager, builder);
    }
 
    @Override

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodTestingUtil.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodTestingUtil.scala
@@ -92,7 +92,7 @@ object HotRodTestingUtil extends Log {
             cfg
          }
       }
-      builder.host(host).port(port).workerThreads(2)
+      builder.host(host).port(port)
       server.start(builder.build(), manager)
 
       server


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5314

* Increasing worker thread pool size avoids propagating SocketTEs into operations executed after the SocketTimeoutException has been thrown back to the client.