### PR TITLE
ISPN-5461 FileDescriptorSource.fromResources and FileDescriptorSource…

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -59,7 +59,7 @@
       
       <version.maven-compiler-plugin>3.1</version.maven-compiler-plugin>
       
-      <version.protostream>3.0.1.Final</version.protostream>
+      <version.protostream>3.0.2.Final</version.protostream>
       <version.aesh>0.33.14</version.aesh>
       <version.antlr>3.5.2</version.antlr>
       <version.c3p0>0.9.5</version.c3p0>
@@ -392,12 +392,6 @@
             <groupId>org.infinispan.protostream</groupId>
             <artifactId>protostream</artifactId>
             <version>${version.protostream}</version>
-            <exclusions>
-               <exclusion>
-                  <groupId>org.javassist</groupId>
-                  <artifactId>javassist</artifactId>
-               </exclusion>
-            </exclusions>
          </dependency>
          <dependency>
             <groupId>org.infinispan.protostream</groupId>

--- a/server/integration/versions/pom.xml
+++ b/server/integration/versions/pom.xml
@@ -39,7 +39,7 @@
       <version.org.xerial.snappy>1.0.5</version.org.xerial.snappy>
       <version.antrun.maven.plugin>1.8</version.antrun.maven.plugin>
       <version.xml.maven.plugin>1.0</version.xml.maven.plugin>
-      <version.org.infinispan.protostream>3.0.1.Final</version.org.infinispan.protostream>
+      <version.org.infinispan.protostream>3.0.2.Final</version.org.infinispan.protostream>
       <version.http.client>4.3</version.http.client>
       <version.org.picketbox>4.0.17.SP2</version.org.picketbox>
       <version.xpp3>1.1.4c</version.xpp3>


### PR DESCRIPTION
….addProtoFiles should have a ClassLoader argument

Protostream is upgraded.

This is for 7.2.x.

jira: https://issues.jboss.org/browse/ISPN-5461