### PR TITLE
ISPN-5444 Filter/converters can work with custom classes

### DIFF
--- a/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
@@ -251,10 +251,15 @@ plugged with the name and the cache event filter factory instance. Plugging the
 Infinispan Server with a custom filter involves the following steps:
 
 1. Create a JAR file with the filter implementation within it.
-2. Create a `META-INF/services/org.infinispan.notifications.cachelistener.filter.CacheEventFilterFactory` file
+2. Optional: If the cache uses custom key/value classes, these must be
+included in the JAR so that the callbacks can be executed with the correctly
+unmarshalled key and/or value instances. If the client listener has `useRawData`
+enabled, this is not necessary since the callback key/value instances will be
+provided in binary format.
+3. Create a `META-INF/services/org.infinispan.notifications.cachelistener.filter.CacheEventFilterFactory` file
 within the JAR file and within it, write the fully qualified class name of the
 filter class implementation.
-3. Deploy the JAR file in the Infinispan Server.
+4. Deploy the JAR file in the Infinispan Server.
 
 On top of that, the client listener needs to be linked with this cache event
 filter factory by adding the factory's name to the @ClientListener annotation:
@@ -410,10 +415,15 @@ plugged with the name and the cache event converter factory instance. Plugging t
 Infinispan Server with an event converter involves the following steps:
 
 1. Create a JAR file with the converter implementation within it.
-2. Create a `META-INF/services/org.infinispan.notifications.cachelistener.filter.CacheEventConverterFactory` file
+2. Optional: If the cache uses custom key/value classes, these must be
+included in the JAR so that the callbacks can be executed with the correctly
+unmarshalled key and/or value instances. If the client listener has `useRawData`
+enabled, this is not necessary since the callback key/value instances will be
+provided in binary format.
+3. Create a `META-INF/services/org.infinispan.notifications.cachelistener.filter.CacheEventConverterFactory` file
 within the JAR file and within it, write the fully qualified class name of the
 converter class implementation.
-3. Deploy the JAR file in the Infinispan Server.
+4. Deploy the JAR file in the Infinispan Server.
 
 On top of that, the client listener needs to be linked with this converter
 factory by adding the factory's name to the @ClientListener annotation:
@@ -531,10 +541,15 @@ name and the cache event converter factory instance. Plugging the Infinispan
 Server with an event converter involves the following steps:
 
 1. Create a JAR file with the converter implementation within it.
-2. Create a `META-INF/services/org.infinispan.notifications.cachelistener.filter.CacheEventFilterConverterFactory` file
+2. Optional: If the cache uses custom key/value classes, these must be
+included in the JAR so that the callbacks can be executed with the correctly
+unmarshalled key and/or value instances. If the client listener has `useRawData`
+enabled, this is not necessary since the callback key/value instances will be
+provided in binary format.
+3. Create a `META-INF/services/org.infinispan.notifications.cachelistener.filter.CacheEventFilterConverterFactory` file
 within the JAR file and within it, write the fully qualified class name of the
 converter class implementation.
-3. Deploy the JAR file in the Infinispan Server.
+4. Deploy the JAR file in the Infinispan Server.
 
 From a client perspective, to be able to use the combined filter and
 converter class, the client listener must define the same filter factory and

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/CustomEvent.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/CustomEvent.java
@@ -2,10 +2,10 @@ package org.infinispan.server.test.client.hotrod;
 
 import java.io.Serializable;
 
