### PR TITLE
ISPN-5328 DummyTransaction does not invoke afterCompletion() if some res...

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/InvocationContextInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/InvocationContextInterceptor.java
@@ -173,7 +173,7 @@ public class InvocationContextInterceptor extends CommandInterceptor {
       } catch (SystemException e) {
          throw new CacheException("Unexpected!", e);
       }
-      return status == Status.STATUS_ACTIVE || status == Status.STATUS_PREPARING;
+      return status == Status.STATUS_ACTIVE;
    }
 
    private boolean isOngoingTransaction(InvocationContext ctx) throws SystemException {

--- a/core/src/main/java/org/infinispan/transaction/tm/DummyBaseTransactionManager.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/DummyBaseTransactionManager.java
@@ -67,18 +67,10 @@ public class DummyBaseTransactionManager implements TransactionManager, Serializ
    public void commit() throws RollbackException, HeuristicMixedException,
                                HeuristicRollbackException, SecurityException,
                                IllegalStateException, SystemException {
-      int status;
       DummyTransaction tx = getTransaction();
       if (tx == null)
          throw new IllegalStateException("thread not associated with transaction");
-      status = tx.getStatus();
-      if (status == Status.STATUS_MARKED_ROLLBACK) {
-         tx.setStatus(Status.STATUS_ROLLEDBACK);
-         rollback();
-         throw new RollbackException("Transaction status is Status.STATUS_MARKED_ROLLBACK");
-      } else {
-         tx.commit();
-      }
+      tx.commit();
 
       // Disassociate tx from thread.
       setTransaction(null);

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -40,6 +40,7 @@ import javax.naming.NamingException;
 import javax.transaction.Synchronization;
 import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
 import javax.xml.namespace.QName;
 import java.io.File;
 import java.io.IOException;
@@ -1302,4 +1303,8 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Maximum data container size is currently 2^48 - 1, the number provided was %s", id = 356)
    CacheConfigurationException evictionSizeTooLarge(long value);
+
+   @LogMessage(level = ERROR)
+   @Message(value = "end() failed for %s", id = 357)
+   void xaResourceEndFailed(XAResource resource, @Cause Throwable t);
 }

--- a/core/src/test/java/org/infinispan/api/mvcc/LockTestBase.java
+++ b/core/src/test/java/org/infinispan/api/mvcc/LockTestBase.java
@@ -91,8 +91,7 @@ public abstract class LockTestBase extends AbstractInfinispanTest {
       cache.put("k", "v");
       assert tm.getTransaction().runPrepare();
       assertLocked("k");
-      tm.getTransaction().runCommitTx();
-      tm.suspend();
+      tm.getTransaction().runCommit(false);
 
       assertNoLocks();
 
@@ -107,7 +106,7 @@ public abstract class LockTestBase extends AbstractInfinispanTest {
       cache.remove("k");
       assert tm.getTransaction().runPrepare();
       assertLocked("k");
-      tm.getTransaction().runCommitTx();
+      tm.getTransaction().runCommit(false);
 
       assertNoLocks();
    }
@@ -122,9 +121,8 @@ public abstract class LockTestBase extends AbstractInfinispanTest {
       final DummyTransaction tx = ((DummyTransactionManager) tm).getTransaction();
       assert tx.runPrepare();
       assertLocked("k");
-      tx.runCommitTx();
+      tx.runCommit(false);
       assertNoLocks();
-      tm.suspend();
 
       tm.begin();
       assert "v".equals(cache.get("k"));
@@ -161,7 +159,7 @@ public abstract class LockTestBase extends AbstractInfinispanTest {
       cache.remove("k");
       tm.getTransaction().runPrepare();
       assertLocked("k");
-      tm.getTransaction().runCommitTx();
+      tm.getTransaction().runCommit(false);
 
       assert !cache.containsKey("k") : "Should not exist";
       assertNoLocks();
@@ -200,7 +198,7 @@ public abstract class LockTestBase extends AbstractInfinispanTest {
 
       assertLocked("k");
       assertLocked("k2");
-      tm.getTransaction().runCommitTx();
+      tm.getTransaction().runCommit(false);
 
       assert cache.isEmpty();
       assertNoLocks();
@@ -316,7 +314,7 @@ public abstract class LockTestBase extends AbstractInfinispanTest {
 
       tm.rollback();
       tm.resume(transaction);
-      transaction.runCommitTx();
+      transaction.runCommit(false);
 
       assertNoLocks();
    }

--- a/core/src/test/java/org/infinispan/api/mvcc/repeatable_read/RepeatableReadLockTest.java
+++ b/core/src/test/java/org/infinispan/api/mvcc/repeatable_read/RepeatableReadLockTest.java
@@ -126,7 +126,7 @@ public class RepeatableReadLockTest extends LockTestBase {
       cache.put("k", "v");
       tm.getTransaction().runPrepare();
       assertLocked("k");
-      tm.getTransaction().runCommitTx();
+      tm.getTransaction().runCommit(false);
       tm.suspend();
 
       assertNoLocks();
@@ -144,7 +144,7 @@ public class RepeatableReadLockTest extends LockTestBase {
       cache.remove("k");
       tm.getTransaction().runPrepare();
       assertLocked("k");
-      tm.getTransaction().runCommitTx();
+      tm.getTransaction().runCommit(false);
 
       assertNoLocks();
    }

--- a/core/src/test/java/org/infinispan/jmx/MvccLockManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/MvccLockManagerMBeanTest.java
@@ -66,7 +66,7 @@ public class MvccLockManagerMBeanTest extends SingleCacheManagerTest {
       cache.put("key", "value");
       tm.getTransaction().runPrepare();
       assertAttributeValue("NumberOfLocksHeld", 1);
-      tm.getTransaction().runCommitTx();
+      tm.getTransaction().runCommit(false);
       assertAttributeValue("NumberOfLocksHeld", 0);
    }
 
@@ -79,7 +79,7 @@ public class MvccLockManagerMBeanTest extends SingleCacheManagerTest {
 
       assertAttributeValue("NumberOfLocksHeld", 1);
       assertAttributeValue("NumberOfLocksAvailable", initialAvailable - 1);
-      tm.rollback();
+      tm.getTransaction().runCommit(true);
       assertAttributeValue("NumberOfLocksAvailable", initialAvailable);
       assertAttributeValue("NumberOfLocksHeld", 0);
    }

--- a/core/src/test/java/org/infinispan/lock/singlelock/AbstractLockOwnerCrashTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/AbstractLockOwnerCrashTest.java
@@ -6,7 +6,6 @@ import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.tm.DummyTransaction;
 import org.testng.annotations.Test;
 
-import javax.transaction.Status;
 import javax.transaction.Transaction;
 
 /**
@@ -40,7 +39,6 @@ public abstract class AbstractLockOwnerCrashTest extends AbstractCrashTest {
                cache(1).put(k, "v");
                transaction = (DummyTransaction) tm(1).getTransaction();
                log.trace("Before preparing");
-               transaction.notifyBeforeCompletion();
                transaction.runPrepare();
                tm(1).suspend();
             } catch (Throwable e) {
@@ -82,9 +80,7 @@ public abstract class AbstractLockOwnerCrashTest extends AbstractCrashTest {
 
       log.trace("Before completing the transaction!");
       tm(1).resume(transaction);
-      transaction.runCommitTx();
-      transaction.notifyAfterCompletion(Status.STATUS_COMMITTED);
-      tm(1).suspend();
+      transaction.runCommit(false);
 
       //make sure the 2nd transaction succeeds as well eventually
       eventually(new AbstractInfinispanTest.Condition() {

--- a/core/src/test/java/org/infinispan/lock/singlelock/AbstractNoCrashTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/AbstractNoCrashTest.java
@@ -98,7 +98,7 @@ public abstract class AbstractNoCrashTest extends MultipleCacheManagersTest {
       assert !lockManager(1).isLocked(k);
       assert !lockManager(2).isLocked(k);
 
-      dtm.runCommitTx();
+      dtm.runCommit(false);
 
       assertNotLocked(k);
       assertValue(k, false);

--- a/core/src/test/java/org/infinispan/lock/singlelock/MainOwnerChangesLockTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/MainOwnerChangesLockTest.java
@@ -97,7 +97,7 @@ public class MainOwnerChangesLockTest extends MultipleCacheManagersTest {
       log.trace("Committing the tx to the new node.");
       for (Transaction tx : key2Tx.values()) {
          tm(nodeThatPuts).resume(tx);
-         dummyTm(nodeThatPuts).getTransaction().runCommitTx();
+         dummyTm(nodeThatPuts).getTransaction().runCommit(false);
       }
       
       for (Object key : key2Tx.keySet()) {

--- a/core/src/test/java/org/infinispan/lock/singlelock/MinViewIdCalculusTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/MinViewIdCalculusTest.java
@@ -102,7 +102,7 @@ public class MinViewIdCalculusTest extends MultipleCacheManagersTest {
       assertEquals(tt1.getMinTopologyId(), topologyId);
 
       tm(1).resume(t);
-      t.runCommitTx();
+      t.runCommit(false);
 
       eventually(new Condition() {
          @Override

--- a/core/src/test/java/org/infinispan/lock/singlelock/OriginatorBecomesOwnerLockTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/OriginatorBecomesOwnerLockTest.java
@@ -116,7 +116,7 @@ public class OriginatorBecomesOwnerLockTest extends MultipleCacheManagersTest {
 
       log.trace("About to commit existing transactions.");
       tm.resume(tx);
-      tx.runCommitTx();
+      tx.runCommit(false);
 
       // read the data from the container, just to make sure all replicas are correctly set
       checkValue(key, "value");
@@ -152,7 +152,7 @@ public class OriginatorBecomesOwnerLockTest extends MultipleCacheManagersTest {
 
       log.trace("About to commit existing transaction.");
       tm.resume(tx);
-      tx.runCommitTx();
+      tx.runCommit(false);
 
       // read the data from the container, just to make sure all replicas are correctly set
       checkValue(key, "value");
@@ -183,7 +183,7 @@ public class OriginatorBecomesOwnerLockTest extends MultipleCacheManagersTest {
             assert success;
 
             log.trace("About to commit transaction.");
-            tx.runCommitTx();
+            tx.runCommit(false);
             return null;
          }
       });

--- a/core/src/test/java/org/infinispan/lock/singlelock/optimistic/BasicSingleLockOptimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/optimistic/BasicSingleLockOptimisticTest.java
@@ -6,8 +6,6 @@ import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.tm.DummyTransaction;
 import org.testng.annotations.Test;
 
-import javax.transaction.Status;
-
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -38,8 +36,7 @@ public class BasicSingleLockOptimisticTest extends AbstractNoCrashTest {
       assert lockManager(1).isLocked(k);
       assert !lockManager(2).isLocked(k);
 
-      dtm.runCommitTx();
-      tm(0).suspend();
+      dtm.runCommit(false);
 
       assertNotLocked(k);
 
@@ -66,8 +63,7 @@ public class BasicSingleLockOptimisticTest extends AbstractNoCrashTest {
       assert !lockManager(1).isLocked(k2);
       assert lockManager(2).isLocked(k2);
 
-      dtm.runCommitTx();
-      tm(0).suspend();
+      dtm.runCommit(false);
 
       assertNotLocked(k1);
       assertNotLocked(k2);
@@ -124,9 +120,7 @@ public class BasicSingleLockOptimisticTest extends AbstractNoCrashTest {
 
 
       tm(0).resume(dtm);
-      dtm.runCommitTx();
-      dtm.notifyAfterCompletion(Status.STATUS_COMMITTED);
-      tm(0).suspend();
+      dtm.runCommit(false);
 
       assertValue(k, false);
 

--- a/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/BasicSingleLockPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/BasicSingleLockPessimisticTest.java
@@ -123,9 +123,7 @@ public class BasicSingleLockPessimisticTest extends AbstractNoCrashTest {
 
       log.trace("about to commit transaction.");
       tm(0).resume(dtm);
-      dtm.runPrepare();
-      dtm.runCommitTx();
-      tm(0).suspend();
+      tm(0).commit();
 
       assertValue(k, false);
 

--- a/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/LockOwnerCrashPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/LockOwnerCrashPessimisticTest.java
@@ -191,7 +191,7 @@ public class LockOwnerCrashPessimisticTest extends AbstractLockOwnerCrashTest {
 
       tm(1).resume(transaction);
       if (!crashBeforePrepare) {
-         transaction.runCommitTx();
+         transaction.runCommit(false);
       } else {
          tm(1).commit();
       }

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/optimistic/BasicSingleLockReplOptTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/optimistic/BasicSingleLockReplOptTest.java
@@ -33,8 +33,7 @@ public class BasicSingleLockReplOptTest extends AbstractNoCrashTest {
       assert !lockManager(1).isLocked("k");
       assert !lockManager(2).isLocked("k");
 
-      dtm.runCommitTx();
-      tm(0).suspend();
+      dtm.runCommit(false);
 
       assertNotLocked("k");
 
@@ -58,8 +57,7 @@ public class BasicSingleLockReplOptTest extends AbstractNoCrashTest {
       assert !lockManager(1).isLocked(k2);
       assert !lockManager(2).isLocked(k2);
 
-      dtm.runCommitTx();
-      tm(0).suspend();
+      dtm.runCommit(false);
 
       assertNotLocked(k1);
       assertNotLocked(k2);
@@ -79,8 +77,7 @@ public class BasicSingleLockReplOptTest extends AbstractNoCrashTest {
       assert !lockManager(1).isLocked("k0");
       assert !lockManager(2).isLocked("k0");
 
-      dtm.runCommitTx();
-      tm(0).suspend();
+      dtm.runCommit(false);
 
       assertNotLocked("k0");
       assertValue("k0", false);
@@ -133,8 +130,7 @@ public class BasicSingleLockReplOptTest extends AbstractNoCrashTest {
 
 
       tm(0).resume(dtm);
-      dtm.runCommitTx();
-      tm(0).suspend();
+      dtm.runCommit(false);
 
       assertValue("k0", false);
 

--- a/core/src/test/java/org/infinispan/statetransfer/TxDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/TxDuringStateTransferTest.java
@@ -87,7 +87,7 @@ public class TxDuringStateTransferTest extends MultipleCacheManagersTest {
 
       assertEquals("Wrong transaction status after killing backup owner.",
                    Status.STATUS_PREPARED, transaction.getStatus());
-      transaction.runCommitTx();
+      transaction.runCommit(false);
 
       for (Cache<Object, Object> cache : caches()) {
          //all the caches are owner

--- a/core/src/test/java/org/infinispan/statetransfer/TxReplay2Test.java
+++ b/core/src/test/java/org/infinispan/statetransfer/TxReplay2Test.java
@@ -118,7 +118,7 @@ public class TxReplay2Test extends MultipleCacheManagersTest {
       checkIfTransactionExists(newBackupOwnerCache);
       assertEquals("Wrong transaction status after killing backup owner.",
             Status.STATUS_PREPARED, transaction.getStatus());
-      transaction.runCommitTx();
+      transaction.runCommit(false);
 
       secondCommitFuture.get(10, SECONDS);
 

--- a/core/src/test/java/org/infinispan/statetransfer/TxReplayTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/TxReplayTest.java
@@ -58,7 +58,7 @@ public class TxReplayTest extends MultipleCacheManagersTest {
       checkIfTransactionExists(newBackupOwnerCache);
       assertEquals("Wrong transaction status after killing backup owner.",
                    Status.STATUS_PREPARED, transaction.getStatus());
-      transaction.runCommitTx();
+      transaction.runCommit(false);
 
       assertNoTransactions();
 

--- a/core/src/test/java/org/infinispan/test/SingleCacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/test/SingleCacheManagerTest.java
@@ -116,6 +116,10 @@ public abstract class SingleCacheManagerTest extends AbstractCacheTest {
    }
 
    protected void assertNoTransactions() {
+      assertNoTransactions(cache);
+   }
+
+   protected void assertNoTransactions(final Cache<?, ?> cache) {
       eventually(new Condition() {
          @Override
          public boolean isSatisfied() throws Exception {

--- a/core/src/test/java/org/infinispan/tx/DummyTransactionTest.java
+++ b/core/src/test/java/org/infinispan/tx/DummyTransactionTest.java
@@ -1,0 +1,447 @@
+package org.infinispan.tx;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.RollbackException;
+import javax.transaction.Synchronization;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.testng.AssertJUnit.assertNull;
+
+/**
+ * Set of tests for the DummyTransaction.
+ *
+ * @author Pedro Ruivo
+ * @since 7.2
+ */
+@Test(groups = "functional", testName = "tx.DummyTransactionTest")
+public class DummyTransactionTest extends SingleCacheManagerTest {
+
+   private static final String SYNC_CACHE_NAME = "sync-cache";
+   private static final String XA_CACHE_NAME = "xa-cache";
+
+   private static final String KEY = "key";
+   private static final String VALUE = "value";
+
+   public void testFailBeforeWithMarkRollbackFirstSync() throws Exception {
+      doCommitWithRollbackExceptionTest(Arrays.asList(
+            new RegisterFailSynchronization(FailMode.BEFORE_MARK_ROLLBACK),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+      ));
+   }
+
+   public void testFailBeforeWithExceptionFirstSync() throws Exception {
+      doCommitWithRollbackExceptionTest(Arrays.asList(
+            new RegisterFailSynchronization(FailMode.BEFORE_THROW_EXCEPTION),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+      ));
+   }
+
+   public void testFailBeforeWithMarkRollbackSecondSync() throws Exception {
+      doCommitWithRollbackExceptionTest(Arrays.asList(
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterFailSynchronization(FailMode.BEFORE_MARK_ROLLBACK),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+      ));
+   }
+
+   public void testFailBeforeWithExceptionSecondSync() throws Exception {
+      doCommitWithRollbackExceptionTest(Arrays.asList(
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterFailSynchronization(FailMode.BEFORE_THROW_EXCEPTION),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+      ));
+   }
+
+   public void testEndFailFirstXa() throws Exception {
+      doCommitWithRollbackExceptionTest(Arrays.asList(
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterFailXaResource(FailMode.XA_END),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+      ));
+   }
+
+   public void testEndFailSecondXa() throws Exception {
+      doCommitWithRollbackExceptionTest(Arrays.asList(
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME)),
+            new RegisterFailXaResource(FailMode.XA_END)
+      ));
+   }
+
+   public void testPrepareFailFirstXa() throws Exception {
+      doCommitWithRollbackExceptionTest(Arrays.asList(
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterFailXaResource(FailMode.XA_PREPARE),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+      ));
+   }
+
+   public void testPrepareFailSecondXa() throws Exception {
+      doCommitWithRollbackExceptionTest(Arrays.asList(
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME)),
+            new RegisterFailXaResource(FailMode.XA_PREPARE)
+      ));
+   }
+
+   public void testCommitFailFirstXa() throws Exception {
+      doCommitWithHeuristicExceptionTest(Arrays.asList(
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterFailXaResource(FailMode.XA_COMMIT),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+      ));
+   }
+
+   public void testCommitFailSecondXa() throws Exception {
+      doCommitWithHeuristicExceptionTest(Arrays.asList(
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME)),
+            new RegisterFailXaResource(FailMode.XA_COMMIT)
+      ));
+   }
+
+   public void testRollbackFailFirstXa() throws Exception {
+      doRollbackWithHeuristicExceptionTest(Arrays.asList(
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterFailXaResource(FailMode.XA_ROLLBACK),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+      ));
+   }
+
+   public void testRollbackFailSecondXa() throws Exception {
+      doRollbackWithHeuristicExceptionTest(Arrays.asList(
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME)),
+            new RegisterFailXaResource(FailMode.XA_ROLLBACK)
+      ));
+   }
+
+   public void testFailAfterFirstSync() throws Exception {
+      doAfterCompletionFailTest(Arrays.asList(
+            new RegisterFailSynchronization(FailMode.AFTER_THROW_EXCEPTION),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+      ));
+   }
+
+   public void testFailAfterSecondSync() throws Exception {
+      doAfterCompletionFailTest(Arrays.asList(
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(SYNC_CACHE_NAME)),
+            new RegisterFailSynchronization(FailMode.AFTER_THROW_EXCEPTION),
+            new RegisterCacheTransaction(cacheManager.<String, String>getCache(XA_CACHE_NAME))
+      ));
+   }
+
+   public void testReadOnlyResource() throws Exception {
+      //test for ISPN-2813
+      DummyTransactionManager transactionManager = DummyTransactionManager.getInstance();
+      transactionManager.begin();
+      cacheManager.<String, String>getCache(SYNC_CACHE_NAME).put(KEY, VALUE);
+      cacheManager.<String, String>getCache(XA_CACHE_NAME).put(KEY, VALUE);
+      transactionManager.getTransaction().enlistResource(new ReadOnlyXaResource());
+      transactionManager.commit();
+
+      assertData();
+      assertNoTxInAllCaches();
+      assertNull(transactionManager.getTransaction());
+   }
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      EmbeddedCacheManager cacheManager = TestCacheManagerFactory.createCacheManager(getDefaultStandaloneCacheConfig(true));
+
+      ConfigurationBuilder builder = getDefaultStandaloneCacheConfig(true);
+      builder.transaction().useSynchronization(true);
+      builder.transaction().transactionManagerLookup(new DummyTransactionManagerLookup());
+      cacheManager.defineConfiguration(SYNC_CACHE_NAME, builder.build());
+
+      builder = getDefaultStandaloneCacheConfig(true);
+      builder.transaction().useSynchronization(false);
+      builder.transaction().transactionManagerLookup(new DummyTransactionManagerLookup());
+      cacheManager.defineConfiguration(XA_CACHE_NAME, builder.build());
+      return cacheManager;
+   }
+
+   private void doCommitWithRollbackExceptionTest(Collection<RegisterTransaction> registerTransactionCollection) throws Exception {
+      DummyTransactionManager transactionManager = DummyTransactionManager.getInstance();
+      transactionManager.begin();
+      for (RegisterTransaction registerTransaction : registerTransactionCollection) {
+         registerTransaction.register(transactionManager);
+      }
+      try {
+         transactionManager.commit();
+         AssertJUnit.fail("RollbackException expected!");
+      } catch (RollbackException e) {
+         //expected
+      }
+
+      assertEmpty();
+      assertNoTxInAllCaches();
+      assertNull(transactionManager.getTransaction());
+   }
+
+   private void doCommitWithHeuristicExceptionTest(Collection<RegisterTransaction> registerTransactionCollection) throws Exception {
+      DummyTransactionManager transactionManager = DummyTransactionManager.getInstance();
+      transactionManager.begin();
+      for (RegisterTransaction registerTransaction : registerTransactionCollection) {
+         registerTransaction.register(transactionManager);
+      }
+      try {
+         transactionManager.commit();
+         AssertJUnit.fail("HeuristicMixedException expected!");
+      } catch (HeuristicMixedException e) {
+         //expected
+      }
+
+      assertData();
+      assertNoTxInAllCaches();
+      assertNull(transactionManager.getTransaction());
+   }
+
+   private void doRollbackWithHeuristicExceptionTest(Collection<RegisterTransaction> registerTransactionCollection) throws Exception {
+      DummyTransactionManager transactionManager = DummyTransactionManager.getInstance();
+      transactionManager.begin();
+      for (RegisterTransaction registerTransaction : registerTransactionCollection) {
+         registerTransaction.register(transactionManager);
+      }
+      try {
+         transactionManager.rollback();
+         AssertJUnit.fail("SystemException expected!");
+      } catch (SystemException e) {
+         //expected
+      }
+
+      assertEmpty();
+      assertNoTxInAllCaches();
+      assertNull(transactionManager.getTransaction());
+   }
+
+   private void doAfterCompletionFailTest(Collection<RegisterTransaction> registerTransactionCollection) throws Exception {
+      DummyTransactionManager transactionManager = DummyTransactionManager.getInstance();
+      transactionManager.begin();
+      for (RegisterTransaction registerTransaction : registerTransactionCollection) {
+         registerTransaction.register(transactionManager);
+      }
+      transactionManager.commit();
+
+      assertData();
+      assertNoTxInAllCaches();
+      assertNull(transactionManager.getTransaction());
+   }
+
+   private void assertEmpty() {
+      AssertJUnit.assertTrue(cacheManager.getCache(SYNC_CACHE_NAME).isEmpty());
+      AssertJUnit.assertTrue(cacheManager.getCache(XA_CACHE_NAME).isEmpty());
+   }
+
+   private void assertData() {
+      AssertJUnit.assertEquals(VALUE, cacheManager.getCache(SYNC_CACHE_NAME).get(KEY));
+      AssertJUnit.assertEquals(VALUE, cacheManager.getCache(XA_CACHE_NAME).get(KEY));
+   }
+
+   private void assertNoTxInAllCaches() {
+      assertNoTransactions(cacheManager.getCache(XA_CACHE_NAME));
+      assertNoTransactions(cacheManager.getCache(SYNC_CACHE_NAME));
+   }
+
+   private enum FailMode {
+      BEFORE_MARK_ROLLBACK, BEFORE_THROW_EXCEPTION, AFTER_THROW_EXCEPTION,
+      XA_PREPARE, XA_COMMIT, XA_ROLLBACK, XA_END
+   }
+
+   private interface RegisterTransaction {
+      void register(TransactionManager transactionManager) throws Exception;
+   }
+
+   //a little hacky, but it is just to avoid implementing everything
+   private static class ReadOnlyXaResource extends FailXaResource {
+
+      private boolean finished;
+
+      private ReadOnlyXaResource() {
+         super(null);
+      }
+
+      @Override
+      public int prepare(Xid xid) throws XAException {
+         finished = true;
+         return XA_OK;
+      }
+
+      @Override
+      public void commit(Xid xid, boolean b) throws XAException {
+         if (finished) {
+            throw new XAException(XAException.XAER_NOTA);
+         }
+      }
+
+      @Override
+      public void rollback(Xid xid) throws XAException {
+         if (finished) {
+            throw new XAException(XAException.XAER_NOTA);
+         }
+      }
+   }
+
+   private static class FailXaResource implements XAResource {
+
+      private final FailMode failMode;
+
+      private FailXaResource(FailMode failMode) {
+         this.failMode = failMode;
+      }
+
+      @Override
+      public void commit(Xid xid, boolean b) throws XAException {
+         if (failMode == FailMode.XA_COMMIT) {
+            throw new XAException(XAException.XA_HEURCOM);
+         }
+      }
+
+      @Override
+      public void end(Xid xid, int i) throws XAException {
+         if (failMode == FailMode.XA_END) {
+            throw new XAException();
+         }
+      }
+
+      @Override
+      public void forget(Xid xid) throws XAException {/*no-op*/}
+
+      @Override
+      public int getTransactionTimeout() throws XAException {
+         return 0;
+      }
+
+      @Override
+      public boolean isSameRM(XAResource xaResource) throws XAException {
+         return xaResource instanceof FailSynchronization && ((FailSynchronization) xaResource).failMode == failMode;
+      }
+
+      @Override
+      public int prepare(Xid xid) throws XAException {
+         if (failMode == FailMode.XA_PREPARE) {
+            throw new XAException();
+         }
+         return XA_OK;
+      }
+
+      @Override
+      public Xid[] recover(int i) throws XAException {
+         return new Xid[0];
+      }
+
+      @Override
+      public void rollback(Xid xid) throws XAException {
+         if (failMode == FailMode.XA_ROLLBACK) {
+            throw new XAException();
+         }
+      }
+
+      @Override
+      public boolean setTransactionTimeout(int i) throws XAException {
+         return false;
+      }
+
+      @Override
+      public void start(Xid xid, int i) throws XAException {/*no-op*/}
+   }
+
+   private static class FailSynchronization implements Synchronization {
+
+      private final Transaction transaction;
+      private final FailMode failMode;
+
+      private FailSynchronization(Transaction transaction, FailMode failMode) {
+         this.transaction = transaction;
+         this.failMode = failMode;
+      }
+
+      @Override
+      public void beforeCompletion() {
+         switch (failMode) {
+            case BEFORE_MARK_ROLLBACK:
+               try {
+                  transaction.setRollbackOnly();
+               } catch (SystemException e) {
+                  /* ignored */
+               }
+               break;
+            case BEFORE_THROW_EXCEPTION:
+               throw new RuntimeException("induced!");
+         }
+      }
+
+      @Override
+      public void afterCompletion(int status) {
+         if (failMode == FailMode.AFTER_THROW_EXCEPTION) {
+            throw new RuntimeException("induced!");
+         }
+      }
+   }
+
+   private static class RegisterCacheTransaction implements RegisterTransaction {
+
+      private final Cache<String, String> cache;
+
+      private RegisterCacheTransaction(Cache<String, String> cache) {
+         this.cache = cache;
+      }
+
+      @Override
+      public void register(TransactionManager transactionManager) throws Exception {
+         cache.put(KEY, VALUE);
+      }
+   }
+
+   private static class RegisterFailSynchronization implements RegisterTransaction {
+
+      private final FailMode failMode;
+
+      private RegisterFailSynchronization(FailMode failMode) {
+         this.failMode = failMode;
+      }
+
+      @Override
+      public void register(TransactionManager transactionManager) throws Exception {
+         Transaction transaction = transactionManager.getTransaction();
+         FailSynchronization failSynchronization = new FailSynchronization(transaction, failMode);
+         transaction.registerSynchronization(failSynchronization);
+      }
+   }
+
+   private static class RegisterFailXaResource implements RegisterTransaction {
+
+      private final FailMode failMode;
+
+      private RegisterFailXaResource(FailMode failMode) {
+         this.failMode = failMode;
+      }
+
+      @Override
+      public void register(TransactionManager transactionManager) throws Exception {
+         Transaction transaction = transactionManager.getTransaction();
+         transaction.enlistResource(new FailXaResource(failMode));
+      }
+   }
+
+}

