### PR TITLE
ISPN-5561 Problem in dealing with the HQL queries that contain string comparison operations, when it involves empty string as an operand

### DIFF
--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
@@ -223,6 +223,30 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
+   public void testEqEmptyString() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .having("name").eq("")
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertTrue(list.isEmpty());
+   }
+
+   @Test
+   public void testEqSentence() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getAccountImplClass())
+            .having("description").eq("John Doe's first bank account")
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertEquals(1, list.size());
+   }
+
+   @Test
    public void testEq() throws Exception {
       QueryFactory qf = getQueryFactory();
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -120,7 +120,7 @@
       <version.hibernate.annotations>3.5.6-Final</version.hibernate.annotations>
       <version.hibernate.core>4.3.6.Final</version.hibernate.core>
       <version.hibernate.entitymanager>${version.hibernate.core}</version.hibernate.entitymanager>
-      <version.hibernate.hql.parser>1.2.0.Final</version.hibernate.hql.parser>
+      <version.hibernate.hql.parser>1.2.1.Final</version.hibernate.hql.parser>
       <version.hibernate.osgi>${version.hibernate.core}</version.hibernate.osgi>
       <version.hibernate_dep.antlr>2.7.7_5</version.hibernate_dep.antlr>
       <version.hibernate_dep.classmate>0.5.4</version.hibernate_dep.classmate>

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
@@ -205,6 +205,28 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       assertEquals("Doe", list.get(0).getSurname());
    }
 
+   public void testEqEmptyString() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .having("name").eq("")
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertTrue(list.isEmpty());
+   }
+
+   public void testEqSentence() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getAccountImplClass())
+            .having("description").eq("John Doe's first bank account")
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertEquals(1, list.size());
+   }
+
    public void testEq() throws Exception {
       QueryFactory qf = getQueryFactory();
 


### PR DESCRIPTION
jira: https://issues.jboss.org/browse/ISPN-5561
       https://issues.jboss.org/browse/ISPN-5587