### PR TITLE
ISPN-5528 Expose segment ownership in the Hot Rod client

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/CacheTopologyInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/CacheTopologyInfo.java
@@ -1,0 +1,25 @@
+package org.infinispan.client.hotrod;
+
+import java.net.SocketAddress;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Contains information about cache topology including servers and owned segments.
+ *
+ * @author gustavonalle
+ * @since 8.0
+ */
+public interface CacheTopologyInfo {
+
+   /**
+    * @return The number of configured segments for the cache.
+    */
+   int getNumSegments();
+
+   /**
+    * @return Segments owned by each server.
+    */
+   Map<SocketAddress, Set<Integer>> getSegmentsPerServer();
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCache.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCache.java
@@ -1,13 +1,13 @@
 package org.infinispan.client.hotrod;
 
+import org.infinispan.commons.api.BasicCache;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.concurrent.NotifyingFuture;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
-import org.infinispan.commons.api.BasicCache;
-import org.infinispan.commons.util.CloseableIterator;
-import org.infinispan.commons.util.concurrent.NotifyingFuture;
 
 /**
  * Provides remote reference to a Hot Rod server/cluster. It implements {@link org.infinispan.Cache}, but given its
@@ -343,4 +343,9 @@ public interface RemoteCache<K, V> extends BasicCache<K, V> {
     * Executes a remote script passing a set of named parameters
     */
    <T> T execute(String scriptName, Map<String, ?> params);
+
+   /**
+    * Returns {@link CacheTopologyInfo} for this cache.
+    */
+   CacheTopologyInfo getCacheTopologyInfo();
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -144,7 +144,7 @@ public class RemoteCacheManager implements BasicCacheContainer {
 
    private volatile boolean started = false;
    private final Map<String, RemoteCacheHolder> cacheName2RemoteCache = new HashMap<String, RemoteCacheHolder>();
-   private final AtomicInteger defaultCacheTopologyId = new AtomicInteger(-1);
+   private final AtomicInteger defaultCacheTopologyId = new AtomicInteger(HotRodConstants.DEFAULT_CACHE_TOPOLOGY);
    private Configuration configuration;
    private Codec codec;
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/CacheTopologyInfoImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/CacheTopologyInfoImpl.java
@@ -1,0 +1,46 @@
+package org.infinispan.client.hotrod.impl;
+
+import org.infinispan.client.hotrod.CacheTopologyInfo;
+
+import java.net.SocketAddress;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author gustavonalle
+ * @since 8.0
+ */
+public class CacheTopologyInfoImpl implements CacheTopologyInfo {
+   private final Map<SocketAddress, Set<Integer>> segmentsByServer;
+   private final Integer numSegments;
+   private final Integer topologyId;
+
+   public CacheTopologyInfoImpl(Map<SocketAddress, Set<Integer>> segmentsByServer, Integer numSegments, Integer topologyId) {
+      this.segmentsByServer = segmentsByServer;
+      this.numSegments = numSegments;
+      this.topologyId = topologyId;
+   }
+
+   @Override
+   public int getNumSegments() {
+      return numSegments;
+   }
+
+   public Integer getTopologyId() {
+      return topologyId;
+   }
+
+   @Override
+   public Map<SocketAddress, Set<Integer>> getSegmentsPerServer() {
+      return segmentsByServer;
+   }
+
+   @Override
+   public String toString() {
+      return "CacheTopologyInfoImpl{" +
+              "segmentsByServer=" + segmentsByServer +
+              ", numSegments=" + numSegments +
+              ", topologyId=" + topologyId +
+              '}';
+   }
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.client.hotrod.CacheTopologyInfo;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.MetadataValue;
 import org.infinispan.client.hotrod.RemoteCache;
@@ -712,4 +713,9 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
 		ExecuteOperation op = operationsFactory.newExecuteOperation(taskName, marshalledParams);
 		return MarshallerUtil.bytes2obj(marshaller, op.execute());
 	}
+
+   @Override
+   public CacheTopologyInfo getCacheTopologyInfo() {
+      return operationsFactory.getCacheTopologyInfo();
+   }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/TopologyInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/TopologyInfo.java
@@ -1,0 +1,124 @@
+package org.infinispan.client.hotrod.impl;
+
+import org.infinispan.client.hotrod.CacheTopologyInfo;
+import org.infinispan.client.hotrod.configuration.Configuration;
+import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHash;
+import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashFactory;
+import org.infinispan.client.hotrod.impl.consistenthash.SegmentConsistentHash;
+import org.infinispan.client.hotrod.logging.Log;
+import org.infinispan.client.hotrod.logging.LogFactory;
+import org.infinispan.commons.equivalence.AnyEquivalence;
+import org.infinispan.commons.equivalence.ByteArrayEquivalence;
+import org.infinispan.commons.util.CollectionFactory;
+import org.infinispan.commons.util.Immutables;
+
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.IntStream.range;
+import static org.infinispan.commons.util.InfinispanCollections.emptySet;
+
+/**
+ * Maintains topology information about caches.
+ *
+ * @author gustavonalle
+ */
+public final class TopologyInfo {
+
+   private static final Log log = LogFactory.getLog(TopologyInfo.class, Log.class);
+
+   private Collection<SocketAddress> servers = new ArrayList<>();
+   private Map<byte[], ConsistentHash> consistentHashes = CollectionFactory.makeMap(ByteArrayEquivalence.INSTANCE, AnyEquivalence.getInstance());
+   private Map<byte[], Integer> segmentsByCache = CollectionFactory.makeMap(ByteArrayEquivalence.INSTANCE, AnyEquivalence.getInstance());
+   private volatile AtomicInteger topologyId;
+   private final ConsistentHashFactory hashFactory = new ConsistentHashFactory();
+
+   public TopologyInfo(AtomicInteger topologyId, Collection<SocketAddress> servers, Configuration configuration) {
+      this.topologyId = topologyId;
+      this.servers = servers;
+      hashFactory.init(configuration);
+   }
+
+   private Map<SocketAddress, Set<Integer>> getSegmentsByServer(byte[] cacheName) {
+      ConsistentHash consistentHash = consistentHashes.get(cacheName);
+      if (consistentHash != null) {
+         return consistentHash.getSegmentsByServer();
+      } else {
+         Optional<Integer> numSegments = Optional.ofNullable(segmentsByCache.get(cacheName));
+         Optional<Set<Integer>> segments = numSegments.map(n -> range(0, n).boxed().collect(Collectors.toSet()));
+         return Immutables.immutableMapWrap(
+               servers.stream().collect(toMap(identity(), s -> segments.orElse(emptySet())))
+         );
+      }
+   }
+
+   public Collection<SocketAddress> getServers() {
+      return servers;
+   }
+
+   public void updateTopology(Map<SocketAddress, Set<Integer>> servers2Hash, int numKeyOwners, short hashFunctionVersion, int hashSpace, byte[] cacheName) {
+      ConsistentHash hash = hashFactory.newConsistentHash(hashFunctionVersion);
+      if (hash == null) {
+         log.noHasHFunctionConfigured(hashFunctionVersion);
+      } else {
+         hash.init(servers2Hash, numKeyOwners, hashSpace);
+      }
+      consistentHashes.put(cacheName, hash);
+
+   }
+
+   public void updateTopology(SocketAddress[][] segmentOwners, int numSegments, short hashFunctionVersion, byte[] cacheName) {
+      if (hashFunctionVersion > 0) {
+         SegmentConsistentHash hash = hashFactory.newConsistentHash(hashFunctionVersion);
+         if (hash == null) {
+            log.noHasHFunctionConfigured(hashFunctionVersion);
+         } else {
+            hash.init(segmentOwners, numSegments);
+         }
+         consistentHashes.put(cacheName, hash);
+      }
+      segmentsByCache.put(cacheName, numSegments);
+
+   }
+
+   public Optional<SocketAddress> getHashAwareServer(byte[] key, byte[] cacheName) {
+      Optional<SocketAddress> server = Optional.empty();
+      ConsistentHash consistentHash = consistentHashes.get(cacheName);
+      if (consistentHash != null) {
+         server = Optional.of(consistentHash.getServer(key));
+         if (log.isTraceEnabled()) {
+            log.tracef("Using consistent hash for determining the server: " + server);
+         }
+      }
+      return server;
+   }
+
+   public void updateServers(Collection<SocketAddress> updatedServers) {
+      servers = updatedServers;
+   }
+
+   public ConsistentHash getConsistentHash(byte[] cacheName) {
+      return consistentHashes.get(cacheName);
+   }
+
+   public ConsistentHashFactory getConsistentHashFactory() {
+      return hashFactory;
+   }
+
+   public void setTopologyId(int topologyId) {
+      this.topologyId.set(topologyId);
+   }
+
+   public CacheTopologyInfo getCacheTopologyInfo(byte[] cacheName) {
+      return new CacheTopologyInfoImpl(getSegmentsByServer(cacheName), segmentsByCache.get(cacheName), topologyId.get());
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHash.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHash.java
@@ -24,4 +24,7 @@ public interface ConsistentHash {
     * @return a non-null, non-negative normalized hash code for a given object
     */
    int getNormalizedHash(Object object);
+
+   Map<SocketAddress, Set<Integer>> getSegmentsByServer();
+
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHashV1.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHashV1.java
@@ -120,4 +120,10 @@ public class ConsistentHashV1 implements ConsistentHash {
    public final int getNormalizedHash(Object object) {
       return Util.getNormalizedHash(object, hash);
    }
+
+   @Override
+   public Map<SocketAddress, Set<Integer>> getSegmentsByServer() {
+      throw new UnsupportedOperationException();
+   }
+
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/SegmentConsistentHash.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/SegmentConsistentHash.java
@@ -8,7 +8,14 @@ import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
 import org.infinispan.commons.hash.Hash;
 import org.infinispan.commons.hash.MurmurHash3;
+import org.infinispan.commons.util.Immutables;
 import org.infinispan.commons.util.Util;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.stream.IntStream;
+
+import static java.util.Arrays.stream;
 
 /**
  * @author Galder Zamarreño
@@ -52,6 +59,16 @@ public final class SegmentConsistentHash implements ConsistentHash {
       return Util.getNormalizedHash(object, hash);
    }
 
+   @Override
+   public Map<SocketAddress, Set<Integer>> getSegmentsByServer() {
+      Map<SocketAddress, Set<Integer>> map = new HashMap<>();
+      IntStream.range(0, segmentOwners.length).forEach(seg -> {
+         SocketAddress[] owners = segmentOwners[seg];
+         stream(owners).forEach(s -> map.computeIfAbsent(s, k -> new HashSet<>(owners.length)).add(seg));
+      });
+      return Immutables.immutableMapWrap(map);
+   }
+   
    public int getNumSegments() {
       return numSegments;
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod.impl.operations;
 
 import net.jcip.annotations.Immutable;
 
+import org.infinispan.client.hotrod.CacheTopologyInfo;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.event.ClientListenerNotifier;
@@ -10,16 +11,11 @@ import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.impl.query.RemoteQuery;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
-import org.infinispan.commons.util.InfinispanCollections;
 
-import java.net.SocketAddress;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -239,6 +235,10 @@ public class OperationsFactory implements HotRodConstants {
       for(Flag flag : flags)
          list.add(flag);
 
+   }
+
+   public CacheTopologyInfo getCacheTopologyInfo() {
+      return transportFactory.getCacheTopologyInfo(cacheNameBytes);
    }
 
    public IterationStartOperation newIterationStartOperation(String filterConverterFactory, Set<Integer> segments, int batchSize) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
@@ -388,12 +388,14 @@ public class Codec20 implements Codec, HotRodConstants {
       short hashFunctionVersion = transport.readByte();
       int numSegments = transport.readVInt();
       SocketAddress[][] segmentOwners = new SocketAddress[numSegments][];
-      for (int i = 0; i < numSegments; i++) {
-         short numOwners = transport.readByte();
-         segmentOwners[i] = new SocketAddress[numOwners];
-         for (int j = 0; j < numOwners; j++) {
-            int memberIndex = transport.readVInt();
-            segmentOwners[i][j] = addresses[memberIndex];
+      if (hashFunctionVersion > 0) {
+         for (int i = 0; i < numSegments; i++) {
+            short numOwners = transport.readByte();
+            segmentOwners[i] = new SocketAddress[numOwners];
+            for (int j = 0; j < numOwners; j++) {
+               int memberIndex = transport.readVInt();
+               segmentOwners[i][j] = addresses[memberIndex];
+            }
          }
       }
 
@@ -410,8 +412,8 @@ public class Codec20 implements Codec, HotRodConstants {
          if (trace)
             localLog.tracef("Updating client hash function with %s number of segments", numSegments);
 
-         transport.getTransportFactory().updateHashFunction(segmentOwners, numSegments, hashFunctionVersion, cacheName);
       }
+      transport.getTransportFactory().updateHashFunction(segmentOwners, numSegments, hashFunctionVersion, cacheName);
    }
 
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HotRodConstants.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HotRodConstants.java
@@ -110,4 +110,6 @@ public interface HotRodConstants {
 
    static final byte INFINITE_LIFESPAN = 0x01;
    static final byte INFINITE_MAXIDLE = 0x02;
+
+   static final int DEFAULT_CACHE_TOPOLOGY = -1;
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.net.ssl.SSLContext;
 
+import org.infinispan.client.hotrod.CacheTopologyInfo;
 import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.event.ClientListenerNotifier;
 import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHash;
@@ -32,6 +33,8 @@ public interface TransportFactory {
    void updateServers(Collection<SocketAddress> newServers, byte[] cacheName, boolean quiet);
 
    void destroy();
+
+   CacheTopologyInfo getCacheTopologyInfo(byte[] cacheName);
 
    /**
     * @deprecated Only called for Hot Rod 1.x protocol.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/BaseSegmentOwnershipTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/BaseSegmentOwnershipTest.java
@@ -1,0 +1,52 @@
+package org.infinispan.client.hotrod;
+
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.server.hotrod.test.HotRodTestingUtil;
+
+import java.net.SocketAddress;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author gustavonalle
+ * @since 8.0
+ */
+public abstract class BaseSegmentOwnershipTest extends MultiHotRodServersTest {
+
+   static final int NUM_SEGMENTS = 20;
+   static final int NUM_OWNERS = 2;
+   static final int NUM_SERVERS = 3;
+
+   protected Map<Integer, Set<SocketAddress>> invertMap(Map<SocketAddress, Set<Integer>> segmentsByServer) {
+      Map<Integer, Set<SocketAddress>> serversBySegment = new HashMap<>();
+      for (Map.Entry<SocketAddress, Set<Integer>> entry : segmentsByServer.entrySet()) {
+         for (Integer seg : entry.getValue()) {
+            serversBySegment.computeIfAbsent(seg, v -> new HashSet<>()).add(entry.getKey());
+         }
+      }
+      return serversBySegment;
+   }
+
+   protected abstract CacheMode getCacheMode();
+
+   protected ConfigurationBuilder getCacheConfiguration() {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(getCacheMode(), false);
+      builder.clustering().hash().numOwners(NUM_OWNERS).numSegments(NUM_SEGMENTS);
+      return HotRodTestingUtil.hotRodCacheConfiguration(builder);
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createHotRodServers(NUM_SERVERS, getCacheConfiguration());
+   }
+
+   @Override
+   protected org.infinispan.client.hotrod.configuration.ConfigurationBuilder createHotRodClientConfigurationBuilder(int serverPort) {
+      return super.createHotRodClientConfigurationBuilder(serverPort).pingOnStartup(true);
+   }
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashComparisonTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashComparisonTest.java
@@ -181,5 +181,9 @@ public class ConsistentHashComparisonTest {
          return Util.getNormalizedHash(key, hash);
       }
 
+      @Override
+      public Map<SocketAddress, Set<Integer>> getSegmentsByServer() {
+         return null;
+      }
    }
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SegmentOwnershipDistTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SegmentOwnershipDistTest.java
@@ -1,0 +1,33 @@
+package org.infinispan.client.hotrod;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.testng.annotations.Test;
+
+import java.net.SocketAddress;
+import java.util.Map;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author gustavonalle
+ * @since 8.0
+ */
+@Test(groups = "functional", testName = "client.hotrod.SegmentOwnershipDistTest")
+public class SegmentOwnershipDistTest extends BaseSegmentOwnershipTest {
+
+   public void testObtainSegmentOwnership() throws Exception {
+      RemoteCache<Object, Object> remoteCache = client(0).getCache();
+      Map<SocketAddress, Set<Integer>> segmentsByServer = remoteCache.getCacheTopologyInfo().getSegmentsPerServer();
+      Map<Integer, Set<SocketAddress>> serversBySegment = invertMap(segmentsByServer);
+
+      assertEquals(segmentsByServer.keySet().size(), NUM_SERVERS);
+      assertTrue(serversBySegment.entrySet().stream().allMatch(e -> e.getValue().size() == NUM_OWNERS));
+   }
+
+   @Override
+   protected CacheMode getCacheMode() {
+      return CacheMode.DIST_SYNC;
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SegmentOwnershipLocalTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SegmentOwnershipLocalTest.java
@@ -1,0 +1,36 @@
+package org.infinispan.client.hotrod;
+
+import org.infinispan.client.hotrod.test.SingleHotRodServerTest;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.testng.annotations.Test;
+
+import java.net.SocketAddress;
+import java.util.Map;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+
+/**
+ * @author gustavonalle
+ * @since 8.0
+ */
+@Test(groups = "functional", testName = "client.hotrod.SegmentOwnershipDistTest")
+public class SegmentOwnershipLocalTest extends SingleHotRodServerTest {
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      return super.createCacheManager();
+   }
+
+   @Test
+   public void testSegmentMap() throws Exception {
+      RemoteCache<Object, Object> cache = remoteCacheManager.getCache();
+
+      Map<SocketAddress, Set<Integer>> segmentsByServer = cache.getCacheTopologyInfo().getSegmentsPerServer();
+
+      assertNotNull(segmentsByServer);
+      assertEquals(segmentsByServer.keySet().size(), 1);
+      assertEquals(segmentsByServer.values().iterator().next().size(), 0);
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SegmentOwnershipReplTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SegmentOwnershipReplTest.java
@@ -1,0 +1,34 @@
+package org.infinispan.client.hotrod;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.testng.annotations.Test;
+
+import java.net.SocketAddress;
+import java.util.Map;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author gustavonalle
+ * @since 8.0
+ */
+@Test(groups = "functional", testName = "client.hotrod.SegmentOwnershipReplTest")
+public class SegmentOwnershipReplTest extends BaseSegmentOwnershipTest {
+
+   @Override
+   protected CacheMode getCacheMode() {
+      return CacheMode.REPL_SYNC;
+   }
+
+   @Test
+   public void testObtainSegmentOwnership() throws Exception {
+      RemoteCache<Object, Object> remoteCache = client(0).getCache();
+      Map<SocketAddress, Set<Integer>> segmentsByServer = remoteCache.getCacheTopologyInfo().getSegmentsPerServer();
+
+      assertEquals(segmentsByServer.keySet().size(), NUM_SERVERS);
+      assertTrue(segmentsByServer.entrySet().stream().allMatch(e -> e.getValue().size() == NUM_SEGMENTS));
+   }
+
+}

--- a/jcache/remote/src/main/java/org/infinispan/jcache/remote/RemoteCacheWrapper.java
+++ b/jcache/remote/src/main/java/org/infinispan/jcache/remote/RemoteCacheWrapper.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.infinispan.client.hotrod.CacheTopologyInfo;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.MetadataValue;
 import org.infinispan.client.hotrod.RemoteCache;
@@ -391,6 +392,11 @@ abstract class RemoteCacheWrapper<K, V> implements RemoteCache<K, V> {
    @Override
    public <T> T execute(String scriptName, Map<String, ?> params) {
       return delegate.execute(scriptName, params);
+   }
+
+   @Override
+   public CacheTopologyInfo getCacheTopologyInfo() {
+      return delegate.getCacheTopologyInfo();
    }
 
    @Override

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/AbstractEncoder1x.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/AbstractEncoder1x.scala
@@ -181,7 +181,7 @@ abstract class AbstractEncoder1x extends AbstractVersionedEncoder with Constants
 
       val config = cache.getCacheConfiguration
       if (r.clientIntel == INTELLIGENCE_TOPOLOGY_AWARE || !config.clustering().cacheMode().isDistributed) {
-         TopologyAwareResponse(responseTopologyId, serverEndpointsMap)
+         TopologyAwareResponse(responseTopologyId, serverEndpointsMap, 0)
       } else {
          // Must be 3 and distributed
          createHashDistAwareResp(responseTopologyId, serverEndpointsMap, config)
@@ -190,7 +190,7 @@ abstract class AbstractEncoder1x extends AbstractVersionedEncoder with Constants
 
    protected def createHashDistAwareResp(topologyId: Int, serverEndpointsMap: Map[Address, ServerAddress],
                                          cfg: Configuration): AbstractHashDistAwareResponse = {
-      HashDistAwareResponse(topologyId, serverEndpointsMap, cfg.clustering().hash().numOwners(),
+      HashDistAwareResponse(topologyId, serverEndpointsMap, 0, cfg.clustering().hash().numOwners(),
          DEFAULT_CONSISTENT_HASH_VERSION_1x, Integer.MAX_VALUE)
    }
 

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Response.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Response.scala
@@ -293,30 +293,34 @@ class ExecResponse(override val version: Byte, override val messageId: Long, ove
 }
 
 
-abstract class AbstractTopologyResponse(val topologyId: Int, val serverEndpointsMap : Map[Address, ServerAddress])
+abstract class AbstractTopologyResponse(val topologyId: Int, val serverEndpointsMap : Map[Address, ServerAddress], val numSegments: Int)
 
 abstract class AbstractHashDistAwareResponse(override val topologyId: Int,
                                              override val serverEndpointsMap : Map[Address, ServerAddress],
+                                             override val numSegments: Int,
                                              val numOwners: Int, val hashFunction: Byte, val hashSpace: Int)
-        extends AbstractTopologyResponse(topologyId, serverEndpointsMap)
+        extends AbstractTopologyResponse(topologyId, serverEndpointsMap, numSegments)
 
 case class TopologyAwareResponse(override val topologyId: Int,
-                                 override val serverEndpointsMap : Map[Address, ServerAddress])
-      extends AbstractTopologyResponse(topologyId, serverEndpointsMap)
+                                 override val serverEndpointsMap : Map[Address, ServerAddress],
+                                 override val numSegments: Int)
+      extends AbstractTopologyResponse(topologyId, serverEndpointsMap, numSegments)
 
 case class HashDistAwareResponse(override val topologyId: Int,
                                  override val serverEndpointsMap : Map[Address, ServerAddress],
+                                 override val numSegments: Int,
                                  override val numOwners: Int, override val hashFunction: Byte,
                                  override val hashSpace: Int)
-        extends AbstractHashDistAwareResponse(topologyId, serverEndpointsMap, numOwners, hashFunction, hashSpace)
+        extends AbstractHashDistAwareResponse(topologyId, serverEndpointsMap, numSegments, numOwners, hashFunction, hashSpace)
 
 case class HashDistAware11Response(override val topologyId: Int,
                                    override val serverEndpointsMap : Map[Address, ServerAddress],
                                    override val numOwners: Int, override val hashFunction: Byte,
                                    override val hashSpace: Int, numVNodes: Int)
-        extends AbstractHashDistAwareResponse(topologyId, serverEndpointsMap, numOwners, hashFunction, hashSpace)
+        extends AbstractHashDistAwareResponse(topologyId, serverEndpointsMap, 0, numOwners, hashFunction, hashSpace)
 
 case class HashDistAware20Response(override val topologyId: Int,
         override val serverEndpointsMap : Map[Address, ServerAddress],
+        override val numSegments: Int,
         hashFunction: Byte)
-        extends AbstractTopologyResponse(topologyId, serverEndpointsMap)
+        extends AbstractTopologyResponse(topologyId, serverEndpointsMap, numSegments)

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodClient.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodClient.scala
@@ -613,14 +613,16 @@ private class Decoder(client: HotRodClient) extends ReplayingDecoder[Void] with 
       val hashFunction = buf.readByte
       val numSegments = readUnsignedInt(buf)
       var segments = mutable.ListBuffer[Iterable[ServerAddress]]()
-      for (i <- 1 to numSegments) {
-         val owners = buf.readByte()
-         var membersInSegment = mutable.ListBuffer[ServerAddress]()
-         for (j <- 1 to owners) {
-            val index = readUnsignedInt(buf)
-            membersInSegment += members(index)
+      if(hashFunction > 0) {
+         for (i <- 1 to numSegments) {
+            val owners = buf.readByte()
+            var membersInSegment = mutable.ListBuffer[ServerAddress]()
+            for (j <- 1 to owners) {
+               val index = readUnsignedInt(buf)
+               membersInSegment += members(index)
+            }
+            segments += membersInSegment.toList
          }
-         segments += membersInSegment.toList
       }
 
       Some(TestHashDistAware20Response(topologyId, members.toList, segments.toList, hashFunction))


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5528

Changes in the server:

* Always send ```numSegments``` for clustered caches. 
* Sends all owners instead of only 2 during topology changes

Changes in the client:

* Added ```getSegmentsByServer()``` method that:
   * if there's topology in the server, but hash function is zero, assumes REPL cache and every server is associated with all segments ```{0...numSegments-1}```
   * if there's no topology present (topologyId < 0), associates the server with an empty set (LOCAL cache)   
   * If both ```numSegments``` and ```hashFunction``` are present (DIST) uses the consistent hash to associate the segments to each server