### PR TITLE
ISPN-5457 Infinispan with Wildfly 8.2 random fails using customized k…

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/parsing/XmlConfigHelper.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/XmlConfigHelper.java
@@ -466,6 +466,11 @@ public class XmlConfigHelper {
                }
 
                Class<?> parameterType = paramTypes[0];
+               
+               if (parameterType.equals(Class.class)) {
+            	   log.tracef("Rejecting setter %s on class %s due to class parameter is type class", m, objectClass);
+                   continue; // try another param with the same name. 
+               }
                PropertyEditor editor = PropertyEditorManager.findEditor(parameterType);
                if (editor == null) {
                   throw new CacheConfigurationException("Couldn't find a property editor for parameter type " + parameterType);


### PR DESCRIPTION
This PR patch an issue found in Wildfly 8.2 with Infinispan 6.0.2 using the JDBC string based storage with customized string mapper random fails. 
```xml
<string-keyed-jdbc-store preload="true" passivation="false" fetch-state="true" singleton="true" datasource="java:jboss/datasources/PostgresDS" dialect="POSTGRES">
 <write-behind/>
       <property name="key2StringMapper">
             org.infinispan.lucene.LuceneKey2StringMapper
       </property>
       <string-keyed-table>
            <id-column name="ID_COLUMN" type="VARCHAR(255)"/>
            <data-column name="DATA_COLUMN" type="bytea"/>
            <timestamp-column name="TIMESTAMP_COLUMN" type="BIGINT"/>
      </string-keyed-table>
</string-keyed-jdbc-store>
```