### PR TITLE
ISPN-5531 java.lang.UnsupportedOperationException during remove (using RemoteCacheManager)

### DIFF
--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/distexec/LocalDistributedExecutorTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/distexec/LocalDistributedExecutorTest.java
@@ -177,7 +177,7 @@ public class LocalDistributedExecutorTest extends org.infinispan.distexec.LocalD
    }
 
    @Test(expected = IllegalArgumentException.class)
-   public void testBasicTargetCallableWithIllegalTarget() {
+   public void testBasicTargetCallableWithIllegalTarget() throws ExecutionException, InterruptedException {
       super.testBasicTargetCallableWithIllegalTarget();
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5531