### PR TITLE
Use generics in ThreadPoolExecutorFactory properly to avoid compiler war...

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/executors/BlockingThreadPoolExecutorFactory.java
+++ b/commons/src/main/java/org/infinispan/commons/executors/BlockingThreadPoolExecutorFactory.java
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * @author Galder Zamarreño
  */
-public class BlockingThreadPoolExecutorFactory implements ThreadPoolExecutorFactory {
+public class BlockingThreadPoolExecutorFactory implements ThreadPoolExecutorFactory<ExecutorService> {
 
    private static final Log log = LogFactory.getLog(BlockingThreadPoolExecutorFactory.class);
 

--- a/commons/src/main/java/org/infinispan/commons/executors/CachedThreadPoolExecutorFactory.java
+++ b/commons/src/main/java/org/infinispan/commons/executors/CachedThreadPoolExecutorFactory.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ThreadFactory;
 /**
  * @author Galder Zamarreño
  */
-public class CachedThreadPoolExecutorFactory implements ThreadPoolExecutorFactory {
+public class CachedThreadPoolExecutorFactory implements ThreadPoolExecutorFactory<ExecutorService> {
 
    private static final CachedThreadPoolExecutorFactory INSTANCE = new CachedThreadPoolExecutorFactory();
 

--- a/commons/src/main/java/org/infinispan/commons/executors/ScheduledThreadPoolExecutorFactory.java
+++ b/commons/src/main/java/org/infinispan/commons/executors/ScheduledThreadPoolExecutorFactory.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ThreadFactory;
 /**
  * @author Galder Zamarreño
  */
-public class ScheduledThreadPoolExecutorFactory implements ThreadPoolExecutorFactory {
+public class ScheduledThreadPoolExecutorFactory implements ThreadPoolExecutorFactory<ScheduledExecutorService> {
 
    private static final ScheduledThreadPoolExecutorFactory INSTANCE = new ScheduledThreadPoolExecutorFactory();
 

--- a/commons/src/main/java/org/infinispan/commons/executors/ThreadPoolExecutorFactory.java
+++ b/commons/src/main/java/org/infinispan/commons/executors/ThreadPoolExecutorFactory.java
@@ -6,9 +6,9 @@ import java.util.concurrent.ThreadFactory;
 /**
  * @author Galder Zamarreño
  */
-public interface ThreadPoolExecutorFactory {
+public interface ThreadPoolExecutorFactory<T extends ExecutorService> {
 
-   <T extends ExecutorService> T createExecutor(ThreadFactory factory);
+   T createExecutor(ThreadFactory factory);
 
    /**
     * Validate parameters for the thread pool executor factory

--- a/core/src/main/java/org/infinispan/executors/LazyInitializingBlockingTaskAwareExecutorService.java
+++ b/core/src/main/java/org/infinispan/executors/LazyInitializingBlockingTaskAwareExecutorService.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -24,13 +25,13 @@ import java.util.concurrent.TimeoutException;
  */
 public final class LazyInitializingBlockingTaskAwareExecutorService implements BlockingTaskAwareExecutorService {
 
-   private final ThreadPoolExecutorFactory executorFactory;
+   private final ThreadPoolExecutorFactory<ExecutorService> executorFactory;
    private final ThreadFactory threadFactory;
    private final TimeService timeService;
    private volatile BlockingTaskAwareExecutorService delegate;
 
    public LazyInitializingBlockingTaskAwareExecutorService(
-         ThreadPoolExecutorFactory executorFactory, ThreadFactory threadFactory,
+         ThreadPoolExecutorFactory<ExecutorService> executorFactory, ThreadFactory threadFactory,
          TimeService timeService) {
       this.executorFactory = executorFactory;
       this.threadFactory = threadFactory;

--- a/core/src/main/java/org/infinispan/executors/LazyInitializingExecutorService.java
+++ b/core/src/main/java/org/infinispan/executors/LazyInitializingExecutorService.java
@@ -23,11 +23,11 @@ import java.util.concurrent.TimeoutException;
 public final class LazyInitializingExecutorService implements ExecutorService {
 
    private volatile ExecutorService delegate;
-   private final ThreadPoolExecutorFactory executorFactory;
+   private final ThreadPoolExecutorFactory<ExecutorService> executorFactory;
    private final ThreadFactory threadFactory;
 
    public LazyInitializingExecutorService(
-         ThreadPoolExecutorFactory executorFactory, ThreadFactory threadFactory) {
+         ThreadPoolExecutorFactory<ExecutorService> executorFactory, ThreadFactory threadFactory) {
       this.executorFactory = executorFactory;
       this.threadFactory = threadFactory;
    }

--- a/core/src/main/java/org/infinispan/executors/LazyInitializingScheduledExecutorService.java
+++ b/core/src/main/java/org/infinispan/executors/LazyInitializingScheduledExecutorService.java
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * A delegating scheduled executor that lazily constructs and initalizes the underlying scheduled executor, since
+ * A delegating scheduled executor that lazily constructs and initializes the underlying scheduled executor, since
  * unused JDK executors are expensive.
  *
  * @author Manik Surtani
@@ -24,11 +24,11 @@ import java.util.concurrent.TimeoutException;
 public class LazyInitializingScheduledExecutorService implements ScheduledExecutorService {
 
    private volatile ScheduledExecutorService delegate;
-   private final ThreadPoolExecutorFactory executorFactory;
+   private final ThreadPoolExecutorFactory<ScheduledExecutorService> executorFactory;
    private final ThreadFactory threadFactory;
 
    public LazyInitializingScheduledExecutorService(
-         ThreadPoolExecutorFactory executorFactory, ThreadFactory threadFactory) {
+         ThreadPoolExecutorFactory<ScheduledExecutorService> executorFactory, ThreadFactory threadFactory) {
       this.executorFactory = executorFactory;
       this.threadFactory = threadFactory;
    }


### PR DESCRIPTION
...nings

hey @galderz , is there any reason why ThreadPoolExecutorFactory https://github.com/infinispan/infinispan/pull/3328/files#diff-588ccd0dfaf112f59a3f289f2a05d71fL9) could not use class-scoped type variable to avoid compilation warnings? 