### PR TITLE
Remove deprecated and confusing thread configuration methods

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/global/AbstractGlobalConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/AbstractGlobalConfigurationBuilder.java
@@ -28,66 +28,6 @@ abstract class AbstractGlobalConfigurationBuilder implements GlobalConfiguration
       return globalConfig.serialization();
    }
 
-   /**
-    * @deprecated This method always returns null now.
-    * Set thread pool via {@link #listenerThreadPool()} instead.
-    */
-   @Deprecated
-   @Override
-   public ExecutorFactoryConfigurationBuilder asyncListenerExecutor() {
-      return globalConfig.asyncListenerExecutor();
-   }
-
-   /**
-    * @deprecated This method always returns null now.
-    * Set thread pool via {@link #persistenceThreadPool()} instead.
-    */
-   @Deprecated
-   @Override
-   public ExecutorFactoryConfigurationBuilder persistenceExecutor() {
-      return globalConfig.persistenceExecutor();
-   }
-
-   /**
-    * @deprecated This method always returns {@code null} now.
-    * Set thread pool via {@link TransportConfigurationBuilder#transportThreadPool()} instead.
-    */
-   @Deprecated
-   @Override
-   public ExecutorFactoryConfigurationBuilder asyncTransportExecutor() {
-      return globalConfig.asyncTransportExecutor();
-   }
-
-   /**
-    * @deprecated This method always returns null now.
-    * Set thread pool via {@link TransportConfigurationBuilder#remoteCommandThreadPool()} instead.
-    */
-   @Deprecated
-   @Override
-   public ExecutorFactoryConfigurationBuilder remoteCommandsExecutor() {
-      return globalConfig.remoteCommandsExecutor();
-   }
-
-   /**
-    * @deprecated This method always returns null now.
-    * Set thread pool via {@link #evictionThreadPool()} instead.
-    */
-   @Deprecated
-   @Override
-   public ScheduledExecutorFactoryConfigurationBuilder evictionScheduledExecutor() {
-      return globalConfig.evictionScheduledExecutor();
-   }
-
-   /**
-    * @deprecated This method always returns null now.
-    * Set thread pool via {@link #replicationQueueThreadPool()} instead.
-    */
-   @Deprecated
-   @Override
-   public ScheduledExecutorFactoryConfigurationBuilder replicationQueueScheduledExecutor() {
-      return globalConfig.replicationQueueScheduledExecutor();
-   }
-
    @Override
    public ThreadPoolConfigurationBuilder listenerThreadPool() {
       return globalConfig.listenerThreadPool();

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalConfigurationBuilder.java
@@ -101,61 +101,6 @@ public class GlobalConfigurationBuilder implements GlobalConfigurationChildBuild
    }
 
    /**
-    * @deprecated This method always returns null now.
-    * Set thread pool via {@link TransportConfigurationBuilder#transportThreadPool()} instead.
-    */
-   @Deprecated
-   @Override
-   public ExecutorFactoryConfigurationBuilder asyncTransportExecutor() {
-      return null;
-   }
-
-   /**
-    * @deprecated This method always returns null now.
-    * Set thread pool via {@link #listenerThreadPool()} instead.
-    */
-   @Deprecated
-   @Override
-   public ExecutorFactoryConfigurationBuilder asyncListenerExecutor() {
-      return null;
-   }
-
-   /**
-    * @deprecated This method always returns null now.
-    * Set thread pool via {@link #persistenceThreadPool()} instead.
-    */
-   @Deprecated
-   @Override
-   public ExecutorFactoryConfigurationBuilder persistenceExecutor() {
-      return null;
-   }
-
-   /**
-    * @deprecated This method always returns null now.
-    * Set thread pool via {@link TransportConfigurationBuilder#remoteCommandThreadPool()} instead.
-    */
-   @Deprecated
-   @Override
-   public ExecutorFactoryConfigurationBuilder remoteCommandsExecutor() {
-      return null;
-   }
-
-   @Override
-   public ScheduledExecutorFactoryConfigurationBuilder evictionScheduledExecutor() {
-      return null;
-   }
-
-   /**
-    * @deprecated This method always returns null now.
-    * Set thread pool via {@link #replicationQueueThreadPool()} instead.
-    */
-   @Deprecated
-   @Override
-   public ScheduledExecutorFactoryConfigurationBuilder replicationQueueScheduledExecutor() {
-      return null;
-   }
-
-   /**
     * @deprecated this returns the thread pool returned from {@link GlobalConfigurationBuilder#expirationThreadPool}
     */
    @Deprecated
@@ -221,15 +166,6 @@ public class GlobalConfigurationBuilder implements GlobalConfigurationChildBuild
       } catch (Exception e) {
          throw new CacheConfigurationException("Could not instantiate module configuration builder '" + klass.getName() + "'", e);
       }
-   }
-
-   /**
-    * @deprecated This method always returns null now.
-    * Set thread pool via {@link TransportConfigurationBuilder#totalOrderThreadPool()} instead.
-    */
-   @Deprecated
-   public ExecutorFactoryConfigurationBuilder totalOrderExecutor() {
-      return null;
    }
 
    @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalConfigurationChildBuilder.java
@@ -7,14 +7,6 @@ public interface GlobalConfigurationChildBuilder {
 
    SerializationConfigurationBuilder serialization();
 
-   ExecutorFactoryConfigurationBuilder asyncListenerExecutor();
-
-   ExecutorFactoryConfigurationBuilder persistenceExecutor();
-
-   ExecutorFactoryConfigurationBuilder asyncTransportExecutor();
-
-   ExecutorFactoryConfigurationBuilder remoteCommandsExecutor();
-
    ThreadPoolConfigurationBuilder listenerThreadPool();
 
    ThreadPoolConfigurationBuilder replicationQueueThreadPool();
@@ -32,10 +24,6 @@ public interface GlobalConfigurationChildBuilder {
    ThreadPoolConfigurationBuilder stateTransferThreadPool();
 
    ThreadPoolConfigurationBuilder asyncThreadPool();
-
-   ScheduledExecutorFactoryConfigurationBuilder evictionScheduledExecutor();
-
-   ScheduledExecutorFactoryConfigurationBuilder replicationQueueScheduledExecutor();
 
    GlobalSecurityConfigurationBuilder security();
 

--- a/core/src/main/java/org/infinispan/util/concurrent/WithinThreadExecutor.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/WithinThreadExecutor.java
@@ -2,7 +2,6 @@ package org.infinispan.util.concurrent;
 
 import org.infinispan.commons.util.InfinispanCollections;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
IIRC this originally came to existence as a workaround for "you can't just remove methods from public API" but this is even worse, since upgrading infinispan in a project does compile but fails with NPE at runtime when trying to use these configuration methods...