### PR TITLE
ISPN-5500 direct init of tmpDirs in LevelDB tests, removed @BeforeClass

### DIFF
--- a/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBMultiCacheStoreFunctionalTest.java
+++ b/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBMultiCacheStoreFunctionalTest.java
@@ -14,12 +14,7 @@ import java.io.File;
 @Test(groups = "unit", testName = "persistence.leveldb.LevelDBMultiCacheStoreFunctionalTest")
 public class LevelDBMultiCacheStoreFunctionalTest extends MultiStoresFunctionalTest<LevelDBStoreConfigurationBuilder> {
 
-   private File tmpDir;
-
-   @BeforeClass
-   protected void setPaths() {
-      tmpDir = new File(TestingUtil.tmpDirectory(this.getClass()));
-   }
+   private File tmpDir = new File(TestingUtil.tmpDirectory(this.getClass()));
 
    @BeforeMethod
    protected void cleanDataFiles() {
@@ -27,7 +22,6 @@ public class LevelDBMultiCacheStoreFunctionalTest extends MultiStoresFunctionalT
          TestingUtil.recursiveFileRemove(tmpDir);
       }
    }
-
 
    @Override
    protected LevelDBStoreConfigurationBuilder buildCacheStoreConfig(PersistenceConfigurationBuilder p, String discriminator) throws Exception {

--- a/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBStoreFunctionalTest.java
+++ b/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBStoreFunctionalTest.java
@@ -10,12 +10,7 @@ import org.testng.annotations.BeforeClass;
 import java.io.File;
 
 public abstract class LevelDBStoreFunctionalTest extends BaseStoreFunctionalTest {
-   protected String tmpDirectory;
-
-   @BeforeClass(alwaysRun = true)
-   protected void setUpTempDir() {
-      tmpDirectory = TestingUtil.tmpDirectory(this.getClass());
-   }
+   protected String tmpDirectory = TestingUtil.tmpDirectory(this.getClass());
 
    @AfterClass(alwaysRun = true)
    protected void clearTempDir() {

--- a/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBStoreTest.java
+++ b/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBStoreTest.java
@@ -28,12 +28,7 @@ import org.testng.annotations.Test;
 @Test(groups = "unit", testName = "persistence.leveldb.LevelDBStoreTest")
 public class LevelDBStoreTest extends BaseStoreTest {
 
-   private String tmpDirectory;
-
-   @BeforeClass
-   protected void setUpTempDir() {
-      tmpDirectory = TestingUtil.tmpDirectory(this.getClass());
-   }
+   private String tmpDirectory = TestingUtil.tmpDirectory(this.getClass());
 
    @AfterClass(alwaysRun = true)
    protected void clearTempDir() {

--- a/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/config/ConfigurationTest.java
+++ b/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/config/ConfigurationTest.java
@@ -28,16 +28,9 @@ import static org.testng.AssertJUnit.assertTrue;
  */
 @Test(groups = "unit", testName = "persistence.leveldb.configuration.ConfigurationTest")
 public class ConfigurationTest extends AbstractInfinispanTest {
-   private String tmpDirectory;
-   private String tmpDataDirectory;
-   private String tmpExpiredDirectory;
-
-   @BeforeClass
-   protected void setUpTempDir() {
-      tmpDirectory = TestingUtil.tmpDirectory(this.getClass());
-      tmpDataDirectory = tmpDirectory + "/data";
-      tmpExpiredDirectory = tmpDirectory + "/expired";
-   }
+   private String tmpDirectory = TestingUtil.tmpDirectory(this.getClass());
+   private String tmpDataDirectory = tmpDirectory + "/data";
+   private String tmpExpiredDirectory = tmpDirectory + "/expired";
 
    @AfterClass(alwaysRun = true)
    protected void clearTempDir() {


### PR DESCRIPTION
There is more info in JIRA desc.

https://issues.jboss.org/browse/ISPN-5500
