### PR TITLE
ISPN-5420 Thread pools are depleted by ClusterTopologyManagerImpl.waitFo...

### DIFF
--- a/core/src/main/java/org/infinispan/executors/SemaphoreCompletionService.java
+++ b/core/src/main/java/org/infinispan/executors/SemaphoreCompletionService.java
@@ -77,6 +77,7 @@ public class SemaphoreCompletionService<T> implements CompletionService<T> {
       } else {
          semaphore.release();
          if (trace) log.tracef("Background task finished, available permits %d", semaphore.availablePermits());
+         executeFront();
       }
       return futureTask;
    }
@@ -85,6 +86,7 @@ public class SemaphoreCompletionService<T> implements CompletionService<T> {
    public Future<T> submit(final Callable<T> task) {
       QueueingTask futureTask = new QueueingTask(task);
       queue.add(futureTask);
+      if (trace) log.tracef("New task submitted, tasks in queue %d, available permits %d", queue.size(), semaphore.availablePermits());
       executeFront();
       return futureTask;
    }
@@ -93,6 +95,7 @@ public class SemaphoreCompletionService<T> implements CompletionService<T> {
    public Future<T> submit(final Runnable task, T result) {
       QueueingTask futureTask = new QueueingTask(task, result);
       queue.add(futureTask);
+      if (trace) log.tracef("New task submitted, tasks in queue %d, available permits %d", queue.size(), semaphore.availablePermits());
       executeFront();
       return futureTask;
    }
@@ -159,11 +162,11 @@ public class SemaphoreCompletionService<T> implements CompletionService<T> {
 
       private void runInternal() {
          try {
-            if (trace) log.tracef("Task started, available permits %d", semaphore.availablePermits());
+            if (trace) log.tracef("Task started, tasks in queue %d, available permits %d", queue.size(), semaphore.availablePermits());
             super.run();
          } finally {
             completionQueue.offer(this);
-            if (trace) log.tracef("Task finished, available permits %d", semaphore.availablePermits());
+            if (trace) log.tracef("Task finished, tasks in queue %d, available permits %d", queue.size(), semaphore.availablePermits());
          }
       }
    }

--- a/core/src/main/java/org/infinispan/statetransfer/StateRequestCommand.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateRequestCommand.java
@@ -93,7 +93,8 @@ public class StateRequestCommand extends BaseRpcCommand implements TopologyAffec
 
    @Override
    public boolean canBlock() {
-      return type == Type.GET_TRANSACTIONS || type == Type.START_STATE_TRANSFER;
+      // All state request commands need to wait for the proper topology
+      return true;
    }
 
    public Type getType() {

--- a/core/src/test/java/org/infinispan/distribution/rehash/PessimisticStateTransferLocksTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/PessimisticStateTransferLocksTest.java
@@ -3,6 +3,8 @@ package org.infinispan.distribution.rehash;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.statetransfer.StateConsumer;
+import org.infinispan.statetransfer.StateProvider;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.concurrent.InvocationMatcher;
@@ -20,6 +22,7 @@ import org.testng.annotations.Test;
 
 import java.util.Collections;
 
+import static org.infinispan.test.concurrent.StateSequencerUtil.advanceOnComponentMethod;
 import static org.infinispan.test.concurrent.StateSequencerUtil.advanceOnGlobalComponentMethod;
 import static org.infinispan.test.concurrent.StateSequencerUtil.matchMethodCall;
 import static org.testng.AssertJUnit.assertEquals;
@@ -158,8 +161,8 @@ public class PessimisticStateTransferLocksTest extends MultipleCacheManagersTest
       advanceOnGlobalComponentMethod(sequencer, manager(0), ClusterTopologyManager.class,
             rebalanceCompletedMatcher).before("rebalance:before_confirm");
 
-      InvocationMatcher localRebalanceMatcher = matchMethodCall("handleRebalance").build();
-      advanceOnGlobalComponentMethod(sequencer, manager(2), LocalTopologyManager.class,
+      InvocationMatcher localRebalanceMatcher = matchMethodCall("onTopologyUpdate").withParam(1, true).build();
+      advanceOnComponentMethod(sequencer, cache(2), StateConsumer.class,
             localRebalanceMatcher).before("rebalance:before_get_tx").after("rebalance:after_get_tx");
       consistentHashFactory.setOwnerIndexes(2, 1);
       consistentHashFactory.triggerRebalance(cache(0));

--- a/core/src/test/java/org/infinispan/partitionhandling/EntryRetrieverDistPartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/EntryRetrieverDistPartitionHandlingTest.java
@@ -36,6 +36,7 @@ public class EntryRetrieverDistPartitionHandlingTest extends BasePartitionHandli
    @Test( expectedExceptions = AvailabilityException.class)
    public void testRetrievalWhenPartitionIsDegrated() {
       splitCluster(new int[]{0, 1}, new int[]{2, 3});
+      partition(0).assertDegradedMode();
 
       try (EntryIterable iterable = cache(0).getAdvancedCache().filterEntries(AcceptAllKeyValueFilter.getInstance())) {
          iterable.iterator();
@@ -44,6 +45,7 @@ public class EntryRetrieverDistPartitionHandlingTest extends BasePartitionHandli
 
    public void testRetrievalWhenPartitionIsDegratedButLocal() {
       splitCluster(new int[]{0, 1}, new int[]{2, 3});
+      partition(0).assertDegradedMode();
 
       try (EntryIterable iterable = cache(0).getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).filterEntries(
             AcceptAllKeyValueFilter.getInstance())) {

--- a/core/src/test/java/org/infinispan/stress/LargeCluster2StressTest.java
+++ b/core/src/test/java/org/infinispan/stress/LargeCluster2StressTest.java
@@ -1,0 +1,216 @@
+package org.infinispan.stress;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.executors.BlockingThreadPoolExecutorFactory;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.distribution.ch.impl.SyncConsistentHashFactory;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CleanupAfterTest;
+import org.infinispan.test.fwk.TestResourceTracker;
+import org.infinispan.util.concurrent.TimeoutException;
+import org.infinispan.util.concurrent.WithinThreadExecutor;
+import org.jgroups.conf.ConfiguratorFactory;
+import org.jgroups.conf.ProtocolConfiguration;
+import org.jgroups.conf.ProtocolStackConfigurator;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Test that we're able to start a cluster with lots of caches in a single JVM.
+ *
+ * @author Dan Berindei
+ * @since 7.2
+ */
+@CleanupAfterTest
+@Test(groups = "stress", testName = "stress.LargeCluster2StressTest")
+public class LargeCluster2StressTest extends MultipleCacheManagersTest {
+
+   private static final int NUM_NODES = 10;
+   private static final int NUM_CACHES = 100;
+   private static final int NUM_THREADS = 200;
+   private static final int NUM_SEGMENTS = 1000;
+   private static final int TIMEOUT_SECONDS = 180;
+
+   public static final int OOB_MAX_THREADS = 50;
+   public static final int TRANSPORT_MAX_THREADS = 10;
+   public static final int TRANSPORT_QUEUE_SIZE = 1000;
+   public static final int REMOTE_MAX_THREADS = 50;
+   public static final int REMOTE_QUEUE_SIZE = 0;
+   public static final int STATE_TRANSFER_MAX_THREADS = 10;
+   public static final int STATE_TRANSFER_QUEUE_SIZE = 0;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      // start the cache managers in the test itself
+   }
+
+   public void testLargeClusterStart() throws Exception {
+      if ((NUM_CACHES & 1) != 0)
+         throw new IllegalStateException("NUM_CACHES must be even");
+
+      final ProtocolStackConfigurator configurator = ConfiguratorFactory.getStackConfigurator("default-configs/default-jgroups-udp.xml");
+      ProtocolConfiguration udpConfiguration = configurator.getProtocolStack().get(0);
+      assertEquals("UDP", udpConfiguration.getProtocolName());
+      udpConfiguration.getProperties().put("mcast_addr", "224.0.0.15");
+      udpConfiguration.getProperties().put("oob_thread_pool.min_threads", "1");
+      udpConfiguration.getProperties().put("oob_thread_pool.max_threads", String.valueOf(OOB_MAX_THREADS));
+      ProtocolConfiguration gmsConfiguration = configurator.getProtocolStack().get(9);
+      assertEquals("pbcast.GMS", gmsConfiguration.getProtocolName());
+      gmsConfiguration.getProperties().put("join_timeout", "5000");
+
+      final Configuration distConfig = new ConfigurationBuilder()
+            .clustering().cacheMode(CacheMode.DIST_SYNC)
+            .clustering().stateTransfer().awaitInitialTransfer(false)
+//            .hash().consistentHashFactory(new TopologyAwareSyncConsistentHashFactory()).numSegments(NUM_SEGMENTS)
+            .hash().consistentHashFactory(new SyncConsistentHashFactory()).numSegments(NUM_SEGMENTS)
+            .build();
+      final Configuration replConfig = new ConfigurationBuilder()
+            .clustering().cacheMode(CacheMode.REPL_SYNC)
+            .clustering().hash().numSegments(NUM_SEGMENTS)
+            .clustering().stateTransfer().awaitInitialTransfer(false)
+            .build();
+
+      // Start the caches (and the JGroups channels) in separate threads
+      final CountDownLatch managersLatch = new CountDownLatch(NUM_NODES);
+      ExecutorService executor = Executors.newFixedThreadPool(NUM_THREADS);
+      final ExecutorCompletionService<Void> managerCompletionService = new ExecutorCompletionService<>(executor);
+//      final ExecutorCompletionService<Void> cacheCompletionService = new ExecutorCompletionService<Void>(new WithinThreadExecutor());
+      final ExecutorCompletionService<Void> cacheCompletionService = new ExecutorCompletionService<Void>(executor);
+      try {
+         for (int nodeIndex = 0; nodeIndex < NUM_NODES; nodeIndex++) {
+            final String nodeName = TestResourceTracker.getNameForIndex(nodeIndex);
+            final String machineId = "m" + (nodeIndex / 2);
+            managerCompletionService.submit(new Callable<Void>() {
+               @Override
+               public Void call() throws Exception {
+                  GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
+                  gcb.globalJmxStatistics().allowDuplicateDomains(true);
+                  gcb.transport().defaultTransport().nodeName(nodeName)
+                        .addProperty(JGroupsTransport.CONFIGURATION_STRING, configurator.getProtocolStackString());
+                  BlockingThreadPoolExecutorFactory transportExecutorFactory = new BlockingThreadPoolExecutorFactory(
+                        TRANSPORT_MAX_THREADS, TRANSPORT_MAX_THREADS, TRANSPORT_QUEUE_SIZE, 60000);
+                  gcb.transport().transportThreadPool().threadPoolFactory(transportExecutorFactory);
+                  BlockingThreadPoolExecutorFactory remoteExecutorFactory = new BlockingThreadPoolExecutorFactory(
+                        REMOTE_MAX_THREADS, REMOTE_MAX_THREADS, REMOTE_QUEUE_SIZE, 60000);
+                  gcb.transport().remoteCommandThreadPool().threadPoolFactory(remoteExecutorFactory);
+                  BlockingThreadPoolExecutorFactory stateTransferExecutorFactory = new
+                        BlockingThreadPoolExecutorFactory(
+                        STATE_TRANSFER_MAX_THREADS, STATE_TRANSFER_MAX_THREADS, STATE_TRANSFER_QUEUE_SIZE, 60000);
+                  gcb.transport().stateTransferThreadPool().threadPoolFactory(stateTransferExecutorFactory);
+                  final EmbeddedCacheManager cm = new DefaultCacheManager(gcb.build());
+                  try {
+                     for (int i = 0; i < NUM_CACHES / 2; i++) {
+                        final int cacheIndex = i;
+                        cm.defineConfiguration("repl-cache-" + cacheIndex, replConfig);
+                        cm.defineConfiguration("dist-cache-" + cacheIndex, distConfig);
+                        cacheCompletionService.submit(new Callable<Void>() {
+                           @Override
+                           public Void call() throws Exception {
+                              String cacheName = "repl-cache-" + cacheIndex;
+                              Thread.currentThread().setName(cacheName + "-start-thread," + nodeName);
+                              Cache<Object, Object> replCache = cm.getCache(cacheName);
+//                              replCache.put(cm.getAddress(), "bla");
+                              return null;
+                           }
+                        });
+                        cacheCompletionService.submit(new Callable<Void>() {
+                           @Override
+                           public Void call() throws Exception {
+                              String cacheName = "dist-cache-" + cacheIndex;
+                              Thread.currentThread().setName(cacheName + "-start-thread," + nodeName);
+                              Cache<Object, Object> distCache = cm.getCache(cacheName);
+//                              distCache.put(cm.getAddress(), "bla");
+                              return null;
+                           }
+                        });
+                        managersLatch.countDown();
+                     }
+                  } finally {
+                     registerCacheManager(cm);
+                  }
+                  log.infof("Started cache manager %s", nodeName);
+                  return null;
+               }
+            });
+         }
+
+         long endTime = System.nanoTime() + SECONDS.toNanos(TIMEOUT_SECONDS);
+
+         for (int i = 0; i < NUM_NODES; i++) {
+            Future<Void> future = managerCompletionService.poll(TIMEOUT_SECONDS, SECONDS);
+            future.get(0, SECONDS);
+            if (System.nanoTime() - endTime > 0) {
+               throw new TimeoutException("Took too long to start the cluster");
+            }
+         }
+
+         int i = 0;
+         while (i < NUM_NODES * NUM_CACHES) {
+            Future<Void> future = cacheCompletionService.poll(1, SECONDS);
+            if (future != null) {
+               future.get(0, SECONDS);
+               i++;
+            }
+            if (System.nanoTime() - endTime > 0) {
+               throw new TimeoutException("Took too long to start the cluster");
+            }
+         }
+      } finally {
+         executor.shutdownNow();
+      }
+
+      log.infof("All %d cache managers started, waiting for state transfer to finish for each cache", NUM_NODES);
+
+      for (int j = 0; j < NUM_CACHES/2; j++) {
+         waitForClusterToForm("repl-cache-" + j);
+         waitForClusterToForm("dist-cache-" + j);
+      }
+   }
+
+   @Test(dependsOnMethods = "testLargeClusterStart")
+   public void testLargeClusterStop() {
+      for (int i = 0; i < NUM_NODES - 1; i++) {
+         int killIndex = -1;
+         for (int j = 0; j < cacheManagers.size(); j++) {
+            if (address(j).equals(manager(0).getCoordinator())) {
+               killIndex = j;
+               break;
+            }
+         }
+
+         log.debugf("Killing coordinator %s", address(killIndex));
+         manager(killIndex).stop();
+         cacheManagers.remove(killIndex);
+         if (cacheManagers.size() > 0) {
+            TestingUtil.blockUntilViewsReceived(60000, false, cacheManagers);
+            for (int j = 0; j < NUM_CACHES/2; j++) {
+               TestingUtil.waitForRehashToComplete(caches("repl-cache-" + j));
+               TestingUtil.waitForRehashToComplete(caches("dist-cache-" + j));
+            }
+         }
+      }
+   }
+
+   @AfterMethod
+   @Override
+   protected void clearContent() throws Throwable {
+      // Do nothing
+   }
+}

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -49,6 +49,7 @@ import org.infinispan.security.impl.SecureCacheImpl;
 import org.infinispan.statetransfer.StateTransferManager;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.transaction.impl.TransactionTable;
+import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.concurrent.WithinThreadExecutor;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.logging.Log;
@@ -296,7 +297,7 @@ public class TestingUtil {
          }
       }
 
-      throw new RuntimeException(String.format(
+      throw new TimeoutException(String.format(
          "Timed out before caches had complete views.  Expected %d members in each view.  Views are as follows: %s",
          cacheContainers.length, incompleteViews));
    }


### PR DESCRIPTION
...rView() and causing deadlock

https://issues.jboss.org/browse/ISPN-5420

* LargeCluster2StressTest: New stress test with fewer nodes but more caches than LargeClusterStressTest
* Better logging of command responses
* Add a queue for the state transfer executor (embedded only for now)
* Fix SemaphoreCompletionService.continueTaskInBackground(null)
* Move all StateRequestCommands to the remote executor thread pool
* Check for tasks to execute immediately after installing the topology,
  because StateRequestCommands don't wait for the transaction data
* Don't send a rebalance confirmation if we were not a member
* In case the state transfer executor has a caller runs policy, don't keep
  the transfer maps lock while submitting the segments request task
* Undo the SemaphoreCompletionService for view handling in ClusterTopologyManagerImpl
* Update the cache members without holding the view handling lock
* Use a SemaphoreCompletionService per cache to handle topology updates in
  LocalTopologyManagerImpl