### PR TITLE
ISPN-5046 PartitionHandling: split during commit can leave the cache inc...

### DIFF
--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -897,11 +897,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
 
    @Override
    public AvailabilityMode getAvailability() {
-      if (partitionHandlingManager != null) {
-         return partitionHandlingManager.getAvailabilityMode();
-      } else {
-         return AvailabilityMode.AVAILABLE;
-      }
+      return partitionHandlingManager.getAvailabilityMode();
    }
 
    @Override
@@ -1020,7 +1016,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
 
    @Override
    public XAResource getXAResource() {
-      return new TransactionXaAdapter(txTable, recoveryManager, txCoordinator, commandsFactory, rpcManager, null, config, name);
+      return new TransactionXaAdapter(txTable, recoveryManager, txCoordinator, commandsFactory, rpcManager, null, config, name, partitionHandlingManager);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/factories/PartitionHandlingManagerFactory.java
+++ b/core/src/main/java/org/infinispan/factories/PartitionHandlingManagerFactory.java
@@ -2,6 +2,7 @@ package org.infinispan.factories;
 
 
 import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.partitionhandling.impl.AvailablePartitionHandlingManager;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManagerImpl;
 
@@ -10,8 +11,8 @@ import org.infinispan.partitionhandling.impl.PartitionHandlingManagerImpl;
  * @since 7.0
  */
 @DefaultFactoryFor(classes = PartitionHandlingManager.class)
-public class PartitionHandlingManagerFactory extends AbstractNamedCacheComponentFactory implements
-      AutoInstantiableFactory {
+public class PartitionHandlingManagerFactory extends AbstractNamedCacheComponentFactory implements AutoInstantiableFactory {
+
    @Override
    @SuppressWarnings("unchecked")
    public <T> T construct(Class<T> componentType) {
@@ -21,6 +22,6 @@ public class PartitionHandlingManagerFactory extends AbstractNamedCacheComponent
             return (T) new PartitionHandlingManagerImpl();
          }
       }
-      return null;
+      return (T) AvailablePartitionHandlingManager.getInstance();
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/TxInterceptor.java
@@ -24,8 +24,11 @@ import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.Configurations;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.context.impl.LocalTxInvocationContext;
+import org.infinispan.context.impl.RemoteTxInvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.interceptors.base.CommandInterceptor;
@@ -40,10 +43,8 @@ import org.infinispan.jmx.annotations.ManagedOperation;
 import org.infinispan.jmx.annotations.MeasurementType;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
-import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.transaction.impl.RemoteTransaction;
-import org.infinispan.transaction.impl.TransactionCoordinator;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoverableTransactionIdentifier;
@@ -68,35 +69,33 @@ import java.util.concurrent.atomic.AtomicLong;
 @MBean(objectName = "Transactions", description = "Component that manages the cache's participation in JTA transactions.")
 public class TxInterceptor extends CommandInterceptor implements JmxStatisticsExposer {
 
-   private TransactionTable txTable;
+   private static final Log log = LogFactory.getLog(TxInterceptor.class);
+   private static final boolean trace = log.isTraceEnabled();
 
    private final AtomicLong prepares = new AtomicLong(0);
    private final AtomicLong commits = new AtomicLong(0);
    private final AtomicLong rollbacks = new AtomicLong(0);
-   private boolean statisticsEnabled;
-   protected TransactionCoordinator txCoordinator;
-   protected RpcManager rpcManager;
 
-   private static final Log log = LogFactory.getLog(TxInterceptor.class);
-   private static final boolean trace = log.isTraceEnabled();
+   private RpcManager rpcManager;
+   private CommandsFactory commandsFactory;
+   private Cache cache;
    private RecoveryManager recoveryManager;
+   private TransactionTable txTable;
+
    private boolean isTotalOrder;
    private boolean useOnePhaseForAutoCommitTx;
    private boolean useVersioning;
-   private CommandsFactory commandsFactory;
-   private Cache cache;
+   private boolean statisticsEnabled;
 
-   @Override
-   protected Log getLog() {
-      return log;
+   private static boolean shouldEnlist(InvocationContext ctx) {
+      return ctx.isInTxScope() && ctx.isOriginLocal();
    }
 
    @Inject
-   public void init(TransactionTable txTable, Configuration configuration, TransactionCoordinator txCoordinator, RpcManager rpcManager,
+   public void init(TransactionTable txTable, Configuration configuration, RpcManager rpcManager,
                     RecoveryManager recoveryManager, CommandsFactory commandsFactory, Cache cache) {
       this.cacheConfiguration = configuration;
       this.txTable = txTable;
-      this.txCoordinator = txCoordinator;
       this.rpcManager = rpcManager;
       this.recoveryManager = recoveryManager;
       this.commandsFactory = commandsFactory;
@@ -105,8 +104,7 @@ public class TxInterceptor extends CommandInterceptor implements JmxStatisticsEx
       statisticsEnabled = cacheConfiguration.jmxStatistics().enabled();
       isTotalOrder = configuration.transaction().transactionProtocol().isTotalOrder();
       useOnePhaseForAutoCommitTx = cacheConfiguration.transaction().use1PcForAutoCommitTransactions();
-      useVersioning = configuration.transaction().transactionMode().isTransactional() && configuration.locking().writeSkewCheck() &&
-            configuration.transaction().lockingMode() == LockingMode.OPTIMISTIC && configuration.versioning().enabled();
+      useVersioning = Configurations.isVersioningEnabled(configuration);
    }
 
    @Override
@@ -131,57 +129,6 @@ public class TxInterceptor extends CommandInterceptor implements JmxStatisticsEx
       return result;
    }
 
-   private Object invokeNextInterceptorAndVerifyTransaction(TxInvocationContext ctx, AbstractTransactionBoundaryCommand command) throws Throwable {
-      try {
-         return invokeNextInterceptor(ctx, command);
-      } finally {
-         if (!ctx.isOriginLocal()) {
-            // command.getOrigin() and ctx.getOrigin() are not reliable for LockControlCommands started by
-            // ClusteredGetCommands, or for PrepareCommands started by MultipleRpcCommands (when the replication queue
-            // is enabled).
-            Address origin = ctx.getGlobalTransaction().getAddress();
-            //It is possible to receive a prepare or lock control command from a node that crashed. If that's the case rollback
-            //the transaction forcefully in order to cleanup resources.
-            boolean originatorMissing = !rpcManager.getTransport().getMembers().contains(origin);
-            // It is also possible that the LCC timed out on the originator's end and this node has processed
-            // a TxCompletionNotification.  So we need to check the presence of the remote transaction to
-            // see if we need to clean up any acquired locks on our end.
-            boolean alreadyCompleted = txTable.isTransactionCompleted(command.getGlobalTransaction()) ||
-                    !txTable.containRemoteTx(command.getGlobalTransaction());
-            // We want to throw an exception if the originator left the cluster and the transaction is not finished
-            // and/or it was rolled back by TransactionTable.cleanupLeaverTransactions().
-            // We don't want to throw an exception if the originator left the cluster but the transaction already
-            // completed successfully. So far, this only seems possible when forcing the commit of an orphaned
-            // transaction (with recovery enabled).
-            boolean completedSuccessfully = alreadyCompleted && !ctx.getCacheTransaction().isMarkedForRollback();
-            if (trace) {
-               log.tracef("invokeNextInterceptorAndVerifyTransaction :: originatorMissing=%s, alreadyCompleted=%s",
-                       originatorMissing, alreadyCompleted);
-            }
-
-            if (alreadyCompleted || originatorMissing) {
-               if (trace) {
-                  log.tracef("Rolling back remote transaction %s because either already completed (%s) or originator no " +
-                          "longer in the cluster (%s).",
-                          command.getGlobalTransaction(), alreadyCompleted, originatorMissing);
-               }
-               RollbackCommand rollback = new RollbackCommand(command.getCacheName(), command.getGlobalTransaction());
-               try {
-                  invokeNextInterceptor(ctx, rollback);
-               } finally {
-                  RemoteTransaction remoteTx = (RemoteTransaction) ctx.getCacheTransaction();
-                  remoteTx.markForRollback(true);
-                  txTable.removeRemoteTransaction(command.getGlobalTransaction());
-               }
-            }
-
-            if (originatorMissing && !completedSuccessfully) {
-               throw log.orphanTransactionRolledBack(ctx.getGlobalTransaction());
-            }
-         }
-      }
-   }
-
    @Override
    public Object visitCommitCommand(TxInvocationContext ctx, CommitCommand command) throws Throwable {
       GlobalTransaction gtx = ctx.getGlobalTransaction();
@@ -193,28 +140,7 @@ public class TxInterceptor extends CommandInterceptor implements JmxStatisticsEx
          }
 
          if (!isTotalOrder) {
-            // If a commit is received for a transaction that doesn't have its 'lookedUpEntries' populated
-            // we know for sure this transaction is 2PC and was received via state transfer but the preceding PrepareCommand
-            // was not received by local node because it was executed on the previous key owners. We need to re-prepare
-            // the transaction on local node to ensure its locks are acquired and lookedUpEntries is properly populated.
-            RemoteTransaction remoteTx = (RemoteTransaction) ctx.getCacheTransaction();
-            if (trace) {
-               log.tracef("Remote tx topology id %d and command topology is %d", remoteTx.lookedUpEntriesTopology(),
-                          command.getTopologyId());
-            }
-            if (remoteTx.lookedUpEntriesTopology() < command.getTopologyId()) {
-               PrepareCommand prepareCommand;
-               if (useVersioning) {
-                  prepareCommand = commandsFactory.buildVersionedPrepareCommand(ctx.getGlobalTransaction(), ctx.getModifications(), false);
-               } else {
-                  prepareCommand = commandsFactory.buildPrepareCommand(ctx.getGlobalTransaction(), ctx.getModifications(), false);
-               }
-               commandsFactory.initializeReplicableCommand(prepareCommand, true);
-               prepareCommand.setOrigin(ctx.getOrigin());
-               if (trace)
-                  log.tracef("Replaying the transactions received as a result of state transfer %s", prepareCommand);
-               visitPrepareCommand(ctx, prepareCommand);
-            }
+            replayRemoteTransactionIfNeeded((RemoteTxInvocationContext) ctx, command.getTopologyId());
          }
       }
 
@@ -238,9 +164,9 @@ public class TxInterceptor extends CommandInterceptor implements JmxStatisticsEx
       } finally {
          //for tx that rollback we do not send a TxCompletionNotification, so we should cleanup
          // the recovery info here
-         if (recoveryManager!=null) {
+         if (recoveryManager != null) {
             GlobalTransaction gtx = command.getGlobalTransaction();
-            recoveryManager.removeRecoveryInformation(((RecoverableTransactionIdentifier)gtx).getXid());
+            recoveryManager.removeRecoveryInformation(((RecoverableTransactionIdentifier) gtx).getXid());
          }
       }
    }
@@ -325,12 +251,146 @@ public class TxInterceptor extends CommandInterceptor implements JmxStatisticsEx
    public EntryIterable visitEntryRetrievalCommand(InvocationContext ctx, EntryRetrievalCommand command) throws Throwable {
       // Enlistment shouldn't be needed for this command.  The remove on the iterator will internally make a remove
       // command and the iterator itself does not place read values into the context.
-      EntryIterable iterable = (EntryIterable) super.visitEntryRetrievalCommand(ctx, command);
+      EntryIterable iterable = (EntryIterable) invokeNextInterceptor(ctx, command);
       if (ctx.isInTxScope()) {
-         return new TransactionAwareEntryIterable(iterable, command.getFilter(), 
-               (TxInvocationContext<LocalTransaction>) ctx, cache);
+         //noinspection unchecked
+         return new TransactionAwareEntryIterable(iterable, command.getFilter(), (LocalTxInvocationContext) ctx, cache);
       } else {
          return iterable;
+      }
+   }
+
+   @Override
+   public boolean getStatisticsEnabled() {
+      return isStatisticsEnabled();
+   }
+
+   @ManagedOperation(
+         description = "Resets statistics gathered by this component",
+         displayName = "Reset Statistics"
+   )
+   public void resetStatistics() {
+      prepares.set(0);
+      commits.set(0);
+      rollbacks.set(0);
+   }
+
+   @ManagedAttribute(
+         displayName = "Statistics enabled",
+         dataType = DataType.TRAIT,
+         writable = true
+   )
+   public boolean isStatisticsEnabled() {
+      return this.statisticsEnabled;
+   }
+
+   @Override
+   public void setStatisticsEnabled(boolean enabled) {
+      statisticsEnabled = enabled;
+   }
+
+   @ManagedAttribute(
+         description = "Number of transaction prepares performed since last reset",
+         displayName = "Prepares",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
+   public long getPrepares() {
+      return prepares.get();
+   }
+
+   @ManagedAttribute(
+         description = "Number of transaction commits performed since last reset",
+         displayName = "Commits",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
+   public long getCommits() {
+      return commits.get();
+   }
+
+   @ManagedAttribute(
+         description = "Number of transaction rollbacks performed since last reset",
+         displayName = "Rollbacks",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
+   public long getRollbacks() {
+      return rollbacks.get();
+   }
+
+   @Override
+   protected Log getLog() {
+      return log;
+   }
+
+   private LocalTransaction enlist(TxInvocationContext ctx) throws SystemException {
+      Transaction transaction = ctx.getTransaction();
+      if (transaction == null) throw new IllegalStateException("This should only be called in an tx scope");
+      int status = transaction.getStatus();
+      if (isNotValid(status)) throw new IllegalStateException("Transaction " + transaction +
+                                                                    " is not in a valid state to be invoking cache operations on.");
+      LocalTransaction localTransaction = txTable.getLocalTransaction(transaction);
+      txTable.enlist(transaction, localTransaction);
+      return localTransaction;
+   }
+
+   private Object invokeNextInterceptorAndVerifyTransaction(TxInvocationContext ctx, AbstractTransactionBoundaryCommand command) throws Throwable {
+      try {
+         return invokeNextInterceptor(ctx, command);
+      } finally {
+         if (!ctx.isOriginLocal()) {
+            verifyRemoteTransaction((RemoteTxInvocationContext) ctx, command);
+         }
+      }
+   }
+
+   private void verifyRemoteTransaction(RemoteTxInvocationContext ctx, AbstractTransactionBoundaryCommand command) throws Throwable {
+      final GlobalTransaction globalTransaction = command.getGlobalTransaction();
+
+      // command.getOrigin() and ctx.getOrigin() are not reliable for LockControlCommands started by
+      // ClusteredGetCommands, or for PrepareCommands started by MultipleRpcCommands (when the replication queue
+      // is enabled).
+      final Address origin = globalTransaction.getAddress();
+
+      //It is possible to receive a prepare or lock control command from a node that crashed. If that's the case rollback
+      //the transaction forcefully in order to cleanup resources.
+      boolean originatorMissing = !rpcManager.getTransport().getMembers().contains(origin);
+
+      // It is also possible that the LCC timed out on the originator's end and this node has processed
+      // a TxCompletionNotification.  So we need to check the presence of the remote transaction to
+      // see if we need to clean up any acquired locks on our end.
+      boolean alreadyCompleted = txTable.isTransactionCompleted(globalTransaction) || !txTable.containRemoteTx(globalTransaction);
+
+      // We want to throw an exception if the originator left the cluster and the transaction is not finished
+      // and/or it was rolled back by TransactionTable.cleanupLeaverTransactions().
+      // We don't want to throw an exception if the originator left the cluster but the transaction already
+      // completed successfully. So far, this only seems possible when forcing the commit of an orphaned
+      // transaction (with recovery enabled).
+      boolean completedSuccessfully = alreadyCompleted && !ctx.getCacheTransaction().isMarkedForRollback();
+
+      if (trace) {
+         log.tracef("invokeNextInterceptorAndVerifyTransaction :: originatorMissing=%s, alreadyCompleted=%s",
+                    originatorMissing, alreadyCompleted);
+      }
+
+      if (alreadyCompleted || originatorMissing) {
+         if (trace) {
+            log.tracef("Rolling back remote transaction %s because either already completed (%s) or originator no longer in the cluster (%s).",
+                       globalTransaction, alreadyCompleted, originatorMissing);
+         }
+         RollbackCommand rollback = commandsFactory.buildRollbackCommand(command.getGlobalTransaction());
+         try {
+            invokeNextInterceptor(ctx, rollback);
+         } finally {
+            RemoteTransaction remoteTx = ctx.getCacheTransaction();
+            remoteTx.markForRollback(true);
+            txTable.removeRemoteTransaction(globalTransaction);
+         }
+      }
+
+      if (originatorMissing && !completedSuccessfully) {
+         throw log.orphanTransactionRolledBack(globalTransaction);
       }
    }
 
@@ -372,83 +432,34 @@ public class TxInterceptor extends CommandInterceptor implements JmxStatisticsEx
       return rv;
    }
 
-   public LocalTransaction enlist(TxInvocationContext ctx) throws SystemException {
-      Transaction transaction = ctx.getTransaction();
-      if (transaction == null) throw new IllegalStateException("This should only be called in an tx scope");
-      int status = transaction.getStatus();
-      if (isNotValid(status)) throw new IllegalStateException("Transaction " + transaction +
-            " is not in a valid state to be invoking cache operations on.");
-      LocalTransaction localTransaction = txTable.getLocalTransaction(transaction);
-      txTable.enlist(transaction, localTransaction);
-      return localTransaction;
-   }
-
    private boolean isNotValid(int status) {
       return status != Status.STATUS_ACTIVE
             && status != Status.STATUS_PREPARING
             && status != Status.STATUS_COMMITTING;
    }
 
-   private static boolean shouldEnlist(InvocationContext ctx) {
-      return ctx.isInTxScope() && ctx.isOriginLocal();
-   }
-
-   @Override
-   public boolean getStatisticsEnabled() {
-      return isStatisticsEnabled();
-   }
-
-   @Override
-   public void setStatisticsEnabled(boolean enabled) {
-      statisticsEnabled = enabled;
-   }
-
-   @ManagedOperation(
-         description = "Resets statistics gathered by this component",
-         displayName = "Reset Statistics"
-   )
-   public void resetStatistics() {
-      prepares.set(0);
-      commits.set(0);
-      rollbacks.set(0);
-   }
-
-   @ManagedAttribute(
-         displayName = "Statistics enabled",
-         dataType = DataType.TRAIT,
-         writable = true
-   )
-   public boolean isStatisticsEnabled() {
-      return this.statisticsEnabled;
-   }
-
-   @ManagedAttribute(
-         description = "Number of transaction prepares performed since last reset",
-         displayName = "Prepares",
-         measurementType = MeasurementType.TRENDSUP,
-         displayType = DisplayType.SUMMARY
-   )
-   public long getPrepares() {
-      return prepares.get();
-   }
-
-   @ManagedAttribute(
-         description = "Number of transaction commits performed since last reset",
-         displayName = "Commits",
-         measurementType = MeasurementType.TRENDSUP,
-         displayType = DisplayType.SUMMARY
-   )
-   public long getCommits() {
-      return commits.get();
-   }
-
-   @ManagedAttribute(
-         description = "Number of transaction rollbacks performed since last reset",
-         displayName = "Rollbacks",
-         measurementType = MeasurementType.TRENDSUP,
-         displayType = DisplayType.SUMMARY
-   )
-   public long getRollbacks() {
-      return rollbacks.get();
+   private void replayRemoteTransactionIfNeeded(RemoteTxInvocationContext ctx, int topologyId) throws Throwable {
+      // If a commit is received for a transaction that doesn't have its 'lookedUpEntries' populated
+      // we know for sure this transaction is 2PC and was received via state transfer but the preceding PrepareCommand
+      // was not received by local node because it was executed on the previous key owners. We need to re-prepare
+      // the transaction on local node to ensure its locks are acquired and lookedUpEntries is properly populated.
+      RemoteTransaction remoteTx = ctx.getCacheTransaction();
+      if (trace) {
+         log.tracef("Remote tx topology id %d and command topology is %d", remoteTx.lookedUpEntriesTopology(), topologyId);
+      }
+      if (remoteTx.lookedUpEntriesTopology() < topologyId) {
+         PrepareCommand prepareCommand;
+         if (useVersioning) {
+            prepareCommand = commandsFactory.buildVersionedPrepareCommand(ctx.getGlobalTransaction(), ctx.getModifications(), false);
+         } else {
+            prepareCommand = commandsFactory.buildPrepareCommand(ctx.getGlobalTransaction(), ctx.getModifications(), false);
+         }
+         commandsFactory.initializeReplicableCommand(prepareCommand, true);
+         prepareCommand.setOrigin(ctx.getOrigin());
+         if (trace) {
+            log.tracef("Replaying the transactions received as a result of state transfer %s", prepareCommand);
+         }
+         visitPrepareCommand(ctx, prepareCommand);
+      }
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
@@ -40,11 +40,9 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Base class for distribution of entries across a cluster.
@@ -198,11 +196,9 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
          throw new CacheException("Attempted execution of non-transactional write command in a transactional invocation context");
       }
 
-      RecipientGenerator recipientGenerator = new SingleKeyRecipientGenerator(command.getKey());
-
       // see if we need to load values from remote sources first
       if (needValuesFromPreviousOwners(ctx, command)) {
-         remoteGetBeforeWrite(ctx, command, recipientGenerator);
+         remoteGetBeforeWrite(ctx, command, command.getKey());
       }
 
       // invoke the command locally, we need to know if it's successful or not
@@ -238,7 +234,7 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
                log.tracef("Skipping the replication of the conditional command as it did not succeed on primary owner (%s).", command);
                return localResult;
             }
-            List<Address> recipients = recipientGenerator.generateRecipients();
+            List<Address> recipients = cdl.getOwners(command.getKey());
             // Ignore the previous value on the backup owners
             command.setValueMatcher(ValueMatcher.MATCH_ALWAYS);
             try {
@@ -256,7 +252,7 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
                log.tracef("Skipping the replication of the command as it did not succeed on primary owner (%s).", command);
                return localResult;
             }
-            List<Address> recipients = recipientGenerator.generateRecipients();
+            List<Address> recipients = cdl.getOwners(command.getKey());
             log.tracef("I'm the primary owner, sending the command to all the backups (%s) in order to be applied.",
                   recipients);
             // check if a single owner has been configured and the target for the key is the local address
@@ -353,59 +349,5 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
     */
    protected abstract boolean needValuesFromPreviousOwners(InvocationContext ctx, WriteCommand command);
 
-   protected abstract void remoteGetBeforeWrite(InvocationContext ctx, WriteCommand command, RecipientGenerator keygen) throws Throwable;
-
-   interface RecipientGenerator {
-
-      Collection<Object> getKeys();
-
-      List<Address> generateRecipients();
-   }
-
-   class SingleKeyRecipientGenerator implements RecipientGenerator {
-      private final Object key;
-      private final Set<Object> keys;
-      private List<Address> recipients = null;
-
-      SingleKeyRecipientGenerator(Object key) {
-         this.key = key;
-         keys = Collections.singleton(key);
-      }
-
-      @Override
-      public List<Address> generateRecipients() {
-         if (recipients == null) {
-            recipients = cdl.getOwners(key);
-         }
-         return recipients;
-      }
-
-      @Override
-      public Collection<Object> getKeys() {
-         return keys;
-      }
-   }
-
-   class MultipleKeysRecipientGenerator implements RecipientGenerator {
-
-      private final Collection<Object> keys;
-      private List<Address> recipients = null;
-
-      MultipleKeysRecipientGenerator(Collection<Object> keys) {
-         this.keys = keys;
-      }
-
-      @Override
-      public List<Address> generateRecipients() {
-         if (recipients == null) {
-            recipients = cdl.getOwners(keys);
-         }
-         return recipients;
-      }
-
-      @Override
-      public Collection<Object> getKeys() {
-         return keys;
-      }
-   }
+   protected abstract void remoteGetBeforeWrite(InvocationContext ctx, WriteCommand command, Object key) throws Throwable;
 }

--- a/core/src/main/java/org/infinispan/interceptors/distribution/NonTxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/NonTxDistributionInterceptor.java
@@ -203,13 +203,11 @@ public class NonTxDistributionInterceptor extends BaseDistributionInterceptor {
       return handleNonTxWriteCommand(ctx, command);
    }
 
-   protected void remoteGetBeforeWrite(InvocationContext ctx, WriteCommand command, RecipientGenerator keygen) throws Throwable {
-      for (Object k : keygen.getKeys()) {
-         if (cdl.localNodeIsPrimaryOwner(k)) {
-            // Then it makes sense to try a local get and wrap again. This will compensate the fact the the entry was not local
-            // earlier when the EntryWrappingInterceptor executed during current invocation context but it should be now.
-            localGetCacheEntry(ctx, k, true, command);
-         }
+   protected void remoteGetBeforeWrite(InvocationContext ctx, WriteCommand command, Object key) throws Throwable {
+      if (cdl.localNodeIsPrimaryOwner(key)) {
+         // Then it makes sense to try a local get and wrap again. This will compensate the fact the the entry was not local
+         // earlier when the EntryWrappingInterceptor executed during current invocation context but it should be now.
+         localGetCacheEntry(ctx, key, true, command);
       }
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -8,24 +8,30 @@ import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
+import org.infinispan.commands.tx.VersionedCommitCommand;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.PutMapCommand;
 import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commands.write.ValueMatcher;
 import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.configuration.cache.Configurations;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.container.versioning.EntryVersionsMap;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.LocalTxInvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
+import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.responses.CacheNotFoundResponse;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.responses.UnsureResponse;
 import org.infinispan.remoting.rpc.ResponseMode;
+import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.rpc.RpcOptions;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.jgroups.SuspectException;
@@ -35,10 +41,10 @@ import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeoutException;
 
 import static org.infinispan.util.DeltaCompositeKeyUtil.filterDeltaCompositeKey;
 import static org.infinispan.util.DeltaCompositeKeyUtil.filterDeltaCompositeKeys;
@@ -55,13 +61,39 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
    private static Log log = LogFactory.getLog(TxDistributionInterceptor.class);
    private static final boolean trace = log.isTraceEnabled();
 
+   private PartitionHandlingManager partitionHandlingManager;
+
    private boolean isPessimisticCache;
    private boolean useClusteredWriteSkewCheck;
+   private boolean partitionHandlingEnabled;
+
+   private RpcOptions commitRpcOptions;
+   private RpcOptions rollbackRpcOptions;
+
+   @Inject
+   public void inject(PartitionHandlingManager partitionHandlingManager) {
+      this.partitionHandlingManager = partitionHandlingManager;
+   }
+
+   @Start
+   public void start() {
+      isPessimisticCache = cacheConfiguration.transaction().lockingMode() == LockingMode.PESSIMISTIC;
+      useClusteredWriteSkewCheck = Configurations.isVersioningEnabled(cacheConfiguration);
+      partitionHandlingEnabled = cacheConfiguration.clustering().partitionHandling().enabled();
+
+      boolean partitionHandlingEnabled = cacheConfiguration.clustering().partitionHandling().enabled();
+      rollbackRpcOptions = createRpcOptionsFor2ndPhase(cacheConfiguration.transaction().syncRollbackPhase(),
+                                                       partitionHandlingEnabled, rpcManager);
+
+      commitRpcOptions = createRpcOptionsFor2ndPhase(cacheConfiguration.transaction().syncCommitPhase(),
+                                                     partitionHandlingEnabled, rpcManager);
+
+   }
 
    @Override
    public Object visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) throws Throwable {
       try {
-         return handleTxWriteCommand(ctx, command, new SingleKeyRecipientGenerator(command.getKey()), false);
+         return handleTxWriteCommand(ctx, command, command.getKey(), false);
       } finally {
          if (ctx.isOriginLocal()) {
             // If the state transfer interceptor has to retry the command, it should ignore the previous value.
@@ -73,7 +105,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
    @Override
    public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
       try {
-         return handleTxWriteCommand(ctx, command, new SingleKeyRecipientGenerator(command.getKey()), false);
+         return handleTxWriteCommand(ctx, command, command.getKey(), false);
       } finally {
          if (ctx.isOriginLocal()) {
             // If the state transfer interceptor has to retry the command, it should ignore the previous value.
@@ -82,32 +114,26 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       }
    }
 
-   @Start
-   public void start() {
-      isPessimisticCache = cacheConfiguration.transaction().lockingMode() == LockingMode.PESSIMISTIC;
-      useClusteredWriteSkewCheck = !isPessimisticCache &&
-            cacheConfiguration.versioning().enabled() && cacheConfiguration.locking().writeSkewCheck();
-   }
-
    @Override
    public Object visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) throws Throwable {
       if (command.hasFlag(Flag.PUT_FOR_EXTERNAL_READ)) {
          return handleNonTxWriteCommand(ctx, command);
       }
 
-      SingleKeyRecipientGenerator skrg = new SingleKeyRecipientGenerator(command.getKey());
-      Object returnValue = handleTxWriteCommand(ctx, command, skrg, command.hasFlag(Flag.PUT_FOR_STATE_TRANSFER));
-      if (ctx.isOriginLocal()) {
-         // If the state transfer interceptor has to retry the command, it should ignore the previous value.
-         command.setValueMatcher(command.isSuccessful() ? ValueMatcher.MATCH_ALWAYS : ValueMatcher.MATCH_NEVER);
+      try {
+         return handleTxWriteCommand(ctx, command, command.getKey(), command.hasFlag(Flag.PUT_FOR_STATE_TRANSFER));
+      } finally {
+         if (ctx.isOriginLocal()) {
+            // If the state transfer interceptor has to retry the command, it should ignore the previous value.
+            command.setValueMatcher(command.isSuccessful() ? ValueMatcher.MATCH_ALWAYS : ValueMatcher.MATCH_NEVER);
+         }
       }
-      return returnValue;
    }
 
    @Override
    public Object visitPutMapCommand(InvocationContext ctx, PutMapCommand command) throws Throwable {
       // don't bother with a remote get for the PutMapCommand!
-      return handleTxWriteCommand(ctx, command, new MultipleKeysRecipientGenerator(command.getMap().keySet()), true);
+      return handleTxWriteCommand(ctx, command, null, true);
    }
 
    @Override
@@ -130,8 +156,115 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       }
    }
 
+   @Override
+   public Object visitLockControlCommand(TxInvocationContext ctx, LockControlCommand command) throws Throwable {
+      if (ctx.isOriginLocal()) {
+         //In Pessimistic mode, the delta composite keys were sent to the wrong owner and never locked.
+         final Collection<Address> affectedNodes = cdl.getOwners(filterDeltaCompositeKeys(command.getKeys()));
+         ((LocalTxInvocationContext) ctx).remoteLocksAcquired(affectedNodes == null ? dm.getConsistentHash().getMembers() : affectedNodes);
+         if (trace) {
+            log.tracef("Registered remote locks acquired %s", affectedNodes);
+         }
+         try {
+            rpcManager.invokeRemotely(affectedNodes, command, rpcManager.getDefaultRpcOptions(true, DeliverOrder.NONE));
+         } catch (SuspectException e) {
+            partitionHandlingManager.addPartialRollbackTransaction(command.getGlobalTransaction(), ((LocalTxInvocationContext) ctx).getRemoteLocksAcquired(), ctx.getLockedKeys(), e);
+            //always throw exception
+            throw e;
+         }
+      }
+      return invokeNextInterceptor(ctx, command);
+   }
+
+   @Override
+   public Object visitCommitCommand(TxInvocationContext ctx, CommitCommand command) throws Throwable {
+      if (shouldInvokeRemoteTxCommand(ctx)) {
+         Collection<Address> recipients = getCommitNodes(ctx);
+         try {
+            Map<Address, Response> responseMap = rpcManager.invokeRemotely(recipients, command, commitRpcOptions);
+            checkTxCommandResponses(responseMap);
+         } catch (SuspectException e) {
+            EntryVersionsMap newVersion = null;
+            if (command instanceof VersionedCommitCommand) {
+               newVersion = ((VersionedCommitCommand) command).getUpdatedVersions();
+            }
+            partitionHandlingManager.addPartialCommit2PCTransaction(command.getGlobalTransaction(), recipients,
+                                                                         ctx.getLockedKeys(), newVersion, e);
+         }
+
+      }
+      return invokeNextInterceptor(ctx, command);
+   }
+
+   @Override
+   public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
+      Object retVal = invokeNextInterceptor(ctx, command);
+
+      if (shouldInvokeRemoteTxCommand(ctx)) {
+         Collection<Address> recipients = cdl.getOwners(getAffectedKeysFromContext(ctx));
+
+         try {
+            prepareOnAffectedNodes(ctx, command, recipients, defaultSynchronous);
+         } catch (SuspectException e) {
+            if (command.isOnePhaseCommit()) {
+               partitionHandlingManager.addPartialCommit1PCTransaction(command.getGlobalTransaction(), recipients,
+                                                                       ctx.getLockedKeys(), Arrays.asList(command.getModifications()), e);
+            } else {
+               throw e;
+            }
+         }
+
+         ((LocalTxInvocationContext) ctx).remoteLocksAcquired(recipients == null ? dm.getWriteConsistentHash().getMembers() : recipients);
+      }
+      return retVal;
+   }
+
+   @Override
+   public Object visitRollbackCommand(TxInvocationContext ctx, RollbackCommand command) throws Throwable {
+      if (shouldInvokeRemoteTxCommand(ctx)) {
+         Collection<Address> recipients = getCommitNodes(ctx);
+         try {
+            Map<Address, Response> responseMap = rpcManager.invokeRemotely(recipients, command, rollbackRpcOptions);
+            checkTxCommandResponses(responseMap);
+         } catch (SuspectException e) {
+            partitionHandlingManager.addPartialRollbackTransaction(command.getGlobalTransaction(), recipients,
+                                                                   ctx.getLockedKeys(), e);
+         }
+      }
+
+      return invokeNextInterceptor(ctx, command);
+   }
+
+   protected void prepareOnAffectedNodes(TxInvocationContext<?> ctx, PrepareCommand command, Collection<Address> recipients, boolean sync) {
+      try {
+         // this method will return immediately if we're the only member (because exclude_self=true)
+         RpcOptions rpcOptions;
+         if (sync && command.isOnePhaseCommit() && !partitionHandlingEnabled) {
+            rpcOptions = rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS, DeliverOrder.NONE).build();
+         } else {
+            rpcOptions = rpcManager.getDefaultRpcOptions(sync);
+         }
+         Map<Address, Response> responseMap = rpcManager.invokeRemotely(recipients, command, rpcOptions);
+         checkTxCommandResponses(responseMap);
+      } finally {
+         transactionRemotelyPrepared(ctx);
+      }
+   }
+
+   protected void remoteGetBeforeWrite(InvocationContext ctx, WriteCommand command, Object key) throws Throwable {
+      CacheEntry entry = ctx.lookupEntry(key);
+      boolean skipRemoteGet = entry != null && entry.skipLookup();
+      if (skipRemoteGet) {
+         return;
+      }
+      InternalCacheEntry ice = remoteGet(ctx, key, true, command);
+      if (ice == null) {
+         localGet(ctx, key, true, command, false);
+      }
+   }
+
    private Object visitGetCommand(InvocationContext ctx, AbstractDataCommand command,
-      boolean isGetCacheEntry) throws Throwable {
+                                  boolean isGetCacheEntry) throws Throwable {
       Object returnValue = invokeNextInterceptor(ctx, command);
 
       //if the cache entry has the value lock flag set, skip the remote get.
@@ -156,94 +289,11 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       return returnValue;
    }
 
-   protected void lockAndWrap(InvocationContext ctx, Object key, InternalCacheEntry ice, FlagAffectedCommand command) throws InterruptedException {
-      boolean skipLocking = hasSkipLocking(command);
-      long lockTimeout = getLockAcquisitionTimeout(command, skipLocking);
-      lockManager.acquireLock(ctx, key, lockTimeout, skipLocking);
-      entryFactory.wrapEntryForPut(ctx, key, ice, false, command, false);
-   }
-
-   @Override
-   public Object visitLockControlCommand(TxInvocationContext ctx, LockControlCommand command) throws Throwable {
-      if (ctx.isOriginLocal()) {
-         //In Pessimistic mode, the delta composite keys were sent to the wrong owner and never locked.
-         final Collection<Address> affectedNodes = cdl.getOwners(filterDeltaCompositeKeys(command.getKeys()));
-         ((LocalTxInvocationContext) ctx).remoteLocksAcquired(affectedNodes == null ? dm.getConsistentHash().getMembers() : affectedNodes);
-         log.tracef("Registered remote locks acquired %s", affectedNodes);
-         rpcManager.invokeRemotely(affectedNodes, command, rpcManager.getDefaultRpcOptions(true, DeliverOrder.NONE));
-      }
-      return invokeNextInterceptor(ctx, command);
-   }
-
-   // ---- TX boundary commands
-   @Override
-   public Object visitCommitCommand(TxInvocationContext ctx, CommitCommand command) throws Throwable {
-      if (shouldInvokeRemoteTxCommand(ctx)) {
-         sendCommitCommand(ctx, command);
-      }
-      return invokeNextInterceptor(ctx, command);
-   }
-
-   @Override
-   public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
-      Object retVal = invokeNextInterceptor(ctx, command);
-
-      if (shouldInvokeRemoteTxCommand(ctx)) {
-         Collection<Address> recipients = cdl.getOwners(getAffectedKeysFromContext(ctx));
-         prepareOnAffectedNodes(ctx, command, recipients, defaultSynchronous);
-         ((LocalTxInvocationContext) ctx).remoteLocksAcquired(recipients == null ? dm.getWriteConsistentHash().getMembers() : recipients);
-      }
-      return retVal;
-   }
-
-   protected void prepareOnAffectedNodes(TxInvocationContext<?> ctx, PrepareCommand command, Collection<Address> recipients, boolean sync) {
-      try {
-         // this method will return immediately if we're the only member (because exclude_self=true)
-         RpcOptions rpcOptions;
-         if (sync && command.isOnePhaseCommit()) {
-            rpcOptions = rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS, DeliverOrder.NONE).build();
-         } else {
-            rpcOptions = rpcManager.getDefaultRpcOptions(sync);
-         }
-         Map<Address, Response> responseMap = rpcManager.invokeRemotely(recipients, command, rpcOptions);
-         checkTxCommandResponses(responseMap);
-      } finally {
-         transactionRemotelyPrepared(ctx);
-      }
-   }
-
-   @Override
-   public Object visitRollbackCommand(TxInvocationContext ctx, RollbackCommand command) throws Throwable {
-      if (shouldInvokeRemoteTxCommand(ctx)) {
-         boolean syncRollback = cacheConfiguration.transaction().syncRollbackPhase();
-         ResponseMode responseMode = syncRollback ? ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS : ResponseMode.ASYNCHRONOUS;
-         RpcOptions rpcOptions = rpcManager.getRpcOptionsBuilder(responseMode, DeliverOrder.NONE).build();
-         Collection<Address> recipients = getCommitNodes(ctx);
-         Map<Address, Response> responseMap = rpcManager.invokeRemotely(recipients, command, rpcOptions);
-         checkTxCommandResponses(responseMap);
-      }
-
-      return invokeNextInterceptor(ctx, command);
-   }
-
    private Collection<Address> getCommitNodes(TxInvocationContext ctx) {
       LocalTransaction localTx = (LocalTransaction) ctx.getCacheTransaction();
       Collection<Address> affectedNodes = cdl.getOwners(getAffectedKeysFromContext(ctx));
       List<Address> members = dm.getConsistentHash().getMembers();
       return localTx.getCommitNodes(affectedNodes, rpcManager.getTopologyId(), members);
-   }
-
-   private void sendCommitCommand(TxInvocationContext ctx, CommitCommand command) throws TimeoutException, InterruptedException {
-      Collection<Address> recipients = getCommitNodes(ctx);
-      boolean syncCommitPhase = cacheConfiguration.transaction().syncCommitPhase();
-      RpcOptions rpcOptions;
-      if (syncCommitPhase) {
-         rpcOptions = rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS, DeliverOrder.NONE).build();
-      } else {
-         rpcOptions = rpcManager.getDefaultRpcOptions(false, DeliverOrder.NONE);
-      }
-      Map<Address, Response> responseMap = rpcManager.invokeRemotely(recipients, command, rpcOptions);
-      checkTxCommandResponses(responseMap);
    }
 
    protected void checkTxCommandResponses(Map<Address, Response> responseMap) {
@@ -269,10 +319,10 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       // Note: the primary owner always already has the data, so this method is always going to return false
       if (useClusteredWriteSkewCheck && ctx.isInTxScope() && dm.isRehashInProgress()) {
          for (Object key : cmd.getAffectedKeys()) {
-            // TODO Dan: Do we need a special check for total order?
             boolean shouldPerformWriteSkewCheck = cdl.localNodeIsPrimaryOwner(key);
             // TODO Dan: remoteGet() already checks if the key is available locally or not
-            if (shouldPerformWriteSkewCheck && dm.isAffectedByRehash(key) && !dataContainer.containsKey(key)) return true;
+            if (shouldPerformWriteSkewCheck && dm.isAffectedByRehash(key) && !dataContainer.containsKey(key))
+               return true;
          }
       }
       return false;
@@ -282,10 +332,10 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
     * If we are within one transaction we won't do any replication as replication would only be performed at commit
     * time. If the operation didn't originate locally we won't do any replication either.
     */
-   private Object handleTxWriteCommand(InvocationContext ctx, WriteCommand command, RecipientGenerator recipientGenerator, boolean skipRemoteGet) throws Throwable {
+   private Object handleTxWriteCommand(InvocationContext ctx, WriteCommand command, Object key, boolean skipRemoteGet) throws Throwable {
       // see if we need to load values from remote sources first
       if (!skipRemoteGet && needValuesFromPreviousOwners(ctx, command))
-         remoteGetBeforeWrite(ctx, command, recipientGenerator);
+         remoteGetBeforeWrite(ctx, command, key);
 
       // FIRST pass this call up the chain.  Only if it succeeds (no exceptions) locally do we attempt to distribute.
       return invokeNextInterceptor(ctx, command);
@@ -303,7 +353,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
    }
 
    private Object localGet(InvocationContext ctx, Object key, boolean isWrite,
-         FlagAffectedCommand command, boolean isGetCacheEntry) throws Throwable {
+                           FlagAffectedCommand command, boolean isGetCacheEntry) throws Throwable {
       InternalCacheEntry ice = fetchValueLocallyIfAvailable(dm.getReadConsistentHash(), key);
       if (ice != null) {
          if (isWrite && isPessimisticCache && ctx.isInTxScope()) {
@@ -311,27 +361,13 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
          }
          if (!ctx.replaceValue(key, ice)) {
             if (isWrite)
-               lockAndWrap(ctx, key, ice, command);
+               entryFactory.wrapEntryForPut(ctx, key, ice, false, command, false);
             else
                ctx.putLookedUpEntry(key, ice);
          }
          return isGetCacheEntry ? ice : ice.getValue();
       }
       return null;
-   }
-
-   protected void remoteGetBeforeWrite(InvocationContext ctx, WriteCommand command, RecipientGenerator keygen) throws Throwable {
-      for (Object k : keygen.getKeys()) {
-         CacheEntry entry = ctx.lookupEntry(k);
-         boolean skipRemoteGet =  entry != null && entry.skipLookup();
-         if (skipRemoteGet) {
-            continue;
-         }
-         InternalCacheEntry ice = remoteGet(ctx, k, true, command);
-         if (ice == null) {
-            localGet(ctx, k, true, command, false);
-         }
-      }
    }
 
    private InternalCacheEntry remoteGet(InvocationContext ctx, Object key, boolean isWrite, FlagAffectedCommand command) throws Throwable {
@@ -352,12 +388,12 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
 
          if (ice != null) {
             if (useClusteredWriteSkewCheck && ctx.isInTxScope()) {
-               ((TxInvocationContext)ctx).getCacheTransaction().putLookedUpRemoteVersion(key, ice.getMetadata().version());
+               ((TxInvocationContext) ctx).getCacheTransaction().putLookedUpRemoteVersion(key, ice.getMetadata().version());
             }
 
             if (!ctx.replaceValue(key, ice)) {
                if (isWrite)
-                  lockAndWrap(ctx, key, ice, command);
+                  entryFactory.wrapEntryForPut(ctx, key, ice, false, command, false);
                else {
                   ctx.putLookedUpEntry(key, ice);
                   if (ctx.isInTxScope()) {
@@ -368,8 +404,21 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
             return ice;
          }
       } else {
-         if (trace) log.tracef("Not doing a remote get for key %s since entry is mapped to current node (%s), or is in L1.  Owners are %s", key, rpcManager.getAddress(), dm.locate(key));
+         if (trace) {
+            log.tracef("Not doing a remote get for key %s since entry is mapped to current node (%s), or is in L1. Owners are %s", key, rpcManager.getAddress(), dm.locate(key));
+         }
       }
       return null;
+   }
+
+   private static RpcOptions createRpcOptionsFor2ndPhase(boolean sync, boolean partitionHandlingEnabled,
+                                                         RpcManager rpcManager) {
+      if (partitionHandlingEnabled && sync) {
+         return rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS, DeliverOrder.NONE).build();
+      } else if (sync) {
+         return rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS, DeliverOrder.NONE).build();
+      } else {
+         return rpcManager.getRpcOptionsBuilder(ResponseMode.ASYNCHRONOUS, DeliverOrder.NONE).build();
+      }
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/locking/AbstractTxLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/AbstractTxLockingInterceptor.java
@@ -1,11 +1,7 @@
 package org.infinispan.interceptors.locking;
 
-import static org.infinispan.commons.util.Util.toStr;
-
-import java.util.Collection;
-import java.util.concurrent.TimeUnit;
-
 import org.infinispan.atomic.DeltaCompositeKey;
+import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
@@ -15,6 +11,7 @@ import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.transaction.impl.TransactionTable;
@@ -23,6 +20,11 @@ import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.TimeService;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.logging.Log;
+
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import static org.infinispan.commons.util.Util.toStr;
 
 /**
  * Base class for transaction based locking interceptors.
@@ -36,14 +38,16 @@ public abstract class AbstractTxLockingInterceptor extends AbstractLockingInterc
    protected RpcManager rpcManager;
    private boolean clustered;
    private TimeService timeService;
+   private PartitionHandlingManager partitionHandlingManager;
 
    @Inject
-   @SuppressWarnings("unused")
-   public void setDependencies(TransactionTable txTable, RpcManager rpcManager, TimeService timeService) {
+   public void setDependencies(TransactionTable txTable, RpcManager rpcManager, TimeService timeService,
+                               PartitionHandlingManager partitionHandlingManager, CommandsFactory commandsFactory) {
       this.txTable = txTable;
       this.rpcManager = rpcManager;
       clustered = rpcManager != null;
       this.timeService = timeService;
+      this.partitionHandlingManager = partitionHandlingManager;
    }
 
    @Override
@@ -191,17 +195,13 @@ public abstract class AbstractTxLockingInterceptor extends AbstractLockingInterc
       }
    }
 
-   private TimeoutException newTimeoutException(Object key, TxInvocationContext txContext) {
-      return new TimeoutException("Could not acquire lock on " + key + " on behalf of transaction " +
-                                       txContext.getGlobalTransaction() + "." + "Lock is being held by " + lockManager.getOwner(key));
-   }
-   
-   private TimeoutException newTimeoutException(Object key, CacheTransaction tx, TxInvocationContext txContext) {                  
+   private TimeoutException newTimeoutException(Object key, CacheTransaction tx, TxInvocationContext txContext) {
       return new TimeoutException("Could not acquire lock on " + key + " on behalf of transaction " +
                                        txContext.getGlobalTransaction() + ". Waiting to complete tx: " + tx + ".");
    }
 
    private boolean releaseLockOnTxCompletion(TxInvocationContext ctx) {
-      return ctx.isOriginLocal() || Configurations.isSecondPhaseAsync(cacheConfiguration);
+      return (ctx.isOriginLocal() && partitionHandlingManager.isTransactionPartiallyCommitted(ctx.getGlobalTransaction()) ||
+                    (!ctx.isOriginLocal() && Configurations.isSecondPhaseAsync(cacheConfiguration)));
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderDistributionInterceptor.java
@@ -1,12 +1,9 @@
 package org.infinispan.interceptors.totalorder;
 
-import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.configuration.cache.Configurations;
-import org.infinispan.container.entries.InternalCacheEntry;
-import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.interceptors.distribution.TxDistributionInterceptor;
 import org.infinispan.remoting.transport.Address;
@@ -65,11 +62,6 @@ public class TotalOrderDistributionInterceptor extends TxDistributionInterceptor
       } finally {
          transactionRemotelyPrepared(ctx);
       }
-   }
-
-   @Override
-   protected void lockAndWrap(InvocationContext ctx, Object key, InternalCacheEntry ice, FlagAffectedCommand command) throws InterruptedException {
-      entryFactory.wrapEntryForPut(ctx, key, ice, false, command, true);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedDistributionInterceptor.java
@@ -1,14 +1,11 @@
 package org.infinispan.interceptors.totalorder;
 
-import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.commands.tx.VersionedPrepareCommand;
 import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.configuration.cache.Configurations;
-import org.infinispan.container.entries.InternalCacheEntry;
-import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.interceptors.distribution.VersionedDistributionInterceptor;
 import org.infinispan.remoting.responses.KeysValidateFilter;
@@ -75,11 +72,6 @@ public class TotalOrderVersionedDistributionInterceptor extends VersionedDistrib
       } finally {
          transactionRemotelyPrepared(ctx);
       }
-   }
-
-   @Override
-   protected void lockAndWrap(InvocationContext ctx, Object key, InternalCacheEntry ice, FlagAffectedCommand command) throws InterruptedException {
-      entryFactory.wrapEntryForPut(ctx, key, ice, false, command, true);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/partitionhandling/impl/AvailablePartitionHandlingManager.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/impl/AvailablePartitionHandlingManager.java
@@ -1,0 +1,91 @@
+package org.infinispan.partitionhandling.impl;
+
+import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.container.versioning.EntryVersionsMap;
+import org.infinispan.partitionhandling.AvailabilityMode;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.jgroups.SuspectException;
+import org.infinispan.topology.CacheTopology;
+import org.infinispan.transaction.xa.GlobalTransaction;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * {@link PartitionHandlingManager} implementation when the cluster is always available.
+ *
+ * @author Pedro Ruivo
+ * @since 7.2
+ */
+public class AvailablePartitionHandlingManager implements PartitionHandlingManager {
+
+
+   private AvailablePartitionHandlingManager() {}
+
+   public static AvailablePartitionHandlingManager getInstance() {
+      return SingletonHolder.INSTANCE;
+   }
+
+   @Override
+   public AvailabilityMode getAvailabilityMode() {
+      return AvailabilityMode.AVAILABLE;
+   }
+
+   @Override
+   public void setAvailabilityMode(AvailabilityMode availabilityMode) {/*no-op*/}
+
+   @Override
+   public void checkWrite(Object key) {/*no-op*/}
+
+   @Override
+   public void checkRead(Object key) {/*no-op*/}
+
+   @Override
+   public void checkClear() {/*no-op*/}
+
+   @Override
+   public void checkBulkRead() {/*no-op*/}
+
+   @Override
+   public CacheTopology getLastStableTopology() {
+      return null;
+   }
+
+   @Override
+   public void addPartialRollbackTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes, Collection<Object> lockedKeys, SuspectException suspectException) {
+      throw suspectException;
+   }
+
+   @Override
+   public void addPartialCommit2PCTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes, Collection<Object> lockedKeys, EntryVersionsMap newVersions, SuspectException suspectException) {
+      throw suspectException;
+   }
+
+   @Override
+   public void addPartialCommit1PCTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes, Collection<Object> lockedKeys, List<WriteCommand> modifications, SuspectException suspectException) {
+      throw suspectException;
+   }
+
+   @Override
+   public boolean isTransactionPartiallyCommitted(GlobalTransaction globalTransaction) {
+      return true;
+   }
+
+   @Override
+   public Collection<GlobalTransaction> getPartialTransactions() {
+      return Collections.emptyList();
+   }
+
+   @Override
+   public boolean canRollbackTransactionAfterOriginatorLeave(GlobalTransaction globalTransaction) {
+      return true;
+   }
+
+   @Override
+   public void onTopologyUpdate(CacheTopology cacheTopology) {/*no-op*/}
+
+   private static class SingletonHolder {
+      private static final AvailablePartitionHandlingManager INSTANCE = new AvailablePartitionHandlingManager();
+   }
+}

--- a/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingManager.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingManager.java
@@ -1,16 +1,24 @@
 package org.infinispan.partitionhandling.impl;
 
+import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.container.versioning.EntryVersionsMap;
 import org.infinispan.partitionhandling.AvailabilityMode;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.jgroups.SuspectException;
 import org.infinispan.topology.CacheTopology;
+import org.infinispan.transaction.xa.GlobalTransaction;
+
+import java.util.Collection;
+import java.util.List;
 
 /**
  * @author Dan Berindei
  * @since 7.0
  */
 public interface PartitionHandlingManager {
-   void setAvailabilityMode(AvailabilityMode availabilityMode);
-
    AvailabilityMode getAvailabilityMode();
+
+   void setAvailabilityMode(AvailabilityMode availabilityMode);
 
    void checkWrite(Object key);
 
@@ -20,5 +28,87 @@ public interface PartitionHandlingManager {
 
    void checkBulkRead();
 
+   @Deprecated
+      //test use only. it can be removed if we update the tests
    CacheTopology getLastStableTopology();
+
+   /**
+    * Adds a partially aborted transaction.
+    * <p/>
+    * The transaction should be registered when it is not sure if the abort happens successfully in all the affected
+    * nodes. It can rethrow the exception is the transaction is not registered.
+    *
+    * @param globalTransaction the global transaction.
+    * @param affectedNodes     the nodes involved in the transaction and they must abort the transaction.
+    * @param lockedKeys        the keys locally locked.
+    * @param suspectException  the suspected exception. It contains the node who left the view.
+    */
+   void addPartialRollbackTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes,
+                                      Collection<Object> lockedKeys, SuspectException suspectException);
+
+   /**
+    * Adds a partially committed transaction.
+    * <p/>
+    * The transaction is committed in the second phase and it is register if it is not sure that the transaction was
+    * committed successfully in all the affected nodes. It can rethrow the exception if the transaction is not
+    * registered.
+    *
+    * @param globalTransaction the global transaction.
+    * @param affectedNodes     the nodes involved in the transaction and they must commit it.
+    * @param lockedKeys        the keys locally locked.
+    * @param newVersions       the updated versions. Only used when versioning is enabled.
+    * @param suspectException  the suspected exception. It contains the node who left the view.
+    */
+   void addPartialCommit2PCTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes,
+                                       Collection<Object> lockedKeys, EntryVersionsMap newVersions, SuspectException suspectException);
+
+   /**
+    * Adds a partially committed transaction.
+    * <p/>
+    * The transaction is committed in one phase and it is register if it is not sure that the transaction was committed
+    * successfully in all the affected nodes. It can rethrow the exception if the transaction is not registered.
+    *
+    * @param globalTransaction the global transaction.
+    * @param affectedNodes     the nodes involved in the transaction and they must commit it.
+    * @param lockedKeys        the keys locally locked.
+    * @param modifications     the transaction's modification log.
+    * @param suspectException  the suspected exception. It contains the node who left the view.
+    */
+   void addPartialCommit1PCTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes,
+                                       Collection<Object> lockedKeys, List<WriteCommand> modifications, SuspectException suspectException);
+
+   /**
+    * It checks if the transaction resources (for example locks) can be released.
+    * <p/>
+    * The transaction resource can't be released when the transaction is partially committed.
+    *
+    * @param globalTransaction the transaction.
+    * @return {@code true} if the resources can be released, {@code false} otherwise.
+    */
+   boolean isTransactionPartiallyCommitted(GlobalTransaction globalTransaction);
+
+   /**
+    * @return a collection of partial committed or aborted transactions.
+    */
+   Collection<GlobalTransaction> getPartialTransactions();
+
+   /**
+    * It checks if the transaction can be aborted when the originator leaves the cluster.
+    * <p/>
+    * The only case in which it is not possible to abort is when partition handling is enabled and the originator didn't
+    * leave gracefully. The transaction will complete when the partition heals.
+    *
+    * @param globalTransaction the global transaction.
+    * @return {@code true} if the transaction can be aborted, {@code false} otherwise.
+    */
+   boolean canRollbackTransactionAfterOriginatorLeave(GlobalTransaction globalTransaction);
+
+   /**
+    * Notifies the {@link PartitionHandlingManager} that the cache topology was update.
+    * <p/>
+    * It detects when the partition is merged and tries to complete all the partially completed transactions.
+    *
+    * @param cacheTopology the new cache topology.
+    */
+   void onTopologyUpdate(CacheTopology cacheTopology);
 }

