### PR TITLE
ISPN-5429 Avoid CacheEntryFilterConverter duplicate callbacks

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientCustomEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientCustomEventsTest.java
@@ -4,15 +4,7 @@ import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.withClie
 
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.annotation.ClientListener;
-import org.infinispan.client.hotrod.event.CustomEventLogListener.CustomEvent;
-import org.infinispan.client.hotrod.event.CustomEventLogListener.DynamicConverterFactory;
-import org.infinispan.client.hotrod.event.CustomEventLogListener.DynamicCustomEventLogListener;
-import org.infinispan.client.hotrod.event.CustomEventLogListener.DynamicCustomEventWithStateLogListener;
-import org.infinispan.client.hotrod.event.CustomEventLogListener.RawStaticConverterFactory;
-import org.infinispan.client.hotrod.event.CustomEventLogListener.RawStaticCustomEventLogListener;
-import org.infinispan.client.hotrod.event.CustomEventLogListener.StaticConverterFactory;
-import org.infinispan.client.hotrod.event.CustomEventLogListener.StaticCustomEventLogListener;
-import org.infinispan.client.hotrod.event.CustomEventLogListener.StaticCustomEventLogWithStateListener;
+import org.infinispan.client.hotrod.event.CustomEventLogListener.*;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.client.hotrod.test.RemoteCacheManagerCallable;
 import org.infinispan.client.hotrod.test.SingleHotRodServerTest;
@@ -42,11 +34,11 @@ public class ClientCustomEventsTest extends SingleHotRodServerTest {
             RemoteCache<Integer, String> cache = rcm.getCache();
             eventListener.expectNoEvents();
             cache.put(1, "one");
-            eventListener.expectOnlyCreatedCustomEvent(new CustomEvent(1, "one"));
+            eventListener.expectCreatedEvent(new CustomEvent(1, "one", 0));
             cache.put(1, "newone");
-            eventListener.expectOnlyModifiedCustomEvent(new CustomEvent(1, "newone"));
+            eventListener.expectModifiedEvent(new CustomEvent(1, "newone", 0));
             cache.remove(1);
-            eventListener.expectOnlyRemovedCustomEvent(new CustomEvent(1, null));
+            eventListener.expectRemovedEvent(new CustomEvent(1, null, 0));
          }
       });
    }
@@ -87,9 +79,9 @@ public class ClientCustomEventsTest extends SingleHotRodServerTest {
             RemoteCache<Integer, String> cache = rcm.getCache();
             eventListener.expectNoEvents();
             cache.put(1, "one");
-            eventListener.expectOnlyCreatedCustomEvent(new CustomEvent(1, "one"));
+            eventListener.expectCreatedEvent(new CustomEvent(1, "one", 0));
             cache.put(2, "two");
-            eventListener.expectOnlyCreatedCustomEvent(new CustomEvent(2, null));
+            eventListener.expectCreatedEvent(new CustomEvent(2, null, 0));
          }
       });
    }
@@ -101,7 +93,7 @@ public class ClientCustomEventsTest extends SingleHotRodServerTest {
       withClientListener(staticEventListener, new RemoteCacheManagerCallable(remoteCacheManager) {
          @Override
          public void call() {
-            staticEventListener.expectOnlyCreatedCustomEvent(new CustomEvent(1, "one"));
+            staticEventListener.expectCreatedEvent(new CustomEvent(1, "one", 0));
          }
       });
       final DynamicCustomEventWithStateLogListener dynamicEventListener = new DynamicCustomEventWithStateLogListener();
@@ -109,7 +101,7 @@ public class ClientCustomEventsTest extends SingleHotRodServerTest {
       withClientListener(dynamicEventListener, null, new Object[]{2}, new RemoteCacheManagerCallable(remoteCacheManager) {
          @Override
          public void call() {
-            dynamicEventListener.expectOnlyCreatedCustomEvent(new CustomEvent(2, null));
+            dynamicEventListener.expectCreatedEvent(new CustomEvent(2, null, 0));
          }
       });
    }
@@ -143,12 +135,12 @@ public class ClientCustomEventsTest extends SingleHotRodServerTest {
             eventListener.expectNoEvents();
             cache.put(1, "one");
             // 1 = [3,75,0,0,0,1], "one" = [3,62,3,111,110,101]
-            eventListener.expectOnlyCreatedCustomEvent(new byte[]{3, 75, 0, 0, 0, 1, 3, 62, 3, 111, 110, 101});
+            eventListener.expectCreatedEvent(new byte[]{3, 75, 0, 0, 0, 1, 3, 62, 3, 111, 110, 101});
             cache.put(1, "newone");
             // "newone" = [3,62,6,110,101,119,111,110,101]
-            eventListener.expectOnlyModifiedCustomEvent(new byte[]{3, 75, 0, 0, 0, 1, 3, 62, 6, 110, 101, 119, 111, 110, 101});
+            eventListener.expectModifiedEvent(new byte[]{3, 75, 0, 0, 0, 1, 3, 62, 6, 110, 101, 119, 111, 110, 101});
             cache.remove(1);
-            eventListener.expectOnlyRemovedCustomEvent(new byte[]{3, 75, 0, 0, 0, 1});
+            eventListener.expectRemovedEvent(new byte[]{3, 75, 0, 0, 0, 1});
          }
       });
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientCustomFilterEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientCustomFilterEventsTest.java
@@ -44,19 +44,18 @@ public class ClientCustomFilterEventsTest extends SingleHotRodServerTest {
          @Override
          public void call() {
             RemoteCache<Integer, String> cache = rcm.getCache();
-            eventListener.expectNoEvents();
             cache.put(1, "one");
-            eventListener.expectOnlyCreatedCustomEvent(new CustomEvent(1, null));
+            eventListener.expectCreatedEvent(new CustomEvent(1, null, 1));
             cache.put(1, "newone");
-            eventListener.expectOnlyModifiedCustomEvent(new CustomEvent(1, null));
+            eventListener.expectModifiedEvent(new CustomEvent(1, null, 2));
             cache.put(2, "two");
-            eventListener.expectOnlyCreatedCustomEvent(new CustomEvent(2, "two"));
+            eventListener.expectCreatedEvent(new CustomEvent(2, "two", 3));
             cache.put(2, "dos");
-            eventListener.expectOnlyModifiedCustomEvent(new CustomEvent(2, "dos"));
+            eventListener.expectModifiedEvent(new CustomEvent(2, "dos", 4));
             cache.remove(1);
-            eventListener.expectOnlyRemovedCustomEvent(new CustomEvent(1, null));
+            eventListener.expectRemovedEvent(new CustomEvent(1, null, 5));
             cache.remove(2);
-            eventListener.expectOnlyRemovedCustomEvent(new CustomEvent(2, null));
+            eventListener.expectRemovedEvent(new CustomEvent(2, null, 6));
          }
       });
    }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
