### PR TITLE
Futures: fix compilation problem

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/concurrent/Futures.java
+++ b/commons/src/main/java/org/infinispan/commons/util/concurrent/Futures.java
@@ -25,7 +25,7 @@ public final class Futures {
     * @return a new composite NotifyingFuture
     */
    public static <T> NotifyingFuture<List<T>> combine(final List<NotifyingFuture<T>> futures) {
-      if (futures == null || futures.isEmpty()) return new NoOpFuture<>(null);
+      if (futures == null || futures.isEmpty()) return new NoOpFuture<>((List<T>) null);
       return new CompositeNotifyingFuture<>(futures);
    }
 


### PR DESCRIPTION
...caused by "ISPN-5531 java.lang.UnsupportedOperationException during
remove (using RemoteCacheManager)" addign a second NoOpFuture constructor.

First commit from https://github.com/infinispan/infinispan/pull/3548