### PR TITLE
ISPN-5046 PartitionHandling: split during commit can leave the cache …

### DIFF
--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -948,11 +948,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
 
    @Override
    public AvailabilityMode getAvailability() {
-      if (partitionHandlingManager != null) {
-         return partitionHandlingManager.getAvailabilityMode();
-      } else {
-         return AvailabilityMode.AVAILABLE;
-      }
+      return partitionHandlingManager.getAvailabilityMode();
    }
 
    @Override
@@ -1071,7 +1067,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
 
    @Override
    public XAResource getXAResource() {
-      return new TransactionXaAdapter(txTable, recoveryManager, txCoordinator, commandsFactory, rpcManager, null, config, name);
+      return new TransactionXaAdapter(txTable, recoveryManager, txCoordinator, commandsFactory, rpcManager, null, config, name, partitionHandlingManager);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/TxCompletionNotificationCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/TxCompletionNotificationCommand.java
@@ -114,7 +114,7 @@ public class TxCompletionNotificationCommand  extends RecoveryCommand implements
    private void forwardCommandRemotely(RemoteTransaction remoteTx) {
       Set<Object> affectedKeys = remoteTx.getAffectedKeys();
       log.tracef("Invoking forward of TxCompletionNotification for transaction %s. Affected keys: %s", gtx, affectedKeys);
-      stateTransferManager.forwardCommandIfNeeded(this, affectedKeys, remoteTx.getGlobalTransaction().getAddress(), false);
+      stateTransferManager.forwardCommandIfNeeded(this, affectedKeys, remoteTx.getGlobalTransaction().getAddress());
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/factories/PartitionHandlingManagerFactory.java
+++ b/core/src/main/java/org/infinispan/factories/PartitionHandlingManagerFactory.java
@@ -2,6 +2,7 @@ package org.infinispan.factories;
 
 
 import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.partitionhandling.impl.AvailablePartitionHandlingManager;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManagerImpl;
 
@@ -10,8 +11,8 @@ import org.infinispan.partitionhandling.impl.PartitionHandlingManagerImpl;
  * @since 7.0
  */
 @DefaultFactoryFor(classes = PartitionHandlingManager.class)
-public class PartitionHandlingManagerFactory extends AbstractNamedCacheComponentFactory implements
-      AutoInstantiableFactory {
+public class PartitionHandlingManagerFactory extends AbstractNamedCacheComponentFactory implements AutoInstantiableFactory {
+
    @Override
    @SuppressWarnings("unchecked")
    public <T> T construct(Class<T> componentType) {
@@ -21,6 +22,6 @@ public class PartitionHandlingManagerFactory extends AbstractNamedCacheComponent
             return (T) new PartitionHandlingManagerImpl();
          }
       }
-      return null;
+      return (T) AvailablePartitionHandlingManager.getInstance();
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/distribution/NonTxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/NonTxDistributionInterceptor.java
@@ -204,13 +204,11 @@ public class NonTxDistributionInterceptor extends BaseDistributionInterceptor {
       return handleNonTxWriteCommand(ctx, command);
    }
 
-   protected void remoteGetBeforeWrite(InvocationContext ctx, WriteCommand command, RecipientGenerator keygen) throws Throwable {
-      for (Object k : keygen.getKeys()) {
-         if (cdl.localNodeIsPrimaryOwner(k)) {
-            // Then it makes sense to try a local get and wrap again. This will compensate the fact the the entry was not local
-            // earlier when the EntryWrappingInterceptor executed during current invocation context but it should be now.
-            localGetCacheEntry(ctx, k, true, command);
-         }
+   protected void remoteGetBeforeWrite(InvocationContext ctx, WriteCommand command, Object key) throws Throwable {
+      if (cdl.localNodeIsPrimaryOwner(key)) {
+         // Then it makes sense to try a local get and wrap again. This will compensate the fact the the entry was not local
+         // earlier when the EntryWrappingInterceptor executed during current invocation context but it should be now.
+         localGetCacheEntry(ctx, key, true, command);
       }
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderDistributionInterceptor.java
@@ -1,12 +1,9 @@
 package org.infinispan.interceptors.totalorder;
 
-import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.configuration.cache.Configurations;
-import org.infinispan.container.entries.InternalCacheEntry;
-import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.interceptors.distribution.TxDistributionInterceptor;
 import org.infinispan.remoting.transport.Address;
@@ -46,8 +43,7 @@ public class TotalOrderDistributionInterceptor extends TxDistributionInterceptor
    }
 
    @Override
-   protected void prepareOnAffectedNodes(TxInvocationContext<?> ctx, PrepareCommand command, Collection<Address> recipients,
-                                         boolean sync) {
+   protected void prepareOnAffectedNodes(TxInvocationContext<?> ctx, PrepareCommand command, Collection<Address> recipients) {
       if (log.isTraceEnabled()) {
          log.tracef("Total Order Anycast transaction %s with Total Order", command.getGlobalTransaction().globalId());
       }
@@ -65,11 +61,6 @@ public class TotalOrderDistributionInterceptor extends TxDistributionInterceptor
       } finally {
          transactionRemotelyPrepared(ctx);
       }
-   }
-
-   @Override
-   protected void lockAndWrap(InvocationContext ctx, Object key, InternalCacheEntry ice, FlagAffectedCommand command) throws InterruptedException {
-      entryFactory.wrapEntryForPut(ctx, key, ice, false, command, true);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedDistributionInterceptor.java
@@ -1,14 +1,11 @@
 package org.infinispan.interceptors.totalorder;
 
-import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.commands.tx.VersionedPrepareCommand;
 import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.configuration.cache.Configurations;
-import org.infinispan.container.entries.InternalCacheEntry;
-import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.interceptors.distribution.VersionedDistributionInterceptor;
 import org.infinispan.remoting.responses.KeysValidateFilter;
@@ -50,7 +47,7 @@ public class TotalOrderVersionedDistributionInterceptor extends VersionedDistrib
    }
 
    @Override
-   protected void prepareOnAffectedNodes(TxInvocationContext<?> ctx, PrepareCommand command, Collection<Address> recipients, boolean sync) {
+   protected void prepareOnAffectedNodes(TxInvocationContext<?> ctx, PrepareCommand command, Collection<Address> recipients) {
       if (log.isTraceEnabled()) {
          log.tracef("Total Order Anycast transaction %s with Total Order", command.getGlobalTransaction().globalId());
       }
@@ -75,11 +72,6 @@ public class TotalOrderVersionedDistributionInterceptor extends VersionedDistrib
       } finally {
          transactionRemotelyPrepared(ctx);
       }
-   }
-
-   @Override
-   protected void lockAndWrap(InvocationContext ctx, Object key, InternalCacheEntry ice, FlagAffectedCommand command) throws InterruptedException {
-      entryFactory.wrapEntryForPut(ctx, key, ice, false, command, true);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/partitionhandling/impl/AvailablePartitionHandlingManager.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/impl/AvailablePartitionHandlingManager.java
@@ -1,0 +1,94 @@
+package org.infinispan.partitionhandling.impl;
+
+import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.container.versioning.EntryVersionsMap;
+import org.infinispan.partitionhandling.AvailabilityMode;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.topology.CacheTopology;
+import org.infinispan.transaction.xa.GlobalTransaction;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * {@link PartitionHandlingManager} implementation when the cluster is always available.
+ *
+ * @author Pedro Ruivo
+ * @since 8.0
+ */
+public class AvailablePartitionHandlingManager implements PartitionHandlingManager {
+
+
+   private AvailablePartitionHandlingManager() {
+   }
+
+   public static AvailablePartitionHandlingManager getInstance() {
+      return SingletonHolder.INSTANCE;
+   }
+
+   @Override
+   public AvailabilityMode getAvailabilityMode() {
+      return AvailabilityMode.AVAILABLE;
+   }
+
+   @Override
+   public void setAvailabilityMode(AvailabilityMode availabilityMode) {/*no-op*/}
+
+   @Override
+   public void checkWrite(Object key) {/*no-op*/}
+
+   @Override
+   public void checkRead(Object key) {/*no-op*/}
+
+   @Override
+   public void checkClear() {/*no-op*/}
+
+   @Override
+   public void checkBulkRead() {/*no-op*/}
+
+   @Override
+   public CacheTopology getLastStableTopology() {
+      return null;
+   }
+
+   @Override
+   public boolean addPartialRollbackTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes,
+                                                Collection<Object> lockedKeys) {
+      return false;
+   }
+
+   @Override
+   public boolean addPartialCommit2PCTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes,
+                                                 Collection<Object> lockedKeys, EntryVersionsMap newVersions) {
+      return false;
+   }
+
+   @Override
+   public boolean addPartialCommit1PCTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes,
+                                                 Collection<Object> lockedKeys, List<WriteCommand> modifications) {
+      return false;
+   }
+
+   @Override
+   public boolean isTransactionPartiallyCommitted(GlobalTransaction globalTransaction) {
+      return false;
+   }
+
+   @Override
+   public Collection<GlobalTransaction> getPartialTransactions() {
+      return Collections.emptyList();
+   }
+
+   @Override
+   public boolean canRollbackTransactionAfterOriginatorLeave(GlobalTransaction globalTransaction) {
+      return true;
+   }
+
+   @Override
+   public void onTopologyUpdate(CacheTopology cacheTopology) {/*no-op*/}
+
+   private static class SingletonHolder {
+      private static final AvailablePartitionHandlingManager INSTANCE = new AvailablePartitionHandlingManager();
+   }
+}

--- a/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingInterceptor.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingInterceptor.java
@@ -161,7 +161,7 @@ public class PartitionHandlingInterceptor extends CommandInterceptor {
    }
 
    protected void postTxCommandCheck(TxInvocationContext ctx) {
-      if (ctx.hasModifications() && partitionHandlingManager.getAvailabilityMode() != AvailabilityMode.AVAILABLE) {
+      if (ctx.hasModifications() && partitionHandlingManager.getAvailabilityMode() != AvailabilityMode.AVAILABLE && !partitionHandlingManager.isTransactionPartiallyCommitted(ctx.getGlobalTransaction())) {
          for (Object key : ctx.getAffectedKeys()) {
             partitionHandlingManager.checkWrite(key);
          }

--- a/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingManager.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingManager.java
@@ -1,16 +1,23 @@
 package org.infinispan.partitionhandling.impl;
 
+import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.container.versioning.EntryVersionsMap;
 import org.infinispan.partitionhandling.AvailabilityMode;
+import org.infinispan.remoting.transport.Address;
 import org.infinispan.topology.CacheTopology;
+import org.infinispan.transaction.xa.GlobalTransaction;
+
+import java.util.Collection;
+import java.util.List;
 
 /**
  * @author Dan Berindei
  * @since 7.0
  */
 public interface PartitionHandlingManager {
-   void setAvailabilityMode(AvailabilityMode availabilityMode);
-
    AvailabilityMode getAvailabilityMode();
+
+   void setAvailabilityMode(AvailabilityMode availabilityMode);
 
    void checkWrite(Object key);
 
@@ -20,5 +27,86 @@ public interface PartitionHandlingManager {
 
    void checkBulkRead();
 
+   @Deprecated //test use only. it can be removed if we update the tests
    CacheTopology getLastStableTopology();
+
+   /**
+    * Adds a partially aborted transaction.
+    * <p/>
+    * The transaction should be registered when it is not sure if the abort happens successfully in all the affected
+    * nodes.
+    *
+    * @param globalTransaction the global transaction.
+    * @param affectedNodes     the nodes involved in the transaction and they must abort the transaction.
+    * @param lockedKeys        the keys locally locked.
+    * @return {@code true} if the {@link PartitionHandlingManager} will handle it, {@code false} otherwise.
+    */
+   boolean addPartialRollbackTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes,
+                                         Collection<Object> lockedKeys);
+
+   /**
+    * Adds a partially committed transaction.
+    * <p/>
+    * The transaction is committed in the second phase and it is register if it is not sure that the transaction was
+    * committed successfully in all the affected nodes.
+    *
+    * @param globalTransaction the global transaction.
+    * @param affectedNodes     the nodes involved in the transaction and they must commit it.
+    * @param lockedKeys        the keys locally locked.
+    * @param newVersions       the updated versions. Only used when versioning is enabled.
+    * @return {@code true} if the {@link PartitionHandlingManager} will handle it, {@code false} otherwise.
+    */
+   boolean addPartialCommit2PCTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes,
+                                          Collection<Object> lockedKeys, EntryVersionsMap newVersions);
+
+   /**
+    * Adds a partially committed transaction.
+    * <p/>
+    * The transaction is committed in one phase and it is register if it is not sure that the transaction was committed
+    * successfully in all the affected nodes.
+    *
+    * @param globalTransaction the global transaction.
+    * @param affectedNodes     the nodes involved in the transaction and they must commit it.
+    * @param lockedKeys        the keys locally locked.
+    * @param modifications     the transaction's modification log.
+    * @return {@code true} if the {@link PartitionHandlingManager} will handle it, {@code false} otherwise.
+    */
+   boolean addPartialCommit1PCTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes,
+                                          Collection<Object> lockedKeys, List<WriteCommand> modifications);
+
+   /**
+    * It checks if the transaction resources (for example locks) can be released.
+    * <p/>
+    * The transaction resource can't be released when the transaction is partially committed.
+    *
+    * @param globalTransaction the transaction.
+    * @return {@code true} if the resources can be released, {@code false} otherwise.
+    */
+   boolean isTransactionPartiallyCommitted(GlobalTransaction globalTransaction);
+
+   /**
+    * @return a collection of partial committed or aborted transactions.
+    */
+   Collection<GlobalTransaction> getPartialTransactions();
+
+   /**
+    * It checks if the transaction can be aborted when the originator leaves the cluster.
+    * <p/>
+    * The only case in which it is not possible to abort is when partition handling is enabled and the originator didn't
+    * leave gracefully. The transaction will complete when the partition heals.
+    *
+    * @param globalTransaction the global transaction.
+    * @return {@code true} if the transaction can be aborted, {@code false} otherwise.
+    */
+   boolean canRollbackTransactionAfterOriginatorLeave(GlobalTransaction globalTransaction);
+
+   /**
+    * Notifies the {@link PartitionHandlingManager} that the cache topology was update.
+    * <p/>
+    * It detects when the partition is merged and tries to complete all the partially completed transactions.
+    *
+    * @param cacheTopology the new cache topology.
+    */
+   void onTopologyUpdate(CacheTopology cacheTopology);
+
 }

--- a/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingManagerImpl.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingManagerImpl.java
@@ -1,24 +1,40 @@
 package org.infinispan.partitionhandling.impl;
 
 import org.infinispan.Cache;
+import org.infinispan.commands.CommandsFactory;
+import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.commands.remote.recovery.TxCompletionNotificationCommand;
+import org.infinispan.commands.tx.VersionedCommitCommand;
+import org.infinispan.commands.write.WriteCommand;
+import org.infinispan.commons.util.CollectionFactory;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.Configurations;
+import org.infinispan.container.versioning.EntryVersionsMap;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.partitionhandling.AvailabilityMode;
+import org.infinispan.remoting.inboundhandler.DeliverOrder;
+import org.infinispan.remoting.responses.CacheNotFoundResponse;
+import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.responses.UnsureResponse;
+import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.statetransfer.StateTransferManager;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.topology.LocalTopologyManager;
+import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
-import java.util.List;
+import java.util.*;
 
 public class PartitionHandlingManagerImpl implements PartitionHandlingManager {
    private static final Log log = LogFactory.getLog(PartitionHandlingManagerImpl.class);
    private static final boolean trace = log.isTraceEnabled();
-
+   private final Map<GlobalTransaction, TransactionInfo> partialTransactions;
    private volatile AvailabilityMode availabilityMode = AvailabilityMode.AVAILABLE;
 
    private DistributionManager distributionManager;
@@ -26,19 +42,40 @@ public class PartitionHandlingManagerImpl implements PartitionHandlingManager {
    private StateTransferManager stateTransferManager;
    private String cacheName;
    private CacheNotifier notifier;
+   private CommandsFactory commandsFactory;
+   private Configuration configuration;
+   private RpcManager rpcManager;
+   private LockManager lockManager;
+
+   private boolean isVersioned;
+
+   public PartitionHandlingManagerImpl() {
+      partialTransactions = CollectionFactory.makeConcurrentMap();
+   }
 
    @Inject
-   void init(DistributionManager distributionManager, LocalTopologyManager localTopologyManager,
-         StateTransferManager stateTransferManager, Cache cache, CacheNotifier notifier) {
+   public void init(DistributionManager distributionManager, LocalTopologyManager localTopologyManager,
+                    StateTransferManager stateTransferManager, Cache cache, CacheNotifier notifier, CommandsFactory commandsFactory,
+                    Configuration configuration, RpcManager rpcManager, LockManager lockManager) {
       this.distributionManager = distributionManager;
       this.localTopologyManager = localTopologyManager;
       this.stateTransferManager = stateTransferManager;
       this.cacheName = cache.getName();
       this.notifier = notifier;
+      this.commandsFactory = commandsFactory;
+      this.configuration = configuration;
+      this.rpcManager = rpcManager;
+      this.lockManager = lockManager;
    }
 
    @Start
-   void start() {
+   public void start() {
+      isVersioned = Configurations.isVersioningEnabled(configuration);
+   }
+
+   @Override
+   public AvailabilityMode getAvailabilityMode() {
+      return availabilityMode;
    }
 
    @Override
@@ -52,11 +89,6 @@ public class PartitionHandlingManagerImpl implements PartitionHandlingManager {
    }
 
    @Override
-   public AvailabilityMode getAvailabilityMode() {
-      return availabilityMode;
-   }
-
-   @Override
    public void checkWrite(Object key) {
       doCheck(key);
    }
@@ -64,21 +96,6 @@ public class PartitionHandlingManagerImpl implements PartitionHandlingManager {
    @Override
    public void checkRead(Object key) {
       doCheck(key);
-   }
-
-   private void doCheck(Object key) {
-      if (trace) log.tracef("Checking availability for key=%s, status=%s", key, availabilityMode);
-      if (availabilityMode == AvailabilityMode.AVAILABLE)
-         return;
-
-      List<Address> owners = distributionManager.locate(key);
-      List<Address> actualMembers = stateTransferManager.getCacheTopology().getActualMembers();
-      if (!actualMembers.containsAll(owners)) {
-         if (trace) log.tracef("Partition is in %s mode, access is not allowed for key %s", availabilityMode, key);
-         throw log.degradedModeKeyUnavailable(key);
-      } else {
-         if (trace) log.tracef("Key %s is available.", key);
-      }
    }
 
    @Override
@@ -98,5 +115,258 @@ public class PartitionHandlingManagerImpl implements PartitionHandlingManager {
    @Override
    public CacheTopology getLastStableTopology() {
       return localTopologyManager.getStableCacheTopology(cacheName);
+   }
+
+   @Override
+   public boolean addPartialRollbackTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes, Collection<Object> lockedKeys) {
+      if (trace) {
+         log.tracef("Added partially rollback transaction %s", globalTransaction);
+      }
+      partialTransactions.put(globalTransaction, new RollbackTransactionInfo(globalTransaction, affectedNodes, lockedKeys));
+      return true;
+   }
+
+   @Override
+   public boolean addPartialCommit2PCTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes,
+                                                 Collection<Object> lockedKeys, EntryVersionsMap newVersions) {
+      if (trace) {
+         log.tracef("Added partially committed (2PC) transaction %s", globalTransaction);
+      }
+      partialTransactions.put(globalTransaction, new Commit2PCTransactionInfo(globalTransaction, affectedNodes,
+                                                                              lockedKeys, newVersions));
+      return true;
+   }
+
+   @Override
+   public boolean addPartialCommit1PCTransaction(GlobalTransaction globalTransaction, Collection<Address> affectedNodes,
+                                                 Collection<Object> lockedKeys, List<WriteCommand> modifications) {
+      if (trace) {
+         log.tracef("Added partially committed (1PC) transaction %s", globalTransaction);
+      }
+      partialTransactions.put(globalTransaction, new Commit1PCTransactionInfo(globalTransaction, affectedNodes,
+                                                                              lockedKeys, modifications));
+      return true;
+   }
+
+   @Override
+   public boolean isTransactionPartiallyCommitted(GlobalTransaction globalTransaction) {
+      TransactionInfo transactionInfo = partialTransactions.get(globalTransaction);
+      if (trace) {
+         log.tracef("Can release resources for transaction %s. Transaction info=%s", globalTransaction, transactionInfo);
+      }
+      return transactionInfo != null && !transactionInfo.isRolledBack(); //if we are going to commit, we can't release the resources yet
+   }
+
+   @Override
+   public Collection<GlobalTransaction> getPartialTransactions() {
+      return Collections.unmodifiableCollection(partialTransactions.keySet());
+   }
+
+   @Override
+   public boolean canRollbackTransactionAfterOriginatorLeave(GlobalTransaction globalTransaction) {
+      boolean canRollback = availabilityMode == AvailabilityMode.AVAILABLE &&
+            !getLastStableTopology().getActualMembers().contains(globalTransaction.getAddress());
+      if (trace) {
+         log.tracef("Can rollback transaction? %s", canRollback);
+      }
+      return canRollback;
+   }
+
+   @Override
+   public void onTopologyUpdate(CacheTopology cacheTopology) {
+      boolean isStable = isTopologyStable(cacheTopology);
+      if (trace) {
+         log.tracef("On stable topology update. Has pending tx? %b. Is stable? %b. topology=%s",
+                    !partialTransactions.isEmpty(), isStable, cacheTopology);
+      }
+      if (isStable) {
+         if (!partialTransactions.isEmpty()) {
+            for (TransactionInfo transactionInfo : partialTransactions.values()) {
+               completeTransaction(transactionInfo, cacheTopology);
+            }
+         }
+      }
+   }
+
+   private void completeTransaction(final TransactionInfo transactionInfo, CacheTopology cacheTopology) {
+      rpcManager.invokeRemotelyAsync(transactionInfo.getCommitNodes(cacheTopology),
+              transactionInfo.buildCommand(commandsFactory, isVersioned),
+              rpcManager.getDefaultRpcOptions(true))
+              .whenComplete((responseMap, throwable) -> {
+                 final GlobalTransaction globalTransaction = transactionInfo.getGlobalTransaction();
+                 if (trace) {
+                    log.tracef("Future done for transaction %s", globalTransaction);
+                 }
+
+                 if (throwable != null) {
+                    if (trace) {
+                       log.tracef(throwable, "Exception for transaction %s. Retry later.", globalTransaction);
+                    }
+                    return;
+                 }
+
+                 if (trace) {
+                    log.tracef("Future done for transaction %s. Response are %s", globalTransaction, responseMap);
+                 }
+
+                 for (Response response : responseMap.values()) {
+                    if (response == UnsureResponse.INSTANCE || response == CacheNotFoundResponse.INSTANCE) {
+                       if (trace) {
+                          log.tracef("Another partition or topology changed for transaction %s. Retry later.", globalTransaction);
+                       }
+                       return;
+                    }
+                 }
+                 if (trace) {
+                    log.tracef("Performing cleanup for transaction %s", globalTransaction);
+                 }
+                 lockManager.unlock(transactionInfo.getLockedKeys(), globalTransaction);
+                 partialTransactions.remove(globalTransaction);
+                 TxCompletionNotificationCommand command = commandsFactory.buildTxCompletionNotificationCommand(null, globalTransaction);
+                 //a little bit overkill, but the state transfer can happen during a merge and some nodes can receive the
+                 // transaction that aren't in the original affected nodes.
+                 //no side effects.
+                 rpcManager.invokeRemotely(null, command, rpcManager.getDefaultRpcOptions(false, DeliverOrder.NONE));
+              });
+   }
+
+   private boolean isTopologyStable(CacheTopology cacheTopology) {
+      CacheTopology stableTopology = localTopologyManager.getStableCacheTopology(cacheName);
+      if (trace) {
+         log.tracef("Check if topology %s is stable. Last stable topology is %s", cacheTopology, stableTopology);
+      }
+      return stableTopology != null && cacheTopology.getActualMembers().containsAll(stableTopology.getActualMembers());
+   }
+
+   private void doCheck(Object key) {
+      if (trace) log.tracef("Checking availability for key=%s, status=%s", key, availabilityMode);
+      if (availabilityMode == AvailabilityMode.AVAILABLE)
+         return;
+
+      List<Address> owners = distributionManager.locate(key);
+      List<Address> actualMembers = stateTransferManager.getCacheTopology().getActualMembers();
+      if (!actualMembers.containsAll(owners)) {
+         if (trace) log.tracef("Partition is in %s mode, access is not allowed for key %s", availabilityMode, key);
+         throw log.degradedModeKeyUnavailable(key);
+      } else {
+         if (trace) log.tracef("Key %s is available.", key);
+      }
+   }
+
+   private interface TransactionInfo {
+      boolean isRolledBack();
+
+      List<Address> getCommitNodes(CacheTopology stableTopology);
+
+      ReplicableCommand buildCommand(CommandsFactory commandsFactory, boolean isVersioned);
+
+      GlobalTransaction getGlobalTransaction();
+
+      Collection<Object> getLockedKeys();
+   }
+
+   private static class RollbackTransactionInfo extends BaseTransactionInfo {
+
+      protected RollbackTransactionInfo(GlobalTransaction globalTransaction, Collection<Address> affectedNodes, Collection<Object> lockedKeys) {
+         super(globalTransaction, affectedNodes, lockedKeys);
+      }
+
+      @Override
+      public boolean isRolledBack() {
+         return true;
+      }
+
+      @Override
+      public ReplicableCommand buildCommand(CommandsFactory commandsFactory, boolean isVersioned) {
+         return commandsFactory.buildRollbackCommand(getGlobalTransaction());
+      }
+
+   }
+
+   private static class Commit2PCTransactionInfo extends BaseTransactionInfo {
+
+      private final EntryVersionsMap newVersions;
+
+      public Commit2PCTransactionInfo(GlobalTransaction globalTransaction, Collection<Address> affectedNodes, Collection<Object> lockedKeys, EntryVersionsMap newVersions) {
+         super(globalTransaction, affectedNodes, lockedKeys);
+         this.newVersions = newVersions;
+      }
+
+      @Override
+      public boolean isRolledBack() {
+         return false;
+      }
+
+      @Override
+      public ReplicableCommand buildCommand(CommandsFactory commandsFactory, boolean isVersioned) {
+         if (isVersioned) {
+            VersionedCommitCommand commitCommand = commandsFactory.buildVersionedCommitCommand(getGlobalTransaction());
+            commitCommand.setUpdatedVersions(newVersions);
+            return commitCommand;
+         } else {
+            return commandsFactory.buildCommitCommand(getGlobalTransaction());
+         }
+      }
+   }
+
+   private static class Commit1PCTransactionInfo extends BaseTransactionInfo {
+
+      private final List<WriteCommand> modifications;
+
+      public Commit1PCTransactionInfo(GlobalTransaction globalTransaction, Collection<Address> affectedNodes, Collection<Object> lockedKeys, List<WriteCommand> modifications) {
+         super(globalTransaction, affectedNodes, lockedKeys);
+         this.modifications = modifications;
+      }
+
+      @Override
+      public boolean isRolledBack() {
+         return false;
+      }
+
+      @Override
+      public ReplicableCommand buildCommand(CommandsFactory commandsFactory, boolean isVersioned) {
+         if (isVersioned) {
+            throw new IllegalArgumentException("Cannot build a versioned one-phase-commit prepare command.");
+         }
+         return commandsFactory.buildPrepareCommand(getGlobalTransaction(), modifications, true);
+      }
+   }
+
+   private static abstract class BaseTransactionInfo implements TransactionInfo {
+      private final GlobalTransaction globalTransaction;
+      private final List<Address> affectedNodes;
+      private final Collection<Object> lockedKeys;
+
+      protected BaseTransactionInfo(GlobalTransaction globalTransaction, Collection<Address> affectedNodes, Collection<Object> lockedKeys) {
+         this.globalTransaction = globalTransaction;
+         this.lockedKeys = lockedKeys;
+         this.affectedNodes = new ArrayList<>(affectedNodes);
+      }
+
+      @Override
+      public final List<Address> getCommitNodes(CacheTopology stableTopology) {
+         List<Address> commitNodes = new ArrayList<>(affectedNodes);
+         commitNodes.retainAll(stableTopology.getActualMembers());
+         return commitNodes;
+      }
+
+      @Override
+      public final GlobalTransaction getGlobalTransaction() {
+         return globalTransaction;
+      }
+
+      @Override
+      public Collection<Object> getLockedKeys() {
+         return lockedKeys;
+      }
+
+      @Override
+      public String toString() {
+         return "TransactionInfo{" +
+               "globalTransaction=" + globalTransaction + ", " +
+               "rollback=" + isRolledBack() + ", " +
+               "affectedNodes=" + affectedNodes +
+               '}';
+      }
    }
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/AbstractDelegatingTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/AbstractDelegatingTransport.java
@@ -123,6 +123,10 @@ public abstract class AbstractDelegatingTransport implements Transport {
       return actual.getLog();
    }
 
+   public Transport getDelegate() {
+      return actual;
+   }
+
    /**
     * method invoked before a remote invocation.
     *

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -612,6 +612,15 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
                   throw new TimeoutException("Timed out waiting for valid responses!");
                }
             }
+
+            if (recipients != null) {
+               for (Address dest : recipients) {
+                  if (!dest.equals(getAddress()) && !retval.containsKey(dest)) {
+                     retval.put(dest, CacheNotFoundResponse.INSTANCE);
+                  }
+               }
+            }
+
             return retval;
          });
       } else {

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManager.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManager.java
@@ -53,7 +53,7 @@ public interface StateTransferManager {
     * If there is an state transfer happening at the moment, this method forwards the supplied
     * command to the nodes that are new owners of the data, in order to assure consistency.
     */
-   Map<Address, Response> forwardCommandIfNeeded(TopologyAffectedCommand command, Set<Object> affectedKeys, Address origin, boolean sync);
+   Map<Address, Response> forwardCommandIfNeeded(TopologyAffectedCommand command, Set<Object> affectedKeys, Address origin);
 
    void notifyEndOfRebalance(int topologyId, int rebalanceId);
 

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -20,7 +20,9 @@ import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.rpc.RpcManager;
+import org.infinispan.remoting.rpc.RpcOptions;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.topology.CacheJoinInfo;
 import org.infinispan.topology.CacheTopology;
@@ -207,6 +209,7 @@ public class StateTransferManagerImpl implements StateTransferManager {
             log.tracef("Initial state transfer complete for cache %s on node %s", cacheName, rpcManager.getAddress());
          }
       }
+      partitionHandlingManager.onTopologyUpdate(newCacheTopology);
    }
 
    @Start(priority = 1000)
@@ -257,12 +260,18 @@ public class StateTransferManagerImpl implements StateTransferManager {
 
    @Override
    public Map<Address, Response> forwardCommandIfNeeded(TopologyAffectedCommand command, Set<Object> affectedKeys,
-                                                        Address origin, boolean sync) {
+                                                        Address origin) {
+      final CacheTopology cacheTopology = getCacheTopology();
+      if (cacheTopology == null) {
+         if (trace) {
+            log.tracef("Not fowarding command %s because topology is null.", command);
+         }
+         return Collections.emptyMap();
+      }
       int cmdTopologyId = command.getTopologyId();
       // forward commands with older topology ids to their new targets
       // but we need to make sure we have the latest topology
-      CacheTopology cacheTopology = getCacheTopology();
-      int localTopologyId = cacheTopology != null ? cacheTopology.getTopologyId() : -1;
+      int localTopologyId = cacheTopology.getTopologyId();
       // if it's a tx/lock/write command, forward it to the new owners
       if (trace) {
          log.tracef("CommandTopologyId=%s, localTopologyId=%s", cmdTopologyId, localTopologyId);
@@ -270,7 +279,7 @@ public class StateTransferManagerImpl implements StateTransferManager {
 
       if (cmdTopologyId < localTopologyId) {
          ConsistentHash writeCh = cacheTopology.getWriteConsistentHash();
-         Set<Address> newTargets = new HashSet<Address>(writeCh.locateAllOwners(affectedKeys));
+         Set<Address> newTargets = new HashSet<>(writeCh.locateAllOwners(affectedKeys));
          newTargets.remove(rpcManager.getAddress());
          // Forwarding to the originator would create a cycle
          // TODO This may not be the "real" originator, but one of the original recipients
@@ -284,9 +293,10 @@ public class StateTransferManagerImpl implements StateTransferManager {
             if (trace) {
                log.tracef("Forwarding command %s to new targets %s", command, newTargets);
             }
+            final RpcOptions rpcOptions = rpcManager.getDefaultRpcOptions(false, DeliverOrder.NONE);
             // TODO find a way to forward the command async if it was received async
             // TxCompletionNotificationCommands are the only commands forwarded asynchronously, and they must be OOB
-            return rpcManager.invokeRemotely(newTargets, command, rpcManager.getDefaultRpcOptions(sync, DeliverOrder.NONE));
+            return rpcManager.invokeRemotely(newTargets, command, rpcOptions);
          }
       }
       return Collections.emptyMap();

--- a/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
@@ -27,6 +27,7 @@ import org.infinispan.notifications.cachelistener.event.TopologyChangedEvent;
 import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifier;
 import org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged;
 import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
+import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.transaction.LockingMode;
@@ -88,19 +89,21 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
    protected RpcManager rpcManager;
    protected CommandsFactory commandsFactory;
    protected ClusteringDependentLogic clusteringLogic;
-   protected boolean clustered = false;
-   private ConcurrentMap<Transaction, LocalTransaction> localTransactions;
-   private ConcurrentMap<GlobalTransaction, LocalTransaction> globalToLocalTransactions;
-   private ConcurrentMap<GlobalTransaction, RemoteTransaction> remoteTransactions;
    private InterceptorChain invoker;
    private CacheNotifier notifier;
    private TransactionSynchronizationRegistry transactionSynchronizationRegistry;
-   private Lock minTopologyRecalculationLock;
    private CompletedTransactionsInfo completedTransactionsInfo;
    private ScheduledExecutorService executorService;
    private String cacheName;
    private TimeService timeService;
    private CacheManagerNotifier cacheManagerNotifier;
+   protected PartitionHandlingManager partitionHandlingManager;
+
+   private ConcurrentMap<Transaction, LocalTransaction> localTransactions;
+   private ConcurrentMap<GlobalTransaction, LocalTransaction> globalToLocalTransactions;
+   private ConcurrentMap<GlobalTransaction, RemoteTransaction> remoteTransactions;
+   private Lock minTopologyRecalculationLock;
+   protected boolean clustered = false;
 
    @Inject
    public void initialize(RpcManager rpcManager, Configuration configuration,
@@ -108,7 +111,7 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
                           TransactionFactory gtf, TransactionCoordinator txCoordinator,
                           TransactionSynchronizationRegistry transactionSynchronizationRegistry,
                           CommandsFactory commandsFactory, ClusteringDependentLogic clusteringDependentLogic, Cache cache,
-                          TimeService timeService, CacheManagerNotifier cacheManagerNotifier) {
+                          TimeService timeService, CacheManagerNotifier cacheManagerNotifier, PartitionHandlingManager partitionHandlingManager) {
       this.rpcManager = rpcManager;
       this.configuration = configuration;
       this.icf = icf;
@@ -122,6 +125,7 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
       this.cacheManagerNotifier = cacheManagerNotifier;
       this.cacheName = cache.getName();
       this.timeService = timeService;
+      this.partitionHandlingManager = partitionHandlingManager;
 
       this.clustered = configuration.clustering().cacheMode().isClustered();
    }
@@ -231,7 +235,7 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
       if (!localTransaction.isEnlisted()) {
          SynchronizationAdapter sync = new SynchronizationAdapter(
                 localTransaction, txCoordinator, commandsFactory, rpcManager,
-                this, clusteringLogic, configuration);
+                this, clusteringLogic, configuration, partitionHandlingManager);
          if (transactionSynchronizationRegistry != null) {
             try {
                transactionSynchronizationRegistry.registerInterposedSynchronization(sync);
@@ -281,10 +285,9 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
       if (trace) log.tracef("Checking for transactions originated on leavers. Current cache members are %s, remote transactions: %d",
             members, remoteTransactions.size());
       HashSet<Address> membersSet = new HashSet<>(members);
-      List<GlobalTransaction> toKill = new ArrayList<GlobalTransaction>();
+      List<GlobalTransaction> toKill = new ArrayList<>();
       for (Map.Entry<GlobalTransaction, RemoteTransaction> e : remoteTransactions.entrySet()) {
          GlobalTransaction gt = e.getKey();
-         RemoteTransaction remoteTx = e.getValue();
          if (trace) log.tracef("Checking transaction %s", gt);
          if (!membersSet.contains(gt.getAddress())) {
             toKill.add(gt);
@@ -295,22 +298,25 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
          if (trace) log.tracef("No remote transactions pertain to originator(s) who have left the cluster.");
       } else {
          log.debugf("The originating node left the cluster for %d remote transactions", toKill.size());
-      }
+         for (GlobalTransaction gtx : toKill) {
+            if (partitionHandlingManager.canRollbackTransactionAfterOriginatorLeave(gtx)) {
+               log.debugf("Rolling back transaction %s because originator %s left the cluster", gtx, gtx.getAddress());
+               killTransaction(gtx);
+            } else {
+               log.debugf("Keeping transaction %s after the originator %s left the cluster.", gtx, gtx.getAddress());
+            }
+         }
 
-      for (GlobalTransaction gtx : toKill) {
-         log.debugf("Rolling back transaction %s because originator %s left the cluster", gtx, gtx.getAddress());
-         killTransaction(gtx);
+         if (trace) log.tracef("Completed cleaning transactions originating on leavers. Remote transactions remaining: %d",
+                               remoteTransactions.size());
       }
-
-      if (trace) log.tracef("Completed cleaning transactions originating on leavers. Remote transactions remaining: %d",
-            remoteTransactions.size());
    }
 
    public void cleanupTimedOutTransactions() {
       if (trace) log.tracef("About to cleanup remote transactions older than %d ms", configuration.transaction().completedTxTimeout());
       long beginning = timeService.time();
       long cutoffCreationTime = beginning - TimeUnit.MILLISECONDS.toNanos(configuration.transaction().completedTxTimeout());
-      List<GlobalTransaction> toKill = new ArrayList<GlobalTransaction>();
+      List<GlobalTransaction> toKill = new ArrayList<>();
 
       // Check remote transactions.
       for(Map.Entry<GlobalTransaction, RemoteTransaction> e : remoteTransactions.entrySet()) {
@@ -615,10 +621,8 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
     * @see #markTransactionCompleted(org.infinispan.transaction.xa.GlobalTransaction, boolean)
     */
    public boolean isTransactionCompleted(GlobalTransaction gtx) {
-      if (completedTransactionsInfo == null)
-         return false;
+      return completedTransactionsInfo != null && completedTransactionsInfo.isTransactionCompleted(gtx);
 
-      return completedTransactionsInfo.isTransactionCompleted(gtx);
    }
 
    /**

--- a/core/src/main/java/org/infinispan/transaction/synchronization/SynchronizationAdapter.java
+++ b/core/src/main/java/org/infinispan/transaction/synchronization/SynchronizationAdapter.java
@@ -4,6 +4,7 @@ import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commons.CacheException;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
+import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.transaction.impl.AbstractEnlistmentAdapter;
 import org.infinispan.transaction.impl.LocalTransaction;
@@ -32,8 +33,8 @@ public class SynchronizationAdapter extends AbstractEnlistmentAdapter implements
    public SynchronizationAdapter(LocalTransaction localTransaction, TransactionCoordinator txCoordinator,
                                  CommandsFactory commandsFactory, RpcManager rpcManager,
                                  TransactionTable transactionTable, ClusteringDependentLogic clusteringLogic,
-                                 Configuration configuration) {
-      super(localTransaction, commandsFactory, rpcManager, transactionTable, clusteringLogic, configuration, txCoordinator);
+                                 Configuration configuration, PartitionHandlingManager partitionHandlingManager) {
+      super(localTransaction, commandsFactory, rpcManager, transactionTable, clusteringLogic, configuration, txCoordinator, partitionHandlingManager);
       this.localTransaction = localTransaction;
    }
 

--- a/core/src/main/java/org/infinispan/transaction/tm/DummyTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/tm/DummyTransaction.java
@@ -102,9 +102,7 @@ public class DummyTransaction implements Transaction {
       checkDone("Cannot commit transaction.");
       runPrepare();
       runCommit(false);
-      if (firstRollbackException != null) {
-         throw firstRollbackException;
-      }
+      throwRollbackExceptionIfAny();
    }
 
    /**
@@ -339,6 +337,12 @@ public class DummyTransaction implements Transaction {
    @Override
    public final boolean equals(Object obj) {
       return this == obj;
+   }
+
+   public final void throwRollbackExceptionIfAny() throws RollbackException {
+      if (firstRollbackException != null) {
+         throw firstRollbackException;
+      }
    }
 
    private void markRollbackOnly(RollbackException e) {

--- a/core/src/main/java/org/infinispan/transaction/xa/XaTransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/XaTransactionTable.java
@@ -76,7 +76,7 @@ public class XaTransactionTable extends TransactionTable {
             transaction.enlistResource(new TransactionXaAdapter(
                   localTransaction, this, recoveryManager,
                   txCoordinator, commandsFactory, rpcManager,
-                  clusteringLogic, configuration, cacheName));
+                  clusteringLogic, configuration, cacheName, partitionHandlingManager));
          } catch (Exception e) {
             Xid xid = localTransaction.getXid();
             if (xid != null && !localTransaction.getLookedUpEntries().isEmpty()) {

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAdminOperations.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAdminOperations.java
@@ -92,7 +92,7 @@ public class RecoveryAdminOperations {
          @Parameter(name = "formatId", description = "The formatId of the transaction") int formatId,
          @Parameter(name = "globalTxId", description = "The globalTxId of the transaction") byte[] globalTxId,
          @Parameter(name = "branchQualifier", description = "The branchQualifier of the transaction") byte[] branchQualifier) {
-      recoveryManager.removeRecoveryInformationFromCluster(null, new SerializableXid(branchQualifier, globalTxId, formatId), true, null);
+      recoveryManager.removeRecoveryInformation(null, new SerializableXid(branchQualifier, globalTxId, formatId), true, null, false);
       return "Recovery info removed.";
    }
 

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryManager.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryManager.java
@@ -20,20 +20,24 @@ import java.util.Set;
 public interface RecoveryManager {
 
    /**
-    * Returns the list of transactions in prepared state from both local and remote cluster nodes.
-    * Implementation can take advantage of several optimisations:
-    * <pre>
-    * - in order to get all tx from the cluster a broadcast is performed. This can be performed only once (assuming the call
-    *   is successful), the first time this method is called. After that a local, cached list of tx prepared on this node is returned.
-    * - during the broadcast just return the list of prepared transactions that are not originated on other active nodes of the
-    * cluster.
-    * </pre>
+    * Returns the list of transactions in prepared state from both local and remote cluster nodes. Implementation can
+    * take advantage of several optimisations:
+    *
+    * <ul>
+    *    <li>in order to get all tx from the cluster a broadcast is performed. This can be performed only once
+    * (assuming the call is successful), the first time this method is called. After that a local, cached list of tx
+    * prepared on this node is returned.</li>
+    *    <li>during the broadcast just return the list of prepared transactions that are not originated on other active
+    * nodes of the cluster.</li>
+    * </ul>
     */
    RecoveryIterator getPreparedTransactionsFromCluster();
 
    /**
-    * Returns a {@link Set} containing all the in-doubt transactions from the cluster, including the local node. This does
-    * not include transactions that are prepared successfully and for which the originator is still in the cluster.
+    * Returns a {@link Set} containing all the in-doubt transactions from the cluster, including the local node. This
+    * does not include transactions that are prepared successfully and for which the originator is still in the
+    * cluster.
+    *
     * @see InDoubtTxInfo
     */
    Set<InDoubtTxInfo> getInDoubtTransactionInfoFromCluster();
@@ -45,18 +49,23 @@ public interface RecoveryManager {
 
 
    /**
-    * Removes from the specified nodes (or all nodes if the value of 'where' is null) the recovery information associated with
-    * these Xids.
-    * @param where on which nodes should this be executed.
-    * @param xid the list of xids to be removed.
-    * @param sync execute sync or async (false)
-    * @param gtx
+    * Removes from the specified nodes (or all nodes if the value of 'where' is null) the recovery information
+    * associated with these Xids.
+    *
+    * @param skipTxCompletionCommand {@code true} if it must skip the {@link org.infinispan.commands.remote.recovery.TxCompletionNotificationCommand}.
+    *                                Used when a partition happens.
+    * @param where                   on which nodes should this be executed.
+    * @param xid                     the list of xids to be removed.
+    * @param sync                    execute sync or async (false)
+    * @param gtx                     the global transaction
+    * @param fromCluster
     */
-   void removeRecoveryInformationFromCluster(Collection<Address> where, Xid xid, boolean sync, GlobalTransaction gtx);
+   void removeRecoveryInformation(Collection<Address> where, Xid xid, boolean sync, GlobalTransaction gtx, boolean fromCluster);
 
    /**
-    * Same as {@link #removeRecoveryInformationFromCluster(java.util.Collection} but the transaction
-    * is identified by its internal id, and not by its xid.
+    * Same as {@link #removeRecoveryInformation(java.util.Collection, javax.transaction.xa.Xid, boolean,
+    * org.infinispan.transaction.xa.GlobalTransaction, boolean)} but the transaction is identified by its internal id,
+    * and not by its xid.
     */
    void removeRecoveryInformationFromCluster(Collection<Address> where, long internalId, boolean sync);
 
@@ -81,7 +90,8 @@ public interface RecoveryManager {
    /**
     * Replays the given transaction by re-running the prepare and commit. This call expects the transaction to exist on
     * this node either as a local or remote transaction.
-    * @param xid tx to commit or rollback
+    *
+    * @param xid    tx to commit or rollback
     * @param commit if true tx is committed, if false it is rolled back
     */
    String forceTransactionCompletion(Xid xid, boolean commit);
@@ -105,14 +115,14 @@ public interface RecoveryManager {
    /**
     * Remove recovery information stored on this node (doesn't involve rpc).
     *
-    * @param xid@see  #removeRecoveryInformation(java.util.Collection, javax.transaction.xa.Xid, boolean)
+    * @param xid@see #removeRecoveryInformation(java.util.Collection, javax.transaction.xa.Xid, boolean)
     */
    RecoveryAwareTransaction removeRecoveryInformation(Xid xid);
 
    /**
-   * Stateful structure allowing prepared-tx retrieval in a batch-oriented manner,
-    * as required by {@link javax.transaction.xa.XAResource#recover(int)}.
-   */
+    * Stateful structure allowing prepared-tx retrieval in a batch-oriented manner, as required by {@link
+    * javax.transaction.xa.XAResource#recover(int)}.
+    */
    interface RecoveryIterator extends Iterator<Xid[]> {
 
       Xid[] NOTHING = new Xid[]{};
@@ -140,8 +150,9 @@ public interface RecoveryManager {
       Long getInternalId();
 
       /**
-       * The value represent transaction's state as described by the {@link Status} field. Multiple values are returned
-       * as it is possible for an in-doubt transaction to be at the same time e.g. prepared on one node and committed on the other.
+       * The value represent transaction's state as described by the {@code status} field. Multiple values are returned
+       * as it is possible for an in-doubt transaction to be at the same time e.g. prepared on one node and committed on
+       * the other.
        */
       Set<Integer> getStatus();
 

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryManagerImpl.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryManagerImpl.java
@@ -123,10 +123,11 @@ public class RecoveryManagerImpl implements RecoveryManager {
    }
 
    @Override
-   public void removeRecoveryInformationFromCluster(Collection<Address> lockOwners, Xid xid, boolean sync, GlobalTransaction gtx) {
+   public void removeRecoveryInformation(Collection<Address> lockOwners, Xid xid, boolean sync, GlobalTransaction gtx,
+                                         boolean fromCluster) {
       log.tracef("Forgetting tx information for %s", gtx);
       //todo make sure this gets broad casted or at least flushed
-      if (rpcManager != null) {
+      if (rpcManager != null && !fromCluster) {
          TxCompletionNotificationCommand ftc = commandFactory.buildTxCompletionNotificationCommand(xid, gtx);
          rpcManager.invokeRemotely(lockOwners, ftc, rpcManager.getDefaultRpcOptions(sync, DeliverOrder.NONE));
       }
@@ -302,7 +303,7 @@ public class RecoveryManagerImpl implements RecoveryManager {
             return "Could not commit transaction " + xid + " : " + e.getMessage();
          }
       }
-      removeRecoveryInformationFromCluster(null, xid, false, localTx.getGlobalTransaction());
+      removeRecoveryInformation(null, xid, false, localTx.getGlobalTransaction(), false);
       return commit ? "Commit successful!" : "Rollback successful";
    }
 

--- a/core/src/test/java/org/infinispan/lock/ExplicitUnlockTest.java
+++ b/core/src/test/java/org/infinispan/lock/ExplicitUnlockTest.java
@@ -67,7 +67,7 @@ public class ExplicitUnlockTest extends SingleCacheManagerTest {
          cache.put("" + key, "value");
       }
 
-      List<Future<Boolean>> results = new ArrayList<Future<Boolean>>(nThreads);
+      List<Future<Boolean>> results = new ArrayList<>(nThreads);
 
       for (int i = 1; i <= nThreads; i++) {
          results.add(fork(new Worker(i, cache, withUnlock, stepDelayMsec)));
@@ -80,7 +80,7 @@ public class ExplicitUnlockTest extends SingleCacheManagerTest {
       assertTrue("All worker should complete without exceptions", success);
       assertNoTransactions();
       for (int i = 0; i < NUMBER_OF_KEYS; ++i) {
-         assertNotLocked(cache, valueOf(i));
+         assertEventuallyNotLocked(cache, valueOf(i));
       }
    }
 

--- a/core/src/test/java/org/infinispan/lock/OptimisticTxFailureAfterLockingTest.java
+++ b/core/src/test/java/org/infinispan/lock/OptimisticTxFailureAfterLockingTest.java
@@ -77,6 +77,6 @@ public class OptimisticTxFailureAfterLockingTest extends MultipleCacheManagersTe
       }
 
       assertNoTransactions();
-      assertNotLocked(cache(primaryOwnerIndex), key);
+      assertEventuallyNotLocked(cache(primaryOwnerIndex), key);
    }
 }

--- a/core/src/test/java/org/infinispan/lock/PessimistTxFailureAfterLockingTest.java
+++ b/core/src/test/java/org/infinispan/lock/PessimistTxFailureAfterLockingTest.java
@@ -66,7 +66,7 @@ public class PessimistTxFailureAfterLockingTest extends MultipleCacheManagersTes
 
       assertTrue("Expected an exception", failed);
       assertNoTransactions();
-      assertNotLocked(cache(1), key);
+      assertEventuallyNotLocked(cache(1), key);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/lock/StaleEagerLocksOnPrepareFailureTest.java
+++ b/core/src/test/java/org/infinispan/lock/StaleEagerLocksOnPrepareFailureTest.java
@@ -85,10 +85,10 @@ public class StaleEagerLocksOnPrepareFailureTest extends MultipleCacheManagersTe
          // expected
       }
 
-      assertNotLocked(c1, k1);
-      assertNotLocked(c2, k1);
-      assertNotLocked(c1, k2);
-      assertNotLocked(c2, k2);
+      assertEventuallyNotLocked(c1, k1);
+      assertEventuallyNotLocked(c2, k1);
+      assertEventuallyNotLocked(c1, k2);
+      assertEventuallyNotLocked(c2, k2);
    }
 }
 

--- a/core/src/test/java/org/infinispan/lock/StaleLocksOnPrepareFailureTest.java
+++ b/core/src/test/java/org/infinispan/lock/StaleLocksOnPrepareFailureTest.java
@@ -58,7 +58,7 @@ public class StaleLocksOnPrepareFailureTest extends MultipleCacheManagersTest {
       }
 
       for (int i = 0; i < NUM_CACHES; i++) {
-        assertNotLocked(cache(i), k1);
+        assertEventuallyNotLocked(cache(i), k1);
       }
    }
 }

--- a/core/src/test/java/org/infinispan/lock/StaleLocksTransactionTest.java
+++ b/core/src/test/java/org/infinispan/lock/StaleLocksTransactionTest.java
@@ -55,7 +55,7 @@ public class StaleLocksTransactionTest extends MultipleCacheManagersTest {
       else
          tm(c1).rollback();
 
-      assertNotLocked(c1, "k");
-      assertNotLocked(c2, "k");
+      assertEventuallyNotLocked(c1, "k");
+      assertEventuallyNotLocked(c2, "k");
    }
 }

--- a/core/src/test/java/org/infinispan/lock/singlelock/AbstractInitiatorCrashTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/AbstractInitiatorCrashTest.java
@@ -31,8 +31,8 @@ public abstract class AbstractInitiatorCrashTest extends AbstractCrashTest {
       assert checkTxCount(1, 0, 0);
       assert checkTxCount(2, 0, 1);
 
-      assertNotLocked(cache(0), k);
-      assertNotLocked(cache(1), k);
+      assertEventuallyNotLocked(cache(0), k);
+      assertEventuallyNotLocked(cache(1), k);
       assertLocked(cache(2), k);
 
       killMember(1);
@@ -56,8 +56,8 @@ public abstract class AbstractInitiatorCrashTest extends AbstractCrashTest {
       transaction.runPrepare();
       tm(1).suspend();
 
-      assertNotLocked(cache(0), k);
-      assertNotLocked(cache(1), k);
+      assertEventuallyNotLocked(cache(0), k);
+      assertEventuallyNotLocked(cache(1), k);
       assertLocked(cache(2), k);
 
       checkTxCount(0, 0, 1);

--- a/core/src/test/java/org/infinispan/lock/singlelock/MainOwnerChangesPessimisticLockTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/MainOwnerChangesPessimisticLockTest.java
@@ -62,7 +62,7 @@ public class MainOwnerChangesPessimisticLockTest extends MultipleCacheManagersTe
    }
 
    private void testLockMigration(int nodeThatPuts, boolean commit) throws Exception {
-      Map<Object, Transaction> key2Tx = new HashMap<Object, Transaction>();
+      Map<Object, Transaction> key2Tx = new HashMap<>();
       for (int i = 0; i < NUM_KEYS; i++) {
          Object key = getKeyForCache(0);
          if (key2Tx.containsKey(key)) continue;
@@ -123,9 +123,9 @@ public class MainOwnerChangesPessimisticLockTest extends MultipleCacheManagersTe
          }
 
          // there should not be any locks
-         assertNotLocked(cache(0), migratedKey);
-         assertNotLocked(cache(1), migratedKey);
-         assertNotLocked(cache(2), migratedKey);
+         assertEventuallyNotLocked(cache(0), migratedKey);
+         assertEventuallyNotLocked(cache(1), migratedKey);
+         assertEventuallyNotLocked(cache(2), migratedKey);
 
          // if a new TX tries to write to the migrated key this should not fail, the key should not be locked
          tm(nodeThatPuts).begin();

--- a/core/src/test/java/org/infinispan/lock/singlelock/OriginatorBecomesOwnerLockTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/OriginatorBecomesOwnerLockTest.java
@@ -209,7 +209,7 @@ public class OriginatorBecomesOwnerLockTest extends MultipleCacheManagersTest {
 
 
    private void assertNoLocksOrTxs(Object key, Cache<Object, String> cache) {
-      assertNotLocked(originatorCache, key);
+      assertEventuallyNotLocked(originatorCache, key);
 
       final TransactionTable transactionTable = TestingUtil.extractComponent(cache, TransactionTable.class);
 

--- a/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/InitiatorCrashPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/pessimistic/InitiatorCrashPessimisticTest.java
@@ -31,15 +31,15 @@ public class InitiatorCrashPessimisticTest extends AbstractInitiatorCrashTest {
       cache(1).put(k2, "v2");
 
       assertLocked(cache(0), k0);
-      assertNotLocked(cache(1), k0);
-      assertNotLocked(cache(2), k0);
+      assertEventuallyNotLocked(cache(1), k0);
+      assertEventuallyNotLocked(cache(2), k0);
 
-      assertNotLocked(cache(0), k1);
+      assertEventuallyNotLocked(cache(0), k1);
       assertLocked(cache(1), k1);
-      assertNotLocked(cache(2), k1);
+      assertEventuallyNotLocked(cache(2), k1);
 
-      assertNotLocked(cache(0), k2);
-      assertNotLocked(cache(1), k2);
+      assertEventuallyNotLocked(cache(0), k2);
+      assertEventuallyNotLocked(cache(1), k2);
       assertLocked(cache(2), k2);
 
       assert checkTxCount(0, 0, 1);

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/optimistic/InitiatorCrashOptimisticReplTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/optimistic/InitiatorCrashOptimisticReplTest.java
@@ -34,8 +34,8 @@ public class InitiatorCrashOptimisticReplTest extends AbstractCrashTest {
       txControlInterceptor.commitReceived.await();
 
       assertLocked(cache(0), "k");
-      assertNotLocked(cache(1), "k");
-      assertNotLocked(cache(2), "k");
+      assertEventuallyNotLocked(cache(1), "k");
+      assertEventuallyNotLocked(cache(2), "k");
 
       checkTxCount(0, 0, 1);
       checkTxCount(1, 1, 0);
@@ -65,8 +65,8 @@ public class InitiatorCrashOptimisticReplTest extends AbstractCrashTest {
       assert checkTxCount(2, 0, 1);
 
       assertLocked(cache(0), "k");
-      assertNotLocked(cache(1), "k");
-      assertNotLocked(cache(2), "k");
+      assertEventuallyNotLocked(cache(1), "k");
+      assertEventuallyNotLocked(cache(2), "k");
 
       killMember(1);
 

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/InitiatorCrashPessimisticReplTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/InitiatorCrashPessimisticReplTest.java
@@ -31,8 +31,8 @@ public class InitiatorCrashPessimisticReplTest extends InitiatorCrashOptimisticR
       txControlInterceptor.preparedReceived.await();
 
       assertLocked(cache(0), key);
-      assertNotLocked(cache(1), key);
-      assertNotLocked(cache(2), key);
+      assertEventuallyNotLocked(cache(1), key);
+      assertEventuallyNotLocked(cache(2), key);
 
       checkTxCount(0, 0, 1);
       checkTxCount(1, 1, 0);
@@ -63,8 +63,8 @@ public class InitiatorCrashPessimisticReplTest extends InitiatorCrashOptimisticR
       assert checkTxCount(2, 0, 1);
 
       assertLocked(cache(0), key);
-      assertNotLocked(cache(1), key);
-      assertNotLocked(cache(2), key);
+      assertEventuallyNotLocked(cache(1), key);
+      assertEventuallyNotLocked(cache(2), key);
 
       killMember(1);
 

--- a/core/src/test/java/org/infinispan/partitionhandling/BaseOptimisticTxPartitionAndMergeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BaseOptimisticTxPartitionAndMergeTest.java
@@ -1,0 +1,79 @@
+package org.infinispan.partitionhandling;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.tx.TransactionBoundaryCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.tm.DummyTransactionManager;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * It tests multiple scenarios where a split can happen during a transaction.
+ *
+ * @author Pedro Ruivo
+ * @since 8.0
+ */
+public abstract class BaseOptimisticTxPartitionAndMergeTest extends BaseTxPartitionAndMergeTest {
+
+   protected static final String OPTIMISTIC_TX_CACHE_NAME = "opt-cache";
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      super.createCacheManagers();
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
+      builder.clustering().partitionHandling().enabled(true);
+      builder.transaction().lockingMode(LockingMode.OPTIMISTIC).transactionMode(TransactionMode.TRANSACTIONAL).transactionManagerLookup(new DummyTransactionManagerLookup());
+      defineConfigurationOnAllManagers(OPTIMISTIC_TX_CACHE_NAME, builder);
+   }
+
+   protected abstract void checkLocksDuringPartition(SplitMode splitMode, KeyInfo keyInfo, boolean discard);
+
+   protected abstract boolean forceRollback();
+
+   protected abstract Class<? extends TransactionBoundaryCommand> getCommandClass();
+
+   protected void doTest(final SplitMode splitMode, boolean txFail, boolean discard) throws Exception {
+      waitForClusterToForm(OPTIMISTIC_TX_CACHE_NAME);
+
+      final KeyInfo keyInfo = createKeys(OPTIMISTIC_TX_CACHE_NAME);
+      final Cache<Object, String> originator = cache(0, OPTIMISTIC_TX_CACHE_NAME);
+      final FilterCollection filterCollection = createFilters(OPTIMISTIC_TX_CACHE_NAME, discard, getCommandClass(), splitMode);
+
+      Future<Void> put = fork(() -> {
+         final DummyTransactionManager transactionManager = (DummyTransactionManager) originator.getAdvancedCache().getTransactionManager();
+         transactionManager.begin();
+         keyInfo.putFinalValue(originator);
+         final DummyTransaction transaction = transactionManager.getTransaction();
+         transaction.runPrepare();
+         transaction.runCommit(forceRollback());
+         transaction.throwRollbackExceptionIfAny();
+         return null;
+      });
+
+      filterCollection.await(30, TimeUnit.SECONDS);
+      splitMode.split(this);
+      filterCollection.unblock();
+
+      try {
+         put.get();
+         assertFalse(txFail);
+      } catch (ExecutionException e) {
+         assertTrue(txFail);
+      }
+
+      checkLocksDuringPartition(splitMode, keyInfo, discard);
+
+      mergeCluster();
+      finalAsserts(OPTIMISTIC_TX_CACHE_NAME, keyInfo, txFail ? INITIAL_VALUE : FINAL_VALUE);
+   }
+}

--- a/core/src/test/java/org/infinispan/partitionhandling/BasePessimisticTxPartitionAndMergeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BasePessimisticTxPartitionAndMergeTest.java
@@ -1,0 +1,83 @@
+package org.infinispan.partitionhandling;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.tx.TransactionBoundaryCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * It tests multiple scenarios where a split can happen during a transaction.
+ *
+ * @author Pedro Ruivo
+ * @since 8.0
+ */
+public abstract class BasePessimisticTxPartitionAndMergeTest extends BaseTxPartitionAndMergeTest {
+
+   protected static final String PESSIMISTIC_TX_CACHE_NAME = "pes-cache";
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      super.createCacheManagers();
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC);
+      builder.clustering().partitionHandling().enabled(true);
+      builder.transaction().lockingMode(LockingMode.PESSIMISTIC).transactionMode(TransactionMode.TRANSACTIONAL).transactionManagerLookup(new DummyTransactionManagerLookup());
+      defineConfigurationOnAllManagers(PESSIMISTIC_TX_CACHE_NAME, builder);
+   }
+
+   protected abstract void checkLocksDuringPartition(SplitMode splitMode, KeyInfo keyInfo, boolean discard);
+
+   protected abstract boolean forceRollback();
+
+   protected abstract Class<? extends TransactionBoundaryCommand> getCommandClass();
+
+   protected void doTest(final SplitMode splitMode, boolean txFail, boolean discard) throws Exception {
+      waitForClusterToForm(PESSIMISTIC_TX_CACHE_NAME);
+
+      final KeyInfo keyInfo = createKeys(PESSIMISTIC_TX_CACHE_NAME);
+      final Cache<Object, String> originator = cache(0, PESSIMISTIC_TX_CACHE_NAME);
+      final FilterCollection filterCollection = createFilters(PESSIMISTIC_TX_CACHE_NAME, discard, getCommandClass(), splitMode);
+
+      Future<Void> put = fork(() -> {
+         final TransactionManager transactionManager = originator.getAdvancedCache().getTransactionManager();
+         transactionManager.begin();
+         final Transaction tx = transactionManager.getTransaction();
+         try {
+            keyInfo.putFinalValue(originator);
+            if (forceRollback()) {
+               tx.setRollbackOnly();
+            }
+         } finally {
+            transactionManager.commit();
+         }
+         return null;
+      });
+
+      filterCollection.await(30, TimeUnit.SECONDS);
+      splitMode.split(this);
+      filterCollection.unblock();
+
+      try {
+         put.get();
+         assertFalse(txFail);
+      } catch (ExecutionException e) {
+         assertTrue(txFail);
+      }
+
+      checkLocksDuringPartition(splitMode, keyInfo, discard);
+
+      mergeCluster();
+      finalAsserts(PESSIMISTIC_TX_CACHE_NAME, keyInfo, txFail ? INITIAL_VALUE : FINAL_VALUE);
+   }
+}

--- a/core/src/test/java/org/infinispan/partitionhandling/BaseTxPartitionAndMergeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BaseTxPartitionAndMergeTest.java
@@ -1,0 +1,334 @@
+package org.infinispan.partitionhandling;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.remote.CacheRpcCommand;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.partitionhandling.impl.PartitionHandlingManager;
+import org.infinispan.remoting.inboundhandler.DeliverOrder;
+import org.infinispan.remoting.inboundhandler.PerCacheInboundInvocationHandler;
+import org.infinispan.remoting.inboundhandler.Reply;
+import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.concurrent.ReclosableLatch;
+import org.infinispan.util.concurrent.TimeoutException;
+import org.infinispan.util.concurrent.locks.LockManager;
+import org.infinispan.util.logging.Log;
+import org.testng.AssertJUnit;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.infinispan.test.TestingUtil.extractComponent;
+import static org.infinispan.test.TestingUtil.extractLockManager;
+import static org.infinispan.test.TestingUtil.wrapPerCacheInboundInvocationHandler;
+
+/**
+ * It tests multiple scenarios where a split can happen during a transaction.
+ *
+ * @author Pedro Ruivo
+ * @since 8.0
+ */
+public abstract class BaseTxPartitionAndMergeTest extends BasePartitionHandlingTest {
+
+   protected static final String INITIAL_VALUE = "init-value";
+   protected static final String FINAL_VALUE = "final-value";
+
+   private static NotifierFilter notifyCommandOn(Cache<?, ?> cache, Class<? extends CacheRpcCommand> blockClass) {
+      NotifierFilter filter = new NotifierFilter(blockClass);
+      wrapAndApplyFilter(cache, filter);
+      return filter;
+   }
+
+   private static BlockingFilter blockCommandOn(Cache<?, ?> cache, Class<? extends CacheRpcCommand> blockClass) {
+      BlockingFilter filter = new BlockingFilter(blockClass);
+      wrapAndApplyFilter(cache, filter);
+      return filter;
+   }
+
+   private static DiscardFilter discardCommandOn(Cache<?, ?> cache, Class<? extends CacheRpcCommand> blockClass) {
+      DiscardFilter filter = new DiscardFilter(blockClass);
+      wrapAndApplyFilter(cache, filter);
+      return filter;
+   }
+
+   private static void wrapAndApplyFilter(Cache<?, ?> cache, Filter filter) {
+      ControlledInboundHandler controlledInboundHandler = wrapPerCacheInboundInvocationHandler(cache, (wrapOn, current) -> new ControlledInboundHandler(current), true);
+      controlledInboundHandler.filter = filter;
+   }
+
+   protected FilterCollection createFilters(String cacheName, boolean discard, Class<? extends CacheRpcCommand> commandClass, SplitMode splitMode) {
+      Collection<AwaitAndUnblock> collection = new ArrayList<>(2);
+      if (splitMode == SplitMode.ORIGINATOR_ISOLATED) {
+         if (discard) {
+            collection.add(discardCommandOn(cache(1, cacheName), commandClass));
+            collection.add(discardCommandOn(cache(2, cacheName), commandClass));
+         } else {
+            collection.add(blockCommandOn(cache(1, cacheName), commandClass));
+            collection.add(blockCommandOn(cache(2, cacheName), commandClass));
+         }
+      } else {
+         collection.add(notifyCommandOn(cache(1, cacheName), commandClass));
+         if (discard) {
+            collection.add(discardCommandOn(cache(2, cacheName), commandClass));
+         } else {
+            collection.add(blockCommandOn(cache(2, cacheName), commandClass));
+         }
+      }
+      return new FilterCollection(collection);
+   }
+
+   protected abstract Log getLog();
+
+   protected void mergeCluster() {
+      getLog().debugf("Merging cluster");
+      partition(0).merge(partition(1));
+      getLog().debugf("Cluster merged");
+   }
+
+   protected void finalAsserts(String cacheName, KeyInfo keyInfo, String value) {
+      assertNoTransactions(cacheName);
+      assertNoTransactionsInPartitionHandler(cacheName);
+      assertNoLocks(cacheName);
+
+      assertValue(keyInfo.getKey1(), value, this.<Object, String>caches(cacheName));
+      assertValue(keyInfo.getKey2(), value, this.<Object, String>caches(cacheName));
+   }
+
+   protected void assertNoLocks(String cacheName) {
+      eventually("Expected no locks acquired in all nodes.", () -> {
+         for (Cache<?, ?> cache : caches(cacheName)) {
+            LockManager lockManager = extractLockManager(cache);
+            getLog().tracef("Locks info=%s", lockManager.printLockInfo());
+            if (lockManager.getNumberOfLocksHeld() != 0) {
+               getLog().warnf("Locks acquired on cache '%s'", cache);
+               return false;
+            }
+         }
+         return true;
+      }, 30000, 500, TimeUnit.MILLISECONDS);
+   }
+
+   protected void assertValue(Object key, String value, Collection<Cache<Object, String>> caches) {
+      for (Cache<Object, String> cache : caches) {
+         AssertJUnit.assertEquals("Wrong value in cache " + address(cache), value, cache.get(key));
+      }
+   }
+
+   protected KeyInfo createKeys(String cacheName) {
+      final Object key1 = new MagicKey("k1", cache(1, cacheName), cache(2, cacheName));
+      final Object key2 = new MagicKey("k2", cache(2, cacheName), cache(1, cacheName));
+      cache(1, cacheName).put(key1, INITIAL_VALUE);
+      cache(2, cacheName).put(key2, INITIAL_VALUE);
+      return new KeyInfo(key1, key2);
+   }
+
+   private void assertNoTransactionsInPartitionHandler(final String cacheName) {
+      eventually("Transactions pending in PartitionHandlingManager", () -> {
+         for (Cache<?, ?> cache : caches(cacheName)) {
+            Collection<GlobalTransaction> partialTransactions = extractComponent(cache, PartitionHandlingManager.class).getPartialTransactions();
+            if (!partialTransactions.isEmpty()) {
+               getLog().debugf("transactions not finished in %s. %s", address(cache), partialTransactions);
+               return false;
+            }
+         }
+         return true;
+      });
+   }
+
+   protected enum SplitMode {
+      ORIGINATOR_ISOLATED {
+         @Override
+         public void split(BaseTxPartitionAndMergeTest test) {
+            test.getLog().debug("Splitting cluster isolating the originator.");
+            test.splitCluster(new int[]{0}, new int[]{1, 2, 3});
+            test.getLog().debug("Cluster split.");
+         }
+      },
+      BOTH_DEGRADED {
+         @Override
+         public void split(BaseTxPartitionAndMergeTest test) {
+            test.getLog().debug("Splitting cluster in equal partition");
+            test.splitCluster(new int[]{0, 1}, new int[]{2, 3});
+            test.getLog().debug("Cluster split.");
+         }
+      },
+      PRIMARY_OWNER_ISOLATED {
+         @Override
+         public void split(BaseTxPartitionAndMergeTest test) {
+            test.getLog().debug("Splitting cluster isolating a primary owner.");
+            test.splitCluster(new int[]{2}, new int[]{0, 1, 3});
+            test.getLog().debug("Cluster split.");
+         }
+      };
+
+      public abstract void split(BaseTxPartitionAndMergeTest test);
+   }
+
+   private interface AwaitAndUnblock {
+      void await(long timeout, TimeUnit timeUnit) throws InterruptedException;
+
+      void unblock();
+   }
+
+   private interface Filter extends AwaitAndUnblock {
+      boolean before(CacheRpcCommand command, Reply reply, DeliverOrder order);
+   }
+
+   private static class ControlledInboundHandler implements PerCacheInboundInvocationHandler {
+
+      private final PerCacheInboundInvocationHandler delegate;
+      private volatile Filter filter;
+
+      private ControlledInboundHandler(PerCacheInboundInvocationHandler delegate) {
+         this.delegate = delegate;
+      }
+
+      @Override
+      public void handle(CacheRpcCommand command, Reply reply, DeliverOrder order) {
+         final Filter currentFilter = filter;
+         if (currentFilter != null && currentFilter.before(command, reply, order)) {
+            delegate.handle(command, reply, order);
+         }
+      }
+   }
+
+   private static class BlockingFilter implements Filter {
+
+      private final Class<? extends CacheRpcCommand> aClass;
+      private final ReclosableLatch notifier;
+      private final ReclosableLatch blocker;
+
+      private BlockingFilter(Class<? extends CacheRpcCommand> aClass) {
+         this.aClass = aClass;
+         blocker = new ReclosableLatch(false);
+         notifier = new ReclosableLatch(false);
+      }
+
+      @Override
+      public boolean before(CacheRpcCommand command, Reply reply, DeliverOrder order) {
+         if (aClass.isAssignableFrom(command.getClass())) {
+            notifier.open();
+            try {
+               blocker.await();
+            } catch (InterruptedException e) {
+               Thread.currentThread().interrupt();
+            }
+         }
+         return true;
+      }
+
+      public void await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+         if (!notifier.await(timeout, timeUnit)) {
+            throw new TimeoutException();
+         }
+      }
+
+      public void unblock() {
+         blocker.open();
+      }
+   }
+
+   private static class NotifierFilter implements Filter {
+
+      private final Class<? extends CacheRpcCommand> aClass;
+      private final CountDownLatch notifier;
+
+      private NotifierFilter(Class<? extends CacheRpcCommand> aClass) {
+         this.aClass = aClass;
+         notifier = new CountDownLatch(1);
+      }
+
+      @Override
+      public boolean before(CacheRpcCommand command, Reply reply, DeliverOrder order) {
+         if (aClass.isAssignableFrom(command.getClass())) {
+            notifier.countDown();
+         }
+         return true;
+      }
+
+      public void await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+         if (!notifier.await(timeout, timeUnit)) {
+            throw new TimeoutException();
+         }
+      }
+
+      @Override
+      public void unblock() {
+         /*no-op*/
+      }
+   }
+
+   private static class DiscardFilter implements Filter {
+
+      private final Class<? extends CacheRpcCommand> aClass;
+      private final ReclosableLatch notifier;
+
+      private DiscardFilter(Class<? extends CacheRpcCommand> aClass) {
+         this.aClass = aClass;
+         notifier = new ReclosableLatch(false);
+      }
+
+      @Override
+      public boolean before(CacheRpcCommand command, Reply reply, DeliverOrder order) {
+         if (!notifier.isOpened() && aClass.isAssignableFrom(command.getClass())) {
+            notifier.open();
+            return false;
+         }
+         return true;
+      }
+
+      public void await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+         if (!notifier.await(timeout, timeUnit)) {
+            throw new TimeoutException();
+         }
+      }
+
+      @Override
+      public void unblock() {
+         /*no-op*/
+      }
+   }
+
+   protected static class KeyInfo {
+      private final Object key1;
+      private final Object key2;
+
+      public KeyInfo(Object key1, Object key2) {
+         this.key1 = key1;
+         this.key2 = key2;
+      }
+
+      public void putFinalValue(Cache<Object, String> cache) {
+         cache.put(key1, FINAL_VALUE);
+         cache.put(key2, FINAL_VALUE);
+      }
+
+      public Object getKey1() {
+         return key1;
+      }
+
+      public Object getKey2() {
+         return key2;
+      }
+   }
+
+   protected static class FilterCollection implements AwaitAndUnblock {
+      private final Collection<AwaitAndUnblock> collection;
+
+      public FilterCollection(Collection<AwaitAndUnblock> collection) {
+         this.collection = collection;
+      }
+
+      @Override
+      public void await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+         for (AwaitAndUnblock await : collection) {
+            await.await(timeout, timeUnit);
+         }
+      }
+
+      public void unblock() {
+         collection.forEach(BaseTxPartitionAndMergeTest.AwaitAndUnblock::unblock);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/partitionhandling/OptimisticTxPartitionAndMergeDuringCommitTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/OptimisticTxPartitionAndMergeDuringCommitTest.java
@@ -1,0 +1,94 @@
+package org.infinispan.partitionhandling;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.tx.CommitCommand;
+import org.infinispan.commands.tx.TransactionBoundaryCommand;
+import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+/**
+ * It tests multiple scenarios where a split can happen during a transaction.
+ *
+ * @author Pedro Ruivo
+ * @since 8.0
+ */
+@Test(groups = "functional", testName = "partitionhandling.OptimisticTxPartitionAndMergeDuringCommitTest")
+public class OptimisticTxPartitionAndMergeDuringCommitTest extends BaseOptimisticTxPartitionAndMergeTest {
+
+   private static final Log log = LogFactory.getLog(OptimisticTxPartitionAndMergeDuringCommitTest.class);
+
+   public void testDegradedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.BOTH_DEGRADED, false, true);
+   }
+
+   public void testDegradedPartition() throws Exception {
+      doTest(SplitMode.BOTH_DEGRADED, false, false);
+   }
+
+   public void testOriginatorIsolatedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.ORIGINATOR_ISOLATED, false, true);
+   }
+
+   public void testOriginatorIsolatedPartition() throws Exception {
+      doTest(SplitMode.ORIGINATOR_ISOLATED, false, false);
+   }
+
+   public void testPrimaryOwnerIsolatedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.PRIMARY_OWNER_ISOLATED, false, true);
+   }
+
+   public void testPrimaryOwnerIsolatedPartition() throws Exception {
+      doTest(SplitMode.PRIMARY_OWNER_ISOLATED, false, false);
+   }
+
+   public void testSplitBeforeCommit() throws Exception {
+      //the transaction is successfully prepare and then the split happens before the commit phase starts.
+      waitForClusterToForm(OPTIMISTIC_TX_CACHE_NAME);
+      final KeyInfo keyInfo = createKeys(OPTIMISTIC_TX_CACHE_NAME);
+      final Cache<Object, String> originator = cache(0, OPTIMISTIC_TX_CACHE_NAME);
+
+      final DummyTransactionManager transactionManager = (DummyTransactionManager) originator.getAdvancedCache().getTransactionManager();
+      transactionManager.begin();
+      final DummyTransaction transaction = transactionManager.getTransaction();
+      keyInfo.putFinalValue(originator);
+      AssertJUnit.assertTrue(transaction.runPrepare());
+      transactionManager.suspend();
+
+      SplitMode.BOTH_DEGRADED.split(this);
+
+      transactionManager.resume(transaction);
+      transaction.runCommit(false);
+
+      assertLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+      assertLocked(cache(2, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+
+      mergeCluster();
+      finalAsserts(OPTIMISTIC_TX_CACHE_NAME, keyInfo, FINAL_VALUE);
+   }
+
+   @Override
+   protected void checkLocksDuringPartition(SplitMode splitMode, KeyInfo keyInfo, boolean discard) {
+      //on both caches, the key is locked and it is unlocked after the merge
+      assertLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+      assertLocked(cache(2, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+   }
+
+   @Override
+   protected boolean forceRollback() {
+      return false;
+   }
+
+   @Override
+   protected Class<? extends TransactionBoundaryCommand> getCommandClass() {
+      return CommitCommand.class;
+   }
+
+   @Override
+   protected Log getLog() {
+      return log;
+   }
+}

--- a/core/src/test/java/org/infinispan/partitionhandling/OptimisticTxPartitionAndMergeDuringPrepareTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/OptimisticTxPartitionAndMergeDuringPrepareTest.java
@@ -1,0 +1,78 @@
+package org.infinispan.partitionhandling;
+
+import org.infinispan.commands.tx.PrepareCommand;
+import org.infinispan.commands.tx.TransactionBoundaryCommand;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.testng.annotations.Test;
+
+/**
+ * It tests multiple scenarios where a split can happen during a transaction.
+ *
+ * @author Pedro Ruivo
+ * @since 8.0
+ */
+@Test(groups = "functional", testName = "partitionhandling.OptimisticTxPartitionAndMergeDuringPrepareTest")
+public class OptimisticTxPartitionAndMergeDuringPrepareTest extends BaseOptimisticTxPartitionAndMergeTest {
+
+   private static final Log log = LogFactory.getLog(OptimisticTxPartitionAndMergeDuringPrepareTest.class);
+
+   public void testDegradedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.BOTH_DEGRADED, true, true);
+   }
+
+   public void testDegradedPartition() throws Exception {
+      doTest(SplitMode.BOTH_DEGRADED, true, false);
+   }
+
+   public void testOriginatorIsolatedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.ORIGINATOR_ISOLATED, true, true);
+   }
+
+   public void testOriginatorIsolatedPartition() throws Exception {
+      doTest(SplitMode.ORIGINATOR_ISOLATED, true, false);
+   }
+
+   public void testPrimaryOwnerIsolatedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.PRIMARY_OWNER_ISOLATED, false, true);
+   }
+
+   public void testPrimaryOwnerIsolatedPartition() throws Exception {
+      doTest(SplitMode.PRIMARY_OWNER_ISOLATED, false, false);
+   }
+
+   @Override
+   protected void checkLocksDuringPartition(SplitMode splitMode, KeyInfo keyInfo, boolean discard) {
+      switch (splitMode) {
+         case ORIGINATOR_ISOLATED:
+            //they assume that the originator has crashed, so the prepare is never processed.
+            assertEventuallyNotLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+            break;
+         case PRIMARY_OWNER_ISOLATED:
+            //the originator can recover and will retry the prepare command until it succeeds.
+            assertEventuallyNotLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+            break;
+         case BOTH_DEGRADED:
+            //with the new changes, the rollback succeeds on the originator partition. Cache1 releases the lock.
+            assertEventuallyNotLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+            break;
+      }
+      //or the prepare is never received, so key never locked, or it is received and it decides to rollback the transaction.
+      assertEventuallyNotLocked(cache(2, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+   }
+
+   @Override
+   protected boolean forceRollback() {
+      return false;
+   }
+
+   @Override
+   protected Class<? extends TransactionBoundaryCommand> getCommandClass() {
+      return PrepareCommand.class;
+   }
+
+   @Override
+   protected Log getLog() {
+      return log;
+   }
+}

--- a/core/src/test/java/org/infinispan/partitionhandling/OptimisticTxPartitionAndMergeDuringRollbackTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/OptimisticTxPartitionAndMergeDuringRollbackTest.java
@@ -1,0 +1,105 @@
+package org.infinispan.partitionhandling;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.tx.RollbackCommand;
+import org.infinispan.commands.tx.TransactionBoundaryCommand;
+import org.infinispan.transaction.tm.DummyTransaction;
+import org.infinispan.transaction.tm.DummyTransactionManager;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+/**
+ * It tests multiple scenarios where a split can happen during a transaction.
+ *
+ * @author Pedro Ruivo
+ * @since 8.0
+ */
+@Test(groups = "functional", testName = "partitionhandling.OptimisticTxPartitionAndMergeDuringRollbackTest")
+public class OptimisticTxPartitionAndMergeDuringRollbackTest extends BaseOptimisticTxPartitionAndMergeTest {
+
+   private static final Log log = LogFactory.getLog(OptimisticTxPartitionAndMergeDuringRollbackTest.class);
+
+   public void testDegradedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.BOTH_DEGRADED, true, true);
+   }
+
+   public void testDegradedPartition() throws Exception {
+      doTest(SplitMode.BOTH_DEGRADED, true, false);
+   }
+
+   public void testOriginatorIsolatedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.ORIGINATOR_ISOLATED, true, true);
+   }
+
+   public void testOriginatorIsolatedPartition() throws Exception {
+      doTest(SplitMode.ORIGINATOR_ISOLATED, true, false);
+   }
+
+   public void testPrimaryOwnerIsolatedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.PRIMARY_OWNER_ISOLATED, true, true);
+   }
+
+   public void testPrimaryOwnerIsolatedPartition() throws Exception {
+      doTest(SplitMode.PRIMARY_OWNER_ISOLATED, true, false);
+   }
+
+   public void testSplitBeforeRollback() throws Exception {
+      //the transaction is successfully prepare and then the split happens before the commit phase starts.
+      waitForClusterToForm(OPTIMISTIC_TX_CACHE_NAME);
+      final KeyInfo keyInfo = createKeys(OPTIMISTIC_TX_CACHE_NAME);
+      final Cache<Object, String> originator = cache(0, OPTIMISTIC_TX_CACHE_NAME);
+
+      final DummyTransactionManager transactionManager = (DummyTransactionManager) originator.getAdvancedCache().getTransactionManager();
+      transactionManager.begin();
+      final DummyTransaction transaction = transactionManager.getTransaction();
+      keyInfo.putFinalValue(originator);
+      AssertJUnit.assertTrue(transaction.runPrepare());
+      transactionManager.suspend();
+
+      SplitMode.BOTH_DEGRADED.split(this);
+
+      transactionManager.resume(transaction);
+      transaction.runCommit(true);
+
+      assertEventuallyNotLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+      assertLocked(cache(2, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+
+      mergeCluster();
+      finalAsserts(OPTIMISTIC_TX_CACHE_NAME, keyInfo, INITIAL_VALUE);
+   }
+
+   @Override
+   protected void checkLocksDuringPartition(SplitMode splitMode, KeyInfo keyInfo, boolean discard) {
+      if (splitMode == SplitMode.ORIGINATOR_ISOLATED && discard) {
+         //rollback never received, so key is locked until the merge occurs.
+         assertLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+      } else {
+         //key is unlocked because the rollback is always received in cache1
+         assertEventuallyNotLocked(cache(1, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+      }
+      if (discard) {
+         //rollback never received, so key is locked until the merge occurs.
+         assertLocked(cache(2, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+      } else {
+         //rollback received, so key is unlocked
+         assertEventuallyNotLocked(cache(2, OPTIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+      }
+   }
+
+   @Override
+   protected boolean forceRollback() {
+      return true;
+   }
+
+   @Override
+   protected Class<? extends TransactionBoundaryCommand> getCommandClass() {
+      return RollbackCommand.class;
+   }
+
+   @Override
+   protected Log getLog() {
+      return log;
+   }
+}

--- a/core/src/test/java/org/infinispan/partitionhandling/PessimisticTxPartitionAndMergeDuringPrepareTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/PessimisticTxPartitionAndMergeDuringPrepareTest.java
@@ -1,0 +1,99 @@
+package org.infinispan.partitionhandling;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.tx.PrepareCommand;
+import org.infinispan.commands.tx.TransactionBoundaryCommand;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.testng.annotations.Test;
+
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+
+/**
+ * It tests multiple scenarios where a split can happen during a transaction.
+ *
+ * @author Pedro Ruivo
+ * @since 8.0
+ */
+@Test(groups = "functional", testName = "partitionhandling.PessimisticTxPartitionAndMergeDuringPrepareTest")
+public class PessimisticTxPartitionAndMergeDuringPrepareTest extends BasePessimisticTxPartitionAndMergeTest {
+
+   private static final Log log = LogFactory.getLog(PessimisticTxPartitionAndMergeDuringPrepareTest.class);
+
+   public void testDegradedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.BOTH_DEGRADED, false, true);
+   }
+
+   public void testDegradedPartition() throws Exception {
+      doTest(SplitMode.BOTH_DEGRADED, false, false);
+   }
+
+   public void testOriginatorIsolatedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.ORIGINATOR_ISOLATED, false, true);
+   }
+
+   public void testOriginatorIsolatedPartition() throws Exception {
+      doTest(SplitMode.ORIGINATOR_ISOLATED, false, false);
+   }
+
+   public void testPrimaryOwnerIsolatedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.PRIMARY_OWNER_ISOLATED, false, true);
+   }
+
+   public void testPrimaryOwnerIsolatedPartition() throws Exception {
+      doTest(SplitMode.PRIMARY_OWNER_ISOLATED, false, false);
+   }
+
+   public void testSplitBeforePrepare() throws Exception {
+      //split happens before the commit() or rollback(). Locks are acquired
+      waitForClusterToForm(PESSIMISTIC_TX_CACHE_NAME);
+
+      final KeyInfo keyInfo = createKeys(PESSIMISTIC_TX_CACHE_NAME);
+      final Cache<Object, String> originator = cache(0, PESSIMISTIC_TX_CACHE_NAME);
+
+      final TransactionManager transactionManager = originator.getAdvancedCache().getTransactionManager();
+      transactionManager.begin();
+      keyInfo.putFinalValue(originator);
+      final Transaction transaction = transactionManager.suspend();
+
+      SplitMode.BOTH_DEGRADED.split(this);
+
+      transactionManager.resume(transaction);
+      transactionManager.commit();
+
+      assertLocked(cache(1, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+      assertLocked(cache(2, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+
+      mergeCluster();
+      finalAsserts(PESSIMISTIC_TX_CACHE_NAME, keyInfo, FINAL_VALUE);
+   }
+
+   @Override
+   protected void checkLocksDuringPartition(SplitMode splitMode, KeyInfo keyInfo, boolean discard) {
+      //always locked: locks acquired in runtime
+      assertLocked(cache(1, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+      if (discard) {
+         //locks are acquired during runtime
+         assertLocked(cache(2, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+      } else {
+         //prepare will succeed, but the locks are not released (the TxCompletionNotificationCommand will do it)
+         assertLocked(cache(2, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+      }
+   }
+
+   @Override
+   protected boolean forceRollback() {
+      return false;
+   }
+
+   @Override
+   protected Class<? extends TransactionBoundaryCommand> getCommandClass() {
+      return PrepareCommand.class;
+   }
+
+   @Override
+   protected Log getLog() {
+      return log;
+   }
+}

--- a/core/src/test/java/org/infinispan/partitionhandling/PessimisticTxPartitionAndMergeDuringRollbackTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/PessimisticTxPartitionAndMergeDuringRollbackTest.java
@@ -1,0 +1,109 @@
+package org.infinispan.partitionhandling;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.tx.RollbackCommand;
+import org.infinispan.commands.tx.TransactionBoundaryCommand;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.testng.annotations.Test;
+
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+
+/**
+ * It tests multiple scenarios where a split can happen during a transaction.
+ *
+ * @author Pedro Ruivo
+ * @since 8.0
+ */
+@Test(groups = "functional", testName = "partitionhandling.PessimisticTxPartitionAndMergeDuringRollbackTest")
+public class PessimisticTxPartitionAndMergeDuringRollbackTest extends BasePessimisticTxPartitionAndMergeTest {
+
+   private static final Log log = LogFactory.getLog(PessimisticTxPartitionAndMergeDuringRollbackTest.class);
+
+   public void testDegradedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.BOTH_DEGRADED, true, true);
+   }
+
+   public void testDegradedPartition() throws Exception {
+      doTest(SplitMode.BOTH_DEGRADED, true, false);
+   }
+
+   public void testOriginatorIsolatedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.ORIGINATOR_ISOLATED, true, true);
+   }
+
+   public void testOriginatorIsolatedPartition() throws Exception {
+      doTest(SplitMode.ORIGINATOR_ISOLATED, true, false);
+   }
+
+   public void testPrimaryOwnerIsolatedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.PRIMARY_OWNER_ISOLATED, true, true);
+   }
+
+   public void testPrimaryOwnerIsolatedPartition() throws Exception {
+      doTest(SplitMode.PRIMARY_OWNER_ISOLATED, true, false);
+   }
+
+   public void testSplitBeforeRollback() throws Exception {
+      //split happens before the commit() or rollback(). Locks are acquired
+      waitForClusterToForm(PESSIMISTIC_TX_CACHE_NAME);
+
+      final KeyInfo keyInfo = createKeys(PESSIMISTIC_TX_CACHE_NAME);
+      final Cache<Object, String> originator = cache(0, PESSIMISTIC_TX_CACHE_NAME);
+
+      final TransactionManager transactionManager = originator.getAdvancedCache().getTransactionManager();
+      transactionManager.begin();
+      keyInfo.putFinalValue(originator);
+      final Transaction transaction = transactionManager.suspend();
+
+      SplitMode.BOTH_DEGRADED.split(this);
+
+      transactionManager.resume(transaction);
+      transactionManager.rollback();
+
+      assertEventuallyNotLocked(cache(1, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+      assertLocked(cache(2, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+
+      mergeCluster();
+      finalAsserts(PESSIMISTIC_TX_CACHE_NAME, keyInfo, INITIAL_VALUE);
+   }
+
+   @Override
+   protected void checkLocksDuringPartition(SplitMode splitMode, KeyInfo keyInfo, boolean discard) {
+      if (splitMode == SplitMode.ORIGINATOR_ISOLATED) {
+         if (discard) {
+            //rollback is never received.
+            assertLocked(cache(1, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+         } else {
+            //rollback can be delivered
+            assertEventuallyNotLocked(cache(1, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+         }
+      } else {
+         //key is unlocked because the rollback is always received in cache1
+         assertEventuallyNotLocked(cache(1, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+      }
+      if (discard) {
+         //rollback never received, so key is locked until the merge occurs.
+         assertLocked(cache(2, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+      } else {
+         //rollback received, so key is unlocked
+         assertEventuallyNotLocked(cache(2, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+      }
+   }
+
+   @Override
+   protected boolean forceRollback() {
+      return true;
+   }
+
+   @Override
+   protected Class<? extends TransactionBoundaryCommand> getCommandClass() {
+      return RollbackCommand.class;
+   }
+
+   @Override
+   protected Log getLog() {
+      return log;
+   }
+}

--- a/core/src/test/java/org/infinispan/partitionhandling/PessimisticTxPartitionAndMergeDuringRuntimeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/PessimisticTxPartitionAndMergeDuringRuntimeTest.java
@@ -1,0 +1,76 @@
+package org.infinispan.partitionhandling;
+
+import org.infinispan.commands.control.LockControlCommand;
+import org.infinispan.commands.tx.TransactionBoundaryCommand;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.testng.annotations.Test;
+
+/**
+ * It tests multiple scenarios where a split can happen during a transaction.
+ *
+ * @author Pedro Ruivo
+ * @since 8.0
+ */
+@Test(groups = "functional", testName = "partitionhandling.PessimisticTxPartitionAndMergeDuringRuntimeTest")
+public class PessimisticTxPartitionAndMergeDuringRuntimeTest extends BasePessimisticTxPartitionAndMergeTest {
+
+   private static final Log log = LogFactory.getLog(PessimisticTxPartitionAndMergeDuringRuntimeTest.class);
+
+   public void testDegradedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.BOTH_DEGRADED, true, true);
+   }
+
+   public void testDegradedPartition() throws Exception {
+      doTest(SplitMode.BOTH_DEGRADED, true, false);
+   }
+
+   public void testOriginatorIsolatedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.ORIGINATOR_ISOLATED, true, true);
+   }
+
+   public void testOriginatorIsolatedPartition() throws Exception {
+      doTest(SplitMode.ORIGINATOR_ISOLATED, true, false);
+   }
+
+   public void testPrimaryOwnerIsolatedPartitionWithDiscard() throws Exception {
+      doTest(SplitMode.PRIMARY_OWNER_ISOLATED, false, true);
+   }
+
+   public void testPrimaryOwnerIsolatedPartition() throws Exception {
+      doTest(SplitMode.PRIMARY_OWNER_ISOLATED, false, false);
+   }
+
+   @Override
+   protected void checkLocksDuringPartition(SplitMode splitMode, KeyInfo keyInfo, boolean discard) {
+      switch (splitMode) {
+         case ORIGINATOR_ISOLATED:
+            //lock command never received or ignored because the originator is in another partition
+            //(safe because we will rollback anyway)
+            assertEventuallyNotLocked(cache(1, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+         case BOTH_DEGRADED:
+            //originator rollbacks which is received by cache1
+            assertEventuallyNotLocked(cache(1, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+         case PRIMARY_OWNER_ISOLATED:
+            //originator can commit the transaction, key is eventually unlocked
+            assertEventuallyNotLocked(cache(1, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey1());
+      }
+      //lock command is discarded since the transaction originator is missing
+      assertEventuallyNotLocked(cache(2, PESSIMISTIC_TX_CACHE_NAME), keyInfo.getKey2());
+   }
+
+   @Override
+   protected boolean forceRollback() {
+      return false;
+   }
+
+   @Override
+   protected Class<? extends TransactionBoundaryCommand> getCommandClass() {
+      return LockControlCommand.class;
+   }
+
+   @Override
+   protected Log getLog() {
+      return log;
+   }
+}

--- a/core/src/test/java/org/infinispan/replication/AsyncReplTest.java
+++ b/core/src/test/java/org/infinispan/replication/AsyncReplTest.java
@@ -22,8 +22,8 @@ public class AsyncReplTest extends MultipleCacheManagersTest {
 
    public void testWithNoTx() throws Exception {
 
-      Cache cache1 = cache(0,"asyncRepl");
-      Cache cache2 = cache(1,"asyncRepl");
+      Cache<String, String> cache1 = cache(0,"asyncRepl");
+      Cache<String, String> cache2 = cache(1,"asyncRepl");
       String key = "key";
 
       replListener(cache2).expect(PutKeyValueCommand.class);
@@ -44,15 +44,15 @@ public class AsyncReplTest extends MultipleCacheManagersTest {
    }
 
    public void testWithTx() throws Exception {
-      Cache cache1 = cache(0,"asyncRepl");
-      Cache cache2 = cache(1,"asyncRepl");
+      Cache<String, String> cache1 = cache(0,"asyncRepl");
+      Cache<String, String> cache2 = cache(1,"asyncRepl");
       
       String key = "key";
       replListener(cache2).expect(PutKeyValueCommand.class);
       cache1.put(key, "value1");
       // allow for replication
       replListener(cache2).waitForRpc();
-      assertNotLocked(cache1, key);
+      assertEventuallyNotLocked(cache1, key);
 
       assertEquals("value1", cache1.get(key));
       assertEquals("value1", cache2.get(key));
@@ -65,7 +65,7 @@ public class AsyncReplTest extends MultipleCacheManagersTest {
       assertEquals("value1", cache2.get(key));
       mgr.commit();
       replListener(cache2).waitForRpc();
-      assertNotLocked(cache1, key);
+      assertEventuallyNotLocked(cache1, key);
 
       assertEquals("value2", cache1.get(key));
       assertEquals("value2", cache2.get(key));
@@ -80,13 +80,13 @@ public class AsyncReplTest extends MultipleCacheManagersTest {
       assertEquals("value2", cache1.get(key));
       assertEquals("value2", cache2.get(key));
 
-      assertNotLocked(cache1, key);
+      assertEventuallyNotLocked(cache1, key);
 
    }
 
    public void simpleTest() throws Exception {
-      Cache cache1 = cache(0,"asyncRepl");
-      Cache cache2 = cache(1,"asyncRepl");
+      Cache<String, String> cache1 = cache(0,"asyncRepl");
+      cache(1, "asyncRepl");
       
       String key = "key";
       TransactionManager mgr = TestingUtil.getTransactionManager(cache1);
@@ -95,7 +95,7 @@ public class AsyncReplTest extends MultipleCacheManagersTest {
       cache1.put(key, "value3");
       mgr.rollback();
 
-      assertNotLocked(cache1, key);
+      assertEventuallyNotLocked(cache1, key);
 
    }
 }

--- a/core/src/test/java/org/infinispan/replication/SyncReplLockingTest.java
+++ b/core/src/test/java/org/infinispan/replication/SyncReplLockingTest.java
@@ -81,8 +81,8 @@ public class SyncReplLockingTest extends MultipleCacheManagersTest {
       cache1.get(k);
       mgr.commit();
 
-      assertNotLocked(cache1, "testcache");
-      assertNotLocked(cache2, "testcache");
+      assertEventuallyNotLocked(cache1, "testcache");
+      assertEventuallyNotLocked(cache2, "testcache");
 
       assert cache1.isEmpty();
       assert cache2.isEmpty();
@@ -111,8 +111,8 @@ public class SyncReplLockingTest extends MultipleCacheManagersTest {
 		assertNull("Should be null", cache1.get(k));
 		mgr.commit();
 
-		assertNotLocked(cache1, "testcache");
-		assertNotLocked(cache2, "testcache");
+		assertEventuallyNotLocked(cache1, "testcache");
+		assertEventuallyNotLocked(cache2, "testcache");
 
 		assert cache1.isEmpty();
 		assert cache2.isEmpty();

--- a/core/src/test/java/org/infinispan/statetransfer/StaleLocksWithCommitDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StaleLocksWithCommitDuringStateTransferTest.java
@@ -124,10 +124,10 @@ public class StaleLocksWithCommitDuringStateTransferTest extends MultipleCacheMa
       }
 
       // test that we don't leak locks
-      assertNotLocked(c1, k1);
-      assertNotLocked(c2, k1);
-      assertNotLocked(c1, k2);
-      assertNotLocked(c2, k2);
+      assertEventuallyNotLocked(c1, k1);
+      assertEventuallyNotLocked(c2, k1);
+      assertEventuallyNotLocked(c1, k2);
+      assertEventuallyNotLocked(c2, k2);
    }
 
    public void testRollbackSuspectFailure() throws Exception {
@@ -201,7 +201,7 @@ public class StaleLocksWithCommitDuringStateTransferTest extends MultipleCacheMa
       }
 
       // test that we don't leak locks
-      assertNotLocked(c1, k1);
-      assertNotLocked(c1, k2);
+      assertEventuallyNotLocked(c1, k1);
+      assertEventuallyNotLocked(c1, k2);
    }
 }

--- a/core/src/test/java/org/infinispan/test/AbstractCacheTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractCacheTest.java
@@ -7,7 +7,11 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.CleanupAfterTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.util.concurrent.locks.LockManager;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.String.format;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Base class for {@link org.infinispan.test.SingleCacheManagerTest} and {@link org.infinispan.test.MultipleCacheManagersTest}.
@@ -16,7 +20,7 @@ import org.infinispan.util.concurrent.locks.LockManager;
  */
 public class AbstractCacheTest extends AbstractInfinispanTest {
 
-   public static enum CleanupPhase {
+   public enum CleanupPhase {
       AFTER_METHOD, AFTER_TEST
    }
 
@@ -70,23 +74,31 @@ public class AbstractCacheTest extends AbstractInfinispanTest {
       return (b1 || b2) && !(b1 && b2);
    }
 
-   protected void assertNotLocked(final Cache cache, final Object key) {
+   protected void assertEventuallyNotLocked(final Cache cache, final Object key) {
       //lock release happens async, hence the eventually...
-      eventually(new Condition() {
+      eventually(format("Expected key '%s' to be unlocked on cache '%s'", key, cache), new Condition() {
          @Override
          public boolean isSatisfied() throws Exception {
             return !checkLocked(cache, key);
          }
-      });
+      }, 20000, 500, TimeUnit.MILLISECONDS);
+   }
+
+   protected void assertEventuallyLocked(final Cache cache, final Object key) {
+      eventually(format("Expected key '%s' to be locked on cache '%s'", key, cache), new Condition() {
+         @Override
+         public boolean isSatisfied() throws Exception {
+            return checkLocked(cache, key);
+         }
+      }, 20000, 500, TimeUnit.MILLISECONDS);
    }
 
    protected void assertLocked(Cache cache, Object key) {
-      assert checkLocked(cache, key) : "expected key '" + key + "' to be locked on cache " + cache + ", but it is not";
+      assertTrue(format("Expected key '%s' to be locked on cache '%s'", key, cache), checkLocked(cache, key));
    }
 
    protected boolean checkLocked(Cache cache, Object key) {
-      LockManager lockManager = TestingUtil.extractLockManager(cache);
-      return lockManager.isLocked(key);
+      return TestingUtil.extractLockManager(cache).isLocked(key);
    }
 
    public EmbeddedCacheManager manager(Cache c) {

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -172,7 +172,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
     * Creates a new optionally transactional cache manager, starts it, and adds it to the list of known cache managers on
     * the current thread.  Uses a default clustered cache manager global config.
     *
-    * @param defaultConfig default cfg to use
+    * @param builder default cfg to use
     * @return the new CacheManager
     */
    protected EmbeddedCacheManager addClusterEnabledCacheManager(ConfigurationBuilder builder, TransportFlags flags) {
@@ -186,13 +186,6 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       cacheManagers.add(cm);
       return cm;
    }
-
-   /**
-    * Creates a new cache manager, starts it, and adds it to the list of known cache managers on the current thread.
-    * @param mode cache mode to use
-    * @param transactional if true, the configuration will be decorated with necessary transactional settings
-    * @return an embedded cache manager
-    */
 
    protected void createCluster(ConfigurationBuilder builder, int count) {
       for (int i = 0; i < count; i++) addClusterEnabledCacheManager(builder);
@@ -268,7 +261,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
 
    protected <K, V> List<Cache<K, V>> createClusteredCaches(
          int numMembersInCluster, String cacheName, ConfigurationBuilder builder, TransportFlags flags) {
-      List<Cache<K, V>> caches = new ArrayList<Cache<K, V>>(numMembersInCluster);
+      List<Cache<K, V>> caches = new ArrayList<>(numMembersInCluster);
       for (int i = 0; i < numMembersInCluster; i++) {
          EmbeddedCacheManager cm = addClusterEnabledCacheManager(flags);
          cm.defineConfiguration(cacheName, builder.build());
@@ -281,7 +274,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
 
    protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster,
                                                             ConfigurationBuilder defaultConfigBuilder) {
-      List<Cache<K, V>> caches = new ArrayList<Cache<K, V>>(numMembersInCluster);
+      List<Cache<K, V>> caches = new ArrayList<>(numMembersInCluster);
       for (int i = 0; i < numMembersInCluster; i++) {
          EmbeddedCacheManager cm = addClusterEnabledCacheManager(defaultConfigBuilder);
          Cache<K, V> cache = cm.getCache();
@@ -295,7 +288,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    protected <K, V> List<Cache<K, V>> createClusteredCaches(int numMembersInCluster,
                                                             ConfigurationBuilder defaultConfig,
                                                             TransportFlags flags) {
-      List<Cache<K, V>> caches = new ArrayList<Cache<K, V>>(numMembersInCluster);
+      List<Cache<K, V>> caches = new ArrayList<>(numMembersInCluster);
       for (int i = 0; i < numMembersInCluster; i++) {
          EmbeddedCacheManager cm = addClusterEnabledCacheManager(defaultConfig, flags);
          Cache<K, V> cache = cm.getCache();
@@ -306,7 +299,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    }
 
    /**
-    * Create cacheNames.lenght in each CacheManager (numMembersInCluster cacheManagers).
+    * Create cacheNames.length in each CacheManager (numMembersInCluster cacheManagers).
     *
     * @param numMembersInCluster
     * @param defaultConfigBuilder
@@ -315,10 +308,10 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
     */
    protected <K, V> List<List<Cache<K, V>>> createClusteredCaches(int numMembersInCluster,
          ConfigurationBuilder defaultConfigBuilder, String[] cacheNames) {
-      List<List<Cache<K, V>>> allCaches = new ArrayList<List<Cache<K, V>>>(numMembersInCluster);
+      List<List<Cache<K, V>>> allCaches = new ArrayList<>(numMembersInCluster);
       for (int i = 0; i < numMembersInCluster; i++) {
          EmbeddedCacheManager cm = addClusterEnabledCacheManager(defaultConfigBuilder);
-         List<Cache<K, V>> currentCacheManagerCaches = new ArrayList<Cache<K, V>>(cacheNames.length);
+         List<Cache<K, V>> currentCacheManagerCaches = new ArrayList<>(cacheNames.length);
 
          for (String cacheName : cacheNames) {
             Cache<K, V> cache = cm.getCache(cacheName);
@@ -498,7 +491,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    }
 
    protected void assertNotLocked(int cacheIndex, Object key) {
-      assertNotLocked(cache(cacheIndex), key);
+      assertEventuallyNotLocked(cache(cacheIndex), key);
    }
 
    protected void assertLocked(int cacheIndex, Object key) {
@@ -516,13 +509,13 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    protected <K, V> Cache<K, V> getLockOwner(Object key, String cacheName) {
       Configuration c = getCache(0, cacheName).getCacheConfiguration();
       if (c.clustering().cacheMode().isReplicated() || c.clustering().cacheMode().isInvalidation()) {
-         return (Cache<K, V>) getCache(0, cacheName); //for replicated caches only the coordinator acquires lock
+         return getCache(0, cacheName); //for replicated caches only the coordinator acquires lock
       }  else {
          if (!c.clustering().cacheMode().isDistributed()) throw new IllegalStateException("This is not a clustered cache!");
          final Address address = getCache(0, cacheName).getAdvancedCache().getDistributionManager().locate(key).get(0);
-         for (Cache<?, ?> cache : caches(cacheName)) {
+         for (Cache<K, V> cache : this.<K, V>caches(cacheName)) {
             if (cache.getAdvancedCache().getRpcManager().getTransport().getAddress().equals(address)) {
-               return (Cache<K, V>) cache;
+               return cache;
             }
          }
          throw new IllegalStateException();
@@ -543,8 +536,8 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       }
    }
 
-   private Cache<?, ?> getCache(int index, String name) {
-      return name == null ? cache(index) : cache(index, name);
+   private <K, V> Cache<K, V> getCache(int index, String name) {
+      return name == null ? this.<K, V>cache(index) : this.<K, V>cache(index, name);
    }
 
    protected void forceTwoPhase(int cacheIndex) throws SystemException, RollbackException {
@@ -554,15 +547,20 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
    }
 
    protected void assertNoTransactions() {
-      eventually(new Condition() {
+      assertNoTransactions(null);
+   }
+
+   protected void assertNoTransactions(final String cacheName) {
+      eventually("There are pending transactions!", new Condition() {
          @Override
          public boolean isSatisfied() throws Exception {
-            for (int i = 0; i < caches().size(); i++) {
-               int localTxCount = transactionTable(i).getLocalTxCount();
-               int remoteTxCount = transactionTable(i).getRemoteTxCount();
+            for (Cache<?, ?> cache : caches(cacheName)) {
+               final TransactionTable transactionTable = TestingUtil.extractComponent(cache, TransactionTable.class);
+               int localTxCount = transactionTable.getLocalTxCount();
+               int remoteTxCount = transactionTable.getRemoteTxCount();
                if (localTxCount != 0 || remoteTxCount != 0) {
-                  log.tracef("Local tx=%s, remote tx=%s, for cache %s ",
-                        localTxCount, remoteTxCount, i);
+                  log.tracef("Local tx=%s, remote tx=%s, for cache %s ", transactionTable.getLocalGlobalTransaction(),
+                             transactionTable.getRemoteGlobalTransaction(), address(cache));
                   return false;
                }
             }
@@ -582,7 +580,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
          @Override
          public boolean isSatisfied() throws Exception {
             return value == null
-                  ? value == cache(cacheIndex).get(key)
+                  ? null == cache(cacheIndex).get(key)
                   : value.equals(cache(cacheIndex).get(key));
          }
       });

--- a/core/src/test/java/org/infinispan/test/arquillian/DatagridManager.java
+++ b/core/src/test/java/org/infinispan/test/arquillian/DatagridManager.java
@@ -79,7 +79,7 @@ public class DatagridManager extends MultipleCacheManagersTest
 
    //name change
    public void assertKeyNotLocked(Cache cache, Object key) {
-      assertNotLocked(cache, key);
+      assertEventuallyNotLocked(cache, key);
    }
 
    //name change

--- a/core/src/test/java/org/infinispan/tx/StaleLockAfterTxAbortTest.java
+++ b/core/src/test/java/org/infinispan/tx/StaleLockAfterTxAbortTest.java
@@ -37,7 +37,7 @@ public class StaleLockAfterTxAbortTest extends SingleCacheManagerTest {
    public void doTest() throws Throwable {
       cache.put(k, "value"); // init value
 
-      assertNotLocked(cache, k);
+      assertEventuallyNotLocked(cache, k);
 
 //      InvocationContextContainerImpl icc = (InvocationContextContainerImpl) TestingUtil.extractComponent(cache, InvocationContextContainer.class);
 //      InvocationContext ctx = icc.getInvocationContext();
@@ -71,7 +71,7 @@ public class StaleLockAfterTxAbortTest extends SingleCacheManagerTest {
       transaction.runCommit(true);
       transactionThread.join();
 
-      assertNotLocked(cache, k);
+      assertEventuallyNotLocked(cache, k);
    }
 
    private class TxThread extends Thread {

--- a/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
@@ -35,9 +35,6 @@ import static org.testng.AssertJUnit.assertEquals;
  */
 @Test(testName = "tx.TransactionXaAdapterTmIntegrationTest", groups = "unstable", description = "Disabled due to instability - see ISPN-1123 -- original group: unit")
 public class TransactionXaAdapterTmIntegrationTest {
-   private Configuration configuration;
-   private XaTransactionTable txTable;
-   private GlobalTransaction globalTransaction;
    private LocalXaTransaction localTx;
    private TransactionXaAdapter xaAdapter;
    private DummyXid xid;
@@ -47,15 +44,15 @@ public class TransactionXaAdapterTmIntegrationTest {
    @BeforeMethod
    public void setUp() throws XAException {
       Cache mockCache = mock(Cache.class);
-      configuration = new ConfigurationBuilder().build();
-      txTable = new XaTransactionTable();
+      Configuration configuration = new ConfigurationBuilder().build();
+      XaTransactionTable txTable = new XaTransactionTable();
       txTable.initialize(null, configuration, null, null, null, null,
-            null, null, null, null, mockCache, null, null);
+                         null, null, null, null, mockCache, null, null, null);
       txTable.start();
       txTable.startXidMapping();
       TransactionFactory gtf = new TransactionFactory();
       gtf.init(false, false, true, false);
-      globalTransaction = gtf.newGlobalTransaction(null, false);
+      GlobalTransaction globalTransaction = gtf.newGlobalTransaction(null, false);
       DummyBaseTransactionManager tm = new DummyBaseTransactionManager();
       localTx = new LocalXaTransaction(new DummyTransaction(tm), globalTransaction, false, 1, AnyEquivalence.getInstance(), 0);
       xid = new DummyXid(uuid);
@@ -66,7 +63,7 @@ public class TransactionXaAdapterTmIntegrationTest {
       txCoordinator = new TransactionCoordinator();
       txCoordinator.init(commandsFactory, icf, invoker, txTable, null, configuration);
       xaAdapter = new TransactionXaAdapter(localTx, txTable, null, txCoordinator, null, null,
-                                           new ClusteringDependentLogic.InvalidationLogic(), configuration, "");
+                                           new ClusteringDependentLogic.InvalidationLogic(), configuration, "", null);
 
       xaAdapter.start(xid, 0);
    }

--- a/core/src/test/java/org/infinispan/tx/recovery/PostCommitRecoveryStateTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/PostCommitRecoveryStateTest.java
@@ -89,11 +89,11 @@ public class PostCommitRecoveryStateTest extends MultipleCacheManagersTest {
       }
 
       @Override
-      public void removeRecoveryInformationFromCluster(Collection<Address> where, Xid xid, boolean sync, GlobalTransaction gtx) {
+      public void removeRecoveryInformation(Collection<Address> where, Xid xid, boolean sync, GlobalTransaction gtx, boolean fromCluster) {
          if (swallowRemoveRecoveryInfoCalls){
             log.trace("PostCommitRecoveryStateTest$RecoveryManagerDelegate.removeRecoveryInformation");
          } else {
-            this.rm.removeRecoveryInformationFromCluster(where, xid, sync, null);
+            this.rm.removeRecoveryInformation(where, xid, sync, null, false);
          }
       }
 

--- a/extended-statistics/src/test/java/org/infinispan/stats/BaseTxClusterExtendedStatisticLogicTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/stats/BaseTxClusterExtendedStatisticLogicTest.java
@@ -74,7 +74,7 @@ public abstract class BaseTxClusterExtendedStatisticLogicTest extends MultipleCa
    private final boolean sync2ndPhase;
    private final boolean totalOrder;
    private final CacheMode cacheMode;
-   private final List<Object> keys = new ArrayList<Object>(128);
+   private final List<Object> keys = new ArrayList<>(128);
 
    protected BaseTxClusterExtendedStatisticLogicTest(CacheMode cacheMode, boolean sync2ndPhase, boolean totalOrder) {
       this.sync = cacheMode.isSynchronous();
@@ -201,9 +201,9 @@ public abstract class BaseTxClusterExtendedStatisticLogicTest extends MultipleCa
       for (int i = 0; i < NUM_NODES; ++i) {
          lockManagers[i] = extractLockManager(cache(i));
          ExtendedStatisticInterceptor interceptor = extendedStatisticInterceptors[i];
-         CacheStatisticManager manager = (CacheStatisticManager) extractField(interceptor, "cacheStatisticManager");
-         CacheStatisticCollector collector = (CacheStatisticCollector) extractField(manager, "cacheStatisticCollector");
-         ConcurrentGlobalContainer globalContainer = (ConcurrentGlobalContainer) extractField(collector, "globalContainer");
+         CacheStatisticManager manager = extractField(interceptor, "cacheStatisticManager");
+         CacheStatisticCollector collector = extractField(manager, "cacheStatisticCollector");
+         ConcurrentGlobalContainer globalContainer = extractField(collector, "globalContainer");
          replaceField(TEST_TIME_SERVICE, "timeService", manager, CacheStatisticManager.class);
          replaceField(TEST_TIME_SERVICE, "timeService", collector, CacheStatisticCollector.class);
          replaceField(TEST_TIME_SERVICE, "timeService", globalContainer, ConcurrentGlobalContainer.class);
@@ -287,10 +287,6 @@ public abstract class BaseTxClusterExtendedStatisticLogicTest extends MultipleCa
             if (isRemote(key, cache(txExecutor))) {
                remotePuts++;
                involvesRemoteNode = true;
-               //remote puts always acquires local locks
-               if (operation == WriteOperation.REPLACE) {
-                  localLocks++;
-               }
             } else {
                localPuts++;
             }


### PR DESCRIPTION
…inconsistent after merge

* keep the transaction resources while the partition is not healed.
* when the merge happens, complete the pending transactions.

https://issues.jboss.org/browse/ISPN-5046