### PR TITLE
ISPN-5368 Out of order events produced when using the MassIndexer with async backend

### DIFF
--- a/query/src/main/java/org/infinispan/query/indexmanager/RemoteIndexingBackend.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/RemoteIndexingBackend.java
@@ -82,11 +82,11 @@ final class RemoteIndexingBackend implements IndexingBackend {
     * Decides whether a command should be sent sync or async
     */
    private boolean shouldSendSync(LuceneWork operation) {
-      return SYNC_ONLY_WORKS.contains(operation.getClass()) || !async;
+      return !async || SYNC_ONLY_WORKS.contains(operation.getClass());
    }
 
    private boolean shouldSendSync(List<LuceneWork> operations) {
-      return operations.size() == 1 && shouldSendSync(operations.get(0));
+      return !async || (operations.size() == 1 && shouldSendSync(operations.get(0)));
    }
 
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5368