--- a/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingManagerImpl.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingManagerImpl.java
@@ -1,24 +1,46 @@
 package org.infinispan.partitionhandling.impl;
 
 import org.infinispan.Cache;
+import org.infinispan.commands.CommandsFactory;
+import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.commands.remote.recovery.TxCompletionNotificationCommand;
+import org.infinispan.commands.tx.VersionedCommitCommand;
+import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.commons.util.concurrent.FutureListener;
+import org.infinispan.commons.util.concurrent.NotifyingFutureImpl;
+import org.infinispan.commons.util.concurrent.NotifyingNotifiableFuture;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.Configurations;
+import org.infinispan.container.versioning.EntryVersionsMap;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.partitionhandling.AvailabilityMode;
+import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.jgroups.SuspectException;
 import org.infinispan.statetransfer.StateTransferManager;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.topology.LocalTopologyManager;
+import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
 
 public class PartitionHandlingManagerImpl implements PartitionHandlingManager {
    private static final Log log = LogFactory.getLog(PartitionHandlingManagerImpl.class);
    private static final boolean trace = log.isTraceEnabled();
-
+   private final Map<GlobalTransaction, TransactionInfo> partialTransactions;
    private volatile AvailabilityMode availabilityMode = AvailabilityMode.AVAILABLE;
 
    private DistributionManager distributionManager;
@@ -26,19 +48,40 @@ public class PartitionHandlingManagerImpl implements PartitionHandlingManager {
    private StateTransferManager stateTransferManager;
    private String cacheName;
    private CacheNotifier notifier;
+   private CommandsFactory commandsFactory;
+   private Configuration configuration;
+   private RpcManager rpcManager;
+   private LockManager lockManager;
+
+   private boolean isVersioned;
+
+   public PartitionHandlingManagerImpl() {
+      partialTransactions = new ConcurrentHashMap<>();
+   }
 
    @Inject
-   void init(DistributionManager distributionManager, LocalTopologyManager localTopologyManager,
-         StateTransferManager stateTransferManager, Cache cache, CacheNotifier notifier) {
+   public void init(DistributionManager distributionManager, LocalTopologyManager localTopologyManager,
+                    StateTransferManager stateTransferManager, Cache cache, CacheNotifier notifier, CommandsFactory commandsFactory,
+                    Configuration configuration, RpcManager rpcManager, LockManager lockManager) {
       this.distributionManager = distributionManager;
       this.localTopologyManager = localTopologyManager;
       this.stateTransferManager = stateTransferManager;
       this.cacheName = cache.getName();
       this.notifier = notifier;
+      this.commandsFactory = commandsFactory;
+      this.configuration = configuration;
+      this.rpcManager = rpcManager;
+      this.lockManager = lockManager;
    }
 
    @Start
-   void start() {
+   public void start() {
+      isVersioned = Configurations.isVersioningEnabled(configuration);
+   }
+
+   @Override
+   public AvailabilityMode getAvailabilityMode() {
+      return availabilityMode;
    }
 
    @Override
@@ -52,11 +95,6 @@ public class PartitionHandlingManagerImpl implements PartitionHandlingManager {
    }
 
    @Override
-   public AvailabilityMode getAvailabilityMode() {
-      return availabilityMode;
-   }
-
-   @Override
    public void checkWrite(Object key) {
       doCheck(key);
    }
@@ -64,21 +102,6 @@ public class PartitionHandlingManagerImpl implements PartitionHandlingManager {
    @Override
    public void checkRead(Object key) {
       doCheck(key);
-   }
-
-   private void doCheck(Object key) {
-      if (trace) log.tracef("Checking availability for key=%s, status=%s", key, availabilityMode);
-      if (availabilityMode == AvailabilityMode.AVAILABLE)
-         return;
-
-      List<Address> owners = distributionManager.locate(key);
-      List<Address> actualMembers = stateTransferManager.getCacheTopology().getActualMembers();
-      if (!actualMembers.containsAll(owners)) {
-         if (trace) log.tracef("Partition is in %s mode, access is not allowed for key %s", availabilityMode, key);
-         throw log.degradedModeKeyUnavailable(key);
-      } else {
-         if (trace) log.tracef("Key %s is available.", key);
-      }
    }
 
    @Override
@@ -98,5 +121,241 @@ public class PartitionHandlingManagerImpl implements PartitionHandlingManager {
    @Override
    public CacheTopology getLastStableTopology() {
       return localTopologyManager.getStableCacheTopology(cacheName);
+   }
+
+   @Override
+   public void addPartialRollbackTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes, Collection<Object> lockedKeys, SuspectException suspectException) {
+      if (trace) {
+         log.tracef("Added partially rollback transaction %s", globalTransaction);
+      }
+      partialTransactions.put(globalTransaction, new RollbackTransactionInfo(globalTransaction, affectedNodes, lockedKeys));
+   }
+
+   @Override
+   public void addPartialCommit2PCTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes,
+                                              Collection<Object> lockedKeys, EntryVersionsMap newVersions, SuspectException suspectException) {
+      if (trace) {
+         log.tracef("Added partially committed (2PC) transaction %s", globalTransaction);
+      }
+      partialTransactions.put(globalTransaction, new Commit2PCTransactionInfo(globalTransaction, affectedNodes,
+                                                                              lockedKeys, newVersions));
+   }
+
+   @Override
+   public void addPartialCommit1PCTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes,
+                                              Collection<Object> lockedKeys, List<WriteCommand> modifications, SuspectException suspectException) {
+      if (trace) {
+         log.tracef("Added partially committed (1PC) transaction %s", globalTransaction);
+      }
+      partialTransactions.put(globalTransaction, new Commit1PCTransactionInfo(globalTransaction, affectedNodes,
+                                                                              lockedKeys, modifications));
+   }
+
+   @Override
+   public boolean isTransactionPartiallyCommitted(GlobalTransaction globalTransaction) {
+      TransactionInfo transactionInfo = partialTransactions.get(globalTransaction);
+      if (trace) {
+         log.tracef("Can release resources for transaction %s. Transaction info=%s", globalTransaction, transactionInfo);
+      }
+      return transactionInfo == null || transactionInfo.isRolledBack(); //if we are going to commit, we can't release the resources yet
+   }
+
+   @Override
+   public Collection<GlobalTransaction> getPartialTransactions() {
+      return Collections.unmodifiableCollection(partialTransactions.keySet());
+   }
+
+   @Override
+   public boolean canRollbackTransactionAfterOriginatorLeave(GlobalTransaction globalTransaction) {
+      boolean canRollback = availabilityMode == AvailabilityMode.AVAILABLE &&
+            !getLastStableTopology().getActualMembers().contains(globalTransaction.getAddress());
+      if (trace) {
+         log.tracef("Can rollback transaction? %s", canRollback);
+      }
+      return canRollback;
+   }
+
+   @Override
+   public void onTopologyUpdate(CacheTopology cacheTopology) {
+      boolean isStable = isTopologyStable(cacheTopology);
+      if (trace) {
+         log.tracef("On stable topology update. has pending transactions? %b. Is stable? %b. topology=%s",
+                    !partialTransactions.isEmpty(), isStable, cacheTopology);
+      }
+      if (isStable) {
+         for (TransactionInfo transactionInfo : partialTransactions.values()) {
+            completeTransaction(transactionInfo, cacheTopology);
+         }
+      }
+   }
+
+   private void completeTransaction(final TransactionInfo transactionInfo, CacheTopology cacheTopology) {
+      final Collection<Address> affectedNodes = transactionInfo.getCommitNodes(cacheTopology);
+      NotifyingNotifiableFuture<Map<Address, Response>> notifyingFuture = new NotifyingFutureImpl<>();
+      notifyingFuture.attachListener(new FutureListener<Map<Address, Response>>() {
+         @Override
+         public void futureDone(Future<Map<Address, Response>> future) {
+            final GlobalTransaction globalTransaction = transactionInfo.getGlobalTransaction();
+            if (trace) {
+               log.tracef("Future done for transaction %s", globalTransaction);
+            }
+            try {
+               future.get();
+            } catch (Throwable e) {
+               if (trace) {
+                  log.tracef(e, "Exception for transaction %s", globalTransaction);
+               }
+               return;
+            }
+            if (trace) {
+               log.tracef("Performing cleanup for transaction %s", globalTransaction);
+            }
+            lockManager.unlock(transactionInfo.getLockedKeys(), globalTransaction);
+            partialTransactions.remove(globalTransaction);
+            TxCompletionNotificationCommand command = commandsFactory.buildTxCompletionNotificationCommand(null, globalTransaction);
+            rpcManager.invokeRemotely(affectedNodes, command, rpcManager.getDefaultRpcOptions(false));
+         }
+      });
+      rpcManager.invokeRemotelyInFuture(notifyingFuture, affectedNodes, transactionInfo.buildCommand(commandsFactory, isVersioned), rpcManager.getDefaultRpcOptions(true));
+   }
+
+   private boolean isTopologyStable(CacheTopology cacheTopology) {
+      CacheTopology stableTopology = localTopologyManager.getStableCacheTopology(cacheName);
+      if (trace) {
+         log.tracef("Check if topology %s is stable. Last stable topology is %s", cacheTopology, stableTopology);
+      }
+      return stableTopology != null && cacheTopology.getActualMembers().containsAll(stableTopology.getActualMembers());
+   }
+
+   private void doCheck(Object key) {
+      if (trace) log.tracef("Checking availability for key=%s, status=%s", key, availabilityMode);
+      if (availabilityMode == AvailabilityMode.AVAILABLE)
+         return;
+
+      List<Address> owners = distributionManager.locate(key);
+      List<Address> actualMembers = stateTransferManager.getCacheTopology().getActualMembers();
+      if (!actualMembers.containsAll(owners)) {
+         if (trace) log.tracef("Partition is in %s mode, access is not allowed for key %s", availabilityMode, key);
+         throw log.degradedModeKeyUnavailable(key);
+      } else {
+         if (trace) log.tracef("Key %s is available.", key);
+      }
+   }
+
+   private interface TransactionInfo {
+      boolean isRolledBack();
+
+      List<Address> getCommitNodes(CacheTopology stableTopology);
+
+      ReplicableCommand buildCommand(CommandsFactory commandsFactory, boolean isVersioned);
+
+      GlobalTransaction getGlobalTransaction();
+
+      Collection<Object> getLockedKeys();
+   }
+
+   private static class RollbackTransactionInfo extends BaseTransactionInfo {
+
+      protected RollbackTransactionInfo(GlobalTransaction globalTransaction, Collection<Address> affectedNodes, Collection<Object> lockedKeys) {
+         super(globalTransaction, affectedNodes, lockedKeys);
+      }
+
+      @Override
+      public boolean isRolledBack() {
+         return true;
+      }
+
+      @Override
+      public ReplicableCommand buildCommand(CommandsFactory commandsFactory, boolean isVersioned) {
+         return commandsFactory.buildRollbackCommand(getGlobalTransaction());
+      }
+
+   }
+
+   private static class Commit2PCTransactionInfo extends BaseTransactionInfo {
+
+      private final EntryVersionsMap newVersions;
+
+      public Commit2PCTransactionInfo(GlobalTransaction globalTransaction, Collection<Address> affectedNodes, Collection<Object> lockedKeys, EntryVersionsMap newVersions) {
+         super(globalTransaction, affectedNodes, lockedKeys);
+         this.newVersions = newVersions;
+      }
+
+      @Override
+      public boolean isRolledBack() {
+         return false;
+      }
+
+      @Override
+      public ReplicableCommand buildCommand(CommandsFactory commandsFactory, boolean isVersioned) {
+         if (isVersioned) {
+            VersionedCommitCommand commitCommand = commandsFactory.buildVersionedCommitCommand(getGlobalTransaction());
+            commitCommand.setUpdatedVersions(newVersions);
+            return commitCommand;
+         } else {
+            return commandsFactory.buildCommitCommand(getGlobalTransaction());
+         }
+      }
+   }
+
+   private static class Commit1PCTransactionInfo extends BaseTransactionInfo {
+
+      private final List<WriteCommand> modifications;
+
+      public Commit1PCTransactionInfo(GlobalTransaction globalTransaction, Collection<Address> affectedNodes, Collection<Object> lockedKeys, List<WriteCommand> modifications) {
+         super(globalTransaction, affectedNodes, lockedKeys);
+         this.modifications = modifications;
+      }
+
+      @Override
+      public boolean isRolledBack() {
+         return false;
+      }
+
+      @Override
+      public ReplicableCommand buildCommand(CommandsFactory commandsFactory, boolean isVersioned) {
+         if (isVersioned) {
+            throw new IllegalArgumentException("Cannot build a versioned one-phase-commit prepare command.");
+         }
+         return commandsFactory.buildPrepareCommand(getGlobalTransaction(), modifications, true);
+      }
+   }
+
+   private static abstract class BaseTransactionInfo implements TransactionInfo {
+      private final GlobalTransaction globalTransaction;
+      private final List<Address> affectedNodes;
+      private final Collection<Object> lockedKeys;
+
+      protected BaseTransactionInfo(GlobalTransaction globalTransaction, Collection<Address> affectedNodes, Collection<Object> lockedKeys) {
+         this.globalTransaction = globalTransaction;
+         this.lockedKeys = lockedKeys;
+         this.affectedNodes = new ArrayList<>(affectedNodes);
+      }
+
+      @Override
+      public final List<Address> getCommitNodes(CacheTopology stableTopology) {
+         List<Address> commitNodes = new ArrayList<>(affectedNodes);
+         commitNodes.retainAll(stableTopology.getActualMembers());
+         return commitNodes;
+      }
+
+      @Override
+      public final GlobalTransaction getGlobalTransaction() {
+         return globalTransaction;
+      }
+
+      @Override
+      public Collection<Object> getLockedKeys() {
+         return lockedKeys;
+      }
+
+      @Override
+      public String toString() {
+         return "TransactionInfo{" +
+               "globalTransaction=" + globalTransaction + ", " +
+               "rollback=" + isRolledBack() + ", " +
+               "affectedNodes=" + affectedNodes +
+               '}';
+      }
    }
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/AbstractDelegatingTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/AbstractDelegatingTransport.java
@@ -108,6 +108,10 @@ public abstract class AbstractDelegatingTransport implements Transport {
       return actual.getLog();
    }
 
+   public Transport getDelegate() {
+      return actual;
+   }
+
    /**
     * method invoked before a remote invocation.
     *

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
@@ -32,7 +32,6 @@ import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.responses.SuccessfulResponse;
 import org.infinispan.remoting.responses.UnsureResponse;
 import org.infinispan.remoting.transport.Address;
-import org.infinispan.remoting.transport.Transport;
 import org.infinispan.remoting.transport.jgroups.SuspectException;
 import org.infinispan.transaction.xa.CacheTransaction;
 import org.infinispan.util.logging.Log;
@@ -68,7 +67,6 @@ public class StateTransferInterceptor extends BaseStateTransferInterceptor {
    private static boolean trace = log.isTraceEnabled();
 
    private StateTransferManager stateTransferManager;
-   private Transport transport;
 
    private final AffectedKeysVisitor affectedKeysVisitor = new AffectedKeysVisitor();
 
@@ -78,9 +76,8 @@ public class StateTransferInterceptor extends BaseStateTransferInterceptor {
    }
 
    @Inject
-   public void init(StateTransferManager stateTransferManager, Transport transport) {
+   public void init(StateTransferManager stateTransferManager) {
       this.stateTransferManager = stateTransferManager;
-      this.transport = transport;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -158,11 +158,9 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
          for (Map.Entry<String, LocalCacheStatus> e : runningCaches.entrySet()) {
             String cacheName = e.getKey();
             LocalCacheStatus cacheStatus = runningCaches.get(cacheName);
-            AvailabilityMode availabilityMode = cacheStatus.getPartitionHandlingManager() != null ?
-                    cacheStatus.getPartitionHandlingManager().getAvailabilityMode() : null;
             caches.put(e.getKey(), new CacheStatusResponse(cacheStatus.getJoinInfo(),
                     cacheStatus.getCurrentTopology(), cacheStatus.getStableTopology(),
-                    availabilityMode));
+                    cacheStatus.getPartitionHandlingManager().getAvailabilityMode()));
          }
       }
 
@@ -223,10 +221,8 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
          unionTopology.logRoutingTableInformation();
 
          boolean updateAvailabilityModeFirst = availabilityMode != AvailabilityMode.AVAILABLE;
-         if (updateAvailabilityModeFirst) {
-            if (cacheStatus.getPartitionHandlingManager() != null && availabilityMode != null) {
-               cacheStatus.getPartitionHandlingManager().setAvailabilityMode(availabilityMode);
-            }
+         if (updateAvailabilityModeFirst && availabilityMode != null) {
+            cacheStatus.getPartitionHandlingManager().setAvailabilityMode(availabilityMode);
          }
          if ((existingTopology == null || existingTopology.getRebalanceId() != cacheTopology.getRebalanceId()) && unionCH != null) {
             // This CH_UPDATE command was sent after a REBALANCE_START command, but arrived first.
@@ -238,9 +234,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
          }
 
          if (!updateAvailabilityModeFirst) {
-            if (cacheStatus.getPartitionHandlingManager() != null && availabilityMode != null) {
-               cacheStatus.getPartitionHandlingManager().setAvailabilityMode(availabilityMode);
-            }
+            cacheStatus.getPartitionHandlingManager().setAvailabilityMode(availabilityMode);
          }
       }
    }
@@ -348,13 +342,13 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
    @Override
    public CacheTopology getCacheTopology(String cacheName) {
       LocalCacheStatus cacheStatus = runningCaches.get(cacheName);
-      return cacheStatus.getCurrentTopology();
+      return cacheStatus != null ? cacheStatus.getCurrentTopology() : null;
    }
 
    @Override
    public CacheTopology getStableCacheTopology(String cacheName) {
       LocalCacheStatus cacheStatus = runningCaches.get(cacheName);
-      return cacheStatus.getCurrentTopology();
+      return cacheStatus != null ? cacheStatus.getStableTopology() : null;
    }
 
    @Override
@@ -401,10 +395,8 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
       AvailabilityMode clusterAvailability = AvailabilityMode.AVAILABLE;
       synchronized (runningCaches) {
          for (LocalCacheStatus cacheStatus : runningCaches.values()) {
-            AvailabilityMode availabilityMode = cacheStatus.getPartitionHandlingManager() != null ?
-                  cacheStatus.getPartitionHandlingManager().getAvailabilityMode() : null;
-            clusterAvailability = availabilityMode != null ? clusterAvailability.min(availabilityMode) : clusterAvailability;
-
+            AvailabilityMode availabilityMode = cacheStatus.getPartitionHandlingManager().getAvailabilityMode();
+            clusterAvailability = clusterAvailability.min(availabilityMode);
          }
       }
       return clusterAvailability.toString();
@@ -413,9 +405,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
    @Override
    public AvailabilityMode getCacheAvailability(String cacheName) {
       LocalCacheStatus cacheStatus = runningCaches.get(cacheName);
-      AvailabilityMode availabilityMode = cacheStatus.getPartitionHandlingManager() != null ?
-            cacheStatus.getPartitionHandlingManager().getAvailabilityMode() : AvailabilityMode.AVAILABLE;
-      return availabilityMode;
+      return cacheStatus.getPartitionHandlingManager().getAvailabilityMode();
    }
 
    @Override
@@ -454,16 +444,15 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
    private void executeOnCoordinatorAsync(final ReplicableCommand command) throws Exception {
       // if we are the coordinator, the execution is actually synchronous
       if (transport.isCoordinator()) {
-         asyncTransportExecutor.submit(new Callable<Object>() {
+         asyncTransportExecutor.execute(new Runnable() {
             @Override
-            public Object call() throws Exception {
+            public void run() {
                if (log.isTraceEnabled()) log.tracef("Attempting to execute command on self: %s", command);
                gcr.wireDependencies(command);
                try {
-                  return command.perform(null);
+                  command.perform(null);
                } catch (Throwable t) {
                   log.errorf(t, "Failed to execute ReplicableCommand %s on coordinator async: %s", command, t.getMessage());
-                  throw new Exception(t);
                }
             }
          });

--- a/core/src/main/java/org/infinispan/transaction/impl/AbstractEnlistmentAdapter.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/AbstractEnlistmentAdapter.java
@@ -5,6 +5,7 @@ import org.infinispan.commands.remote.recovery.TxCompletionNotificationCommand;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.Configurations;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
+import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
@@ -37,15 +38,18 @@ public abstract class AbstractEnlistmentAdapter {
    private final boolean isPessimisticLocking;
    private final boolean isTotalOrder;
    protected final TransactionCoordinator txCoordinator;
+   protected final PartitionHandlingManager partitionHandlingManager;
 
    public AbstractEnlistmentAdapter(CacheTransaction cacheTransaction,
-            CommandsFactory commandsFactory, RpcManager rpcManager,
-            TransactionTable txTable, ClusteringDependentLogic clusteringLogic,
-            Configuration configuration, TransactionCoordinator txCoordinator) {
+                                    CommandsFactory commandsFactory, RpcManager rpcManager,
+                                    TransactionTable txTable, ClusteringDependentLogic clusteringLogic,
+                                    Configuration configuration, TransactionCoordinator txCoordinator,
+                                    PartitionHandlingManager partitionHandlingManager) {
       this.commandsFactory = commandsFactory;
       this.rpcManager = rpcManager;
       this.txTable = txTable;
       this.clusteringLogic = clusteringLogic;
+      this.partitionHandlingManager = partitionHandlingManager;
       this.isSecondPhaseAsync = Configurations.isSecondPhaseAsync(configuration);
       this.isPessimisticLocking = configuration.transaction().lockingMode() == LockingMode.PESSIMISTIC;
       this.isTotalOrder = configuration.transaction().transactionProtocol().isTotalOrder();
@@ -54,12 +58,14 @@ public abstract class AbstractEnlistmentAdapter {
    }
 
    public AbstractEnlistmentAdapter(CommandsFactory commandsFactory,
-            RpcManager rpcManager, TransactionTable txTable,
-            ClusteringDependentLogic clusteringLogic, Configuration configuration, TransactionCoordinator txCoordinator) {
+                                    RpcManager rpcManager, TransactionTable txTable,
+                                    ClusteringDependentLogic clusteringLogic, Configuration configuration, TransactionCoordinator txCoordinator,
+                                    PartitionHandlingManager partitionHandlingManager) {
       this.commandsFactory = commandsFactory;
       this.rpcManager = rpcManager;
       this.txTable = txTable;
       this.clusteringLogic = clusteringLogic;
+      this.partitionHandlingManager = partitionHandlingManager;
       this.isSecondPhaseAsync = Configurations.isSecondPhaseAsync(configuration);
       this.isPessimisticLocking = configuration.transaction().lockingMode() == LockingMode.PESSIMISTIC;
       this.isTotalOrder = configuration.transaction().transactionProtocol().isTotalOrder();
@@ -79,7 +85,7 @@ public abstract class AbstractEnlistmentAdapter {
    }
 
    private void removeTransactionInfoRemotely(LocalTransaction localTransaction, GlobalTransaction gtx) {
-      if (mayHaveRemoteLocks(localTransaction) && !isSecondPhaseAsync) {
+      if (mayHaveRemoteLocks(localTransaction) && !isSecondPhaseAsync && partitionHandlingManager.isTransactionPartiallyCommitted(gtx)) {
          final TxCompletionNotificationCommand command = commandsFactory.buildTxCompletionNotificationCommand(null, gtx);
          final Collection<Address> owners = clusteringLogic.getOwners(filterDeltaCompositeKeys(localTransaction.getAffectedKeys()));
          Collection<Address> commitNodes = localTransaction.getCommitNodes(owners, rpcManager.getTopologyId(), rpcManager.getMembers());

--- a/core/src/main/java/org/infinispan/transaction/synchronization/SynchronizationAdapter.java
+++ b/core/src/main/java/org/infinispan/transaction/synchronization/SynchronizationAdapter.java
@@ -4,6 +4,7 @@ import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commons.CacheException;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
+import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.transaction.impl.AbstractEnlistmentAdapter;
 import org.infinispan.transaction.impl.LocalTransaction;
@@ -32,8 +33,8 @@ public class SynchronizationAdapter extends AbstractEnlistmentAdapter implements
    public SynchronizationAdapter(LocalTransaction localTransaction, TransactionCoordinator txCoordinator,
                                  CommandsFactory commandsFactory, RpcManager rpcManager,
                                  TransactionTable transactionTable, ClusteringDependentLogic clusteringLogic,
-                                 Configuration configuration) {
-      super(localTransaction, commandsFactory, rpcManager, transactionTable, clusteringLogic, configuration, txCoordinator);
+                                 Configuration configuration, PartitionHandlingManager partitionHandlingManager) {
+      super(localTransaction, commandsFactory, rpcManager, transactionTable, clusteringLogic, configuration, txCoordinator, partitionHandlingManager);
       this.localTransaction = localTransaction;
    }
 

--- a/core/src/main/java/org/infinispan/transaction/xa/TransactionXaAdapter.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/TransactionXaAdapter.java
@@ -3,6 +3,7 @@ package org.infinispan.transaction.xa;
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
+import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.transaction.impl.AbstractEnlistmentAdapter;
 import org.infinispan.transaction.impl.TransactionCoordinator;
@@ -55,8 +56,8 @@ public class TransactionXaAdapter extends AbstractEnlistmentAdapter implements X
                                RecoveryManager rm, TransactionCoordinator txCoordinator,
                                CommandsFactory commandsFactory, RpcManager rpcManager,
                                ClusteringDependentLogic clusteringDependentLogic,
-                               Configuration configuration, String cacheName) {
-      super(localTransaction, commandsFactory, rpcManager, txTable, clusteringDependentLogic, configuration, txCoordinator);
+                               Configuration configuration, String cacheName, PartitionHandlingManager partitionHandlingManager) {
+      super(localTransaction, commandsFactory, rpcManager, txTable, clusteringDependentLogic, configuration, txCoordinator, partitionHandlingManager);
       this.localTransaction = localTransaction;
       this.txTable = (XaTransactionTable) txTable;
       this.recoveryManager = rm;
@@ -66,12 +67,13 @@ public class TransactionXaAdapter extends AbstractEnlistmentAdapter implements X
       this.onePhaseTotalOrder = configuration.transaction().transactionProtocol().isTotalOrder() &&
             !(configuration.clustering().cacheMode().isDistributed() && configuration.locking().writeSkewCheck());
    }
+
    public TransactionXaAdapter(TransactionTable txTable,
                                RecoveryManager rm, TransactionCoordinator txCoordinator,
                                CommandsFactory commandsFactory, RpcManager rpcManager,
                                ClusteringDependentLogic clusteringDependentLogic,
-                               Configuration configuration, String cacheName) {
-      super(commandsFactory, rpcManager, txTable, clusteringDependentLogic, configuration, txCoordinator);
+                               Configuration configuration, String cacheName, PartitionHandlingManager partitionHandlingManager) {
+      super(commandsFactory, rpcManager, txTable, clusteringDependentLogic, configuration, txCoordinator, partitionHandlingManager);
       localTransaction = null;
       this.txTable = (XaTransactionTable) txTable;
       this.recoveryManager = rm;
@@ -145,7 +147,7 @@ public class TransactionXaAdapter extends AbstractEnlistmentAdapter implements X
       if (trace) log.tracef("forget called for xid %s", xid);
       try {
          if (recoveryEnabled) {
-            recoveryManager.removeRecoveryInformationFromCluster(null, xid, true, null);
+            recoveryManager.removeRecoveryInformationFromCluster(null, xid, true, null, false);
          } else {
             if (trace) log.trace("Recovery not enabled");
          }
@@ -221,7 +223,8 @@ public class TransactionXaAdapter extends AbstractEnlistmentAdapter implements X
    private void forgetSuccessfullyCompletedTransaction(RecoveryManager recoveryManager, Xid xid, LocalXaTransaction localTransaction, boolean committedInOnePhase) {
       final GlobalTransaction gtx = localTransaction.getGlobalTransaction();
       if (recoveryEnabled) {
-         recoveryManager.removeRecoveryInformationFromCluster(localTransaction.getRemoteLocksAcquired(), xid, false, gtx);
+         recoveryManager.removeRecoveryInformationFromCluster(localTransaction.getRemoteLocksAcquired(), xid, false, gtx,
+                                                              !partitionHandlingManager.isTransactionPartiallyCommitted(gtx));
          txTable.removeLocalTransaction(localTransaction);
       } else {
          releaseLocksForCompletedTransaction(localTransaction, committedInOnePhase);

--- a/core/src/main/java/org/infinispan/transaction/xa/XaTransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/XaTransactionTable.java
@@ -76,7 +76,7 @@ public class XaTransactionTable extends TransactionTable {
             transaction.enlistResource(new TransactionXaAdapter(
                   localTransaction, this, recoveryManager,
                   txCoordinator, commandsFactory, rpcManager,
-                  clusteringLogic, configuration, cacheName));
+                  clusteringLogic, configuration, cacheName, partitionHandlingManager));
          } catch (Exception e) {
             Xid xid = localTransaction.getXid();
             if (xid != null && !localTransaction.getLookedUpEntries().isEmpty()) {

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAdminOperations.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAdminOperations.java
@@ -92,7 +92,7 @@ public class RecoveryAdminOperations {
          @Parameter(name = "formatId", description = "The formatId of the transaction") int formatId,
          @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId,
          @Parameter(name = "branchQualifier", description = "The branchQualifier of the transaction") byte[] branchQualifier) {
-      recoveryManager.removeRecoveryInformationFromCluster(null, new SerializableXid(branchQualifier, globalTxId, formatId), true, null);
+      recoveryManager.removeRecoveryInformationFromCluster(null, new SerializableXid(branchQualifier, globalTxId, formatId), true, null, false);
       return "Recovery info removed.";
    }
 

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryManager.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryManager.java
@@ -20,20 +20,24 @@ import java.util.Set;
 public interface RecoveryManager {
 
    /**
-    * Returns the list of transactions in prepared state from both local and remote cluster nodes.
-    * Implementation can take advantage of several optimisations:
-    * <pre>
-    * - in order to get all tx from the cluster a broadcast is performed. This can be performed only once (assuming the call
-    *   is successful), the first time this method is called. After that a local, cached list of tx prepared on this node is returned.
-    * - during the broadcast just return the list of prepared transactions that are not originated on other active nodes of the
-    * cluster.
-    * </pre>
+    * Returns the list of transactions in prepared state from both local and remote cluster nodes. Implementation can
+    * take advantage of several optimisations:
+    *
+    * <ul>
+    *    <li>in order to get all tx from the cluster a broadcast is performed. This can be performed only once
+    * (assuming the call is successful), the first time this method is called. After that a local, cached list of tx
+    * prepared on this node is returned.</li>
+    *    <li>during the broadcast just return the list of prepared transactions that are not originated on other active
+    * nodes of the cluster.</li>
+    * </ul>
     */
    RecoveryIterator getPreparedTransactionsFromCluster();
 
    /**
-    * Returns a {@link Set} containing all the in-doubt transactions from the cluster, including the local node. This does
-    * not include transactions that are prepared successfully and for which the originator is still in the cluster.
+    * Returns a {@link Set} containing all the in-doubt transactions from the cluster, including the local node. This
+    * does not include transactions that are prepared successfully and for which the originator is still in the
+    * cluster.
+    *
     * @see InDoubtTxInfo
     */
    Set<InDoubtTxInfo> getInDoubtTransactionInfoFromCluster();
@@ -45,18 +49,22 @@ public interface RecoveryManager {
 
 
    /**
-    * Removes from the specified nodes (or all nodes if the value of 'where' is null) the recovery information associated with
-    * these Xids.
-    * @param where on which nodes should this be executed.
-    * @param xid the list of xids to be removed.
-    * @param sync execute sync or async (false)
-    * @param gtx
+    * Removes from the specified nodes (or all nodes if the value of 'where' is null) the recovery information
+    * associated with these Xids.
+    *
+    * @param where                   on which nodes should this be executed.
+    * @param xid                     the list of xids to be removed.
+    * @param sync                    execute sync or async (false)
+    * @param gtx                     the global transaction
+    * @param skipTxCompletionCommand {@code true} if it must skip the {@link org.infinispan.commands.remote.recovery.TxCompletionNotificationCommand}.
+    *                                Used when a partition happens.
     */
-   void removeRecoveryInformationFromCluster(Collection<Address> where, Xid xid, boolean sync, GlobalTransaction gtx);
+   void removeRecoveryInformationFromCluster(Collection<Address> where, Xid xid, boolean sync, GlobalTransaction gtx, boolean skipTxCompletionCommand);
 
    /**
-    * Same as {@link #removeRecoveryInformationFromCluster(java.util.Collection} but the transaction
-    * is identified by its internal id, and not by its xid.
+    * Same as {@link #removeRecoveryInformationFromCluster(java.util.Collection, javax.transaction.xa.Xid, boolean,
+    * org.infinispan.transaction.xa.GlobalTransaction, boolean)} but the transaction is identified by its internal id,
+    * and not by its xid.
     */
    void removeRecoveryInformationFromCluster(Collection<Address> where, long internalId, boolean sync);
 
@@ -81,7 +89,8 @@ public interface RecoveryManager {
    /**
     * Replays the given transaction by re-running the prepare and commit. This call expects the transaction to exist on
     * this node either as a local or remote transaction.
-    * @param xid tx to commit or rollback
+    *
+    * @param xid    tx to commit or rollback
     * @param commit if true tx is committed, if false it is rolled back
     */
    String forceTransactionCompletion(Xid xid, boolean commit);
@@ -92,8 +101,8 @@ public interface RecoveryManager {
    String forceTransactionCompletionFromCluster(Xid xid, Address where, boolean commit);
 
    /**
-    * Checks both internal state and transaction table's state for the given tx. If it finds it, returns true if tx
-    * is prepared.
+    * Checks both internal state and transaction table's state for the given tx. If it finds it, returns true if tx is
+    * prepared.
     */
    boolean isTransactionPrepared(GlobalTransaction globalTx);
 
@@ -105,14 +114,14 @@ public interface RecoveryManager {
    /**
     * Remove recovery information stored on this node (doesn't involve rpc).
     *
-    * @param xid@see  #removeRecoveryInformation(java.util.Collection, javax.transaction.xa.Xid, boolean)
+    * @param xid@see #removeRecoveryInformation(java.util.Collection, javax.transaction.xa.Xid, boolean)
     */
    RecoveryAwareTransaction removeRecoveryInformation(Xid xid);
 
    /**
-   * Stateful structure allowing prepared-tx retrieval in a batch-oriented manner,
-    * as required by {@link javax.transaction.xa.XAResource#recover(int)}.
-   */
+    * Stateful structure allowing prepared-tx retrieval in a batch-oriented manner, as required by {@link
+    * javax.transaction.xa.XAResource#recover(int)}.
+    */
    interface RecoveryIterator extends Iterator<Xid[]> {
 
       Xid[] NOTHING = new Xid[]{};
@@ -140,8 +149,9 @@ public interface RecoveryManager {
       Long getInternalId();
 
       /**
-       * The value represent transaction's state as described by the {@link Status} field. Multiple values are returned
-       * as it is possible for an in-doubt transaction to be at the same time e.g. prepared on one node and committed on the other.
+       * The value represent transaction's state as described by the {@code status} field. Multiple values are returned
+       * as it is possible for an in-doubt transaction to be at the same time e.g. prepared on one node and committed on
+       * the other.
        */
       Set<Integer> getStatus();
 

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryManagerImpl.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryManagerImpl.java
@@ -123,10 +123,10 @@ public class RecoveryManagerImpl implements RecoveryManager {
    }
 
    @Override
-   public void removeRecoveryInformationFromCluster(Collection<Address> lockOwners, Xid xid, boolean sync, GlobalTransaction gtx) {
+   public void removeRecoveryInformationFromCluster(Collection<Address> lockOwners, Xid xid, boolean sync, GlobalTransaction gtx, boolean skipTxCompletionCommand) {
       log.tracef("Forgetting tx information for %s", gtx);
       //todo make sure this gets broad casted or at least flushed
-      if (rpcManager != null) {
+      if (rpcManager != null && !skipTxCompletionCommand) {
          TxCompletionNotificationCommand ftc = commandFactory.buildTxCompletionNotificationCommand(xid, gtx);
          rpcManager.invokeRemotely(lockOwners, ftc, rpcManager.getDefaultRpcOptions(sync, DeliverOrder.NONE));
       }
@@ -302,7 +302,7 @@ public class RecoveryManagerImpl implements RecoveryManager {
             return "Could not commit transaction " + xid + " : " + e.getMessage();
          }
       }
-      removeRecoveryInformationFromCluster(null, xid, false, localTx.getGlobalTransaction());
+      removeRecoveryInformationFromCluster(null, xid, false, localTx.getGlobalTransaction(), false);
       return commit ? "Commit successful!" : "Rollback successful";
    }
 

--- a/core/src/test/java/org/infinispan/lock/ExplicitUnlockTest.java
+++ b/core/src/test/java/org/infinispan/lock/ExplicitUnlockTest.java
@@ -67,7 +67,7 @@ public class ExplicitUnlockTest extends SingleCacheManagerTest {
          cache.put("" + key, "value");
       }
 
-      List<Future<Boolean>> results = new ArrayList<Future<Boolean>>(nThreads);
+      List<Future<Boolean>> results = new ArrayList<>(nThreads);
 
       for (int i = 1; i <= nThreads; i++) {
          results.add(fork(new Worker(i, cache, withUnlock, stepDelayMsec)));
@@ -80,7 +80,7 @@ public class ExplicitUnlockTest extends SingleCacheManagerTest {
       assertTrue("All worker should complete without exceptions", success);
       assertNoTransactions();
       for (int i = 0; i < NUMBER_OF_KEYS; ++i) {
-         assertNotLocked(cache, valueOf(i));
+         assertEventuallyNotLocked(cache, valueOf(i));
       }
    }
 

--- a/core/src/test/java/org/infinispan/lock/OptimisticTxFailureAfterLockingTest.java
+++ b/core/src/test/java/org/infinispan/lock/OptimisticTxFailureAfterLockingTest.java
@@ -77,6 +77,6 @@ public class OptimisticTxFailureAfterLockingTest extends MultipleCacheManagersTe
       }
 
       assertNoTransactions();
-      assertNotLocked(cache(primaryOwnerIndex), key);
+      assertEventuallyNotLocked(cache(primaryOwnerIndex), key);
    }
 }

--- a/core/src/test/java/org/infinispan/lock/PessimistTxFailureAfterLockingTest.java
+++ b/core/src/test/java/org/infinispan/lock/PessimistTxFailureAfterLockingTest.java
@@ -66,7 +66,7 @@ public class PessimistTxFailureAfterLockingTest extends MultipleCacheManagersTes
 
       assertTrue("Expected an exception", failed);
       assertNoTransactions();
-      assertNotLocked(cache(1), key);
+      assertEventuallyNotLocked(cache(1), key);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/lock/StaleEagerLocksOnPrepareFailureTest.java
+++ b/core/src/test/java/org/infinispan/lock/StaleEagerLocksOnPrepareFailureTest.java
@@ -85,10 +85,10 @@ public class StaleEagerLocksOnPrepareFailureTest extends MultipleCacheManagersTe
          // expected
       }
 
-      assertNotLocked(c1, k1);
-      assertNotLocked(c2, k1);
-      assertNotLocked(c1, k2);
-      assertNotLocked(c2, k2);
+      assertEventuallyNotLocked(c1, k1);
+      assertEventuallyNotLocked(c2, k1);
+      assertEventuallyNotLocked(c1, k2);
+      assertEventuallyNotLocked(c2, k2);
    }
 }
 

--- a/core/src/test/java/org/infinispan/lock/StaleLocksOnPrepareFailureTest.java
+++ b/core/src/test/java/org/infinispan/lock/StaleLocksOnPrepareFailureTest.java
@@ -58,7 +58,7 @@ public class StaleLocksOnPrepareFailureTest extends MultipleCacheManagersTest {
       }
 
       for (int i = 0; i < NUM_CACHES; i++) {
-        assertNotLocked(cache(i), k1);
+        assertEventuallyNotLocked(cache(i), k1);
       }
    }
 }

--- a/core/src/test/java/org/infinispan/lock/StaleLocksTransactionTest.java
+++ b/core/src/test/java/org/infinispan/lock/StaleLocksTransactionTest.java
@@ -55,7 +55,7 @@ public class StaleLocksTransactionTest extends MultipleCacheManagersTest {
       else
          tm(c1).rollback();
 
-      assertNotLocked(c1, "k");
-      assertNotLocked(c2, "k");
+      assertEventuallyNotLocked(c1, "k");
+      assertEventuallyNotLocked(c2, "k");
    }
 }

--- a/core/src/test/java/org/infinispan/lock/singlelock/AbstractInitiatorCrashTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/AbstractInitiatorCrashTest.java
@@ -31,8 +31,8 @@ public abstract class AbstractInitiatorCrashTest extends AbstractCrashTest {
       assert checkTxCount(1, 0, 0);
       assert checkTxCount(2, 0, 1);
 
-      assertNotLocked(cache(0), k);
-      assertNotLocked(cache(1), k);
+      assertEventuallyNotLocked(cache(0), k);
+      assertEventuallyNotLocked(cache(1), k);
       assertLocked(cache(2), k);
 
       killMember(1);
@@ -56,8 +56,8 @@ public abstract class AbstractInitiatorCrashTest extends AbstractCrashTest {
       transaction.runPrepare();
       tm(1).suspend();
 
-      assertNotLocked(cache(0), k);
-      assertNotLocked(cache(1), k);
+      assertEventuallyNotLocked(cache(0), k);
+      assertEventuallyNotLocked(cache(1), k);
       assertLocked(cache(2), k);
 
       checkTxCount(0, 0, 1);

--- a/core/src/test/java/org/infinispan/lock/singlelock/MainOwnerChangesPessimisticLockTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/MainOwnerChangesPessimisticLockTest.java
@@ -62,7 +62,7 @@ public class MainOwnerChangesPessimisticLockTest extends MultipleCacheManagersTe
    }
 
    private void testLockMigration(int nodeThatPuts, boolean commit) throws Exception {
-      Map<Object, Transaction> key2Tx = new HashMap<Object, Transaction>();
+      Map<Object, Transaction> key2Tx = new HashMap<>();
       for (int i = 0; i < NUM_KEYS; i++) {
          Object key = getKeyForCache(0);
          if (key2Tx.containsKey(key)) continue;
@@ -123,9 +123,9 @@ public class MainOwnerChangesPessimisticLockTest extends MultipleCacheManagersTe
          }
 
          // there should not be any locks
-         assertNotLocked(cache(0), migratedKey);
-         assertNotLocked(cache(1), migratedKey);
-         assertNotLocked(cache(2), migratedKey);
+         assertEventuallyNotLocked(cache(0), migratedKey);
+         assertEventuallyNotLocked(cache(1), migratedKey);
+         assertEventuallyNotLocked(cache(2), migratedKey);
 
          // if a new TX tries to write to the migrated key this should not fail, the key should not be locked
          tm(nodeThatPuts).begin();

--- a/core/src/test/java/org/infinispan/lock/singlelock/OriginatorBecomesOwnerLockTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/OriginatorBecomesOwnerLockTest.java
@@ -209,7 +209,7 @@ public class OriginatorBecomesOwnerLockTest extends MultipleCacheManagersTest {
 
 
    private void assertNoLocksOrTxs(Object key, Cache<Object, String> cache) {
-      assertNotLocked(originatorCache, key);
+      assertEventuallyNotLocked(originatorCache, key);
 
       final TransactionTable transactionTable = TestingUtil.extractComponent(cache, TransactionTable.class);
 

--- a/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/InitiatorCrashPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/InitiatorCrashPessimisticTest.java
@@ -31,15 +31,15 @@ public class InitiatorCrashPessimisticTest extends AbstractInitiatorCrashTest {
       cache(1).put(k2, "v2");
 
       assertLocked(cache(0), k0);
-      assertNotLocked(cache(1), k0);
-      assertNotLocked(cache(2), k0);
+      assertEventuallyNotLocked(cache(1), k0);
+      assertEventuallyNotLocked(cache(2), k0);
 
-      assertNotLocked(cache(0), k1);
+      assertEventuallyNotLocked(cache(0), k1);
       assertLocked(cache(1), k1);
-      assertNotLocked(cache(2), k1);
+      assertEventuallyNotLocked(cache(2), k1);
 
-      assertNotLocked(cache(0), k2);
-      assertNotLocked(cache(1), k2);
+      assertEventuallyNotLocked(cache(0), k2);
+      assertEventuallyNotLocked(cache(1), k2);
       assertLocked(cache(2), k2);
 
       assert checkTxCount(0, 0, 1);

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/optimistic/InitiatorCrashOptimisticReplTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/optimistic/InitiatorCrashOptimisticReplTest.java
@@ -34,8 +34,8 @@ public class InitiatorCrashOptimisticReplTest extends AbstractCrashTest {
       txControlInterceptor.commitReceived.await();
 
       assertLocked(cache(0), "k");
-      assertNotLocked(cache(1), "k");
-      assertNotLocked(cache(2), "k");
+      assertEventuallyNotLocked(cache(1), "k");
+      assertEventuallyNotLocked(cache(2), "k");
 
       checkTxCount(0, 0, 1);
       checkTxCount(1, 1, 0);
@@ -65,8 +65,8 @@ public class InitiatorCrashOptimisticReplTest extends AbstractCrashTest {
       assert checkTxCount(2, 0, 1);
 
       assertLocked(cache(0), "k");
-      assertNotLocked(cache(1), "k");
-      assertNotLocked(cache(2), "k");
+      assertEventuallyNotLocked(cache(1), "k");
+      assertEventuallyNotLocked(cache(2), "k");
 
       killMember(1);
 

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/InitiatorCrashPessimisticReplTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/InitiatorCrashPessimisticReplTest.java
@@ -31,8 +31,8 @@ public class InitiatorCrashPessimisticReplTest extends InitiatorCrashOptimisticR
       txControlInterceptor.preparedReceived.await();
 
       assertLocked(cache(0), key);
-      assertNotLocked(cache(1), key);
-      assertNotLocked(cache(2), key);
+      assertEventuallyNotLocked(cache(1), key);
+      assertEventuallyNotLocked(cache(2), key);
 
       checkTxCount(0, 0, 1);
       checkTxCount(1, 1, 0);
@@ -63,8 +63,8 @@ public class InitiatorCrashPessimisticReplTest extends InitiatorCrashOptimisticR
       assert checkTxCount(2, 0, 1);
 
       assertLocked(cache(0), key);
-      assertNotLocked(cache(1), key);
-      assertNotLocked(cache(2), key);
+      assertEventuallyNotLocked(cache(1), key);
+      assertEventuallyNotLocked(cache(2), key);
 
       killMember(1);
 

--- a/core/src/test/java/org/infinispan/partitionhandling/TransactionalPartitionAndMergeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/TransactionalPartitionAndMergeTest.java
@@ -1,0 +1,640 @@
+package org.infinispan.partitionhandling;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.commands.control.LockControlCommand;
+import org.infinispan.commands.remote.CacheRpcCommand;
+import org.infinispan.commands.tx.CommitCommand;
+import org.infinispan.commands.tx.PrepareCommand;
+import org.infinispan.commands.tx.RollbackCommand;
+import org.infinispan.commons.CacheException;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
+import org.infinispan.remoting.inboundhandler.DeliverOrder;
+import org.infinispan.remoting.inboundhandler.PerCacheInboundInvocationHandler;
+import org.infinispan.remoting.inboundhandler.Reply;
+import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.test.TestingUtil.WrapFactory;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.AbstractControlledRpcManager;
+import org.infinispan.util.concurrent.ReclosableLatch;
+import org.infinispan.util.concurrent.TimeoutException;
+import org.infinispan.util.concurrent.locks.LockManager;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+import javax.transaction.RollbackException;
+import javax.transaction.Status;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.infinispan.test.TestingUtil.extractComponent;
+import static org.infinispan.test.TestingUtil.extractLockManager;
+import static org.infinispan.test.TestingUtil.wrapComponent;
+import static org.infinispan.test.TestingUtil.wrapPerCacheInboundInvocationHandler;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * It tests multiple scenarios where a split can happen during a transaction.
+ *
+ * @author Pedro Ruivo
+ * @since 7.2
+ */
+@Test(groups = "functional", testName = "partitionhandling.TransactionalPartitionAndMergeTest")
+public class TransactionalPartitionAndMergeTest extends BasePartitionHandlingTest {
+
+   private static final String OPTIMISTIC_TX_CACHE_NAME = "opt-cache";
+   private static final String PESSIMISTIC_TX_CACHE_NAME = "pes-cache";
+   private static final String INITIAL_VALUE = "init-value";
+   private static final String FINAL_VALUE = "final-value";
+   private static final Log log = LogFactory.getLog(TransactionalPartitionAndMergeTest.class);
+
+   private static NotifierFilter notifyCommandOn(Cache<?, ?> cache, Class<? extends CacheRpcCommand> blockClass) {
+      NotifierFilter filter = new NotifierFilter(blockClass);
+      wrapAndApplyFilter(cache, filter);
+      return filter;
+   }
+
+   private static BlockingFilter blockCommandOn(Cache<?, ?> cache, Class<? extends CacheRpcCommand> blockClass) {
+      BlockingFilter filter = new BlockingFilter(blockClass);
+      wrapAndApplyFilter(cache, filter);
+      return filter;
+   }
+
+   private static DiscardFilter discardCommandOn(Cache<?, ?> cache, Class<? extends CacheRpcCommand> blockClass) {
+      DiscardFilter filter = new DiscardFilter(blockClass);
+      wrapAndApplyFilter(cache, filter);
+      return filter;
+   }
+
+   private static void wrapAndApplyFilter(Cache<?, ?> cache, Filter filter) {
+      ControlledInboundHandler controlledInboundHandler = wrapPerCacheInboundInvocationHandler(cache, new WrapFactory<PerCacheInboundInvocationHandler, ControlledInboundHandler, Cache<?, ?>>() {
+         @Override
+         public ControlledInboundHandler wrap(Cache<?, ?> wrapOn, PerCacheInboundInvocationHandler current) {
+            return new ControlledInboundHandler(current);
+         }
+      }, true);
+      controlledInboundHandler.filter = filter;
+   }
+
+   public void testSplitDuringPrepareWithOptimistic() throws Exception {
+      doOptimisticTxTest(TransactionPhase.PREPARE, true, true);
+   }
+
+   public void testSplitDuringPrepareWithOptimistic2() throws Exception {
+      doOptimisticTxTest(TransactionPhase.PREPARE, true, false);
+   }
+
+   public void testSplitDuringCommitWithOptimistic() throws Exception {
+      doOptimisticTxTest(TransactionPhase.COMMIT, false, true);
+   }
+
+   public void testSplitDuringCommitWithOptimistic2() throws Exception {
+      doOptimisticTxTest(TransactionPhase.COMMIT, false, false);
+   }
+
+   public void testSplitDuringRollbackWithOptimistic() throws Exception {
+      doOptimisticTxTest(TransactionPhase.ROLLBACK, true, true);
+   }
+
+   public void testSplitDuringRollbackWithOptimistic2() throws Exception {
+      doOptimisticTxTest(TransactionPhase.ROLLBACK, true, false);
+   }
+
+   public void testSplitBeforeCommitWithOptimistic() throws Exception {
+      doTestSplitBeforeWithOptimistic(true);
+   }
+
+   public void testSplitBeforeRollbackWithOptimistic() throws Exception {
+      doTestSplitBeforeWithOptimistic(false);
+   }
+
+   public void testSplitDuringLockWithPessimistic() throws Exception {
+      doPessimisticTxTest(TransactionPhase.RUNTIME_LOCK, true, true);
+   }
+
+   public void testSplitDuringLockWithPessimistic2() throws Exception {
+      doPessimisticTxTest(TransactionPhase.RUNTIME_LOCK, true, false);
+   }
+
+   public void testSplitDuringRollbackWithPessimistic() throws Exception {
+      doPessimisticTxTest(TransactionPhase.ROLLBACK, true, true);
+   }
+
+   public void testSplitDuringRollbackWithPessimistic2() throws Exception {
+      doPessimisticTxTest(TransactionPhase.ROLLBACK, true, false);
+   }
+
+   public void testSplitDuringCommitWithPessimistic() throws Exception {
+      doPessimisticTxTest(TransactionPhase.PREPARE, false, true);
+   }
+
+   public void testSplitDuringCommitWithPessimistic2() throws Exception {
+      doPessimisticTxTest(TransactionPhase.PREPARE, false, false);
+   }
+
+   public void testSplitBeforePrepareWithPessimistic() throws Exception {
+      doTestSplitBeforeWithPessimistic(true);
+   }
+
+   public void testSplitBeforeRollbackWithPessimistic() throws Exception {
+      doTestSplitBeforeWithPessimistic(false);
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      super.createCacheManagers();
+      defineConfigurationOnAllManagers(OPTIMISTIC_TX_CACHE_NAME, getConfiguration(LockingMode.OPTIMISTIC));
+      defineConfigurationOnAllManagers(PESSIMISTIC_TX_CACHE_NAME, getConfiguration(LockingMode.PESSIMISTIC));
+   }
+
+   private void doTestSplitBeforeWithPessimistic(boolean commit) throws Exception {
+      //split happens before the commit() or rollback(). Locks are acquired
+      waitForClusterToForm(PESSIMISTIC_TX_CACHE_NAME);
+
+      final KeyInfo keyInfo = createKeys(PESSIMISTIC_TX_CACHE_NAME);
+      final Cache<Object, String> originator = cache(0, PESSIMISTIC_TX_CACHE_NAME);
+
+      final TransactionManager transactionManager = originator.getAdvancedCache().getTransactionManager();
+      transactionManager.begin();
+      keyInfo.putFinalValue(originator);
+      final Transaction transaction = transactionManager.suspend();
+
+      splitCluster();
+
+      transactionManager.resume(transaction);
+      if (commit) {
+         transactionManager.commit();
+      } else {
+         transactionManager.rollback();
+      }
+
+      assertLocked(cache(1, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+      assertLocked(cache(2, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+
+      mergeCluster();
+      finalAsserts(PESSIMISTIC_TX_CACHE_NAME, keyInfo, commit ? FINAL_VALUE : INITIAL_VALUE);
+   }
+
+   private void doTestSplitBeforeWithOptimistic(boolean commit) throws Exception {
+      //the transaction is successfully prepare and then the split happens before the commit phase starts.
+      waitForClusterToForm(OPTIMISTIC_TX_CACHE_NAME);
+      final KeyInfo keyInfo = createKeys(OPTIMISTIC_TX_CACHE_NAME);
+      final Cache<Object, String> originator = cache(0, OPTIMISTIC_TX_CACHE_NAME);
+
+      final DummyTransactionManager transactionManager = (DummyTransactionManager) originator.getAdvancedCache().getTransactionManager();
+      transactionManager.begin();
+      final DummyTransaction transaction = transactionManager.getTransaction();
+      keyInfo.putFinalValue(originator);
+      AssertJUnit.assertTrue(transaction.runPrepare());
+      transactionManager.suspend();
+
+      splitCluster();
+
+      transactionManager.resume(transaction);
+      transaction.runCommit(!commit);
+
+      //the rollback is not sent. the locks are kept
+      assertLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+      assertLocked(cache(2, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+
+      mergeCluster();
+      finalAsserts(OPTIMISTIC_TX_CACHE_NAME, keyInfo, commit ? FINAL_VALUE : INITIAL_VALUE);
+   }
+
+   private void doOptimisticTxTest(TransactionPhase phase, boolean txFail, boolean discard) throws Exception {
+      waitForClusterToForm(OPTIMISTIC_TX_CACHE_NAME);
+
+      final KeyInfo keyInfo = createKeys(OPTIMISTIC_TX_CACHE_NAME);
+      final Cache<Object, String> originator = cache(0, OPTIMISTIC_TX_CACHE_NAME);
+      final FilterInfo filterInfo = createFilters(OPTIMISTIC_TX_CACHE_NAME, discard, phase.getCommandClass());
+
+      if (phase == TransactionPhase.ROLLBACK) {
+         //make the transaction fail!
+         wrapComponent(cache(0, OPTIMISTIC_TX_CACHE_NAME), RpcManager.class, new WrapFactory<RpcManager, RpcManager, Cache<?, ?>>() {
+            @Override
+            public RpcManager wrap(Cache<?, ?> wrapOn, RpcManager current) {
+               return new AbstractControlledRpcManager(current) {
+                  @Override
+                  protected Map<Address, Response> afterInvokeRemotely(ReplicableCommand command, Map<Address, Response> responseMap) {
+                     if (command instanceof PrepareCommand) {
+                        throw new CacheException("Induced fail!");
+                     }
+                     return super.afterInvokeRemotely(command, responseMap);
+                  }
+               };
+            }
+         }, true);
+      }
+
+      Future<Void> put = fork(new Callable<Void>() {
+         @Override
+         public Void call() throws Exception {
+            final TransactionManager transactionManager = originator.getAdvancedCache().getTransactionManager();
+            transactionManager.begin();
+            keyInfo.putFinalValue(originator);
+            transactionManager.commit();
+            return null;
+         }
+      });
+
+      filterInfo.await();
+      splitCluster();
+      filterInfo.unblock();
+
+      try {
+         put.get();
+         assertFalse(txFail);
+      } catch (ExecutionException e) {
+         assertTrue(txFail);
+      }
+
+      switch (phase) {
+         case PREPARE:
+            //always locked. cache0 is unable to send rollback because it fails with suspected exception.
+            assertLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+            //or the prepare is never received, so key never locked, or it is received and it decides to rollback the transaction.
+            assertEventuallyNotLocked(cache(2, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+            break;
+         case ROLLBACK:
+            //key is unlocked because the rollback is always received in cache1
+            assertEventuallyNotLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+            if (discard) {
+               //rollback never received, so key is locked until the merge occurs.
+               assertLocked(cache(2, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+            } else {
+               //rollback received, so key is unlocked
+               assertEventuallyNotLocked(cache(2, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+            }
+            break;
+         case COMMIT:
+            //on both caches, the key is locked and it is unlocked after the merge
+            assertLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+            assertLocked(cache(2, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+            break;
+      }
+
+      mergeCluster();
+      finalAsserts(OPTIMISTIC_TX_CACHE_NAME, keyInfo, txFail ? INITIAL_VALUE : FINAL_VALUE);
+   }
+
+   private void doPessimisticTxTest(final TransactionPhase phase, boolean txFail, boolean discard) throws Exception {
+      waitForClusterToForm(PESSIMISTIC_TX_CACHE_NAME);
+
+      final KeyInfo keyInfo = createKeys(PESSIMISTIC_TX_CACHE_NAME);
+      final Cache<Object, String> originator = cache(0, PESSIMISTIC_TX_CACHE_NAME);
+      final FilterInfo filterInfo = createFilters(PESSIMISTIC_TX_CACHE_NAME, discard, phase.getCommandClass());
+
+      Future<Void> put = fork(new Callable<Void>() {
+         @Override
+         public Void call() throws Exception {
+            final TransactionManager transactionManager = originator.getAdvancedCache().getTransactionManager();
+            transactionManager.begin();
+            final Transaction tx = transactionManager.getTransaction();
+            try {
+               keyInfo.putFinalValue(originator);
+               if (phase == TransactionPhase.ROLLBACK) {
+                  tx.setRollbackOnly();
+               }
+            } finally {
+               if (tx.getStatus() == Status.STATUS_MARKED_ROLLBACK) {
+                  transactionManager.rollback();
+                  //just to make assert in the main thread
+                  //noinspection ThrowFromFinallyBlock
+                  throw new RollbackException("rollback");
+               } else {
+                  transactionManager.commit();
+               }
+            }
+            return null;
+         }
+      });
+
+      filterInfo.await();
+      splitCluster();
+      filterInfo.unblock();
+
+      try {
+         put.get();
+         assertFalse(txFail);
+      } catch (ExecutionException e) {
+         assertTrue(txFail);
+      }
+
+      switch (phase) {
+         case PREPARE:
+            //always locked: locks acquired in runtime
+            assertLocked(cache(1, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+            if (discard) {
+               //locks are acquired during runtime
+               assertLocked(cache(2, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+            } else {
+               //prepare will release the lock
+               assertEventuallyNotLocked(cache(2, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+            }
+            break;
+         case ROLLBACK:
+            //key is unlocked because the rollback is always received in cache1
+            assertEventuallyNotLocked(cache(1, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+            if (discard) {
+               //rollback never received, so key is locked until the merge occurs.
+               assertLocked(cache(2, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+            } else {
+               //rollback received, so key is unlocked
+               assertEventuallyNotLocked(cache(2, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+            }
+            break;
+         case RUNTIME_LOCK:
+            //locked rollback is never sent
+            assertLocked(cache(1, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+            //lock command is discarded since the transaction originator is missing
+            assertEventuallyNotLocked(cache(2, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+            break;
+      }
+
+      mergeCluster();
+      finalAsserts(PESSIMISTIC_TX_CACHE_NAME, keyInfo, txFail ? INITIAL_VALUE : FINAL_VALUE);
+   }
+
+   private FilterInfo createFilters(String cacheName, boolean discard, Class<? extends CacheRpcCommand> commandClass) {
+      final NotifierFilter notifierFilter = notifyCommandOn(cache(1, cacheName), commandClass);
+      final DiscardFilter discardFilter = discard ? discardCommandOn(cache(2, cacheName), commandClass) : null;
+      final BlockingFilter blockingFilter = !discard ? blockCommandOn(cache(2, cacheName), commandClass) : null;
+      return new FilterInfo(notifierFilter, discardFilter, blockingFilter);
+   }
+
+   private void splitCluster() {
+      log.debugf("Splitting cluster");
+      splitCluster(new int[]{0, 1}, new int[]{2, 3});
+   }
+
+   private void mergeCluster() {
+      log.debugf("Merging cluster");
+      partition(0).merge(partition(1));
+      log.debugf("Cluster merged");
+   }
+
+   private void finalAsserts(String cacheName, KeyInfo keyInfo, String value) {
+      assertNoTransactions(cacheName);
+      assertNoTransactionsInPartitionHandler(cacheName);
+      assertNoLocks(cacheName);
+
+      assertValue(keyInfo.getKey1(), value, this.<Object, String>caches(cacheName));
+      assertValue(keyInfo.getKey2(), value, this.<Object, String>caches(cacheName));
+   }
+
+   private void assertNoLocks(String cacheName) {
+      for (Cache<?, ?> cache : caches(cacheName)) {
+         LockManager lockManager = extractLockManager(cache);
+         log.tracef("Locks info=%s", lockManager.printLockInfo());
+         AssertJUnit.assertEquals(String.format("Locks acquired on cache '%s'", cache), 0, lockManager.getNumberOfLocksHeld());
+      }
+   }
+
+   private void assertValue(Object key, String value, Collection<Cache<Object, String>> caches) {
+      for (Cache<Object, String> cache : caches) {
+         AssertJUnit.assertEquals("Wrong value in cache " + address(cache), value, cache.get(key));
+      }
+   }
+
+   private ConfigurationBuilder getConfiguration(LockingMode lockingMode) {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
+      builder.clustering().partitionHandling().enabled(true);
+      builder.transaction().lockingMode(lockingMode).transactionMode(TransactionMode.TRANSACTIONAL).transactionManagerLookup(new DummyTransactionManagerLookup());
+      return builder;
+   }
+
+   private void assertNoTransactionsInPartitionHandler(final String cacheName) {
+      eventually("Transactions pending in PartitionHandlingManager", new Condition() {
+         @Override
+         public boolean isSatisfied() throws Exception {
+            for (Cache<?, ?> cache : caches(cacheName)) {
+               Collection<GlobalTransaction> partialTransactions = extractComponent(cache, PartitionHandlingManager.class).getPartialTransactions();
+               if (!partialTransactions.isEmpty()) {
+                  log.debugf("transactions not finished in %s. %s", address(cache), partialTransactions);
+                  return false;
+               }
+            }
+            return true;
+         }
+      });
+   }
+
+   private KeyInfo createKeys(String cacheName) {
+      final Object key1 = new MagicKey("k1", cache(1, cacheName), cache(2, cacheName));
+      final Object key2 = new MagicKey("k2", cache(2, cacheName), cache(1, cacheName));
+      cache(1, cacheName).put(key1, INITIAL_VALUE);
+      cache(2, cacheName).put(key2, INITIAL_VALUE);
+      return new KeyInfo(key1, key2);
+   }
+
+   private enum TransactionPhase {
+      PREPARE {
+         @Override
+         Class<? extends CacheRpcCommand> getCommandClass() {
+            return PrepareCommand.class;
+         }
+      },
+      COMMIT {
+         @Override
+         Class<? extends CacheRpcCommand> getCommandClass() {
+            return CommitCommand.class;
+         }
+      },
+      ROLLBACK {
+         @Override
+         Class<? extends CacheRpcCommand> getCommandClass() {
+            return RollbackCommand.class;
+         }
+      },
+      RUNTIME_LOCK {
+         @Override
+         Class<? extends CacheRpcCommand> getCommandClass() {
+            return LockControlCommand.class;
+         }
+      };
+
+      abstract Class<? extends CacheRpcCommand> getCommandClass();
+   }
+
+   private interface Filter {
+      boolean before(CacheRpcCommand command, Reply reply, DeliverOrder order);
+   }
+
+   private static class ControlledInboundHandler implements PerCacheInboundInvocationHandler {
+
+      private final PerCacheInboundInvocationHandler delegate;
+      private volatile Filter filter;
+
+      private ControlledInboundHandler(PerCacheInboundInvocationHandler delegate) {
+         this.delegate = delegate;
+      }
+
+      @Override
+      public void handle(CacheRpcCommand command, Reply reply, DeliverOrder order) {
+         final Filter currentFilter = filter;
+         if (currentFilter != null && currentFilter.before(command, reply, order)) {
+            delegate.handle(command, reply, order);
+         }
+      }
+   }
+
+   private static class BlockingFilter implements Filter {
+
+      private final Class<? extends CacheRpcCommand> aClass;
+      private final ReclosableLatch notifier;
+      private final ReclosableLatch blocker;
+
+      private BlockingFilter(Class<? extends CacheRpcCommand> aClass) {
+         this.aClass = aClass;
+         blocker = new ReclosableLatch(false);
+         notifier = new ReclosableLatch(false);
+      }
+
+      @Override
+      public boolean before(CacheRpcCommand command, Reply reply, DeliverOrder order) {
+         if (aClass.isAssignableFrom(command.getClass())) {
+            notifier.open();
+            try {
+               blocker.await();
+            } catch (InterruptedException e) {
+               Thread.currentThread().interrupt();
+            }
+         }
+         return true;
+      }
+
+      public void awaitUntilBlocked(long timeout, TimeUnit timeUnit) throws InterruptedException {
+         if (!notifier.await(timeout, timeUnit)) {
+            throw new TimeoutException();
+         }
+      }
+
+      public void unblock() {
+         blocker.open();
+      }
+   }
+
+   private static class NotifierFilter implements Filter {
+
+      private final Class<? extends CacheRpcCommand> aClass;
+      private final CountDownLatch notifier;
+
+      private NotifierFilter(Class<? extends CacheRpcCommand> aClass) {
+         this.aClass = aClass;
+         notifier = new CountDownLatch(1);
+      }
+
+      @Override
+      public boolean before(CacheRpcCommand command, Reply reply, DeliverOrder order) {
+         if (aClass.isAssignableFrom(command.getClass())) {
+            notifier.countDown();
+         }
+         return true;
+      }
+
+      public void await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+         if (!notifier.await(timeout, timeUnit)) {
+            throw new TimeoutException();
+         }
+      }
+   }
+
+   private static class DiscardFilter implements Filter {
+
+      private final Class<? extends CacheRpcCommand> aClass;
+      private final ReclosableLatch notifier;
+
+      private DiscardFilter(Class<? extends CacheRpcCommand> aClass) {
+         this.aClass = aClass;
+         notifier = new ReclosableLatch(false);
+      }
+
+      @Override
+      public boolean before(CacheRpcCommand command, Reply reply, DeliverOrder order) {
+         if (!notifier.isOpened() && aClass.isAssignableFrom(command.getClass())) {
+            notifier.open();
+            return false;
+         }
+         return true;
+      }
+
+      public void awaitUntilDiscarded(long timeout, TimeUnit timeUnit) throws InterruptedException {
+         if (!notifier.await(timeout, timeUnit)) {
+            throw new TimeoutException();
+         }
+      }
+   }
+
+   private static class KeyInfo {
+      private final Object key1;
+      private final Object key2;
+
+      public KeyInfo(Object key1, Object key2) {
+         this.key1 = key1;
+         this.key2 = key2;
+      }
+
+      public void putFinalValue(Cache<Object, String> cache) {
+         cache.put(key1, FINAL_VALUE);
+         cache.put(key2, FINAL_VALUE);
+      }
+
+      public Object getKey1() {
+         return key1;
+      }
+
+      public Object getKey2() {
+         return key2;
+      }
+   }
+
+   private static class FilterInfo {
+      private final NotifierFilter notifierFilter;
+      private final DiscardFilter discardFilter;
+      private final BlockingFilter blockingFilter;
+
+      public FilterInfo(NotifierFilter notifierFilter, DiscardFilter discardFilter, BlockingFilter blockingFilter) {
+         this.notifierFilter = notifierFilter;
+         this.discardFilter = discardFilter;
+         this.blockingFilter = blockingFilter;
+      }
+
+      public void await() throws InterruptedException {
+         if (notifierFilter != null) {
+            notifierFilter.await(30, TimeUnit.SECONDS);
+         }
+         if (discardFilter != null) {
+            discardFilter.awaitUntilDiscarded(30, TimeUnit.SECONDS);
+         }
+         if (blockingFilter != null) {
+            blockingFilter.awaitUntilBlocked(30, TimeUnit.SECONDS);
+         }
+      }
+
+      public void unblock() {
+         if (blockingFilter != null) {
+            blockingFilter.unblock();
+         }
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/replication/AsyncReplTest.java
+++ b/core/src/test/java/org/infinispan/replication/AsyncReplTest.java
@@ -22,8 +22,8 @@ public class AsyncReplTest extends MultipleCacheManagersTest {
 
    public void testWithNoTx() throws Exception {
 
-      Cache cache1 = cache(0,"asyncRepl");
-      Cache cache2 = cache(1,"asyncRepl");
+      Cache<String, String> cache1 = cache(0,"asyncRepl");
+      Cache<String, String> cache2 = cache(1,"asyncRepl");
       String key = "key";
 
       replListener(cache2).expect(PutKeyValueCommand.class);
@@ -44,15 +44,15 @@ public class AsyncReplTest extends MultipleCacheManagersTest {
    }
 
    public void testWithTx() throws Exception {
-      Cache cache1 = cache(0,"asyncRepl");
-      Cache cache2 = cache(1,"asyncRepl");
+      Cache<String, String> cache1 = cache(0,"asyncRepl");
+      Cache<String, String> cache2 = cache(1,"asyncRepl");
       
       String key = "key";
       replListener(cache2).expect(PutKeyValueCommand.class);
       cache1.put(key, "value1");
       // allow for replication
       replListener(cache2).waitForRpc();
-      assertNotLocked(cache1, key);
+      assertEventuallyNotLocked(cache1, key);
 
       assertEquals("value1", cache1.get(key));
       assertEquals("value1", cache2.get(key));
@@ -65,7 +65,7 @@ public class AsyncReplTest extends MultipleCacheManagersTest {
       assertEquals("value1", cache2.get(key));
       mgr.commit();
       replListener(cache2).waitForRpc();
-      assertNotLocked(cache1, key);
+      assertEventuallyNotLocked(cache1, key);
 
       assertEquals("value2", cache1.get(key));
       assertEquals("value2", cache2.get(key));
@@ -80,13 +80,13 @@ public class AsyncReplTest extends MultipleCacheManagersTest {
       assertEquals("value2", cache1.get(key));
       assertEquals("value2", cache2.get(key));
 
-      assertNotLocked(cache1, key);
+      assertEventuallyNotLocked(cache1, key);
 
    }
 
    public void simpleTest() throws Exception {
-      Cache cache1 = cache(0,"asyncRepl");
-      Cache cache2 = cache(1,"asyncRepl");
+      Cache<String, String> cache1 = cache(0,"asyncRepl");
+      cache(1, "asyncRepl");
       
       String key = "key";
       TransactionManager mgr = TestingUtil.getTransactionManager(cache1);
@@ -95,7 +95,7 @@ public class AsyncReplTest extends MultipleCacheManagersTest {
       cache1.put(key, "value3");
       mgr.rollback();
 
-      assertNotLocked(cache1, key);
+      assertEventuallyNotLocked(cache1, key);
 
    }
 }

--- a/core/src/test/java/org/infinispan/replication/SyncReplLockingTest.java
+++ b/core/src/test/java/org/infinispan/replication/SyncReplLockingTest.java
@@ -81,8 +81,8 @@ public class SyncReplLockingTest extends MultipleCacheManagersTest {
       cache1.get(k);
       mgr.commit();
 
-      assertNotLocked(cache1, "testcache");
-      assertNotLocked(cache2, "testcache");
+      assertEventuallyNotLocked(cache1, "testcache");
+      assertEventuallyNotLocked(cache2, "testcache");
 
       assert cache1.isEmpty();
       assert cache2.isEmpty();
@@ -111,8 +111,8 @@ public class SyncReplLockingTest extends MultipleCacheManagersTest {
 		assertNull("Should be null", cache1.get(k));
 		mgr.commit();
 
-		assertNotLocked(cache1, "testcache");
-		assertNotLocked(cache2, "testcache");
+		assertEventuallyNotLocked(cache1, "testcache");
+		assertEventuallyNotLocked(cache2, "testcache");
 
 		assert cache1.isEmpty();
 		assert cache2.isEmpty();

--- a/core/src/test/java/org/infinispan/statetransfer/StaleLocksWithCommitDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StaleLocksWithCommitDuringStateTransferTest.java
@@ -124,10 +124,10 @@ public class StaleLocksWithCommitDuringStateTransferTest extends MultipleCacheMa
       }
 
       // test that we don't leak locks
-      assertNotLocked(c1, k1);
-      assertNotLocked(c2, k1);
-      assertNotLocked(c1, k2);
-      assertNotLocked(c2, k2);
+      assertEventuallyNotLocked(c1, k1);
+      assertEventuallyNotLocked(c2, k1);
+      assertEventuallyNotLocked(c1, k2);
+      assertEventuallyNotLocked(c2, k2);
    }
 
    public void testRollbackSuspectFailure() throws Exception {
@@ -201,7 +201,7 @@ public class StaleLocksWithCommitDuringStateTransferTest extends MultipleCacheMa
       }
 
       // test that we don't leak locks
-      assertNotLocked(c1, k1);
-      assertNotLocked(c1, k2);
+      assertEventuallyNotLocked(c1, k1);
+      assertEventuallyNotLocked(c1, k2);
    }
 }

--- a/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractInfinispanTest.java
@@ -73,7 +73,15 @@ public class AbstractInfinispanTest {
       eventually(ec, timeout, 10);
    }
 
+   protected void eventually(String message, Condition ec, long timeout) {
+      eventually(message, ec, timeout, 10);
+   }
+
    protected void eventually(Condition ec, long timeout, int loops) {
+      eventually(null, ec, timeout, loops);
+   }
+
+   protected void eventually(String message, Condition ec, long timeout, int loops) {
       if (loops <= 0) {
          throw new IllegalArgumentException("Number of loops must be positive");
       }
@@ -87,7 +95,7 @@ public class AbstractInfinispanTest {
             if (ec.isSatisfied()) return;
             Thread.sleep(sleepDuration);
          }
-         assertTrue(ec.isSatisfied());
+         assertTrue(message, ec.isSatisfied());
       } catch (Exception e) {
          throw new RuntimeException("Unexpected!", e);
       }
@@ -212,8 +220,8 @@ public class AbstractInfinispanTest {
       }
       CompletionService<V> completionService = completionService();
       CyclicBarrier barrier = new CyclicBarrier(tasks.length);
-      for (int i = 0; i < tasks.length; i++) {
-         completionService.submit(new ConcurrentCallable<V>(new LoggingCallable<V>(tasks[i]), barrier));
+      for (Callable task : tasks) {
+         completionService.submit(new ConcurrentCallable<>(new LoggingCallable<V>(task), barrier));
       }
 
       return completionService;
@@ -404,8 +412,12 @@ public class AbstractInfinispanTest {
       eventually(ec, 10000);
    }
 
+   protected void eventually(String message, Condition ec) {
+      eventually(message, ec, 10000);
+   }
+
    protected interface Condition {
-      public boolean isSatisfied() throws Exception;
+      boolean isSatisfied() throws Exception;
    }
 
    private class LoggingCallable<T> implements Callable<T> {

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -172,7 +172,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
     * Creates a new optionally transactional cache manager, starts it, and adds it to the list of known cache managers on
     * the current thread.  Uses a default clustered cache manager global config.
     *
-    * @param defaultConfig default cfg to use
+    * @param builder default cfg to use
     * @return the new CacheManager
     */
    protected EmbeddedCacheManager addClusterEnabledCacheManager(ConfigurationBuilder builder, TransportFlags flags) {
@@ -186,13 +186,6 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       cacheManagers.add(cm);
       return cm;
    }
-
-   /**
-    * Creates a new cache manager, starts it, and adds it to the list of known cache managers on the current thread.
-    * @param mode cache mode to use
-    * @param transactional if true, the configuration will be decorated with necessary transactional settings
-    * @return an embedded cache manager
-    */
 
    protected void createCluster(ConfigurationBuilder builder, int count) {
       for (int i = 0; i < count; i++) addClusterEnabledCacheManager(builder);
@@ -268,7 +261,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
 
    protected <K, V> List<Cache<K, V>> createClusteredCaches(
          int numMembersInCluster, String cacheName, ConfigurationBuilder builder, TransportFlags flags) {
-      List<Cache<K, V>> caches = new ArrayList<Cache<K, V>>(numMembersInCluster);
+      List<Cache<K, V>> caches = new ArrayList<>(numMembersInCluster);
       for (int i = 0; i < numMembersInCluster; i++) {
          EmbeddedCacheManager cm = addClusterEnabledCacheManager(flags);
          cm.defineConfiguration(cacheName, builder.build());
@@ -281,7 +274,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
 
    protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster,
                                                             ConfigurationBuilder defaultConfigBuilder) {
-      List<Cache<K, V>> caches = new ArrayList<Cache<K, V>>(numMembersInCluster);
+      List<Cache<K, V>> caches = new ArrayList<>(numMembersInCluster);
       for (int i = 0; i < numMembersInCluster; i++) {
          EmbeddedCacheManager cm = addClusterEnabledCacheManager(defaultConfigBuilder);
          Cache<K, V> cache = cm.getCache();
@@ -295,7 +288,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster,
                                                             ConfigurationBuilder defaultConfig,
                                                             TransportFlags flags) {
-      List<Cache<K, V>> caches = new ArrayList<Cache<K, V>>(numMembersInCluster);
+      List<Cache<K, V>> caches = new ArrayList<>(numMembersInCluster);
       for (int i = 0; i < numMembersInCluster; i++) {
          EmbeddedCacheManager cm = addClusterEnabledCacheManager(defaultConfig, flags);
          Cache<K, V> cache = cm.getCache();
@@ -306,7 +299,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    }
 
    /**
-    * Create cacheNames.lenght in each CacheManager (numMembersInCluster cacheManagers).
+    * Create cacheNames.length in each CacheManager (numMembersInCluster cacheManagers).
     *
     * @param numMembersInCluster
     * @param defaultConfigBuilder
@@ -315,10 +308,10 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
     */
    protected <K, V> List<List<Cache<K, V>>> createClusteredCaches(int numMembersInCluster,
          ConfigurationBuilder defaultConfigBuilder, String[] cacheNames) {
-      List<List<Cache<K, V>>> allCaches = new ArrayList<List<Cache<K, V>>>(numMembersInCluster);
+      List<List<Cache<K, V>>> allCaches = new ArrayList<>(numMembersInCluster);
       for (int i = 0; i < numMembersInCluster; i++) {
          EmbeddedCacheManager cm = addClusterEnabledCacheManager(defaultConfigBuilder);
-         List<Cache<K, V>> currentCacheManagerCaches = new ArrayList<Cache<K, V>>(cacheNames.length);
+         List<Cache<K, V>> currentCacheManagerCaches = new ArrayList<>(cacheNames.length);
 
          for (String cacheName : cacheNames) {
             Cache<K, V> cache = cm.getCache(cacheName);
@@ -498,7 +491,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    }
 
    protected void assertNotLocked(int cacheIndex, Object key) {
-      assertNotLocked(cache(cacheIndex), key);
+      assertEventuallyNotLocked(cache(cacheIndex), key);
    }
 
    protected void assertLocked(int cacheIndex, Object key) {
@@ -516,13 +509,13 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    protected <K, V> Cache<K, V> getLockOwner(Object key, String cacheName) {
       Configuration c = getCache(0, cacheName).getCacheConfiguration();
       if (c.clustering().cacheMode().isReplicated() || c.clustering().cacheMode().isInvalidation()) {
-         return (Cache<K, V>) getCache(0, cacheName); //for replicated caches only the coordinator acquires lock
+         return getCache(0, cacheName); //for replicated caches only the coordinator acquires lock
       }  else {
          if (!c.clustering().cacheMode().isDistributed()) throw new IllegalStateException("This is not a clustered cache!");
          final Address address = getCache(0, cacheName).getAdvancedCache().getDistributionManager().locate(key).get(0);
-         for (Cache<?, ?> cache : caches(cacheName)) {
+         for (Cache<K, V> cache : this.<K, V>caches(cacheName)) {
             if (cache.getAdvancedCache().getRpcManager().getTransport().getAddress().equals(address)) {
-               return (Cache<K, V>) cache;
+               return cache;
             }
          }
          throw new IllegalStateException();
@@ -543,8 +536,8 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       }
    }
 
-   private Cache<?, ?> getCache(int index, String name) {
-      return name == null ? cache(index) : cache(index, name);
+   private <K, V> Cache<K, V> getCache(int index, String name) {
+      return name == null ? this.<K, V>cache(index) : this.<K, V>cache(index, name);
    }
 
    protected void forceTwoPhase(int cacheIndex) throws SystemException, RollbackException {
@@ -554,15 +547,20 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    }
 
    protected void assertNoTransactions() {
-      eventually(new Condition() {
+      assertNoTransactions(null);
+   }
+
+   protected void assertNoTransactions(final String cacheName) {
+      eventually("There are pending transactions!", new Condition() {
          @Override
          public boolean isSatisfied() throws Exception {
-            for (int i = 0; i < caches().size(); i++) {
-               int localTxCount = transactionTable(i).getLocalTxCount();
-               int remoteTxCount = transactionTable(i).getRemoteTxCount();
+            for (Cache<?, ?> cache : caches(cacheName)) {
+               final TransactionTable transactionTable = TestingUtil.extractComponent(cache, TransactionTable.class);
+               int localTxCount = transactionTable.getLocalTxCount();
+               int remoteTxCount = transactionTable.getRemoteTxCount();
                if (localTxCount != 0 || remoteTxCount != 0) {
-                  log.tracef("Local tx=%s, remote tx=%s, for cache %s ",
-                        localTxCount, remoteTxCount, i);
+                  log.tracef("Local tx=%s, remote tx=%s, for cache %s ", transactionTable.getLocalGlobalTransaction(),
+                             transactionTable.getRemoteGlobalTransaction(), address(cache));
                   return false;
                }
             }
@@ -582,7 +580,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
          @Override
          public boolean isSatisfied() throws Exception {
             return value == null
-                  ? value == cache(cacheIndex).get(key)
+                  ? null == cache(cacheIndex).get(key)
                   : value.equals(cache(cacheIndex).get(key));
          }
       });

--- a/core/src/test/java/org/infinispan/test/arquillian/DatagridManager.java
+++ b/core/src/test/java/org/infinispan/test/arquillian/DatagridManager.java
@@ -79,7 +79,7 @@ public class DatagridManager extends MultipleCacheManagersTest
 
    //name change
    public void assertKeyNotLocked(Cache cache, Object key) {
-      assertNotLocked(cache, key);
+      assertEventuallyNotLocked(cache, key);
    }
 
    //name change

--- a/core/src/test/java/org/infinispan/tx/StaleLockAfterTxAbortTest.java
+++ b/core/src/test/java/org/infinispan/tx/StaleLockAfterTxAbortTest.java
@@ -37,7 +37,7 @@ public class StaleLockAfterTxAbortTest extends SingleCacheManagerTest {
    public void doTest() throws Throwable {
       cache.put(k, "value"); // init value
 
-      assertNotLocked(cache, k);
+      assertEventuallyNotLocked(cache, k);
 
 //      InvocationContextContainerImpl icc = (InvocationContextContainerImpl) TestingUtil.extractComponent(cache, InvocationContextContainer.class);
 //      InvocationContext ctx = icc.getInvocationContext();
@@ -71,7 +71,7 @@ public class StaleLockAfterTxAbortTest extends SingleCacheManagerTest {
       transaction.runCommit(true);
       transactionThread.join();
 
-      assertNotLocked(cache, k);
+      assertEventuallyNotLocked(cache, k);
    }
 
    private class TxThread extends Thread {

--- a/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
@@ -35,9 +35,6 @@ import static org.testng.AssertJUnit.assertEquals;
  */
 @Test(testName = "tx.TransactionXaAdapterTmIntegrationTest", groups = "unstable", description = "Disabled due to instability - see ISPN-1123 -- original group: unit")
 public class TransactionXaAdapterTmIntegrationTest {
-   private Configuration configuration;
-   private XaTransactionTable txTable;
-   private GlobalTransaction globalTransaction;
    private LocalXaTransaction localTx;
    private TransactionXaAdapter xaAdapter;
    private DummyXid xid;
@@ -47,15 +44,15 @@ public class TransactionXaAdapterTmIntegrationTest {
    @BeforeMethod
    public void setUp() throws XAException {
       Cache mockCache = mock(Cache.class);
-      configuration = new ConfigurationBuilder().build();
-      txTable = new XaTransactionTable();
+      Configuration configuration = new ConfigurationBuilder().build();
+      XaTransactionTable txTable = new XaTransactionTable();
       txTable.initialize(null, configuration, null, null, null, null,
-            null, null, null, null, mockCache, null, null);
+                         null, null, null, null, mockCache, null, null, null);
       txTable.start();
       txTable.startXidMapping();
       TransactionFactory gtf = new TransactionFactory();
       gtf.init(false, false, true, false);
-      globalTransaction = gtf.newGlobalTransaction(null, false);
+      GlobalTransaction globalTransaction = gtf.newGlobalTransaction(null, false);
       DummyBaseTransactionManager tm = new DummyBaseTransactionManager();
       localTx = new LocalXaTransaction(new DummyTransaction(tm), globalTransaction, false, 1, AnyEquivalence.getInstance(), 0);
       xid = new DummyXid(uuid);
@@ -66,7 +63,7 @@ public class TransactionXaAdapterTmIntegrationTest {
       txCoordinator = new TransactionCoordinator();
       txCoordinator.init(commandsFactory, icf, invoker, txTable, null, configuration);
       xaAdapter = new TransactionXaAdapter(localTx, txTable, null, txCoordinator, null, null,
-                                           new ClusteringDependentLogic.InvalidationLogic(), configuration, "");
+                                           new ClusteringDependentLogic.InvalidationLogic(), configuration, "", null);
 
       xaAdapter.start(xid, 0);
    }

--- a/core/src/test/java/org/infinispan/tx/recovery/PostCommitRecoveryStateTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/PostCommitRecoveryStateTest.java
@@ -89,11 +89,11 @@ public class PostCommitRecoveryStateTest extends MultipleCacheManagersTest {
       }
 
       @Override
-      public void removeRecoveryInformationFromCluster(Collection<Address> where, Xid xid, boolean sync, GlobalTransaction gtx) {
+      public void removeRecoveryInformationFromCluster(Collection<Address> where, Xid xid, boolean sync, GlobalTransaction gtx, boolean skipTxCompletionCommand) {
          if (swallowRemoveRecoveryInfoCalls){
             log.trace("PostCommitRecoveryStateTest$RecoveryManagerDelegate.removeRecoveryInformation");
          } else {
-            this.rm.removeRecoveryInformationFromCluster(where, xid, sync, null);
+            this.rm.removeRecoveryInformationFromCluster(where, xid, sync, null, false);
          }
       }
 

--- a/core/src/test/java/org/infinispan/tx/totalorder/writeskew/DistTotalOrderL1WriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/tx/totalorder/writeskew/DistTotalOrderL1WriteSkewTest.java
@@ -35,7 +35,7 @@ public class DistTotalOrderL1WriteSkewTest extends DistL1WriteSkewTest {
          assert false;
       } catch (Throwable e) {
          //expected
-         e.printStackTrace();
+         log.trace("Expected Exception", e);
       }
       assertEquals("v3", cache(0).get("k"));
       assertEventuallyEquals(1, "k", "v3");

--- a/core/src/test/java/org/infinispan/tx/totalorder/writeskew/DistTotalOrderWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/tx/totalorder/writeskew/DistTotalOrderWriteSkewTest.java
@@ -35,7 +35,7 @@ public class DistTotalOrderWriteSkewTest extends DistWriteSkewTest {
          assert false;
       } catch (Throwable e) {
          //expected
-         e.printStackTrace();
+         log.trace("Expected Exception", e);
       }
       assertEquals("v3", cache(0).get("k"));
       assertEventuallyEquals(1, "k", "v3");

--- a/core/src/test/java/org/infinispan/tx/totalorder/writeskew/TotalOrderWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/tx/totalorder/writeskew/TotalOrderWriteSkewTest.java
@@ -32,7 +32,7 @@ public class TotalOrderWriteSkewTest extends ReplWriteSkewTest {
          assert false;
       } catch (Throwable e) {
          //expected
-         e.printStackTrace();
+         log.trace("Expected Exception", e);
       }
       assertEquals("v3", cache(0).get("k"));
       assertEventuallyEquals(1, "k", "v3");


### PR DESCRIPTION
...onsistent after merge

* keep the transaction resources while the partition is not healed.
* when the merge happens, complete the pending transactions.

https://issues.jboss.org/browse/ISPN-5046