@@ -1089,7 +1089,7 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
          this.invocation = invocation;
          this.filter = filter;
          this.converter = converter;
-         this.filterAndConvert = filter instanceof CacheEventFilterConverter && (filter == converter || converter == null);
+         this.filterAndConvert = filter instanceof CacheEventFilterConverter && (filter.equals(converter) || converter == null);
          this.onlyPrimary = onlyPrimary;
          this.clustered = clustered;
          this.identifier = identifier;

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedHotRodTest.java
@@ -357,13 +357,13 @@ public class EmbeddedHotRodTest extends AbstractInfinispanTest {
          eventListener.expectNoEvents();
          remote.put(1, "one");
          assertEquals("one", embedded.get(1));
-         eventListener.expectOnlyCreatedCustomEvent(new CustomEvent(1, "one"));
+         eventListener.expectCreatedEvent(new CustomEvent(1, "one", 0));
          remote.put(1, "new-one");
          assertEquals("new-one", embedded.get(1));
-         eventListener.expectOnlyModifiedCustomEvent(new CustomEvent(1, "new-one"));
+         eventListener.expectModifiedEvent(new CustomEvent(1, "new-one", 0));
          remote.remove(1);
          assertNull(embedded.get(1));
-         eventListener.expectOnlyRemovedCustomEvent(new CustomEvent(1, null));
+         eventListener.expectRemovedEvent(new CustomEvent(1, null, 0));
       } finally {
          remote.removeClientListener(eventListener);
       }
@@ -378,16 +378,16 @@ public class EmbeddedHotRodTest extends AbstractInfinispanTest {
          eventListener.expectNoEvents();
          remote.put(1, "one");
          assertEquals("one", embedded.get(1));
-         eventListener.expectOnlyCreatedCustomEvent(new CustomEvent(1, "one"));
+         eventListener.expectCreatedEvent(new CustomEvent(1, "one", 0));
          remote.put(2, "two");
          assertEquals("two", embedded.get(2));
-         eventListener.expectOnlyCreatedCustomEvent(new CustomEvent(2, null));
+         eventListener.expectCreatedEvent(new CustomEvent(2, null, 0));
          remote.remove(1);
          assertNull(embedded.get(1));
-         eventListener.expectOnlyRemovedCustomEvent(new CustomEvent(1, null));
+         eventListener.expectRemovedEvent(new CustomEvent(1, null, 0));
          remote.remove(2);
          assertNull(embedded.get(2));
-         eventListener.expectOnlyRemovedCustomEvent(new CustomEvent(2, null));
+         eventListener.expectRemovedEvent(new CustomEvent(2, null, 0));
       } finally {
          remote.removeClientListener(eventListener);
       }


### PR DESCRIPTION
@wburns Can you please review this? :)

* When plugging a CacheEntryFilterConverter in a cluster, it can lead to duplicate callbacks as a result of listener invocation base class not detecting that the CacheEntryFilterConverter is both a filter and converter.
* When clustering CacheEntryFilterConverter instances, these are wrapped to avoid pre-events, and the wrapping halts the discovery that the CacheEntryFilterConverter is both a filter and converter.
* Overriding equals() in wrapper classes and making sure base listener invocation uses equals() instead of referential equality solves the problem.
* Added remote listener tests to verify the expected amount of callbacks are received by CacheEntryFilterConverter implementations.