### PR TITLE
ISPN-5573 Node shutting down can throw IllegalLifecycleStateException

### DIFF
--- a/core/src/main/java/org/infinispan/IllegalLifecycleStateException.java
+++ b/core/src/main/java/org/infinispan/IllegalLifecycleStateException.java
@@ -1,5 +1,7 @@
 package org.infinispan;
 
+import org.infinispan.commons.CacheException;
+
 /**
  * This exception is thrown when the cache or cache manager does not have the
  * right lifecycle state for operations to be called on it. Situations like
@@ -8,7 +10,7 @@ package org.infinispan;
  *
  * @since 7.0
  */
-public class IllegalLifecycleStateException extends IllegalStateException {
+public class IllegalLifecycleStateException extends CacheException {
    public IllegalLifecycleStateException() {
    }
 

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
@@ -234,6 +234,8 @@ public class CommandAwareRpcDispatcher extends RpcDispatcher {
       Buffer buf;
       try {
          buf = marshaller.objectToBuffer(command);
+      } catch (RuntimeException e) {
+         throw e;
       } catch (Exception e) {
          throw new RuntimeException("Failure to marshal argument(s)", e);
       }

--- a/core/src/test/java/org/infinispan/api/TerminatedCacheTest.java
+++ b/core/src/test/java/org/infinispan/api/TerminatedCacheTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.api;
 
 import org.infinispan.Cache;
+import org.infinispan.IllegalLifecycleStateException;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -22,7 +23,7 @@ public class TerminatedCacheTest extends SingleCacheManagerTest {
       return TestCacheManagerFactory.createCacheManager(false);
    }
 
-   @Test(expectedExceptions = IllegalStateException.class)
+   @Test(expectedExceptions = IllegalLifecycleStateException.class)
    public void testCacheStopFollowedByGetCache() {
       Cache cache = cacheManager.getCache();
       cache.put("k", "v");
@@ -31,7 +32,7 @@ public class TerminatedCacheTest extends SingleCacheManagerTest {
       cache2.put("k", "v2");
    }
 
-   @Test(expectedExceptions = IllegalStateException.class)
+   @Test(expectedExceptions = IllegalLifecycleStateException.class)
    public void testCacheStopFollowedByCacheOp() {
       Cache cache = cacheManager.getCache("big");
       cache.put("k", "v");

--- a/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.manager;
 
 import org.infinispan.Cache;
+import org.infinispan.IllegalLifecycleStateException;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.configuration.BuiltBy;
 import org.infinispan.commons.configuration.ConfigurationFor;
@@ -240,7 +241,7 @@ public class CacheManagerTest extends AbstractInfinispanTest {
       }
    }
 
-   @Test(expectedExceptions = IllegalStateException.class)
+   @Test(expectedExceptions = IllegalLifecycleStateException.class)
    public void testCacheStopManagerStopFollowedByGetCache() {
       EmbeddedCacheManager localCacheManager = createCacheManager(false);
       try {
@@ -254,7 +255,7 @@ public class CacheManagerTest extends AbstractInfinispanTest {
       }
    }
 
-   @Test(expectedExceptions = IllegalStateException.class)
+   @Test(expectedExceptions = IllegalLifecycleStateException.class)
    public void testCacheStopManagerStopFollowedByCacheOp() {
       EmbeddedCacheManager localCacheManager = createCacheManager(false);
       try {

--- a/core/src/test/java/org/infinispan/tx/TerminatedCacheWhileInTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/TerminatedCacheWhileInTxTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.tx;
 
 import org.infinispan.Cache;
+import org.infinispan.IllegalLifecycleStateException;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -48,7 +49,7 @@ public class TerminatedCacheWhileInTxTest extends SingleCacheManagerTest {
     * on-going transactions or non-transactional invocations are not allowed
     * once the cache is in stopping mode.
     */
-   @Test(expectedExceptions = IllegalStateException.class)
+   @Test(expectedExceptions = IllegalLifecycleStateException.class)
    public void testNotAllowCallsWhileStopping(Method m) throws Throwable {
       stopCacheCalls(m, true);
    }

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/embedded/JCache.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/embedded/JCache.java
@@ -367,6 +367,9 @@ public class JCache<K, V> extends AbstractJCache<K, V> {
 
    @Override
    public Iterator<Cache.Entry<K, V>> iterator() {
+      if (isClosed()) {
+         throw log.cacheClosed(cache.getStatus());
+      }
       return new Itr();
    }
 
@@ -498,6 +501,9 @@ public class JCache<K, V> extends AbstractJCache<K, V> {
 
    @Override
    public void removeAll() {
+      if (isClosed()) {
+         throw log.cacheClosed(cache.getStatus());
+      }
       // Calling cache.clear() won't work since there's currently no way to
       // for an Infinispan cache store to figure out all keys store and pass
       // them to CacheWriter.deleteAll(), hence, delete individually.


### PR DESCRIPTION
wrapped multiple times

* Don't wrap Runtime with another Runtime for marshaller
* Changed ILSE to extend CacheException to prevent extra wrapping

https://issues.jboss.org/browse/ISPN-5573