### PR TITLE
ISPN-5544 Deprecate eager near cache mode

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/NearCacheMode.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/NearCacheMode.java
@@ -1,13 +1,48 @@
 package org.infinispan.client.hotrod.configuration;
 
+/**
+ * Decides how client-side near caching should work.
+ *
+ * @since 7.1
+ */
 public enum NearCacheMode {
 
-   DISABLED, LAZY, EAGER;
+   // TODO: Add SELECTIVE (or similar) when ISPN-5545 implemented
+
+   /**
+    * Near caching is disabled.
+    */
+   DISABLED,
+
+   /**
+    * Near cache is invalidated, so when entries are updated or removed
+    * server-side, invalidation messages will be sent to clients to remove
+    * them from the near cache.
+    */
+   INVALIDATED,
+
+   /**
+    * @deprecated Replaced by INVALIDATED
+    */
+   @Deprecated LAZY,
+
+   /**
+    * @deprecated To be removed without replacement
+    */
+   @Deprecated EAGER;
 
    public boolean enabled() {
       return this != DISABLED;
    }
 
+   public boolean invalidated() {
+      return this == INVALIDATED || this == LAZY;
+   }
+
+   /**
+    * @deprecated To be removed without replacement
+    */
+   @Deprecated
    public boolean eager() {
       return this == EAGER;
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/near/NearCacheService.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/near/NearCacheService.java
@@ -53,9 +53,9 @@ public class NearCacheService<K, V> implements NearCache<K, V> {
    }
 
    private Object createListener(RemoteCache<K, V> remote) {
-      return config.mode().eager()
-            ? new EagerNearCacheListener<K, V>(this, remote.getRemoteCacheManager().getMarshaller())
-            : new LazyNearCacheListener<K, V>(this);
+      return config.mode().invalidated()
+            ? new InvalidatedNearCacheListener<K, V>(this)
+            : new EagerNearCacheListener<K, V>(this, remote.getRemoteCacheManager().getMarshaller());
    }
 
    public void stop(RemoteCache<K, V> remote) {
@@ -134,14 +134,15 @@ public class NearCacheService<K, V> implements NearCache<K, V> {
    }
 
    @ClientListener
-   private static class LazyNearCacheListener<K, V> {
-      private static final Log log = LogFactory.getLog(LazyNearCacheListener.class);
+   private static class InvalidatedNearCacheListener<K, V> {
+      private static final Log log = LogFactory.getLog(InvalidatedNearCacheListener.class);
       private final NearCache<K, V> cache;
 
-      private LazyNearCacheListener(NearCache<K, V> cache) {
+      private InvalidatedNearCacheListener(NearCache<K, V> cache) {
          this.cache = cache;
       }
 
+      // TODO: Created events should not be fired by the server for near cache, see ISPN-5545
       @ClientCacheEntryCreated
       @SuppressWarnings("unused")
       public void handleCreatedEvent(ClientCacheEntryCreatedEvent<K> event) {
@@ -180,6 +181,7 @@ public class NearCacheService<K, V> implements NearCache<K, V> {
     * classes between client and server, it uses raw data in the converter.
     * This listener does not apply any filtering, so all keys are considered.
     */
+   @Deprecated
    @ClientListener(converterFactoryName = "___eager-key-value-version-converter", useRawData = true)
    private static class EagerNearCacheListener<K, V> {
       private static final Log log = LogFactory.getLog(EagerNearCacheListener.class);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/ClusterEagerNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/ClusterEagerNearCacheTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 
+@Deprecated
 @Test(groups = "functional", testName = "client.hotrod.near.ClusterEagerNearCacheTest")
 public class ClusterEagerNearCacheTest extends MultiHotRodServersTest {
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/ClusterInvalidatedNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/ClusterInvalidatedNearCacheTest.java
@@ -1,0 +1,15 @@
+package org.infinispan.client.hotrod.near;
+
+
+import org.infinispan.client.hotrod.configuration.NearCacheMode;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "client.hotrod.near.ClusterInvalidatedNearCacheTest")
+public class ClusterInvalidatedNearCacheTest extends ClusterLazyNearCacheTest {
+
+   @Override
+   protected NearCacheMode getNearCacheMode() {
+      return NearCacheMode.INVALIDATED;
+   }
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/ClusterLazyNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/ClusterLazyNearCacheTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.near;
 import org.infinispan.client.hotrod.configuration.NearCacheMode;
 import org.testng.annotations.Test;
 
+@Deprecated
 @Test(groups = "functional", testName = "client.hotrod.near.ClusterLazyNearCacheTest")
 public class ClusterLazyNearCacheTest extends ClusterEagerNearCacheTest {
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EagerFailoverNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EagerFailoverNearCacheTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.findServerAndKill;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 
+@Deprecated
 @Test(groups = "functional", testName = "client.hotrod.near.EagerFailoverNearCacheTest")
 public class EagerFailoverNearCacheTest extends MultiHotRodServersTest {
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EagerNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EagerNearCacheTest.java
@@ -12,6 +12,7 @@ import org.infinispan.client.hotrod.test.SingleHotRodServerTest;
 import org.infinispan.commons.CacheConfigurationException;
 import org.testng.annotations.Test;
 
+@Deprecated
 @Test(groups = "functional", testName = "client.hotrod.near.EagerNearCacheTest")
 public class EagerNearCacheTest extends SingleHotRodServerTest {
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EvictEagerNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EvictEagerNearCacheTest.java
@@ -6,6 +6,7 @@ import org.infinispan.client.hotrod.configuration.NearCacheMode;
 import org.infinispan.client.hotrod.test.SingleHotRodServerTest;
 import org.testng.annotations.Test;
 
+@Deprecated
 @Test(groups = "functional", testName = "client.hotrod.near.EvictEagerNearCacheTest")
 public class EvictEagerNearCacheTest extends SingleHotRodServerTest {
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EvictInvalidatedNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EvictInvalidatedNearCacheTest.java
@@ -1,0 +1,14 @@
+package org.infinispan.client.hotrod.near;
+
+import org.infinispan.client.hotrod.configuration.NearCacheMode;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "client.hotrod.near.EvictInvalidatedNearCacheTest")
+public class EvictInvalidatedNearCacheTest extends EvictLazyNearCacheTest {
+
+   @Override
+   protected NearCacheMode getNearCacheMode() {
+      return NearCacheMode.INVALIDATED;
+   }
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EvictLazyNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EvictLazyNearCacheTest.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.near;
 import org.infinispan.client.hotrod.configuration.NearCacheMode;
 import org.testng.annotations.Test;
 
+@Deprecated
 @Test(groups = "functional", testName = "client.hotrod.near.EvictLazyNearCacheTest")
 public class EvictLazyNearCacheTest extends EvictEagerNearCacheTest {
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedFailoverNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedFailoverNearCacheTest.java
@@ -1,0 +1,14 @@
+package org.infinispan.client.hotrod.near;
+
+import org.infinispan.client.hotrod.configuration.NearCacheMode;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "client.hotrod.near.InvalidatedFailoverNearCacheTest")
+public class InvalidatedFailoverNearCacheTest extends LazyFailoverNearCacheTest {
+
+   @Override
+   protected NearCacheMode getNearCacheMode() {
+      return NearCacheMode.INVALIDATED;
+   }
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/InvalidatedNearCacheTest.java
@@ -1,0 +1,14 @@
+package org.infinispan.client.hotrod.near;
+
+import org.infinispan.client.hotrod.configuration.NearCacheMode;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "client.hotrod.near.InvalidatedNearCacheTest")
+public class InvalidatedNearCacheTest extends LazyNearCacheTest {
+
+   @Override
+   protected NearCacheMode getNearCacheMode() {
+      return NearCacheMode.INVALIDATED;
+   }
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/LazyFailoverNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/LazyFailoverNearCacheTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.findServerAndKill;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 
+@Deprecated
 @Test(groups = "functional", testName = "client.hotrod.near.LazyFailoverNearCacheTest")
 public class LazyFailoverNearCacheTest extends EagerFailoverNearCacheTest {
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/LazyNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/LazyNearCacheTest.java
@@ -6,6 +6,7 @@ import org.testng.annotations.Test;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.withRemoteCacheManager;
 
+@Deprecated
 @Test(groups = "functional", testName = "client.hotrod.near.LazyNearCacheTest")
 public class LazyNearCacheTest extends EagerNearCacheTest {
    @Override

--- a/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
@@ -729,27 +729,14 @@ data. Enabling near caching can significantly improve the performance of read
 operations `get` and `getVersioned` since data can potentially be located
 locally within the Hot Rod client instead of having to go remote.
 
-To enable near caching, the user must decide how to configure the near cache
-to work, either `lazy` or `eager`, and define its size:
+To enable near caching, the user must set the near cache mode to `INVALIDATED`.
+By doing that near cache is populated upon retrievals from the server via
+calls to `get` or `getVersioned` operations. When near cached entries are
+updated or removed server-side, the cached near cache entries are invalidated.
+If a key is requested after it's been invalidated, it'll have to be re-fetched
+from the server.
 
-* Lazy near caching: In lazy mode, near cache is only populated upon retrievals
-from the server via calls to `get` or `getVersioned` operations. When near
-cached entries are updated or removed server-side, the cached near cache
-entries are eliminated. The advantage of lazy mode is that it's the most
-lightweight mode, but the downside is that if a key is requested after it's
-been modified, it'll have to be re-fetched from the server.
-
-* Eager near caching: In eager mode, the near cache is populated when
-`get`/`getVersioned` are called, and when new entries are created server side,
-and when entries are modified. The advantage of eager caching is that the near
-cache is eagerly updated without the need to call `get`/`getVersioned`
-operations. On top of that, when an entry is modified, the new value is
-directly sent to the client so that if a `get`/`getVersioned` operation is
-executed, the value is directly fetched from the near cache. The downside of
-eager mode is that it's a more heavyweight mode and hence takes up more
-resources in terms of bandwith.
-
-* Size: When near cache is enabled, its size must be configured by defining
+When near cache is enabled, its size must be configured by defining
 the maximum number of entries to keep in the near cache. When the maximum is
 reached, near cached entries are evicted using a least-recently-used (LRU)
 algorithm. If providing 0 or a negative value, it is assumed that the near
@@ -768,13 +755,13 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.NearCacheMode;
 ...
 
-// For lazy near caches
-ConfigurationBuilder lazyUnbounded = new ConfigurationBuilder();
-lazy.nearCache().mode(NearCacheMode.LAZY).maxEntries(-1);
+// Unbounded invalidated near cache
+ConfigurationBuilder unbounded = new ConfigurationBuilder();
+unbounded.nearCache().mode(NearCacheMode.INVALIDATED).maxEntries(-1);
 
-// For eager near caches
-ConfigurationBuilder eagerBounded = new ConfigurationBuilder();
-eager.nearCache().mode(NearCacheMode.EAGER).maxEntries(100);
+// Bounded invalidated near cache
+ConfigurationBuilder bounded = new ConfigurationBuilder();
+bounded.nearCache().mode(NearCacheMode.INVALIDATED).maxEntries(100);
 ----
 
 NOTE: Near caches work the same way for local caches as they do for clustered


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5544

* Deprecate eager near caching.
* Rename LAZY near cache mode to INVALIDATED.