### PR TITLE
ISPN-5477 Only unbox compatibility returns when operations are local

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/DistTopologyChangeUnderLoadSingleOwnerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/DistTopologyChangeUnderLoadSingleOwnerTest.java
@@ -31,6 +31,11 @@ public class DistTopologyChangeUnderLoadSingleOwnerTest extends MultiHotRodServe
       return hotRodCacheConfiguration(builder);
    }
 
+   @Override
+   protected int maxRetries() {
+      return 1;
+   }
+
    public void testRestartServerWhilePutting() throws Exception {
       RemoteCache<Integer, String> remote = client(0).getCache();
       remote.put(1, "v1");

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/DistTopologyChangeUnderLoadTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/DistTopologyChangeUnderLoadTest.java
@@ -33,6 +33,11 @@ public class DistTopologyChangeUnderLoadTest extends MultiHotRodServersTest {
       return hotRodCacheConfiguration(builder);
    }
 
+   @Override
+   protected int maxRetries() {
+      return 1;
+   }
+
    public void testPutsSucceedWhileTopologyChanges() throws Exception {
       RemoteCache<Integer, String> remote = client(0).getCache();
       remote.put(1, "v1");

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/CompleteShutdownReplRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/CompleteShutdownReplRetryTest.java
@@ -19,6 +19,11 @@ public class CompleteShutdownReplRetryTest extends MultiHotRodServersTest {
       // Empty
    }
 
+   @Override
+   protected int maxRetries() {
+      return 1;
+   }
+
    public void testRetryAfterCompleteShutdown() {
       ConfigurationBuilder builder = hotRodCacheConfiguration(
          getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false));

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
@@ -1,7 +1,6 @@
 package org.infinispan.client.hotrod.test;
 
 import org.infinispan.client.hotrod.RemoteCacheManager;
-import org.infinispan.client.hotrod.test.InternalRemoteCacheManager;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -58,8 +57,13 @@ public abstract class MultiHotRodServersTest extends MultipleCacheManagersTest {
       clientBuilder.addServer()
             .host("localhost")
             .port(serverPort)
+            .maxRetries(maxRetries())
             .pingOnStartup(false);
       return clientBuilder;
+   }
+
+   protected int maxRetries() {
+      return 0;
    }
 
    @AfterMethod(alwaysRun = true)

--- a/core/src/main/java/org/infinispan/commands/read/GetCacheEntryCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/GetCacheEntryCommand.java
@@ -49,11 +49,6 @@ public final class GetCacheEntryCommand extends AbstractDataCommand implements R
          return null;
       }
 
-      if (entry instanceof InternalCacheEntry) {
-         InternalCacheEntry ice = (InternalCacheEntry) entry;
-         if (ice.isL1Entry()) setRemotelyFetchedValue(ice);
-      }
-
       return entryFactory.copy(entry);
    }
 

--- a/core/src/main/java/org/infinispan/commands/read/GetKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/GetKeyValueCommand.java
@@ -56,11 +56,6 @@ public class GetKeyValueCommand extends AbstractDataCommand implements RemoteFet
          return null;
       }
 
