### PR TITLE
ISPN-5561 HQL queries with empty string operands fail due to analysis

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/NonIndexedEmbeddedCompatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/NonIndexedEmbeddedCompatTest.java
@@ -26,8 +26,8 @@ public class NonIndexedEmbeddedCompatTest extends EmbeddedCompatTest {
 
    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Indexing was not enabled on this cache.*")
    @Override
-   public void testEmbeddedQuery() throws Exception {
+   public void testEmbeddedLuceneQuery() throws Exception {
       // this would only make sense for Lucene based query
-      super.testEmbeddedQuery();
+      super.testEmbeddedLuceneQuery();
    }
 }

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
@@ -242,8 +242,9 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .having("description").eq("John Doe's first bank account")
             .toBuilder().build();
 
-      List<User> list = q.list();
+      List<Account> list = q.list();
       assertEquals(1, list.size());
+      assertEquals(1, list.get(0).getId());
    }
 
    @Test
@@ -285,6 +286,19 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
+   public void testEqHybridQuery() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .having("notes").eq("Lorem ipsum dolor sit amet")
+            .and().having("surname").eq("Doe")
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertEquals(1, list.size());
+      assertEquals(1, list.get(0).getId());
+   }
+
    public void testEqInNested1() throws Exception {
       QueryFactory qf = getQueryFactory();
 
@@ -751,6 +765,30 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       assertEquals(3, list.size());
    }
 
