### PR TITLE
Improve StateTransferLockImpl.waitForTransactionData logging

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferLockImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferLockImpl.java
@@ -75,14 +75,13 @@ public class StateTransferLockImpl implements StateTransferLock {
    @Override
    public void waitForTransactionData(int expectedTopologyId, long timeout,
                                       TimeUnit unit) throws InterruptedException {
-      if (trace) {
-         log.tracef("Waiting for transaction data for topology %d, current topology is %d", expectedTopologyId,
-               transactionDataTopologyId);
-      }
-
       if (transactionDataTopologyId >= expectedTopologyId)
          return;
 
+      if (trace) {
+         log.tracef("Waiting for transaction data for topology %d, current topology is %d", expectedTopologyId,
+                    transactionDataTopologyId);
+      }
       transactionDataLock.lock();
       try {
          long timeoutNanos = unit.toNanos(timeout);


### PR DESCRIPTION
Don't log "Waiting for transaction data..." message if transactionDataLock is not acquired. This clutters logs especially with incoming ClusteredGet commands.