### PR TITLE
ISPN-5561 Additional tests for queries with empty string operands

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
@@ -406,6 +406,78 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
       });
    }
 
+   public void testEqEmptyStringRemote() throws Exception {
+      UserHS user = new UserHS();
+      user.setId(1);
+      user.setName("test name");
+      user.setSurname("test surname");
+      user.setNotes("1234567890");
+      cache.put(1, user);
+
+      QueryFactory qf = Search.getQueryFactory(remoteCache);
+
+      Query q = qf.from(UserPB.class)
+            .having("name").eq("")
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertTrue(list.isEmpty());
+   }
+
+   public void testEqSentenceRemote() throws Exception {
+      AccountHS account = new AccountHS();
+      account.setId(1);
+      account.setDescription("John Doe's first bank account");
+      account.setCreationDate(new Date(42));
+      cache.put(1, account);
+
+      QueryFactory qf = Search.getQueryFactory(remoteCache);
+
+      Query q = qf.from(AccountPB.class)
+            .having("description").eq("John Doe's first bank account")
+            .toBuilder().build();
+
+      List<Account> list = q.list();
+      assertEquals(1, list.size());
+      assertEquals(1, list.get(0).getId());
+   }
+
+   public void testEqEmptyStringEmbedded() throws Exception {
+      UserHS user = new UserHS();
+      user.setId(1);
+      user.setName("test name");
+      user.setSurname("test surname");
+      user.setNotes("1234567890");
+      cache.put(1, user);
+
+      QueryFactory qf = org.infinispan.query.Search.getQueryFactory(cache);
+
+      Query q = qf.from(UserHS.class)
+            .having("name").eq("")
+            .toBuilder().build();
+
+      List<User> list = q.list();
+      assertTrue(list.isEmpty());
+   }
+
+   public void testEqSentenceEmbedded() throws Exception {
+      AccountHS account = new AccountHS();
+      account.setId(1);
+      account.setDescription("John Doe's first bank account");
+      account.setCreationDate(new Date(42));
+      cache.put(1, account);
+
+      QueryFactory qf = org.infinispan.query.Search.getQueryFactory(cache);
+
+      Query q = qf.from(AccountHS.class)
+            .having("description").eq("John Doe's first bank account")
+            .toBuilder().build();
+
+      List<Account> list = q.list();
+      assertEquals(1, list.size());
+      assertEquals(1, list.get(0).getId());
+   }
+
    private AccountPB createAccountPB(int id) {
       AccountPB account = new AccountPB();
       account.setId(id);

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
@@ -232,8 +232,9 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .having("description").eq("John Doe's first bank account")
             .toBuilder().build();
 
-      List<User> list = q.list();
+      List<Account> list = q.list();
       assertEquals(1, list.size());
+      assertEquals(1, list.get(0).getId());
    }
 
    @Test

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
@@ -224,8 +224,9 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .having("description").eq("John Doe's first bank account")
             .toBuilder().build();
 
-      List<User> list = q.list();
+      List<Account> list = q.list();
       assertEquals(1, list.size());
+      assertEquals(1, list.get(0).getId());
    }
 
    public void testEq() throws Exception {


### PR DESCRIPTION
jira: https://issues.jboss.org/browse/ISPN-5561

This just adds more tests. The issue is already fixed on 8.0