### PR TITLE
ISPN-5653 keySet().iterator() does not propagate flags to remove()

### DIFF
--- a/core/src/main/java/org/infinispan/commands/read/EntryRetrievalCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/EntryRetrievalCommand.java
@@ -40,10 +40,18 @@ public class EntryRetrievalCommand<K, V> extends AbstractLocalCommand implements
 
    @Override
    public EntryIterable<K, V> perform(InvocationContext ctx) throws Throwable {
+      Cache<K, V> cacheToUse;
+      EnumSet<Flag> flagsToUse;
+      if (flags != null) {
+         flagsToUse = EnumSet.copyOf(flags);
+         cacheToUse = cache.getAdvancedCache().withFlags(flags.toArray(new Flag[flags.size()]));
+      } else {
+         flagsToUse = null;
+         cacheToUse = cache;
+      }
       // We need to copy the flag set since it is possible to modify the flags after retrieving the
       // EntryIterable and we don't want it to effect that.
-      return new EntryIterableImpl<>(retriever, filter, flags != null ? EnumSet.copyOf(flags) :
-            EnumSet.noneOf(Flag.class), cache);
+      return new EntryIterableImpl<>(retriever, filter, flagsToUse, cacheToUse);
    }
 
    public KeyValueFilter<K, V> getFilter() {

--- a/core/src/test/java/org/infinispan/iteration/BaseEntryRetrieverTest.java
+++ b/core/src/test/java/org/infinispan/iteration/BaseEntryRetrieverTest.java
@@ -1,17 +1,23 @@
 package org.infinispan.iteration;
 
 import org.infinispan.Cache;
+import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commons.util.CloseableIterable;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.TransientMortalCacheEntry;
+import org.infinispan.context.Flag;
+import org.infinispan.context.InvocationContext;
 import org.infinispan.distribution.MagicKey;
+import org.infinispan.filter.AcceptAllKeyValueFilter;
 import org.infinispan.filter.CollectionKeyFilter;
 import org.infinispan.filter.CompositeKeyValueFilterConverter;
 import org.infinispan.filter.KeyFilterAsKeyValueFilter;
 import org.infinispan.filter.KeyValueFilter;
 import org.infinispan.filter.KeyValueFilterConverter;
+import org.infinispan.filter.NullValueConverter;
+import org.infinispan.interceptors.base.BaseCustomInterceptor;
 import org.infinispan.iteration.impl.EntryRetriever;
 import org.testng.annotations.Test;
 
@@ -25,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Base class for entry retriever tests
@@ -203,6 +210,50 @@ public abstract class BaseEntryRetrieverTest extends BaseSetupEntryRetrieverTest
          for (Map.Entry<Object, String> entry : values.entrySet()) {
             assertEquals(entry.getValue().substring(2, 7), results.get(entry.getKey()));
          }
+      }
+   }
+
+   @Test
+   public void testIteratorRemoveWithFlagsAPI() {
+      Map<Object, String> values = putValuesInCache();
+
+      final Cache<Object, Object> cache = cache(0, CACHE_NAME);
+
+      cache.getAdvancedCache().addInterceptor(new BaseCustomInterceptor() {
+         @Override
+         public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
+            assertTrue(command.hasFlag(Flag.SKIP_CACHE_STORE));
+            return super.visitRemoveCommand(ctx, command);
+         }
+      }, 0);
+
+      for (Iterator it = cache(0, CACHE_NAME).getAdvancedCache().withFlags(Flag.SKIP_CACHE_STORE).keySet().iterator();
+           it.hasNext();) {
+         assertTrue(values.containsKey(it.next()));
+         it.remove();
+      }
+   }
+
+   @Test
+   public void testIteratorRemoveWithFlags() {
+      Map<Object, String> values = putValuesInCache();
+
+      final Cache<Object, Object> cache = cache(0, CACHE_NAME);
+
+      cache.getAdvancedCache().addInterceptor(new BaseCustomInterceptor() {
+         @Override
+         public Object visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
+            assertTrue(command.hasFlag(Flag.SKIP_CACHE_STORE));
+            return super.visitRemoveCommand(ctx, command);
+         }
+      }, 0);
+
+      for (Iterator<CacheEntry<Object, Void>> it = cache(0, CACHE_NAME).getAdvancedCache().withFlags(
+              Flag.SKIP_CACHE_STORE).filterEntries(AcceptAllKeyValueFilter.getInstance()).converter(
+              NullValueConverter.getInstance()).iterator();
+           it.hasNext();) {
+         assertTrue(values.containsKey(it.next().getKey()));
+         it.remove();
       }
    }
 }


### PR DESCRIPTION
* Made sure command passes a cache with flags set properly

https://issues.jboss.org/browse/ISPN-5653