### PR TITLE
ISPN-5345 Allow eviction for based on approximation of size compared to element count

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/MemoryUnit.java
+++ b/commons/src/main/java/org/infinispan/commons/util/MemoryUnit.java
@@ -1,0 +1,580 @@
+package org.infinispan.commons.util;
+
+public enum MemoryUnit {
+   BYTES("B") {
+
+      @Override
+      public long convert(long sourceSize, MemoryUnit sourceUnit) {
+         return sourceUnit.toBytes(sourceSize);
+      }
+
+      @Override
+      public long toBytes(long size) {
+         return size;
+      }
+
+      @Override
+      public long toKiloBytes(long size) {
+         return size / KILO;
+      }
+
+      @Override
+      public long toKibiBytes(long size) {
+         return size / KIBI;
+      }
+
+      @Override
+      public long toMegaBytes(long size) {
+         return size / MEGA;
+      }
+
+      @Override
+      public long toMebiBytes(long size) {
+         return size / MEBI;
+      }
+
+      @Override
+      public long toGigaBytes(long size) {
+         return size / GIGA;
+      }
+
+      @Override
+      public long toGibiBytes(long size) {
+         return size / GIBI;
+      }
+
+      @Override
+      public long toTeraBytes(long size) {
+         return size / TERA;
+      }
+
+      @Override
+      public long toTebiBytes(long size) {
+         return size / TEBI;
+      }
+   },
+
+   KILOBYTES("K") {
+
+      @Override
+      public long convert(long sourceSize, MemoryUnit sourceUnit) {
+         return sourceUnit.toKiloBytes(sourceSize);
+      }
+
+      @Override
+      public long toBytes(long size) {
+         return x(size, KILO, MAX / KILO);
+      }
+
+      @Override
+      public long toKiloBytes(long size) {
+         return size;
+      }
+
+      @Override
+      public long toKibiBytes(long size) {
+         return f(size, KILO, KIBI);
+      }
+
+      @Override
+      public long toMegaBytes(long size) {
+         return size / KILO;
+      }
+
+      @Override
+      public long toMebiBytes(long size) {
+         return f(size, KILO, MEBI);
+      }
+
+      @Override
+      public long toGigaBytes(long size) {
+         return size / MEGA;
+      }
+
+      @Override
+      public long toGibiBytes(long size) {
+         return f(size, KILO, GIBI);
+      }
+
+      @Override
+      public long toTeraBytes(long size) {
+         return size / GIGA;
+      }
+
+      @Override
+      public long toTebiBytes(long size) {
+         return f(size, KILO, TEBI);
+      }
+
+   },
+
+   KIBIBYTES("Ki") {
+
+      @Override
+      public long convert(long sourceSize, MemoryUnit sourceUnit) {
+         return sourceUnit.toKibiBytes(sourceSize);
+      }
+
+      @Override
+      public long toBytes(long size) {
+         return x(size, KIBI, MAX / KIBI);
+      }
+
+      @Override
+      public long toKiloBytes(long size) {
+         return f(size, KIBI, KILO);
+      }
+
+      @Override
+      public long toKibiBytes(long size) {
+         return size;
+      }
+
+      @Override
+      public long toMegaBytes(long size) {
+         return f(size, KIBI, MEGA);
+      }
+
+      @Override
+      public long toMebiBytes(long size) {
+         return size / KIBI;
+      }
+
+      @Override
+      public long toGigaBytes(long size) {
+         return f(size, KIBI, GIGA);
+      }
+
+      @Override
+      public long toGibiBytes(long size) {
+         return size / MEBI;
+      }
+
+      @Override
+      public long toTeraBytes(long size) {
+         return f(size, KIBI, TERA);
+      }
+
+      @Override
+      public long toTebiBytes(long size) {
+         return size / GIBI;
+      }
+
+   },
+
+   MEGABYTES("M") {
+
+      @Override
+      public long convert(long sourceSize, MemoryUnit sourceUnit) {
+         return sourceUnit.toMegaBytes(sourceSize);
+      }
+
+      @Override
+      public long toBytes(long size) {
+         return x(size, MEGA, MAX / MEGA);
+      }
+
+      @Override
+      public long toKiloBytes(long size) {
+         return x(size, KILO, MAX / KILO);
+      }
+
+      @Override
+      public long toKibiBytes(long size) {
+         return f(size, MEGA, KIBI);
+      }
+
+      @Override
+      public long toMegaBytes(long size) {
+         return size;
+      }
+
+      @Override
+      public long toMebiBytes(long size) {
+         return f(size, MEGA, MEBI);
+      }
+
+      @Override
+      public long toGigaBytes(long size) {
+         return size / KILO;
+      }
+
+      @Override
+      public long toGibiBytes(long size) {
+         return f(size, MEGA, GIBI);
+      }
+
+      @Override
+      public long toTeraBytes(long size) {
+         return size / MEGA;
+      }
+
+      @Override
+      public long toTebiBytes(long size) {
+         return f(size, MEGA, TEBI);
+      }
+
+   },
+
+   MEBIBYTES("Mi") {
+
+      @Override
+      public long convert(long sourceSize, MemoryUnit sourceUnit) {
+         return sourceUnit.toMebiBytes(sourceSize);
+      }
+
+      @Override
+      public long toBytes(long size) {
+         return x(size, MEBI, MAX / MEBI);
+      }
+
+      @Override
+      public long toKiloBytes(long size) {
+         return f(size, MEBI, KILO);
+      }
+
+      @Override
+      public long toKibiBytes(long size) {
+         return x(size, KIBI, MAX / KIBI);
+      }
+
+      @Override
+      public long toMegaBytes(long size) {
+         return f(size, MEBI, MEGA);
+      }
+
+      @Override
+      public long toMebiBytes(long size) {
+         return size;
+      }
+
+      @Override
+      public long toGigaBytes(long size) {
+         return f(size, MEBI, GIGA);
+      }
+
+      @Override
+      public long toGibiBytes(long size) {
+         return size / KIBI;
+      }
+
+      @Override
+      public long toTeraBytes(long size) {
+         return f(size, MEBI, TERA);
+      }
+
+      @Override
+      public long toTebiBytes(long size) {
+         return size / MEBI;
+      }
+
+   },
+
+   GIGABYTES("G") {
+
+      @Override
+      public long convert(long sourceSize, MemoryUnit sourceUnit) {
+         return sourceUnit.toGigaBytes(sourceSize);
+      }
+
+      @Override
+      public long toBytes(long size) {
+         return x(size, GIGA, MAX / GIGA);
+      }
+
+      @Override
+      public long toKiloBytes(long size) {
+         return x(size, MEGA, MAX / MEGA);
+      }
+
+      @Override
+      public long toKibiBytes(long size) {
+         return f(size, GIGA, KIBI);
+      }
+
+      @Override
+      public long toMegaBytes(long size) {
+         return x(size, KILO, MAX / KILO);
+      }
+
+      @Override
+      public long toMebiBytes(long size) {
+         return f(size, GIGA, MEBI);
+      }
+
+      @Override
+      public long toGigaBytes(long size) {
+         return size;
+      }
+
+      @Override
+      public long toGibiBytes(long size) {
+         return f(size, GIGA, GIBI);
+      }
+
+      @Override
+      public long toTeraBytes(long size) {
+         return size / KILO;
+      }
+
+      @Override
+      public long toTebiBytes(long size) {
+         return f(size, GIGA, TEBI);
+      }
+
+   },
+
+   GIBIBYTES("Gi") {
+
+      @Override
+      public long convert(long sourceSize, MemoryUnit sourceUnit) {
+         return sourceUnit.toGibiBytes(sourceSize);
+      }
+
+      @Override
+      public long toBytes(long size) {
+         return x(size, GIBI, MAX / GIBI);
+      }
+
+      @Override
+      public long toKiloBytes(long size) {
+         return f(size, GIBI, KILO);
+      }
+
+      @Override
+      public long toKibiBytes(long size) {
+         return x(size, MEBI, MAX / MEBI);
+      }
+
+      @Override
+      public long toMegaBytes(long size) {
+         return f(size, GIBI, MEGA);
+      }
+
+      @Override
+      public long toMebiBytes(long size) {
+         return x(size, KIBI, MAX / KIBI);
+      }
+
+      @Override
+      public long toGigaBytes(long size) {
+         return f(size, GIBI, GIGA);
+      }
+
+      @Override
+      public long toGibiBytes(long size) {
+         return size;
+      }
+
+      @Override
+      public long toTeraBytes(long size) {
+         return f(size, GIBI, TERA);
+      }
+
+      @Override
+      public long toTebiBytes(long size) {
+         return size / KIBI;
+      }
+
+   },
+
+   TERABYTES("T") {
+
+      @Override
+      public long convert(long sourceSize, MemoryUnit sourceUnit) {
+         return sourceUnit.toTeraBytes(sourceSize);
+      }
+
+      @Override
+      public long toBytes(long size) {
+         return x(size, TERA, MAX / TERA);
+      }
+
+      @Override
+      public long toKiloBytes(long size) {
+         return x(size, GIGA, MAX / GIGA);
+      }
+
+      @Override
+      public long toKibiBytes(long size) {
+         return f(size, TERA, KIBI);
+      }
+
+      @Override
+      public long toMegaBytes(long size) {
+         return x(size, MEGA, MAX / MEGA);
+      }
+
+      @Override
+      public long toMebiBytes(long size) {
+         return f(size, TERA, MEBI);
+      }
+
+      @Override
+      public long toGigaBytes(long size) {
+         return x(size, KILO, MAX / KILO);
+      }
+
+      @Override
+      public long toGibiBytes(long size) {
+         return f(size, TERA, GIBI);
+      }
+
+      @Override
+      public long toTeraBytes(long size) {
+         return size;
+      }
+
+      @Override
+      public long toTebiBytes(long size) {
+         return f(size, TERA, TEBI);
+      }
+
+   },
+
+   TEBIBYTES("Ti") {
+
+      @Override
+      public long convert(long sourceSize, MemoryUnit sourceUnit) {
+         return sourceUnit.toTebiBytes(sourceSize);
+      }
+
+      @Override
+      public long toBytes(long size) {
+         return x(size, TEBI, MAX / TEBI);
+      }
+
+      @Override
+      public long toKiloBytes(long size) {
+         return f(size, TEBI, KILO);
+      }
+
+      @Override
+      public long toKibiBytes(long size) {
+         return x(size, GIBI, MAX / GIBI);
+      }
+
+      @Override
+      public long toMegaBytes(long size) {
+         return f(size, TEBI, MEGA);
+      }
+
+      @Override
+      public long toMebiBytes(long size) {
+         return x(size, MEBI, MAX / MEBI);
+      }
+
+      @Override
+      public long toGigaBytes(long size) {
+         return f(size, TEBI, GIGA);
+      }
+
+      @Override
+      public long toGibiBytes(long size) {
+         return x(size, KIBI, MAX / KIBI);
+      }
+
+      @Override
+      public long toTeraBytes(long size) {
+         return f(size, TEBI, TERA);
+      }
+
+      @Override
+      public long toTebiBytes(long size) {
+         return size;
+      }
+   };
+
+   private static final long KILO = 1000;
+   private static final long KIBI = 1024;
+   private static final long MEGA = KILO * KILO;
+   private static final long MEBI = KIBI * KIBI;
+   private static final long GIGA = KILO * MEGA;
+   private static final long GIBI = KIBI * MEBI;
+   private static final long TERA = KILO * GIGA;
+   private static final long TEBI = KIBI * GIBI;
+   static final long MAX = Long.MAX_VALUE;
+
+   private final String suffix;
+
+   MemoryUnit(String suffix) {
+      this.suffix = suffix;
+   }
+
+   public String getSuffix() {
+      return suffix;
+   }
+
+   static long f(long d, long numerator, long denominator) {
+      return (long) (((float)d) * ((float)numerator) / (denominator));
+   }
+;
+   static long x(long d, long m, long over) {
+      if (d > over)
+         return Long.MAX_VALUE;
+      if (d < -over)
+         return Long.MIN_VALUE;
+      return d * m;
+   }
+
+   public long convert(long sourceSize, MemoryUnit sourceUnit) {
+      throw new AbstractMethodError();
+   }
+
+   public long toBytes(long size) {
+      throw new AbstractMethodError();
+   }
+
+   public long toKiloBytes(long size) {
+      throw new AbstractMethodError();
+   }
+
+   public long toKibiBytes(long size) {
+      throw new AbstractMethodError();
+   }
+
+   public long toMegaBytes(long size) {
+      throw new AbstractMethodError();
+   }
+
+   public long toMebiBytes(long size) {
+      throw new AbstractMethodError();
+   }
+
+   public long toGigaBytes(long size) {
+      throw new AbstractMethodError();
+   }
+
+   public long toGibiBytes(long size) {
+      throw new AbstractMethodError();
+   }
+
+   public long toTeraBytes(long size) {
+      throw new AbstractMethodError();
+   }
+
+   public long toTebiBytes(long size) {
+      throw new AbstractMethodError();
+   }
+
+   public static long parseBytes(String s) {
+      if (s == null)
+         throw new NullPointerException();
+      int us = s.length();
+      while (us > 0 && !Character.isDigit(s.charAt(us - 1))) {
+         us--;
+      }
+      if (us == s.length()) {
+         return Long.parseLong(s);
+      }
+      String suffix = s.substring(us);
+      for(MemoryUnit u : MemoryUnit.values()) {
+         if (u.suffix.equals(suffix)) {
+            long size = Long.parseLong(s.substring(0, us));
+            return u.toBytes(size);
+         }
+      }
+      throw new IllegalArgumentException(s);
+   }
+
+}

