### PR TITLE
ISPN-5434 ClusteringConfigurationBuilder.l1() does not enable L1

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/ClusteringConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ClusteringConfigurationBuilder.java
@@ -77,6 +77,7 @@ public class ClusteringConfigurationBuilder extends AbstractConfigurationChildBu
     */
    @Override
    public L1ConfigurationBuilder l1() {
+      l1ConfigurationBuilder.enable();
       return l1ConfigurationBuilder;
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5434

