### PR TITLE
ISPN-5264 Optimize PutAll operations (library mode)

### DIFF
--- a/core/src/main/java/org/infinispan/commands/write/PutMapCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/PutMapCommand.java
@@ -38,6 +38,14 @@ public class PutMapCommand extends AbstractFlagAffectedCommand implements WriteC
       this.flags = flags;
    }
 
+   public PutMapCommand(PutMapCommand command) {
+      this.map = command.map;
+      this.notifier = command.notifier;
+      this.metadata = command.metadata;
+      this.flags = command.flags;
+      this.isForwarded = command.isForwarded;
+   }
+
    public void init(CacheNotifier notifier) {
       this.notifier = notifier;
    }

--- a/core/src/main/java/org/infinispan/distribution/util/ReadOnlySegmentAwareEntryIterator.java
+++ b/core/src/main/java/org/infinispan/distribution/util/ReadOnlySegmentAwareEntryIterator.java
@@ -1,0 +1,32 @@
+package org.infinispan.distribution.util;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.infinispan.distribution.ch.ConsistentHash;
+
+/**
+ * Iterator implementation that shows a read only view of the provided iterator by only
+ * allowing values that map to a given segment using the provided consistent hash.
+ * <p>
+ * This iterator is specifically used with the {@link ReadOnlySegmentAwareEntrySet} so
+ * that it will properly filter out entries by their key instead of by the entry instance
+ * 
+ * @author wburns
+ * @since 7.2
+ */
+public class ReadOnlySegmentAwareEntryIterator<K, V> extends ReadOnlySegmentAwareIterator<Entry<K, V>> {
+
+   public ReadOnlySegmentAwareEntryIterator(Iterator<Entry<K, V>> iter, ConsistentHash ch, Set<Integer> allowedSegments) {
+      super(iter, ch, allowedSegments);
+   }
+
+   @Override
+   protected boolean valueAllowed(Object obj) {
+      if (obj instanceof Entry) {
+         return super.valueAllowed(((Entry<?, ?>)obj).getKey());
+      }
+      return false;
+   }
+}

--- a/core/src/main/java/org/infinispan/distribution/util/ReadOnlySegmentAwareEntrySet.java
+++ b/core/src/main/java/org/infinispan/distribution/util/ReadOnlySegmentAwareEntrySet.java
@@ -1,0 +1,39 @@
+package org.infinispan.distribution.util;
+
+import java.util.Map.Entry;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.infinispan.distribution.ch.ConsistentHash;
+
+/**
+ * Iterator implementation that shows a read only view of the provided iterator by only
+ * allowing values that map to a given segment using the provided consistent hash.
+ * <p>
+ * This iterator is used with specifically with the {@link ReadOnlySegmentAwareEntrySet}
+ * to properly filter the entry by the key instead of the entry instance itself.
+ * 
+ * @author wburns
+ * @since 7.2
+ */
+public class ReadOnlySegmentAwareEntrySet<K, V> extends ReadOnlySegmentAwareSet<Entry<K, V>> {
+
+   public ReadOnlySegmentAwareEntrySet(Set<Entry<K, V>> set, ConsistentHash ch,
+         Set<Integer> allowedSegments) {
+      super(set, ch, allowedSegments);
+   }
+
+   @Override
+   protected boolean valueAllowed(Object obj) {
+      if (obj instanceof Entry) {
+         return super.valueAllowed(((Entry<?, ?>)obj).getKey());
+      }
+      return false;
+   }
+
+   @Override
+   public Iterator<Entry<K, V>> iterator() {
+      return new ReadOnlySegmentAwareEntryIterator<>(delegate().iterator(), ch,
+            allowedSegments);
+   }
+}

