### PR TITLE
modify the cache for the script to retrieve using getScriptCache.

### DIFF
--- a/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingManagerImpl.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingManagerImpl.java
@@ -173,7 +173,7 @@ public class ScriptingManagerImpl implements ScriptingManager {
             return new NoOpFuture<T>(result);
          } else {
             ScriptEngine engine = getEngineForScript(metadata);
-            T result = (T) engine.eval(scriptCache.get(metadata.name()), bindings);
+            T result = (T) engine.eval(getScriptCache().get(metadata.name()), bindings);
             return new NoOpFuture<T>(result);
          }
       } catch (ScriptException e) {


### PR DESCRIPTION
When execute is called, modify the cache for the script to retrieve using the getScriptCache.

When the script of "distributed mode", the Node does not call the ScriptingManager.addScript, it seems to remain scriptCache is not acquired.

```
   Cause: java.lang.NullPointerException:
   at org.infinispan.scripting.impl.ScriptingManagerImpl.execute(ScriptingManagerImpl.java:176)
   at org.infinispan.scripting.impl.DistributedScript.call(DistributedScript.java:30)
   at org.infinispan.commands.read.DistributedExecuteCommand.perform(DistributedExecuteCommand.java:98)
   at org.infinispan.remoting.inboundhandler.BasePerCacheInboundInvocationHandler.invokePerform(BasePerCacheInboundInvocationHandler.java:84)
   at org.infinispan.remoting.inboundhandler.BaseBlockingRunnable.run(BaseBlockingRunnable.java:31)
   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
   at java.lang.Thread.run(Thread.java:745)
```