### PR TITLE
ISPN-5477 Too agressive unboxing leading to wrong L1 returns

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/CompatibilityModeConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/CompatibilityModeConfigurationBuilder.java
@@ -58,6 +58,10 @@ public class CompatibilityModeConfigurationBuilder
       return this;
    }
 
+   public Marshaller marshaller() {
+      return attributes.attribute(MARSHALLER).get();
+   }
+
    @Override
    public void validate() {
       // No-op

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/ByteArrayKeyDistEmbeddedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/ByteArrayKeyDistEmbeddedHotRodTest.java
@@ -19,10 +19,10 @@ public class ByteArrayKeyDistEmbeddedHotRodTest extends ByteArrayKeyReplEmbedded
    @Override
    @BeforeClass
    protected void setup() throws Exception {
-      cacheFactory1 = new CompatibilityCacheFactory<Object, Object>(CacheMode.DIST_SYNC, 1)
+      cacheFactory1 = new CompatibilityCacheFactory<Object, Object>(CacheMode.DIST_SYNC, 1, false)
             .keyEquivalence(ByteArrayEquivalence.INSTANCE)
             .setup();
-      cacheFactory2 = new CompatibilityCacheFactory<Object, Object>(CacheMode.DIST_SYNC, 1)
+      cacheFactory2 = new CompatibilityCacheFactory<Object, Object>(CacheMode.DIST_SYNC, 1, false)
             .keyEquivalence(ByteArrayEquivalence.INSTANCE)
             .setup(cacheFactory1.getHotRodPort(), 100);
    }

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/ByteArrayValueDistEmbeddedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/ByteArrayValueDistEmbeddedHotRodTest.java
@@ -19,10 +19,10 @@ public class ByteArrayValueDistEmbeddedHotRodTest extends ByteArrayValueReplEmbe
    @Override
    @BeforeClass
    protected void setup() throws Exception {
-      cacheFactory1 = new CompatibilityCacheFactory<Object, Object>(CacheMode.DIST_SYNC, 1)
+      cacheFactory1 = new CompatibilityCacheFactory<Object, Object>(CacheMode.DIST_SYNC, 1, false)
             .valueEquivalence(ByteArrayEquivalence.INSTANCE)
             .setup();
-      cacheFactory2 = new CompatibilityCacheFactory<Object, Object>(CacheMode.DIST_SYNC, 1)
+      cacheFactory2 = new CompatibilityCacheFactory<Object, Object>(CacheMode.DIST_SYNC, 1, false)
             .valueEquivalence(ByteArrayEquivalence.INSTANCE)
             .setup(cacheFactory1.getHotRodPort(), 100);
    }

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/CompatibilityCacheFactory.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/CompatibilityCacheFactory.java
@@ -54,6 +54,7 @@ public class CompatibilityCacheFactory<K, V> {
    private int restPort;
    private final int defaultNumOwners = 2;
    private int numOwners = defaultNumOwners;
+   private boolean l1Enable = false;
    private Equivalence keyEquivalence = null;
    private Equivalence valueEquivalence = null;
 
@@ -63,9 +64,10 @@ public class CompatibilityCacheFactory<K, V> {
       this.cacheMode = cacheMode;
    }
 
-   CompatibilityCacheFactory(CacheMode cacheMode, int numOwners) {
+   CompatibilityCacheFactory(CacheMode cacheMode, int numOwners, boolean l1Enable) {
       this(cacheMode);
       this.numOwners = numOwners;
+      this.l1Enable = l1Enable;
    }
 
    CompatibilityCacheFactory(String cacheName, Marshaller marshaller, CacheMode cacheMode) {
@@ -125,6 +127,10 @@ public class CompatibilityCacheFactory<K, V> {
 
       if (cacheMode.isDistributed() && numOwners != defaultNumOwners) {
          builder.clustering().hash().numOwners(numOwners);
+      }
+
+      if (cacheMode.isDistributed() && l1Enable) {
+         builder.clustering().l1().enable();
       }
 
       if (keyEquivalence != null) {

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/DistEmbeddedHotRodBulkTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/DistEmbeddedHotRodBulkTest.java
@@ -32,8 +32,8 @@ public class DistEmbeddedHotRodBulkTest extends AbstractInfinispanTest {
 
     @BeforeClass
     protected void setup() throws Exception {
-        cacheFactory1 = new CompatibilityCacheFactory<String, Integer>(CacheMode.DIST_SYNC, numOwners).setup();
-        cacheFactory2 = new CompatibilityCacheFactory<String, Integer>(CacheMode.DIST_SYNC, numOwners)
+        cacheFactory1 = new CompatibilityCacheFactory<String, Integer>(CacheMode.DIST_SYNC, numOwners, false).setup();
+        cacheFactory2 = new CompatibilityCacheFactory<String, Integer>(CacheMode.DIST_SYNC, numOwners, false)
                 .setup(cacheFactory1.getHotRodPort(), 100);
     }
 

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/DistEmbeddedRestHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/DistEmbeddedRestHotRodTest.java
@@ -20,8 +20,8 @@ public class DistEmbeddedRestHotRodTest extends ReplEmbeddedRestHotRodTest {
    @Override
    @BeforeClass
    protected void setup() throws Exception {
-      cacheFactory1 = new CompatibilityCacheFactory<Object, Object>(CacheMode.DIST_SYNC, numOwners).setup();
-      cacheFactory2 = new CompatibilityCacheFactory<Object, Object>(CacheMode.DIST_SYNC, numOwners)
+      cacheFactory1 = new CompatibilityCacheFactory<Object, Object>(CacheMode.DIST_SYNC, numOwners, false).setup();
+      cacheFactory2 = new CompatibilityCacheFactory<Object, Object>(CacheMode.DIST_SYNC, numOwners, false)
             .setup(cacheFactory1.getHotRodPort(), 100);
    }
 

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/DistL1EmbeddedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/DistL1EmbeddedHotRodTest.java
@@ -1,0 +1,61 @@
+package org.infinispan.it.compatibility;
+
+import org.infinispan.Cache;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.distribution.MagicKey;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.getSplitIntKeyForServer;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+@Test(groups = "functional", testName = "it.compatibility.DistL1EmbeddedHotRodTest")
+public class DistL1EmbeddedHotRodTest extends AbstractInfinispanTest {
+
+   private static final int NUM_OWNERS = 1;
+
+   private CompatibilityCacheFactory<Integer, String> cacheFactory1;
+   private CompatibilityCacheFactory<Integer, String> cacheFactory2;
+
+   @BeforeClass
+   protected void setup() throws Exception {
+      cacheFactory1 = new CompatibilityCacheFactory<Integer, String>(CacheMode.DIST_SYNC, NUM_OWNERS, true).setup();
+      cacheFactory2 = new CompatibilityCacheFactory<Integer, String>(CacheMode.DIST_SYNC, NUM_OWNERS, true)
+            .setup(cacheFactory1.getHotRodPort(), 100);
+
+      List<Cache<Integer, String>> caches = Arrays.asList(cacheFactory1.getEmbeddedCache(), cacheFactory2.getEmbeddedCache());
+      TestingUtil.blockUntilViewsReceived(30000, caches);
+      TestingUtil.waitForRehashToComplete(caches);
+
+      assertTrue(cacheFactory1.getHotRodCache().isEmpty());
+      assertTrue(cacheFactory2.getHotRodCache().isEmpty());
+   }
+
+   @AfterClass
+   protected void teardown() {
+      CompatibilityCacheFactory.killCacheFactories(cacheFactory1, cacheFactory2);
+   }
+
+   public void testEmbeddedPutHotRodGetFromL1() {
+      Cache<Integer, String> embedded1 = cacheFactory1.getEmbeddedCache();
+      Cache<Integer, String> embedded2 = cacheFactory2.getEmbeddedCache();
+
+      Integer key = getSplitIntKeyForServer(cacheFactory1.getHotrodServer(), cacheFactory2.getHotrodServer(), null);
+
+      // Put it owner, forcing the remote node to get it from L1
+      embedded1.put(key, "uno");
+
+      // Should get it from L1
+      assertEquals("uno", cacheFactory1.getHotRodCache().get(key));
+      assertEquals("uno", cacheFactory1.getHotRodCache().get(key));
+   }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5477

* Unboxing of entries for external client consumption should only happen when commands are local, since remote commands come from internal clustering.