--- a/core/src/main/java/org/infinispan/distribution/util/ReadOnlySegmentAwareIterator.java
+++ b/core/src/main/java/org/infinispan/distribution/util/ReadOnlySegmentAwareIterator.java
@@ -1,0 +1,68 @@
+package org.infinispan.distribution.util;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.infinispan.distribution.ch.ConsistentHash;
+
+/**
+ * Iterator implementation that shows a read only view of the provided iterator by only
+ * allowing values that map to a given segment using the provided consistent hash.
+ * <p>
+ * This iterator is used with the other various SegmentAware Collections such as
+ * {@link ReadOnlySegmentAwareSet}
+ * 
+ * @author wburns
+ * @since 7.2
+ */
+public class ReadOnlySegmentAwareIterator<E> implements Iterator<E> {
+   protected final Iterator<E> iter;
+   protected final ConsistentHash ch;
+   protected final Set<Integer> allowedSegments;
+
+   protected E next;
+
+   public ReadOnlySegmentAwareIterator(Iterator<E> iter, ConsistentHash ch, Set<Integer> allowedSegments) {
+      super();
+      this.iter = iter;
+      this.ch = ch;
+      this.allowedSegments = allowedSegments;
+      next = findNext();
+   }
+
+   protected boolean valueAllowed(Object obj) {
+      int segment = ch.getSegment(obj);
+      return allowedSegments.contains(segment);
+   }
+
+   protected E findNext() {
+      while (iter.hasNext()) {
+         E next = iter.next();
+         if (valueAllowed(next)) {
+            return next;
+         }
+      }
+      return null;
+   }
+
+   @Override
+   public boolean hasNext() {
+      return next != null;
+   }
+
+   @Override
+   public E next() {
+      E prev = next;
+      if (prev == null) {
+         throw new NoSuchElementException();
+      }
+      next = findNext();
+      return prev;
+   }
+
+   @Override
+   public void remove() {
+      throw new UnsupportedOperationException("remove");
+  }
+}

