### PR TITLE
ISPN-5612 Make filter by segment more efficient in the Remote iterator

### DIFF
--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/iteration/IterationManager.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/iteration/IterationManager.scala
@@ -1,21 +1,21 @@
 package org.infinispan.server.hotrod.iteration
 
 import java.util
-import java.util.UUID
+import java.util.stream.Collectors
+import java.util.{BitSet => JavaBitSet, UUID}
 
+import org.infinispan.CacheStream
 import org.infinispan.commons.marshall.Marshaller
 import org.infinispan.commons.util.{CloseableIterator, CollectionFactory, InfinispanCollections}
 import org.infinispan.configuration.cache.CompatibilityModeConfiguration
 import org.infinispan.container.entries.CacheEntry
-import org.infinispan.filter.{KeyValueFilterConverter, KeyValueFilterConverterFactory}
-import org.infinispan.iteration.impl.EntryRetriever
-import org.infinispan.iteration.impl.EntryRetriever.SegmentListener
+import org.infinispan.filter.CacheFilters.filterAndConvert
+import org.infinispan.filter.{CacheFilters, KeyValueFilterConverter, KeyValueFilterConverterFactory}
 import org.infinispan.manager.EmbeddedCacheManager
 import org.infinispan.server.hotrod.OperationStatus.OperationStatus
 import org.infinispan.server.hotrod._
 import org.infinispan.server.hotrod.logging.Log
 import org.infinispan.util.concurrent.ConcurrentHashSet
-import java.util.{BitSet => JavaBitSet}
 
 /**
  * @author gustavonalle
@@ -32,20 +32,20 @@ trait IterationManager {
    def activeIterations: Int
 }
 
-class IterationSegmentsListener extends SegmentListener {
-   var finished: java.util.Set[Int] = new ConcurrentHashSet[Int]()
+class IterationSegmentsListener extends CacheStream.SegmentCompletionListener {
+   var finished: util.Set[Integer] = new ConcurrentHashSet[Integer]()
 
    def clear() = finished.clear()
 
-   override def segmentTransferred(segment: Int, sentLastEntry: Boolean): Unit = finished.add(segment)
+   override def segmentCompleted(segments: util.Set[Integer]): Unit = finished addAll segments
 }
 
 class IterationState(val listener: IterationSegmentsListener, val iterator: CloseableIterator[CacheEntry[AnyRef, AnyRef]], val batch: Integer, val compatInfo: CompatInfo)
 
-class IterableIterationResult(finishedSegments: java.util.Set[Int], val statusCode: OperationStatus, entries: List[CacheEntry[AnyRef, AnyRef]], compatInfo: CompatInfo) {
+class IterableIterationResult(finishedSegments: util.Set[Integer], val statusCode: OperationStatus, entries: List[CacheEntry[AnyRef, AnyRef]], compatInfo: CompatInfo) {
    def segmentsToBytes = {
       val bs = new util.BitSet
-      finishedSegments.stream().forEach((i: Int) => bs.set(i))
+      finishedSegments.stream().forEach((i: Integer) => bs.set(i))
       bs.toByteArray
    }
 
@@ -80,18 +80,23 @@ class DefaultIterationManager(val cacheManager: EmbeddedCacheManager) extends It
 
    override def start(cacheName: String, segments: Option[JavaBitSet], filterConverterFactory: Option[String], batch: Integer): IterationId = {
       val iterationId = UUID.randomUUID().toString
-      val entryRetriever = cacheManager.getCache(cacheName).getAdvancedCache.getComponentRegistry.getComponent(classOf[EntryRetriever[_, _]])
+      val stream = cacheManager.getCache(cacheName).getAdvancedCache.cacheEntrySet.stream().asInstanceOf[CacheStream[_]]
+      segments.map(bitSet => {
+         val segments = bitSet.stream().boxed().collect(Collectors.toSet[Integer])
+         stream.filterKeySegments(segments)
+      })
+
       val segmentListener = new IterationSegmentsListener
       val compatInfo = CompatInfo(cacheManager.getCacheConfiguration(cacheName).compatibility())
 
-      val filter = {
-         val customFilter = buildCustomFilter(filterConverterFactory)
-         if (customFilter.isDefined || segments.isDefined) {
-            new IterationFilter(compatInfo.enabled, customFilter, segments, marshaller)
-         } else null
+      val customFilter = buildCustomFilter(filterConverterFactory).map { providedFilter =>
+         new IterationFilter(compatInfo.enabled, Some(providedFilter), marshaller)
       }
 
-      val iterator = entryRetriever.retrieveEntries(filter.asInstanceOf[KeyValueFilterConverter[Any, Any, Any]], null, null, segmentListener)
+      val iterator = customFilter.map { case f =>
+         filterAndConvert(stream.asInstanceOf[util.stream.Stream[CacheEntry[Any, Any]]], f.asInstanceOf[KeyValueFilterConverter[Any, Any, Any]])
+      }.getOrElse(stream).iterator()
+
       val iterationState = new IterationState(segmentListener, iterator.asInstanceOf[CloseableIterator[CacheEntry[AnyRef, AnyRef]]], batch, compatInfo)
 
       iterationStateMap.put(iterationId, iterationState)


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5612

Removed the filter by segment emulation and started to use distributed streams.