### PR TITLE
ISPN-5494 Node replies with NullPointerException during shutdown

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/marshall/jboss/AbstractJBossMarshaller.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/jboss/AbstractJBossMarshaller.java
@@ -3,17 +3,16 @@ package org.infinispan.commons.marshall.jboss;
 import org.infinispan.commons.io.ByteBuffer;
 import org.infinispan.commons.io.ByteBufferImpl;
 import org.infinispan.commons.io.ExposedByteArrayOutputStream;
-import org.infinispan.commons.logging.BasicLogFactory;
+import org.infinispan.commons.logging.Log;
+import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.commons.marshall.AbstractMarshaller;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.commons.util.concurrent.ConcurrentWeakKeyHashMap;
-import org.jboss.logging.BasicLogger;
 import org.jboss.marshalling.ExceptionListener;
 import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;
 import org.jboss.marshalling.TraceInformation;
 import org.jboss.marshalling.Unmarshaller;
-import org.jboss.marshalling.reflect.SunReflectiveCreator;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -38,7 +37,7 @@ import static org.infinispan.commons.util.Util.EMPTY_OBJECT_ARRAY;
  */
 public abstract class AbstractJBossMarshaller extends AbstractMarshaller implements StreamingMarshaller {
 
-   protected static final BasicLogger log = BasicLogFactory.getLog(AbstractJBossMarshaller.class);
+   protected static final Log log = LogFactory.getLog(AbstractJBossMarshaller.class);
    protected static final boolean trace = log.isTraceEnabled();
    protected static final JBossMarshallerFactory factory = new JBossMarshallerFactory();
    protected static final int DEF_INSTANCE_COUNT = 16;

--- a/core/src/main/java/org/infinispan/marshall/core/JBossMarshaller.java
+++ b/core/src/main/java/org/infinispan/marshall/core/JBossMarshaller.java
@@ -2,6 +2,7 @@ package org.infinispan.marshall.core;
 
 import java.io.IOException;
 
+import org.infinispan.IllegalLifecycleStateException;
 import org.infinispan.commons.marshall.SerializeWith;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.commons.marshall.jboss.AbstractJBossMarshaller;
@@ -140,7 +141,11 @@ public class JBossMarshaller extends AbstractJBossMarshaller implements Streamin
 
       @Override
       public Writer getObjectWriter(Object o) throws IOException {
-         return externalizerTable.getObjectWriter(o);
+         ExternalizerTable table = this.externalizerTable;
+         if (table == null) {
+            throw new IllegalLifecycleStateException("Cache marshaller has been stopped");
+         }
+         return table.getObjectWriter(o);
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/remoting/transport/AbstractTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/AbstractTransport.java
@@ -68,7 +68,11 @@ public abstract class AbstractTransport implements Transport {
             throw new CacheException("Remote (" + sender + ") failed unexpectedly", exception);
          }
          
-         if (checkResponse(responseObject, sender)) responseListToAddTo.put(sender, (Response) responseObject);
+         if (checkResponse(responseObject, sender)) {
+            responseListToAddTo.put(sender, (Response) responseObject);
+         } else if (!ignoreLeavers && responseObject instanceof CacheNotFoundResponse) {
+            throw new SuspectException("Cache is stopping on node " + sender, sender);
+         }
       } else if (wasSuspected) {
          if (!ignoreLeavers) {
             throw new SuspectException("Suspected member: " + sender, sender);


### PR DESCRIPTION
Replace the exception with a CacheNotFoundResponse

https://issues.jboss.org/browse/ISPN-5494

Please integrate in 7.2.xz as well.