### PR TITLE
ISPN-5480 Speed up xsite tests

### DIFF
--- a/core/src/test/java/org/infinispan/api/AsyncAPITest.java
+++ b/core/src/test/java/org/infinispan/api/AsyncAPITest.java
@@ -353,7 +353,7 @@ public class AsyncAPITest extends SingleCacheManagerTest {
                   return entry == null || entry.isExpired(System.currentTimeMillis());
                }
             }
-         }, 3 * expectedLifetime, (int) (3 * expectedLifetime / pollInterval) + 1);
+         }, 3 * expectedLifetime, pollInterval, TimeUnit.MILLISECONDS);
          long waitTime = Util.currentMillisFromNanotime() - startTime;
          Object value = c.get(key);
          assertNull(value);

--- a/core/src/test/java/org/infinispan/distribution/DistSyncL1FuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncL1FuncTest.java
@@ -272,7 +272,7 @@ public class DistSyncL1FuncTest extends BaseDistSyncL1Test {
             public boolean isSatisfied() throws Exception {
                return !isInL1(nonOwnerCache, key);
             }
-         }, 5000, 250);
+         }, 5000, 50, TimeUnit.MILLISECONDS);
 
          // This should come back from the backup owner, since the primary owner is blocked
          assertEquals(firstValue, nonOwnerCache.get(key));

--- a/core/src/test/java/org/infinispan/lock/singlelock/AbstractLockOwnerCrashTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/AbstractLockOwnerCrashTest.java
@@ -88,7 +88,7 @@ public abstract class AbstractLockOwnerCrashTest extends AbstractCrashTest {
          public boolean isSatisfied() throws Exception {
             return cache(0).get(k).equals("v2") && cache(1).get(k).equals("v2");
          }
-      }, 15000, 15);
+      }, 15000);
       assertNotLocked(k);
 
       eventually(new Condition() {

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -647,9 +647,12 @@ public class TestingUtil {
             log.warn("Problems stopping cache manager " + cm, e);
          }
       }
-      for (EmbeddedCacheManager cm : cacheManagers) {
+      // Stop the managers in reverse order to prevent each of them from becoming coordinator in turn
+      for (int i = cacheManagers.length - 1; i >= 0; i--) {
+         EmbeddedCacheManager cm = cacheManagers[i];
          try {
-            if (cm != null) cm.stop();
+            if (cm != null)
+               cm.stop();
          } catch (Throwable e) {
             log.warn("Problems killing cache manager " + cm, e);
          }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5480

* Stop cache managers in reverse order to avoid JGRP-1927
* Keep the eventually() poll interval constant regardless of timeout