### PR TITLE
ISPN-5558 DistributedTaskPart.equals() implementation is wrong

### DIFF
--- a/core/src/main/java/org/infinispan/distexec/DefaultExecutorService.java
+++ b/core/src/main/java/org/infinispan/distexec/DefaultExecutorService.java
@@ -936,40 +936,6 @@ public class DefaultExecutorService extends AbstractExecutorService implements D
          return part.get(timeout, unit);
       }
 
-      @Override
-      public int hashCode() {
-         final int prime = 31;
-         int result = 1;
-         result = prime * result + getOuterType().hashCode();
-         result = prime * result + ((distCommand == null) ? 0 : distCommand.hashCode());
-         return result;
-      }
-
-      @Override
-      public boolean equals(Object obj) {
-         if (this == obj) {
-            return true;
-         }
-         if (obj == null) {
-            return false;
-         }
-         if (!(obj instanceof DistributedTaskPart)) {
-            return false;
-         }
-         DistributedTaskPart other = (DistributedTaskPart) obj;
-         if (!getOuterType().equals(other.getOuterType())) {
-            return false;
-         }
-         if (distCommand == null) {
-            if (other.distCommand != null) {
-               return false;
-            }
-         } else if (!distCommand.equals(other.distCommand)) {
-            return false;
-         }
-         return true;
-      }
-
       protected void setCancelled() {
          cancelled = true;
       }


### PR DESCRIPTION
Remove the equals() and hashCode() implementations

https://issues.jboss.org/browse/ISPN-5558