### PR TITLE
fix "AsyncCacheWriter is dead!" and other bugs

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/concurrent/Futures.java
+++ b/commons/src/main/java/org/infinispan/commons/util/concurrent/Futures.java
@@ -25,7 +25,7 @@ public final class Futures {
     * @return a new composite NotifyingFuture
     */
    public static <T> NotifyingFuture<List<T>> combine(final List<NotifyingFuture<T>> futures) {
-      if (futures == null || futures.isEmpty()) return new NoOpFuture<>(null);
+      if (futures == null || futures.isEmpty()) return new NoOpFuture<>((List<T>) null);
       return new CompositeNotifyingFuture<>(futures);
    }
 

--- a/core/src/main/java/org/infinispan/configuration/cache/AsyncStoreConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AsyncStoreConfiguration.java
@@ -1,7 +1,5 @@
 package org.infinispan.configuration.cache;
 
-import java.util.concurrent.TimeUnit;
-
 import org.infinispan.commons.configuration.attributes.Attribute;
 import org.infinispan.commons.configuration.attributes.AttributeDefinition;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
@@ -15,19 +13,15 @@ import org.infinispan.commons.configuration.attributes.AttributeSet;
  */
 public class AsyncStoreConfiguration {
    public static final AttributeDefinition<Boolean> ENABLED = AttributeDefinition.builder("enabled", false).immutable().build();
-   public static final AttributeDefinition<Long> FLUSH_LOCK_TIMEOUT = AttributeDefinition.builder("flushLockTimeout", 1l).build();
    public static final AttributeDefinition<Integer> MODIFICATION_QUEUE_SIZE  = AttributeDefinition.builder("modificationQueueSize", 1024).immutable().build();
-   public static final AttributeDefinition<Long> SHUTDOWN_TIMEOUT = AttributeDefinition.builder("shutdownTimeout", TimeUnit.SECONDS.toMillis(25)).build();
    public static final AttributeDefinition<Integer> THREAD_POOL_SIZE = AttributeDefinition.builder("threadPoolSize", 1).immutable().build();
 
    static AttributeSet attributeDefinitionSet() {
-      return new AttributeSet(AsyncStoreConfiguration.class, ENABLED, FLUSH_LOCK_TIMEOUT, MODIFICATION_QUEUE_SIZE, SHUTDOWN_TIMEOUT, THREAD_POOL_SIZE);
+      return new AttributeSet(AsyncStoreConfiguration.class, ENABLED, MODIFICATION_QUEUE_SIZE, THREAD_POOL_SIZE);
    }
 
    private final Attribute<Boolean> enabled;
-   private final Attribute<Long> flushLockTimeout;
    private final Attribute<Integer> modificationQueueSize;
-   private final Attribute<Long> shutdownTimeout;
    private final Attribute<Integer> threadPoolSize;
 
    private final AttributeSet attributes;
@@ -35,9 +29,7 @@ public class AsyncStoreConfiguration {
    AsyncStoreConfiguration(AttributeSet attributes) {
       this.attributes = attributes.checkProtection();
       enabled = attributes.attribute(ENABLED);
-      flushLockTimeout = attributes.attribute(FLUSH_LOCK_TIMEOUT);
       modificationQueueSize = attributes.attribute(MODIFICATION_QUEUE_SIZE);
-      shutdownTimeout = attributes.attribute(SHUTDOWN_TIMEOUT);
       threadPoolSize = attributes.attribute(THREAD_POOL_SIZE);
    }
 
@@ -49,21 +41,18 @@ public class AsyncStoreConfiguration {
    }
 
    /**
-    * Timeout to acquire the lock which guards the state to be flushed to the cache store
-    * periodically. The timeout can be adjusted for a running cache.
-    *
-    * @return
+    * Unused
     */
+   @Deprecated
    public long flushLockTimeout() {
-      return flushLockTimeout.get();
+      return 0;
    }
 
    /**
-    * Timeout to acquire the lock which guards the state to be flushed to the cache store
-    * periodically. The timeout can be adjusted for a running cache.
+    * Unused
     */
+   @Deprecated
    public AsyncStoreConfiguration flushLockTimeout(long l) {
-      flushLockTimeout.set(l);
       return this;
    }
 
@@ -78,16 +67,18 @@ public class AsyncStoreConfiguration {
    }
 
    /**
-    * Timeout to stop the cache store. When the store is stopped it's possible that some
-    * modifications still need to be applied; you likely want to set a very large timeout to make
-    * sure to not loose data
+    * Unused
     */
+   @Deprecated
    public long shutdownTimeout() {
-      return shutdownTimeout.get();
+      return 0;
    }
 
+   /**
+    * Unused
+    */
+   @Deprecated
    public AsyncStoreConfiguration shutdownTimeout(long l) {
-      shutdownTimeout.set(l);
       return this;
    }
 

--- a/core/src/main/java/org/infinispan/configuration/cache/AsyncStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AsyncStoreConfigurationBuilder.java
@@ -42,20 +42,19 @@ public class AsyncStoreConfigurationBuilder<S> extends AbstractStoreConfiguratio
    }
 
    /**
-    * Timeout to acquire the lock which guards the state to be flushed to the cache store
-    * periodically. The timeout can be adjusted for a running cache.
+    * Unused.
     */
+   @Deprecated
    public AsyncStoreConfigurationBuilder<S> flushLockTimeout(long l) {
-      attributes.attribute(FLUSH_LOCK_TIMEOUT).set(l);
       return this;
    }
 
    /**
-    * Timeout to acquire the lock which guards the state to be flushed to the cache store
-    * periodically. The timeout can be adjusted for a running cache.
+    * Unused.
     */
+   @Deprecated
    public AsyncStoreConfigurationBuilder<S> flushLockTimeout(long l, TimeUnit unit) {
-      return flushLockTimeout(unit.toMillis(l));
+      return this;
    }
 
    /**
@@ -70,22 +69,19 @@ public class AsyncStoreConfigurationBuilder<S> extends AbstractStoreConfiguratio
    }
 
    /**
-    * Timeout to stop the cache store. When the store is stopped it's possible that some
-    * modifications still need to be applied; you likely want to set a very large timeout to make
-    * sure to not loose data
+    * Unused.
     */
+   @Deprecated
    public AsyncStoreConfigurationBuilder<S> shutdownTimeout(long l) {
-      attributes.attribute(SHUTDOWN_TIMEOUT).set(l);
       return this;
    }
 
    /**
-    * Timeout to stop the cache store. When the store is stopped it's possible that some
-    * modifications still need to be applied; you likely want to set a very large timeout to make
-    * sure to not loose data
+    * Unused.
     */
+   @Deprecated
    public AsyncStoreConfigurationBuilder<S> shutdownTimeout(long l, TimeUnit unit) {
-      return shutdownTimeout(unit.toMillis(l));
+      return this;
    }
 
    /**

--- a/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
@@ -42,6 +42,7 @@ public enum Attribute {
     EXPIRATION_EXECUTOR("expiration-executor"),
     FAILURE_POLICY_CLASS("failure-policy-class"),
     FETCH_STATE("fetch-state"),
+    @Deprecated
     FLUSH_LOCK_TIMEOUT("flush-lock-timeout"),
     GROUP_NAME("group-name"),
     ID("id"),
@@ -99,6 +100,7 @@ public enum Attribute {
     SEGMENTS("segments"),
     SHARED("shared"),
     SHUTDOWN_HOOK("shutdown-hook"),
+    @Deprecated
     SHUTDOWN_TIMEOUT("shutdown-timeout"),
     SINGLETON("singleton"),
     SITE("site"),

--- a/core/src/main/java/org/infinispan/persistence/async/AdvancedAsyncCacheWriter.java
+++ b/core/src/main/java/org/infinispan/persistence/async/AdvancedAsyncCacheWriter.java
@@ -22,7 +22,7 @@ public class AdvancedAsyncCacheWriter extends AsyncCacheWriter implements Advanc
 
    @Override
    public void clear() {
-      stateLock.writeLock(1);
+      stateLock.writeLock(0);
       try {
          assertNotStopped();
          state.set(newState(true, state.get().next));

--- a/core/src/main/java/org/infinispan/persistence/async/AdvancedAsyncCacheWriter.java
+++ b/core/src/main/java/org/infinispan/persistence/async/AdvancedAsyncCacheWriter.java
@@ -24,6 +24,7 @@ public class AdvancedAsyncCacheWriter extends AsyncCacheWriter implements Advanc
    public void clear() {
       stateLock.writeLock(1);
       try {
+         assertNotStopped();
          state.set(newState(true, state.get().next));
       } finally {
          stateLock.reset(1);

--- a/core/src/main/java/org/infinispan/persistence/async/AsyncCacheWriter.java
+++ b/core/src/main/java/org/infinispan/persistence/async/AsyncCacheWriter.java
@@ -195,12 +195,7 @@ public class AsyncCacheWriter extends DelegatingCacheWriter {
          LogFactory.pushNDC(cacheName, trace);
          try {
             for (;;) {
-               State s, head, tail;
-               s = state.get();
-               if (shouldStop(s)) {
-                  return;
-               }
-
+               final State s, head, tail;
                stateLock.readLock();
                try {
                   s = state.get();
@@ -262,7 +257,7 @@ public class AsyncCacheWriter extends DelegatingCacheWriter {
                   }
 
                   // if this is the last state to process, wait for background threads, then quit
-                  if (shouldStop(s)) {
+                  if (s.stopped && head.modifications.isEmpty()) {
                      s.workerThreads.await();
                      return;
                   }
@@ -273,10 +268,6 @@ public class AsyncCacheWriter extends DelegatingCacheWriter {
          } finally {
             LogFactory.popNDC(trace);
          }
-      }
-
-      private boolean shouldStop(State s) {
-         return s.stopped && s.modifications.isEmpty();
       }
    }
 

--- a/core/src/main/java/org/infinispan/persistence/async/AsyncCacheWriter.java
+++ b/core/src/main/java/org/infinispan/persistence/async/AsyncCacheWriter.java
@@ -118,7 +118,7 @@ public class AsyncCacheWriter extends DelegatingCacheWriter {
    @Override
    public void stop() {
       if (trace) log.tracef("Stop async store %s", this);
-      stateLock.writeLock(1);
+      stateLock.writeLock(0);
       stopped = true;
       stateLock.writeUnlock();
       try {

--- a/core/src/main/java/org/infinispan/persistence/async/AsyncCacheWriter.java
+++ b/core/src/main/java/org/infinispan/persistence/async/AsyncCacheWriter.java
@@ -306,15 +306,18 @@ public class AsyncCacheWriter extends DelegatingCacheWriter {
 
       @Override
       public void run() {
-         // try 3 times to store the modifications
-         retryWork(3);
+         try {
+            // try 3 times to store the modifications
+            retryWork(3);
 
-         // decrement active worker threads and disconnect myState if this was the last one
-         myState.workerThreads.countDown();
-         if (myState.workerThreads.getCount() == 0)
-            for (State s = state.get(); s != null; s = s.next)
-               if (s.next == myState)
-                  s.next = null;
+         } finally {
+            // decrement active worker threads and disconnect myState if this was the last one
+            myState.workerThreads.countDown();
+            if (myState.workerThreads.getCount() == 0)
+               for (State s = state.get(); s != null; s = s.next)
+                  if (s.next == myState)
+                     s.next = null;
+         }
       }
 
       private void retryWork(int maxRetries) {

--- a/core/src/main/java/org/infinispan/persistence/async/AsyncCacheWriter.java
+++ b/core/src/main/java/org/infinispan/persistence/async/AsyncCacheWriter.java
@@ -167,7 +167,7 @@ public class AsyncCacheWriter extends DelegatingCacheWriter {
    }
 
 
-   State newState(boolean clear, State next) {
+   protected State newState(boolean clear, State next) {
       ConcurrentMap<Object, Modification> map = CollectionFactory.makeConcurrentMap(64, concurrencyLevel);
       return new State(clear, map, next);
    }

--- a/core/src/main/java/org/infinispan/persistence/async/AsyncCacheWriter.java
+++ b/core/src/main/java/org/infinispan/persistence/async/AsyncCacheWriter.java
@@ -64,7 +64,6 @@ public class AsyncCacheWriter extends DelegatingCacheWriter {
    private ExecutorService executor;
    private Thread coordinator;
    private int concurrencyLevel;
-   private long shutdownTimeout;
    private String cacheName;
 
    protected BufferLock stateLock;
@@ -85,18 +84,7 @@ public class AsyncCacheWriter extends DelegatingCacheWriter {
       Cache cache = ctx.getCache();
       Configuration cacheCfg = cache != null ? cache.getCacheConfiguration() : null;
       concurrencyLevel = cacheCfg != null ? cacheCfg.locking().concurrencyLevel() : 16;
-      long cacheStopTimeout = cacheCfg != null ? cacheCfg.transaction().cacheStopTimeout() : 30000;
-      Long configuredAsyncStopTimeout = this.asyncConfiguration.shutdownTimeout();
       cacheName = cache != null ? cache.getName() : null;
-
-      // Async store shutdown timeout cannot be bigger than
-      // the overall cache stop timeout, so limit it accordingly.
-      if (configuredAsyncStopTimeout >= cacheStopTimeout) {
-         shutdownTimeout = Math.round(cacheStopTimeout * 0.90);
-         log.asyncStoreShutdownTimeoutTooHigh(configuredAsyncStopTimeout, cacheStopTimeout, shutdownTimeout);
-      } else {
-         shutdownTimeout = configuredAsyncStopTimeout;
-      }
    }
 
    @Override
@@ -105,6 +93,8 @@ public class AsyncCacheWriter extends DelegatingCacheWriter {
       state.set(newState(false, null));
       stateLock = new BufferLock(asyncConfiguration.modificationQueueSize());
 
+      // Create a thread pool with unbounded work queue, so that all work is accepted and eventually
+      // executed. A bounded queue could throw RejectedExecutionException and thus lose data.
       int poolSize = asyncConfiguration.threadPoolSize();
       executor = new ThreadPoolExecutor(0, poolSize, 120L, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>(),
                                         new ThreadFactory() {
@@ -127,8 +117,17 @@ public class AsyncCacheWriter extends DelegatingCacheWriter {
       state.get().stopped = true;
       stateLock.writeUnlock();
       try {
-         coordinator.join(shutdownTimeout);
-         if (coordinator.isAlive())
+         // It is safe to wait without timeout because the thread pool uses an unbounded work queue (i.e.
+         // all work handed to the pool will be accepted and eventually executed) and AsyncStoreProcessors
+         // decrement the workerThreads latch in a finally block (i.e. even if the back-end store throws
+         // java.lang.Error). The coordinator thread can only block forever if the back-end's write() /
+         // remove() methods block, but this is no different from PassivationManager.stop() being blocked
+         // in a synchronous call to write() / remove().
+         coordinator.join();
+         // The coordinator thread waits for AsyncStoreProcessor threads to count down their latch (nearly
+         // at the end). Thus the threads should have terminated or terminate instantly.
+         executor.shutdown();
+         if (!executor.awaitTermination(1, TimeUnit.SECONDS))
             log.errorAsyncStoreNotStopped();
       } catch (InterruptedException e) {
          log.interruptedWaitingAsyncStorePush(e);
@@ -271,22 +270,7 @@ public class AsyncCacheWriter extends DelegatingCacheWriter {
                }
             }
          } finally {
-            try {
-               // Wait for existing workers to finish
-               boolean workersTerminated = false;
-               try {
-                  executor.shutdown();
-                  workersTerminated = executor.awaitTermination(shutdownTimeout, TimeUnit.MILLISECONDS);
-               } catch (InterruptedException e) {
-                  Thread.currentThread().interrupt();
-               }
-               if (!workersTerminated) {
-                  // if the worker threads did not finish cleanly in the allotted time then we try to interrupt them to shut down
-                  executor.shutdownNow();
-               }
-            } finally {
-               LogFactory.popNDC(trace);
-            }
+            LogFactory.popNDC(trace);
          }
       }
 

--- a/core/src/main/java/org/infinispan/persistence/async/BufferLock.java
+++ b/core/src/main/java/org/infinispan/persistence/async/BufferLock.java
@@ -135,13 +135,13 @@ class BufferLock {
 
    /**
     * Acquires the write lock and consumes the specified amount of buffer space. Blocks if the
-    * buffer is full or if the object is currently locked for reading.
+    * object is currently locked for reading, or if the buffer is full and count is greater than 0.
     *
     * @param count
     *           number of items the caller intends to write
     */
    void writeLock(int count) {
-      if (counter != null)
+      if (count > 0 && counter != null)
          counter.acquireShared(count);
       sync.acquireShared(1);
    }

--- a/core/src/main/java/org/infinispan/persistence/async/State.java
+++ b/core/src/main/java/org/infinispan/persistence/async/State.java
@@ -1,6 +1,5 @@
 package org.infinispan.persistence.async;
 
-import org.infinispan.commons.CacheException;
 import org.infinispan.persistence.modifications.Clear;
 import org.infinispan.persistence.modifications.Modification;
 import org.infinispan.persistence.modifications.ModificationsList;
@@ -37,11 +36,6 @@ public class State {
    volatile State next;
 
    /**
-    * True if the CacheStore has been stopped (i.e. this is the last state to process).
-    */
-   volatile boolean stopped = false;
-
-   /**
     * Number of worker threads that currently work with this instance.
     */
    CountDownLatch workerThreads;
@@ -50,8 +44,6 @@ public class State {
       this.clear = clear;
       this.modifications = modMap;
       this.next = next;
-      if (next != null)
-         stopped = next.stopped;
    }
 
    /**
@@ -81,8 +73,6 @@ public class State {
     *           the Modification to add, supports modification types STORE, REMOVE and LIST
     */
    void put(Modification mod) {
-      if (stopped)
-         throw new CacheException("AsyncCacheWriter stopped; no longer accepting more entries.");
       switch (mod.getType()) {
          case STORE:
             modifications.put(((Store) mod).getKey(), mod);

--- a/core/src/main/java/org/infinispan/persistence/async/State.java
+++ b/core/src/main/java/org/infinispan/persistence/async/State.java
@@ -40,7 +40,7 @@ public class State {
     */
    CountDownLatch workerThreads;
 
-   State(boolean clear, ConcurrentMap<Object, Modification> modMap, State next) {
+   public State(boolean clear, ConcurrentMap<Object, Modification> modMap, State next) {
       this.clear = clear;
       this.modifications = modMap;
       this.next = next;

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -566,12 +566,6 @@ public interface Log extends BasicLogger {
    void couldNotRollbackPrepared1PcTransaction(LocalTransaction localTransaction, @Cause Throwable e1);
 
    @LogMessage(level = WARN)
-   @Message(value = "The async store shutdown timeout (%d ms) is too high compared " +
-         "to cache stop timeout (%d ms), so instead using %d ms for async store stop wait", id = 142)
-   void asyncStoreShutdownTimeoutTooHigh(long configuredAsyncStopTimeout,
-      long cacheStopTimeout, long asyncStopTimeout);
-
-   @LogMessage(level = WARN)
    @Message(value = "Received a key that doesn't map to this node: %s, mapped to %s", id = 143)
    void keyDoesNotMapToLocalNode(Object key, Collection<Address> nodes);
 

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -53,7 +53,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
 
 import static org.jboss.logging.Logger.Level.*;
 
@@ -259,10 +258,6 @@ public interface Log extends BasicLogger {
    @LogMessage(level = WARN)
    @Message(value = "Unable to process some async modifications after %d retries!", id = 53)
    void unableToProcessAsyncModifications(int retries);
-
-   @LogMessage(level = ERROR)
-   @Message(value = "AsyncStoreCoordinator interrupted", id = 54)
-   void asyncStoreCoordinatorInterrupted(@Cause InterruptedException e);
 
    @LogMessage(level = ERROR)
    @Message(value = "Unexpected error in AsyncStoreCoordinator thread. AsyncCacheWriter is dead!", id = 55)
@@ -868,9 +863,6 @@ public interface Log extends BasicLogger {
 
    @Message(value="Cache is in an invalid state: %s", id = 232)
    IllegalStateException invalidCacheState(String cacheState);
-
-   @Message(value="Waiting on work threads latch failed: %s", id = 233)
-   TimeoutException waitingForWorkerThreadsFailed(CountDownLatch latch);
 
    @Message(value = "Root element for %s already registered in ParserRegistry", id = 234)
    IllegalArgumentException parserRootElementAlreadyRegistered(QName qName);

--- a/core/src/test/java/org/infinispan/configuration/SampleConfigFilesCorrectnessTest.java
+++ b/core/src/test/java/org/infinispan/configuration/SampleConfigFilesCorrectnessTest.java
@@ -37,7 +37,7 @@ public class SampleConfigFilesCorrectnessTest {
       log4jLogger.setLevel(Level.WARN);
       appender = new InMemoryAppender();
       log4jLogger.addAppender(appender);
-      configRoot = "../distribution/src/main/release/common/configs/config-samples".replaceAll("/", File.separator);
+      configRoot = "../distribution/src/main/release/common/configs/config-samples".replace('/', File.separatorChar);
    }
 
    @AfterMethod

--- a/core/src/test/java/org/infinispan/configuration/XmlFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/XmlFileParsingTest.java
@@ -465,7 +465,6 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       assertTrue(loaderCfg.purgeOnStartup());
       assertEquals("/tmp/FileCacheStore-Location", loaderCfg.location());
       assertEquals(5, loaderCfg.async().threadPoolSize());
-      assertEquals(15000, loaderCfg.async().flushLockTimeout());
       assertTrue(loaderCfg.async().enabled());
       assertEquals(700, loaderCfg.async().modificationQueueSize());
 

--- a/core/src/test/java/org/infinispan/configuration/parsing/UnifiedXmlFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/parsing/UnifiedXmlFileParsingTest.java
@@ -176,9 +176,7 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
       assertFalse(fileStore.purgeOnStartup());
       assertTrue(fileStore.preload());
       assertTrue(fileStore.shared());
-      assertEquals(2, fileStore.async().flushLockTimeout());
       assertEquals(2048, fileStore.async().modificationQueueSize());
-      assertEquals(20000, fileStore.async().shutdownTimeout());
       assertEquals(1, fileStore.async().threadPoolSize());
       assertEquals(Index.NONE, c.indexing().index());
 

--- a/core/src/test/java/org/infinispan/persistence/support/AsyncStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/support/AsyncStoreTest.java
@@ -389,6 +389,8 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
             .addStore(new LockableStoreConfigurationBuilder(builder.persistence()));
       lcscsBuilder.async()
             .modificationQueueSize(10);
+      lcscsBuilder.async()
+            .shutdownTimeout(50);
 
       writer = new AdvancedAsyncCacheWriter(underlying);
       writer.init(PersistenceMockUtil.createContext(getClass().getSimpleName(), builder.build(), marshaller));


### PR DESCRIPTION
Revisiting my own code after two years is really astonishing :blush:

We recently ran into the "AsyncCacheWriter is dead!" bug on some of our servers...so I started digging. I think the most important fixes in this series are:
* b35cfff: fix "AsyncCacheWriter is dead!" bug
* c8efff7: fix race condition that may cause CacheLoader.load() to return wrong data
* 132c1a9 and 27a71dc: write all remaining data when stopping the store
* 7e1c75d: make things multi-threaded

Have fun,
Karsten

PS: I actually need these fixes for Infinispan 6, so I could also provide the backported / rebased series if you like.


Edit: here are the links to the respective Jira-Tickets:
* [ISPN-3532](https://issues.jboss.org/browse/ISPN-3532): AsyncStore has only one live AsyncStoreProcessor (thread) in one time
* [ISPN-5559](https://issues.jboss.org/browse/ISPN-5559): "AsyncCacheWriter is dead!" errors cause deadlock or unbounded use of memory
* [ISPN-5562](https://issues.jboss.org/browse/ISPN-5562): AsyncCacheWriter should write all data to the back-end store before shutting down
* [ISPN-5563](https://issues.jboss.org/browse/ISPN-5563): AsyncCacheLoader.load() may still return stale data
* [ISPN-5564](https://issues.jboss.org/browse/ISPN-5564): AsyncCacheWriter stop() and clear() should not wait for space in the modifications queue