### PR TITLE
ISPN-5390 QueryCache should use the internal cache registry

### DIFF
--- a/core/src/main/java/org/infinispan/registry/InternalCacheRegistry.java
+++ b/core/src/main/java/org/infinispan/registry/InternalCacheRegistry.java
@@ -16,7 +16,7 @@ import org.infinispan.factories.scopes.Scopes;
  */
 @Scope(Scopes.GLOBAL)
 public interface InternalCacheRegistry {
-   public enum Flag {
+   enum Flag {
       EXCLUSIVE, // means that the cache must be declared only once
       USER, // means that this cache is visible to users
    }


### PR DESCRIPTION
Unfortunately this change implies that config of query cache cannot be overridden by the user anymore. Not a big deal from my POV. Would you consider this a limitation?

jira: https://issues.jboss.org/browse/ISPN-5390