+   @Test
+   public void testTautology() {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .having("name").gt("A").or().having("name").lte("A")
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertEquals(3, list.size());
+   }
+
+   @Test
+   public void testContradiction() {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .having("name").gt("A").and().having("name").lte("A")
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertTrue(list.isEmpty());
+   }
+
    @Test(expected = ParsingException.class)
    public void testInvalidEmbeddedAttributeQuery() throws Exception {
       QueryFactory qf = getQueryFactory();
@@ -762,7 +800,31 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
-   public void testIsNull() throws Exception {
+   public void testIsNull1() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .having("surname").isNull()
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertEquals(0, list.size());
+   }
+
+   @Test
+   public void testIsNull2() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .not().having("surname").isNull()
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertEquals(3, list.size());
+   }
+
+   @Test
+   public void testIsNull3() throws Exception {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/CompatModeNonIndexedQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/CompatModeNonIndexedQueryDslConditionsTest.java
@@ -10,7 +10,7 @@ import org.testng.annotations.Test;
  * @author anistor@redhat.com
  * @since 7.0
  */
-@Test(groups = "functional", testName = "query.dsl.CompatModeNonIndexedQueryDslConditionsTest")
+@Test(groups = "functional", testName = "query.dsl.embedded.CompatModeNonIndexedQueryDslConditionsTest")
 public class CompatModeNonIndexedQueryDslConditionsTest extends NonIndexedQueryDslConditionsTest {
 
    @Override

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/CompatModeQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/CompatModeQueryDslConditionsTest.java
@@ -12,7 +12,7 @@ import org.testng.annotations.Test;
  * @author Martin Gencur
  * @since 6.0
  */
-@Test(groups = "functional", testName = "query.dsl.CompatModeQueryDslConditionsTest")
+@Test(groups = "functional", testName = "query.dsl.embedded.CompatModeQueryDslConditionsTest")
 public class CompatModeQueryDslConditionsTest extends QueryDslConditionsTest {
 
    @Override

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedClusteredDummyInMemoryStoreQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedClusteredDummyInMemoryStoreQueryDslConditionsTest.java
@@ -9,7 +9,7 @@ import org.testng.annotations.Test;
  * @author anistor@redhat.com
  * @since 7.0
  */
-@Test(groups = "functional", testName = "query.dsl.NonIndexedClusteredDummyInMemoryStoreQueryDslConditionsTest")
+@Test(groups = "functional", testName = "query.dsl.embedded.NonIndexedClusteredDummyInMemoryStoreQueryDslConditionsTest")
 public class NonIndexedClusteredDummyInMemoryStoreQueryDslConditionsTest extends NonIndexedQueryDslConditionsTest {
 
    @Override

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedClusteredQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedClusteredQueryDslConditionsTest.java
@@ -8,7 +8,7 @@ import org.testng.annotations.Test;
  * @author anistor@redhat.com
  * @since 7.0
  */
-@Test(groups = "functional", testName = "query.dsl.NonIndexedClusteredQueryDslConditionsTest")
+@Test(groups = "functional", testName = "query.dsl.embedded.NonIndexedClusteredQueryDslConditionsTest")
 public class NonIndexedClusteredQueryDslConditionsTest extends NonIndexedQueryDslConditionsTest {
 
    @Override

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedQueryDslConditionsTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
  * @author anistor@redhat.com
  * @since 7.0
  */
-@Test(groups = "functional", testName = "query.dsl.NonIndexedQueryDslConditionsTest")
+@Test(groups = "functional", testName = "query.dsl.embedded.NonIndexedQueryDslConditionsTest")
 public class NonIndexedQueryDslConditionsTest extends QueryDslConditionsTest {
 
    @Override

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedSingleFileStoreQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedSingleFileStoreQueryDslConditionsTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
  * @author anistor@redhat.com
  * @since 7.0
  */
-@Test(groups = "functional", testName = "query.dsl.NonIndexedSingleFileStoreQueryDslConditionsTest")
+@Test(groups = "functional", testName = "query.dsl.embedded.NonIndexedSingleFileStoreQueryDslConditionsTest")
 public class NonIndexedSingleFileStoreQueryDslConditionsTest extends NonIndexedQueryDslConditionsTest {
 
    private final String tmpDirectory = TestingUtil.tmpDirectory(getClass());

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
@@ -223,8 +223,9 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .having("description").eq("John Doe's first bank account")
             .toBuilder().build();
 
-      List<User> list = q.list();
+      List<Account> list = q.list();
       assertEquals(1, list.size());
+      assertEquals(1, list.get(0).getId());
    }
 
    public void testEq() throws Exception {
@@ -255,6 +256,19 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("notes").eq("Lorem ipsum dolor sit amet")
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertEquals(1, list.size());
+      assertEquals(1, list.get(0).getId());
+   }
+
+   public void testEqHybridQuery() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .having("notes").eq("Lorem ipsum dolor sit amet")
+            .and().having("surname").eq("Doe")
             .toBuilder().build();
 
       List<User> list = q.list();
@@ -698,6 +712,28 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       assertEquals(3, list.size());
    }
 
+   public void testTautology() {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .having("name").gt("A").or().having("name").lte("A")
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertEquals(3, list.size());
+   }
+
+   public void testContradiction() {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .having("name").gt("A").and().having("name").lte("A")
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertTrue(list.isEmpty());
+   }
+
    @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = "HQL100005:.*")
    public void testInvalidEmbeddedAttributeQuery() throws Exception {
       QueryFactory qf = getQueryFactory();
@@ -708,7 +744,29 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       queryBuilder.build();  // exception expected
    }
 
-   public void testIsNull() throws Exception {
+   public void testIsNull1() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .having("surname").isNull()
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertEquals(0, list.size());
+   }
+
+   public void testIsNull2() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .not().having("surname").isNull()
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertEquals(3, list.size());
+   }
+
+   public void testIsNull3() throws Exception {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
  * @author rvansa@redhat.com
  * @since 6.0
  */
-@Test(groups = {"functional", "smoke"}, testName = "query.dsl.QueryDslConditionsTest")
+@Test(groups = {"functional", "smoke"}, testName = "query.dsl.embedded.QueryDslConditionsTest")
 public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
    @BeforeClass(alwaysRun = true)

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslIterationTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslIterationTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.*;
  * @author anistor@redhat.com
  * @since 6.0
  */
-@Test(groups = "functional", testName = "query.dsl.QueryDslIterationTest")
+@Test(groups = "functional", testName = "query.dsl.embedded.QueryDslIterationTest")
 public class QueryDslIterationTest extends AbstractQueryDslTest {
 
    @BeforeClass(alwaysRun = true)


### PR DESCRIPTION
jira: https://issues.jboss.org/browse/ISPN-5561

Reopening, as this still fails on 7.2.x for remote queries running on a compat mode cache. Previous PR fixed only embedded mode queries in a compat mode cache.