### PR TITLE
ISPN-5591 Simple local cache without interceptor stack

### DIFF
--- a/cdi/src/test/java/org/infinispan/cdi/test/event/CacheEventTest.java
+++ b/cdi/src/test/java/org/infinispan/cdi/test/event/CacheEventTest.java
@@ -155,7 +155,7 @@ public class CacheEventTest extends Arquillian {
 
    public void testFiringEntryInvalidatedWhenUsingCacheNotifier() throws Exception {
       //when
-      cache1Notifier.notifyCacheEntryInvalidated("pete", "Edinburgh", true, invocationContext, null);
+      cache1Notifier.notifyCacheEntryInvalidated("pete", "Edinburgh", null, true, invocationContext, null);
 
       //then
       assertThat(cacheObserver, Cache1.class).hasEntryInvalidatedEvent("pete");

--- a/commons/src/main/java/org/infinispan/commons/equivalence/AnyEquivalence.java
+++ b/commons/src/main/java/org/infinispan/commons/equivalence/AnyEquivalence.java
@@ -32,7 +32,7 @@ public final class AnyEquivalence<T> implements Equivalence<T> {
 
    @Override
    public int hashCode(Object obj) {
-      return obj.hashCode();
+      return obj == null ? 0 : obj.hashCode();
    }
 
    @Override
@@ -42,7 +42,7 @@ public final class AnyEquivalence<T> implements Equivalence<T> {
 
    @Override
    public String toString(Object obj) {
-      return obj.toString();
+      return String.valueOf(obj);
    }
 
    @Override

--- a/commons/src/main/java/org/infinispan/commons/util/ByRef.java
+++ b/commons/src/main/java/org/infinispan/commons/util/ByRef.java
@@ -25,4 +25,24 @@ public class ByRef<T> {
    public void set(T t) {
       ref = t;
    }
+
+	/**
+    * Implementation for primitive type
+    */
+   public static class Boolean {
+      boolean ref;
+
+      public Boolean(boolean b) {
+         ref = b;
+      }
+
+      public boolean get() {
+         return ref;
+      }
+
+      public void set(boolean b) {
+         this.ref = b;
+      }
+   }
+
 }

--- a/commons/src/main/java/org/infinispan/commons/util/CloseableIteratorCollectionAdapter.java
+++ b/commons/src/main/java/org/infinispan/commons/util/CloseableIteratorCollectionAdapter.java
@@ -1,0 +1,86 @@
+package org.infinispan.commons.util;
+
+import java.util.Collection;
+
+/**
+ * Adapts {@link java.util.Collection} to {@link CloseableIteratorCollection}
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class CloseableIteratorCollectionAdapter<E> implements CloseableIteratorCollection<E> {
+   protected final Collection<E> delegate;
+
+   public CloseableIteratorCollectionAdapter(Collection<E> delegate) {
+      this.delegate = delegate;
+   }
+
+   @Override
+   public int size() {
+      return delegate.size();
+   }
+
+   @Override
+   public boolean isEmpty() {
+      return delegate.isEmpty();
+   }
+
+   @Override
+   public boolean contains(Object o) {
+      return delegate.contains(o);
+   }
+
+   @Override
+   public CloseableIterator<E> iterator() {
+      return Closeables.iterator(delegate.iterator());
+   }
+
+   @Override
+   public CloseableSpliterator<E> spliterator() {
+      return Closeables.spliterator(delegate.spliterator());
+   }
+
+   @Override
+   public Object[] toArray() {
+      return delegate.toArray();
+   }
+
+   @Override
+   public <T> T[] toArray(T[] a) {
+      return delegate.toArray(a);
+   }
+
+   @Override
+   public boolean add(E e) {
+      return delegate.add(e);
+   }
+
+   @Override
+   public boolean remove(Object o) {
+      return delegate.remove(o);
+   }
+
+   @Override
+   public boolean containsAll(Collection<?> c) {
+      return delegate.containsAll(c);
+   }
+
+   @Override
+   public boolean addAll(Collection<? extends E> c) {
+      return delegate.addAll(c);
+   }
+
+   @Override
+   public boolean retainAll(Collection<?> c) {
+      return delegate.retainAll(c);
+   }
+
+   @Override
+   public boolean removeAll(Collection<?> c) {
+      return delegate.removeAll(c);
+   }
+
+   @Override
+   public void clear() {
+      delegate.clear();
+   }
+}

--- a/commons/src/main/java/org/infinispan/commons/util/CloseableIteratorSetAdapter.java
+++ b/commons/src/main/java/org/infinispan/commons/util/CloseableIteratorSetAdapter.java
@@ -1,0 +1,20 @@
+package org.infinispan.commons.util;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Adapts {@link Set} to {@link CloseableIteratorSet}
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class CloseableIteratorSetAdapter<E> extends CloseableIteratorCollectionAdapter<E> implements CloseableIteratorSet<E> {
+   public CloseableIteratorSetAdapter(Set<E> delegate) {
+      super(delegate);
+   }
+
+   @Override
+   public CloseableSpliterator<E> spliterator() {
+      return Closeables.spliterator(delegate.spliterator());
+   }
+}

--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -977,7 +977,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    @Override
    public boolean startBatch() {
       if (!config.invocationBatching().enabled()) {
-         throw new CacheConfigurationException("Invocation batching not enabled in current configuration! Please enable it.");
+         throw log.invocationBatchingNotEnabled();
       }
       return batchContainer.startBatch();
    }
@@ -985,7 +985,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    @Override
    public void endBatch(boolean successful) {
       if (!config.invocationBatching().enabled()) {
-         throw new CacheConfigurationException("Invocation batching not enabled in current configuration! Please enable it.");
+         throw log.invocationBatchingNotEnabled();
       }
       batchContainer.endBatch(successful);
    }

--- a/core/src/main/java/org/infinispan/cache/impl/StatsCollectingCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/StatsCollectingCache.java
@@ -1,0 +1,336 @@
+package org.infinispan.cache.impl;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.commons.util.ByRef;
+import org.infinispan.commons.util.CloseableIteratorSet;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.context.Flag;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.metadata.Metadata;
+import org.infinispan.stats.Stats;
+import org.infinispan.stats.impl.StatsCollector;
+import org.infinispan.stats.impl.StatsImpl;
+import org.infinispan.util.TimeService;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Wraps existing {@link AdvancedCache} to collect statistics
+ *
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+public class StatsCollectingCache<K, V> extends SimpleCacheImpl<K, V> {
+   private StatsCollector statsCollector;
+   private TimeService timeService;
+
+   public StatsCollectingCache(String cacheName) {
+      super(cacheName);
+   }
+
+   @Inject
+   public void injectDependencies(StatsCollector statsCollector, TimeService timeService) {
+      this.statsCollector = statsCollector;
+      this.timeService = timeService;
+   }
+
+   @Override
+   public AdvancedCache<K, V> withFlags(Flag... flags) {
+      return this;
+   }
+
+   @Override
+   public AdvancedCache<K, V> with(ClassLoader classLoader) {
+      return this;
+   }
+
+   @Override
+   public Stats getStats() {
+      return new StatsImpl(statsCollector.getStatisticsEnabled() ? statsCollector : null);
+   }
+
+   @Override
+   public V get(Object key) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      V value = super.get(key);
+      if (statisticsEnabled) {
+         long end = timeService.time();
+         if (value == null) {
+            statsCollector.recordMisses(1, end - start);
+         } else {
+            statsCollector.recordHits(1, end - start);
+         }
+      }
+      return value;
+   }
+
+   @Override
+   public CacheEntry<K, V> getCacheEntry(Object k) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      CacheEntry<K, V> entry = super.getCacheEntry(k);
+      if (statisticsEnabled) {
+         long end = timeService.time();
+         if (entry == null) {
+            statsCollector.recordMisses(1, end - start);
+         } else {
+            statsCollector.recordHits(1, end - start);
+         }
+      }
+      return entry;
+   }
+
+   @Override
+   public Map<K, V> getAll(Set<?> keys) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      Map<K, V> map = super.getAll(keys);
+      if (statisticsEnabled) {
+         long end = timeService.time();
+         int requests = keys.size();
+         int hits = 0;
+         for (V value : map.values()) {
+            if (value != null) hits++;
+         }
+         int misses = requests - hits;
+         if (hits > 0) {
+            statsCollector.recordHits(hits, hits * (end - start) / requests);
+         }
+         if (misses > 0) {
+            statsCollector.recordMisses(misses, misses * (end - start) / requests);
+         }
+      }
+      return map;
+   }
+
+   @Override
+   public Map<K, CacheEntry<K, V>> getAllCacheEntries(Set<?> keys) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      Map<K, CacheEntry<K, V>> map = super.getAllCacheEntries(keys);
+      if (statisticsEnabled) {
+         long end = timeService.time();
+         int requests = keys.size();
+         int hits = 0;
+         for (CacheEntry<K, V> entry : map.values()) {
+            if (entry != null && entry.getValue() != null) hits++;
+         }
+         int misses = requests - hits;
+         if (hits > 0) {
+            statsCollector.recordHits(hits, hits * (end - start) / requests);
+         }
+         if (misses > 0) {
+            statsCollector.recordMisses(misses, misses * (end - start) / requests);
+         }
+      }
+      return map;
+   }
+
+   @Override
+   public void evict(K key) {
+      super.evict(key);
+      statsCollector.recordEviction();
+   }
+
+   @Override
+   protected V getAndPutInternal(K key, V value, Metadata metadata) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      V ret = super.getAndPutInternal(key, value, metadata);
+      if (statisticsEnabled) {
+         long end = timeService.time();
+         statsCollector.recordStores(1, end - start);
+      }
+      return ret;
+   }
+
+   @Override
+   protected V getAndReplaceInternal(K key, V value, Metadata metadata) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      V ret = super.getAndReplaceInternal(key, value, metadata);
+      if (statisticsEnabled && ret != null) {
+         long end = timeService.time();
+         statsCollector.recordStores(1, end - start);
+      }
+      return ret;
+   }
+
+   @Override
+   protected void putForExternalReadInternal(K key, V value, Metadata metadata, ByRef.Boolean isCreatedRef) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      super.putForExternalReadInternal(key, value, metadata, isCreatedRef);
+      if (statisticsEnabled && isCreatedRef.get()) {
+         long end = timeService.time();
+         statsCollector.recordStores(1, end - start);
+      }
+   }
+
+   @Override
+   protected V putIfAbsentInternal(K key, V value, Metadata metadata) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      V ret = super.putIfAbsentInternal(key, value, metadata);
+      if (statisticsEnabled && ret == null) {
+         long end = timeService.time();
+         statsCollector.recordStores(1, end - start);
+      }
+      return ret;
+   }
+
+   @Override
+   public V remove(Object key) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      V ret = super.remove(key);
+      if (statisticsEnabled) {
+         long end = timeService.time();
+         if (ret != null) {
+            statsCollector.recordRemoveHits(1, end - start);
+         } else {
+            statsCollector.recordRemoveMisses(1);
+         }
+      }
+      return ret;
+   }
+
+   @Override
+   public boolean remove(Object key, Object value) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      boolean removed = super.remove(key, value);
+      if (statisticsEnabled) {
+         long end = timeService.time();
+         if (removed) {
+            statsCollector.recordRemoveHits(1, end - start);
+         } else {
+            statsCollector.recordRemoveMisses(1);
+         }
+      }
+      return removed;
+   }
+
+   @Override
+   protected boolean replaceInternal(K key, V oldValue, V value, Metadata metadata) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      boolean replaced = super.replaceInternal(key, oldValue, value, metadata);
+      if (statisticsEnabled && replaced) {
+         long end = timeService.time();
+         statsCollector.recordStores(1, end - start);
+      }
+      return replaced;
+   }
+
+   @Override
+   protected V computeIfAbsentInternal(K key, Function<? super K, ? extends V> mappingFunction, ByRef<V> newValueRef) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      V ret = super.computeIfAbsentInternal(key, mappingFunction, newValueRef);
+      if (statisticsEnabled) {
+         long end = timeService.time();
+         if (newValueRef.get() != null) {
+            statsCollector.recordStores(1, end - start);
+         }
+      }
+      return ret;
+   }
+
+   @Override
+   protected V computeIfPresentInternal(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction, CacheEntryChange<K, V> ref) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      V ret = super.computeIfPresentInternal(key, remappingFunction, ref);
+      if (statisticsEnabled) {
+         long end = timeService.time();
+         if (ref.getNewValue() != null) {
+            statsCollector.recordStores(1, end - start);
+         } else if (ref.getKey() != null) {
+            statsCollector.recordRemoveHits(1, end - start);
+         }
+      }
+      return ret;
+   }
+
+   @Override
+   protected V computeInternal(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction, CacheEntryChange<K, V> ref) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      V ret = super.computeInternal(key, remappingFunction, ref);
+      if (statisticsEnabled) {
+         long end = timeService.time();
+         if (ref.getNewValue() != null) {
+            statsCollector.recordStores(1, end - start);
+         } else if (ref.getKey() != null) {
+            statsCollector.recordRemoveHits(1, end - start);
+         }
+      }
+      return ret;
+   }
+
+   @Override
+   protected V mergeInternal(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction, CacheEntryChange<K, V> ref) {
+      boolean statisticsEnabled = statsCollector.getStatisticsEnabled();
+      long start = 0;
+      if (statisticsEnabled) {
+         start = timeService.time();
+      }
+      V ret = super.mergeInternal(key, value, remappingFunction, ref);
+      if (statisticsEnabled) {
+         long end = timeService.time();
+         if (ref.getNewValue() != null) {
+            statsCollector.recordStores(1, end - start);
+         } else if (ref.getKey() != null) {
+            statsCollector.recordRemoveHits(1, end - start);
+         }
+      }
+      return ret;
+   }
+}

--- a/core/src/main/java/org/infinispan/commands/write/InvalidateCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/InvalidateCommand.java
@@ -76,7 +76,7 @@ public class InvalidateCommand extends RemoveCommand {
    @Override
    public void notify(InvocationContext ctx, Object removedValue, Metadata removedMetadata,
          boolean isPre) {
-      notifier.notifyCacheEntryInvalidated(key, removedValue, isPre, ctx, this);
+      notifier.notifyCacheEntryInvalidated(key, removedValue, removedMetadata, isPre, ctx, this);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/write/PutKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/PutKeyValueCommand.java
@@ -220,7 +220,7 @@ public class PutKeyValueCommand extends AbstractDataWriteCommand implements Meta
       Object o;
 
       if (!e.isCreated()) {
-         notifier.notifyCacheEntryModified(key, value, entryValue, e.getMetadata(), true, ctx, this);
+         notifier.notifyCacheEntryModified(key, value, metadata, entryValue, e.getMetadata(), true, ctx, this);
       }
 
       if (value instanceof Delta) {

--- a/core/src/main/java/org/infinispan/commands/write/PutMapCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/PutMapCommand.java
@@ -96,7 +96,7 @@ public class PutMapCommand extends AbstractFlagAffectedCommand implements WriteC
          if (me != null) {
             Object value = me.getValue();
             previousValues.put(key, value);
-            notifier.notifyCacheEntryModified(key, e.getValue(), value, me.getMetadata(), true, ctx, this);
+            notifier.notifyCacheEntryModified(key, e.getValue(), metadata, value, me.getMetadata(), true, ctx, this);
             me.setValue(e.getValue());
             me.setChanged(true);
          }

--- a/core/src/main/java/org/infinispan/commands/write/ReplaceCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/ReplaceCommand.java
@@ -100,7 +100,7 @@ public class ReplaceCommand extends AbstractDataWriteCommand implements Metadata
       Object previousValue = oldValue == null ? beingReplaced : oldValue;
 
       if (successful) {
-         notifier.notifyCacheEntryModified(key, newValue, previousValue, previousMetadata, true, ctx, this);
+         notifier.notifyCacheEntryModified(key, newValue, metadata, previousValue, previousMetadata, true, ctx, this);
       }
 
       if (oldValue == null) {

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractConfigurationChildBuilder.java
@@ -13,6 +13,15 @@ abstract class AbstractConfigurationChildBuilder implements ConfigurationChildBu
       return builder.template(template);
    }
 
+   public ConfigurationChildBuilder simpleCache(boolean simpleCache) {
+      return builder.simpleCache(simpleCache);
+   }
+
+   @Override
+   public boolean simpleCache() {
+      return builder.simpleCache();
+   }
+
    @Override
    public ClusteringConfigurationBuilder clustering() {
       return builder.clustering();

--- a/core/src/main/java/org/infinispan/configuration/cache/Configuration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/Configuration.java
@@ -1,12 +1,22 @@
 package org.infinispan.configuration.cache;
 
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class Configuration {
+   public static final AttributeDefinition<Boolean> SIMPLE_CACHE = AttributeDefinition.builder("simpleCache", false).immutable().build();
 
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(Configuration.class, SIMPLE_CACHE);
+   }
+
+   private final Attribute<Boolean> simpleCache;
    private final ClusteringConfiguration clusteringConfiguration;
    private final CustomInterceptorsConfiguration customInterceptorsConfiguration;
    private final DataContainerConfiguration dataContainerConfiguration;
@@ -26,9 +36,11 @@ public class Configuration {
    private final SecurityConfiguration securityConfiguration;
    private final SitesConfiguration sitesConfiguration;
    private final CompatibilityModeConfiguration compatibilityConfiguration;
+   private final AttributeSet attributes;
    private final boolean template;
 
-   Configuration(boolean template, ClusteringConfiguration clusteringConfiguration,
+   Configuration(boolean template, AttributeSet attributes,
+                 ClusteringConfiguration clusteringConfiguration,
                  CustomInterceptorsConfiguration customInterceptorsConfiguration,
                  DataContainerConfiguration dataContainerConfiguration, DeadlockDetectionConfiguration deadlockDetectionConfiguration,
                  EvictionConfiguration evictionConfiguration, ExpirationConfiguration expirationConfiguration,
@@ -44,6 +56,8 @@ public class Configuration {
                  CompatibilityModeConfiguration compatibilityConfiguration,
                  List<?> modules) {
       this.template = template;
+      this.attributes = attributes.checkProtection();
+      this.simpleCache = attributes.attribute(SIMPLE_CACHE);
       this.clusteringConfiguration = clusteringConfiguration;
       this.customInterceptorsConfiguration = customInterceptorsConfiguration;
       this.dataContainerConfiguration = dataContainerConfiguration;
@@ -67,6 +81,14 @@ public class Configuration {
          modulesMap.put(module.getClass(), module);
       }
       this.moduleConfiguration = Collections.unmodifiableMap(modulesMap);
+   }
+
+   public AttributeSet attributes() {
+      return attributes;
+   }
+
+   public boolean simpleCache() {
+      return simpleCache.get();
    }
 
    public ClusteringConfiguration clustering() {
@@ -157,7 +179,8 @@ public class Configuration {
    @Override
    public String toString() {
       return "Configuration{" +
-            "clustering=" + clusteringConfiguration +
+            "simpleCache=" + simpleCache +
+            ", clustering=" + clusteringConfiguration +
             ", customInterceptors=" + customInterceptorsConfiguration +
             ", dataContainer=" + dataContainerConfiguration +
             ", deadlockDetection=" + deadlockDetectionConfiguration +
@@ -183,6 +206,7 @@ public class Configuration {
    public int hashCode() {
       final int prime = 31;
       int result = 1;
+      result = prime * result + (simpleCache.get() ? 0 : 1);
       result = prime * result + (template ? 1231 : 1237);
       result = prime * result + ((clusteringConfiguration == null) ? 0 : clusteringConfiguration.hashCode());
       result = prime * result + ((compatibilityConfiguration == null) ? 0 : compatibilityConfiguration.hashCode());
@@ -219,6 +243,9 @@ public class Configuration {
          return false;
       Configuration other = (Configuration) obj;
       if (template != other.template) {
+         return false;
+      }
+      if (!simpleCache.get().equals(other.simpleCache.get())) {
          return false;
       }
       if (clusteringConfiguration == null) {

--- a/core/src/main/java/org/infinispan/configuration/cache/ConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ConfigurationChildBuilder.java
@@ -4,6 +4,10 @@ import org.infinispan.configuration.global.GlobalConfiguration;
 
 public interface ConfigurationChildBuilder {
 
+   ConfigurationChildBuilder simpleCache(boolean simpleCache);
+
+   boolean simpleCache();
+
    ClusteringConfigurationBuilder clustering();
 
    CustomInterceptorsConfigurationBuilder customInterceptors();

--- a/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
@@ -107,6 +107,7 @@ public enum Attribute {
     SHUTDOWN_HOOK("shutdown-hook"),
     @Deprecated
     SHUTDOWN_TIMEOUT("shutdown-timeout"),
+    SIMPLE_CACHE("simple-cache"),
     SINGLETON("singleton"),
     SITE("site"),
     SIZE("size"),

--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser80.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser80.java
@@ -840,6 +840,9 @@ public class Parser80 implements ConfigurationParser {
             log.ignoreXmlAttribute(attribute);
             break;
          }
+         case SIMPLE_CACHE:
+            builder.simpleCache(Boolean.valueOf(value));
+            break;
          case STATISTICS: {
             builder.jmxStatistics().enabled(Boolean.valueOf(value));
             break;
@@ -1674,7 +1677,8 @@ public class Parser80 implements ConfigurationParser {
                throw ParseUtils.unexpectedAttribute(reader, i);
          }
       }
-
+      // clear in order to override any configuration defined in default cache
+      builder.persistence().clearStores();
       while (reader.hasNext() && (reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {
          Element element = Element.forName(reader.getLocalName());
          switch (element) {

--- a/core/src/main/java/org/infinispan/container/EntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/EntryFactoryImpl.java
@@ -289,7 +289,7 @@ public class EntryFactoryImpl implements EntryFactory {
          newValue = null;
       }
 
-      notifier.notifyCacheEntryCreated(key, newValue, true, ctx, cmd);
+      notifier.notifyCacheEntryCreated(key, newValue, providedMetadata, true, ctx, cmd);
       mvccEntry = createWrappedEntry(key, null, ctx, providedMetadata, true, false, skipRead);
       mvccEntry.setCreated(true);
       ctx.putLookedUpEntry(key, mvccEntry);

--- a/core/src/main/java/org/infinispan/distexec/DefaultExecutorService.java
+++ b/core/src/main/java/org/infinispan/distexec/DefaultExecutorService.java
@@ -30,6 +30,7 @@ import org.infinispan.distexec.spi.DistributedTaskLifecycleService;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.interceptors.InterceptorChain;
+import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.remoting.responses.Response;
@@ -177,6 +178,7 @@ public class DefaultExecutorService extends AbstractExecutorService implements D
 
       ensureAccessPermissions(masterCacheNode.getAdvancedCache());
       ensureProperCacheState(masterCacheNode.getAdvancedCache());
+      ensureFullCache(masterCacheNode.getAdvancedCache());
 
       this.cache = masterCacheNode.getAdvancedCache();
       ComponentRegistry registry = SecurityActions.getCacheComponentRegistry(cache);
@@ -655,6 +657,13 @@ public class DefaultExecutorService extends AbstractExecutorService implements D
       // {@link Start} annotation
       if (cache.getStatus() != ComponentStatus.RUNNING && cache.getStatus() != ComponentStatus.INITIALIZING)
          throw new IllegalStateException("Invalid cache state " + cache.getStatus());
+   }
+
+   private void ensureFullCache(AdvancedCache<?, ?> advancedCache) {
+      List<CommandInterceptor> interceptorChain = SecurityActions.getInterceptorChain(advancedCache);
+      if (interceptorChain == null || interceptorChain.isEmpty()) {
+         throw log.distributedExecutorsNotSupported();
+      }
    }
 
    private static class RandomNodeTaskFailoverPolicy implements DistributedTaskFailoverPolicy {

--- a/core/src/main/java/org/infinispan/distexec/SecurityActions.java
+++ b/core/src/main/java/org/infinispan/distexec/SecurityActions.java
@@ -2,11 +2,13 @@ package org.infinispan.distexec;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.List;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.security.AuthorizationManager;
 import org.infinispan.security.Security;
@@ -14,6 +16,7 @@ import org.infinispan.security.actions.GetCacheAuthorizationManagerAction;
 import org.infinispan.security.actions.GetCacheComponentRegistryAction;
 import org.infinispan.security.actions.GetCacheConfigurationAction;
 import org.infinispan.security.actions.GetCacheDistributionManagerAction;
+import org.infinispan.security.actions.GetCacheInterceptorChainAction;
 import org.infinispan.security.actions.GetCacheRpcManagerAction;
 
 /**
@@ -56,6 +59,11 @@ final class SecurityActions {
 
    static Configuration getCacheConfiguration(final AdvancedCache<?, ?> cache) {
       GetCacheConfigurationAction action = new GetCacheConfigurationAction(cache);
+      return doPrivileged(action);
+   }
+
+   static List<CommandInterceptor> getInterceptorChain(final AdvancedCache<?, ?> cache) {
+      GetCacheInterceptorChainAction action = new GetCacheInterceptorChainAction(cache);
       return doPrivileged(action);
    }
 }

--- a/core/src/main/java/org/infinispan/distexec/mapreduce/SecurityActions.java
+++ b/core/src/main/java/org/infinispan/distexec/mapreduce/SecurityActions.java
@@ -2,11 +2,13 @@ package org.infinispan.distexec.mapreduce;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.List;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.security.AuthorizationManager;
 import org.infinispan.security.Security;
@@ -14,6 +16,7 @@ import org.infinispan.security.actions.GetCacheAuthorizationManagerAction;
 import org.infinispan.security.actions.GetCacheComponentRegistryAction;
 import org.infinispan.security.actions.GetCacheConfigurationAction;
 import org.infinispan.security.actions.GetCacheDistributionManagerAction;
+import org.infinispan.security.actions.GetCacheInterceptorChainAction;
 import org.infinispan.security.actions.GetCacheRpcManagerAction;
 
 /**
@@ -56,6 +59,11 @@ final class SecurityActions {
 
    static Configuration getCacheConfiguration(final AdvancedCache<?, ?> cache) {
       GetCacheConfigurationAction action = new GetCacheConfigurationAction(cache);
+      return doPrivileged(action);
+   }
+
+   static List<CommandInterceptor> getInterceptorChain(final AdvancedCache<?, ?> cache) {
+      GetCacheInterceptorChainAction action = new GetCacheInterceptorChainAction(cache);
       return doPrivileged(action);
    }
 }

--- a/core/src/main/java/org/infinispan/eviction/impl/ActivationManagerStub.java
+++ b/core/src/main/java/org/infinispan/eviction/impl/ActivationManagerStub.java
@@ -1,0 +1,23 @@
+package org.infinispan.eviction.impl;
+
+import org.infinispan.eviction.ActivationManager;
+import org.infinispan.factories.annotations.SurvivesRestarts;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+@SurvivesRestarts
+public class ActivationManagerStub implements ActivationManager {
+	@Override
+   public void onUpdate(Object key, boolean newEntry) {
+   }
+
+	@Override
+   public void onRemove(Object key, boolean newEntry) {
+   }
+
+	@Override
+   public long getActivationCount() {
+      return 0;
+   }
+}

--- a/core/src/main/java/org/infinispan/eviction/impl/EvictionManagerImpl.java
+++ b/core/src/main/java/org/infinispan/eviction/impl/EvictionManagerImpl.java
@@ -18,7 +18,7 @@ public class EvictionManagerImpl<K, V> implements EvictionManager<K, V> {
    private CacheNotifier<K, V> cacheNotifier;
 
    @Inject
-   public void initialize(CacheNotifier<K, V> cacheNotifier, ExpirationManager<K, V> expirationManager) {
+   public void initialize(CacheNotifier<K, V> cacheNotifier) {
       this.cacheNotifier = cacheNotifier;
    }
 

--- a/core/src/main/java/org/infinispan/eviction/impl/PassivationManagerStub.java
+++ b/core/src/main/java/org/infinispan/eviction/impl/PassivationManagerStub.java
@@ -1,0 +1,44 @@
+package org.infinispan.eviction.impl;
+
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.eviction.PassivationManager;
+import org.infinispan.factories.annotations.SurvivesRestarts;
+import org.infinispan.persistence.spi.PersistenceException;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+@SurvivesRestarts
+public class PassivationManagerStub implements PassivationManager {
+	@Override
+   public boolean isEnabled() {
+      return false;
+   }
+
+	@Override
+   public void passivate(InternalCacheEntry entry) {
+   }
+
+	@Override
+   public void passivateAll() throws PersistenceException {
+   }
+
+	@Override
+   public long getPassivations() {
+      return 0;
+   }
+
+	@Override
+   public void resetStatistics() {
+   }
+
+	@Override
+   public boolean getStatisticsEnabled() {
+      return false;
+   }
+
+	@Override
+   public void setStatisticsEnabled(boolean enabled) {
+      throw new UnsupportedOperationException();
+   }
+}

--- a/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/ComponentRegistry.java
@@ -43,7 +43,7 @@ public class ComponentRegistry extends AbstractComponentRegistry {
    private CacheManagerNotifier cacheManagerNotifier;
 
    //Cached fields:
-   private StreamingMarshaller cacheMarshaler;
+   protected StreamingMarshaller cacheMarshaler;
    private StateTransferManager stateTransferManager;
    private ResponseGenerator responseGenerator;
    private CommandsFactory commandsFactory;

--- a/core/src/main/java/org/infinispan/interceptors/locking/ClusteringDependentLogic.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/ClusteringDependentLogic.java
@@ -155,7 +155,7 @@ public interface ClusteringDependentLogic {
             // Notify entry event after container has been updated
             if (created) {
                notifier.notifyCacheEntryCreated(
-                  entry.getKey(), entry.getValue(), false, ctx, command);
+                  entry.getKey(), entry.getValue(), entry.getMetadata(), false, ctx, command);
 
                // A write-only command only writes and so can't 100% guarantee
                // that an entry has been created, so only send create event
@@ -165,7 +165,7 @@ public interface ClusteringDependentLogic {
 
                functionalNotifier.notifyOnWrite(() -> EntryViews.readOnly(entry));
             } else {
-               notifier.notifyCacheEntryModified(entry.getKey(), entry.getValue(), previousValue, previousMetadata,
+               notifier.notifyCacheEntryModified(entry.getKey(), entry.getValue(), entry.getMetadata(), previousValue, previousMetadata,
                                                  false, ctx, command);
 
                // A write-only command only writes and so can't 100% guarantee

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifier.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifier.java
@@ -26,30 +26,30 @@ import java.util.Collection;
 public interface CacheNotifier<K, V> extends ClassLoaderAwareFilteringListenable<K, V>, ClassLoaderAwareListenable {
 
    /**
-    * Notifies all registered listeners of a CacheEntryCreated event.
+    * Notifies all registered listeners of a {@link org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent} event.
     */
-   void notifyCacheEntryCreated(K key, V value, boolean pre, InvocationContext ctx, FlagAffectedCommand command);
+   void notifyCacheEntryCreated(K key, V value, Metadata metadata, boolean pre, InvocationContext ctx, FlagAffectedCommand command);
 
    /**
-    * Notifies all registered listeners of a CacheEntryModified event.
+    * Notifies all registered listeners of a {@link org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent} event.
     */
-   void notifyCacheEntryModified(K key, V value, V previousValue, Metadata previousMetadata, boolean pre,
+   void notifyCacheEntryModified(K key, V value, Metadata metadata, V previousValue, Metadata previousMetadata, boolean pre,
                                  InvocationContext ctx, FlagAffectedCommand command);
 
    /**
-    * Notifies all registered listeners of a CacheEntryRemoved event.
+    * Notifies all registered listeners of a {@link org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent} event.
     */
    void notifyCacheEntryRemoved(K key, V previousValue, Metadata previousMetadata, boolean pre, InvocationContext ctx,
                                 FlagAffectedCommand command);
 
    /**
-    * Notifies all registered listeners of a CacheEntryVisited event.
+    * Notifies all registered listeners of a {@link org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent} event.
     */
    void notifyCacheEntryVisited(K key, V value, boolean pre,
          InvocationContext ctx, FlagAffectedCommand command);
 
    /**
-    * Notifies all registered listeners of a CacheEntriesEvicted event.
+    * Notifies all registered listeners of a {@link org.infinispan.notifications.cachelistener.event.CacheEntriesEvictedEvent} event.
     */
    void notifyCacheEntriesEvicted(Collection<InternalCacheEntry<? extends K, ? extends V>> entries,
          InvocationContext ctx, FlagAffectedCommand command);
@@ -60,25 +60,25 @@ public interface CacheNotifier<K, V> extends ClassLoaderAwareFilteringListenable
    void notifyCacheEntryExpired(K key, V value, Metadata metadata, InvocationContext ctx);
 
    /**
-    * Notifies all registered listeners of a CacheEntryInvalidated event.
+    * Notifies all registered listeners of a {@link org.infinispan.notifications.cachelistener.event.CacheEntryInvalidatedEvent} event.
     */
-   void notifyCacheEntryInvalidated(K key, V value, boolean pre,
+   void notifyCacheEntryInvalidated(K key, V value, Metadata metadata, boolean pre,
          InvocationContext ctx, FlagAffectedCommand command);
 
    /**
-    * Notifies all registered listeners of a CacheEntryLoaded event.
+    * Notifies all registered listeners of a {@link org.infinispan.notifications.cachelistener.event.CacheEntryLoadedEvent} event.
     */
    void notifyCacheEntryLoaded(K key, V value, boolean pre,
          InvocationContext ctx, FlagAffectedCommand command);
 
    /**
-    * Notifies all registered listeners of a CacheEntryActivated event.
+    * Notifies all registered listeners of a {@link org.infinispan.notifications.cachelistener.event.CacheEntryActivatedEvent} event.
     */
    void notifyCacheEntryActivated(K key, V value, boolean pre,
          InvocationContext ctx, FlagAffectedCommand command);
 
    /**
-    * Notifies all registered listeners of a CacheEntryPassivated event.
+    * Notifies all registered listeners of a {@link org.infinispan.notifications.cachelistener.event.CacheEntryPassivatedEvent} event.
     */
    void notifyCacheEntryPassivated(K key, V value, boolean pre,
          InvocationContext ctx, FlagAffectedCommand command);

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/SecurityActions.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/SecurityActions.java
@@ -2,10 +2,13 @@ package org.infinispan.notifications.cachelistener;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.List;
 
 import org.infinispan.Cache;
 import org.infinispan.distexec.DefaultExecutorService;
+import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.security.Security;
+import org.infinispan.security.actions.GetCacheInterceptorChainAction;
 import org.infinispan.security.actions.GetDefaultExecutorServiceAction;
 
 /**
@@ -28,6 +31,11 @@ final class SecurityActions {
 
    static DefaultExecutorService getDefaultExecutorService(final Cache<?, ?> cache) {
       GetDefaultExecutorServiceAction action = new GetDefaultExecutorServiceAction(cache);
+      return doPrivileged(action);
+   }
+
+   static List<CommandInterceptor> getInterceptorChain(final Cache<?, ?> cache) {
+      GetCacheInterceptorChainAction action = new GetCacheInterceptorChainAction(cache.getAdvancedCache());
       return doPrivileged(action);
    }
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntriesEvicted.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/annotation/CacheEntriesEvicted.java
@@ -14,8 +14,6 @@ import java.lang.annotation.Target;
  * <p/>
  *  Locking: notification is performed WITH locks on the given key.
  * <p/>
- * Any exceptions thrown by the listener will abort the call. Any other listeners not yet called will not be called,
- * and any transactions in progress will be rolled back.
  *
  * @author Manik Surtani
  * @author Galder Zamarreño

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/impl/ClusterEventManagerStub.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/impl/ClusterEventManagerStub.java
@@ -1,0 +1,28 @@
+package org.infinispan.notifications.cachelistener.cluster.impl;
+
+import org.infinispan.commons.CacheException;
+import org.infinispan.factories.annotations.SurvivesRestarts;
+import org.infinispan.notifications.cachelistener.cluster.ClusterEvent;
+import org.infinispan.notifications.cachelistener.cluster.ClusterEventManager;
+import org.infinispan.remoting.transport.Address;
+
+import java.util.Collection;
+import java.util.UUID;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+@SurvivesRestarts
+public class ClusterEventManagerStub<K, V> implements ClusterEventManager<K, V> {
+   @Override
+   public void addEvents(Address target, UUID identifier, Collection<ClusterEvent<K, V>> clusterEvents, boolean sync) {
+   }
+
+   @Override
+   public void sendEvents() throws CacheException {
+   }
+
+   @Override
+   public void dropEvents() {
+   }
+}

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerStub.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerStub.java
@@ -1,0 +1,97 @@
+package org.infinispan.persistence.manager;
+
+import org.infinispan.context.InvocationContext;
+import org.infinispan.factories.annotations.SurvivesRestarts;
+import org.infinispan.filter.KeyFilter;
+import org.infinispan.marshall.core.MarshalledEntry;
+import org.infinispan.persistence.manager.PersistenceManager;
+import org.infinispan.persistence.spi.AdvancedCacheLoader;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.Executor;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+@SurvivesRestarts
+public class PersistenceManagerStub implements PersistenceManager {
+   @Override
+   public void start() {
+   }
+
+   @Override
+   public void stop() {
+   }
+
+   @Override
+   public void preload() {
+   }
+
+   @Override
+   public void disableStore(String storeType) {
+   }
+
+   @Override
+   public <T> Set<T> getStores(Class<T> storeClass) {
+      return Collections.EMPTY_SET;
+   }
+
+   @Override
+   public Collection<String> getStoresAsString() {
+      return Collections.EMPTY_SET;
+   }
+
+   @Override
+   public void purgeExpired() {
+   }
+
+   @Override
+   public void clearAllStores(AccessMode mode) {
+   }
+
+   @Override
+   public boolean deleteFromAllStores(Object key, AccessMode mode) {
+      return false;
+   }
+
+   @Override
+   public void processOnAllStores(KeyFilter keyFilter, AdvancedCacheLoader.CacheLoaderTask task, boolean fetchValue, boolean fetchMetadata) {
+   }
+
+   @Override
+   public void processOnAllStores(Executor executor, KeyFilter keyFilter, AdvancedCacheLoader.CacheLoaderTask task, boolean fetchValue, boolean fetchMetadata) {
+   }
+
+   @Override
+   public void processOnAllStores(KeyFilter keyFilter, AdvancedCacheLoader.CacheLoaderTask task, boolean fetchValue, boolean fetchMetadata, AccessMode mode) {
+   }
+
+   @Override
+   public void processOnAllStores(Executor executor, KeyFilter keyFilter, AdvancedCacheLoader.CacheLoaderTask task, boolean fetchValue, boolean fetchMetadata, AccessMode mode) {
+   }
+
+   @Override
+   public MarshalledEntry loadFromAllStores(Object key, InvocationContext context) {
+      return null;
+   }
+
+   @Override
+   public void writeToAllStores(MarshalledEntry marshalledEntry, AccessMode modes) {
+   }
+
+   @Override
+   public AdvancedCacheLoader getStateTransferProvider() {
+      return null;
+   }
+
+   @Override
+   public int size() {
+      return 0;
+   }
+
+   @Override
+   public void setClearOnStop(boolean clearOnStop) {
+   }
+}

--- a/core/src/main/java/org/infinispan/stats/impl/StatsCollector.java
+++ b/core/src/main/java/org/infinispan/stats/impl/StatsCollector.java
@@ -1,0 +1,311 @@
+package org.infinispan.stats.impl;
+
+import org.infinispan.commons.CacheException;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.container.DataContainer;
+import org.infinispan.factories.AbstractNamedCacheComponentFactory;
+import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.SurvivesRestarts;
+import org.infinispan.jmx.JmxStatisticsExposer;
+import org.infinispan.jmx.annotations.DisplayType;
+import org.infinispan.jmx.annotations.MBean;
+import org.infinispan.jmx.annotations.ManagedAttribute;
+import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.jmx.annotations.MeasurementType;
+import org.infinispan.jmx.annotations.Units;
+import org.infinispan.stats.Stats;
+import org.infinispan.util.TimeService;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+@MBean(objectName = "Statistics", description = "General statistics such as timings, hit/miss ratio, etc.")
+public class StatsCollector implements Stats, JmxStatisticsExposer {
+   private final LongAdder hitTimes = new LongAdder();
+   private final LongAdder missTimes = new LongAdder();
+   private final LongAdder storeTimes = new LongAdder();
+   private final LongAdder removeTimes = new LongAdder();
+   private final LongAdder hits = new LongAdder();
+   private final LongAdder misses = new LongAdder();
+   private final LongAdder stores = new LongAdder();
+   private final LongAdder evictions = new LongAdder();
+   private final AtomicLong startNanoseconds = new AtomicLong(0);
+   private final AtomicLong resetNanoseconds = new AtomicLong(0);
+   private final LongAdder removeHits = new LongAdder();
+   private final LongAdder removeMisses = new LongAdder();
+
+   private TimeService timeService;
+   private DataContainer dataContainer;
+   private Configuration configuration;
+
+   @Inject
+   public void injectDependencies(TimeService timeService, DataContainer dataContainer, Configuration configuration) {
+      this.timeService = timeService;
+      this.dataContainer = dataContainer;
+      this.configuration = configuration;
+   }
+
+   @Start
+   public void start() {
+      statisticsEnabled = configuration.jmxStatistics().enabled();
+   }
+
+   // probably it's not *that* important to have perfect stats to make this variable volatile
+   @ManagedAttribute(description = "Enables or disables the gathering of statistics by this component", writable = true)
+   private boolean statisticsEnabled = false;
+
+   @ManagedAttribute(
+         description = "Number of cache attribute hits",
+         displayName = "Number of cache hits",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY)
+   public long getHits() {
+      return hits.sum();
+   }
+
+   @ManagedAttribute(
+         description = "Number of cache attribute misses",
+         displayName = "Number of cache misses",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
+   public long getMisses() {
+      return misses.sum();
+   }
+
+   @ManagedAttribute(
+         description = "Number of cache removal hits",
+         displayName = "Number of cache removal hits",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
+   public long getRemoveHits() {
+      return removeHits.sum();
+   }
+
+   @ManagedAttribute(
+         description = "Number of cache removals where keys were not found",
+         displayName = "Number of cache removal misses",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
+   public long getRemoveMisses() {
+      return removeMisses.sum();
+   }
+
+   @ManagedAttribute(
+         description = "number of cache attribute put operations",
+         displayName = "Number of cache puts" ,
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
+   public long getStores() {
+      return stores.sum();
+   }
+
+   @Override
+   public long getRetrievals() {
+      return hits.longValue() + misses.longValue();
+   }
+
+   @ManagedAttribute(
+         description = "Number of cache eviction operations",
+         displayName = "Number of cache evictions",
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
+   public long getEvictions() {
+      return evictions.sum();
+   }
+
+   @ManagedAttribute(
+         description = "Percentage hit/(hit+miss) ratio for the cache",
+         displayName = "Hit ratio",
+         units = Units.PERCENTAGE,
+         displayType = DisplayType.SUMMARY
+   )
+   @SuppressWarnings("unused")
+   public double getHitRatio() {
+      long hitsL = hits.sum();
+      double total = hitsL + misses.sum();
+      // The reason for <= is that equality checks
+      // should be avoided for floating point numbers.
+      if (total <= 0)
+         return 0;
+      return (hitsL / total);
+   }
+
+   @ManagedAttribute(
+         description = "read/writes ratio for the cache",
+         displayName = "Read/write ratio",
+         units = Units.PERCENTAGE,
+         displayType = DisplayType.SUMMARY
+   )
+   public double getReadWriteRatio() {
+      long sum = stores.sum();
+      if (sum == 0)
+         return 0;
+      return (((double) (hits.sum() + misses.sum()) / (double) sum));
+   }
+
+   @ManagedAttribute(
+         description = "Average number of milliseconds for a read operation on the cache",
+         displayName = "Average read time",
+         units = Units.MILLISECONDS,
+         displayType = DisplayType.SUMMARY
+   )
+   public long getAverageReadTime() {
+      long total = hits.sum() + misses.sum();
+      if (total == 0)
+         return 0;
+      return (hitTimes.sum() + missTimes.sum()) / total;
+   }
+
+   @ManagedAttribute(
+         description = "Average number of milliseconds for a write operation in the cache",
+         displayName = "Average write time",
+         units = Units.MILLISECONDS,
+         displayType = DisplayType.SUMMARY
+   )
+   @SuppressWarnings("unused")
+   public long getAverageWriteTime() {
+      long sum = stores.sum();
+      if (sum == 0)
+         return 0;
+      return (storeTimes.sum()) / sum;
+   }
+
+   @ManagedAttribute(
+         description = "Average number of milliseconds for a remove operation in the cache",
+         displayName = "Average remove time",
+         units = Units.MILLISECONDS,
+         displayType = DisplayType.SUMMARY
+   )
+   @SuppressWarnings("unused")
+   public long getAverageRemoveTime() {
+      long removes = getRemoveHits();
+      if (removes == 0)
+         return 0;
+      return (removeTimes.sum()) / removes;
+   }
+
+   @Override
+   public void reset() {
+      resetStatistics();
+   }
+
+   @Override
+   public boolean getStatisticsEnabled() {
+      return statisticsEnabled;
+   }
+
+   @Override
+   public void setStatisticsEnabled(boolean enabled) {
+      statisticsEnabled = enabled;
+   }
+
+   @ManagedAttribute(
+         description = "Number of entries currently in the cache",
+         displayName = "Number of current cache entries",
+         displayType = DisplayType.SUMMARY
+   )
+   public int getNumberOfEntries() {
+      return dataContainer.size();
+   }
+
+   @ManagedAttribute(
+         description = "Number of seconds since cache started",
+         displayName = "Seconds since cache started",
+         units = Units.SECONDS,
+         measurementType = MeasurementType.TRENDSUP,
+         displayType = DisplayType.SUMMARY
+   )
+   public long getTimeSinceStart() {
+      return timeService.timeDuration(startNanoseconds.get(), TimeUnit.SECONDS);
+   }
+
+   @ManagedAttribute(
+         description = "Number of seconds since the cache statistics were last reset",
+         displayName = "Seconds since cache statistics were reset",
+         units = Units.SECONDS,
+         displayType = DisplayType.SUMMARY
+   )
+   public long getTimeSinceReset() {
+      return timeService.timeDuration(resetNanoseconds.get(), TimeUnit.SECONDS);
+   }
+
+   @Override
+   public int getCurrentNumberOfEntries() {
+      return getNumberOfEntries();
+   }
+
+   @Override
+   public long getTotalNumberOfEntries() {
+      return stores.longValue();
+   }
+
+   @ManagedOperation(
+         description = "Resets statistics gathered by this component",
+         displayName = "Reset Statistics (Statistics)"
+   )
+   public void resetStatistics() {
+      hits.reset();
+      misses.reset();
+      stores.reset();
+      evictions.reset();
+      hitTimes.reset();
+      missTimes.reset();
+      storeTimes.reset();
+      removeHits.reset();
+      removeTimes.reset();
+      removeMisses.reset();
+      resetNanoseconds.set(timeService.time());
+   }
+
+   public void recordMisses(int misses, long time) {
+      this.misses.add(misses);
+      this.missTimes.add(time);
+   }
+
+   public void recordHits(int hits, long time) {
+      this.hits.add(hits);
+      this.hitTimes.add(time);
+   }
+
+   public void recordEviction() {
+      evictions.increment();
+   }
+
+   public void recordStores(int stores, long time) {
+      this.stores.add(stores);
+      this.storeTimes.add(time);
+   }
+
+   public void recordRemoveHits(int removes, long time) {
+      this.removeHits.add(removes);
+      this.removeTimes.add(time);
+   }
+
+   public void recordRemoveMisses(int removes) {
+      this.removeMisses.add(removes);
+   }
+
+   @DefaultFactoryFor(classes = StatsCollector.class)
+   @SurvivesRestarts
+   public static class Factory extends AbstractNamedCacheComponentFactory {
+      @Override
+      public <T> T construct(Class<T> componentType) {
+         if (componentType.isAssignableFrom(StatsCollector.class)) {
+            return componentType.cast(new StatsCollector());
+         } else {
+            throw new CacheException("Don't know how to handle type " + componentType);
+         }
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/stats/impl/StatsImpl.java
+++ b/core/src/main/java/org/infinispan/stats/impl/StatsImpl.java
@@ -29,10 +29,12 @@ public class StatsImpl implements Stats {
    final long averageWriteTime;
    final long averageRemoveTime;
    final CacheMgmtInterceptor mgmtInterceptor;
+   final Stats source;
 
    public StatsImpl(InterceptorChain chain) {
       mgmtInterceptor = (CacheMgmtInterceptor) chain
             .getInterceptorsWhichExtend(CacheMgmtInterceptor.class).get(0);
+      source = null;
 
       if (mgmtInterceptor.getStatisticsEnabled()) {
          timeSinceReset = mgmtInterceptor.getTimeSinceReset();
@@ -49,6 +51,42 @@ public class StatsImpl implements Stats {
          averageReadTime = mgmtInterceptor.getAverageReadTime();
          averageWriteTime = mgmtInterceptor.getAverageWriteTime();
          averageRemoveTime = mgmtInterceptor.getAverageRemoveTime();
+      } else {
+         timeSinceReset = -1;
+         timeSinceStart = -1;
+         currentNumberOfEntries = -1;
+         totalNumberOfEntries = -1;
+         retrievals = -1;
+         stores = -1;
+         hits = -1;
+         misses = -1;
+         removeHits = -1;
+         removeMisses = -1;
+         evictions = -1;
+         averageReadTime = -1;
+         averageWriteTime = -1;
+         averageRemoveTime = -1;
+      }
+   }
+
+   public StatsImpl(Stats other) {
+      mgmtInterceptor = null;
+      source = other;
+      if (other != null) {
+         timeSinceReset = other.getTimeSinceReset();
+         timeSinceStart = other.getTimeSinceStart();
+         currentNumberOfEntries = other.getCurrentNumberOfEntries();
+         totalNumberOfEntries = other.getTotalNumberOfEntries();
+         retrievals = other.getRetrievals();
+         stores = other.getStores();
+         hits = other.getHits();
+         misses = other.getMisses();
+         removeHits = other.getRemoveHits();
+         removeMisses = other.getRemoveMisses();
+         evictions = other.getEvictions();
+         averageReadTime = other.getAverageReadTime();
+         averageWriteTime = other.getAverageWriteTime();
+         averageRemoveTime = other.getAverageRemoveTime();
       } else {
          timeSinceReset = -1;
          timeSinceStart = -1;
@@ -139,11 +177,19 @@ public class StatsImpl implements Stats {
 
    @Override
    public void reset() {
-      mgmtInterceptor.resetStatistics();
+      if (mgmtInterceptor != null) {
+         mgmtInterceptor.resetStatistics();
+      } else if (source != null) {
+         source.reset();
+      }
    }
 
    @Override
    public void setStatisticsEnabled(boolean enabled) {
-      mgmtInterceptor.setStatisticsEnabled(enabled);
+      if (mgmtInterceptor != null) {
+         mgmtInterceptor.setStatisticsEnabled(enabled);
+      } else if (source != null) {
+         source.setStatisticsEnabled(enabled);
+      }
    }
 }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1337,7 +1337,7 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Statistics are enabled while attribute 'available' is set to false.", id = 372)
    CacheConfigurationException statisticsEnabledNotAvailable();
-   
+
    @Message(value = "Attempted to start a cache using configuration template '%s'", id = 373)
    CacheConfigurationException templateConfigurationStartAttempt(String cacheName);
 
@@ -1346,4 +1346,22 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Cannot use configuration '%s' as a template", id = 375)
    CacheConfigurationException noConfiguration(String extend);
+
+   @Message(value = "Interceptor stack is not supported in simple cache", id = 376)
+   UnsupportedOperationException interceptorStackNotSupported();
+
+   @Message(value = "Explicit lock operations are not supported in simple cache", id = 377)
+   UnsupportedOperationException lockOperationsNotSupported();
+
+   @Message(value = "Invocation batching not enabled in current configuration! Please enable it.", id = 378)
+   CacheConfigurationException invocationBatchingNotEnabled();
+
+   @Message(value = "Map Reduce Framework is not supported in simple cache", id = 379)
+   CacheConfigurationException mapReduceNotSupported();
+
+   @Message(value = "Distributed Executors Framework is not supported in simple cache", id = 380)
+   CacheConfigurationException distributedExecutorsNotSupported();
+
+   @Message(value = "This configuration is not supported for simple cache", id = 381)
+   CacheConfigurationException notSupportedInSimpleCache();
 }

--- a/core/src/main/resources/schema/infinispan-config-8.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-8.0.xsd
@@ -705,7 +705,15 @@
 
   <xs:complexType name="local-cache">
     <xs:complexContent>
-      <xs:extension base="tns:cache"></xs:extension>
+      <xs:extension base="tns:cache">
+        <xs:attribute name="simple-cache" default="false">
+          <xs:annotation>
+            <xs:documentation>
+              This cache will be using optimized (faster) implementation that does not support transactions/invocation batching, persistence, custom interceptors, indexing, store-as-binary or compatibility. Also, this type of cache does not support Map-Reduce jobs or Distributed Executor framework.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
     </xs:complexContent>
   </xs:complexType>
 

--- a/core/src/test/java/org/infinispan/api/SimpleCacheTest.java
+++ b/core/src/test/java/org/infinispan/api/SimpleCacheTest.java
@@ -1,0 +1,80 @@
+package org.infinispan.api;
+
+import org.infinispan.cache.impl.SimpleCacheImpl;
+import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.CustomInterceptorConfigTest;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.Index;
+import org.infinispan.distexec.DefaultExecutorService;
+import org.infinispan.distexec.mapreduce.MapReduceTask;
+import org.infinispan.interceptors.base.BaseCustomInterceptor;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.transaction.TransactionMode;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+@Test(groups = "functional", testName = "api.SimpleCacheTest")
+public class SimpleCacheTest extends APINonTxTest {
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      ConfigurationBuilder cb = new ConfigurationBuilder();
+      cb.simpleCache(true);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(cb);
+
+      assertTrue(cm.getCache() instanceof SimpleCacheImpl);
+      return cm;
+   }
+
+   @Test(expectedExceptions = UnsupportedOperationException.class)
+   public void testAddInterceptor() {
+      cache().getAdvancedCache().addInterceptor(new CustomInterceptorConfigTest.DummyInterceptor(), 0);
+   }
+
+   @Test(expectedExceptions = CacheConfigurationException.class)
+   public void testMapReduce() {
+      new MapReduceTask<>(cache()).execute();
+   }
+
+   @Test(expectedExceptions = CacheConfigurationException.class)
+   public void testDistributedExecutor() {
+      new DefaultExecutorService(cache()).submit(() -> null);
+   }
+
+   @Test(expectedExceptions = CacheConfigurationException.class)
+   public void testTransactions() {
+      new ConfigurationBuilder().simpleCache(true)
+            .transaction().transactionMode(TransactionMode.TRANSACTIONAL).build();
+   }
+
+   @Test(expectedExceptions = CacheConfigurationException.class)
+   public void testInterceptors() {
+      new ConfigurationBuilder().simpleCache(true)
+            .customInterceptors().addInterceptor().interceptor(new BaseCustomInterceptor()).build();
+   }
+
+   @Test(expectedExceptions = CacheConfigurationException.class)
+   public void testBatching() {
+      new ConfigurationBuilder().simpleCache(true).invocationBatching().enable(true).build();
+   }
+
+   @Test(expectedExceptions = CacheConfigurationException.class)
+   public void testIndexing() {
+      new ConfigurationBuilder().simpleCache(true).indexing().index(Index.LOCAL).build();
+   }
+
+   @Test(expectedExceptions = CacheConfigurationException.class)
+   public void testStoreAsBinary() {
+      new ConfigurationBuilder().simpleCache(true).storeAsBinary().enabled(true).build();
+   }
+
+   @Test(expectedExceptions = CacheConfigurationException.class)
+   public void testCompatibility() {
+      new ConfigurationBuilder().simpleCache(true).compatibility().enabled(true).build();
+   }
+}

--- a/core/src/test/java/org/infinispan/configuration/DataContainerTest.java
+++ b/core/src/test/java/org/infinispan/configuration/DataContainerTest.java
@@ -89,7 +89,7 @@ public class DataContainerTest extends AbstractInfinispanTest {
 
          cache.put("name", "Pete");
 
-         Assert.assertTrue(checkLoggedOperations(dataContainer.getLoggedOperations(), "put(name, Pete"));
+         Assert.assertTrue(checkLoggedOperations(dataContainer.getLoggedOperations(), "put(name, Pete", "compute(name,"));
       } finally {
       	TestingUtil.killCacheManagers(cm);
       }
@@ -123,16 +123,18 @@ public class DataContainerTest extends AbstractInfinispanTest {
 
          cache.put("name", "Pete");
 
-         Assert.assertTrue(checkLoggedOperations(dataContainer.getLoggedOperations(), "put(name, Pete"));
+         Assert.assertTrue(checkLoggedOperations(dataContainer.getLoggedOperations(), "put(name, Pete", "compute(name,"));
       } finally {
       	TestingUtil.killCacheManagers(cm);
       }
    }
 
-   boolean checkLoggedOperations(Collection<String> loggedOperations, String prefix) {
+   boolean checkLoggedOperations(Collection<String> loggedOperations, String... prefixes) {
       for (String loggedOperation : loggedOperations) {
-         if (loggedOperation.startsWith(prefix)) {
-            return true;
+         for (String prefix : prefixes) {
+            if (loggedOperation.startsWith(prefix)) {
+               return true;
+            }
          }
       }
       return false;

--- a/core/src/test/java/org/infinispan/manager/CacheManagerComponentRegistryTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerComponentRegistryTest.java
@@ -90,7 +90,7 @@ public class CacheManagerComponentRegistryTest extends AbstractCacheTest {
    }
 
    public void testOverridingComponents() {
-      cm = TestCacheManagerFactory.createClusteredCacheManager();
+      cm = TestCacheManagerFactory.createClusteredCacheManager(new ConfigurationBuilder());
 
       // default cache with no overrides
       Cache c = cm.getCache();

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/BaseCacheNotifierImplInitialTransferTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/BaseCacheNotifierImplInitialTransferTest.java
@@ -66,8 +66,8 @@ public abstract class BaseCacheNotifierImplInitialTransferTest extends AbstractI
          @Override
          public void raiseEvent(CacheNotifier notifier, Object key, Object prevValue, Object newValue,
                                 InvocationContext ctx) {
-            notifier.notifyCacheEntryModified(key, newValue, prevValue, null, true, ctx, null);
-            notifier.notifyCacheEntryModified(key, newValue, prevValue, null, false, ctx, null);
+            notifier.notifyCacheEntryModified(key, newValue, null, prevValue, null, true, ctx, null);
+            notifier.notifyCacheEntryModified(key, newValue, null, prevValue, null, false, ctx, null);
          }
       }, REMOVE(Event.Type.CACHE_ENTRY_REMOVED) {
          @Override
@@ -80,8 +80,8 @@ public abstract class BaseCacheNotifierImplInitialTransferTest extends AbstractI
          @Override
          public void raiseEvent(CacheNotifier notifier, Object key, Object prevValue, Object newValue,
                                 InvocationContext ctx) {
-            notifier.notifyCacheEntryCreated(key, newValue, true, ctx, null);
-            notifier.notifyCacheEntryCreated(key, newValue, false, ctx, null);
+            notifier.notifyCacheEntryCreated(key, newValue, null, true, ctx, null);
+            notifier.notifyCacheEntryCreated(key, newValue, null, false, ctx, null);
          }
       };
 
@@ -315,8 +315,8 @@ public abstract class BaseCacheNotifierImplInitialTransferTest extends AbstractI
          case CREATE:
             key = "new-key";
             String value = "new-value";
-            n.notifyCacheEntryCreated(key, value, true, ctx, null);
-            n.notifyCacheEntryCreated(key, value, false, ctx, null);
+            n.notifyCacheEntryCreated(key, value, null, true, ctx, null);
+            n.notifyCacheEntryCreated(key, value, null, false, ctx, null);
 
             // Need to add a new value to the end
             initialValues.add(new ImmortalCacheEntry(key, value));
@@ -325,8 +325,8 @@ public abstract class BaseCacheNotifierImplInitialTransferTest extends AbstractI
             key = "key-3";
             value = "value-3-changed";
 
-            n.notifyCacheEntryModified(key, initialValues.get(3).getValue(), value, null, true, ctx, null);
-            n.notifyCacheEntryModified(key, initialValues.get(3).getValue(), value, null, false, ctx, null);
+            n.notifyCacheEntryModified(key, initialValues.get(3).getValue(), null, value, null, true, ctx, null);
+            n.notifyCacheEntryModified(key, initialValues.get(3).getValue(), null, value, null, false, ctx, null);
 
             // Now remove the old value and put in the new one
             initialValues.remove(3);

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
@@ -62,8 +62,8 @@ public class CacheNotifierImplTest extends AbstractInfinispanTest {
    }
 
    public void testNotifyCacheEntryCreated() {
-      n.notifyCacheEntryCreated("k", "v1", true, ctx, null);
-      n.notifyCacheEntryCreated("k", "v1", false, ctx, null);
+      n.notifyCacheEntryCreated("k", "v1", null, true, ctx, null);
+      n.notifyCacheEntryCreated("k", "v1", null, false, ctx, null);
 
       assert cl.isReceivedPost();
       assert cl.isReceivedPre();
@@ -79,8 +79,8 @@ public class CacheNotifierImplTest extends AbstractInfinispanTest {
    }
 
    public void testNotifyCacheEntryModified() {
-      n.notifyCacheEntryModified("k", "v2", "v1", null, true, ctx, null);
-      n.notifyCacheEntryModified("k", "v2", "v1", null, false, ctx, null);
+      n.notifyCacheEntryModified("k", "v2", null, "v1", null, true, ctx, null);
+      n.notifyCacheEntryModified("k", "v2", null, "v1", null, false, ctx, null);
 
       assert cl.isReceivedPost();
       assert cl.isReceivedPre();
@@ -173,8 +173,8 @@ public class CacheNotifierImplTest extends AbstractInfinispanTest {
    }
 
    public void testNotifyCacheEntryInvalidated() {
-      n.notifyCacheEntryInvalidated("k", "v", true, ctx, null);
-      n.notifyCacheEntryInvalidated("k", "v", false, ctx, null);
+      n.notifyCacheEntryInvalidated("k", "v", null, true, ctx, null);
+      n.notifyCacheEntryInvalidated("k", "v", null, false, ctx, null);
 
       assert cl.isReceivedPost();
       assert cl.isReceivedPre();

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierTxTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierTxTest.java
@@ -18,7 +18,6 @@ import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.metadata.Metadata;
@@ -82,11 +81,11 @@ public class CacheNotifierTxTest extends AbstractInfinispanTest {
 
       expectTransactionBoundaries(true);
       verify(mockNotifier, atLeastOnce()).notifyCacheEntryCreated(anyObject(),
-            anyObject(), anyBoolean(), isA(InvocationContext.class),
-            any(PutKeyValueCommand.class));
+            anyObject(), any(Metadata.class), anyBoolean(),
+            isA(InvocationContext.class), any(PutKeyValueCommand.class));
       verify(mockNotifier, atLeastOnce()).notifyCacheEntryModified(anyObject(),
-            anyObject(), anyObject(), any(Metadata.class), eq(true), isA(InvocationContext.class),
-            any(PutKeyValueCommand.class));
+            anyObject(), any(Metadata.class), anyObject(), any(Metadata.class), eq(true),
+            isA(InvocationContext.class), any(PutKeyValueCommand.class));
       reset(mockNotifier);
    }
 
@@ -99,15 +98,15 @@ public class CacheNotifierTxTest extends AbstractInfinispanTest {
    }
 
    static void expectSingleEntryCreated(Object key, Object value, CacheNotifier mockNotifier) {
-      verify(mockNotifier).notifyCacheEntryCreated(eq(key), eq(value), eq(true),
-            isA(InvocationContext.class), isA(PutKeyValueCommand.class));
-      verify(mockNotifier).notifyCacheEntryCreated(eq(key), eq(value), eq(false),
-            isA(InvocationContext.class), isNull(FlagAffectedCommand.class));
+      verify(mockNotifier).notifyCacheEntryCreated(eq(key), eq(value), isNotNull(Metadata.class),
+            eq(true), isA(InvocationContext.class), isA(PutKeyValueCommand.class));
+      verify(mockNotifier).notifyCacheEntryCreated(eq(key), eq(value), isNotNull(Metadata.class),
+            eq(false), isA(InvocationContext.class), isNull(FlagAffectedCommand.class));
    }
 
    static void expectSingleEntryOnlyPreCreated(Object key, Object value, CacheNotifier mockNotifier) {
-      verify(mockNotifier).notifyCacheEntryCreated(eq(key), eq(value), eq(true),
-            isA(InvocationContext.class), isA(PutKeyValueCommand.class));
+      verify(mockNotifier).notifyCacheEntryCreated(eq(key), eq(value), isNotNull(Metadata.class),
+            eq(true), isA(InvocationContext.class), isA(PutKeyValueCommand.class));
    }
 
    private void expectTransactionBoundaries(boolean successful) {
@@ -150,10 +149,10 @@ public class CacheNotifierTxTest extends AbstractInfinispanTest {
       tm.commit();
 
       expectTransactionBoundaries(true);
-      verify(mockNotifier).notifyCacheEntryModified(eq("key"), eq("value2"), eq("value"), any(Metadata.class),
-            eq(true), isA(InvocationContext.class), isA(PutKeyValueCommand.class));
-      verify(mockNotifier).notifyCacheEntryModified(eq("key"), eq("value2"), eq("value"), any(Metadata.class),
-            eq(false), isA(InvocationContext.class), isNull(FlagAffectedCommand.class));
+      verify(mockNotifier).notifyCacheEntryModified(eq("key"), eq("value2"), any(Metadata.class), eq("value"),
+            any(Metadata.class), eq(true), isA(InvocationContext.class), isA(PutKeyValueCommand.class));
+      verify(mockNotifier).notifyCacheEntryModified(eq("key"), eq("value2"), any(Metadata.class), eq("value"),
+            any(Metadata.class), eq(false), isA(InvocationContext.class), isNull(FlagAffectedCommand.class));
    }
 
    public void testTxRemoveData() throws Exception {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/KeyFilterTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/KeyFilterTest.java
@@ -60,15 +60,15 @@ public class KeyFilterTest extends AbstractInfinispanTest {
    }
 
    public void testFilters() {
-      n.notifyCacheEntryCreated("reject", "v1", true, ctx, null);
-      n.notifyCacheEntryCreated("reject", "v1", false, ctx, null);
+      n.notifyCacheEntryCreated("reject", "v1", null, true, ctx, null);
+      n.notifyCacheEntryCreated("reject", "v1", null, false, ctx, null);
 
       assert !cl.isReceivedPost();
       assert !cl.isReceivedPre();
       assert cl.getInvocationCount() == 0;
 
-      n.notifyCacheEntryCreated("accept", "v1", true, ctx, null);
-      n.notifyCacheEntryCreated("accept", "v1", false, ctx, null);
+      n.notifyCacheEntryCreated("accept", "v1", null, true, ctx, null);
+      n.notifyCacheEntryCreated("accept", "v1", null, false, ctx, null);
 
       assert cl.isReceivedPost();
       assert cl.isReceivedPre();

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
@@ -112,8 +112,8 @@ public class OnlyPrimaryOwnerTest {
       // Is not owner nor primary owner
       cdl.isOwner = false;
       cdl.isPrimaryOwner = false;
-      n.notifyCacheEntryCreated("reject", "v1", true, ctx, null);
-      n.notifyCacheEntryCreated("reject", "v1", false, ctx, null);
+      n.notifyCacheEntryCreated("reject", "v1", null, true, ctx, null);
+      n.notifyCacheEntryCreated("reject", "v1", null, false, ctx, null);
 
       assert !cl.isReceivedPost();
       assert !cl.isReceivedPre();
@@ -122,8 +122,8 @@ public class OnlyPrimaryOwnerTest {
       // Is an owner but not primary owner
       cdl.isOwner = true;
       cdl.isPrimaryOwner = false;
-      n.notifyCacheEntryCreated("reject", "v1", true, ctx, null);
-      n.notifyCacheEntryCreated("reject", "v1", false, ctx, null);
+      n.notifyCacheEntryCreated("reject", "v1", null, true, ctx, null);
+      n.notifyCacheEntryCreated("reject", "v1", null, false, ctx, null);
 
       assert !cl.isReceivedPost();
       assert !cl.isReceivedPre();
@@ -132,8 +132,8 @@ public class OnlyPrimaryOwnerTest {
       // Is primary owner
       cdl.isOwner = true;
       cdl.isPrimaryOwner = true;
-      n.notifyCacheEntryCreated("accept", "v1", true, ctx, null);
-      n.notifyCacheEntryCreated("accept", "v1", false, ctx, null);
+      n.notifyCacheEntryCreated("accept", "v1", null, true, ctx, null);
+      n.notifyCacheEntryCreated("accept", "v1", null, false, ctx, null);
 
       assert cl.isReceivedPost();
       assert cl.isReceivedPre();

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/SimpleCacheNotifierTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/SimpleCacheNotifierTest.java
@@ -1,0 +1,50 @@
+package org.infinispan.notifications.cachelistener;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.core.IsNull;
+import org.infinispan.Cache;
+import org.infinispan.commands.FlagAffectedCommand;
+import org.infinispan.commands.write.PutMapCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryVisited;
+import org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.isNull;
+
+/**
+ * @author Mircea Markus
+ * @since 5.1
+ */
+@Test(groups = "functional", testName = "notifications.cachelistener.SimpleCacheNotifierTest")
+public class SimpleCacheNotifierTest extends CacheNotifierTest {
+   @Override
+   protected Cache<Object, Object> getCache() {
+      cm.defineConfiguration("simple", new ConfigurationBuilder().read(cm.getDefaultCacheConfiguration())
+            .clustering().simpleCache(true)
+            .jmxStatistics().available(false)
+            .build());
+      Cache cache = cm.getCache("simple");
+      // without any listeners the notifications are ignored
+      cache.addListener(new DummyListener());
+      return cache;
+   }
+
+   @Override
+   protected Matcher<FlagAffectedCommand> getFlagMatcher() {
+      return new IsNull<>();
+   }
+
+   @Override
+   protected PutMapCommand getExpectedPutMapCommand() {
+      return isNull(PutMapCommand.class);
+   }
+
+   @Listener
+   private class DummyListener {
+      @CacheEntryVisited
+      public void onVisited(CacheEntryVisitedEvent e) {}
+   }
+}

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/SkipListenerCacheNotifierTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/SkipListenerCacheNotifierTest.java
@@ -1,0 +1,36 @@
+package org.infinispan.notifications.cachelistener;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.infinispan.Cache;
+import org.infinispan.commands.FlagAffectedCommand;
+import org.infinispan.context.Flag;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+@Test(groups = "functional", testName = "notifications.cachelistener.SkipListenerCacheNotifierTest")
+public class SkipListenerCacheNotifierTest extends CacheNotifierTest {
+   @Override
+   protected Cache<Object, Object> getCache() {
+      return cm.getCache().getAdvancedCache().withFlags(Flag.SKIP_LISTENER_NOTIFICATION);
+   }
+
+   @Override
+   protected Matcher<FlagAffectedCommand> getFlagMatcher() {
+      return new BaseMatcher<FlagAffectedCommand>() {
+         @Override
+         public boolean matches(Object o) {
+            boolean expected = o instanceof FlagAffectedCommand;
+            boolean isSkipListener = ((FlagAffectedCommand) o).hasFlag(Flag.SKIP_LISTENER_NOTIFICATION);
+            return expected && isSkipListener;
+         }
+
+         @Override
+         public void describeTo(Description description) {
+         }
+      };
+   }
+}

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
@@ -324,11 +324,11 @@ public abstract class AbstractClusterListenerUtilTest extends MultipleCacheManag
             }
          }
       };
-      doAnswer(answer).when(mockNotifier).notifyCacheEntryCreated(any(), any(), eq(false), any(InvocationContext.class),
-                                                                  any(FlagAffectedCommand.class));
-      doAnswer(answer).when(mockNotifier).notifyCacheEntryModified(any(), any(), any(), any(Metadata.class),
-                                                                   anyBoolean(), any(InvocationContext.class),
-                                                                   any(FlagAffectedCommand.class));
+      doAnswer(answer).when(mockNotifier).notifyCacheEntryCreated(any(), any(), any(Metadata.class), eq(false),
+            any(InvocationContext.class), any(FlagAffectedCommand.class));
+      doAnswer(answer).when(mockNotifier).notifyCacheEntryModified(any(), any(), any(Metadata.class), any(),
+            any(Metadata.class), anyBoolean(),
+            any(InvocationContext.class), any(FlagAffectedCommand.class));
       doAnswer(answer).when(mockNotifier).notifyCacheEntryRemoved(any(), any(), any(Metadata.class), eq(false),
                                                                   any(InvocationContext.class),
                                                                   any(FlagAffectedCommand.class));

--- a/core/src/test/java/org/infinispan/replication/SyncReplPessimisticLockingTest.java
+++ b/core/src/test/java/org/infinispan/replication/SyncReplPessimisticLockingTest.java
@@ -71,8 +71,8 @@ public class SyncReplPessimisticLockingTest extends MultipleCacheManagersTest {
       cache1.get(k);
       mgr.commit();
 
-      assertNotLocked(cache1);
-      assertNotLocked(cache2);
+      assertNotLocked(cache1.getName(), k);
+      assertNotLocked(cache2.getName(), k);
       cache1.clear();
       cache2.clear();
    }
@@ -97,8 +97,8 @@ public class SyncReplPessimisticLockingTest extends MultipleCacheManagersTest {
 
       mgr.commit();
 
-      assertNotLocked(cache1);
-      assertNotLocked(cache2);
+      assertNotLocked(cache1.getName(), k);
+      assertNotLocked(cache2.getName(), k);
       cache1.clear();
       cache2.clear();
    }

--- a/core/src/test/java/org/infinispan/stream/SimpleParallelStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/SimpleParallelStreamTest.java
@@ -1,0 +1,27 @@
+package org.infinispan.stream;
+
+import org.infinispan.CacheCollection;
+import org.infinispan.CacheStream;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+@Test(groups = "functional", testName = "streams.LocalStreamTest")
+public class SimpleParallelStreamTest extends BaseStreamTest {
+   public SimpleParallelStreamTest() {
+      super(false, CacheMode.LOCAL);
+   }
+
+   @Override
+   protected void enhanceConfiguration(ConfigurationBuilder builder) {
+      builder.simpleCache(true);
+   }
+
+   @Override
+   protected <E> CacheStream<E> createStream(CacheCollection<E> cacheCollection) {
+      return cacheCollection.parallelStream();
+   }
+}

--- a/core/src/test/java/org/infinispan/stream/SimpleStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/SimpleStreamTest.java
@@ -1,0 +1,27 @@
+package org.infinispan.stream;
+
+import org.infinispan.CacheCollection;
+import org.infinispan.CacheStream;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.stream.BaseStreamTest;import org.testng.annotations.Test;import java.lang.Override;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt;
+ */
+@Test(groups = "functional", testName = "streams.LocalStreamTest")
+public class SimpleStreamTest extends BaseStreamTest {
+   public SimpleStreamTest() {
+      super(false, CacheMode.LOCAL);
+   }
+
+   @Override
+   protected void enhanceConfiguration(ConfigurationBuilder builder) {
+      builder.simpleCache(true);
+   }
+
+   @Override
+   protected <E> CacheStream<E> createStream(CacheCollection<E> cacheCollection) {
+      return cacheCollection.stream();
+   }
+}

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -1284,7 +1284,9 @@ public class TestingUtil {
     */
    public static void assertNoLocks(Cache<?,?> cache) {
       LockManager lm = TestingUtil.extractLockManager(cache);
-      for (Object key : cache.keySet()) assert !lm.isLocked(key);
+      if (lm != null) {
+         for (Object key : cache.keySet()) assert !lm.isLocked(key);
+      }
    }
 
    /**

--- a/core/src/test/resources/configs/named-cache-test.xml
+++ b/core/src/test/resources/configs/named-cache-test.xml
@@ -130,6 +130,7 @@
       <local-cache name="statisticsDisabled" statistics="false" statistics-available="false">
          <transaction notifications="false" />
       </local-cache>
+      <local-cache name="simplCache" simple-cache="true"/>
    </cache-container>
 
 </infinispan>

--- a/core/src/test/resources/configs/unified/7.0.xml
+++ b/core/src/test/resources/configs/unified/7.0.xml
@@ -49,7 +49,7 @@
          <eviction max-entries="21000" strategy="FIFO"/>
          <expiration interval="11000" lifespan="12" max-idle="12"/>
          <persistence>
-            <cluster-loader remote-timeout="35000" preload="true"/>
+            <cluster-loader remote-timeout="35000" preload="false"/>
          </persistence>
          <state-transfer enabled="false" timeout="60000" chunk-size="10000" />
       </replicated-cache>

--- a/core/src/test/resources/configs/unified/7.1.xml
+++ b/core/src/test/resources/configs/unified/7.1.xml
@@ -49,7 +49,7 @@
          <eviction max-entries="21000" strategy="FIFO"/>
          <expiration interval="11000" lifespan="12" max-idle="12"/>
          <persistence>
-            <cluster-loader remote-timeout="35000" preload="true"/>
+            <cluster-loader remote-timeout="35000" preload="false"/>
          </persistence>
          <state-transfer enabled="false" timeout="60000" chunk-size="10000" />
       </replicated-cache>

--- a/core/src/test/resources/configs/unified/7.2.xml
+++ b/core/src/test/resources/configs/unified/7.2.xml
@@ -50,7 +50,7 @@
          <eviction max-entries="21000" strategy="FIFO"/>
          <expiration interval="11000" lifespan="12" max-idle="12"/>
          <persistence>
-            <cluster-loader remote-timeout="35000" preload="true"/>
+            <cluster-loader remote-timeout="35000" preload="false"/>
          </persistence>
          <state-transfer enabled="false" timeout="60000" chunk-size="10000" />
       </replicated-cache>

--- a/core/src/test/resources/configs/unified/8.0.xml
+++ b/core/src/test/resources/configs/unified/8.0.xml
@@ -62,7 +62,7 @@
          <eviction max-entries="21000" strategy="FIFO"/>
          <expiration interval="11000" lifespan="12" max-idle="12"/>
          <persistence>
-            <cluster-loader remote-timeout="35000" preload="true"/>
+            <cluster-loader remote-timeout="35000" preload="false"/>
          </persistence>
          <state-transfer enabled="false" timeout="60000" chunk-size="10000" />
       </replicated-cache>
@@ -171,7 +171,12 @@
       <local-cache name="store-as-binary">
          <store-as-binary keys="true" values="false"/>
       </local-cache>
-      
+      <local-cache name="simple-cache" simple-cache="true">
+         <transaction mode="NONE"/>
+         <persistence>
+         </persistence>
+      </local-cache>
+
       <!-- template configurations -->
       <local-cache-configuration name="local-template" start="EAGER" module="org.infinispan" statistics="true">
          <locking acquire-timeout="30000" concurrency-level="2000" isolation="NONE" striping="true"/>
@@ -185,7 +190,7 @@
          </persistence>
       </local-cache-configuration>
       <local-cache name="local-instance" configuration="local-template"/>
-      
+
       <invalidation-cache-configuration name="invalidation-template" mode="ASYNC" queue-flush-interval="10" queue-size="1000" start="LAZY" statistics="true">
          <locking acquire-timeout="30500" concurrency-level="2500" isolation="READ_UNCOMMITTED" striping="true"/>
          <transaction mode="BATCH" stop-timeout="60500"  locking="OPTIMISTIC"/>
@@ -193,7 +198,7 @@
          <expiration interval="10500" lifespan="11" max-idle="11"/>
       </invalidation-cache-configuration>
       <invalidation-cache name="invalidation-instance" configuration="invalidation-template" />
-      
+
       <replicated-cache-configuration name="repl-template" mode="ASYNC" queue-flush-interval="11" queue-size="1500" start="EAGER" statistics="true">
          <locking acquire-timeout="31000" concurrency-level="3000" isolation="SERIALIZABLE" striping="true"/>
          <transaction mode="BATCH" stop-timeout="61000" locking="PESSIMISTIC"/>
@@ -207,7 +212,7 @@
       <replicated-cache name="repl-instance" configuration="repl-template">
          <locking acquire-timeout="32000"/>
       </replicated-cache>
-      
+
       <distributed-cache-configuration name="dist-template" mode="SYNC" l1-lifespan="1200000" owners="4"
                          remote-timeout="35000" start="EAGER" segments="2" statistics="true"
                          consistent-hash-factory="org.infinispan.distribution.ch.impl.SyncConsistentHashFactory">

--- a/documentation/src/main/asciidoc/user_guide/chapter-77-Simple_Cache.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-77-Simple_Cache.adoc
@@ -1,0 +1,53 @@
+== Simple Cache
+
+Traditional local caches use the same architecture as clustered caches - interceptor stack.
+That way a lot of the implementation can be reused. However, if the advanced features
+are not needed and the performance is more important, the interceptor stack can be stripped
+away and simple cache can be used.
+
+So, which features are stripped away? From the configuration perspective, simple cache does not support:
+
+* transactions and invocation batching
+* persistence (cache stores and loaders)
+* custom interceptors (there's no interceptor stack!)
+* indexing
+* compatibility (embedded/server mode)
+* store as binary (which is hardly useful for local caches)
+
+From the API perspective these features throw an exception:
+
+* adding custom interceptors
+* Map Reduce Framework
+* Distributed Executors Framework
+
+So, what's left?
+
+* basic map-like API
+* cache listeners (local ones)
+* expiration
+* eviction
+* security
+* JMX access
+* statistics (though for max performance it is recommended to switch this off using statistics-available=false)
+
+=== Declarative configuration
+
+[source,xml]
+----
+   <local-cache name="mySimpleCache" simple-cache="true">
+        <!-- expiration, eviction, security... -->
+   </local-cache>
+----
+
+=== Programmatic configuration
+
+[source,java]
+----
+CacheManager cm = getCacheManager();
+ConfigurationBuilder builder = new ConfigurationBuilder().simpleCache(true);
+cm.defineConfiguration("mySimpleCache", builder.build());
+Cache cache = cm.getCache("mySimpleCache");
+----
+
+Simple cache checks against features it does not support, if you configure it to use e.g. transactions,
+configuration validation will throw an exception.

--- a/documentation/src/main/asciidoc/user_guide/user_guide.adoc
+++ b/documentation/src/main/asciidoc/user_guide/user_guide.adoc
@@ -53,3 +53,4 @@ include::chapter-72-Storing_objects_e_g_arrays_with_custom_Equivalence_functions
 include::chapter-73-Interoperability_between_Embedded_and_Remote_Server_Endpoints.adoc[]
 include::chapter-75-Security.adoc[]
 include::chapter-76-Functional_Map_API.adoc[]
+include::chapter-77-Simple_Cache.adoc[]

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -237,6 +237,9 @@ public class LifecycleManager extends AbstractModuleLifecycle {
 
    private boolean verifyChainContainsQueryInterceptor(ComponentRegistry cr) {
       InterceptorChain interceptorChain = cr.getComponent(InterceptorChain.class);
+      if (interceptorChain == null) {
+         return false;
+      }
       return interceptorChain.containsInterceptorType(QueryInterceptor.class, true);
    }
 

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/LifecycleManager.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/LifecycleManager.java
@@ -168,6 +168,9 @@ public final class LifecycleManager extends AbstractModuleLifecycle {
 
    private boolean verifyChainContainsRemoteValueWrapperInterceptor(ComponentRegistry cr) {
       InterceptorChain interceptorChain = cr.getComponent(InterceptorChain.class);
+      if (interceptorChain == null) {
+         return false;
+      }
       return interceptorChain.containsInterceptorType(RemoteValueWrapperInterceptor.class, true);
    }
 

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Attribute.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Attribute.java
@@ -136,6 +136,7 @@ public enum Attribute {
     SEGMENTS(ModelKeys.SEGMENTS),
     SHARED(ModelKeys.SHARED),
     SHUTDOWN_TIMEOUT(ModelKeys.SHUTDOWN_TIMEOUT),
+    SIMPLE_CACHE(ModelKeys.SIMPLE_CACHE),
     SINGLETON(ModelKeys.SINGLETON),
     SITE(ModelKeys.SITE),
     SIZE(ModelKeys.SIZE),

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationAdd.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationAdd.java
@@ -350,6 +350,7 @@ public abstract class CacheConfigurationAdd extends AbstractAddStepHandler imple
         final boolean autoConfig = CacheConfigurationResource.INDEXING_AUTO_CONFIG.resolveModelAttribute(context, cache).asBoolean();
         final boolean batching = CacheConfigurationResource.BATCHING.resolveModelAttribute(context, cache).asBoolean();
 
+        builder.simpleCache(CacheConfigurationResource.SIMPLE_CACHE.resolveModelAttribute(context, cache).asBoolean());
         // set the cache mode (may be modified when setting up clustering attributes)
         builder.clustering().cacheMode(this.mode);
         final ModelNode indexingPropertiesModel = CacheConfigurationResource.INDEXING_PROPERTIES.resolveModelAttribute(context, cache);

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationResource.java
@@ -117,6 +117,14 @@ public class CacheConfigurationResource extends SimpleResourceDefinition impleme
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .build();
 
+    static final SimpleAttributeDefinition SIMPLE_CACHE =
+            new SimpleAttributeDefinitionBuilder(ModelKeys.SIMPLE_CACHE, ModelType.BOOLEAN, true)
+                    .setXmlName(Attribute.SIMPLE_CACHE.getLocalName())
+                    .setAllowExpression(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .setDefaultValue(new ModelNode().set(false))
+                    .build();
+
     static final SimpleAttributeDefinition START =
             new SimpleAttributeDefinitionBuilder(ModelKeys.START, ModelType.STRING, true)
                     .setXmlName(Attribute.START.getLocalName())
@@ -156,7 +164,7 @@ public class CacheConfigurationResource extends SimpleResourceDefinition impleme
                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                    .build();
 
-    static final AttributeDefinition[] ATTRIBUTES = {BATCHING, CACHE_MODULE, CONFIGURATION, INDEXING, INDEXING_AUTO_CONFIG, INDEXING_PROPERTIES, JNDI_NAME, START, STATISTICS, STATISTICS_AVAILABLE, REMOTE_CACHE, REMOTE_SITE};
+    static final AttributeDefinition[] ATTRIBUTES = {BATCHING, CACHE_MODULE, CONFIGURATION, INDEXING, INDEXING_AUTO_CONFIG, INDEXING_PROPERTIES, JNDI_NAME, SIMPLE_CACHE, START, STATISTICS, STATISTICS_AVAILABLE, REMOTE_CACHE, REMOTE_SITE};
 
     // here for legacy purposes only
     static final SimpleAttributeDefinition NAME =

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanResourceDescriptionResolver.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanResourceDescriptionResolver.java
@@ -157,6 +157,7 @@ public class InfinispanResourceDescriptionResolver extends SubsystemResourceDesc
         sharedAttributeResolver.put(ModelKeys.NAME, "cache");
         sharedAttributeResolver.put(ModelKeys.REMOTE_CACHE, "cache");
         sharedAttributeResolver.put(ModelKeys.REMOTE_SITE, "cache");
+        sharedAttributeResolver.put(ModelKeys.SIMPLE_CACHE, "cache");
         sharedAttributeResolver.put(ModelKeys.START, "cache");
         sharedAttributeResolver.put(ModelKeys.STATISTICS, "cache");
         sharedAttributeResolver.put(ModelKeys.STATISTICS_AVAILABLE, "cache");

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader.java
@@ -556,6 +556,10 @@ public final class InfinispanSubsystemXMLReader implements XMLElementReader<List
                 CacheConfigurationResource.CACHE_MODULE.parseAndSetParameter(value, cache, reader);
                 break;
             }
+            case SIMPLE_CACHE: {
+                CacheConfigurationResource.SIMPLE_CACHE.parseAndSetParameter(value, cache, reader);
+                break;
+            }
             case STATISTICS: {
                 CacheConfigurationResource.STATISTICS.parseAndSetParameter(value, cache, reader);
                 break;

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
@@ -254,6 +254,7 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
         this.writeOptional(writer, Attribute.BATCHING, cache, ModelKeys.BATCHING);
         this.writeOptional(writer, Attribute.JNDI_NAME, cache, ModelKeys.JNDI_NAME);
         this.writeOptional(writer, Attribute.MODULE, cache, ModelKeys.MODULE);
+        this.writeOptional(writer, Attribute.SIMPLE_CACHE, cache, ModelKeys.SIMPLE_CACHE);
         this.writeOptional(writer, Attribute.STATISTICS, cache, ModelKeys.STATISTICS);
         this.writeOptional(writer, Attribute.STATISTICS_AVAILABLE, cache, ModelKeys.STATISTICS_AVAILABLE);
 

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
@@ -194,6 +194,7 @@ public class ModelKeys {
     static final String CAPACITY_FACTOR = "capacity-factor";
     static final String SHARED = "shared";
     static final String SHUTDOWN_TIMEOUT = "shutdown-timeout";
+    static final String SIMPLE_CACHE = "simple-cache";
     static final String SINGLETON = "singleton";
     static final String SITE = "site";
     static final String SIZE = "size";

--- a/server/integration/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/server/integration/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -103,6 +103,7 @@ datagrid-infinispan.transport.total-order-executor=The executor to use for proce
 datagrid-infinispan.cache.name=The name of the cache.
 datagrid-infinispan.cache.configuration=The name of a cache configuration.
 datagrid-infinispan.cache.mode=The cache mode. Internal use only.
+datagrid-infinispan.cache.simple-cache=Use performance-optimized implementation that does support some feature (transactions, persistence, compatibility etc.)
 datagrid-infinispan.cache.start=The cache start mode, which can be EAGER (immediate start) or LAZY (on-demand start).
 datagrid-infinispan.cache.statistics=If enabled, statistics will be collected for this cache
 datagrid-infinispan.cache.statistics-available=If set to false, statistics gathering cannot be enabled during runtime. Performance optimization.

--- a/server/integration/infinispan/src/main/resources/schema/jboss-infinispan-core_8_0.xsd
+++ b/server/integration/infinispan/src/main/resources/schema/jboss-infinispan-core_8_0.xsd
@@ -494,7 +494,13 @@
 
     <xs:complexType name="local-cache">
         <xs:complexContent>
-            <xs:extension base="tns:cache"></xs:extension>
+            <xs:extension base="tns:cache">
+                <xs:attribute name="simple-cache" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>This cache will be using optimized (faster) implementation that does not support transactions/invocation batching, persistence, custom interceptors, indexing, store-as-binary or compatibility. Also, this type of cache does not support Map-Reduce jobs or Distributed Executor framework.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
         </xs:complexContent>
     </xs:complexType>
 

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/CustomStoreConfigurationBuilder.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/cs/factory/CustomStoreConfigurationBuilder.java
@@ -47,6 +47,16 @@ public class CustomStoreConfigurationBuilder implements StoreConfigurationBuilde
    }
 
    @Override
+   public ConfigurationChildBuilder simpleCache(boolean simpleCache) {
+      return null;
+   }
+
+   @Override
+   public boolean simpleCache() {
+      return false;
+   }
+
+   @Override
    public AsyncStoreConfigurationBuilder async() {
       return null;
    }

--- a/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/SubsystemParsingTestCase.java
+++ b/server/integration/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/SubsystemParsingTestCase.java
@@ -67,7 +67,7 @@ public class SubsystemParsingTestCase extends ClusteringSubsystemTest {
                                          { Namespace.INFINISPAN_SERVER_7_0, 126 },
                                          { Namespace.INFINISPAN_SERVER_7_1, 126 },
                                          { Namespace.INFINISPAN_SERVER_7_2, 126 },
-                                         { Namespace.INFINISPAN_SERVER_8_0, 135 },
+                                         { Namespace.INFINISPAN_SERVER_8_0, 138 },
                                        };
       return Arrays.asList(data);
     }

--- a/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_8_0.xml
+++ b/server/integration/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan_8_0.xml
@@ -72,6 +72,9 @@
         <local-cache name="short-stack-tx" statistics-available="false">
             <transaction mode="NON_DURABLE_XA" notifications="false"/>
         </local-cache>
+        <local-cache name="simple-cache" simple-cache="true">
+            <transaction mode="NONE"/>
+        </local-cache>
         <invalidation-cache-configuration name="invalidation-template" mode="ASYNC">
         </invalidation-cache-configuration>
         <invalidation-cache name="invalidation-instance" configuration="invalidation-template"/>


### PR DESCRIPTION
* the cache is returned as default for local cache when transactions, persistence
  indexing, storeAsBinary or jmx statistics is not used. As e.g. map reduce or
  distributed executors are not a part of configuration, to run these
  (unsupported by SimpleLocalCacheImpl) setting allow-simple="false"
  is required as a new configuration attribute.
* also passing metadata to certain methods of CacheNotifier as param