### PR TITLE
[7.2.x] ISPN-5650 NPE when trying to execute script from Hot Rod client

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerWithFilterAndProtobufTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerWithFilterAndProtobufTest.java
@@ -55,7 +55,7 @@ public class ClientListenerWithFilterAndProtobufTest extends MultiHotRodServersT
          // WARNING! This is not the actual instance used at runtime. A new instance is created instead, so all state is lost unless it is re-created in the constructor!
          ProtoStreamMarshaller marshaller = new CustomProtoStreamMarshaller();
 
-         server(i).setEventMarshaller(marshaller);
+         server(i).setMarshaller(marshaller);
       }
 
       //initialize server-side serialization context

--- a/scripting/src/main/java/org/infinispan/scripting/ScriptingManager.java
+++ b/scripting/src/main/java/org/infinispan/scripting/ScriptingManager.java
@@ -4,6 +4,7 @@ import javax.script.Bindings;
 import javax.script.ScriptEngine;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.concurrent.NotifyingFuture;
 
 /**
@@ -36,6 +37,19 @@ public interface ScriptingManager {
     *           the name of the script ro remove
     */
    void removeScript(String name);
+
+   /**
+    * Configures a custom marshaller to be exposed to scripts
+    * as a binding variable
+    *
+    * @param marshaller
+    */
+   void setMarshaller(Marshaller marshaller);
+
+   /**
+    * @return configured marshaller
+    */
+   Marshaller getMarshaller();
 
    /**
     * Runs a named script

--- a/scripting/src/main/java/org/infinispan/scripting/impl/MapperScript.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/MapperScript.java
@@ -34,6 +34,7 @@ public class MapperScript<KIn, VIn, KOut, VOut> implements Mapper<KIn, VIn, KOut
    public void setEnvironment(EmbeddedCacheManager cacheManager) {
       scriptManager = (ScriptingManagerImpl) SecurityActions.getGlobalComponentRegistry(cacheManager).getComponent(ScriptingManager.class);
       bindings = new SimpleBindings();
+      bindings.put("marshaller", scriptManager.getMarshaller());
       bindings.put("cacheManager", cacheManager);
    }
 

--- a/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingManagerImpl.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingManagerImpl.java
@@ -12,6 +12,7 @@ import javax.script.ScriptException;
 import javax.script.SimpleBindings;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.jboss.GenericJBossMarshaller;
 import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.commons.util.concurrent.NoOpFuture;
@@ -53,6 +54,7 @@ public class ScriptingManagerImpl implements ScriptingManager {
    Cache<String, String> scriptCache;
    ConcurrentMap<String, CompiledScript> compiledScripts = CollectionFactory.makeConcurrentMap();
    private AuthorizationManager authzManager;
+   private Marshaller marshaller;
 
 
    public ScriptingManagerImpl() {
@@ -118,6 +120,16 @@ public class ScriptingManagerImpl implements ScriptingManager {
       if (getScriptCache().remove(name) == null) {
          throw log.noNamedScript(name);
       }
+   }
+
+   @Override
+   public void setMarshaller(Marshaller marshaller) {
+      this.marshaller = marshaller;
+   }
+
+   @Override
+   public Marshaller getMarshaller() {
+         return this.marshaller;
    }
 
    @Override

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
@@ -293,7 +293,7 @@ object Decoder2x extends AbstractVersionedDecoder with ServerConstants with Log 
             new SizeResponse(h.version, h.messageId, h.cacheName, h.clientIntel,
                h.topologyId, size)
          case ExecRequest =>
-            val marshaller = new GenericJBossMarshaller() // FIXME: don't create a new one every time and allow changing it
+            val marshaller = Option(server.getMarshaller).getOrElse(new GenericJBossMarshaller)
             val name = readString(buffer)
             val paramCount = readUnsignedInt(buffer)
             val params = new HashMap[String, Object]
@@ -304,7 +304,8 @@ object Decoder2x extends AbstractVersionedDecoder with ServerConstants with Log 
             }
             params.put("marshaller", marshaller)
             params.put("cache", cache)
-            val scriptingManager = SecurityActions.getCacheGlobalComponentRegistry(cache).getComponent(classOf[ScriptingManager]);
+            val scriptingManager = SecurityActions.getCacheGlobalComponentRegistry(cache).getComponent(classOf[ScriptingManager])
+            scriptingManager.setMarshaller(marshaller)
             val result: Any = scriptingManager.runScript(name, cache, new SimpleBindings(params)).get
             new ExecResponse(h.version, h.messageId, h.cacheName, h.clientIntel, h.topologyId, marshaller.objectToByteBuffer(result))
       }
@@ -510,7 +511,17 @@ object Decoder2x extends AbstractVersionedDecoder with ServerConstants with Log 
 
    private def createServerErrorResponse(h: HotRodHeader, t: Throwable): ErrorResponse = {
       new ErrorResponse(h.version, h.messageId, h.cacheName, h.clientIntel,
-         ServerError, h.topologyId, t.toString)
+         ServerError, h.topologyId, createErrorMsg(t))
+   }
+
+   def createErrorMsg(t: Throwable): String = {
+      val causes = mutable.LinkedHashSet[Throwable]()
+      var initial = t
+      while (initial != null && !causes.contains(initial)) {
+         causes += initial
+         initial = initial.getCause
+      }
+      causes.mkString("\n")
    }
 
    override def getOptimizedCache(h: HotRodHeader, c: Cache): Cache = {

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodServer.scala
@@ -46,8 +46,11 @@ class HotRodServer extends AbstractProtocolServer("HotRod") with Log {
    private var queryFacades: Seq[QueryFacade] = _
    private val saslMechFactories = CollectionFactory.makeConcurrentMap[String, SaslServerFactory](4, 0.9f, 16)
    private var clientListenerRegistry: ClientListenerRegistry = _
+   private var marshaller: Marshaller = _
 
    def getAddress: ServerAddress = address
+
+   def getMarshaller = marshaller
 
    def getQueryFacades: Seq[QueryFacade] = queryFacades
 
@@ -251,7 +254,8 @@ class HotRodServer extends AbstractProtocolServer("HotRod") with Log {
       clientListenerRegistry.removeCacheEventFilterConverterFactory(name)
    }
 
-   def setEventMarshaller(marshaller: Marshaller): Unit = {
+   def setMarshaller(marshaller: Marshaller): Unit = {
+      this.marshaller = marshaller
       clientListenerRegistry.setEventMarshaller(Option(marshaller))
    }
 

--- a/server/integration/build/src/main/resources/modules/system/layers/base/org/infinispan/server/endpoint/main/module.xml
+++ b/server/integration/build/src/main/resources/modules/system/layers/base/org/infinispan/server/endpoint/main/module.xml
@@ -26,11 +26,13 @@
       <module name="org.apache.xerces" services="import" />
       <module name="org.hibernate.validator" services="import" />
       <module name="org.infinispan" />
+      <module name="org.infinispan.scripting" services="import"/>
       <module name="org.infinispan.persistence.jdbc" />
       <module name="org.infinispan.persistence.remote" />
       <module name="org.infinispan.server" />
       <module name="org.infinispan.server.hotrod" />
       <module name="org.infinispan.remote-query.server" services="import"/>
+      <module name="org.infinispan.server.hotrod" services="import"/>
       <module name="org.infinispan.server.memcached" />
       <module name="org.infinispan.server.rest" />
       <module name="org.infinispan.server.websocket" />

--- a/server/integration/build/src/main/resources/modules/system/layers/base/org/infinispan/server/hotrod/main/module.xml
+++ b/server/integration/build/src/main/resources/modules/system/layers/base/org/infinispan/server/hotrod/main/module.xml
@@ -32,6 +32,7 @@
       <module name="org.apache.xerces" services="import" />
       <module name="org.infinispan" />
       <module name="org.infinispan.server" />
+      <module name="org.infinispan.scripting" services="import"/>
       <module name="org.infinispan.remote-query.server" services="import"/>
       <module name="org.infinispan.objectfilter" />
       <module name="org.infinispan.query" />

--- a/server/integration/build/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
+++ b/server/integration/build/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
@@ -67,6 +67,8 @@
       <module name="org.jboss.staxmapper"/>
       <module name="org.jboss.threads"/>
       <module name="org.jgroups"/>
+
+      <module name="sun.jdk" services="import"/>
    </dependencies>
 </module>
 

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/ExtensionManagerService.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/ExtensionManagerService.java
@@ -145,7 +145,7 @@ public class ExtensionManagerService implements Service<ExtensionManagerService>
     public void setMarshaller(Marshaller marshaller) {
        synchronized (servers) {
           for (HotRodServer server : servers)
-             server.setEventMarshaller(marshaller);
+             server.setMarshaller(marshaller);
        }
     }
 

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/ScriptExecIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/ScriptExecIT.java
@@ -1,0 +1,96 @@
+package org.infinispan.server.test.client.hotrod;
+
+import org.infinispan.arquillian.core.InfinispanResource;
+import org.infinispan.arquillian.core.RemoteInfinispanServer;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.Configuration;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.server.test.category.HotRodLocal;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.infinispan.test.TestingUtil.loadFileAsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author gustavonalle
+ * @since 8.0
+ */
+@RunWith(Arquillian.class)
+@Category(HotRodLocal.class)
+public class ScriptExecIT {
+
+   private static final String SCRIPT_CACHE_NAME = "___script_cache";
+   private static final String MAPPER = "mapper.js";
+   private static final String REDUCER = "reducer.js";
+   private static final String COLLATOR = "collator.js";
+
+   static RemoteCacheManager remoteCacheManager;
+   RemoteCache<Integer, String> remoteCache;
+   RemoteCache<String, String> scriptCache;
+
+   @InfinispanResource("container1")
+   RemoteInfinispanServer server1;
+
+   @Before
+   public void initialize() {
+      if (remoteCacheManager == null) {
+         Configuration config = createRemoteCacheManagerConfiguration();
+         remoteCacheManager = new RemoteCacheManager(config, true);
+      }
+      scriptCache = remoteCacheManager.getCache(SCRIPT_CACHE_NAME);
+      remoteCache = remoteCacheManager.getCache();
+   }
+
+   private Configuration createRemoteCacheManagerConfiguration() {
+      ConfigurationBuilder config = new ConfigurationBuilder();
+      config.addServer()
+              .host(server1.getHotrodEndpoint().getInetAddress().getHostName())
+              .port(server1.getHotrodEndpoint().getPort());
+      return config.build();
+   }
+
+   @Test
+   public void testScriptExecution() throws Exception {
+      remoteCache.clear();
+      remoteCache.put(1, "word1 word2 word3");
+      remoteCache.put(2, "word1 word2");
+      remoteCache.put(3, "word1");
+
+      addScripts(MAPPER, REDUCER, COLLATOR);
+
+      Map<String, Double> results = remoteCache.execute(MAPPER, new HashMap<String,Double>());
+
+      assertEquals(3, results.size());
+      assertTrue(results.get("word1").equals(Double.valueOf(3)));
+      assertTrue(results.get("word2").equals(Double.valueOf(2)));
+      assertTrue(results.get("word3").equals(Double.valueOf(1)));
+   }
+
+   private void addScripts(String... scripts) throws IOException {
+      for (String script : scripts) {
+         try (InputStream in = this.getClass().getClassLoader().getResourceAsStream(script)) {
+            scriptCache.put(script, loadFileAsString(in));
+         }
+      }
+   }
+
+   @AfterClass
+   public static void release() {
+      if (remoteCacheManager != null) {
+         remoteCacheManager.stop();
+      }
+   }
+
+}

