### PR TITLE
ISPN-5394  JmxManagementIT.testCacheManagerAttributes fails

### DIFF
--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/jmx/management/JmxManagementIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/jmx/management/JmxManagementIT.java
@@ -159,19 +159,18 @@ public class JmxManagementIT {
 
     @Test
     public void testCacheManagerAttributes() throws Exception {
-        assertEquals(4, Integer.parseInt(getAttribute(provider, cacheManagerMBean, "CreatedCacheCount")));
-        assertEquals(4, Integer.parseInt(getAttribute(provider, cacheManagerMBean, "DefinedCacheCount")));
+        assertEquals(5, Integer.parseInt(getAttribute(provider, cacheManagerMBean, "CreatedCacheCount")));
+        assertEquals(5, Integer.parseInt(getAttribute(provider, cacheManagerMBean, "DefinedCacheCount")));
         assertEquals("clustered", getAttribute(provider, cacheManagerMBean, "Name"));
         assertEquals(2, Integer.parseInt(getAttribute(provider, cacheManagerMBean, "ClusterSize")));
         assertEquals("RUNNING", getAttribute(provider, cacheManagerMBean, "CacheManagerStatus"));
         assertNotEquals(0, getAttribute(provider, cacheManagerMBean, "ClusterMembers").length());
         assertNotEquals(0, getAttribute(provider, cacheManagerMBean, "NodeAddress").length());
-        assertEquals(4, Integer.parseInt(getAttribute(provider, cacheManagerMBean, "RunningCacheCount")));
+        assertEquals(5, Integer.parseInt(getAttribute(provider, cacheManagerMBean, "RunningCacheCount")));
         assertNotEquals(0, getAttribute(provider, cacheManagerMBean, "PhysicalAddresses").length());
         assertEquals(Version.getVersion(), getAttribute(provider, cacheManagerMBean, "Version"));
         String names = getAttribute(provider, cacheManagerMBean, "DefinedCacheNames");
-        assertTrue(names.contains("default") && names.contains("memcachedCache") &&
-                names.contains("hotRodTopologyCache"));
+        assertTrue(names.contains("default") && names.contains("memcachedCache"));
     }
 
     @Ignore("Not supported - https://bugzilla.redhat.com/show_bug.cgi?id=785105")


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5394