### PR TITLE
ISPN-5618 Upgrade server to WildFly 9.0.0.Final

### DIFF
--- a/server/integration/feature-pack/src/main/resources/content/bin/standalone.sh
+++ b/server/integration/feature-pack/src/main/resources/content/bin/standalone.sh
@@ -157,13 +157,6 @@ if [ "$PRESERVE_JAVA_OPTS" != "true" ]; then
         fi
     fi
 
-    if [ $CLIENT_VM = false ]; then
-        NO_COMPRESSED_OOPS=`echo $JAVA_OPTS | $GREP "\-XX:\-UseCompressedOops"`
-        if [ "x$NO_COMPRESSED_OOPS" = "x" ]; then
-            "$JAVA" $JVM_OPTVERSION -server -XX:+UseCompressedOops -version >/dev/null 2>&1 && PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -XX:+UseCompressedOops"
-        fi
-    fi
-
     JAVA_OPTS="$PREPEND_JAVA_OPTS $JAVA_OPTS"
 fi
 

--- a/server/integration/versions/pom.xml
+++ b/server/integration/versions/pom.xml
@@ -39,7 +39,7 @@
       <version.org.slf4j>1.7.2</version.org.slf4j>
 
       <!-- WildFly dependencies -->
-      <version.org.wildfly>9.0.0.CR2</version.org.wildfly>
+      <version.org.wildfly>9.0.0.Final</version.org.wildfly>
       <version.org.wildfly.arquillian>1.0.0.Final</version.org.wildfly.arquillian>
       <version.org.wildfly.build-tools>1.0.0.Final</version.org.wildfly.build-tools>
 


### PR DESCRIPTION
- Upgrade server to WildFly 9.0.0.Final
- Don't specify CompressedOops explicitly in the server startup options as the JDK already does that automatically

https://issues.jboss.org/browse/ISPN-5618