--- a/core/src/main/java/org/infinispan/distribution/util/ReadOnlySegmentAwareMap.java
+++ b/core/src/main/java/org/infinispan/distribution/util/ReadOnlySegmentAwareMap.java
@@ -1,0 +1,150 @@
+package org.infinispan.distribution.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.util.AbstractDelegatingMap;
+
+/**
+ * Map implementation that shows a read only view of the provided entry by only allowing
+ * entries whose key maps to a given segment using the provided consistent hash.
+ * <p>
+ * Any operation that would modify this map will throw an {@link UnsupportedOperationException}
+ * <p>
+ * This map is useful when you don't want to copy an entire map but only need to see
+ * entries from the given segments.
+ * <p>
+ * Note many operations are not constant time when using this map.  The
+ * {@link ReadOnlySegmentAwareMap#values} method is not supported as well. Please check\
+ * the method you are using to see if it will perform differently than normally expected.
+ * @author wburns
+ * @since 7.2
+ */
+public class ReadOnlySegmentAwareMap<K, V> extends AbstractDelegatingMap<K, V> {
+
+   protected final Map<K, V> map;
+   protected final ConsistentHash ch;
+   protected final Set<Integer> allowedSegments;
+
+   protected ReadOnlySegmentAwareSet<K> segmentAwareKeySet;
+   protected ReadOnlySegmentAwareEntrySet<K, V> segmentAwareEntrySet;
+
+   public ReadOnlySegmentAwareMap(Map<K, V> map, ConsistentHash ch,
+         Set<Integer> allowedSegments) {
+      super();
+      this.map = Collections.unmodifiableMap(map);
+      this.ch = ch;
+      this.allowedSegments = allowedSegments;
+   }
+
+   @Override
+   protected Map<K, V> delegate() {
+      return map;
+   }
+
+   protected boolean keyAllowed(Object key) {
+      int segment = ch.getSegment(key);
+      return allowedSegments.contains(segment);
+   }
+
+   @Override
+   public boolean containsKey(Object key) {
+      if (keyAllowed(key)) {
+         return super.containsKey(key);
+      }
+      return false;
+   }
+
+   @Override
+   public boolean containsValue(Object value) {
+      for (Entry<K, V> entry : entrySet()) {
+         if (value.equals(entry.getValue())) {
+            return true;
+         }
+      }
+      return false;
+   }
+
+   @Override
+   public V get(Object key) {
+      if (keyAllowed(key)) {
+         return super.get(key);
+      }
+      return null;
+   }
+
+   @Override
+   public Set<java.util.Map.Entry<K, V>> entrySet() {
+      if (segmentAwareEntrySet == null) {
+         segmentAwareEntrySet = new ReadOnlySegmentAwareEntrySet<>(delegate().entrySet(),
+               ch, allowedSegments);
+      }
+      return segmentAwareEntrySet;
+   }
+
+   /**
+    * Checks if the provided map is empty.  This is done by iterating over all of the keys
+    * until it can find a key that maps to a given segment.
+    * <p>
+    * This method should always be preferred over checking the size to see if it is empty.
+    * <p>
+    * This time complexity for this method between O(1) to O(N).
+    */
+   @Override
+   public boolean isEmpty() {
+      Set<K> keySet = keySet();
+      Iterator<K> iter = keySet.iterator();
+      return !iter.hasNext();
+   }
+
+   @Override
+   public Set<K> keySet() {
+      if (segmentAwareKeySet == null) {
+         segmentAwareKeySet = new ReadOnlySegmentAwareSet<>(
+               super.keySet(), ch, allowedSegments);
+      }
+      return segmentAwareKeySet;
+   }
+
+   /**
+    * Returns the size of the read only map.  This is done by iterating over all of the
+    * keys counting all that are in the segments.
+    * <p>
+    * If you are using this method to verify if the map is empty, you should instead use
+    * the {@link ReadOnlySegmentAwareEntryMap#isEmpty()} as it will perform better if the
+    * size is only used for this purpose.
+    * <p>
+    * This time complexity for this method is always O(N).
+    */
+   @Override
+   public int size() {
+      Set<K> keySet = keySet();
+      Iterator<K> iter = keySet.iterator();
+      int count = 0;
+      while (iter.hasNext()) {
+         iter.next();
+         count++;
+      }
+      return count;
+   }
+
+   /**
+    * NOTE: this method is not supported.  Due to the nature of this map, we don't want
+    * to copy the underlying value collection.  Thus almost any operation will require
+    * O(N) and therefore this method is not provided.
+    */
+   @Override
+   public Collection<V> values() {
+      throw new UnsupportedOperationException();
+   }
+
+   @Override
+   public String toString() {
+      return "ReadOnlySegmentAwareMap [map=" + map + ", ch=" + ch + 
+            ", allowedSegments=" + allowedSegments + "]";
+   }
+}

