### PR TITLE
ISPN-5565 Memory leak in Hot Rod client tests

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/SingleHotRodServerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/SingleHotRodServerTest.java
@@ -43,7 +43,7 @@ public abstract class SingleHotRodServerTest extends SingleCacheManagerTest {
       return new InternalRemoteCacheManager(builder.build());
    }
 
-   @AfterClass
+   @AfterClass(alwaysRun = true)
    public void shutDownHotrod() {
       killRemoteCacheManager(remoteCacheManager);
       killServers(hotrodServer);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5565

Before:

| E | O| YGC  | FGC  | GCT|
|---|---|---|---|---|
| 100.00 | 99.99 |39 | 375 | 137.777|
(10+ test failures)

After:

|E|O|YGC|FGC|GCT|
|---|---|---|---|---|
| 92.21 | 99.97 |42 | 40 | 21.366|

(No failures)