### PR TITLE
ISPN-5019 After coordinator change, cache topologies should be installed in parallel

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/marshall/Ids.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/Ids.java
@@ -14,7 +14,8 @@ public interface Ids {
    int EMPTY_SET = 88;
    int EMPTY_MAP = 89;
    int EMPTY_LIST = 90;
-   // internal collections (id=18 no longer in use, might get reused at a later stage)
+   
+   int IMMUTABLE_LIST = 18;
    int IMMUTABLE_MAP = 19;
    int BYTE_BUFFER = 106;
 }

--- a/commons/src/main/java/org/infinispan/commons/util/ReflectionUtil.java
+++ b/commons/src/main/java/org/infinispan/commons/util/ReflectionUtil.java
@@ -167,8 +167,9 @@ public class ReflectionUtil {
          method.setAccessible(true);
          return method.invoke(instance, parameters);
       } catch (InvocationTargetException e) {
+         Throwable cause = e.getCause() != null ? e.getCause() : e;
          throw new CacheException("Unable to invoke method " + method + " on object of type " + (instance == null ? "null" : instance.getClass().getSimpleName()) +
-                                        (parameters != null ? " with parameters " + Arrays.asList(parameters) : ""), e.getCause());
+                                        (parameters != null ? " with parameters " + Arrays.asList(parameters) : ""), cause);
       } catch (Exception e) {
          throw new CacheException("Unable to invoke method " + method + " on object of type " + (instance == null ? "null" : instance.getClass().getSimpleName()) +
                (parameters != null ? " with parameters " + Arrays.asList(parameters) : ""), e);

--- a/core/src/main/java/org/infinispan/executors/SemaphoreCompletionService.java
+++ b/core/src/main/java/org/infinispan/executors/SemaphoreCompletionService.java
@@ -1,0 +1,183 @@
+package org.infinispan.executors;
+
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Executes tasks in the given executor, but never has more than {@code maxConcurrentTasks} tasks running at the same time.
+ *
+ * @author Dan Berindei
+ * @since 7.2
+ */
+public class SemaphoreCompletionService<T> implements CompletionService<T> {
+   private static final Log log = LogFactory.getLog(SemaphoreCompletionService.class);
+   private static final boolean trace = log.isTraceEnabled();
+
+   private final Executor executor;
+   private final CustomSemaphore semaphore;
+   private final BlockingQueue<QueueingTask> queue = new LinkedBlockingQueue<>();
+   private final BlockingQueue<QueueingTask> completionQueue = new LinkedBlockingQueue<>();
+
+   public SemaphoreCompletionService(Executor executor, int maxConcurrentTasks) {
+      this.executor = executor;
+      this.semaphore = new CustomSemaphore(maxConcurrentTasks);
+   }
+
+   public List<? extends Future<T>> drainCompletionQueue() {
+      List<QueueingTask> list = new ArrayList<QueueingTask>();
+      completionQueue.drainTo(list);
+      return list;
+   }
+
+   /**
+    * When stopping, cancel any queued tasks.
+    */
+   public void cancelQueuedTasks() {
+      ArrayList<QueueingTask> queuedTasks = new ArrayList<QueueingTask>();
+      queue.drainTo(queuedTasks);
+      for (QueueingTask task : queuedTasks) {
+         task.cancel(false);
+      }
+   }
+
+   /**
+    * Called from a task to remove the permit that would otherwise be freed when the task finishes running
+    *
+    * When the asynchronous part of the task finishes, it must call {@link #backgroundTaskFinished(Callable)}
+    * to make the permit available again.
+    */
+   public void continueTaskInBackground() {
+      if (trace) log.tracef("Moving task to background, available permits %d", semaphore.availablePermits());
+      //
+      semaphore.removePermit();
+   }
+
+   /**
+    * Signal that a task that called {@link #continueTaskInBackground()} has finished and
+    * optionally execute another task on the just-freed thread.
+    */
+   public Future<T> backgroundTaskFinished(final Callable<T> cleanupTask) {
+      QueueingTask futureTask = null;
+      if (cleanupTask != null) {
+         if (trace) log.tracef("Background task finished, executing cleanup task");
+         futureTask = new QueueingTask(cleanupTask);
+         executor.execute(futureTask);
+      } else {
+         semaphore.release();
+         if (trace) log.tracef("Background task finished, available permits %d", semaphore.availablePermits());
+      }
+      return futureTask;
+   }
+
+   @Override
+   public Future<T> submit(final Callable<T> task) {
+      QueueingTask futureTask = new QueueingTask(task);
+      queue.add(futureTask);
+      executeFront();
+      return futureTask;
+   }
+
+   @Override
+   public Future<T> submit(final Runnable task, T result) {
+      QueueingTask futureTask = new QueueingTask(task, result);
+      queue.add(futureTask);
+      executeFront();
+      return futureTask;
+   }
+
+   private void executeFront() {
+      if (semaphore.tryAcquire()) {
+         QueueingTask next = queue.poll();
+         if (next != null) {
+            executor.execute(next);
+         } else {
+            semaphore.release();
+         }
+      }
+   }
+
+   @Override
+   public Future<T> take() throws InterruptedException {
+      return completionQueue.take();
+   }
+
+   @Override
+   public Future<T> poll() {
+      return completionQueue.poll();
+   }
+
+   @Override
+   public Future<T> poll(long timeout, TimeUnit unit) throws InterruptedException {
+      return completionQueue.poll(timeout, unit);
+   }
+
+   private class QueueingTask extends FutureTask<T> {
+
+      public QueueingTask(Callable<T> task) {
+         super(task);
+      }
+
+      public QueueingTask(Runnable runnable, Object result) {
+         super(runnable, (T) result);
+      }
+
+      @Override
+      public void run() {
+         try {
+            QueueingTask next = this;
+            do {
+               next.runInternal();
+
+               // Don't run another task if the current task called startBackgroundTask()
+               // and there are no more permits available
+               if (semaphore.availablePermits() < 0)
+                  break;
+               next = queue.poll();
+            } while (next != null);
+         } finally {
+            semaphore.release();
+            if (trace) log.tracef("All queued tasks finished, available permits %d", semaphore.availablePermits());
+
+            // In case we just got a new task between queue.poll() and semaphore.release()
+            if (!queue.isEmpty()) {
+               executeFront();
+            }
+         }
+      }
+
+      private void runInternal() {
+         try {
+            if (trace) log.tracef("Task started, available permits %d", semaphore.availablePermits());
+            super.run();
+         } finally {
+            completionQueue.offer(this);
+            if (trace) log.tracef("Task finished, available permits %d", semaphore.availablePermits());
+         }
+      }
+   }
+
+   /**
+    * Extend {@code Semaphore} to expose the {@code reducePermits(int)} method.
+    */
+   private static class CustomSemaphore extends Semaphore {
+      public CustomSemaphore(int permits) {
+         super(permits);
+      }
+
+      protected void removePermit() {
+         super.reducePermits(1);
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -1,19 +1,5 @@
 package org.infinispan.manager;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.infinispan.Cache;
 import org.infinispan.IllegalLifecycleStateException;
 import org.infinispan.Version;
@@ -65,6 +51,20 @@ import org.infinispan.util.CyclicDependencyException;
 import org.infinispan.util.DependencyGraph;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A <tt>CacheManager</tt> is the primary mechanism for retrieving a {@link Cache} instance, and is often used as a
@@ -624,8 +624,9 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
    }
 
    private void terminate(String cacheName) {
-      if (cacheExists(cacheName)) {
-         Cache<?, ?> cache = this.caches.get(cacheName).cache;
+      CacheWrapper cacheWrapper = this.caches.get(cacheName);
+      if (cacheWrapper != null && cacheWrapper.cache != null) {
+         Cache<?, ?> cache = cacheWrapper.cache;
          unregisterCacheMBean(cache);
          cache.stop();
       }

--- a/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
+++ b/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
@@ -1,13 +1,5 @@
 package org.infinispan.marshall.core;
 
-import static org.infinispan.factories.KnownComponentNames.GLOBAL_MARSHALLER;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.WeakHashMap;
-
 import org.infinispan.atomic.DeltaCompositeKey;
 import org.infinispan.atomic.impl.AtomicHashMap;
 import org.infinispan.atomic.impl.AtomicHashMapDelta;
@@ -23,6 +15,7 @@ import org.infinispan.commons.io.ByteBufferImpl;
 import org.infinispan.commons.io.UnsignedNumeric;
 import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.util.ImmutableListCopy;
 import org.infinispan.commons.util.Immutables;
 import org.infinispan.commons.util.InfinispanCollections;
 import org.infinispan.configuration.global.GlobalConfiguration;
@@ -115,6 +108,14 @@ import org.infinispan.xsite.statetransfer.XSiteState;
 import org.jboss.marshalling.Marshaller;
 import org.jboss.marshalling.ObjectTable;
 import org.jboss.marshalling.Unmarshaller;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+import static org.infinispan.factories.KnownComponentNames.GLOBAL_MARSHALLER;
 
 /**
  * The externalizer table maintains information necessary to be able to map a particular type with the corresponding
@@ -247,6 +248,7 @@ public class ExternalizerTable implements ObjectTable {
       addInternalExternalizer(new DldGlobalTransaction.Externalizer());
       addInternalExternalizer(new RecoveryAwareDldGlobalTransaction.Externalizer());
       addInternalExternalizer(new JGroupsAddress.Externalizer());
+      addInternalExternalizer(new ImmutableListCopy.Externalizer());
       addInternalExternalizer(new Immutables.ImmutableMapWrapperExternalizer());
       addInternalExternalizer(new MarshalledValue.Externalizer(globalMarshaller));
       addInternalExternalizer(new ByteBufferImpl.Externalizer());

--- a/core/src/main/java/org/infinispan/marshall/exts/ListExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/ListExternalizer.java
@@ -47,17 +47,18 @@ public class ListExternalizer extends AbstractExternalizer<List> {
    @Override
    public List readObject(ObjectInput input) throws IOException, ClassNotFoundException {
       int magicNumber = input.readUnsignedByte();
+      int size = UnsignedNumeric.readUnsignedInt(input);
+
       List<Object> subject = null;
       switch (magicNumber) {
          case ARRAY_LIST:
-            subject = new ArrayList<Object>();
+            subject = new ArrayList<Object>(size);
             break;
          case LINKED_LIST:
             subject = new LinkedList<Object>();
             break;
       }
 
-      int size = UnsignedNumeric.readUnsignedInt(input);
       for (int i = 0; i < size; i++)
          subject.add(input.readObject());
 

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/NonTotalOrderPerCacheInboundInvocationHandler.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/NonTotalOrderPerCacheInboundInvocationHandler.java
@@ -40,7 +40,10 @@ public class NonTotalOrderPerCacheInboundInvocationHandler extends BasePerCacheI
                                                 true, onExecutorService);
                break;
             case StateRequestCommand.COMMAND_ID:
-               runnable = createDefaultRunnable(command, reply, NO_TOPOLOGY_COMMAND, false, onExecutorService);
+               // StateRequestCommand is special in that it doesn't need transaction data
+               // In fact, waiting for transaction data could cause a deadlock
+               runnable = createDefaultRunnable(command, reply,
+                     extractCommandTopologyId(((StateRequestCommand) command)), false, onExecutorService);
                break;
             default:
                int commandTopologyId = NO_TOPOLOGY_COMMAND;

--- a/core/src/main/java/org/infinispan/remoting/transport/AbstractTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/AbstractTransport.java
@@ -7,6 +7,7 @@ import org.infinispan.partitionhandling.AvailabilityException;
 import org.infinispan.remoting.responses.ExceptionResponse;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.transport.jgroups.SuspectException;
+import org.infinispan.statetransfer.OutdatedTopologyException;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.logging.Log;
 
@@ -37,7 +38,7 @@ public abstract class AbstractTransport implements Transport {
             Exception e = exceptionResponse.getException();
             if (e instanceof SuspectException)
                throw log.thirdPartySuspected(sender, (SuspectException) e);
-            if (e instanceof AvailabilityException)
+            if (e instanceof AvailabilityException || e instanceof OutdatedTopologyException)
                throw e;
 
             // if we have any application-level exceptions make sure we throw them!!

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsAddress.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsAddress.java
@@ -1,14 +1,14 @@
 package org.infinispan.remoting.transport.jgroups;
 
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.util.Set;
-
 import org.infinispan.commons.marshall.InstanceReusingAdvancedExternalizer;
 import org.infinispan.commons.util.Util;
 import org.infinispan.marshall.core.Ids;
 import org.infinispan.remoting.transport.Address;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Set;
 
 /**
  * An encapsulation of a JGroups Address
@@ -77,7 +77,7 @@ public class JGroupsAddress implements Address {
       public JGroupsAddress doReadObject(ObjectInput unmarshaller) throws IOException, ClassNotFoundException {
          try {
             org.jgroups.Address address = org.jgroups.util.Util.readAddress(unmarshaller);
-            return new JGroupsAddress(address);
+            return (JGroupsAddress) JGroupsAddressCache.fromJGroupsAddress(address);
          } catch (Exception e) {
             throw new IOException(e);
          }

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsAddressCache.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsAddressCache.java
@@ -1,0 +1,45 @@
+package org.infinispan.remoting.transport.jgroups;
+
+import org.infinispan.commons.equivalence.AnyEquivalence;
+import org.infinispan.commons.util.concurrent.jdk8backported.EquivalentConcurrentHashMapV8;
+import org.jgroups.Address;
+import org.jgroups.util.ExtendedUUID;
+import org.jgroups.util.UUID;
+
+/**
+ * Cache JGroupsAddress instances
+ *
+ * @author Dan Berindei
+ * @since 7.0
+ */
+public class JGroupsAddressCache {
+   private static final EquivalentConcurrentHashMapV8<org.jgroups.Address, JGroupsAddress> addressCache =
+         new EquivalentConcurrentHashMapV8<>(AnyEquivalence.getInstance(), AnyEquivalence.getInstance());
+
+   // HACK: Avoid the org.jgroups.Address reference in the signature so that local caches can work without the jgroups jar.
+   // Otherwise, instantiating the JGroupsAddress externalizer will try to load the org.jgroups.Address class.
+   static org.infinispan.remoting.transport.Address fromJGroupsAddress(Object address) {
+      final Address addr1 = (Address) address;
+      return addressCache.computeIfAbsent(addr1, new EquivalentConcurrentHashMapV8.Fun<Address, JGroupsAddress>() {
+         @Override
+         public JGroupsAddress apply(Address uuid) {
+            if (addr1 instanceof ExtendedUUID)
+               return new JGroupsTopologyAwareAddress((ExtendedUUID) addr1);
+            else
+               return new JGroupsAddress(addr1);
+         }
+      });
+   }
+
+   static void pruneAddressCache() {
+      // Prune the JGroups addresses no longer in the UUID cache from the our address cache
+      addressCache.forEachKey(Integer.MAX_VALUE, new EquivalentConcurrentHashMapV8.Action<org.jgroups.Address>() {
+         @Override
+         public void apply(org.jgroups.Address address) {
+            if (UUID.get(address) == null) {
+               addressCache.remove(address);
+            }
+         }
+      });
+   }
+}

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTopologyAwareAddress.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTopologyAwareAddress.java
@@ -1,6 +1,5 @@
 package org.infinispan.remoting.transport.jgroups;
 
-import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.marshall.InstanceReusingAdvancedExternalizer;
 import org.infinispan.marshall.core.Ids;
 import org.infinispan.remoting.transport.TopologyAwareAddress;
@@ -88,7 +87,7 @@ public class JGroupsTopologyAwareAddress extends JGroupsAddress implements Topol
       public JGroupsTopologyAwareAddress doReadObject(ObjectInput unmarshaller) throws IOException, ClassNotFoundException {
          try {
             ExtendedUUID jgroupsAddress = (ExtendedUUID) org.jgroups.util.Util.readAddress(unmarshaller);
-            return new JGroupsTopologyAwareAddress(jgroupsAddress);
+            return (JGroupsTopologyAwareAddress) JGroupsAddressCache.fromJGroupsAddress(jgroupsAddress);
          } catch (Exception e) {
             throw new IOException(e);
          }

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -46,7 +46,6 @@ import org.jgroups.protocols.relay.SiteMaster;
 import org.jgroups.protocols.tom.TOA;
 import org.jgroups.stack.AddressGenerator;
 import org.jgroups.util.Buffer;
-import org.jgroups.util.ExtendedUUID;
 import org.jgroups.util.Rsp;
 import org.jgroups.util.RspList;
 import org.jgroups.util.TopologyUUID;
@@ -723,6 +722,8 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
 
          n.emitNotification(oldMembers, newView);
       }
+
+      JGroupsAddressCache.pruneAddressCache();
    }
 
    @Override
@@ -748,11 +749,8 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
       return ((JGroupsAddress) a).address;
    }
 
-   static Address fromJGroupsAddress(org.jgroups.Address addr) {
-      if (addr instanceof ExtendedUUID)
-         return new JGroupsTopologyAwareAddress((ExtendedUUID)addr);
-      else
-         return new JGroupsAddress(addr);
+   static Address fromJGroupsAddress(final org.jgroups.Address addr) {
+      return JGroupsAddressCache.fromJGroupsAddress(addr);
    }
 
    private List<org.jgroups.Address> toJGroupsAddressListExcludingSelf(Collection<Address> list, boolean totalOrder) {

--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -1,7 +1,6 @@
 package org.infinispan.statetransfer;
 
 import net.jcip.annotations.GuardedBy;
-
 import org.infinispan.Cache;
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.write.InvalidateCommand;
@@ -19,6 +18,7 @@ import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.distexec.DistributedCallable;
 import org.infinispan.distribution.L1Manager;
 import org.infinispan.distribution.ch.ConsistentHash;
+import org.infinispan.executors.SemaphoreCompletionService;
 import org.infinispan.factories.KnownComponentNames;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
@@ -51,18 +51,32 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 import javax.transaction.TransactionManager;
-
-import java.util.*;
-import java.util.concurrent.BlockingDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.infinispan.context.Flag.*;
+import static org.infinispan.context.Flag.CACHE_MODE_LOCAL;
+import static org.infinispan.context.Flag.IGNORE_RETURN_VALUES;
+import static org.infinispan.context.Flag.PUT_FOR_STATE_TRANSFER;
+import static org.infinispan.context.Flag.SKIP_LOCKING;
+import static org.infinispan.context.Flag.SKIP_OWNERSHIP_CHECK;
+import static org.infinispan.context.Flag.SKIP_REMOTE_LOOKUP;
+import static org.infinispan.context.Flag.SKIP_SHARED_CACHE_STORE;
+import static org.infinispan.context.Flag.SKIP_XSITE_BACKUP;
+import static org.infinispan.factories.KnownComponentNames.ASYNC_TRANSPORT_EXECUTOR;
 import static org.infinispan.factories.KnownComponentNames.STATE_TRANSFER_EXECUTOR;
 import static org.infinispan.persistence.manager.PersistenceManager.AccessMode.PRIVATE;
 
@@ -79,6 +93,7 @@ public class StateConsumerImpl implements StateConsumer {
    public static final int NO_REBALANCE_IN_PROGRESS = -1;
 
    private Cache cache;
+   private ExecutorService asyncTransportExecutor;
    private StateTransferManager stateTransferManager;
    private String cacheName;
    private Configuration configuration;
@@ -102,7 +117,7 @@ public class StateConsumerImpl implements StateConsumer {
    private boolean isTotalOrder;
    private volatile KeyInvalidationListener keyInvalidationListener; //for test purpose only!
    private CommitManager commitManager;
-   private ExecutorService executorService;
+   private ExecutorService stateTransferExecutor;
 
    private volatile CacheTopology cacheTopology;
 
@@ -139,11 +154,9 @@ public class StateConsumerImpl implements StateConsumer {
    private final Map<Integer, InboundTransferTask> transfersBySegment = new HashMap<Integer, InboundTransferTask>();
 
    /**
-    * Tasks ready to be executed by the transfer thread. These tasks are also present if transfersBySegment and transfersBySource.
+    * Push RPCs on a background thread
     */
-   private final BlockingDeque<InboundTransferTask> taskQueue = new LinkedBlockingDeque<InboundTransferTask>();
-
-   private final AtomicBoolean isTransferThreadRunning = new AtomicBoolean(false);
+   private SemaphoreCompletionService<Void> stateRequestCompletionService;
 
    private volatile boolean ownsData = false;
 
@@ -164,7 +177,8 @@ public class StateConsumerImpl implements StateConsumer {
 
    @Inject
    public void init(Cache cache,
-                    @ComponentName(STATE_TRANSFER_EXECUTOR) ExecutorService executorService,
+                    @ComponentName(ASYNC_TRANSPORT_EXECUTOR) ExecutorService asyncTransportExecutor,
+                    @ComponentName(STATE_TRANSFER_EXECUTOR) ExecutorService stateTransferExecutor,
                     StateTransferManager stateTransferManager,
                     InterceptorChain interceptorChain,
                     InvocationContextFactory icf,
@@ -181,8 +195,9 @@ public class StateConsumerImpl implements StateConsumer {
                     @ComponentName(KnownComponentNames.REMOTE_COMMAND_EXECUTOR) BlockingTaskAwareExecutorService remoteCommandsExecutor,
                     L1Manager l1Manager, CommitManager commitManager) {
       this.cache = cache;
+      this.asyncTransportExecutor = asyncTransportExecutor;
       this.cacheName = cache.getName();
-      this.executorService = executorService;
+      this.stateTransferExecutor = stateTransferExecutor;
       this.stateTransferManager = stateTransferManager;
       this.interceptorChain = interceptorChain;
       this.icf = icf;
@@ -206,6 +221,8 @@ public class StateConsumerImpl implements StateConsumer {
       isTotalOrder = configuration.transaction().transactionProtocol().isTotalOrder();
 
       timeout = configuration.clustering().stateTransfer().timeout();
+
+      stateRequestCompletionService = new SemaphoreCompletionService<>(stateTransferExecutor, 1);
    }
 
    public boolean hasActiveTransfers() {
@@ -313,8 +330,14 @@ public class StateConsumerImpl implements StateConsumer {
                Set<Integer> previousSegments = getOwnedSegments(previousWriteCh);
                Set<Integer> newSegments = getOwnedSegments(newWriteCh);
 
-               Set<Integer> removedSegments = new HashSet<Integer>(previousSegments);
-               removedSegments.removeAll(newSegments);
+               Set<Integer> removedSegments;
+               if (newSegments.size() == newWriteCh.getNumSegments()) {
+                  // Optimization for replicated caches
+                  removedSegments = InfinispanCollections.emptySet();
+               } else {
+                  removedSegments = new HashSet<Integer>(previousSegments);
+                  removedSegments.removeAll(newSegments);
+               }
 
                // This is a rebalance, we need to request the segments we own in the new CH.
                addedSegments = new HashSet<Integer>(newSegments);
@@ -431,6 +454,7 @@ public class StateConsumerImpl implements StateConsumer {
             log.debugf("Finished receiving of segments for cache %s for topology %d.", cacheName, topologyId);
             stopApplyingState();
             stateTransferManager.notifyEndOfRebalance(topologyId, rebalanceId);
+            stateRequestCompletionService.drainCompletionQueue();
          }
       }
    }
@@ -472,7 +496,7 @@ public class StateConsumerImpl implements StateConsumer {
       final Set<Integer> mySegments = wCh.getSegmentsForOwner(rpcManager.getAddress());
       final CountDownLatch countDownLatch = new CountDownLatch(stateChunks.size());
       for (final StateChunk stateChunk : stateChunks) {
-         executorService.submit(new Callable<Void>() {
+         stateTransferExecutor.submit(new Callable<Void>() {
             @Override
             public Void call() throws Exception {
                applyChunk(sender, mySegments, stateChunk);
@@ -611,7 +635,9 @@ public class StateConsumerImpl implements StateConsumer {
       try {
          synchronized (transferMapsLock) {
             // cancel all inbound transfers
-            taskQueue.clear();
+            stateRequestCompletionService.cancelQueuedTasks();
+            stateRequestCompletionService.drainCompletionQueue();
+
             for (Iterator<List<InboundTransferTask>> it = transfersBySource.values().iterator(); it.hasNext(); ) {
                List<InboundTransferTask> inboundTransfers = it.next();
                it.remove();
@@ -795,67 +821,18 @@ public class StateConsumerImpl implements StateConsumer {
       for (Map.Entry<Address, Set<Integer>> e : sources.entrySet()) {
          addTransfer(e.getKey(), e.getValue());
       }
-
-      startTransferThread(excludedSources);
-   }
-
-   private void startTransferThread(final Set<Address> excludedSources) {
-      boolean success = isTransferThreadRunning.compareAndSet(false, true);
-      if (trace) log.tracef("Starting transfer thread: %b", success);
-
-      if (success) {
-         executorService.submit(new Runnable() {
-            @Override
-            public void run() {
-               runTransferTasksInOrder(excludedSources);
-            }
-         });
-      }
-   }
-
-   private void runTransferTasksInOrder(Set<Address> excludedSources) {
-      while (true) {
-         InboundTransferTask task;
-         task = taskQueue.pollFirst();
-         if (task == null) {
-            isTransferThreadRunning.set(false);
-
-            if (!taskQueue.isEmpty() && isTransferThreadRunning.compareAndSet(false, true)) {
-               // We found a new entry in the queue, and another transfer thread hasn't
-               // been started yet. Keep this thread alive.
-               continue;
-            } else {
-               if (trace) log.tracef("Stopping state transfer thread");
-               break;
-            }
-         }
-
-         try {
-            boolean successful = task.requestSegments();
-            if (successful) {
-               successful = task.awaitCompletion();
-            }
-
-            if (!successful) {
-               retryTransferTask(task, excludedSources);
-            }
-         } catch(InterruptedException e) {
-            Thread.currentThread().interrupt();
-            return;
-         } catch (Throwable t) {
-            log.failedToRequestSegments(task.getSegments(), cacheName, task.getSource(), t);
-         }
-      }
    }
 
 
-   private void retryTransferTask(InboundTransferTask task, Set<Address> excludedSources) {
+   private void retryTransferTask(InboundTransferTask task) {
       if (trace) log.tracef("Retrying failed task: %s", task);
+      task.cancel();
 
       // look for other sources for the failed segments and replace all failed tasks with new tasks to be retried
       // remove+add needs to be atomic
       synchronized (transferMapsLock) {
          Set<Integer> failedSegments = new HashSet<Integer>();
+         Set<Address> excludedSources = new HashSet<>();
          if (removeTransfer(task)) {
             excludedSources.add(task.getSource());
             failedSegments.addAll(task.getSegments());
@@ -978,8 +955,7 @@ public class StateConsumerImpl implements StateConsumer {
                   if (trace) {
                      log.tracef("Removing inbound transfers for segments %s from source %s for cache %s", inboundTransfer.getSegments(), source, cacheName);
                   }
-                  taskQueue.remove(inboundTransfer);
-                  inboundTransfer.terminate();
+                  inboundTransfer.cancel();
                   transfersBySegment.keySet().removeAll(inboundTransfer.getSegments());
                   addedSegments.addAll(inboundTransfer.getUnfinishedSegments());
                }
@@ -1015,7 +991,17 @@ public class StateConsumerImpl implements StateConsumer {
                transfersBySource.put(inboundTransfer.getSource(), inboundTransfers);
             }
             inboundTransfers.add(inboundTransfer);
-            taskQueue.add(inboundTransfer);
+
+            stateRequestCompletionService.submit(new Callable<Void>() {
+               @Override
+               public Void call() throws Exception {
+                  inboundTransfer.requestSegments();
+
+                  if (trace) log.tracef("Waiting for inbound transfer to finish: %s", inboundTransfer);
+                  stateRequestCompletionService.continueTaskInBackground();
+                  return null;
+               }
+            });
             return inboundTransfer;
          }
       }
@@ -1025,7 +1011,6 @@ public class StateConsumerImpl implements StateConsumer {
       synchronized (transferMapsLock) {
          if (trace) log.tracef("Removing inbound transfers for segments %s from source %s for cache %s",
                inboundTransfer.getSegments(), inboundTransfer.getSource(), cacheName);
-         taskQueue.remove(inboundTransfer);
          List<InboundTransferTask> transfers = transfersBySource.get(inboundTransfer.getSource());
          if (transfers != null) {
             if (transfers.remove(inboundTransfer)) {
@@ -1040,11 +1025,22 @@ public class StateConsumerImpl implements StateConsumer {
       return false;
    }
 
-   void onTaskCompletion(InboundTransferTask inboundTransfer) {
-      log.tracef("Completion of inbound transfer task: %s ", inboundTransfer);
-      removeTransfer(inboundTransfer);
+   void onTaskCompletion(final InboundTransferTask inboundTransfer) {
+      // This will execute only after inboundTransfer.requestSegments() finished
+      stateRequestCompletionService.backgroundTaskFinished(new Callable<Void>() {
+         @Override
+         public Void call() throws Exception {
+            removeTransfer(inboundTransfer);
 
-      notifyEndOfRebalanceIfNeeded(cacheTopology.getTopologyId(), cacheTopology.getRebalanceId());
+            if (!inboundTransfer.isCompletedSuccessfully()) {
+               retryTransferTask(inboundTransfer);
+            } else {
+               if (trace) log.tracef("Inbound transfer finished: %s", inboundTransfer);
+               notifyEndOfRebalanceIfNeeded(cacheTopology.getTopologyId(), cacheTopology.getRebalanceId());
+            }
+            return null;
+         }
+      });
    }
 
    public interface KeyInvalidationListener {

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -425,7 +425,11 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
          throw new Exception(throwable);
       }
       if (!localResponse.isSuccessful()) {
-         throw new CacheException("Unsuccessful local response: " + localResponse);
+         Exception exception = null;
+         if (localResponse instanceof ExceptionResponse) {
+            exception = ((ExceptionResponse) localResponse).getException();
+         }
+         throw new CacheException("Unsuccessful local response: " + localResponse, exception);
       }
 
       // wait for the remote commands to finish

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManagerImpl.java
@@ -177,6 +177,7 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
       } catch (Throwable t) {
          log.warn("Failed to obtain the rebalancing status", t);
       }
+      log.debugf("Sending cluster status response for view %d", viewId);
       return new ManagerStatusResponse(caches, rebalancingEnabled);
    }
 
@@ -252,12 +253,12 @@ public class LocalTopologyManagerImpl implements LocalTopologyManager {
          if (!sender.equals(transport.getCoordinator())) {
             log.debugf("Ignoring topology %d from old coordinator %s", cacheTopology.getTopologyId(), sender);
             return false;
-         } else {
-            log.debugf("Updating local topology for cache %s: %s", cacheName, cacheTopology);
-            cacheStatus.setCurrentTopology(cacheTopology);
-            return true;
          }
       }
+
+      log.debugf("Updating local topology for cache %s: %s", cacheName, cacheTopology);
+      cacheStatus.setCurrentTopology(cacheTopology);
+      return true;
    }
 
    private void resetLocalTopologyBeforeRebalance(String cacheName, CacheTopology newCacheTopology,

--- a/core/src/test/java/org/infinispan/executors/SemaphoreCompletionServiceTest.java
+++ b/core/src/test/java/org/infinispan/executors/SemaphoreCompletionServiceTest.java
@@ -1,0 +1,116 @@
+package org.infinispan.executors;
+
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.util.concurrent.WithinThreadExecutor;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertSame;
+
+/**
+ * Basic tests for {@link SemaphoreCompletionService}
+ *
+ * @author Dan Berindei
+ */
+@Test(groups = "functional", testName = "executors.SemaphoreCompletionServiceTest")
+public class SemaphoreCompletionServiceTest extends AbstractInfinispanTest {
+   private final ExecutorService executor2Threads = Executors.newFixedThreadPool(2, getTestThreadFactory("Test"));
+
+   @AfterClass(alwaysRun = true)
+   public void stopExecutors() {
+      executor2Threads.shutdownNow();
+   }
+
+   public void testConcurrency1WithinThread() throws Exception {
+      SemaphoreCompletionService<String> completionService = new SemaphoreCompletionService<>(new WithinThreadExecutor(), 1);
+
+
+      Future<String> future1 = completionService.submit(new DummyTask());
+      Future<String> future2 = completionService.poll();
+      assertSame(future1, future2);
+      assertNotNull(future2);
+      assertEquals("bla", future2.get());
+   }
+
+   public void testConcurrencyLimit() throws Exception {
+      SemaphoreCompletionService<String> completionService = new SemaphoreCompletionService<>(executor2Threads, 1);
+      CountDownLatch latch = new CountDownLatch(1);
+
+      Future<String> blockingFuture = completionService.submit(new BlockingTask(latch));
+
+      Future<String> dummyFuture = completionService.submit(new DummyTask());
+      assertNull(completionService.poll(1, SECONDS));
+      assertFalse(dummyFuture.isDone());
+
+      latch.countDown();
+      assertEquals("bla", blockingFuture.get(10, SECONDS));
+      assertEquals("bla", dummyFuture.get(10, SECONDS));
+   }
+
+   public void testBackgroundTasks() throws Exception {
+      SemaphoreCompletionService<String> completionService = new SemaphoreCompletionService<>(executor2Threads, 1);
+      CountDownLatch latch = new CountDownLatch(1);
+
+      Future<String> backgroundInitFuture = completionService.submit(new BackgroundInitTask(completionService));
+      assertEquals("bla", backgroundInitFuture.get(1, SECONDS));
+
+      Future<String> dummyFuture = completionService.submit(new DummyTask());
+      assertSame(backgroundInitFuture, completionService.poll(1, SECONDS));
+      assertFalse(dummyFuture.isDone());
+
+      Future<String> backgroundEndFuture = completionService.backgroundTaskFinished(new BlockingTask(latch));
+      assertNull(completionService.poll(1, SECONDS));
+      assertFalse(dummyFuture.isDone());
+
+      latch.countDown();
+      assertEquals("bla", backgroundEndFuture.get(10, SECONDS));
+      assertEquals("bla", dummyFuture.get(10, SECONDS));
+   }
+
+
+   private static class DummyTask implements Callable<String> {
+      @Override
+      public String call() throws Exception {
+         return "bla";
+      }
+   }
+
+   private static class BlockingTask implements Callable<String> {
+      private final CountDownLatch latch;
+
+      private BlockingTask(CountDownLatch latch) {
+         this.latch = latch;
+      }
+
+      @Override
+      public String call() throws Exception {
+         latch.await(30, SECONDS);
+         return "bla";
+      }
+   }
+
+   private static class BackgroundInitTask implements Callable<String> {
+      private final SemaphoreCompletionService<String> completionService;
+
+      private BackgroundInitTask(SemaphoreCompletionService<String> completionService) {
+         this.completionService = completionService;
+      }
+
+      @Override
+      public String call() throws Exception {
+         completionService.continueTaskInBackground();
+         return "bla";
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
@@ -198,7 +198,7 @@ public class StateConsumerTest extends AbstractInfinispanTest {
 
       // create state provider
       final StateConsumerImpl stateConsumer = new StateConsumerImpl();
-      stateConsumer.init(cache, pooledExecutorService, stateTransferManager, interceptorChain, icf, configuration, rpcManager, null,
+      stateConsumer.init(cache, pooledExecutorService, pooledExecutorService, stateTransferManager, interceptorChain, icf, configuration, rpcManager, null,
             commandsFactory, persistenceManager, dataContainer, transactionTable, stateTransferLock, cacheNotifier,
             totalOrderManager, remoteCommandsExecutor, l1Manager, new CommitManager(AnyEquivalence.getInstance()));
       stateConsumer.start();

--- a/core/src/test/java/org/infinispan/stress/LargeClusterStressTest.java
+++ b/core/src/test/java/org/infinispan/stress/LargeClusterStressTest.java
@@ -4,14 +4,23 @@ import org.infinispan.Cache;
 import org.infinispan.commons.executors.BlockingThreadPoolExecutorFactory;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.distribution.ch.impl.SyncConsistentHashFactory;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CleanupAfterTest;
 import org.infinispan.test.fwk.TestResourceTracker;
-import org.infinispan.topology.LocalTopologyManager;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * Test that we're able to start a large cluster in a single JVM.
@@ -19,49 +28,117 @@ import org.testng.annotations.Test;
  * @author Dan Berindei
  * @since 5.3
  */
+@CleanupAfterTest
 @Test(groups = "stress", testName = "stress.LargeClusterStressTest")
 public class LargeClusterStressTest extends MultipleCacheManagersTest {
 
-   private static final int NUM_NODES = 50;
-   private static final int NUM_CACHES = 50;
+   private static final int NUM_NODES = 40;
+   private static final int NUM_CACHES = 80;
+   private static final int NUM_THREADS = 10;
+   private static final int NUM_SEGMENTS = 1000;
 
    @Override
    protected void createCacheManagers() throws Throwable {
       // start the cache managers in the test itself
    }
 
-   public void testLargeCluster() throws Exception {
-      Configuration distConfig = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false).clustering().stateTransfer().awaitInitialTransfer(false).build();
-      Configuration replConfig = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false).clustering().stateTransfer().awaitInitialTransfer(false).build();
-      for (int i = 0; i < NUM_NODES; i++) {
-         GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
-         gcb.globalJmxStatistics().allowDuplicateDomains(true);
-         gcb.transport().defaultTransport().nodeName(TestResourceTracker.getNameForIndex(i));
-         BlockingThreadPoolExecutorFactory remoteExecutorFactory = new BlockingThreadPoolExecutorFactory(
-               10, 1, 0, 60000);
-         gcb.transport().remoteCommandThreadPool().threadPoolFactory(remoteExecutorFactory);
-         EmbeddedCacheManager cm = new DefaultCacheManager(gcb.build());
-         registerCacheManager(cm);
-         for (int j = 0; j < NUM_CACHES; j++) {
-            if (j % 2 == 0) {
-               cm.defineConfiguration("replcache" + j, replConfig);
-               Cache<Object, Object> cache = cm.getCache("replcache" + j);
-               cache.put(cm.getAddress(), "bla");
-            } else {
-               cm.defineConfiguration("distcache" + j, distConfig);
-               Cache<Object, Object> cache = cm.getCache("distcache" + j);
-               cache.put(cm.getAddress(), "bla");
-            }
+   public void testLargeClusterStart() throws Exception {
+      final Configuration distConfig = new ConfigurationBuilder()
+            .clustering().cacheMode(CacheMode.DIST_SYNC)
+            .clustering().stateTransfer().awaitInitialTransfer(false)
+//            .hash().consistentHashFactory(new TopologyAwareSyncConsistentHashFactory()).numSegments(NUM_SEGMENTS)
+            .hash().consistentHashFactory(new SyncConsistentHashFactory()).numSegments(NUM_SEGMENTS)
+            .build();
+      final Configuration replConfig = new ConfigurationBuilder()
+            .clustering().cacheMode(CacheMode.REPL_SYNC)
+            .clustering().hash().numSegments(NUM_SEGMENTS)
+            .clustering().stateTransfer().awaitInitialTransfer(false)
+            .build();
+
+      // Start the caches (and the JGroups channels) in separate threads
+      ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
+      ExecutorCompletionService<Object> completionService = new ExecutorCompletionService<Object>(executor);
+      Future<Object>[] futures = new Future[NUM_NODES];
+      try {
+         for (int i = 0; i < NUM_NODES; i++) {
+            final String nodeName = TestResourceTracker.getNameForIndex(i);
+            final String machineId = "m" + (i / 2);
+            futures[i] = completionService.submit(new Callable<Object>() {
+               @Override
+               public Object call() throws Exception {
+                  GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
+                  gcb.globalJmxStatistics().allowDuplicateDomains(true);
+                  gcb.transport().defaultTransport().nodeName(nodeName);
+//                  gcb.transport().machineId(machineId);
+                  BlockingThreadPoolExecutorFactory remoteExecutorFactory = new BlockingThreadPoolExecutorFactory(
+                        10, 1, 0, 60000);
+                  gcb.transport().remoteCommandThreadPool().threadPoolFactory(remoteExecutorFactory);
+                  BlockingThreadPoolExecutorFactory stateTransferExecutorFactory = new BlockingThreadPoolExecutorFactory(
+                        4, 1, 0, 60000);
+                  gcb.transport().stateTransferThreadPool().threadPoolFactory(stateTransferExecutorFactory);
+                  EmbeddedCacheManager cm = new DefaultCacheManager(gcb.build());
+                  try {
+                     for (int j = 0; j < NUM_CACHES/2; j++) {
+                        cm.defineConfiguration("repl-cache-" + j, replConfig);
+                        cm.defineConfiguration("dist-cache-" + j, distConfig);
+                     }
+                     for (int j = 0; j < NUM_CACHES/2; j++) {
+                        Cache<Object, Object> replCache = cm.getCache("repl-cache-" + j);
+                        replCache.put(cm.getAddress(), "bla");
+                        Cache<Object, Object> distCache = cm.getCache("dist-cache-" + j);
+                        distCache.put(cm.getAddress(), "bla");
+                     }
+                  } finally {
+                     registerCacheManager(cm);
+                  }
+                  log.infof("Started cache manager %s", cm.getAddress());
+                  return null;
+               }
+            });
          }
-         log.infof("Started cache manager %s", cm.getAddress());
-         // TODO Test is unstable without this wait, needs more investigation after JGRP-1899 is fixed
-         TestingUtil.blockForMemberToFail(30000, cacheManagers.toArray(new EmbeddedCacheManager[0]));
+
+         for (int i = 0; i < NUM_NODES; i++) {
+            completionService.take();
+         }
+      } finally {
+         executor.shutdownNow();
       }
 
-      for (int j = 0; j < NUM_CACHES; j++) {
-         waitForClusterToForm("replcache" + j);
-         waitForClusterToForm("distcache" + j);
+      log.infof("All %d cache managers started, waiting for state transfer to finish for each cache", NUM_NODES);
+
+      for (int j = 0; j < NUM_CACHES/2; j++) {
+         waitForClusterToForm("repl-cache-" + j);
+         waitForClusterToForm("dist-cache-" + j);
       }
-      TestingUtil.extractGlobalComponent(manager(0), LocalTopologyManager.class).setRebalancingEnabled(false);
+   }
+
+   @Test(dependsOnMethods = "testLargeClusterStart")
+   public void testLargeClusterStop() {
+      for (int i = 0; i < NUM_NODES - 1; i++) {
+         int killIndex = -1;
+         for (int j = 0; j < cacheManagers.size(); j++) {
+            if (address(j).equals(manager(0).getCoordinator())) {
+               killIndex = j;
+               break;
+            }
+         }
+
+         log.debugf("Killing coordinator %s", address(killIndex));
+         manager(killIndex).stop();
+         cacheManagers.remove(killIndex);
+         if (cacheManagers.size() > 0) {
+            TestingUtil.blockUntilViewsReceived(60000, false, cacheManagers);
+            for (int j = 0; j < NUM_CACHES/2; j++) {
+               TestingUtil.waitForRehashToComplete(caches("repl-cache-" + j));
+               TestingUtil.waitForRehashToComplete(caches("dist-cache-" + j));
+            }
+         }
+      }
+   }
+
+   @AfterMethod
+   @Override
+   protected void clearContent() throws Throwable {
+      // Do nothing
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5019

* Update LargeClusterStressTest to measure the cluster shutdown as well
* Improve the memory usage and serialization of consistent hash classes
* Install merge cache topologies in parallel
* Don't keep the state transfer thread blocked while waiting for state
* Don't use up a thread for early StateRequestCommands
* Add a JGroupsAddress cache