--- a/core/src/main/java/org/infinispan/distribution/util/ReadOnlySegmentAwareSet.java
+++ b/core/src/main/java/org/infinispan/distribution/util/ReadOnlySegmentAwareSet.java
@@ -1,0 +1,103 @@
+package org.infinispan.distribution.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.util.AbstractDelegatingSet;
+
+/**
+ * Set implementation that shows a read only view of the provided set by only allowing
+ * entries that map to a given segment using the provided consistent hash.
+ * <p>
+ * This set is useful when you don't want to copy an entire set but only need to see
+ * values from the given segments.
+ * <p>
+ * Note many operations are not constant time when using this set.  Please check the method
+ * you are using to see if it will perform differently than normally expected.
+ * @author wburns
+ * @since 7.2
+ */
+public class ReadOnlySegmentAwareSet<E> extends AbstractDelegatingSet<E> {
+
+   protected final Set<E> set;
+   protected final ConsistentHash ch;
+   protected final Set<Integer> allowedSegments;
+
+   public ReadOnlySegmentAwareSet(Set<E> set, ConsistentHash ch, Set<Integer> allowedSegments) {
+      super();
+      this.set = Collections.unmodifiableSet(set);
+      this.ch = ch;
+      this.allowedSegments = allowedSegments;
+   }
+
+   @Override
+   protected Set<E> delegate() {
+      return set;
+   }
+
+   protected boolean valueAllowed(Object obj) {
+      int segment = ch.getSegment(obj);
+      return allowedSegments.contains(segment);
+   }
+
+   @Override
+   public boolean contains(Object o) {
+      if (valueAllowed(o)) {
+         return super.contains(o);
+      }
+      return false;
+   }
+
+   @Override
+   public boolean containsAll(Collection<?> c) {
+      for (Object obj : c) {
+         if (valueAllowed(obj) && !super.contains(obj)) {
+            return false;
+         }
+      }
+      return true;
+   }
+
+   /**
+    * Checks if the provided set is empty.  This is done by iterating over all of the values
+    * until it can find a key that maps to a given segment.
+    * <p>
+    * This method should always be preferred over checking the size to see if it is empty.
+    * <p>
+    * This time complexity for this method between O(1) to O(N).
+    */
+   @Override
+   public boolean isEmpty() {
+      Iterator<E> iter = iterator();
+      return !iter.hasNext();
+   }
+
+   /**
+    * Returns the size of the read only set.  This is done by iterating over all of the
+    * values counting all that are in the segments.
+    * <p>
+    * If you are using this method to verify if the set is empty, you should instead use
+    * the {@link ReadOnlySegmentAwareEntrySet#isEmpty()} as it will perform better if the
+    * size is only used for this purpose.
+    * <p>
+    * This time complexity for this method is always O(N).
+    */
+   @Override
+   public int size() {
+      Iterator<E> iter = iterator();
+      int count = 0;
+      while (iter.hasNext()) {
+         iter.next();
+         count++;
+      }
+      return count;
+   }
+
+   @Override
+   public Iterator<E> iterator() {
+      return new ReadOnlySegmentAwareIterator<>(super.iterator(), ch, allowedSegments);
+   }
+}

--- a/core/src/main/java/org/infinispan/marshall/exts/MapExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/MapExternalizer.java
@@ -6,6 +6,7 @@ import org.infinispan.commons.marshall.AbstractExternalizer;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.util.FastCopyHashMap;
 import org.infinispan.commons.util.Util;
+import org.infinispan.distribution.util.ReadOnlySegmentAwareMap;
 import org.infinispan.marshall.core.Ids;
 import org.jboss.marshalling.util.IdentityIntMap;
 
