### PR TITLE
ISPN-5355 Fix a misconception in the BackupForNotSpecifiedTest that caches inherit from the default cache

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/BackupConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/BackupConfigurationBuilder.java
@@ -6,7 +6,6 @@ import java.lang.invoke.MethodHandles;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
-import org.infinispan.configuration.cache.BackupConfiguration.BackupStrategy;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;

--- a/core/src/main/java/org/infinispan/configuration/cache/SitesConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/SitesConfiguration.java
@@ -144,6 +144,6 @@ public class SitesConfiguration {
 
    @Override
    public String toString() {
-      return "SitesConfiguration [backupFor=" + backupFor + ", attributes=" + attributes + "]";
+      return "SitesConfiguration [backupFor=" + backupFor + ", allBackups=" + allBackups + ", attributes=" + attributes + "]";
    }
 }

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -346,7 +346,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
    @Override
    public Configuration defineConfiguration(String cacheName, String templateName, Configuration configurationOverride) {
       if (templateName != null) {
-         Configuration c = configurationOverrides.get(templateName);
+         Configuration c = DEFAULT_CACHE_NAME.equals(templateName) ? defaultConfiguration : configurationOverrides.get(templateName);
          if (c != null)
             return defineConfiguration(cacheName, configurationOverride, c, false);
          return defineConfiguration(cacheName, configurationOverride);

--- a/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
+++ b/core/src/test/java/org/infinispan/xsite/AbstractXSiteTest.java
@@ -2,6 +2,7 @@ package org.infinispan.xsite;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
+import org.infinispan.commons.api.BasicCacheContainer;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -106,12 +107,11 @@ public abstract class AbstractXSiteTest extends AbstractCacheTest {
       return Collections.unmodifiableList(site(site).<K,V>getCaches(cacheName));
    }
 
-
    protected void startCache(String siteName, String cacheName, ConfigurationBuilder configurationBuilder) {
       TestSite site = site(siteName);
       for (EmbeddedCacheManager ecm : site.cacheManagers) {
          Configuration config = configurationBuilder.build();
-         ecm.defineConfiguration(cacheName, config);
+         ecm.defineConfiguration(cacheName, BasicCacheContainer.DEFAULT_CACHE_NAME, config);
       }
       site.waitForClusterToForm(cacheName);
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5355

Before my recent work on configuration overrides, the BackupForNotSpecifiedTest test was relying on some unintended behaviour that named caches would inherit from the default cache, even though the defineConfiguration(String,Configuration) javadoc said the opposite.