--- a/commons/src/test/java/org/infinispan/commons/util/MemoryUnitTest.java
+++ b/commons/src/test/java/org/infinispan/commons/util/MemoryUnitTest.java
@@ -1,0 +1,20 @@
+package org.infinispan.commons.util;
+
+import static org.testng.AssertJUnit.assertEquals;
+import org.testng.annotations.Test;
+
+@Test(testName="commons.util.MemoryUnitTest", groups="functional")
+public class MemoryUnitTest {
+
+   public void testMemoryUnitParser() {
+      assertEquals(1000, MemoryUnit.parseBytes("1000"));
+      assertEquals(1000, MemoryUnit.parseBytes("1K"));
+      assertEquals(1024, MemoryUnit.parseBytes("1Ki"));
+      assertEquals(1_000_000l, MemoryUnit.parseBytes("1M"));
+      assertEquals(1_048_576l, MemoryUnit.parseBytes("1Mi"));
+      assertEquals(1_000_000_000l, MemoryUnit.parseBytes("1G"));
+      assertEquals(1_073_741_824l, MemoryUnit.parseBytes("1Gi"));
+      assertEquals(1_000_000_000_000l, MemoryUnit.parseBytes("1T"));
+      assertEquals(1_099_511_627_776l, MemoryUnit.parseBytes("1Ti"));
+   }
+}