@@ -33,6 +34,7 @@ public class MapExternalizer extends AbstractExternalizer<Map> {
 
    public MapExternalizer() {
       numbers.put(HashMap.class, HASHMAP);
+      numbers.put(ReadOnlySegmentAwareMap.class, HASHMAP);
       numbers.put(TreeMap.class, TREEMAP);
       numbers.put(FastCopyHashMap.class, FASTCOPYHASHMAP);
       numbers.put(EquivalentHashMap.class, EQUIVALENTHASHMAP);
@@ -90,6 +92,7 @@ public class MapExternalizer extends AbstractExternalizer<Map> {
    @Override
    public Set<Class<? extends Map>> getTypeClasses() {
       return Util.<Class<? extends Map>>asSet(
-            HashMap.class, TreeMap.class, FastCopyHashMap.class, EquivalentHashMap.class);
+            HashMap.class, TreeMap.class, FastCopyHashMap.class, EquivalentHashMap.class,
+            ReadOnlySegmentAwareMap.class);
    }
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
@@ -144,7 +144,7 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
    private Configuration config;
    private DistributionManager distributionManager;
    private EntryRetriever<K, V> entryRetriever;
-   private InternalEntryFactory entryFactory;
+   private InternalEntryFactory entrgetEvictionMaxEntriesyFactory;
    private ClusterEventManager<K, V> eventManager;
 
    private final Map<Object, UUID> clusterListenerIDs = new ConcurrentHashMap<Object, UUID>();

--- a/core/src/main/java/org/infinispan/util/AbstractDelegatingMap.java
+++ b/core/src/main/java/org/infinispan/util/AbstractDelegatingMap.java
@@ -1,0 +1,71 @@
+package org.infinispan.util;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+public abstract class AbstractDelegatingMap<K, V> implements Map<K, V> {
+
+   protected abstract Map<K, V> delegate();
+   
+   @Override
+   public int size() {
+      return delegate().size();
+   }
+
+   @Override
+   public boolean isEmpty() {
+      return delegate().isEmpty();
+   }
+
+   @Override
+   public boolean containsKey(Object key) {
+      return delegate().containsKey(key);
+   }
+
+   @Override
+   public boolean containsValue(Object value) {
+      return delegate().containsValue(value);
+   }
+
+   @Override
+   public V get(Object key) {
+      return delegate().get(key);
+   }
+
+   @Override
+   public V put(K key, V value) {
+      return delegate().put(key, value);
+   }
+
+   @Override
+   public V remove(Object key) {
+      return delegate().remove(key);
+   }
+
+   @Override
+   public void putAll(Map<? extends K, ? extends V> m) {
+      delegate().putAll(m);
+   }
+
+   @Override
+   public void clear() {
+      delegate().clear();
+   }
+
+   @Override
+   public Set<K> keySet() {
+      return delegate().keySet();
+   }
+
+   @Override
+   public Collection<V> values() {
+      return delegate().values();
+   }
+
+   @Override
+   public Set<java.util.Map.Entry<K, V>> entrySet() {
+      return delegate().entrySet();
+   }
+
+}

--- a/core/src/main/java/org/infinispan/util/AbstractDelegatingSet.java
+++ b/core/src/main/java/org/infinispan/util/AbstractDelegatingSet.java
@@ -1,0 +1,76 @@
+package org.infinispan.util;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+
+public abstract class AbstractDelegatingSet<E> implements Set<E> {
+
+   protected abstract Set<E> delegate();
+
+   @Override
+   public int size() {
+      return delegate().size();
+   }
+
+   @Override
+   public boolean isEmpty() {
+      return delegate().isEmpty();
+   }
+
+   @Override
+   public boolean contains(Object o) {
+      return delegate().contains(o);
+   }
+
+   @Override
+   public Iterator<E> iterator() {
+      return delegate().iterator();
+   }
+
+   @Override
+   public Object[] toArray() {
+      return delegate().toArray();
+   }
+
+   @Override
+   public <T> T[] toArray(T[] a) {
+      return delegate().toArray(a);
+   }
+
+   @Override
+   public boolean add(E e) {
+      return delegate().add(e);
+   }
+
+   @Override
+   public boolean remove(Object o) {
+      return delegate().remove(o);
+   }
+
+   @Override
+   public boolean containsAll(Collection<?> c) {
+      return delegate().containsAll(c);
+   }
+
+   @Override
+   public boolean addAll(Collection<? extends E> c) {
+      return delegate().addAll(c);
+   }
+
+   @Override
+   public boolean retainAll(Collection<?> c) {
+      return delegate().removeAll(c);
+   }
+
+   @Override
+   public boolean removeAll(Collection<?> c) {
+      return delegate().removeAll(c);
+   }
+
+   @Override
+   public void clear() {
+      delegate().clear();
+   }
+
+}

--- a/core/src/test/java/org/infinispan/commands/PutMapCommandStressTest.java
+++ b/core/src/test/java/org/infinispan/commands/PutMapCommandStressTest.java
@@ -1,0 +1,212 @@
+package org.infinispan.commands;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.fail;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Exchanger;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.executors.BlockingThreadPoolExecutorFactory;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.context.Flag;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TestResourceTracker;
+import org.infinispan.test.fwk.TransportFlags;
+import org.infinispan.transaction.TransactionMode;
+import org.testng.annotations.Test;
+
+/**
+ * Stress test designed to test to verify that get many works properly under constant
+ * topology changes
+ *
+ * @author wburns
+ * @since 7.2
+ */
+@Test(groups = "stress", testName = "commands.GetManyCommandStressTest")
+public class PutMapCommandStressTest extends MultipleCacheManagersTest {
+   protected final String CACHE_NAME = getClass().getName();
+   protected final static int NUM_OWNERS = 3;
+   protected final static int CACHE_COUNT = 6;
+   protected final static int THREAD_MULTIPLIER = 1;
+   protected final static int THREAD_WORKER_COUNT = (CACHE_COUNT - 1) * THREAD_MULTIPLIER;
+   protected final static int CACHE_ENTRY_COUNT = 50000;
+   protected ConfigurationBuilder builderUsed;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      builderUsed = new ConfigurationBuilder();
+      builderUsed.clustering().cacheMode(CacheMode.DIST_SYNC);
+      builderUsed.clustering().hash().numOwners(NUM_OWNERS);
+      builderUsed.clustering().stateTransfer().chunkSize(25000);
+      // Uncomment this line to make it transactional
+//      builderUsed.transaction().transactionMode(TransactionMode.TRANSACTIONAL);
+      // This is increased just for the put all command when doing full tracing
+      builderUsed.clustering().sync().replTimeout(12000);
+      createClusteredCaches(CACHE_COUNT, CACHE_NAME, builderUsed);
+   }
+
+   protected EmbeddedCacheManager addClusterEnabledCacheManager(TransportFlags flags) {
+      GlobalConfigurationBuilder gcb = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      // Amend first so we can increase the transport thread pool
+      TestCacheManagerFactory.amendGlobalConfiguration(gcb, flags);
+      // we need to increase the transport and remote thread pools to default values
+      BlockingThreadPoolExecutorFactory executorFactory = new BlockingThreadPoolExecutorFactory(
+            25, 25, 10000, 30000);
+      gcb.transport().transportThreadPool().threadPoolFactory(executorFactory);
+
+      gcb.transport().remoteCommandThreadPool().threadPoolFactory(executorFactory);
+
+      EmbeddedCacheManager cm = TestCacheManagerFactory.newDefaultCacheManager(true, gcb,
+            new ConfigurationBuilder(), false);
+      cacheManagers.add(cm);
+      return cm;
+   }
+
+   public void testStressNodesLeavingWhileMultipleIterators() throws InterruptedException, ExecutionException, TimeoutException {
+      final Map<Integer, Integer> masterValues = new HashMap<Integer, Integer>();
+      final Map<Integer, Integer>[] keys = new Map[THREAD_WORKER_COUNT];
+      for (int i = 0; i < keys.length; ++i) {
+         keys[i] = new HashMap<>();
+      }
+      // First populate our caches
+      for (int i = 0; i < CACHE_ENTRY_COUNT; ++i) {
+         masterValues.put(i, i);
+         keys[i % THREAD_WORKER_COUNT].put(i, i);
+      }
+
+      cache(0, CACHE_NAME).putAll(masterValues);
+
+      for (int i = 0; i < keys.length; ++i) {
+         keys[i] = Collections.unmodifiableMap(keys[i]);
+      }
+
+      final AtomicBoolean complete = new AtomicBoolean(false);
+      final Exchanger<Throwable> exchanger = new Exchanger<Throwable>();
+      // Now we spawn off CACHE_COUNT of threads.  All but one will constantly calling to iterator while another
+      // will constantly be killing and adding new caches
+      Future<Void>[] futures = new Future[THREAD_WORKER_COUNT + 1];
+      for (int j = 0; j < THREAD_MULTIPLIER; ++j) {
+      // We iterate over all but the last cache since we kill it constantly
+      for (int i = 0; i < CACHE_COUNT - 1; ++i) {
+         final int offset = j * (CACHE_COUNT -1) + i;
+         final Cache<Integer, Integer> cache = cache(i, CACHE_NAME);
+         futures[i + j * (CACHE_COUNT -1)] = fork(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+               Map<Integer, Integer> keysToUse = keys[offset];
+               try {
+                  int iteration = 0;
+                  
+                  while (!complete.get()) {
+                     log.tracef("Starting iteration %s", iteration);
+                     // UNCOMMENT following to test insertions by themselves
+//                     for (Entry<Integer, Integer> entry : keysToUse.entrySet()) {
+//                        cache.put(entry.getKey(), entry.getValue());
+//                     }
+                     cache.getAdvancedCache().putAll(keysToUse);
+                     // UNCOMMENT following to make sure puts are propagated properly
+//                     List<Cache<Integer, Integer>> caches = caches(CACHE_NAME);
+//                     for (int key : keysToUse.keySet()) {
+//                        int hasValue = 0;
+//                        for (Cache<Integer, Integer> cache : caches) {
+//                           Integer value = cache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).get(key);
+//                           if (value != null && value.intValue() == key) {
+//                              hasValue++;
+//                           }
+//                        }
+//                        if (hasValue != NUM_OWNERS) {
+//                           assertEquals("Key was " + key, NUM_OWNERS, hasValue);
+//                        }
+//                     }
+                     iteration++;
+                  }
+                  System.out.println(Thread.currentThread() + " finished " + iteration + " iterations!");
+                  return null;
+               } catch (Throwable e) {
+                  // Stop all the others as well
+                  complete.set(true);
+                  exchanger.exchange(e);
+                  throw e;
+               }
+            }
+         });
+      }
+      }
+
+      // TODO: need to figure out code to properly test having a node dying constantly
+      // Then spawn a thread that just constantly kills the last cache and recreates over and over again
+//      futures[futures.length - 1] = fork(new Callable<Void>() {
+//         @Override
+//         public Void call() throws Exception {
+//            TestResourceTracker.setThreadTestName("main");
+////            TestResourceTracker.backgroundTestStarted(PutMapCommandStressTest.this);
+//            try {
+//               Cache<?, ?> cacheToKill = cache(CACHE_COUNT - 1);
+//               while (!complete.get()) {
+//                  Thread.sleep(1000);
+//                  if (cacheManagers.remove(cacheToKill.getCacheManager())) {
+//                     log.trace("Killing cache to force rehash");
+//                     cacheToKill.getCacheManager().stop();
+//                     List<Cache<Object, Object>> caches = caches(CACHE_NAME);
+//                     if (caches.size() > 0) {
+//                        TestingUtil.blockUntilViewsReceived(60000, false, caches);
+//                        TestingUtil.waitForRehashToComplete(caches);
+//                     }
+//                  } else {
+//                     throw new IllegalStateException("Cache Manager " + cacheToKill.getCacheManager() +
+//                                                           " wasn't found for some reason!");
+//                  }
+//
+//                  log.trace("Adding new cache again to force rehash");
+//                  // We should only create one so just make it the next cache manager to kill
+//                  cacheToKill = createClusteredCaches(1, CACHE_NAME, builderUsed).get(0);
+//                  log.trace("Added new cache again to force rehash");
+//               }
+//               return null;
+//            } catch (Exception e) {
+//               // Stop all the others as well
+//               complete.set(true);
+//               exchanger.exchange(e);
+//               throw e;
+//            }
+//         }
+//      });
+
+      try {
+         // If this returns means we had an issue
+         Throwable e = exchanger.exchange(null, 5, TimeUnit.MINUTES);
+         e.printStackTrace();
+         fail("Found an throwable in at least 1 thread" + e);
+      } catch (TimeoutException e) { }
+
+      complete.set(true);
+
+      // Make sure they all finish properly
+      for (int i = 0; i < futures.length - 1; ++i) {
+         try {
+            futures[i].get(1, TimeUnit.MINUTES);
+         } catch (TimeoutException e) {
+            System.err.println("Future " + i + " did not complete in time allotted.");
+            throw e;
+         }
+      }
+   }
+}


### PR DESCRIPTION
This is just preview atm.  I still need to fixup some methods in the segment collections.

Also should I move the delegating classes to core instead?

It seems we could reuse the delegating with the other classes. I find that using a delegate() method is better since then you don't need different instance variables as you can use covariant returns to use the higher class in later classes.