### PR TITLE
ISPN-5436 Fix ClientClusterEventsTest random failures

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterEventsTest.java
@@ -27,7 +27,7 @@ import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheCon
 @Test(groups = "functional", testName = "client.hotrod.event.ClientClusterEventsTest")
 public class ClientClusterEventsTest extends MultiHotRodServersTest {
 
-   static final int NUM_SERVERS = 3;
+   static final int NUM_SERVERS = 2;
 
    @Override
    protected void createCacheManagers() throws Throwable {
@@ -35,14 +35,15 @@ public class ClientClusterEventsTest extends MultiHotRodServersTest {
    }
 
    private ConfigurationBuilder getCacheConfiguration() {
-      return hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      builder.clustering().hash().numOwners(1);
+      return hotRodCacheConfiguration(builder);
    }
 
    protected HotRodServer addHotRodServer(ConfigurationBuilder builder) {
       EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder);
       HotRodServerConfigurationBuilder serverBuilder = new HotRodServerConfigurationBuilder();
       HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cm, serverBuilder);
-      server.addCacheEventFilterFactory("static-filter-factory", new StaticCacheEventFilterFactory());
       server.addCacheEventConverterFactory("static-converter-factory", new StaticConverterFactory());
       server.addCacheEventFilterConverterFactory("filter-converter-factory", new FilterConverterFactory());
       servers.add(server);
@@ -50,137 +51,98 @@ public class ClientClusterEventsTest extends MultiHotRodServersTest {
    }
 
    public void testEventForwarding() {
+      final Integer key0 = HotRodClientTestingUtil.getIntKeyForServer(server(0));
+      final Integer key1 = HotRodClientTestingUtil.getIntKeyForServer(server(1));
       final EventLogListener<Integer> eventListener = new EventLogListener<>();
       withClientListener(eventListener, new RemoteCacheManagerCallable(client(0)) {
          @Override
          public void call() {
-            RemoteCache<Integer, String> c3 = client(2).getCache();
+            RemoteCache<Integer, String> remote = client(0).getCache();
             eventListener.expectNoEvents();
-            c3.put(1, "one");
-            eventListener.expectOnlyCreatedEvent(1, cache(0));
-            c3.put(2, "two");
-            eventListener.expectOnlyCreatedEvent(2, cache(0));
-            c3.put(3, "three");
-            eventListener.expectOnlyCreatedEvent(3, cache(0));
-            c3.replace(1, "new-one");
-            eventListener.expectOnlyModifiedEvent(1, cache(0));
-            c3.replace(2, "new-two");
-            eventListener.expectOnlyModifiedEvent(2, cache(0));
-            c3.replace(3, "new-three");
-            eventListener.expectOnlyModifiedEvent(3, cache(0));
-            c3.remove(1);
-            eventListener.expectOnlyRemovedEvent(1, cache(0));
-            c3.remove(2);
-            eventListener.expectOnlyRemovedEvent(2, cache(0));
-            c3.remove(3);
-            eventListener.expectOnlyRemovedEvent(3, cache(0));
+            remote.put(key0, "one");
+            eventListener.expectOnlyCreatedEvent(key0, cache(0));
+            remote.put(key1, "two");
+            eventListener.expectOnlyCreatedEvent(key1, cache(0));
+            remote.replace(key0, "new-one");
+            eventListener.expectOnlyModifiedEvent(key0, cache(0));
+            remote.replace(key1, "new-two");
+            eventListener.expectOnlyModifiedEvent(key1, cache(0));
+            remote.remove(key0);
+            eventListener.expectOnlyRemovedEvent(key0, cache(0));
+            remote.remove(key1);
+            eventListener.expectOnlyRemovedEvent(key1, cache(0));
          }
       });
    }
 
    public void testFilteringInCluster() {
+      // Generate key and add static filter in all servers
+      final Integer key0 = HotRodClientTestingUtil.getIntKeyForServer(server(0));
+      final Integer key1 = HotRodClientTestingUtil.getIntKeyForServer(server(1));
+      for (HotRodServer server : servers)
+         server.addCacheEventFilterFactory("static-filter-factory", new StaticCacheEventFilterFactory(key1));
+
       final StaticFilteredEventLogListener<Integer> eventListener = new StaticFilteredEventLogListener<>();
       withClientListener(eventListener, new RemoteCacheManagerCallable(client(0)) {
          @Override
          public void call() {
-            RemoteCache<Integer, String> c3 = client(2).getCache();
+            RemoteCache<Integer, String> remote = client(0).getCache();
             eventListener.expectNoEvents();
-            c3.put(1, "one");
+            remote.put(key0, "one");
             eventListener.expectNoEvents();
-            c3.put(2, "two");
-            eventListener.expectOnlyCreatedEvent(2, cache(0));
-            c3.remove(1);
+            remote.put(key1, "two");
+            eventListener.expectOnlyCreatedEvent(key1, cache(0));
+            remote.remove(key0);
             eventListener.expectNoEvents();
-            c3.remove(2);
-            eventListener.expectOnlyRemovedEvent(2, cache(0));
+            remote.remove(key1);
+            eventListener.expectOnlyRemovedEvent(key1, cache(0));
          }
       });
    }
 
    public void testConversionInCluster() {
+      final Integer key0 = HotRodClientTestingUtil.getIntKeyForServer(server(0));
+      final Integer key1 = HotRodClientTestingUtil.getIntKeyForServer(server(1));
       final StaticCustomEventLogListener eventListener = new StaticCustomEventLogListener();
       withClientListener(eventListener, new RemoteCacheManagerCallable(client(0)) {
          @Override
          public void call() {
-            RemoteCache<Integer, String> c3 = client(2).getCache();
+            RemoteCache<Integer, String> c3 = client(0).getCache();
             eventListener.expectNoEvents();
-            c3.put(1, "one");
-            eventListener.expectCreatedEvent(new CustomEvent(1, "one", 0));
-            c3.put(2, "two");
-            eventListener.expectCreatedEvent(new CustomEvent(2, "two", 0));
-            c3.remove(1);
-            eventListener.expectRemovedEvent(new CustomEvent(1, null, 0));
-            c3.remove(2);
-            eventListener.expectRemovedEvent(new CustomEvent(2, null, 0));
+            c3.put(key0, "one");
+            eventListener.expectCreatedEvent(new CustomEvent(key0, "one", 0));
+            c3.put(key1, "two");
+            eventListener.expectCreatedEvent(new CustomEvent(key1, "two", 0));
+            c3.remove(key0);
+            eventListener.expectRemovedEvent(new CustomEvent(key0, null, 0));
+            c3.remove(key1);
+            eventListener.expectRemovedEvent(new CustomEvent(key1, null, 0));
          }
       });
    }
 
-   @Test(enabled = false)
    public void testFilterCustomEventsInCluster() {
+      final Integer key0 = HotRodClientTestingUtil.getIntKeyForServer(server(0));
+      final Integer key1 = HotRodClientTestingUtil.getIntKeyForServer(server(1));
       final FilterCustomEventLogListener eventListener = new FilterCustomEventLogListener();
-      withClientListener(eventListener, new Object[]{1}, null, new RemoteCacheManagerCallable(client(0)) {
+      withClientListener(eventListener, new Object[]{key0}, null, new RemoteCacheManagerCallable(client(0)) {
          @Override
          public void call() {
-            RemoteCache<Integer, String> c3 = client(2).getCache();
-            c3.put(1, "one");
-            eventListener.expectCreatedEvent(new CustomEvent(1, null, 1));
-            c3.put(1, "newone");
-            eventListener.expectModifiedEvent(new CustomEvent(1, null, 2));
-            c3.put(2, "two");
-            eventListener.expectCreatedEvent(new CustomEvent(2, "two", 3));
-            c3.put(2, "dos");
-            eventListener.expectModifiedEvent(new CustomEvent(2, "dos", 4));
-            c3.remove(1);
-            eventListener.expectRemovedEvent(new CustomEvent(1, null, 5));
-            c3.remove(2);
-            eventListener.expectRemovedEvent(new CustomEvent(2, null, 6));
+            RemoteCache<Integer, String> remote = client(0).getCache();
+            remote.put(key0, "one");
+            eventListener.expectCreatedEvent(new CustomEvent(key0, null, 1));
+            remote.put(key0, "newone");
+            eventListener.expectModifiedEvent(new CustomEvent(key0, null, 2));
+            remote.put(key1, "two");
+            eventListener.expectCreatedEvent(new CustomEvent(key1, "two", 1));
+            remote.put(key1, "dos");
+            eventListener.expectModifiedEvent(new CustomEvent(key1, "dos", 2));
+            remote.remove(key0);
+            eventListener.expectRemovedEvent(new CustomEvent(key0, null, 3));
+            remote.remove(key1);
+            eventListener.expectRemovedEvent(new CustomEvent(key1, null, 3));
          }
       });
    }
-
-   public void testEventReplayWithAndWithoutStateAfterFailover() {
-      org.infinispan.client.hotrod.configuration.ConfigurationBuilder builder =
-            new org.infinispan.client.hotrod.configuration.ConfigurationBuilder();
-      HotRodServer server = server(0);
-      builder.addServers(server.getHost() + ":" + server.getPort());
-      builder.balancingStrategy(StickyServerLoadBalancingStrategy.class);
-      RemoteCacheManager newClient = new RemoteCacheManager(builder.build());
-      try {
-         WithStateEventLogListener<Integer> statefulListener = new WithStateEventLogListener<>();
-         EventLogListener<Integer> statelessListener = new EventLogListener<>();
-         FailoverEventLogListener<Integer> failoverListener = new FailoverEventLogListener<>();
-         RemoteCache<Integer, String> c = newClient.getCache();
-         c.put(0, "zero");
-         c.remove(0);
-         c.addClientListener(statelessListener);
-         c.addClientListener(statefulListener);
-         c.addClientListener(failoverListener);
-         c.put(1, "one");
-         statefulListener.expectOnlyCreatedEvent(1, cache(0));
-         statelessListener.expectOnlyCreatedEvent(1, cache(0));
-         failoverListener.expectOnlyCreatedEvent(1, cache(0));
-         findServerAndKill(newClient, servers, cacheManagers);
-         c.put(2, "two");
-         // Failover expectations
-         statelessListener.expectNoEvents();
-         statefulListener.expectFailoverEvent();
-         failoverListener.expectFailoverEvent();
-         // State expectations
-         statelessListener.expectNoEvents();
-         failoverListener.expectNoEvents();
-         statefulListener.expectUnorderedEvents(ClientEvent.Type.CLIENT_CACHE_ENTRY_CREATED, 1, 2);
-         c.put(3, "three");
-         statefulListener.expectUnorderedEvents(ClientEvent.Type.CLIENT_CACHE_ENTRY_CREATED, 3);
-         c.remove(1);
-         c.remove(2);
-         c.remove(3);
-      } finally {
-         killRemoteCacheManager(newClient);
-      }
-   }
-
-   @ClientListener(includeCurrentState = true)
-   public static class WithStateEventLogListener<K> extends FailoverEventLogListener<K> {}
 
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterFailoverEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterFailoverEventsTest.java
@@ -1,0 +1,85 @@
+package org.infinispan.client.hotrod.event;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.annotation.ClientListener;
+import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.testng.annotations.Test;
+
+import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.findServerAndKill;
+import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+
+@Test(groups = "functional", testName = "client.hotrod.event.ClientClusterFailoverEventsTest")
+public class ClientClusterFailoverEventsTest extends MultiHotRodServersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      // Empty
+   }
+
+   public void testEventReplayWithAndWithoutStateAfterFailover() {
+      ConfigurationBuilder base = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      //base.clustering().hash().numOwners(1);
+      ConfigurationBuilder builder = hotRodCacheConfiguration(base);
+      createHotRodServers(2, builder);
+      try {
+         final Integer key0 = HotRodClientTestingUtil.getIntKeyForServer(server(0));
+         final Integer key11 = HotRodClientTestingUtil.getIntKeyForServer(server(1));
+         final Integer key21 = HotRodClientTestingUtil.getIntKeyForServer(server(1));
+         final Integer key31 = HotRodClientTestingUtil.getIntKeyForServer(server(1));
+
+         org.infinispan.client.hotrod.configuration.ConfigurationBuilder clientBuilder =
+               new org.infinispan.client.hotrod.configuration.ConfigurationBuilder();
+         HotRodServer server = server(0);
+         clientBuilder.addServers(server.getHost() + ":" + server.getPort());
+         clientBuilder.balancingStrategy(StickyServerLoadBalancingStrategy.class);
+         RemoteCacheManager newClient = new RemoteCacheManager(clientBuilder.build());
+         try {
+            WithStateEventLogListener<Integer> statefulListener = new WithStateEventLogListener<>();
+            EventLogListener<Integer> statelessListener = new EventLogListener<>();
+            FailoverEventLogListener<Integer> failoverListener = new FailoverEventLogListener<>();
+            RemoteCache<Integer, String> c = newClient.getCache();
+            c.addClientListener(statelessListener);
+            c.addClientListener(statefulListener);
+            c.addClientListener(failoverListener);
+            c.put(key0, "zero");
+            statefulListener.expectOnlyCreatedEvent(key0, cache(0));
+            statelessListener.expectOnlyCreatedEvent(key0, cache(0));
+            failoverListener.expectOnlyCreatedEvent(key0, cache(0));
+            c.put(key11, "one");
+            statefulListener.expectOnlyCreatedEvent(key11, cache(0));
+            statelessListener.expectOnlyCreatedEvent(key11, cache(0));
+            failoverListener.expectOnlyCreatedEvent(key11, cache(0));
+            findServerAndKill(newClient, servers, cacheManagers);
+            c.put(key21, "two");
+            // Failover expectations
+            statelessListener.expectNoEvents();
+            statefulListener.expectFailoverEvent();
+            failoverListener.expectFailoverEvent();
+            // State expectations
+            statelessListener.expectNoEvents();
+            failoverListener.expectNoEvents();
+            statefulListener.expectUnorderedEvents(ClientEvent.Type.CLIENT_CACHE_ENTRY_CREATED, key0, key11, key21);
+            c.put(key31, "three");
+            statefulListener.expectUnorderedEvents(ClientEvent.Type.CLIENT_CACHE_ENTRY_CREATED, key31);
+            c.remove(key11);
+            c.remove(key21);
+            c.remove(key31);
+         } finally {
+            killRemoteCacheManager(newClient);
+         }
+      } finally {
+         destroy();
+      }
+
+   }
+
+   @ClientListener(includeCurrentState = true)
+   public static class WithStateEventLogListener<K> extends FailoverEventLogListener<K> {}
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientFilterEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientFilterEventsTest.java
@@ -27,7 +27,7 @@ public class ClientFilterEventsTest extends SingleHotRodServerTest {
    protected HotRodServer createHotRodServer() {
       HotRodServerConfigurationBuilder builder = new HotRodServerConfigurationBuilder();
       HotRodServer server = HotRodClientTestingUtil.startHotRodServer(cacheManager, builder);
-      server.addCacheEventFilterFactory("static-filter-factory", new StaticCacheEventFilterFactory());
+      server.addCacheEventFilterFactory("static-filter-factory", new StaticCacheEventFilterFactory(2));
       server.addCacheEventFilterFactory("dynamic-filter-factory", new DynamicCacheEventFilterFactory());
       server.addCacheEventFilterFactory("raw-static-filter-factory", new RawStaticCacheEventFilterFactory());
       return server;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EventLogListener.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EventLogListener.java
@@ -219,13 +219,24 @@ public class EventLogListener<K> {
 
    @NamedFactory(name = "static-filter-factory")
    public static class StaticCacheEventFilterFactory implements CacheEventFilterFactory {
+      private final int staticKey;
+
+      public StaticCacheEventFilterFactory(int staticKey) {
+         this.staticKey = staticKey;
+      }
+
       @Override
       public CacheEventFilter<Integer, String> getFilter(final Object[] params) {
-         return new StaticCacheEventFilter();
+         return new StaticCacheEventFilter(staticKey);
       }
 
       static class StaticCacheEventFilter implements CacheEventFilter<Integer, String>, Serializable {
-         final Integer staticKey = 2;
+         final Integer staticKey;
+
+         StaticCacheEventFilter(Integer staticKey) {
+            this.staticKey = staticKey;
+         }
+
          @Override
          public boolean accept(Integer key, String previousValue, Metadata previousMetadata, String value,
                                Metadata metadata, EventType eventType) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/HotRodClientTestingUtil.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/HotRodClientTestingUtil.java
@@ -213,6 +213,7 @@ public class HotRodClientTestingUtil {
       try {
          do {
             r.nextBytes(dummy);
+            attemptsLeft--;
          } while (!isFirstOwner(cache, marshaller.objectToByteBuffer(dummy)) && attemptsLeft >= 0);
       } catch (IOException e) {
          throw new AssertionError(e);
@@ -246,6 +247,7 @@ public class HotRodClientTestingUtil {
       do {
          dummyInt = r.nextInt();
          dummy = toBytes(dummyInt);
+         attemptsLeft--;
       } while (!isFirstOwner(cache, dummy) && attemptsLeft >= 0);
 
       if (attemptsLeft < 0)

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedHotRodTest.java
@@ -40,7 +40,7 @@ public class EmbeddedHotRodTest extends AbstractInfinispanTest {
    protected void setup() throws Exception {
       cacheFactory = new CompatibilityCacheFactory<Integer, String>(CacheMode.LOCAL).setup();
       HotRodServer hotrod = cacheFactory.getHotrodServer();
-      hotrod.addCacheEventFilterFactory("static-filter-factory", new StaticCacheEventFilterFactory());
+      hotrod.addCacheEventFilterFactory("static-filter-factory", new StaticCacheEventFilterFactory(2));
       hotrod.addCacheEventFilterFactory("dynamic-filter-factory", new DynamicCacheEventFilterFactory());
       hotrod.addCacheEventConverterFactory("static-converter-factory", new StaticConverterFactory());
       hotrod.addCacheEventConverterFactory("dynamic-converter-factory", new DynamicConverterFactory());


### PR DESCRIPTION
* The cause for the failures is the switch from REPL to DIST that happened in ISPN-5429.
* When using DIST, keys associated with servers are needed to provide stronger guarantees and hence the tests have been amended to do so.
* The failover test has been separated into another class to make it easy to run independently.
* Previous random failures have been noticed in ClientClusterEventsTest, but these might be gone with this switch.