-public class CustomEvent implements Serializable {
-    final Integer key;
-    final String value;
-    CustomEvent(Integer key, String value) {
+public class CustomEvent<K, V> implements Serializable {
+    final K key;
+    final V value;
+    CustomEvent(K key, V value) {
         this.key = key;
         this.value = value;
     }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/CustomEventLogListener.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/CustomEventLogListener.java
@@ -29,7 +29,7 @@ public abstract class CustomEventLogListener {
       assertEquals(0, customEvents.size());
    }
 
-   public void expectSingleCustomEvent(Integer key, String value) {
+   public <K, V> void expectSingleCustomEvent(K key, V value) {
       CustomEvent event = pollEvent();
       assertEquals(key, event.key);
       assertEquals(value, event.value);

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/CustomPojoEventConverterFactory.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/CustomPojoEventConverterFactory.java
@@ -1,0 +1,37 @@
+package org.infinispan.server.test.client.hotrod;
+
+import org.infinispan.metadata.Metadata;
+import org.infinispan.notifications.cachelistener.filter.CacheEventConverter;
+import org.infinispan.notifications.cachelistener.filter.CacheEventConverterFactory;
+import org.infinispan.notifications.cachelistener.filter.EventType;
+import org.infinispan.notifications.cachelistener.filter.NamedFactory;
+import org.infinispan.server.test.client.hotrod.AbstractRemoteCacheIT.Person;
+
+import java.io.Serializable;
+
+@NamedFactory(name = "pojo-converter-factory")
+public class CustomPojoEventConverterFactory implements CacheEventConverterFactory {
+    @Override
+    public CacheEventConverter<Integer, Person, CustomEvent> getConverter(final Object[] params) {
+        return new DynamicCacheEventConverter(params);
+    }
+
+    static class DynamicCacheEventConverter implements CacheEventConverter<Integer, Person, CustomEvent>, Serializable {
+        private final Object[] params;
+
+        public DynamicCacheEventConverter(Object[] params) {
+            this.params = params;
+        }
+
+
+        @Override
+        public CustomEvent convert(Integer key, Person oldValue, Metadata oldMetadata,
+              Person newValue, Metadata newMetadata, EventType eventType) {
+            if (newValue == null || newValue.equals(params[0]))
+                return new CustomEvent<Integer, Person>(key, null);
+
+            return new CustomEvent<Integer, Person>(key, newValue);
+        }
+    }
+
+}

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/CustomPojoEventFilterFactory.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/CustomPojoEventFilterFactory.java
@@ -1,0 +1,35 @@
+package org.infinispan.server.test.client.hotrod;
+
+import org.infinispan.metadata.Metadata;
+import org.infinispan.notifications.cachelistener.filter.CacheEventFilter;
+import org.infinispan.notifications.cachelistener.filter.CacheEventFilterFactory;
+import org.infinispan.notifications.cachelistener.filter.EventType;
+import org.infinispan.notifications.cachelistener.filter.NamedFactory;
+import org.infinispan.server.test.client.hotrod.AbstractRemoteCacheIT.Person;
+
+import java.io.Serializable;
+
+@NamedFactory(name = "pojo-filter-factory")
+public class CustomPojoEventFilterFactory implements CacheEventFilterFactory {
+
+   @Override
+   public CacheEventFilter<Integer, Person> getFilter(Object[] params) {
+      return new CustomPojoCacheEventFilter(params);
+   }
+
+   private static class CustomPojoCacheEventFilter implements CacheEventFilter<Integer, Person>, Serializable {
+      private final Object[] params;
+
+      private CustomPojoCacheEventFilter(Object[] params) {
+         this.params = params;
+      }
+
+      @Override
+      public boolean accept(Integer key, Person oldValue, Metadata oldMetadata,
+            Person newValue, Metadata newMetadata, EventType eventType) {
+         return newValue == null
+               ? oldValue.getName().equals(params[0])
+               : newValue.getName().equals(params[0]);
+      }
+   }
+}

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/CustomPojoFilterConverterFactory.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/CustomPojoFilterConverterFactory.java
@@ -1,0 +1,39 @@
+package org.infinispan.server.test.client.hotrod;
+
+import org.infinispan.metadata.Metadata;
+import org.infinispan.notifications.cachelistener.filter.AbstractCacheEventFilterConverter;
+import org.infinispan.notifications.cachelistener.filter.CacheEventFilterConverter;
+import org.infinispan.notifications.cachelistener.filter.CacheEventFilterConverterFactory;
+import org.infinispan.notifications.cachelistener.filter.EventType;
+import org.infinispan.notifications.cachelistener.filter.NamedFactory;
+import org.infinispan.server.test.client.hotrod.AbstractRemoteCacheIT.Id;
+import org.infinispan.server.test.client.hotrod.AbstractRemoteCacheIT.Person;
+
+import java.io.Serializable;
+
+@NamedFactory(name = "pojo-filter-converter-factory")
+public class CustomPojoFilterConverterFactory implements CacheEventFilterConverterFactory {
+
+   @Override
+   public CacheEventFilterConverter<Id, Person, CustomEvent> getFilterConverter(Object[] params) {
+      return new FilterConverter(params);
+   }
+
+   static class FilterConverter extends AbstractCacheEventFilterConverter<Id, Person, CustomEvent>
+      implements Serializable {
+      private final Object[] params;
+
+      public FilterConverter(Object[] params) {
+         this.params = params;
+      }
+
+      @Override
+      public CustomEvent filterAndConvert(Id key, Person oldValue, Metadata oldMetadata,
+            Person newValue, Metadata newMetadata, EventType eventType) {
+         if (params[0].equals(key))
+            return new CustomEvent<Id, Person>(key, null);
+
+         return new CustomEvent<Id, Person>(key, newValue);
+      }
+   }
+}

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodRemoteCacheIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/HotRodRemoteCacheIT.java
@@ -3,7 +3,6 @@ package org.infinispan.server.test.client.hotrod;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServer;
 import org.infinispan.notifications.cachelistener.filter.CacheEventConverterFactory;
-import org.infinispan.notifications.cachelistener.filter.CacheEventFilterConverter;
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilterConverterFactory;
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilterFactory;
 import org.infinispan.server.test.category.HotRodClustered;
@@ -82,22 +81,28 @@ public class HotRodRemoteCacheIT extends AbstractRemoteCacheIT {
 
     private static Archive<?> createFilterArchive() {
         return ShrinkWrap.create(JavaArchive.class, "filter.jar")
-                .addClasses(StaticCacheEventFilterFactory.class, DynamicCacheEventFilterFactory.class)
+                .addClasses(StaticCacheEventFilterFactory.class, DynamicCacheEventFilterFactory.class,
+                      CustomPojoEventFilterFactory.class, Person.class)
                 .addAsServiceProvider(CacheEventFilterFactory.class,
-                   StaticCacheEventFilterFactory.class, DynamicCacheEventFilterFactory.class);
+                      StaticCacheEventFilterFactory.class, DynamicCacheEventFilterFactory.class,
+                      CustomPojoEventFilterFactory.class);
     }
 
    private static Archive<?> createConverterArchive() {
       return ShrinkWrap.create(JavaArchive.class, "converter.jar")
-         .addClasses(StaticCacheEventConverterFactory.class, DynamicCacheEventConverterFactory.class, CustomEvent.class)
+         .addClasses(StaticCacheEventConverterFactory.class, DynamicCacheEventConverterFactory.class,
+               CustomPojoEventConverterFactory.class, Person.class, CustomEvent.class)
          .addAsServiceProvider(CacheEventConverterFactory.class,
-            StaticCacheEventConverterFactory.class, DynamicCacheEventConverterFactory.class);
+            StaticCacheEventConverterFactory.class, DynamicCacheEventConverterFactory.class,
+               CustomPojoEventConverterFactory.class);
    }
 
    private static Archive<?> createFilterConverterArchive() {
       return ShrinkWrap.create(JavaArchive.class, "filter-converter.jar")
-         .addClasses(FilterConverterFactory.class, CustomEvent.class)
-         .addAsServiceProvider(CacheEventFilterConverterFactory.class, FilterConverterFactory.class);
+         .addClasses(FilterConverterFactory.class, CustomEvent.class,
+               CustomPojoFilterConverterFactory.class, Person.class, Id.class)
+         .addAsServiceProvider(CacheEventFilterConverterFactory.class, FilterConverterFactory.class,
+               CustomPojoFilterConverterFactory.class);
    }
 
    @Override


### PR DESCRIPTION
* For custom classes to work fine with remote filter/converter classes, they need to be deployed in the same JAR along with the filter and/or converter classes.