### PR TITLE
ISPN-5332 Make sure the Query API exposes IndexReader(s) in some way

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteNonIndexedQueryDslConditionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteNonIndexedQueryDslConditionsTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.client.hotrod.query;
 
+import org.hibernate.search.spi.SearchIntegrator;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.query.dsl.Query;
@@ -28,7 +29,7 @@ public class RemoteNonIndexedQueryDslConditionsTest extends RemoteQueryDslCondit
    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Indexing was not enabled on this cache.*")
    @Override
    public void testIndexPresence() {
-      org.infinispan.query.Search.getSearchManager(getEmbeddedCache()).getSearchFactory();
+      org.infinispan.query.Search.getSearchManager(getEmbeddedCache()).unwrap(SearchIntegrator.class);
    }
 
    @Test

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
@@ -107,7 +107,7 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
 
    @Override
    public void testIndexPresence() {
-      SearchIntegrator searchIntegrator = org.infinispan.query.Search.getSearchManager(cache).getSearchFactory();
+      SearchIntegrator searchIntegrator = org.infinispan.query.Search.getSearchManager(cache).unwrap(SearchIntegrator.class);
 
       assertTrue(searchIntegrator.getIndexedTypes().contains(ProtobufValueWrapper.class));
       assertNotNull(searchIntegrator.getIndexManager(ProtobufValueWrapper.class.getName()));

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTunedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTunedTest.java
@@ -42,7 +42,7 @@ public class RemoteQueryDslConditionsTunedTest extends RemoteQueryDslConditionsF
 
    @Override
    public void testIndexPresence() {
-      SearchIntegrator searchIntegrator = Search.getSearchManager(getEmbeddedCache()).getSearchFactory();
+      SearchIntegrator searchIntegrator = Search.getSearchManager(getEmbeddedCache()).unwrap(SearchIntegrator.class);
       assertTrue(searchIntegrator.getIndexedTypes().contains(ProtobufValueWrapper.class));
       for (int shard = 0; shard < 6 ; shard++)
           assertNotNull(searchIntegrator.getIndexManager(ProtobufValueWrapper.class.getName() + "." + shard));

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
@@ -181,7 +181,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
    @Test
    public void testIndexPresence() {
-      SearchIntegrator searchFactory = Search.getSearchManager((Cache) getCacheForQuery()).getSearchFactory();
+      SearchIntegrator searchFactory = Search.getSearchManager((Cache) getCacheForQuery()).unwrap(SearchIntegrator.class);
 
       assertTrue(searchFactory.getIndexedTypes().contains(getModelFactory().getUserImplClass()));
       assertNotNull(searchFactory.getIndexManager(getModelFactory().getUserImplClass().getName()));

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/testdomain/StaticTestingErrorHandler.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/testdomain/StaticTestingErrorHandler.java
@@ -32,7 +32,7 @@ public class StaticTestingErrorHandler implements ErrorHandler {
 
    public static void assertAllGood(Cache cache) {
       SearchManager searchManager = Search.getSearchManager(cache);
-      SearchIntegrator searchFactory = searchManager.getSearchFactory();
+      SearchIntegrator searchFactory = searchManager.unwrap(SearchIntegrator.class);
       ErrorHandler errorHandler = searchFactory.getErrorHandler();
       Assert.assertNotNull(errorHandler);
       Assert.assertTrue(errorHandler instanceof StaticTestingErrorHandler);

--- a/query/src/main/java/org/infinispan/query/Search.java
+++ b/query/src/main/java/org/infinispan/query/Search.java
@@ -5,6 +5,7 @@ import org.infinispan.Cache;
 import org.infinispan.query.dsl.QueryFactory;
 import org.infinispan.query.dsl.embedded.impl.EmbeddedQueryFactory;
 import org.infinispan.query.impl.SearchManagerImpl;
+import org.infinispan.query.spi.SearchManagerImplementor;
 import org.infinispan.security.AuthorizationManager;
 import org.infinispan.security.AuthorizationPermission;
 
@@ -23,7 +24,7 @@ public final class Search {
       ensureAccessPermissions(advancedCache);
 
       if (advancedCache.getCacheConfiguration().indexing().index().isEnabled()) {
-         return getSearchManager(advancedCache).getQueryFactory();
+         return getSearchManager(advancedCache).unwrap(SearchManagerImplementor.class).getQueryFactory();
       }
 
       return new EmbeddedQueryFactory(advancedCache);

--- a/query/src/main/java/org/infinispan/query/SearchManager.java
+++ b/query/src/main/java/org/infinispan/query/SearchManager.java
@@ -108,4 +108,10 @@ public interface SearchManager {
     */
    void purge(Class<?> entityType);
 
+   /**
+    * This method gives access to internal Infinispan types, and should not be normally needed.
+    * The API of the internal types can (and probably will) change without notice.
+    */
+   <T> T unwrap(Class<T> cls);
+
 }

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/EmbeddedLuceneQueryBuilder.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/EmbeddedLuceneQueryBuilder.java
@@ -60,7 +60,7 @@ final class EmbeddedLuceneQueryBuilder extends BaseQueryBuilder<LuceneQuery> {
    }
 
    private LuceneQueryParsingResult parse(String jpqlString) {
-      SearchIntegrator searchFactory = searchManager.getSearchFactory();
+      SearchIntegrator searchFactory = searchManager.unwrap(SearchIntegrator.class);
       LuceneProcessingChain processingChain = new LuceneProcessingChain.Builder(searchFactory, entityNamesResolver).buildProcessingChainForClassBasedEntities();
       QueryParser queryParser = new QueryParser();
       return queryParser.parseQuery(jpqlString, processingChain);

--- a/query/src/main/java/org/infinispan/query/impl/SearchManagerImpl.java
+++ b/query/src/main/java/org/infinispan/query/impl/SearchManagerImpl.java
@@ -5,9 +5,12 @@ import java.util.concurrent.ExecutorService;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.search.Query;
 import org.hibernate.hql.ast.spi.EntityNamesResolver;
+import org.hibernate.search.engine.integration.impl.ExtendedSearchIntegrator;
+import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.query.dsl.EntityContext;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
 import org.hibernate.search.spi.SearchIntegrator;
+import org.hibernate.search.spi.impl.SearchFactoryState;
 import org.hibernate.search.stat.Statistics;
 import org.infinispan.AdvancedCache;
 import org.infinispan.commons.util.Util;
@@ -142,6 +145,20 @@ public class SearchManagerImpl implements SearchManagerImplementor {
    @Override
    public void purge(Class<?> entityType) {
      queryInterceptor.purgeIndex(entityType);
+   }
+
+   @Override
+   public <T> T unwrap(Class<T> cls) {
+      if (SearchIntegrator.class.isAssignableFrom(cls) || ExtendedSearchIntegrator.class.isAssignableFrom(cls)
+            || SearchFactoryState.class.isAssignableFrom(cls)) {
+         return (T) this.searchFactory;
+      }
+      if (SearchManagerImplementor.class.isAssignableFrom(cls)) {
+         return (T) this;
+      }
+      else {
+         throw new IllegalArgumentException("Can not unwrap a SearchManagerImpl into a '" + cls + "'");
+      }
    }
 
 }

--- a/query/src/main/java/org/infinispan/query/indexmanager/AbstractUpdateCommand.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/AbstractUpdateCommand.java
@@ -68,7 +68,7 @@ public abstract class AbstractUpdateCommand extends BaseRpcCommand implements Re
       if (ci.getCacheManager().cacheExists(cacheName)) {
          Cache cache = ci.getCacheManager().getCache(cacheName);
          SearchManager searchManager = Search.getSearchManager(cache);
-         searchFactory = searchManager.getSearchFactory();
+         searchFactory = searchManager.unwrap(SearchIntegrator.class);
          queryInterceptor = ComponentRegistryUtils.getQueryInterceptor(cache);
       }
       else {

--- a/query/src/main/java/org/infinispan/query/spi/SearchManagerImplementor.java
+++ b/query/src/main/java/org/infinispan/query/spi/SearchManagerImplementor.java
@@ -3,6 +3,8 @@ package org.infinispan.query.spi;
 import org.hibernate.search.query.engine.spi.TimeoutExceptionFactory;
 import org.infinispan.query.SearchManager;
 import org.infinispan.query.Transformer;
+import org.infinispan.query.dsl.QueryFactory;
+import org.infinispan.query.dsl.embedded.LuceneQuery;
 
 public interface SearchManagerImplementor extends SearchManager {
 
@@ -28,5 +30,12 @@ public interface SearchManagerImplementor extends SearchManager {
     *           the timeout exception factory to use
     */
    void setTimeoutExceptionFactory(TimeoutExceptionFactory timeoutExceptionFactory);
+
+   /**
+    * Experimental! Obtains the factory for DSL-based queries backed by Lucene indexes.
+    *
+    * @return a factory capable of building queries for the cache this SearchManager belongs to
+    */
+   public QueryFactory<LuceneQuery> getQueryFactory();
 
 }

--- a/query/src/test/java/org/infinispan/query/backend/MultipleEntitiesTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/MultipleEntitiesTest.java
@@ -47,13 +47,13 @@ public class MultipleEntitiesTest extends SingleCacheManagerTest {
       SearchManager searchManager = Search.getSearchManager(cache);
 
       cache.put(123405, new Bond(new Date(System.currentTimeMillis()), 450L));
-      assertEfficientIndexingUsed(searchManager.getSearchFactory(), Bond.class);
+      assertEfficientIndexingUsed(searchManager.unwrap(SearchIntegrator.class), Bond.class);
 
       cache.put(123502, new Debenture("GB", 116d));
-      assertEfficientIndexingUsed(searchManager.getSearchFactory(), Debenture.class);
+      assertEfficientIndexingUsed(searchManager.unwrap(SearchIntegrator.class), Debenture.class);
 
       cache.put(223456, new Bond(new Date(System.currentTimeMillis()), 550L));
-      assertEfficientIndexingUsed(searchManager.getSearchFactory(), Bond.class);
+      assertEfficientIndexingUsed(searchManager.unwrap(SearchIntegrator.class), Bond.class);
 
       CacheQuery query = searchManager.getQuery(new MatchAllDocsQuery(), Bond.class, Debenture.class);
       assertEquals(query.list().size(), 3);

--- a/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
@@ -97,7 +97,7 @@ public class MultipleCachesTest extends SingleCacheManagerTest {
       assertEquals(75, p.getAge());
 
       SearchManager queryFactory = Search.getSearchManager(indexedCache);
-      SearchIntegrator searchImpl = queryFactory.getSearchFactory();
+      SearchIntegrator searchImpl = queryFactory.unwrap(SearchIntegrator.class);
       IndexManager[] indexManagers = searchImpl.getIndexBinding(Person.class).getIndexManagers();
       assert indexManagers != null && indexManagers.length == 1;
       DirectoryBasedIndexManager directory = (DirectoryBasedIndexManager)indexManagers[0];

--- a/query/src/test/java/org/infinispan/query/distributed/MultiNodeDistributedTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/MultiNodeDistributedTest.java
@@ -85,7 +85,7 @@ public class MultiNodeDistributedTest extends AbstractInfinispanTest {
    private boolean isMasterNode(Cache<?,?> cache) {
       //Implicitly verifies the components are setup as configured by casting:
       SearchManager searchManager = Search.getSearchManager(cache);
-      SearchIntegrator searchFactory = searchManager.getSearchFactory();
+      SearchIntegrator searchFactory = searchManager.unwrap(SearchIntegrator.class);
       InfinispanIndexManager indexManager = (InfinispanIndexManager) searchFactory.getIndexManager("person");
       return indexManager.isMasterLocal();
    }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/ClusteredQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/ClusteredQueryDslConditionsTest.java
@@ -65,7 +65,7 @@ public class ClusteredQueryDslConditionsTest extends QueryDslConditionsTest {
    }
 
    private void checkIndexPresence(Cache cache) {
-      SearchIntegrator searchFactory = Search.getSearchManager(cache).getSearchFactory();
+      SearchIntegrator searchFactory = Search.getSearchManager(cache).unwrap(SearchIntegrator.class);
 
       assertTrue(searchFactory.getIndexedTypes().contains(getModelFactory().getUserImplClass()));
       assertNotNull(searchFactory.getIndexManager(getModelFactory().getUserImplClass().getName()));

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedQueryDslConditionsTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.query.dsl.embedded;
 
 import org.hibernate.hql.ParsingException;
+import org.hibernate.search.spi.SearchIntegrator;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.query.Search;
@@ -64,7 +65,7 @@ public class NonIndexedQueryDslConditionsTest extends QueryDslConditionsTest {
    @Override
    public void testIndexPresence() {
       // this is expected to throw an exception
-      Search.getSearchManager((Cache) getCacheForQuery()).getSearchFactory();
+      Search.getSearchManager((Cache) getCacheForQuery()).unwrap(SearchIntegrator.class);
    }
 
    @Override

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
@@ -166,7 +166,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
    }
 
    public void testIndexPresence() {
-      SearchIntegrator searchIntegrator = Search.getSearchManager((Cache) getCacheForQuery()).getSearchFactory();
+      SearchIntegrator searchIntegrator = Search.getSearchManager((Cache) getCacheForQuery()).unwrap(SearchIntegrator.class);
 
       assertTrue(searchIntegrator.getIndexedTypes().contains(getModelFactory().getUserImplClass()));
       assertNotNull(searchIntegrator.getIndexManager(getModelFactory().getUserImplClass().getName()));

--- a/query/src/test/java/org/infinispan/query/helper/StaticTestingErrorHandler.java
+++ b/query/src/test/java/org/infinispan/query/helper/StaticTestingErrorHandler.java
@@ -32,7 +32,7 @@ public class StaticTestingErrorHandler implements ErrorHandler {
 
    public static void assertAllGood(Cache cache) {
       SearchManager searchManager = Search.getSearchManager(cache);
-      SearchIntegrator searchFactory = searchManager.getSearchFactory();
+      SearchIntegrator searchFactory = searchManager.unwrap(SearchIntegrator.class);
       ErrorHandler errorHandler = searchFactory.getErrorHandler();
       Assert.assertNotNull(errorHandler);
       Assert.assertTrue(errorHandler instanceof StaticTestingErrorHandler);

--- a/query/src/test/java/org/infinispan/query/performance/TuningOptionsAppliedTest.java
+++ b/query/src/test/java/org/infinispan/query/performance/TuningOptionsAppliedTest.java
@@ -64,7 +64,7 @@ public class TuningOptionsAppliedTest {
       Cache<Object, Object> cache = embeddedCacheManager.getCache("Indexed");
       cache.put("hey this type exists", new Person("id", "name", 3));
       SearchManager searchManager = Search.getSearchManager(cache);
-      return searchManager.getSearchFactory();
+      return searchManager.unwrap(SearchIntegrator.class);
    }
 
    private NRTIndexManager verifyShardingOptions(SearchIntegrator searchIntegrator, int expectedShards) {

--- a/query/src/test/java/org/infinispan/query/persistence/EntryActivatingTest.java
+++ b/query/src/test/java/org/infinispan/query/persistence/EntryActivatingTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.Query;
+import org.hibernate.search.spi.SearchIntegrator;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -78,7 +79,7 @@ public class EntryActivatingTest extends AbstractInfinispanTest {
       verifyFullTextHasMatches(1);
 
       cache.stop();
-      assert search.getSearchFactory().isStopped();
+      assert search.unwrap(SearchIntegrator.class).isStopped();
       TestingUtil.killCacheManagers(cm);
 
       // Now let's check the entry is not re-indexed during data preloading:

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/QueryFacadeImpl.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/QueryFacadeImpl.java
@@ -124,7 +124,7 @@ public class QueryFacadeImpl implements QueryFacade {
     */
    private QueryResponse executeQuery(AdvancedCache<byte[], byte[]> cache, SerializationContext serCtx, QueryRequest request) {
       final SearchManager searchManager = Search.getSearchManager(cache);
-      final SearchIntegrator searchFactory = searchManager.getSearchFactory();
+      final SearchIntegrator searchFactory = searchManager.unwrap(SearchIntegrator.class);
       final QueryCache queryCache = ComponentRegistryUtils.getQueryCache(cache);  // optional component
 
       LuceneQueryParsingResult parsingResult;

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/indexing/ProtobufWrapperIndexingTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/indexing/ProtobufWrapperIndexingTest.java
@@ -53,7 +53,7 @@ public class ProtobufWrapperIndexingTest extends SingleCacheManagerTest {
 
       SearchManager sm = Search.getSearchManager(cache);
 
-      SearchIntegrator searchFactory = sm.getSearchFactory();
+      SearchIntegrator searchFactory = sm.unwrap(SearchIntegrator.class);
       assertNotNull(searchFactory.getIndexManager(ProtobufValueWrapper.class.getName()));
 
       Query luceneQuery = sm.buildQueryBuilderForClass(ProtobufValueWrapper.class)


### PR DESCRIPTION
A proposal to hide the Advanced Query API, using the same unwrap pattern which Hibernate uses to expose Hibernate capabilities to the JPA API, and the same we used to reorganize the Hibernate Search API.

This should easily differentiate between API and not-so-public "power users" API but still relatively convenient to use.

 - https://issues.jboss.org/browse/ISPN-5332