--- a/core/src/main/java/org/infinispan/configuration/cache/EvictionConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/EvictionConfiguration.java
@@ -5,26 +5,31 @@ import org.infinispan.commons.configuration.attributes.AttributeDefinition;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.eviction.EvictionThreadPolicy;
+import org.infinispan.eviction.EvictionType;
 
 /**
  * Controls the eviction settings for the cache.
  */
 public class EvictionConfiguration {
-   public static final AttributeDefinition<Long> MAX_ENTRIES  = AttributeDefinition.builder("maxEntries", -1l).build();
+   public static final AttributeDefinition<Long> SIZE  = AttributeDefinition.builder("size", -1l).build();
+   public static final AttributeDefinition<EvictionType> TYPE  = AttributeDefinition.builder("type", EvictionType.COUNT).build();
    public static final AttributeDefinition<EvictionStrategy> STRATEGY = AttributeDefinition.builder("strategy", EvictionStrategy.NONE).immutable().build();
    public static final AttributeDefinition<EvictionThreadPolicy> THREAD_POLICY = AttributeDefinition.builder("threadPolicy", EvictionThreadPolicy.DEFAULT).immutable().build();
    static AttributeSet attributeDefinitionSet() {
-      return new AttributeSet(EvictionConfiguration.class, MAX_ENTRIES, STRATEGY, THREAD_POLICY);
+      return new AttributeSet(EvictionConfiguration.class, SIZE,
+            TYPE, STRATEGY, THREAD_POLICY);
    }
 
-   private final Attribute<Long> maxEntries;
+   private final Attribute<Long> size;
+   private final Attribute<EvictionType> type;
    private final Attribute<EvictionStrategy> strategy;
    private final Attribute<EvictionThreadPolicy> threadPolicy;
    private final AttributeSet attributes;
 
    EvictionConfiguration(AttributeSet attributes) {
       this.attributes = attributes.checkProtection();
-      maxEntries = attributes.attribute(MAX_ENTRIES);
+      size = attributes.attribute(SIZE);
+      type = attributes.attribute(TYPE);
       strategy = attributes.attribute(STRATEGY);
       threadPolicy = attributes.attribute(THREAD_POLICY);
    }
@@ -47,10 +52,22 @@ public class EvictionConfiguration {
    /**
     * Maximum number of entries in a cache instance. Cache size is guaranteed not to exceed upper
     * limit specified by max entries. However, due to the nature of eviction it is unlikely to ever
-    * be exactly maximum number of entries specified here.
+    * be exactly maximum number of entries specified here. Only makes sense when using the
+    * COUNT type.
     */
    public long maxEntries() {
-      return maxEntries.get();
+      if (type.get() != EvictionType.COUNT) {
+         throw new IllegalStateException();
+      }
+      return size();
+   }
+
+   public long size() {
+      return size.get();
+   }
+
+   public EvictionType type() {
+      return type.get();
    }
 
    public AttributeSet attributes() {

--- a/core/src/main/java/org/infinispan/configuration/cache/SecurityActions.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/SecurityActions.java
@@ -1,0 +1,33 @@
+package org.infinispan.configuration.cache;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import org.infinispan.security.Security;
+import org.infinispan.security.actions.GetSystemPropertyAction;
+
+/**
+ * SecurityActions for the org.infinispan.configuration.cache package.
+ *
+ * Do not move. Do not change class and method visibility to avoid being called from other
+ * {@link java.security.CodeSource}s, thus granting privilege escalation to external code.
+ *
+ * @author Tristan Tarrant
+ * @since 8.0
+ */
+final class SecurityActions {
+   private static <T> T doPrivileged(PrivilegedAction<T> action) {
+      if (System.getSecurityManager() != null) {
+         return AccessController.doPrivileged(action);
+      } else {
+         return Security.doPrivileged(action);
+      }
+   }
+
+   static String getSystemProperty(String propertyName) {
+      GetSystemPropertyAction action = new GetSystemPropertyAction(propertyName);
+      return doPrivileged(action);
+   }
+
+
+}

--- a/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
@@ -102,6 +102,7 @@ public enum Attribute {
     SHUTDOWN_TIMEOUT("shutdown-timeout"),
     SINGLETON("singleton"),
     SITE("site"),
+    SIZE("size"),
     SPIN_DURATION("deadlock-detection-spin"),
     STATISTICS("statistics"),
     START("start"),
@@ -123,6 +124,7 @@ public enum Attribute {
     TRANSACTION_MANAGER_LOOKUP_CLASS("transaction-manager-lookup"),
     TRANSACTION_PROTOCOL("protocol"),
     TRANSPORT("transport"),
+    TYPE("type"),
     UNRELIABLE_RETURN_VALUES("unreliable-return-values"),
     USE_TWO_PHASE_COMMIT("two-phase-commit"),
     VALUE("value"),
@@ -131,7 +133,7 @@ public enum Attribute {
     VERSIONING_SCHEME("scheme"),
     WAIT_TIME("wait-time"),
     WRITE_SKEW_CHECK("write-skew"),
-    FRAGMENTATION_FACTOR("fragmentation-factor");
+    FRAGMENTATION_FACTOR("fragmentation-factor"),
 
     ;
 

--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser80.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser80.java
@@ -23,6 +23,7 @@ import org.infinispan.distribution.ch.ConsistentHashFactory;
 import org.infinispan.distribution.group.Grouper;
 import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.eviction.EvictionThreadPolicy;
+import org.infinispan.eviction.EvictionType;
 import org.infinispan.factories.threads.DefaultThreadFactory;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.jmx.MBeanServerLookup;
@@ -1371,6 +1372,14 @@ public class Parser80 implements ConfigurationParser {
             }
             case THREAD_POLICY: {
                builder.eviction().threadPolicy(EvictionThreadPolicy.valueOf(value));
+               break;
+            }
+            case TYPE: {
+               builder.eviction().type(EvictionType.valueOf(value));
+               break;
+            }
+            case SIZE: {
+               builder.eviction().size(Long.parseLong(value));
                break;
             }
             default: {

--- a/core/src/main/java/org/infinispan/container/entries/ByteArrayCacheEntrySizeCalculator.java
+++ b/core/src/main/java/org/infinispan/container/entries/ByteArrayCacheEntrySizeCalculator.java
@@ -1,0 +1,31 @@
+package org.infinispan.container.entries;
+
+import org.infinispan.commons.util.concurrent.jdk8backported.BoundedEquivalentConcurrentHashMapV8.AbstractSizeCalculatorHelper;
+
+/**
+ * Entry Size calculator that returns an approximation of how much memory the byte[] for the key and value
+ * use.
+ * @author wburns
+ * @since 8.0
+ */
+public class ByteArrayCacheEntrySizeCalculator extends AbstractSizeCalculatorHelper<byte[], byte[]> {
+   public long calculateSize(byte[] key, byte[] value) {
+      long keySize = byteArraySize(key);
+      long valueSize = byteArraySize(value);
+      return keySize + valueSize;
+   }
+
+   private long byteArraySize(byte[] array) {
+      // There is an offset for the first entry that is overhead
+      long size = ARRAY_BYTE_BASE_OFFSET;
+      // Add in how much the offset is for each byte
+      size += array.length * ARRAY_BYTE_OFFSET;
+      // Arrays are also rounded to nearest size of 8
+      return roundUpToNearest8(size);
+   }
+
+   // Each array has a minimal overhead before the location of the first element
+   private final static int ARRAY_BYTE_BASE_OFFSET = sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+   // The offset between bytes is essentially the size for each
+   private final static int ARRAY_BYTE_OFFSET = sun.misc.Unsafe.ARRAY_BYTE_INDEX_SCALE;
+}

--- a/core/src/main/java/org/infinispan/container/entries/CacheEntrySizeCalculator.java
+++ b/core/src/main/java/org/infinispan/container/entries/CacheEntrySizeCalculator.java
@@ -1,0 +1,100 @@
+package org.infinispan.container.entries;
+
+import org.infinispan.commons.util.concurrent.jdk8backported.BoundedEquivalentConcurrentHashMapV8.AbstractSizeCalculatorHelper;
+import org.infinispan.commons.util.concurrent.jdk8backported.BoundedEquivalentConcurrentHashMapV8.EntrySizeCalculator;
+import org.infinispan.container.entries.metadata.MetadataImmortalCacheEntry;
+import org.infinispan.container.entries.metadata.MetadataMortalCacheEntry;
+import org.infinispan.container.entries.metadata.MetadataTransientCacheEntry;
+import org.infinispan.container.entries.metadata.MetadataTransientMortalCacheEntry;
+import org.infinispan.metadata.EmbeddedMetadata;
+import org.infinispan.metadata.Metadata;
+
+/**
+ * Implementation of a size calculator that calcultes only the size of the value assuming it is an InternalCacheEntry.
+ * This delegates the calculation of the key and the value contained within the InternalCacheEntry to the provided
+ * SizeCalculator.
+ * @param <K> The type of the key
+ * @param <V> The type of the value
+ * @author William Burns
+ * @since 8.0
+ */
+public class CacheEntrySizeCalculator<K, V> extends AbstractSizeCalculatorHelper<K, InternalCacheEntry<K, V>> {
+   private final EntrySizeCalculator<? super K, ? super V> calculator;
+
+   public CacheEntrySizeCalculator(EntrySizeCalculator<? super K, ? super V> calculator) {
+      this.calculator = calculator;
+   }
+
+   @Override
+   public long calculateSize(K key, InternalCacheEntry<K, V> ice) {
+      long objSize = calculator.calculateSize(key, ice.getValue());
+      long iceSize = 0;
+      long metadataSize = 0;
+      // ICE itself is an object and has a reference to it's class
+      iceSize += OBJECT_SIZE + POINTER_SIZE;
+      // Each ICE references key and value
+      iceSize += 2 * POINTER_SIZE;
+      boolean mortalEntry;
+      boolean transientEntry;
+      boolean metadataAware;
+      // We want to put immortal entries first as they are very common.  Also MetadataImmortalCacheEntry extends
+      // ImmortalCacheEntry so it has to come before
+      if (ice instanceof MetadataImmortalCacheEntry) {
+         mortalEntry = false;
+         transientEntry = false;
+         metadataAware = true;
+      } else if (ice instanceof ImmortalCacheEntry) {
+         mortalEntry = false;
+         transientEntry = false;
+         metadataAware = false;
+      } else if (ice instanceof MortalCacheEntry) {
+         mortalEntry = true;
+         transientEntry = false;
+         metadataAware = false;
+      } else if (ice instanceof TransientCacheEntry) {
+         mortalEntry = false;
+         transientEntry = true;
+         metadataAware = false;
+      } else if (ice instanceof TransientMortalCacheEntry) {
+         mortalEntry = true;
+         transientEntry = true;
+         metadataAware = false;
+      } else if (ice instanceof MetadataMortalCacheEntry) {
+         mortalEntry = true;
+         transientEntry = false;
+         metadataAware = true;
+      } else if (ice instanceof MetadataTransientCacheEntry) {
+         mortalEntry = false;
+         transientEntry = true;
+         metadataAware = true;
+      } else if (ice instanceof MetadataTransientMortalCacheEntry) {
+         mortalEntry = true;
+         transientEntry = true;
+         metadataAware = true;
+      } else {
+         mortalEntry = false;
+         transientEntry = false;
+         metadataAware = false;
+      }
+      if (metadataAware) {
+         // Assume it has a pointer for the metadata
+         iceSize += POINTER_SIZE;
+         // The metadata has itself and the class reference
+         metadataSize += OBJECT_SIZE + POINTER_SIZE;
+         Metadata metadata = ice.getMetadata();
+         if (metadata instanceof EmbeddedMetadata) {
+            // The embedded metadata has a reference and NumericVersion instance
+            metadataSize += POINTER_SIZE;
+            metadataSize = roundUpToNearest8(metadataSize);
+            // This is for the NumericVersion and the long inside of it
+            metadataSize += OBJECT_SIZE + POINTER_SIZE + 8;
+            metadataSize = roundUpToNearest8(metadataSize);
+         }
+      }
+      // Mortal uses 2 longs to keep track of created and lifespan
+      iceSize += mortalEntry ? 16 : 0;
+      // Transient uses 2 longs to keep track of last access and max idle
+      iceSize += transientEntry ? 16 : 0;
+      return objSize + roundUpToNearest8(iceSize) + metadataSize;
+   }
+}

--- a/core/src/main/java/org/infinispan/eviction/EvictionType.java
+++ b/core/src/main/java/org/infinispan/eviction/EvictionType.java
@@ -1,0 +1,12 @@
+package org.infinispan.eviction;
+
+/**
+ * Supported eviction type
+ *
+ * @author Tristan Tarrant
+ * @since 8.0
+ */
+public enum EvictionType {
+   COUNT,
+   MEMORY,
+}

--- a/core/src/main/java/org/infinispan/factories/DataContainerFactory.java
+++ b/core/src/main/java/org/infinispan/factories/DataContainerFactory.java
@@ -1,6 +1,5 @@
 package org.infinispan.factories;
 
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.container.DataContainer;
@@ -11,7 +10,7 @@ import org.infinispan.factories.annotations.DefaultFactoryFor;
 
 /**
  * Constructs the data container
- * 
+ *
  * @author Manik Surtani (<a href="mailto:manik@jboss.org">manik@jboss.org</a>)
  * @author Vladimir Blagojevic
  * @since 4.0
@@ -38,9 +37,9 @@ public class DataContainerFactory extends AbstractNamedCacheComponentFactory imp
             case LRU:
             case FIFO:
             case LIRS:
-               long maxEntries = configuration.eviction().maxEntries();
-               //handle case when < 0 value signifies unbounded container 
-               if(maxEntries < 0) {
+               long thresholdSize = configuration.eviction().size();
+               //handle case when < 0 value signifies unbounded container
+               if(thresholdSize < 0) {
                    return (T) DefaultDataContainer.unBoundedDataContainer(
                          level, keyEquivalence);
                }
@@ -48,7 +47,8 @@ public class DataContainerFactory extends AbstractNamedCacheComponentFactory imp
                EvictionThreadPolicy policy = configuration.eviction().threadPolicy();
 
                return (T) DefaultDataContainer.boundedDataContainer(
-                  level, maxEntries, st, policy, keyEquivalence);
+                  level, thresholdSize, st, policy, keyEquivalence,
+                  configuration.eviction().type());
             default:
                throw new CacheConfigurationException("Unknown eviction strategy "
                         + configuration.eviction().strategy());

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -13,6 +13,7 @@ import org.infinispan.container.entries.ImmortalCacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.eviction.EvictionType;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
@@ -645,7 +646,8 @@ public class PersistenceManagerImpl implements PersistenceManager {
 
    private long getMaxEntries() {
       long ne = EvictionConfigurationBuilder.EVICTION_MAX_SIZE;
-      if (configuration.eviction().strategy().isEnabled()) ne = configuration.eviction().maxEntries();
+      if (configuration.eviction().strategy().isEnabled() && configuration.eviction().type() == EvictionType.COUNT)
+         ne = configuration.eviction().maxEntries();
       return ne;
    }
 

--- a/core/src/main/java/org/infinispan/security/actions/GetSystemPropertyAction.java
+++ b/core/src/main/java/org/infinispan/security/actions/GetSystemPropertyAction.java
@@ -1,0 +1,26 @@
+package org.infinispan.security.actions;
+
+import java.security.PrivilegedAction;
+
+/**
+ * GetSystemPropertyAction.
+ *
+ * @author Tristan Tarrant
+ * @since 8.0
+ */
+public class GetSystemPropertyAction implements PrivilegedAction<String> {
+
+   private final String propertyName;
+
+   public GetSystemPropertyAction(String propertyName) {
+      this.propertyName = propertyName;
+   }
+
+   @Override
+   public String run() {
+      return System.getProperty(propertyName);
+   }
+
+
+
+}

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1327,11 +1327,15 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Could not find the specified JGroups configuration file '%s'", id = 365)
    CacheConfigurationException jgroupsConfigurationNotFound(String cfg);
-   
+
    @Message(value = "Unable to add a 'null' Custom Cache Store", id = 366)
    IllegalArgumentException unableToAddNullCustomStore();
 
    @LogMessage(level = ERROR)
    @Message(value = "There was an issue with topology update for topology: %s", id = 367)
    void topologyUpdateError(int topologyId, @Cause Throwable t);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Memory approximation calculation for eviction is unsupported for the '%s' Java VM", id = 368)
+   void memoryApproximationUnsupportedVM(String javaVM);
 }

--- a/core/src/main/resources/schema/infinispan-config-8.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-8.0.xsd
@@ -776,6 +776,16 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="type" type="tns:eviction-type" default="COUNT">
+      <xs:annotation>
+        <xs:documentation>Specifies whether to use entry count or memory-based approximation to decide when to evict entries.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="size" type="xs:long" default="-1">
+      <xs:annotation>
+        <xs:documentation>Maximum size to use for eviction. When using the COUNT type, this is the maximum number of entries in a cache instance. When using the MEMORY threshold policy, this is the maximum number of allocated bytes used by a cache's datacontainer. A value of -1 means no limit.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="expiration">
@@ -1664,6 +1674,21 @@
       <xs:enumeration value="DEFAULT">
         <xs:annotation>
           <xs:documentation>Use the default eviction listener thread policy (PIGGYBACK)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="eviction-type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="COUNT">
+        <xs:annotation>
+          <xs:documentation>Evicts entries from the cache when a specified count has been set</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="MEMORY">
+        <xs:annotation>
+          <xs:documentation>Evicts entries from the cache when a specified memory usage has been reached. Memory usage is computed using an approximation which is tailored for the HotSpot VM. This can only be used when both key and values are stored as byte arrays. To guarantee only byte arrays are stored it is recommended to run with store as binary for both keys and values</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
     </xs:restriction>

--- a/core/src/test/java/org/infinispan/eviction/impl/MemoryBasedEvictionFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/eviction/impl/MemoryBasedEvictionFunctionalTest.java
@@ -1,0 +1,49 @@
+package org.infinispan.eviction.impl;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.eviction.EvictionStrategy;
+import org.infinispan.eviction.EvictionType;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+import java.util.Random;
+
+import static org.testng.AssertJUnit.assertTrue;
+
+@Test(groups = "functional", testName = "eviction.MemoryBasedEvictionFunctionalTest")
+public class MemoryBasedEvictionFunctionalTest extends SingleCacheManagerTest {
+
+   private static final long CACHE_SIZE = 2000;
+
+   protected MemoryBasedEvictionFunctionalTest() {
+      cleanup = CleanupPhase.AFTER_METHOD;
+   }
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      ConfigurationBuilder builder = TestCacheManagerFactory.getDefaultCacheConfiguration(false);
+      builder.eviction().maxEntries(CACHE_SIZE)
+            .strategy(EvictionStrategy.LRU).type(EvictionType.MEMORY);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(builder);
+      cache = cm.getCache();
+      return cm;
+   }
+
+   public void testSimpleEvictionMaxEntries() throws Exception {
+      int keyValueByteSize = 100;
+      long numberInserted = CACHE_SIZE / 2 / keyValueByteSize;
+      Random random = new Random();
+      // Note that there is overhead for the map itself, so we will not get exactly the same amount
+      // More than likely there will be a few hundred byte overhead
+      for (long i = 0; i < numberInserted; i++) {
+         byte[] key = new byte[keyValueByteSize];
+         byte[] value = new byte[keyValueByteSize];
+         random.nextBytes(key);
+         random.nextBytes(value);
+         cache.put(key, value);
+      }
+      assertTrue(cache.getAdvancedCache().getDataContainer().size() < numberInserted);
+   }
+}

--- a/core/src/test/java/org/infinispan/eviction/impl/MemoryEvictionTest.java
+++ b/core/src/test/java/org/infinispan/eviction/impl/MemoryEvictionTest.java
@@ -1,0 +1,75 @@
+package org.infinispan.eviction.impl;
+
+import java.util.Random;
+
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.DataContainer;
+import org.infinispan.eviction.EvictionStrategy;
+import org.infinispan.eviction.EvictionType;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+import org.testng.annotations.Test;
+
+/**
+ * This test is useful to test how much memory is in use by the data container.  Since the Java GC may not clean up
+ * everything on 1 pass, we have to run multiple passes through until we get a number that is relatively stable.
+ * @author William Burns
+ */
+@Test(groups = "profiling", testName = "eviction.MemoryEvictionTest")
+public class MemoryEvictionTest extends SingleCacheManagerTest {
+
+   private final long MAX_MEMORY = 400 * 1000 * 1000;
+   private final int MATCH_COUNT = 5;
+
+   private final static Log log = LogFactory.getLog(MemoryEvictionTest.class);
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      ConfigurationBuilder cfg = new ConfigurationBuilder();
+      cfg
+         .eviction().strategy(EvictionStrategy.LRU).type(EvictionType.MEMORY).size(MAX_MEMORY)
+         .build();
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(cfg);
+      cache = cm.getCache();
+      return cm;
+   }
+
+   public void testSimpleSizeEviction() {
+      log.debugf("Max memory: %d", MAX_MEMORY);
+      DataContainer dc = cache.getAdvancedCache().getDataContainer();
+      printMemoryUsage(dc.size());
+      Random random = new Random();
+      int matchCount = 0;
+      int byteKeySize = 10;
+      int byteValueSize = 100;
+      long previousMemorySize = 0;
+      for (int j = 0; j < 200; ++j) {
+         while (matchCount < this.MATCH_COUNT) {
+            for (int i = 0; i < 20000; ++i) {
+               byte[] keyBytes = new byte[byteKeySize];
+               byte[] valueBytes = new byte[byteValueSize];
+               random.nextBytes(keyBytes);
+               random.nextBytes(valueBytes);
+               cache.getAdvancedCache().put(keyBytes, valueBytes);
+            }
+            long memorySize = printMemoryUsage(dc.size());
+            if (memorySize == previousMemorySize) {
+               matchCount++;
+            }
+            previousMemorySize = memorySize;
+         }
+      }
+   }
+
+   // Also returns size
+   private long printMemoryUsage(int cacheSize) {
+      System.gc(); System.gc();
+      Runtime runtime = Runtime.getRuntime();
+      long usedMemory = runtime.totalMemory() - runtime.freeMemory();
+      log.debugf("Used memory = %d, cache size = %d", usedMemory, cacheSize);
+      return usedMemory;
+   }
+}

--- a/core/src/test/java/org/infinispan/stress/DataContainerStressTest.java
+++ b/core/src/test/java/org/infinispan/stress/DataContainerStressTest.java
@@ -1,15 +1,29 @@
 package org.infinispan.stress;
 
+import org.infinispan.commons.equivalence.ByteArrayEquivalence;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.eviction.ActivationManager;
+import org.infinispan.eviction.EvictionManager;
+import org.infinispan.eviction.EvictionStrategy;
+import org.infinispan.eviction.EvictionThreadPolicy;
+import org.infinispan.eviction.EvictionType;
+import org.infinispan.eviction.PassivationManager;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.container.*;
+import org.infinispan.metadata.Metadata;
+import org.infinispan.persistence.manager.PersistenceManager;
+import org.infinispan.persistence.spi.PersistenceException;
+import org.infinispan.util.DefaultTimeService;
+import org.infinispan.util.TimeService;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -28,13 +42,113 @@ public class DataContainerStressTest {
    final int num_loops = 10000;
    final int warmup_num_loops = 10000;
    boolean use_time = true;
-   final int NUM_KEYS = 100;
+   final int NUM_KEYS = 256;
 
    private static final Log log = LogFactory.getLog(DataContainerStressTest.class);
-   private static final Random R = new Random();
 
    public void testSimpleDataContainer() throws InterruptedException {
-      doTest(DefaultDataContainer.unBoundedDataContainer(5000));
+      DefaultDataContainer dc = DefaultDataContainer.unBoundedDataContainer(5000, ByteArrayEquivalence.INSTANCE);
+      initializeDefaultDataContainer(dc);
+      doTest(dc);
+   }
+
+   public void testEntryBoundedDataContainer() throws InterruptedException {
+      DefaultDataContainer dc = DefaultDataContainer.boundedDataContainer(5000, NUM_KEYS - NUM_KEYS / 4, EvictionStrategy.LRU,
+              EvictionThreadPolicy.PIGGYBACK, ByteArrayEquivalence.INSTANCE, EvictionType.COUNT);
+      initializeDefaultDataContainer(dc);
+      doTest(dc);
+   }
+
+   public void testMemoryBoundedDataContainer() throws InterruptedException {
+      // The key length could be 4 or 5 (90% of the time it will be 5)
+      // The value length could be 6 or 7 (90% of the time it will be 7)
+      DefaultDataContainer dc = DefaultDataContainer.boundedDataContainer(5000, threeQuarterMemorySize(NUM_KEYS, 5, 20), EvictionStrategy.LRU,
+              EvictionThreadPolicy.PIGGYBACK, ByteArrayEquivalence.INSTANCE, EvictionType.MEMORY);
+      initializeDefaultDataContainer(dc);
+      doTest(dc);
+   }
+
+   private void initializeDefaultDataContainer(DefaultDataContainer dc) {
+      InternalEntryFactoryImpl entryFactory = new InternalEntryFactoryImpl();
+      TimeService timeService = new DefaultTimeService();
+      entryFactory.injectTimeService(timeService);
+      // Mockito cannot be used as it will run out of memory from keeping all the invocations, thus we use blank impls
+      dc.initialize(new EvictionManager() {
+                       @Override
+                       public void processEviction() {
+
+                       }
+
+                       @Override
+                       public boolean isEnabled() {
+                          return false;
+                       }
+
+                       @Override
+                       public void onEntryEviction(Map evicted) {
+
+                       }
+                    }, new PassivationManager() {
+                       @Override
+                       public boolean isEnabled() {
+                          return false;
+                       }
+
+                       @Override
+                       public void passivate(InternalCacheEntry entry) {
+
+                       }
+
+                       @Override
+                       public void passivateAll() throws PersistenceException {
+
+                       }
+
+                       @Override
+                       public long getPassivations() {
+                          return 0;
+                       }
+
+                       @Override
+                       public void resetStatistics() {
+
+                       }
+
+                       @Override
+                       public boolean getStatisticsEnabled() {
+                          return false;
+                       }
+
+                       @Override
+                       public void setStatisticsEnabled(boolean enabled) {
+
+                       }
+                    }, entryFactory,
+              new ActivationManager() {
+                 @Override
+                 public void onUpdate(Object key, boolean newEntry) {
+
+                 }
+
+                 @Override
+                 public void onRemove(Object key, boolean newEntry) {
+
+                 }
+
+                 @Override
+                 public long getActivationCount() {
+                    return 0;
+                 }
+              }, null, timeService);
+   }
+
+   private long threeQuarterMemorySize(int numKeys, int keyLength, int valueLength) {
+      // We are assuming each string base takes up 36 bytes (12 for the array, 8 for the class, 8 for the object itself
+      // & 4 for the inner int (this aligned is 36 bytes).
+      // We assume compressed strings are not enabled (so each character is 2 bytes (UTF-16)
+      // We are also ignoring alignment (which the key length and value length should be aligned to the nearest 8 bytes)
+      long total = numKeys * (32 + keyLength + valueLength);
+      return total - total / 4;
    }
 
    private void doTest(final DataContainer dc) throws InterruptedException {
@@ -44,20 +158,26 @@ public class DataContainerStressTest {
 
    private void doTest(final DataContainer dc, boolean warmup) throws InterruptedException {
       latch = new CountDownLatch(1);
-      final String key = "key";
+      final byte[] keyFirstBytes = new byte[4];
       final Map<String, String> perf = new ConcurrentSkipListMap<String, String>();
       final AtomicBoolean run = new AtomicBoolean(true);
       final int actual_num_loops = warmup ? warmup_num_loops : num_loops;
 
       Thread getter = new Thread() {
+         @Override
          public void run() {
+            ThreadLocalRandom R = ThreadLocalRandom.current();
             waitForStart();
             long start = System.nanoTime();
             int runs = 0;
+            byte[] captureByte = new byte[1];
+            byte[] key = Arrays.copyOf(keyFirstBytes, 5);
             while (use_time && run.get() || runs < actual_num_loops) {
-               if (runs % 100000 == 0) log.info("GET run # " + runs);
+//               if (runs % 100000 == 0) log.info("GET run # " + runs);
 //               TestingUtil.sleepThread(10);
-               dc.get(key + R.nextInt(NUM_KEYS));
+               R.nextBytes(captureByte);
+               key[4] = captureByte[0];
+               dc.get(key);
                runs++;
             }
             perf.put("GET", opsPerMS(System.nanoTime() - start, runs));
@@ -65,14 +185,23 @@ public class DataContainerStressTest {
       };
 
       Thread putter = new Thread() {
+         @Override
          public void run() {
+            ThreadLocalRandom R = ThreadLocalRandom.current();
             waitForStart();
             long start = System.nanoTime();
             int runs = 0;
+            byte[] captureByte = new byte[1];
+            byte[] key = Arrays.copyOf(keyFirstBytes, 5);
+            byte[] value = new byte[20];
+            Metadata metadata = new EmbeddedMetadata.Builder().build();
             while (use_time && run.get() || runs < actual_num_loops) {
-               if (runs % 100000 == 0) log.info("PUT run # " + runs);
+//               if (runs % 100000 == 0) log.info("PUT run # " + runs);
 //               TestingUtil.sleepThread(10);
-               dc.put(key + R.nextInt(NUM_KEYS), "value", new EmbeddedMetadata.Builder().build());
+               R.nextBytes(captureByte);
+               key[4] = captureByte[0];
+               R.nextBytes(value);
+               dc.put(key, value, metadata);
                runs++;
             }
             perf.put("PUT", opsPerMS(System.nanoTime() - start, runs));
@@ -80,14 +209,20 @@ public class DataContainerStressTest {
       };
 
       Thread remover = new Thread() {
+         @Override
          public void run() {
+            ThreadLocalRandom R = ThreadLocalRandom.current();
             waitForStart();
             long start = System.nanoTime();
             int runs = 0;
+            byte[] captureByte = new byte[1];
+            byte[] key = Arrays.copyOf(keyFirstBytes, 5);
             while (use_time && run.get() || runs < actual_num_loops) {
-               if (runs % 100000 == 0) log.info("REM run # " + runs);
+//               if (runs % 100000 == 0) log.info("REM run # " + runs);
 //               TestingUtil.sleepThread(10);
-               dc.remove(key + R.nextInt(NUM_KEYS));
+               R.nextBytes(captureByte);
+               key[4] = captureByte[0];
+               dc.remove(key);
                runs++;
             }
             perf.put("REM", opsPerMS(System.nanoTime() - start, runs));

--- a/core/src/test/resources/configs/unified/8.0.xml
+++ b/core/src/test/resources/configs/unified/8.0.xml
@@ -41,7 +41,7 @@
       <invalidation-cache name="invalid" mode="ASYNC" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="true" statistics="true">
          <locking acquire-timeout="30500" concurrency-level="2500" isolation="READ_UNCOMMITTED" striping="true"/>
          <transaction mode="BATCH" stop-timeout="60500"  locking="OPTIMISTIC"/>
-         <eviction max-entries="20500" strategy="LRU"/>
+         <eviction size="20500" strategy="LRU" type="MEMORY"/>
          <expiration interval="10500" lifespan="11" max-idle="11"/>
       </invalidation-cache>
       <replicated-cache name="repl" mode="ASYNC" queue-flush-interval="11" queue-size="1500" start="EAGER"  async-marshalling="false" statistics="true">

--- a/server/integration/build/src/main/resources/docs/schema/jboss-infinispan-core_8_0.xsd
+++ b/server/integration/build/src/main/resources/docs/schema/jboss-infinispan-core_8_0.xsd
@@ -499,6 +499,16 @@
                 <xs:documentation>Maximum number of entries in a cache instance. If selected value is not a power of two the actual value will default to the least power of two larger than selected value. -1 means no limit.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="type" type="tns:eviction-type" default="COUNT">
+            <xs:annotation>
+                <xs:documentation>Specifies whether to use entry count or memory-based approximation to decide when to evict entries.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="size" type="xs:long" default="-1">
+            <xs:annotation>
+                <xs:documentation>Maximum size to use for eviction. When using the COUNT type, this is the maximum number of entries in a cache instance. When using the MEMORY type, this is the maximum number of allocated bytes used by a cache's datacontainer. A value of -1 means no limit.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="expiration">
@@ -1517,6 +1527,21 @@
             <xs:enumeration value="FAIL">
                 <xs:annotation>
                     <xs:documentation>Fail local operations when a backup failure occurs.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:simpleType name="eviction-type">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="COUNT">
+                <xs:annotation>
+                    <xs:documentation>Evicts entries from the cache when a specified count has been set</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MEMORY">
+                <xs:annotation>
+                    <xs:documentation>Evicts entries from the cache when a specified memory usage has been reached. Memory usage is computed using an approximation which is tailored for the HotSpot VM. This can only be used when both key and values are stored as byte arrays. To guarantee only byte arrays are stored it is recommended to run with store as binary for both keys and values</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
         </xs:restriction>

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Attribute.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Attribute.java
@@ -123,6 +123,7 @@ public enum Attribute {
     SHUTDOWN_TIMEOUT(ModelKeys.SHUTDOWN_TIMEOUT),
     SINGLETON(ModelKeys.SINGLETON),
     SITE(ModelKeys.SITE),
+    SIZE(ModelKeys.SIZE),
     SOCKET_TIMEOUT(ModelKeys.SOCKET_TIMEOUT),
     STACK(ModelKeys.STACK),
     START(ModelKeys.START),

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
@@ -45,6 +45,7 @@ import org.infinispan.configuration.cache.StoreConfigurationBuilder;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
 import org.infinispan.eviction.EvictionStrategy;
+import org.infinispan.eviction.EvictionType;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.persistence.factory.CacheStoreFactory;
 import org.infinispan.persistence.jdbc.DatabaseType;
@@ -101,6 +102,7 @@ import org.jboss.tm.XAResourceRecoveryRegistry;
 
 import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -493,8 +495,15 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
             builder.eviction().strategy(strategy);
 
             if (strategy.isEnabled()) {
-                final long maxEntries = EvictionResource.MAX_ENTRIES.resolveModelAttribute(context, eviction).asLong();
-                builder.eviction().maxEntries(maxEntries);
+                if (eviction.hasDefined(ModelKeys.MAX_ENTRIES)) {
+                    final long maxEntries = EvictionResource.MAX_ENTRIES.resolveModelAttribute(context, eviction).asLong();
+                    builder.eviction().maxEntries(maxEntries);
+                } else {
+                    final long size = EvictionResource.SIZE.resolveModelAttribute(context, eviction).asLong();
+                    builder.eviction().size(size);
+                }
+                final EvictionType type = EvictionType.valueOf(EvictionResource.TYPE.resolveModelAttribute(context, eviction).asString());
+                builder.eviction().type(type);
             }
         }
         // expiration is a child resource

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/EvictionResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/EvictionResource.java
@@ -23,6 +23,8 @@
 package org.jboss.as.clustering.infinispan.subsystem;
 
 import org.infinispan.eviction.EvictionStrategy;
+import org.infinispan.eviction.EvictionThreadPolicy;
+import org.infinispan.eviction.EvictionType;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -60,7 +62,24 @@ public class EvictionResource extends CacheChildResource {
                     .setDefaultValue(new ModelNode().set(-1))
                     .build();
 
-    static final AttributeDefinition[] EVICTION_ATTRIBUTES = {EVICTION_STRATEGY, MAX_ENTRIES};
+    static final SimpleAttributeDefinition SIZE =
+            new SimpleAttributeDefinitionBuilder(ModelKeys.SIZE, ModelType.LONG, true)
+                    .setXmlName(Attribute.SIZE.getLocalName())
+                    .setAllowExpression(true)
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .setDefaultValue(new ModelNode().set(-1))
+                    .build();
+
+    static final SimpleAttributeDefinition TYPE =
+            new SimpleAttributeDefinitionBuilder(ModelKeys.TYPE, ModelType.STRING, true)
+                   .setXmlName(Attribute.TYPE.getLocalName())
+                   .setAllowExpression(true)
+                   .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                   .setValidator(new EnumValidator<>(EvictionType.class, true, false))
+                   .setDefaultValue(new ModelNode().set(EvictionType.COUNT.name()))
+                   .build();
+
+    static final AttributeDefinition[] EVICTION_ATTRIBUTES = {EVICTION_STRATEGY, MAX_ENTRIES, SIZE, TYPE};
 
     public EvictionResource(CacheResource cacheResource) {
         super(EVICTION_PATH, ModelKeys.EVICTION, cacheResource, EVICTION_ATTRIBUTES);

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_8_0.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_8_0.java
@@ -798,6 +798,14 @@ public final class InfinispanSubsystemXMLReader_8_0 implements XMLElementReader<
                     EvictionResource.MAX_ENTRIES.parseAndSetParameter(value, eviction, reader);
                     break;
                 }
+                case TYPE: {
+                    EvictionResource.TYPE.parseAndSetParameter(value, eviction, reader);
+                    break;
+                }
+                case SIZE: {
+                    EvictionResource.SIZE.parseAndSetParameter(value, eviction, reader);
+                    break;
+                }
                 default: {
                     throw ParseUtils.unexpectedAttribute(reader, i);
                 }

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
@@ -239,6 +239,8 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
             ModelNode eviction = cache.get(ModelKeys.EVICTION, ModelKeys.EVICTION_NAME);
             this.writeOptional(writer, Attribute.STRATEGY, eviction, ModelKeys.STRATEGY);
             this.writeOptional(writer, Attribute.MAX_ENTRIES, eviction, ModelKeys.MAX_ENTRIES);
+            this.writeOptional(writer, Attribute.TYPE, eviction, ModelKeys.TYPE);
+            this.writeOptional(writer, Attribute.SIZE, eviction, ModelKeys.SIZE);
             writer.writeEndElement();
         }
 

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
@@ -179,6 +179,7 @@ public class ModelKeys {
     static final String SHUTDOWN_TIMEOUT = "shutdown-timeout";
     static final String SINGLETON = "singleton";
     static final String SITE = "site";
+    static final String SIZE = "size";
     static final String SOCKET_TIMEOUT = "socket-timeout";
     static final String STACK = "stack";
     static final String START = "start";

--- a/server/integration/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/server/integration/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -245,7 +245,9 @@ infinispan.transaction.recovery.forget-transaction.internal-id=The internal ID o
 #
 infinispan.eviction=The cache eviction configuration.
 infinispan.eviction.strategy=Sets the cache eviction strategy. Available options are 'UNORDERED', 'FIFO', 'LRU', 'LIRS' and 'NONE' (to disable eviction).
-infinispan.eviction.max-entries=Maximum number of entries in a cache instance. If selected value is not a power of two the actual value will default to the least power of two larger than selected value. -1 means no limit.
+infinispan.eviction.max-entries=Maximum number of entries in a cache instance. -1 means no limit. Also sets the type to COUNT.
+infinispan.eviction.size=Sets the maximum size for the eviction type. 
+infinispan.eviction.type=Specifies whether to use entry count or memory-based approximation. When using MEMORY, size will be the amount in bytes approximately that the data container will use in memory. The approximation is tailored for the HotSpot JVM.
 infinispan.eviction.add=Adds an eviction configuration element to the cache.
 infinispan.eviction.remove=Removes an eviction configuration element from the cache.
 #

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_8_0.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_8_0.xml
@@ -40,7 +40,7 @@
         <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="true"  statistics="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
             <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
-            <eviction max-entries="20000" strategy="LRU"/>
+            <eviction size="20000" strategy="LRU" type="MEMORY"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <remote-store cache="default" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="true" singleton="false" hotrod-wrapping="true" raw-values="true" name="remote-store">
                 <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5345 

* Added in size calculation for byte[] key/value pairs with LRU

This supersedes' @wburns https://github.com/infinispan/infinispan/pull/3467 and introduces the following changes:
- add type=COUNT|MEMORY to choose how to evict entries
- add size which replaces maxEntries and works for both types
- add a warning when not running under HotSpot
- add a MemoryUnit utility class inspired by TimeUnit