### PR TITLE
ISPN-5474 Transactions created when applying state should never be re…

### DIFF
--- a/core/src/main/java/org/infinispan/context/impl/AbstractTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/AbstractTxInvocationContext.java
@@ -54,7 +54,8 @@ public abstract class AbstractTxInvocationContext<T extends AbstractCacheTransac
 
    @Override
    public final boolean hasModifications() {
-      return getModifications() != null && !getModifications().isEmpty();
+      List<WriteCommand> replicableModifications = getModifications();
+      return replicableModifications != null && !replicableModifications.isEmpty();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/base/BaseRpcInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/base/BaseRpcInterceptor.java
@@ -68,9 +68,14 @@ public abstract class BaseRpcInterceptor extends CommandInterceptor {
          return false;
       }
 
+      // Skip the remote invocation if this is a state transfer transaction
+      LocalTxInvocationContext localCtx = (LocalTxInvocationContext) ctx;
+      if (localCtx.getCacheTransaction().getStateTransferFlag() == Flag.PUT_FOR_STATE_TRANSFER) {
+         return false;
+      }
+
       // just testing for empty modifications isn't enough - the Lock API may acquire locks on keys but won't
       // register a Modification.  See ISPN-711.
-      LocalTxInvocationContext localCtx = (LocalTxInvocationContext) ctx;
       boolean shouldInvokeRemotely = ctx.hasModifications() || !localCtx.getRemoteLocksAcquired().isEmpty() ||
          localCtx.getCacheTransaction().getTopologyId() != rpcManager.getTopologyId();
 


### PR DESCRIPTION
…plicated

https://issues.jboss.org/browse/ISPN-5474

Add an explicit check for state transfer transactions in
BaseRpcInterceptor.shouldInvokeRemotely.