### PR TITLE
ISPN-5539 IllegalLifecycleStateException on a remote node should not …

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/BaseBlockingRunnable.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/BaseBlockingRunnable.java
@@ -1,6 +1,8 @@
 package org.infinispan.remoting.inboundhandler;
 
+import org.infinispan.IllegalLifecycleStateException;
 import org.infinispan.commands.remote.CacheRpcCommand;
+import org.infinispan.remoting.responses.CacheNotFoundResponse;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.statetransfer.OutdatedTopologyException;
 import org.infinispan.util.concurrent.BlockingRunnable;
@@ -38,6 +40,9 @@ public abstract class BaseBlockingRunnable implements BlockingRunnable {
       } catch (OutdatedTopologyException oe) {
          response = handler.outdatedTopology(oe);
          onException(oe);
+      } catch (IllegalLifecycleStateException e) {
+         response = CacheNotFoundResponse.INSTANCE;
+         onException(e);
       } catch (Exception e) {
          response = handler.exceptionHandlingCommand(command, e);
          onException(e);


### PR DESCRIPTION
…be sent to the originator

https://issues.jboss.org/browse/ISPN-5539

Also resolves
https://issues.jboss.org/browse/ISPN-5361
https://issues.jboss.org/browse/ISPN-5496
https://issues.jboss.org/browse/ISPN-3924

