### PR TITLE
ISPN-5397 Provide a backwards-compatible EvictionConfigurationBuilder.maxEntries(int) method

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/EvictionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/EvictionConfigurationBuilder.java
@@ -64,6 +64,11 @@ public class EvictionConfigurationBuilder extends AbstractConfigurationChildBuil
       return this;
    }
 
+   @Deprecated
+   public EvictionConfigurationBuilder maxEntries(int maxEntries) {
+      return maxEntries((long)maxEntries);
+   }
+
    @Override
    public void validate() {
       EvictionStrategy strategy = attributes.attribute(STRATEGY).get();


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5397