--- a/server/integration/testsuite/src/test/resources/collator.js
+++ b/server/integration/testsuite/src/test/resources/collator.js
@@ -1,0 +1,11 @@
+// mode=collator,language=javascript
+var entrySet = reducedResults.entrySet();
+var l = new java.util.ArrayList(entrySet);
+
+var results = new java.util.LinkedHashMap();
+for (var i = 0; i < entrySet.size(); i++) {
+   var entry = l.get(i);
+   results.put(entry.getKey(), entry.getValue());
+}
+
+results

--- a/server/integration/testsuite/src/test/resources/mapper.js
+++ b/server/integration/testsuite/src/test/resources/mapper.js
@@ -1,0 +1,10 @@
+// mode=mapper,reducer=reducer.js,collator=collator.js,language=javascript
+var re = /[\W]+/
+var unmarshalledValue = marshaller.objectFromByteBuffer(value)
+var words = unmarshalledValue.split(re)
+for (var i=0; i < words.length; i++) {
+   var word = words[i];
+   if (word != null) {
+      collector.emit(words[i].toLowerCase(), 1);
+   }
+}

--- a/server/integration/testsuite/src/test/resources/mapper.js
+++ b/server/integration/testsuite/src/test/resources/mapper.js
@@ -1,7 +1,6 @@
 // mode=mapper,reducer=reducer.js,collator=collator.js,language=javascript
-var re = /[\W]+/
 var unmarshalledValue = marshaller.objectFromByteBuffer(value)
-var words = unmarshalledValue.split(re)
+var words = unmarshalledValue.split(" ")
 for (var i=0; i < words.length; i++) {
    var word = words[i];
    if (word != null) {

--- a/server/integration/testsuite/src/test/resources/reducer.js
+++ b/server/integration/testsuite/src/test/resources/reducer.js
@@ -1,0 +1,6 @@
+// mode=reducer,language=javascript
+var sum = 0;
+while (iter.hasNext()) {
+   sum += parseInt(iter.next());
+}
+sum


### PR DESCRIPTION
A side effect here:  ```javax.script.ScriptEngineManager``` logs an error to console (!) when it can't find any engine declared via META-INF/services, so when starting the server a red line is printed. For example, java 8 does not ship with rhino anymore, so:

```12:38:57,101 ERROR [stderr] (MSC service thread 1-4) ScriptEngineManager providers.next(): javax.script.ScriptEngineFactory: Provider com.sun.script.javascript.RhinoScriptEngineFactory not found```

This error is harmless though...