--- a/core/src/test/java/org/infinispan/tx/StaleLockAfterTxAbortTest.java
+++ b/core/src/test/java/org/infinispan/tx/StaleLockAfterTxAbortTest.java
@@ -68,7 +68,7 @@ public class StaleLockAfterTxAbortTest extends SingleCacheManagerTest {
 
       // now release the lock
       tm().resume(transaction);
-      transaction.runRollback();
+      transaction.runCommit(true);
       transactionThread.join();
 
       assertNotLocked(cache, k);

--- a/core/src/test/java/org/infinispan/tx/exception/TxAndRemoteTimeoutExceptionTest.java
+++ b/core/src/test/java/org/infinispan/tx/exception/TxAndRemoteTimeoutExceptionTest.java
@@ -137,7 +137,7 @@ public class TxAndRemoteTimeoutExceptionTest extends MultipleCacheManagersTest {
 
       log.trace("Right before second commit");
       tm.resume(k1LockOwner);
-      tm.commit();
+      k1LockOwner.runCommit(false);
       assertEquals("v1", cache(0).get("k1"));
       assertEquals("v1", cache(1).get("k1"));
       assertEquals(0, txTable1.getLocalTxCount());

--- a/core/src/test/java/org/infinispan/tx/locking/AbstractClusteredTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/AbstractClusteredTxTest.java
@@ -5,6 +5,7 @@ import org.infinispan.transaction.tm.DummyTransactionManager;
 import org.testng.annotations.Test;
 
 import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
 import javax.transaction.SystemException;
 import java.util.Collections;
 import java.util.Map;
@@ -72,19 +73,15 @@ public abstract class AbstractClusteredTxTest extends MultipleCacheManagersTest 
    protected void commit() {
       DummyTransactionManager dtm = (DummyTransactionManager) tm(0);
       try {
-         dtm.getTransaction().runCommitTx();
-      } catch (HeuristicMixedException e) {
+         dtm.getTransaction().runCommit(false);
+      } catch (HeuristicMixedException | HeuristicRollbackException e) {
          throw new RuntimeException(e);
       }
    }
 
    protected void prepare() {
       DummyTransactionManager dtm = (DummyTransactionManager) tm(0);
-      try {
-         dtm.getTransaction().runPrepare();
-      } catch (SystemException e) {
-         throw new RuntimeException(e);
-      }
+      dtm.getTransaction().runPrepare();
    }
 
    protected void rollback() {


### PR DESCRIPTION
...ource fails to prepare

Also fixes:
ISPN-2813 DummyTransaction do not commit is last resource transaction is read-only
ISPN-4167 DummyBaseTransactionManager doesn't clean up when rollback fails

JIRA links:
https://issues.jboss.org/browse/ISPN-2813
https://issues.jboss.org/browse/ISPN-5328
https://issues.jboss.org/browse/ISPN-4167