### PR TITLE
ISPN-5378 Additional Lucene Directory Wildfly integration tests

### DIFF
--- a/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/wildfly/InfinispanModuleMemberRegistrationIT.java
+++ b/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/wildfly/InfinispanModuleMemberRegistrationIT.java
@@ -1,5 +1,6 @@
 package org.infinispan.test.integration.as.wildfly;
 
+import org.apache.lucene.document.Document;
 import org.infinispan.test.integration.as.wildfly.controller.MemberRegistration;
 import org.infinispan.test.integration.as.wildfly.model.Member;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -18,8 +19,10 @@ import org.jboss.shrinkwrap.descriptor.api.persistence20.PersistenceDescriptor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import javax.inject.Inject;
 import java.util.List;
+
+import javax.ejb.EJBTransactionRolledbackException;
+import javax.inject.Inject;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -34,6 +37,21 @@ import static org.infinispan.test.integration.as.VersionTestHelper.addHibernateS
  */
 @RunWith(Arquillian.class)
 public class InfinispanModuleMemberRegistrationIT {
+
+   public final static double GD_LATITUDE = 37.769645;
+   public final static double GD_LONGITUDE = -122.446428;
+
+   public final static double CH_LATITUDE = 37.780392;
+   public final static double CH_LONGITUDE = -122.513898;
+
+   public final static double CBGB_LATITUDE = 40.726157;
+   public final static double CBGB_LONGITUDE = -73.992116;
+
+   public final static double KD_LATITUDE = 40.723165;
+   public final static double KD_LONGITUDE = -73.987439;
+
+   public final static double BG_LATITUDE = 41.874808;
+   public final static double BG_LONGITUDE = -87.625983;
 
    @Deployment(name = "dep.active-1")
    @TargetsContainer("container.active-1")
@@ -104,29 +122,48 @@ public class InfinispanModuleMemberRegistrationIT {
       newMember.setName("Davide D'Alto");
       newMember.setEmail("davide@mailinator.com");
       newMember.setPhoneNumber("2125551234");
+      newMember.setLatitude(CH_LATITUDE);
+      newMember.setLongitude(CH_LONGITUDE);
       memberRegistration.register();
 
       assertNotNull(newMember.getId());
+      assertEquals("Index size isn't correct", 1, memberRegistration.indexSize());
+   }
+
+   @Test(expected = EJBTransactionRolledbackException.class)
+   @InSequence(value = 2)
+   @OperateOnDeployment("dep.active-1")
+   public void testRegisterConstraint() throws Exception {
+      Member newMember = memberRegistration.getNewMember();
+      newMember.setName("Davide D'Altoe");
+      newMember.setEmail("davide@mailinator.com");
+      newMember.setPhoneNumber("2125551235");
+      newMember.setLatitude(CH_LATITUDE);
+      newMember.setLongitude(CH_LONGITUDE);
+      memberRegistration.register();
    }
 
    @Test
-   @InSequence(value = 2)
+   @InSequence(value = 3)
    @OperateOnDeployment("dep.active-2")
    public void testNewMemberSearch() throws Exception {
       Member newMember = memberRegistration.getNewMember();
       newMember.setName("Peter O'Tall");
       newMember.setEmail("peter@mailinator.com");
       newMember.setPhoneNumber("4643646643");
+      newMember.setLatitude(KD_LATITUDE);
+      newMember.setLongitude(KD_LONGITUDE);
       memberRegistration.register();
 
       List<Member> search = memberRegistration.search("Peter");
 
       assertFalse("Expected at least one result after the indexing", search.isEmpty());
       assertEquals("Search hasn't found a new member", newMember.getName(), search.get(0).getName());
+      assertEquals("Index size isn't correct", 2, memberRegistration.indexSize());
    }
 
    @Test
-   @InSequence(value = 3)
+   @InSequence(value = 4)
    @OperateOnDeployment("dep.active-2")
    public void testNewMemberLuceneSearch() throws Exception {
       List<Member> search = memberRegistration.luceneSearch("Peter");
@@ -136,7 +173,17 @@ public class InfinispanModuleMemberRegistrationIT {
    }
 
    @Test
-   @InSequence(value = 4)
+   @InSequence(value = 5)
+   @OperateOnDeployment("dep.active-2")
+   public void testNewMemberIndexSearch() throws Exception {
+      List<Document> search = memberRegistration.indexSearch("Peter");
+
+      assertFalse("Expected at least one result after the indexing", search.isEmpty());
+      assertEquals("Lucene search hasn't found a member", "Peter O'Tall", search.get(0).get("name"));
+   }
+
+   @Test
+   @InSequence(value = 6)
    @OperateOnDeployment("dep.active-2")
    public void testNonExistingMember() throws Exception {
       List<Member> search = memberRegistration.search("TotallyInventedName");
@@ -146,7 +193,7 @@ public class InfinispanModuleMemberRegistrationIT {
    }
 
    @Test
-   @InSequence(value = 5)
+   @InSequence(value = 7)
    @OperateOnDeployment("dep.active-2")
    public void testLuceneNonExistingMember() throws Exception {
       List<Member> search = memberRegistration.luceneSearch("TotallyInventedName");
@@ -156,7 +203,17 @@ public class InfinispanModuleMemberRegistrationIT {
    }
 
    @Test
-   @InSequence(value = 6)
+   @InSequence(value = 8)
+   @OperateOnDeployment("dep.active-2")
+   public void testIndexNonExistingMember() throws Exception {
+      List<Document> search = memberRegistration.indexSearch("TotallyInventedName");
+
+      assertNotNull("Search should never return null", search);
+      assertTrue("Search results should be empty", search.isEmpty());
+   }
+
+   @Test
+   @InSequence(value = 9)
    @OperateOnDeployment("dep.active-2")
    public void testPurgeIndex() throws Exception {
       memberRegistration.purgeMemberIndex();
@@ -164,10 +221,11 @@ public class InfinispanModuleMemberRegistrationIT {
 
       assertNotNull("Search should never return null", search);
       assertTrue("Search results should be empty", search.isEmpty());
+      assertEquals("Index size isn't correct", 0, memberRegistration.indexSize());
    }
 
    @Test
-   @InSequence(value = 7)
+   @InSequence(value = 10)
    @OperateOnDeployment("dep.active-2")
    public void testReIndex() throws Exception {
       memberRegistration.indexMembers();
@@ -175,5 +233,88 @@ public class InfinispanModuleMemberRegistrationIT {
 
       assertFalse("Expected at least one result after the indexing", search.isEmpty());
       assertEquals("Search hasn't found a new member after reindex", "Peter O'Tall", search.get(0).getName());
+      assertEquals("Index size isn't correct", 2, memberRegistration.indexSize());
+   }
+
+   @Test
+   @InSequence(value = 11)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchNearGD() throws Exception {
+      List<Member> members = memberRegistration.spatialSearch(GD_LATITUDE, GD_LONGITUDE, 10);
+      assertEquals("Expected one result from spatial search", 1, members.size());
+      assertEquals("Spatial search did not find the correct member", "Davide D'Alto", members.get(0).getName());
+   }
+
+   @Test
+   @InSequence(value = 12)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchNearGDWithDistance() throws Exception {
+      List<Object[]> membersWithDistance = memberRegistration.spatialSearchWithDistance(GD_LATITUDE, GD_LONGITUDE, 10);
+      assertEquals("Expected one result from spatial search", 1, membersWithDistance.size());
+      assertEquals("Spatial search did not find the correct member", "Davide D'Alto",
+            ((Member) membersWithDistance.get(0)[1]).getName());
+      assertTrue("Distance was not greater than zero", (Double) membersWithDistance.get(0)[0] > 0);
+   }
+
+   @Test
+   @InSequence(value = 13)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchNearCBGB() throws Exception {
+      List<Member> members = memberRegistration.spatialSearch(CBGB_LATITUDE, CBGB_LONGITUDE, 10);
+      assertEquals("Expected one result from spatial search", 1, members.size());
+      assertEquals("Spatial search did not find the correct member", "Peter O'Tall", members.get(0).getName());
+   }
+
+   @Test
+   @InSequence(value = 14)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchNearCBGBWithDistance() throws Exception {
+      List<Object[]> membersWithDistance = memberRegistration.spatialSearchWithDistance(CBGB_LATITUDE, CBGB_LONGITUDE,
+            10);
+      assertEquals("Expected one result from spatial search", 1, membersWithDistance.size());
+      assertEquals("Spatial search did not find the correct member", "Peter O'Tall",
+            ((Member) membersWithDistance.get(0)[1]).getName());
+      assertTrue("Distance was not greater than zero", (Double) membersWithDistance.get(0)[0] > 0);
+   }
+
+   @Test
+   @InSequence(value = 15)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchNearBG() throws Exception {
+      List<Member> members = memberRegistration.spatialSearch(BG_LATITUDE, BG_LONGITUDE, 10);
+      assertEquals("Expected one result from spatial search", 0, members.size());
+   }
+
+   @Test
+   @InSequence(value = 16)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchNearBGWithDistance() throws Exception {
+      List<Object[]> membersWithDistance = memberRegistration.spatialSearchWithDistance(BG_LATITUDE, BG_LONGITUDE, 10);
+      assertEquals("Expected one result from spatial search", 0, membersWithDistance.size());
+   }
+
+   @Test
+   @InSequence(value = 17)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchLongDistance() throws Exception {
+      List<Member> members = memberRegistration.spatialSearch(GD_LATITUDE, GD_LONGITUDE, 5000);
+      assertEquals("Expected one result from spatial search", 2, members.size());
+      assertEquals("Spatial search did not find the correct member", "Davide D'Alto", members.get(0).getName());
+      assertEquals("Spatial search did not find the correct member", "Peter O'Tall", members.get(1).getName());
+   }
+
+   @Test
+   @InSequence(value = 18)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchLongDistanceWithDistance() throws Exception {
+      List<Object[]> membersWithDistance = memberRegistration
+            .spatialSearchWithDistance(GD_LATITUDE, GD_LONGITUDE, 5000);
+      assertEquals("Expected one result from spatial search", 2, membersWithDistance.size());
+      assertEquals("Spatial search did not find the correct member", "Davide D'Alto",
+            ((Member) membersWithDistance.get(0)[1]).getName());
+      assertTrue("Distance was not greater than zero", (Double) membersWithDistance.get(0)[0] > 0);
+      assertEquals("Spatial search did not find the correct member", "Peter O'Tall",
+            ((Member) membersWithDistance.get(1)[1]).getName());
+      assertTrue("Distance was not greater than zero", (Double) membersWithDistance.get(1)[0] > 0);
    }
 }

--- a/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/wildfly/controller/MemberRegistration.java
+++ b/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/wildfly/controller/MemberRegistration.java
@@ -1,5 +1,7 @@
 package org.infinispan.test.integration.as.wildfly.controller;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
@@ -11,11 +13,17 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.Query;
 import org.hibernate.search.MassIndexer;
+import org.hibernate.search.SearchFactory;
+import org.hibernate.search.annotations.Spatial;
+import org.hibernate.search.jpa.FullTextQuery;
 import org.hibernate.search.jpa.Search;
+import org.hibernate.search.query.dsl.Unit;
 import org.infinispan.test.integration.as.wildfly.model.Member;
 
 @Stateful
@@ -48,6 +56,59 @@ public class MemberRegistration {
             .forEntity(Member.class).get().keyword().onField("name").matching(name).createQuery();
 
       return Search.getFullTextEntityManager(em).createFullTextQuery(luceneQuery).getResultList();
+   }
+
+   @SuppressWarnings("unchecked")
+   public List<Member> spatialSearch(double latitude, double longitude, double distanceinKM) {
+      Query spatialQuery = Search.getFullTextEntityManager(em).getSearchFactory()
+            .buildQueryBuilder().forEntity( Member.class ).get().spatial()
+            .within( distanceinKM, Unit.KM )
+            .ofLatitude( latitude )
+            .andLongitude( longitude )
+            .createQuery();
+      return Search.getFullTextEntityManager(em).createFullTextQuery(spatialQuery, Member.class).getResultList();
+   }
+
+   @SuppressWarnings("unchecked")
+   public List<Object[]> spatialSearchWithDistance(double latitude, double longitude, double distanceinKM) {
+      Query spatialQuery = Search.getFullTextEntityManager(em).getSearchFactory()
+            .buildQueryBuilder().forEntity(Member.class).get().spatial()
+            .within(distanceinKM, Unit.KM)
+            .ofLatitude(latitude)
+            .andLongitude(longitude)
+            .createQuery();
+
+      FullTextQuery hibQuery = Search.getFullTextEntityManager(em).createFullTextQuery(spatialQuery, Member.class);
+      hibQuery.setProjection(FullTextQuery.SPATIAL_DISTANCE, FullTextQuery.THIS);
+      hibQuery.setSpatialParameters(latitude, longitude, Spatial.COORDINATES_DEFAULT_FIELD);
+      return hibQuery.getResultList();
+   }
+
+   public List<Document> indexSearch(String name) throws IOException {
+      ArrayList<Document> result = new ArrayList<Document>();
+      SearchFactory searchFactory = Search.getFullTextEntityManager(em).getSearchFactory();
+      IndexReader reader = searchFactory.getIndexReaderAccessor().open(Member.class);
+      try {
+         for (int i = 0; i < reader.maxDoc(); i++) {
+            Document member = reader.document(i);
+            if (member != null && member.get("name").contains(name)) {
+               result.add(member);
+            }
+         }
+      } finally {
+         searchFactory.getIndexReaderAccessor().close(reader);
+      }
+      return result;
+   }
+
+   public int indexSize() {
+      SearchFactory searchFactory = Search.getFullTextEntityManager(em).getSearchFactory();
+      IndexReader reader = searchFactory.getIndexReaderAccessor().open(Member.class);
+      try {
+         return reader.maxDoc();
+      } finally {
+         searchFactory.getIndexReaderAccessor().close(reader);
+      }
    }
 
    @SuppressWarnings("unchecked")

--- a/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/wildfly/model/Member.java
+++ b/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/wildfly/model/Member.java
@@ -1,9 +1,6 @@
 package org.infinispan.test.integration.as.wildfly.model;
 
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Index;
-import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.annotations.Store;
+import java.io.Serializable;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -11,10 +8,18 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
-import java.io.Serializable;
+
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Index;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Latitude;
+import org.hibernate.search.annotations.Longitude;
+import org.hibernate.search.annotations.Spatial;
+import org.hibernate.search.annotations.Store;
 
 @Entity
 @Indexed
+@Spatial
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = "email"))
 public class Member implements Serializable {
 
@@ -27,7 +32,13 @@ public class Member implements Serializable {
    @GeneratedValue
    private Long id;
 
-   @Field(index = Index.YES, store = Store.NO)
+   @Latitude
+   private Double latitude;
+
+   @Longitude
+   private Double longitude;
+
+   @Field(index = Index.YES, store = Store.YES)
    private String name;
 
    @Field(index = Index.YES, store = Store.NO)
@@ -66,5 +77,21 @@ public class Member implements Serializable {
 
    public void setPhoneNumber(String phoneNumber) {
       this.phoneNumber = phoneNumber;
+   }
+
+   public Double getLatitude() {
+      return latitude;
+   }
+
+   public void setLatitude(Double latitude) {
+      this.latitude = latitude;
+   }
+
+   public Double getLongitude() {
+      return longitude;
+   }
+
+   public void setLongitude(Double longitude) {
+      this.longitude = longitude;
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5378

Added IndexReader and Spatial search tests

IndexReader tests are working
Spatial search are mostly working. The only test that is failing is the
long distance search with a projection. It is only returning one member
instead of two, as the query without a projection does.

This PR should get integrated on the master and 7.2.x branches after https://github.com/infinispan/infinispan/pull/3448 is integrated.