-      if (entry instanceof InternalCacheEntry) {
-         InternalCacheEntry ice = (InternalCacheEntry) entry;
-         if (ice.isL1Entry()) setRemotelyFetchedValue(ice);
-      }
-
       return entry.getValue();
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/compat/BaseTypeConverterInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/compat/BaseTypeConverterInterceptor.java
@@ -98,7 +98,7 @@ public abstract class BaseTypeConverterInterceptor extends CommandInterceptor {
       }
       Object ret = invokeNextInterceptor(ctx, command);
       if (ret != null) {
-         if (needsUnboxing(command.getRemotelyFetchedValue())) {
+         if (needsUnboxing(ctx)) {
             return converter.unboxValue(ret);
          }
          return ret;
@@ -118,7 +118,7 @@ public abstract class BaseTypeConverterInterceptor extends CommandInterceptor {
       if (ret != null) {
          CacheEntry entry = (CacheEntry) ret;
          Object returnValue = entry.getValue();
-         if (needsUnboxing(command.getRemotelyFetchedValue())) {
+         if (needsUnboxing(ctx)) {
             returnValue = converter.unboxValue(entry.getValue());
          }
          // Create a copy of the entry to avoid modifying the internal entry
@@ -129,8 +129,8 @@ public abstract class BaseTypeConverterInterceptor extends CommandInterceptor {
       return null;
    }
 
-   private boolean needsUnboxing(InternalCacheEntry remotelyFetchedValue) {
-      return remotelyFetchedValue == null;
+   private boolean needsUnboxing(InvocationContext ctx) {
+      return ctx.isOriginLocal();
    }
 
    @Override

--- a/server/core/src/main/scala/org/infinispan/server/core/logging/JavaLog.java
+++ b/server/core/src/main/scala/org/infinispan/server/core/logging/JavaLog.java
@@ -96,4 +96,9 @@ public interface JavaLog extends org.infinispan.util.logging.Log {
    @LogMessage(level = WARN)
    @Message(value = "Server endpoint topology is empty, and cluster members are %s", id = 5021)
    void serverEndpointTopologyEmpty(String clusterMembers);
+
+   @LogMessage(level = ERROR)
+   @Message(value = "Exception writing response with message id %s", id = 5022)
+   void errorWritingResponse(long msgId, @Cause Throwable t);
+
 }

--- a/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
@@ -84,4 +84,6 @@ trait Log {
 
    def logServerEndpointTopologyEmpty(clusterMembers: String) =
       log.serverEndpointTopologyEmpty(clusterMembers)
+
+   def logErrorWritingResponse(msgId: Long, t: Throwable) = log.errorWritingResponse(msgId, t)
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
@@ -7,6 +7,7 @@ import io.netty.handler.codec.MessageToMessageEncoder
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelHandler.Sharable
 import org.infinispan.server.hotrod.Events.Event
+import org.infinispan.server.hotrod.OperationStatus._
 
 /**
  * Hot Rod specific encoder.
@@ -30,15 +31,25 @@ class HotRodEncoder(cacheManager: EmbeddedCacheManager, server: HotRodServer)
       msg match {
          case r: Response =>
             val encoder = getEncoder(r.version)
-            r.version match {
-               case VERSION_10 | VERSION_11 | VERSION_12 | VERSION_13 | VERSION_20 | VERSION_21 | VERSION_22 =>
-                  encoder.writeHeader(r, buf, addressCache, server)
-               // if error before reading version, don't send any topology changes
-               // cos the encoding might vary from one version to the other
-               case 0 => encoder.writeHeader(r, buf, null, null)
-            }
+            try {
+               r.version match {
+                  case VERSION_10 | VERSION_11 | VERSION_12 | VERSION_13 | VERSION_20 | VERSION_21 | VERSION_22 =>
+                     encoder.writeHeader(r, buf, addressCache, server)
+                  // if error before reading version, don't send any topology changes
+                  // cos the encoding might vary from one version to the other
+                  case 0 => encoder.writeHeader(r, buf, null, null)
+               }
 
-            encoder.writeResponse(r, buf, cacheManager, server)
+               encoder.writeResponse(r, buf, cacheManager, server)
+            }
+            catch {
+               case t: Throwable =>
+                  logErrorWritingResponse(r.messageId, t)
+                  buf.clear() // reset buffer
+                  val error = new ErrorResponse(r.version, r.messageId, r.cacheName, r.clientIntel, ServerError, r.topologyId, t.toString)
+                  encoder.writeHeader(error, buf, addressCache, server)
+                  encoder.writeResponse(error, buf, cacheManager, server)
+            }
          case e: Event =>
             val encoder = getEncoder(e.version)
             encoder.writeEvent(e, buf)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5477

Third time lucky. A more robust solution, with capturing of root exception that was happening when responses were being written, and reduce number of Hot Rod retries for more predictable testing.

* Added handling of exceptions when responses are being written. By doing so, ClassCastExceptions that were happening are uncovered, logged and corresponding errors are sent back instead of waiting for socket timeouts.
* Eliminate operation retries were not necessary to make socket timeouts appear more quickly if something hangs.