### PR TITLE
ISPN-5560 NotSerializableException for invalidation-cache

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -8,6 +8,7 @@ import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.util.InfinispanCollections;
 import org.infinispan.commons.util.concurrent.ParallelIterableMap;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.InternalCacheEntry;
@@ -653,7 +654,9 @@ public class StateConsumerImpl implements StateConsumer {
    // Must run after the PersistenceManager
    @Start(priority = 20)
    public void start() {
-      isFetchEnabled = configuration.clustering().stateTransfer().fetchInMemoryState() || configuration.persistence().fetchPersistentState();
+      CacheMode mode = configuration.clustering().cacheMode();
+      isFetchEnabled = (mode.isDistributed() || mode.isReplicated()) &&
+              (configuration.clustering().stateTransfer().fetchInMemoryState() || configuration.persistence().fetchPersistentState());
       //rpc options does not changes in runtime. we can use always the same instance.
       rpcOptions = rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS)
             .timeout(timeout, TimeUnit.MILLISECONDS).build();

--- a/core/src/test/java/org/infinispan/statetransfer/NonTxStateTransferInvalidationTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/NonTxStateTransferInvalidationTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -31,7 +30,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 import static org.testng.AssertJUnit.assertNull;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.fail;
 
 /**
@@ -53,7 +52,7 @@ public class NonTxStateTransferInvalidationTest extends MultipleCacheManagersTes
       waitForClusterToForm();
    }
 
-   public void testStateTransfer() throws Exception {
+   public void testStateTransferDisabled() throws Exception {
       // Insert initial data in the cache
       Set<Object> keys = new HashSet<Object>();
       for (int i = 0; i < NUM_KEYS; i++) {
@@ -77,12 +76,8 @@ public class NonTxStateTransferInvalidationTest extends MultipleCacheManagersTes
          InternalCacheEntry d2 = advancedCache(2).getDataContainer().get(key);
          assertEquals(key, d0.getValue());
          assertNull(d1);
-         if (d2 != null) {
-            keysOnJoiner++;
-         }
+         assertNull(d2);
       }
-
-      assertTrue("The joiner should receive at least one key", keysOnJoiner > 0);
    }
 
    @Test(groups = "unstable", description = "See ISPN-4016")


### PR DESCRIPTION
* Disabled initial transfer when not REPL or DIST

https://issues.jboss.org/browse/ISPN-5560

This should be cherry pickable into 7.2.  This is mostly to get invalidation working properly until a possibly better solution is completed.