### PR TITLE
ISPN-5329 Reduce number of allocations

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/collections/MiniList.java
+++ b/commons/src/main/java/org/infinispan/commons/collections/MiniList.java
@@ -1,0 +1,303 @@
+package org.infinispan.commons.collections;
+
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.util.AbstractList;
+import java.util.Arrays;
+import java.util.RandomAccess;
+
+/**
+ * Collection optimized for holding single element without allocating further objects
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class MiniList<T> extends AbstractList<T> implements RandomAccess, Serializable {
+    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+    private final static int INIT_ARRAY_SIZE = 8;
+    private final static Object[] EMPTY_ARRAY = new Object[0];
+
+    /* union { T, T[] } */
+    private Object holder;
+    private int size;
+    private Type type = Type.EMPTY;
+
+    protected boolean equal(Object o1, Object o2) {
+        return (o1 == null && o2 == null) || o1.equals(o2);
+    }
+
+    @Override
+    public boolean add(T t) {
+        Object[] array;
+        modCount++;
+        switch (type) {
+            case EMPTY:
+                holder = t;
+                type = Type.SINGLE;
+                size = 1;
+                return true;
+            case SINGLE:
+                array = new Object[INIT_ARRAY_SIZE];
+                array[0] = holder;
+                array[1] = t;
+                holder = array;
+                size = 2;
+                type = Type.ARRAY;
+                return true;
+            case ARRAY:
+                array = ensureCapacity(size + 1);
+                array[size] = t;
+                size++;
+                return true;
+        }
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public T set(int index, T element) {
+        checkBounds(index);
+        modCount++;
+        T tmp;
+        switch (type) {
+            case SINGLE:
+                tmp = (T) holder;
+                return tmp;
+            case ARRAY:
+                Object[] array = (Object[]) this.holder;
+                tmp = (T) array[index];
+                array[index] = element;
+                return tmp;
+        }
+        throw new IllegalStateException();
+    }
+
+    private void checkBounds(int index) {
+        if (index >= size || index < 0) {
+            throw outOfBounds(index);
+        }
+    }
+
+    private void checkBoundsForAdd(int index) {
+        if (index > size || index < 0) {
+            throw outOfBounds(index);
+        }
+    }
+
+    private IndexOutOfBoundsException outOfBounds(int index) {
+        return new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        switch (type) {
+            case EMPTY:
+                return -1;
+            case SINGLE:
+                return equal(holder, o) ? 0 : -1;
+            case ARRAY:
+                Object[] array = (Object[]) holder;
+                for (int i = 0; i < size; ++i) {
+                    if (equal(array[i], o)) return i;
+                }
+                return -1;
+        }
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        switch (type) {
+            case EMPTY:
+                return -1;
+            case SINGLE:
+                return equal(holder, o) ? 0 : -1;
+            case ARRAY:
+                Object[] array = (Object[]) holder;
+                for (int i = size - 1; i >= 0; --i) {
+                    if (equal(array[i], o)) return i;
+                }
+                return -1;
+        }
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public void clear() {
+        modCount++;
+        size = 0;
+        holder = null;
+        type = Type.EMPTY;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        switch (type) {
+            case EMPTY:
+                return false;
+            case SINGLE:
+                return equal(holder, o);
+            case ARRAY:
+                Object[] array = (Object[]) holder;
+                for (int i = 0; i < size; ++i) {
+                    if (equal(array[i], o)) return true;
+                }
+                return false;
+        }
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public T remove(int index) {
+        checkBounds(index);
+        modCount++;
+        T tmp;
+        switch (type) {
+            case SINGLE:
+                tmp = (T) holder;
+                holder = null;
+                size = 0;
+                type = Type.EMPTY;
+                return tmp;
+            case ARRAY:
+                Object[] array = (Object[]) holder;
+                tmp = (T) array[index];
+                System.arraycopy(array, index + 1, array, index, size - index - 1);
+                array[--size] = null; // for GC
+                return tmp;
+        }
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public void add(int index, T element) {
+        checkBoundsForAdd(index);
+        modCount++;
+        Object[] array;
+        switch (type) {
+            case EMPTY:
+                holder = element;
+                type = Type.SINGLE;
+                size = 1;
+                return;
+            case SINGLE:
+                array = new Object[INIT_ARRAY_SIZE];
+                if (index == 0) {
+                    array[0] = element;
+                    array[1] = holder;
+                } else {
+                    array[0] = holder;
+                    array[1] = element;
+                }
+                holder = array;
+                size = 2;
+                type = Type.ARRAY;
+                return;
+            case ARRAY:
+                array = ensureCapacity(size + 1);
+                System.arraycopy(array, index, array, index + 1, size - index);
+                array[index] = element;
+                size++;
+                return;
+        }
+        throw new IllegalStateException();
+    }
+
+    private Object[] ensureCapacity(int capacity) {
+        Object[] array = (Object[]) holder;
+        if (capacity > array.length) {
+            int newCapacity = array.length << 1;
+            if (newCapacity < 0) newCapacity = MAX_ARRAY_SIZE;
+            if (capacity < 0 || capacity > newCapacity) {
+                 throw new OutOfMemoryError();
+            }
+            array = Arrays.copyOf(array, Math.max(capacity, newCapacity));
+            holder = array;
+        }
+        return array;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        Object[] array;
+        switch (type) {
+            case EMPTY:
+                return false;
+            case SINGLE:
+                if (equal(holder, o)) {
+                    holder = null;
+                    type = Type.EMPTY;
+                    size = 0;
+                    modCount++;
+                    return true;
+                } else {
+                    return false;
+                }
+            case ARRAY:
+                array = (Object[]) holder;
+                for (int i = 0; i < size; ++i) {
+                    if (equal(array[i], o)) {
+                        System.arraycopy(array, i + 1, array, i, size - i - 1);
+                        array[--size] = null;
+                        modCount++;
+                        return true;
+                    }
+                }
+                return false;
+        }
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public T get(int index) {
+        checkBounds(index);
+        switch (type) {
+            case SINGLE:
+                return (T) holder;
+            case ARRAY:
+                return (T) ((Object[]) holder)[index];
+        }
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public Object[] toArray() {
+        switch (type) {
+            case EMPTY:
+                return EMPTY_ARRAY;
+            case SINGLE:
+                return new Object[] { holder };
+            case ARRAY:
+                return Arrays.copyOf((Object[]) holder, size);
+        }
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public <T1> T1[] toArray(T1[] a) {
+        T1[] newArray = a.length >= size ? a : (T1[]) Array.newInstance(a.getClass().getComponentType(), size);
+        switch (type) {
+            case EMPTY:
+                if (newArray.length > 0) newArray[0] = null;
+                return newArray;
+            case SINGLE:
+                newArray[0] = (T1) holder;
+                if (newArray.length > 1) newArray[1] = null;
+                return newArray;
+            case ARRAY:
+                System.arraycopy(holder, 0, newArray, 0, size);
+                if (newArray.length > size) newArray[size] = null;
+                return newArray;
+        }
+        throw new IllegalStateException();
+    }
+
+    private enum Type {
+        EMPTY,
+        SINGLE,
+        ARRAY
+    }
+}

--- a/commons/src/main/java/org/infinispan/commons/collections/MiniSet.java
+++ b/commons/src/main/java/org/infinispan/commons/collections/MiniSet.java
@@ -1,0 +1,318 @@
+package org.infinispan.commons.collections;
+
+import java.io.Serializable;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.ConcurrentModificationException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * Set optimized for few keys. The optimization is mostly memory-wise, reducing amount of objects created.
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class MiniSet<T> extends AbstractSet<T> implements Serializable {
+    private static final Object DUMMY = new Object();
+    private static final int ARRAY_SIZE = 8;
+    public static final int MAX_OPTIMIZED_CAPACITY = ARRAY_SIZE;
+
+    /*
+     union { T, T[], Map<T, Object> }
+     */
+    private Object holder;
+    protected Type type = Type.EMPTY;
+
+    public MiniSet() {}
+
+    public MiniSet(T... entries) {
+        if (entries.length == 0) {
+            type = Type.EMPTY;
+        } else if (entries.length == 1) {
+            holder = entries[0];
+            if (holder == null) throw new IllegalArgumentException();
+            type = Type.SINGLE;
+        } else if (entries.length < ARRAY_SIZE) {
+            holder = new Object[ARRAY_SIZE];
+            type = Type.ARRAY;
+            for (T entry : entries) {
+                add(entry);
+            }
+        } else {
+            Map<T, Object> map = new HashMap<>();
+            for (T entry : entries) {
+                if (entry == null) throw new IllegalArgumentException();
+                map.put(entry, DUMMY);
+            }
+            holder = map;
+            type = Type.MAP;
+        }
+    }
+
+    public MiniSet(Collection<T> entries) {
+        int size = entries.size();
+        if (size == 0) {
+            // nothing to do
+        } else if (size == 1) {
+            holder = entries.iterator().next();
+            if (holder == null) throw new IllegalArgumentException();
+            type = Type.SINGLE;
+        } else if (size < ARRAY_SIZE) {
+            holder = new Object[ARRAY_SIZE];
+            type = Type.ARRAY;
+            addAll(entries);
+        } else {
+            Map<T, Object> map = new HashMap<>();
+            for (T entry : entries) {
+                if (entry == null) throw new IllegalArgumentException();
+                map.put(entry, DUMMY);
+            }
+            holder = map;
+            type = Type.MAP;
+        }
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        switch (type) {
+            case EMPTY:
+                return false;
+            case SINGLE:
+                return holder.equals(o);
+            case ARRAY:
+                Object[] array = (Object[]) holder;
+                for (int i = 0; i < array.length; ++i) {
+                    if (array[i] == null) return false;
+                    if (array[i].equals(o)) return true;
+                }
+                return false;
+            case MAP:
+                return ((Map<T, Object>) holder).containsKey(o);
+        }
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public boolean add(T o) {
+        if (o == null) throw new IllegalArgumentException("Must not be null");
+        Object[] array;
+        switch (type) {
+            case EMPTY:
+                holder = o;
+                type = Type.SINGLE;
+                return true;
+            case SINGLE:
+                if (holder.equals(o)) return false;
+                array = new Object[ARRAY_SIZE];
+                array[0] = holder;
+                array[1] = o;
+                holder = array;
+                type = Type.ARRAY;
+                return true;
+            case ARRAY:
+                array = (Object[]) holder;
+                for (int i = 0; i < array.length; ++i) {
+                    if (array[i] == null) {
+                        array[i] = o;
+                        return true;
+                    } else if (array[i].equals(o)) {
+                        return false;
+                    }
+                }
+                Map<T, Object> map = new HashMap<>();
+                for (Object e : array) {
+                    if (e != null) map.put((T) e, DUMMY);
+                }
+                map.put(o, DUMMY);
+                holder = map;
+                type = Type.MAP;
+                return true;
+            case MAP:
+                return ((Map<T, Object>) holder).put(o, DUMMY) == null;
+        }
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        // never shrink
+        switch (type) {
+            case EMPTY:
+                return false;
+            case SINGLE:
+                if (holder.equals(o)) {
+                    holder = null; // to allow the object to be GCed
+                    type = Type.EMPTY;
+                    return true;
+                } else {
+                    return false;
+                }
+            case ARRAY:
+                Object[] array = (Object[]) holder;
+                for (int i = 0; i < array.length; ++i) {
+                    if (array[i] == null) return false;
+                    if (array[i].equals(o)) {
+                        if (removeAt(array, i)) return true;
+                        return true;
+                    }
+                }
+                return false;
+            case MAP:
+                return ((Map<T, Object>) holder).remove(o) != null;
+        }
+        throw new IllegalStateException();
+    }
+
+    private static boolean removeAt(Object[] array, int i) {
+        for (int j = array.length - 1; j > i; --j) {
+            if (array[j] != null) {
+                array[i] = array[j];
+                array[j] = null;
+                return true;
+            }
+        }
+        array[i] = null;
+        return false;
+    }
+
+    @Override
+    public void clear() {
+        holder = null;
+        type = Type.EMPTY;
+    }
+
+    @Override
+    public int size() {
+        switch (type) {
+            case EMPTY:
+                return 0;
+            case SINGLE:
+                return 1;
+            case ARRAY:
+                int size = 0;
+                for (Object o : (Object[]) holder) {
+                    if (o != null) size++;
+                }
+                return size;
+            case MAP:
+                return ((Map<T, Object>) holder).size();
+        }
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public java.util.Iterator<T> iterator() {
+        // note: these iterators don't check against modifications
+        switch (type) {
+            case EMPTY:
+                return EmptyIterator.INSTANCE;
+            case SINGLE:
+                return new SingleIterator();
+            case ARRAY:
+                return new ArrayIterator();
+            case MAP:
+                return ((Map<T, Object>) holder).keySet().iterator();
+        }
+        throw new IllegalStateException();
+    }
+
+    protected static class EmptyIterator<T> implements java.util.Iterator<T> {
+        public static final EmptyIterator INSTANCE = new EmptyIterator();
+
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+
+        @Override
+        public T next() {
+            throw new NoSuchElementException();
+        }
+
+        @Override
+        public void remove() {
+            throw new IllegalStateException();
+        }
+    }
+
+    protected class SingleIterator implements java.util.Iterator<T> {
+        private boolean hasNext = true;
+
+        private void assertType() {
+            if (type != Type.SINGLE) {
+                throw new ConcurrentModificationException();
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            return hasNext;
+        }
+
+        @Override
+        public T next() {
+            assertType();
+            if (hasNext) {
+                hasNext = false;
+                return (T) holder;
+            } else {
+                throw new NoSuchElementException();
+            }
+        }
+
+        @Override
+        public void remove() {
+            assertType();
+            if (hasNext) {
+                throw new IllegalStateException();
+            } else {
+                holder = null;
+                type = Type.EMPTY;
+            }
+        }
+    }
+
+    protected class ArrayIterator implements java.util.Iterator<T> {
+        private int index = 0;
+
+        private void assertType() {
+            if (type != Type.ARRAY) {
+                throw new ConcurrentModificationException();
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            return index < ARRAY_SIZE && ((Object[]) holder)[index] != null;
+        }
+
+        @Override
+        public T next() {
+            assertType();
+            Object[] array = (Object[]) holder;
+            if (index < ARRAY_SIZE && array[index] != null) {
+                return (T) array[index++];
+            } else {
+                throw new NoSuchElementException();
+            }
+        }
+
+        @Override
+        public void remove() {
+            assertType();
+            if (index == 0) {
+                throw new IllegalStateException();
+            } else {
+                removeAt((Object[]) holder, index - 1);
+            }
+        }
+    }
+
+    protected enum Type {
+        EMPTY,
+        SINGLE,
+        ARRAY,
+        MAP
+    }
+}

--- a/commons/src/main/java/org/infinispan/commons/collections/SynchronizedMiniList.java
+++ b/commons/src/main/java/org/infinispan/commons/collections/SynchronizedMiniList.java
@@ -1,0 +1,126 @@
+package org.infinispan.commons.collections;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+/**
+ * Synchronized version of {@link MiniList}
+ *
+ * Note that iterators are not synchronized ({@link java.util.Collections#synchronizedList()} does not provide that neither).
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class SynchronizedMiniList<T> extends MiniList<T> {
+    @Override
+    public synchronized boolean add(T t) {
+        return super.add(t);
+    }
+
+    @Override
+    public synchronized T set(int index, T element) {
+        return super.set(index, element);
+    }
+
+    @Override
+    public synchronized int indexOf(Object o) {
+        return super.indexOf(o);
+    }
+
+    @Override
+    public synchronized int lastIndexOf(Object o) {
+        return super.lastIndexOf(o);
+    }
+
+    @Override
+    public synchronized void clear() {
+        super.clear();
+    }
+
+    @Override
+    public synchronized boolean contains(Object o) {
+        return super.contains(o);
+    }
+
+    @Override
+    public synchronized T remove(int index) {
+        return super.remove(index);
+    }
+
+    @Override
+    public synchronized void add(int index, T element) {
+        super.add(index, element);
+    }
+
+    @Override
+    public synchronized boolean remove(Object o) {
+        return super.remove(o);
+    }
+
+    @Override
+    public synchronized T get(int index) {
+        return super.get(index);
+    }
+
+    @Override
+    public synchronized int size() {
+        return super.size();
+    }
+
+    @Override
+    public synchronized boolean addAll(int index, Collection<? extends T> c) {
+        return super.addAll(index, c);
+    }
+
+    @Override
+    public List<T> subList(int fromIndex, int toIndex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected synchronized void removeRange(int fromIndex, int toIndex) {
+        // not sure if this method is needed
+        super.removeRange(fromIndex, toIndex);
+    }
+
+    @Override
+    public synchronized boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public synchronized int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public synchronized Object[] toArray() {
+        return super.toArray();
+    }
+
+    @Override
+    public synchronized <T1> T1[] toArray(T1[] a) {
+        return super.toArray(a);
+    }
+
+    @Override
+    public synchronized boolean containsAll(Collection<?> c) {
+        return super.containsAll(c);
+    }
+
+    @Override
+    public synchronized boolean addAll(Collection<? extends T> c) {
+        return super.addAll(c);
+    }
+
+    @Override
+    public synchronized boolean removeAll(Collection<?> c) {
+        return super.removeAll(c);
+    }
+
+    @Override
+    public synchronized boolean retainAll(Collection<?> c) {
+        return super.retainAll(c);
+    }
+}

--- a/commons/src/main/java/org/infinispan/commons/collections/SynchronizedMiniSet.java
+++ b/commons/src/main/java/org/infinispan/commons/collections/SynchronizedMiniSet.java
@@ -1,0 +1,88 @@
+package org.infinispan.commons.collections;
+
+import java.util.Collection;
+
+/**
+ * Synchronized version of {@link MiniSet}.
+ *
+ * Note that iterators are not synchronized ({@link java.util.Collections.synchronizedSet()} does not provide that neither).
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class SynchronizedMiniSet<T> extends MiniSet<T> {
+    public SynchronizedMiniSet() {
+        super();
+    }
+
+    public SynchronizedMiniSet(T... entries) {
+        super(entries);
+    }
+
+    @Override
+    public synchronized boolean contains(Object o) {
+        return super.contains(o);
+    }
+
+    @Override
+    public synchronized boolean add(T o) {
+        return super.add(o);
+    }
+
+    @Override
+    public synchronized boolean remove(Object o) {
+        return super.remove(o);
+    }
+
+    @Override
+    public synchronized void clear() {
+        super.clear();
+    }
+
+    @Override
+    public synchronized int size() {
+        return super.size();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        synchronized (this) {
+            return super.equals(o);
+        }
+    }
+
+    @Override
+    public synchronized int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public synchronized boolean removeAll(Collection<?> c) {
+        return super.removeAll(c);
+    }
+
+    @Override
+    public synchronized Object[] toArray() {
+        return super.toArray();
+    }
+
+    @Override
+    public synchronized <T1> T1[] toArray(T1[] a) {
+        return super.toArray(a);
+    }
+
+    @Override
+    public synchronized boolean containsAll(Collection<?> c) {
+        return super.containsAll(c);
+    }
+
+    @Override
+    public synchronized boolean addAll(Collection<? extends T> c) {
+        return super.addAll(c);
+    }
+
+    @Override
+    public synchronized boolean retainAll(Collection<?> c) {
+        return super.retainAll(c);
+    }
+}

--- a/commons/src/main/java/org/infinispan/commons/util/CollectionFactory.java
+++ b/commons/src/main/java/org/infinispan/commons/util/CollectionFactory.java
@@ -1,5 +1,9 @@
 package org.infinispan.commons.util;
 
+import org.infinispan.commons.collections.MiniList;
+import org.infinispan.commons.collections.MiniSet;
+import org.infinispan.commons.collections.SynchronizedMiniList;
+import org.infinispan.commons.collections.SynchronizedMiniSet;
 import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.equivalence.EquivalentHashMap;
@@ -9,10 +13,12 @@ import org.infinispan.commons.util.concurrent.jdk8backported.BoundedEquivalentCo
 import org.infinispan.commons.util.concurrent.jdk8backported.ConcurrentParallelHashMapV8;
 import org.infinispan.commons.util.concurrent.jdk8backported.EquivalentConcurrentHashMapV8;
 
-import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -229,17 +235,47 @@ public class CollectionFactory {
    }
 
    public static <T> Set<T> makeSet(Equivalence<? super T> entryEq) {
-      if (requiresEquivalent(entryEq))
+      if (requiresEquivalent(entryEq)) {
          return new EquivalentHashSet<T>(entryEq);
-      else
-         return new HashSet<T>();
+      } else {
+         return new MiniSet<>();
+      }
    }
 
    public static <T> Set<T> makeSet(int initialCapacity, Equivalence<? super T> entryEq) {
-      if (requiresEquivalent(entryEq))
+      if (requiresEquivalent(entryEq)) {
          return new EquivalentHashSet<T>(initialCapacity, entryEq);
-      else
-         return new HashSet<T>(initialCapacity);
+      } else {
+         return makeSet(initialCapacity);
+      }
+   }
+
+   public static <T> Set<T> makeSet(int initialCapacity) {
+      if (initialCapacity > MiniSet.MAX_OPTIMIZED_CAPACITY) {
+         return new HashSet<>();
+      } else {
+         return new MiniSet<T>();
+      }
+   }
+
+   public static <T> Set<T> makeSynchronizedSet(Equivalence<? super T> entryEq) {
+      if (requiresEquivalent(entryEq)) {
+         return Collections.synchronizedSet(new EquivalentHashSet<T>(entryEq));
+      } else {
+         return new SynchronizedMiniSet<>();
+      }
+   }
+
+   public static <T> Set<T> makeSynchronizedSet(int initialCapacity, Equivalence<? super T> entryEq) {
+      if (requiresEquivalent(entryEq)) {
+         return Collections.synchronizedSet(new EquivalentHashSet<T>(initialCapacity, entryEq));
+      } else {
+         return new SynchronizedMiniSet<>();
+      }
+   }
+
+   public static <T> Set<T> makeSynchronizedSet(int initialCapacity) {
+      return new SynchronizedMiniSet<>();
    }
 
    /**
@@ -250,7 +286,19 @@ public class CollectionFactory {
     * @return a set view of the specified array
     */
    public static <T> Set<T> makeSet(T... entries) {
-      return new HashSet<T>(Arrays.asList(entries));
+      return new MiniSet<>(entries);
+   }
+
+   public static <T> Set<T> makeSet(Collection<T> entries) {
+      return new MiniSet<>(entries);
+   }
+
+   public static <T> List<T> makeList(int initialCapacity) {
+      return new MiniList();
+   }
+
+   public static <T> List<T> makeSynchronizedList() {
+      return new SynchronizedMiniList();
    }
 
    private static <K, V> boolean requiresEquivalent(

--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -9,8 +9,8 @@ import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.control.LockControlCommand;
 import org.infinispan.commands.read.EntryRetrievalCommand;
 import org.infinispan.commands.read.EntrySetCommand;
-import org.infinispan.commands.read.GetCacheEntryCommand;
 import org.infinispan.commands.read.GetAllCommand;
+import org.infinispan.commands.read.GetCacheEntryCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.read.KeySetCommand;
 import org.infinispan.commands.read.SizeCommand;
@@ -1695,6 +1695,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    }
 
    private Metadata applyDefaultMetadata(Metadata metadata) {
+      if (defaultMetadata.equals(metadata)) return metadata;
       Metadata.Builder builder = metadata.builder();
       return builder != null ? builder.merge(defaultMetadata).build() : metadata;
    }

--- a/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
@@ -1,5 +1,11 @@
 package org.infinispan.commands.tx;
 
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.infinispan.commands.Visitor;
 import org.infinispan.commands.write.ApplyDeltaCommand;
 import org.infinispan.commands.write.DataWriteCommand;
@@ -20,12 +26,6 @@ import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Command corresponding to the 1st phase of 2PC.

--- a/core/src/main/java/org/infinispan/container/entries/ImmortalCacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ImmortalCacheEntry.java
@@ -1,17 +1,17 @@
 package org.infinispan.container.entries;
 
-import org.infinispan.metadata.EmbeddedMetadata;
-import org.infinispan.metadata.Metadata;
-import org.infinispan.commons.marshall.AbstractExternalizer;
-import org.infinispan.commons.util.Util;
-import org.infinispan.marshall.core.Ids;
+import static org.infinispan.commons.util.Util.toStr;
 
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
 
-import static org.infinispan.commons.util.Util.toStr;
+import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.util.Util;
+import org.infinispan.marshall.core.Ids;
+import org.infinispan.metadata.EmbeddedMetadata;
+import org.infinispan.metadata.Metadata;
 
 /**
  * A cache entry that is immortal/cannot expire
@@ -105,7 +105,7 @@ public class ImmortalCacheEntry extends AbstractInternalCacheEntry {
 
    @Override
    public Metadata getMetadata() {
-      return new EmbeddedMetadata.Builder().build();
+      return EmbeddedMetadata.DEFAULT;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/metadata/EmbeddedMetadata.java
+++ b/core/src/main/java/org/infinispan/metadata/EmbeddedMetadata.java
@@ -1,16 +1,16 @@
 package org.infinispan.metadata;
 
-import org.infinispan.container.versioning.EntryVersion;
-import org.infinispan.commons.marshall.AbstractExternalizer;
-import org.infinispan.commons.util.Util;
-import org.infinispan.marshall.core.Ids;
-import org.jboss.marshalling.util.IdentityIntMap;
-
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.util.Util;
+import org.infinispan.container.versioning.EntryVersion;
+import org.infinispan.marshall.core.Ids;
+import org.jboss.marshalling.util.IdentityIntMap;
 
 /**
  * Metadata class for embedded caches.
@@ -19,6 +19,9 @@ import java.util.concurrent.TimeUnit;
  * @since 5.3
  */
 public class EmbeddedMetadata implements Metadata {
+
+   // modification of this builder is not allowed
+   public final static Metadata DEFAULT = new Builder().build();
 
    final EntryVersion version;
 

--- a/core/src/main/java/org/infinispan/transaction/impl/AbstractCacheTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/AbstractCacheTransaction.java
@@ -1,10 +1,11 @@
 package org.infinispan.transaction.impl;
 
+import static org.infinispan.commons.util.Util.toStr;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -22,8 +23,6 @@ import org.infinispan.transaction.xa.CacheTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-
-import static org.infinispan.commons.util.Util.toStr;
 
 /**
  * Base class for local and remote transaction. Impl note: The aggregated modification list and lookedUpEntries are not
@@ -223,13 +222,13 @@ public abstract class AbstractCacheTransaction implements CacheTransaction {
    @Override
    public void addBackupLockForKey(Object key) {
       // we need to synchronize this collection to be able to get a valid snapshot from another thread during state transfer
-      if (backupKeyLocks == null) backupKeyLocks = Collections.synchronizedSet(new HashSet<Object>(INITIAL_LOCK_CAPACITY));
+      if (backupKeyLocks == null) backupKeyLocks = CollectionFactory.makeSynchronizedSet(INITIAL_LOCK_CAPACITY);
       backupKeyLocks.add(key);
    }
 
    public void registerLockedKey(Object key) {
       // we need to synchronize this collection to be able to get a valid snapshot from another thread during state transfer
-      if (lockedKeys == null) lockedKeys = Collections.synchronizedSet(CollectionFactory.makeSet(INITIAL_LOCK_CAPACITY, keyEquivalence));
+      if (lockedKeys == null) lockedKeys = CollectionFactory.makeSynchronizedSet(INITIAL_LOCK_CAPACITY, keyEquivalence);
       if (trace) log.tracef("Registering locked key: %s", toStr(key));
       lockedKeys.add(key);
    }

--- a/core/src/main/java/org/infinispan/transaction/impl/LocalTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/LocalTransaction.java
@@ -1,5 +1,11 @@
 package org.infinispan.transaction.impl;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.transaction.Transaction;
+
 import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.CacheException;
@@ -13,14 +19,6 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-
-import javax.transaction.Transaction;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Object that holds transaction's state on the node where it originated; as opposed to {@link RemoteTransaction}.
@@ -57,7 +55,8 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
       if (trace) log.tracef("Adding modification %s. Mod list is %s", mod, modifications);
       if (modifications == null) {
          // we need to synchronize this collection to be able to get a valid snapshot from another thread during state transfer
-         modifications = Collections.synchronizedList(new LinkedList<WriteCommand>());
+         //modifications = Collections.synchronizedList(new LinkedList<WriteCommand>());
+         modifications = CollectionFactory.makeSynchronizedList();
       }
       if (mod.hasFlag(Flag.CACHE_MODE_LOCAL)) {
          hasLocalOnlyModifications = true;
@@ -68,7 +67,7 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
    public void locksAcquired(Collection<Address> nodes) {
       if (trace) log.tracef("Adding remote locks on %s. Remote locks are %s", nodes, remoteLockedNodes);
       if (remoteLockedNodes == null)
-         remoteLockedNodes = new HashSet<Address>(nodes);
+         remoteLockedNodes = CollectionFactory.makeSet(nodes);
       else
          remoteLockedNodes.addAll(nodes);
    }

--- a/core/src/main/java/org/infinispan/transaction/tm/DummyTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/DummyTransaction.java
@@ -1,9 +1,9 @@
 package org.infinispan.transaction.tm;
 
 
-import org.infinispan.util.logging.Log;
-import org.infinispan.util.logging.LogFactory;
-
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.HeuristicRollbackException;
 import javax.transaction.RollbackException;
@@ -20,6 +20,10 @@ import java.util.Collections;
 import java.util.List;
 
 import static java.lang.String.format;
+
+import org.infinispan.commons.util.CollectionFactory;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * @author bela
@@ -57,8 +61,8 @@ public class DummyTransaction implements Transaction {
       if (trace) {
          log.tracef("Created new transaction with Xid=%s", xid);
       }
-      syncs = new ArrayList<>(2);
-      resources = new ArrayList<>(2);
+      syncs = CollectionFactory.makeList(2);
+      resources = CollectionFactory.makeList(2);
    }
 
    private static boolean isRollbackCode(XAException ex) {

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/OwnableRefCountingReentrantLock.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/OwnableRefCountingReentrantLock.java
@@ -1,8 +1,8 @@
 package org.infinispan.util.concurrent.locks;
 
-import org.infinispan.util.concurrent.locks.containers.OwnableReentrantPerEntryLockContainer;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import org.infinispan.util.concurrent.locks.containers.OwnableReentrantPerEntryLockContainer;
 
 /**
  * A version of {@link OwnableReentrantLock} that has a reference counter, and implements {@link RefCountingLock}.
@@ -13,15 +13,24 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @see OwnableReentrantPerEntryLockContainer
  */
 public class OwnableRefCountingReentrantLock extends OwnableReentrantLock implements RefCountingLock {
-   private final AtomicInteger references = new AtomicInteger(1);
+   private final static AtomicIntegerFieldUpdater<OwnableRefCountingReentrantLock> updater
+         = AtomicIntegerFieldUpdater.newUpdater(OwnableRefCountingReentrantLock.class, "references");
+
+   private volatile int references = 1;
 
    @Override
-   public AtomicInteger getReferenceCounter() {
-      return references;
+   public int incrementRefCountAndGet() {
+      return updater.incrementAndGet(this);
+   }
+
+   @Override
+   public int decrementRefCountAndGet() {
+      return updater.decrementAndGet(this);
    }
 
    @Override
    public String toString() {
-      return super.toString() + "[References: "+references.toString()+"]";
+      return super.toString() + "[References: "+references+"]";
    }
+
 }

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/RefCountingLock.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/RefCountingLock.java
@@ -1,6 +1,5 @@
 package org.infinispan.util.concurrent.locks;
 
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 
 /**
@@ -10,10 +9,15 @@ import java.util.concurrent.locks.Lock;
  * @since 5.2
  */
 public interface RefCountingLock extends Lock {
+   /**
+    * Increments reference counter for this lock
+    * @return Updated value of the counter
+    */
+   int incrementRefCountAndGet();
 
    /**
-    * Accesses the reference counter for this lock
-    * @return a reference counter
+    * Decrementes reference counter for this lock
+    * @return Updated value of the counter
     */
-   AtomicInteger getReferenceCounter();
+   int decrementRefCountAndGet();
 }

--- a/core/src/main/java/org/infinispan/util/concurrent/locks/VisibleOwnerRefCountingReentrantLock.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/locks/VisibleOwnerRefCountingReentrantLock.java
@@ -1,8 +1,8 @@
 package org.infinispan.util.concurrent.locks;
 
-import org.infinispan.util.concurrent.locks.containers.ReentrantPerEntryLockContainer;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import org.infinispan.util.concurrent.locks.containers.ReentrantPerEntryLockContainer;
 
 /**
  * A version of {@link VisibleOwnerReentrantLock} that has a reference counter, and implements {@link RefCountingLock}.
@@ -13,15 +13,24 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @see ReentrantPerEntryLockContainer
  */
 public class VisibleOwnerRefCountingReentrantLock extends VisibleOwnerReentrantLock implements RefCountingLock {
-   private final AtomicInteger references = new AtomicInteger(1);
+   private final static AtomicIntegerFieldUpdater<VisibleOwnerRefCountingReentrantLock> updater
+         = AtomicIntegerFieldUpdater.newUpdater(VisibleOwnerRefCountingReentrantLock.class, "references");
+
+   private volatile int references = 1;
 
    @Override
-   public AtomicInteger getReferenceCounter() {
-      return references;
+   public int incrementRefCountAndGet() {
+      return updater.incrementAndGet(this);
    }
 
    @Override
+   public int decrementRefCountAndGet() {
+      return updater.decrementAndGet(this);
+   }
+
+
+   @Override
    public String toString() {
-      return super.toString() + "[References: "+references.toString()+"]";
+      return super.toString() + "[References: "+references+"]";
    }
 }


### PR DESCRIPTION
I have analyzed allocations during put() (into local cache) and removed some of the low-hanging fruits. Some of those could be already handled by escape analysis, but most of them cannot, IMO. Though, the difference between performance before and after was within the margin of error of the benchmark. 

You can find both the benchmark and Byteman tooling for analysis at https://github.com/rvansa/benchmarks/tree/master/ispntest