### PR TITLE
ISPN-5568 TestResourceTracker.backgroundTestStarted IDE problems

### DIFF
--- a/cdi/src/test/java/org/infinispan/cdi/test/DefaultTestEmbeddedCacheManagerProducer.java
+++ b/cdi/src/test/java/org/infinispan/cdi/test/DefaultTestEmbeddedCacheManagerProducer.java
@@ -6,6 +6,7 @@ import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TestResourceTracker;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Disposes;
@@ -27,6 +28,10 @@ public class DefaultTestEmbeddedCacheManagerProducer {
    @Produces
    @ApplicationScoped
    public EmbeddedCacheManager getDefaultEmbeddedCacheManager(Configuration defaultConfiguration) {
+      // Sometimes we're called from a remote thread that doesn't have the test name set
+      // We don't have the test name here, either, but we can use a dummy one
+      TestResourceTracker.setThreadTestNameIfMissing("DefaultTestEmbeddedCacheManagerProducer");
+
       ConfigurationBuilder builder = new ConfigurationBuilder();
       GlobalConfigurationBuilder globalConfigurationBuilder = new GlobalConfigurationBuilder();
       globalConfigurationBuilder.globalJmxStatistics().allowDuplicateDomains(true);

--- a/core/src/test/java/org/infinispan/commands/GetAllCommandStressTest.java
+++ b/core/src/test/java/org/infinispan/commands/GetAllCommandStressTest.java
@@ -28,7 +28,6 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.test.fwk.TransportFlags;
-import org.infinispan.transaction.TransactionMode;
 import org.testng.annotations.Test;
 
 /**
@@ -138,8 +137,7 @@ public class GetAllCommandStressTest extends MultipleCacheManagersTest {
       futures[futures.length - 1] = fork(new Callable<Void>() {
          @Override
          public Void call() throws Exception {
-//            TestResourceTracker.setThreadTestName("main");
-            TestResourceTracker.backgroundTestStarted(GetAllCommandStressTest.this);
+            TestResourceTracker.testThreadStarted(GetAllCommandStressTest.this);
             try {
                Cache<?, ?> cacheToKill = cache(CACHE_COUNT - 1);
                while (!complete.get()) {

--- a/core/src/test/java/org/infinispan/commands/PutMapCommandStressTest.java
+++ b/core/src/test/java/org/infinispan/commands/PutMapCommandStressTest.java
@@ -152,8 +152,7 @@ public class PutMapCommandStressTest extends MultipleCacheManagersTest {
       futures[futures.length - 1] = fork(new Callable<Void>() {
          @Override
          public Void call() throws Exception {
-//            TestResourceTracker.setThreadTestName("main");
-            TestResourceTracker.backgroundTestStarted(PutMapCommandStressTest.this);
+            TestResourceTracker.testThreadStarted(PutMapCommandStressTest.this);
             try {
                Cache<?, ?> cacheToKill = cache(CACHE_COUNT - 1);
                while (!complete.get()) {

--- a/core/src/test/java/org/infinispan/configuration/DataContainerTest.java
+++ b/core/src/test/java/org/infinispan/configuration/DataContainerTest.java
@@ -8,6 +8,7 @@ import org.infinispan.container.InternalEntryFactoryImpl;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.eviction.ActivationManager;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.mockito.Mockito;
@@ -24,7 +25,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 
 @Test(testName = "config.DataContainerTest", groups = "functional")
-public class DataContainerTest {
+public class DataContainerTest extends AbstractInfinispanTest {
 
    @Test
    public void testDefault() throws IOException {

--- a/core/src/test/java/org/infinispan/configuration/ParserOverrideTest.java
+++ b/core/src/test/java/org/infinispan/configuration/ParserOverrideTest.java
@@ -9,6 +9,7 @@ import static org.infinispan.test.TestingUtil.withCacheManager;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
+import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.TestingUtil.InfinispanStartTag;
@@ -18,7 +19,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "configuration.ParserOverrideTest")
-public class ParserOverrideTest {
+public class ParserOverrideTest extends AbstractInfinispanTest {
 
    /**
     * This test makes sure that some named cached values are overridden properly

--- a/core/src/test/java/org/infinispan/configuration/SampleConfigFilesCorrectnessTest.java
+++ b/core/src/test/java/org/infinispan/configuration/SampleConfigFilesCorrectnessTest.java
@@ -5,6 +5,7 @@ import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.util.logging.Log;
@@ -23,7 +24,7 @@ import java.util.Arrays;
  * @author Mircea.Markus@jboss.com
  */
 @Test(groups = "functional", testName = "config.SampleConfigFilesCorrectnessTest")
-public class SampleConfigFilesCorrectnessTest {
+public class SampleConfigFilesCorrectnessTest extends AbstractInfinispanTest {
    private static final Log log = LogFactory.getLog(SampleConfigFilesCorrectnessTest.class);
 
    public String configRoot;

--- a/core/src/test/java/org/infinispan/configuration/TxManagerLookupConfigTest.java
+++ b/core/src/test/java/org/infinispan/configuration/TxManagerLookupConfigTest.java
@@ -2,6 +2,7 @@ package org.infinispan.configuration;
 
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.lookup.TransactionManagerLookup;
@@ -19,7 +20,7 @@ import static org.infinispan.test.TestingUtil.withCacheManager;
  * @author Mircea.Markus@jboss.com
  */
 @Test(groups = "functional", testName = "config.TxManagerLookupConfigTest")
-public class TxManagerLookupConfigTest {
+public class TxManagerLookupConfigTest extends AbstractInfinispanTest {
 
    static TmA tma = new TmA();
    static TmB tmb = new TmB();

--- a/core/src/test/java/org/infinispan/configuration/module/ExtendedParserTest.java
+++ b/core/src/test/java/org/infinispan/configuration/module/ExtendedParserTest.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
+import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.TestingUtil.InfinispanStartTag;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -22,7 +23,7 @@ import org.testng.annotations.Test;
  * @since 5.2
  */
 @Test(groups = "unit", testName = "configuration.module.ExtendedParserTest")
-public class ExtendedParserTest {
+public class ExtendedParserTest extends AbstractInfinispanTest {
 
    public void testExtendedParser() throws IOException {
       String config = InfinispanStartTag.LATEST +

--- a/core/src/test/java/org/infinispan/distexec/LocalDistributedExecutorTest.java
+++ b/core/src/test/java/org/infinispan/distexec/LocalDistributedExecutorTest.java
@@ -18,6 +18,8 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -88,7 +90,8 @@ public class LocalDistributedExecutorTest extends MultipleCacheManagersTest {
    }
    
    protected DistributedExecutorService createDES(Cache<?,?> cache){
-      DistributedExecutorService des = new DefaultExecutorService(cache);
+      ExecutorService executorService = Executors.newCachedThreadPool(getTestThreadFactory("DistributedExecutorZ"));
+      DistributedExecutorService des = new DefaultExecutorService(cache, executorService);
       cleanupService = des;
       return des;
    }

--- a/core/src/test/java/org/infinispan/distribution/ConcurrentStartWithReplTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ConcurrentStartWithReplTest.java
@@ -40,7 +40,7 @@ public class ConcurrentStartWithReplTest extends AbstractInfinispanTest {
 
    @Test(timeOut = 60000)
    public void testSequence1() throws ExecutionException, InterruptedException {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       /*
 
       Sequence 1:
@@ -60,7 +60,7 @@ public class ConcurrentStartWithReplTest extends AbstractInfinispanTest {
 
    @Test(timeOut = 60000)
    public void testSequence2() throws ExecutionException, InterruptedException {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       /*
 
       Sequence 2:
@@ -79,7 +79,7 @@ public class ConcurrentStartWithReplTest extends AbstractInfinispanTest {
 
    @Test(timeOut = 60000)
    public void testSequence3() throws ExecutionException, InterruptedException {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       /*
 
       Sequence 3:
@@ -97,7 +97,7 @@ public class ConcurrentStartWithReplTest extends AbstractInfinispanTest {
 
    @Test(timeOut = 60000)
    public void testSequence4() throws ExecutionException, InterruptedException {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       /*
 
       Sequence 4:

--- a/core/src/test/java/org/infinispan/distribution/IllegalMonitorTest.java
+++ b/core/src/test/java/org/infinispan/distribution/IllegalMonitorTest.java
@@ -38,7 +38,7 @@ public class IllegalMonitorTest extends BaseDistFunctionalTest<Object, String> {
     */
    @Test(threadPoolSize = 7, invocationCount = 21)
    public void testScenario() throws InterruptedException {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       int myId = sequencer.incrementAndGet();
       AdvancedCache cache = this.caches.get(myId % this.INIT_CLUSTER_SIZE).getAdvancedCache();
       for (int i = 0; i < 100; i++) {

--- a/core/src/test/java/org/infinispan/distribution/UnknownCacheStartTest.java
+++ b/core/src/test/java/org/infinispan/distribution/UnknownCacheStartTest.java
@@ -36,7 +36,7 @@ public class UnknownCacheStartTest extends AbstractInfinispanTest {
 
    @Test (expectedExceptions = {CacheException.class, TestException.class}, timeOut = 60000)
    public void testStartingUnknownCaches() throws Throwable {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
 
       cm1 = createCacheManager(configuration);
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashWithL1Test.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashWithL1Test.java
@@ -5,6 +5,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.test.fwk.TransportFlags;
 import org.testng.annotations.Test;
 
@@ -43,6 +44,7 @@ public class RehashWithL1Test extends MultipleCacheManagersTest {
             node3Join = fork(new Callable<Void>() {
                @Override
                public Void call() throws Exception {
+                  TestResourceTracker.testThreadStarted(RehashWithL1Test.this);
                   EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder,
                         new TransportFlags().withMerge(true));
                   cm.getCache();

--- a/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverStressTest.java
+++ b/core/src/test/java/org/infinispan/iteration/DistributedEntryRetrieverStressTest.java
@@ -151,7 +151,7 @@ public class DistributedEntryRetrieverStressTest extends MultipleCacheManagersTe
       futures[futures.length - 1] = fork(new Callable<Void>() {
          @Override
          public Void call() throws Exception {
-            TestResourceTracker.backgroundTestStarted(DistributedEntryRetrieverStressTest.this);
+            TestResourceTracker.testThreadStarted(DistributedEntryRetrieverStressTest.this);
             try {
                Cache<?, ?> cacheToKill = cache(CACHE_COUNT - 1);
                while (!complete.get()) {

--- a/core/src/test/java/org/infinispan/marshall/SharedStreamMultiMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/SharedStreamMultiMarshallerTest.java
@@ -8,6 +8,7 @@ import org.infinispan.commons.io.ExposedByteArrayOutputStream;
 import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
+import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.jgroups.stack.IpAddress;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import static org.testng.AssertJUnit.assertEquals;
  * @since 5.1
  */
 @Test(groups = "functional", testName = "marshall.SharedStreamMultiMarshallerTest")
-public class SharedStreamMultiMarshallerTest {
+public class SharedStreamMultiMarshallerTest extends AbstractInfinispanTest {
 
    public void testSharingStream() throws Exception {
       EmbeddedCacheManager cm = TestCacheManagerFactory.createClusteredCacheManager();

--- a/core/src/test/java/org/infinispan/persistence/FlushingAsyncStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/FlushingAsyncStoreTest.java
@@ -38,7 +38,7 @@ public class FlushingAsyncStoreTest extends SingleCacheManagerTest {
 
    @Test(timeOut = 10000)
    public void writeOnStorage() {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       cache = cacheManager.getCache("AsyncStoreInMemory");
       cache.put("key1", "value");
       cache.stop();

--- a/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreStressTest.java
+++ b/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreStressTest.java
@@ -12,6 +12,7 @@ import org.infinispan.persistence.spi.AdvancedCacheLoader;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -334,6 +335,7 @@ public class SingleFileStoreStressTest extends SingleCacheManagerTest {
 
       @Override
       public Object call() throws Exception {
+         TestResourceTracker.testThreadStarted(SingleFileStoreStressTest.this);
          Random random = new Random();
          int i = 0;
          while (stopLatch.getCount() != 0) {

--- a/core/src/test/java/org/infinispan/persistence/support/AsyncStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/support/AsyncStoreTest.java
@@ -126,7 +126,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
 
    @Test(timeOut=30000)
    public void testPutRemove() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       createStore();
 
       final int number = 1000;
@@ -138,7 +138,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
 
    @Test(timeOut=30000)
    public void testRepeatedPutRemove() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       createStore();
 
       final int number = 10;
@@ -160,7 +160,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
 
    @Test(timeOut=30000)
    public void testPutClearPut() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       createStore();
 
       final int number = 1000;
@@ -175,7 +175,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
 
    @Test(timeOut=30000)
    public void testRepeatedPutClearPut() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       createStore();
 
       final int number = 10;
@@ -199,7 +199,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
 
    @Test(timeOut=30000)
    public void testMultiplePutsOnSameKey() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       createStore();
 
       final int number = 1000;
@@ -211,7 +211,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
 
    @Test(timeOut=30000)
    public void testRestrictionOnAddingToAsyncQueue() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       createStore();
 
       writer.delete("blah");
@@ -276,7 +276,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
 
    @Test(timeOut=30000)
    public void testConcurrentWriteAndStop() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       createStore(true);
 
       final int lastValue[] = { 0 };
@@ -309,7 +309,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
 
    @Test(timeOut=30000)
    public void testConcurrentClearAndStop() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       createStore(true);
 
       // start a thread that keeps clearing the store until its stopped

--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartTest.java
@@ -23,8 +23,6 @@ import org.infinispan.test.fwk.JGroupsConfigBuilder;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.test.fwk.TransportFlags;
 import org.infinispan.topology.CacheTopologyControlCommand;
-import org.infinispan.util.logging.Log;
-import org.infinispan.util.logging.LogFactory;
 import org.infinispan.xsite.XSiteReplicateCommand;
 import org.jgroups.Channel;
 import org.jgroups.JChannel;
@@ -58,7 +56,7 @@ public class ConcurrentStartTest extends MultipleCacheManagersTest {
 
    @Test(timeOut = 60000)
    public void testConcurrentStart() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       final CheckPoint checkPoint = new CheckPoint();
 
       // Create and connect both channels beforehand

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferFunctionalTest.java
@@ -250,7 +250,7 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
    }
 
    public void testSTWithWritingNonTxThread(Method m) throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       testCount++;
       logTestStart(m);
       writingThreadTest(false);
@@ -258,7 +258,7 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
    }
 
    public void testSTWithWritingTxThread(Method m) throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       testCount++;
       logTestStart(m);
       writingThreadTest(true);

--- a/core/src/test/java/org/infinispan/util/ThreadLocalLeakTest.java
+++ b/core/src/test/java/org/infinispan/util/ThreadLocalLeakTest.java
@@ -8,6 +8,7 @@ import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestResourceTracker;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -68,6 +69,7 @@ public class ThreadLocalLeakTest extends AbstractInfinispanTest {
             new Callable<Map<String, Map<ThreadLocal<?>, Object>>>() {
          @Override
          public Map<String, Map<ThreadLocal<?>, Object>> call() throws Exception {
+            TestResourceTracker.testThreadStarted(ThreadLocalLeakTest.this);
             Thread forkedThread = doStuffWithCache(builder);
 
             beforeGC();

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/distexec/LocalDistributedExecutorTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/distexec/LocalDistributedExecutorTest.java
@@ -35,7 +35,7 @@ public class LocalDistributedExecutorTest extends org.infinispan.distexec.LocalD
 
    @Before
    public void setUp() {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(getCacheMode(), false);
       createClusteredCaches(1, cacheName(), builder);
    }

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/distexec/mapreduce/DistributedTwoNodesMapReduceTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/distexec/mapreduce/DistributedTwoNodesMapReduceTest.java
@@ -27,7 +27,7 @@ public class DistributedTwoNodesMapReduceTest extends BaseWordCountMapReduceTest
 
    @Before
    public void setUp() {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(getCacheMode(), true);
       builder.clustering().stateTransfer().chunkSize(2);
       createClusteredCaches(2, cacheName(), builder);

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/notifications/CustomClassLoaderListenerTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/notifications/CustomClassLoaderListenerTest.java
@@ -37,7 +37,7 @@ public class CustomClassLoaderListenerTest extends org.infinispan.notifications.
 
    @Before
    public void setUp() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       ConfigurationBuilder builder = getDefaultStandaloneCacheConfig(false);
       builder.persistence().passivation(true).addStore(DummyInMemoryStoreConfigurationBuilder.class);
       cacheManager = TestCacheManagerFactory.createCacheManager(builder);

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/file/SingleFileStoreFunctionalTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/file/SingleFileStoreFunctionalTest.java
@@ -46,7 +46,7 @@ public class SingleFileStoreFunctionalTest extends org.infinispan.persistence.fi
    @Before
    @Override
    public void setup() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       super.setup();
    }
 

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jdbc/configuration/XmlFileParsingTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jdbc/configuration/XmlFileParsingTest.java
@@ -34,19 +34,19 @@ public class XmlFileParsingTest extends org.infinispan.persistence.jdbc.configur
 
    @Test
    public void testStringKeyedJdbcStore() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       super.testStringKeyedJdbcStore();
    }
 
    @Test
    public void testBinaryKeyedJdbcStore() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       super.testBinaryKeyedJdbcStore();
    }
 
    @Test
    public void testMixedKeyedJdbcStore() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       super.testMixedKeyedJdbcStore();
    }
 }

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jdbc/stringbased/JdbcStringBasedStoreFunctionalTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jdbc/stringbased/JdbcStringBasedStoreFunctionalTest.java
@@ -47,7 +47,7 @@ public class JdbcStringBasedStoreFunctionalTest extends BaseStoreFunctionalTest 
    @Before
    @Override
    public void setup() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       super.setup();
    }
 

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreFunctionalTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreFunctionalTest.java
@@ -27,7 +27,7 @@ public class JpaStoreFunctionalTest extends org.infinispan.persistence.jpa.JpaSt
    @Before
    @Override
    public void setup() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       super.setup();
    }
 

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStorePersonEntityTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStorePersonEntityTest.java
@@ -28,7 +28,7 @@ public class JpaStorePersonEntityTest extends org.infinispan.persistence.jpa.Jpa
    @Before
    @Override
    public void setUp() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       super.setUp();
    }
 

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreTest.java
@@ -28,7 +28,7 @@ public class JpaStoreTest extends org.infinispan.persistence.jpa.JpaStoreTest {
    @Before
    @Override
    public void setUp() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       super.setUp();
    }
 

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreUserEntityTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreUserEntityTest.java
@@ -28,7 +28,7 @@ public class JpaStoreUserEntityTest extends org.infinispan.persistence.jpa.JpaSt
    @Before
    @Override
    public void setUp() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       super.setUp();
    }
 

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreVehicleEntityTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/jpa/JpaStoreVehicleEntityTest.java
@@ -28,7 +28,7 @@ public class JpaStoreVehicleEntityTest extends org.infinispan.persistence.jpa.Jp
    @Before
    @Override
    public void setUp() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       super.setUp();
    }
 

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/leveldb/JniLevelDBStoreFunctionalTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/leveldb/JniLevelDBStoreFunctionalTest.java
@@ -50,7 +50,7 @@ public class JniLevelDBStoreFunctionalTest extends BaseStoreFunctionalTest {
    @Before
    @Override
    public void setup() throws Exception {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       super.setup();
    }
 

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/tx/CustomObjectsReplicatedCacheTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/tx/CustomObjectsReplicatedCacheTest.java
@@ -50,7 +50,7 @@ public class CustomObjectsReplicatedCacheTest extends MultipleCacheManagersTest 
 
    @Before
    public void setUp() {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       ConfigurationBuilder c = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
       createCluster(c, 2);
    }

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/tx/TransactionsSpanningReplicatedCachesTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/tx/TransactionsSpanningReplicatedCachesTest.java
@@ -36,7 +36,7 @@ public class TransactionsSpanningReplicatedCachesTest extends org.infinispan.tx.
 
    @Before
    public void setUp() {
-      TestResourceTracker.backgroundTestStarted(this);
+      TestResourceTracker.testThreadStarted(this);
       ConfigurationBuilder c = getConfiguration();
       addClusterEnabledCacheManager(c);
       addClusterEnabledCacheManager(c);

--- a/spring/spring/src/test/java/org/infinispan/spring/support/embedded/InfinispanNamedEmbeddedCacheFactoryBeanTest.java
+++ b/spring/spring/src/test/java/org/infinispan/spring/support/embedded/InfinispanNamedEmbeddedCacheFactoryBeanTest.java
@@ -31,11 +31,15 @@ public class InfinispanNamedEmbeddedCacheFactoryBeanTest {
    private static final ClassPathResource NAMED_ASYNC_CACHE_CONFIG_LOCATION = new ClassPathResource(
          "named-async-cache.xml", InfinispanNamedEmbeddedCacheFactoryBeanTest.class);
 
-   private static final EmbeddedCacheManager DEFAULT_CACHE_MANAGER = TestCacheManagerFactory.createCacheManager();
+   private EmbeddedCacheManager DEFAULT_CACHE_MANAGER;
 
-   private static final EmbeddedCacheManager PRECONFIGURED_DEFAULT_CACHE_MANAGER;
+   private EmbeddedCacheManager PRECONFIGURED_DEFAULT_CACHE_MANAGER;
 
-   static {
+   @BeforeClass
+   public void startCacheManagers() {
+      DEFAULT_CACHE_MANAGER = TestCacheManagerFactory.createCacheManager();
+      DEFAULT_CACHE_MANAGER.start();
+
       InputStream configStream = null;
       try {
          configStream = NAMED_ASYNC_CACHE_CONFIG_LOCATION.getInputStream();
@@ -51,16 +55,11 @@ public class InfinispanNamedEmbeddedCacheFactoryBeanTest {
             }
          }
       }
-   }
-
-   @BeforeClass
-   public static void startCacheManagers() {
-      DEFAULT_CACHE_MANAGER.start();
       PRECONFIGURED_DEFAULT_CACHE_MANAGER.start();
    }
 
    @AfterClass
-   public static void stopCacheManagers() {
+   public void stopCacheManagers() {
       PRECONFIGURED_DEFAULT_CACHE_MANAGER.stop();
       DEFAULT_CACHE_MANAGER.stop();
    }

--- a/spring/spring4/src/test/java/org/infinispan/spring/support/embedded/InfinispanNamedEmbeddedCacheFactoryBeanTest.java
+++ b/spring/spring4/src/test/java/org/infinispan/spring/support/embedded/InfinispanNamedEmbeddedCacheFactoryBeanTest.java
@@ -31,11 +31,15 @@ public class InfinispanNamedEmbeddedCacheFactoryBeanTest {
    private static final ClassPathResource NAMED_ASYNC_CACHE_CONFIG_LOCATION = new ClassPathResource(
          "named-async-cache.xml", InfinispanNamedEmbeddedCacheFactoryBeanTest.class);
 
-   private static final EmbeddedCacheManager DEFAULT_CACHE_MANAGER = TestCacheManagerFactory.createCacheManager();
+   private EmbeddedCacheManager DEFAULT_CACHE_MANAGER;
 
-   private static final EmbeddedCacheManager PRECONFIGURED_DEFAULT_CACHE_MANAGER;
+   private EmbeddedCacheManager PRECONFIGURED_DEFAULT_CACHE_MANAGER;
 
-   static {
+   @BeforeClass
+   public void startCacheManagers() {
+      DEFAULT_CACHE_MANAGER = TestCacheManagerFactory.createCacheManager();
+      DEFAULT_CACHE_MANAGER.start();
+
       InputStream configStream = null;
       try {
          configStream = NAMED_ASYNC_CACHE_CONFIG_LOCATION.getInputStream();
@@ -53,14 +57,8 @@ public class InfinispanNamedEmbeddedCacheFactoryBeanTest {
       }
    }
 
-   @BeforeClass
-   public static void startCacheManagers() {
-      DEFAULT_CACHE_MANAGER.start();
-      PRECONFIGURED_DEFAULT_CACHE_MANAGER.start();
-   }
-
    @AfterClass
-   public static void stopCacheManagers() {
+   public void stopCacheManagers() {
       PRECONFIGURED_DEFAULT_CACHE_MANAGER.stop();
       DEFAULT_CACHE_MANAGER.stop();
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5586

* Add TestResourceTracker.testStarted and testFinished calls in
  AbstractInfinispanTest
* Rename TestResourceTracker.backgroundTestStarted to testThreadStarted
* Replace the AbstractInfinispanTest.TrackingThreadFactory with a
  Cleaner implementation for Thread resources