### PR TITLE
ISPN-5369 SuspectException can be thrown without the target node leaving

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
@@ -24,12 +24,15 @@ import org.jgroups.Channel;
 import org.jgroups.Message;
 import org.jgroups.SuspectedException;
 import org.jgroups.UpHandler;
+import org.jgroups.blocks.RequestCorrelator;
+import org.jgroups.blocks.RequestHandler;
 import org.jgroups.blocks.RequestOptions;
 import org.jgroups.blocks.ResponseMode;
 import org.jgroups.blocks.RpcDispatcher;
 import org.jgroups.blocks.RspFilter;
 import org.jgroups.blocks.mux.Muxer;
 import org.jgroups.protocols.relay.SiteAddress;
+import org.jgroups.stack.Protocol;
 import org.jgroups.util.Buffer;
 import org.jgroups.util.FutureListener;
 import org.jgroups.util.NotifyingFuture;
@@ -91,6 +94,11 @@ public class CommandAwareRpcDispatcher extends RpcDispatcher {
       }
       channel.addChannelListener(this);
       asyncDispatching(true);
+   }
+
+   @Override
+   protected RequestCorrelator createRequestCorrelator(Protocol transport, RequestHandler handler, Address local_addr) {
+      return new CustomRequestCorrelator(transport, handler, local_addr);
    }
 
    private boolean isValid(Message req) {

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/CustomRequestCorrelator.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/CustomRequestCorrelator.java
@@ -1,0 +1,27 @@
+package org.infinispan.remoting.transport.jgroups;
+
+import org.jgroups.Address;
+import org.jgroups.blocks.RequestCorrelator;
+import org.jgroups.blocks.RequestHandler;
+import org.jgroups.conf.ClassConfigurator;
+import org.jgroups.stack.Protocol;
+
+/**
+ * Extend {@link RequestCorrelator} to ignore {@link org.jgroups.Event#SUSPECT} events.
+ *
+ * {@link SuspectException} will only be thrown when the target actually leaves the view.
+ *
+ * @author Dan Berindei
+ * @since 7.2
+ */
+public class CustomRequestCorrelator extends RequestCorrelator {
+   public CustomRequestCorrelator(Protocol transport, RequestHandler handler, Address local_addr) {
+      // Make sure we use the same protocol id as the parent class
+      super(ClassConfigurator.getProtocolId(RequestCorrelator.class), transport, handler, local_addr);
+   }
+
+   @Override
+   public void receiveSuspect(Address mbr) {
+      // Ignore suspect events, if the node actually left that will be handled by receiveView(View)
+   }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5369

Ignore SUSPECT events in the request correlator