### PR TITLE
ISPN-5607 Preemptively invalidate near cache after writes [7.2.x]

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/EagerNearRemoteCache.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/EagerNearRemoteCache.java
@@ -11,11 +11,12 @@ import org.infinispan.client.hotrod.near.NearCacheService;
  * @param <K>
  * @param <V>
  */
-public class NearRemoteCache<K, V> extends RemoteCacheImpl<K, V> {
+@Deprecated
+public class EagerNearRemoteCache<K, V> extends RemoteCacheImpl<K, V> {
 
    private final NearCacheService<K, V> nearcache;
 
-   public NearRemoteCache(RemoteCacheManager rcm, String name, NearCacheService<K, V> nearcache) {
+   public EagerNearRemoteCache(RemoteCacheManager rcm, String name, NearCacheService<K, V> nearcache) {
       super(rcm, name);
       this.nearcache = nearcache;
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/InvalidatedNearRemoteCache.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/InvalidatedNearRemoteCache.java
@@ -1,0 +1,111 @@
+package org.infinispan.client.hotrod.impl;
+
+import org.infinispan.client.hotrod.Flag;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.VersionedValue;
+import org.infinispan.client.hotrod.near.NearCacheService;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Near {@link org.infinispan.client.hotrod.RemoteCache} implementation
+ * enabling
+ *
+ * @param <K>
+ * @param <V>
+ */
+public class InvalidatedNearRemoteCache<K, V> extends RemoteCacheImpl<K, V> {
+
+   private final NearCacheService<K, V> nearcache;
+
+   public InvalidatedNearRemoteCache(RemoteCacheManager rcm, String name, NearCacheService<K, V> nearcache) {
+      super(rcm, name);
+      this.nearcache = nearcache;
+   }
+
+   @Override
+   public V get(Object key) {
+      VersionedValue<V> versioned = getVersioned((K) key);
+      return versioned != null ? versioned.getValue() : null;
+   }
+
+   @Override
+   public VersionedValue<V> getVersioned(K key) {
+      VersionedValue<V> nearValue = nearcache.get(key);
+      if (nearValue == null) {
+         VersionedValue<V> remoteValue = super.getVersioned(key);
+         if (remoteValue != null)
+            nearcache.putIfAbsent(key, remoteValue);
+
+         return remoteValue;
+      }
+
+      return nearValue;
+   }
+
+   @Override
+   public V put(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+      V ret = super.put(key, value, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+      nearcache.remove(key); // Eager invalidation to avoid race
+      return ret;
+   }
+
+   @Override
+   public void putAll(Map<? extends K, ? extends V> map, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+      super.putAll(map, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+      for (K k : map.keySet()) nearcache.remove(k);
+   }
+
+   @Override
+   public V replace(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+      boolean hasForceReturnValue = operationsFactory.hasFlag(Flag.FORCE_RETURN_VALUE);
+      V prev = super.replace(key, value, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+      invalidateNearCacheIfNeeded(hasForceReturnValue, key, prev);
+      return prev;
+   }
+
+   @Override
+   public boolean replaceWithVersion(K key, V newValue, long version, int lifespanSeconds, int maxIdleTimeSeconds) {
+      boolean replaced = super.replaceWithVersion(key, newValue, version, lifespanSeconds, maxIdleTimeSeconds);    // TODO: Customise this generated block
+      if (replaced) nearcache.remove(key);
+      return replaced;
+   }
+
+   @Override
+   public V remove(Object key) {
+      boolean hasForceReturnValue = operationsFactory.hasFlag(Flag.FORCE_RETURN_VALUE);
+      V prev = super.remove(key);
+      invalidateNearCacheIfNeeded(hasForceReturnValue, key, prev);
+      return prev;
+   }
+
+   @Override
+   public boolean removeWithVersion(K key, long version) {
+      boolean removed = super.removeWithVersion(key, version);
+      if (removed) nearcache.remove(key); // Eager invalidation to avoid race
+      return removed;
+   }
+
+   @Override
+   public void clear() {
+      super.clear();
+      nearcache.clear(); // Clear near cache too
+   }
+
+   @SuppressWarnings("unchecked")
+   void invalidateNearCacheIfNeeded(boolean hasForceReturnValue, Object key, Object prev) {
+      if (!hasForceReturnValue || prev != null)
+         nearcache.remove((K) key);
+   }
+
+   @Override
+   public void start() {
+      nearcache.start(this);
+   }
+
+   @Override
+   public void stop() {
+      nearcache.stop(this);
+   }
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -43,7 +43,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    private final String name;
    private final RemoteCacheManager remoteCacheManager;
    private volatile ExecutorService executorService;
-   private OperationsFactory operationsFactory;
+   protected OperationsFactory operationsFactory;
    private int estimateKeySize;
    private int estimateValueSize;
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
@@ -239,4 +239,10 @@ public class OperationsFactory implements HotRodConstants {
          list.add(flag);
 
    }
+
+   public boolean hasFlag(Flag flag) {
+      List<Flag> list = this.flagsMap.get();
+      return list != null && list.contains(flag);
+   }
+
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/AssertsNearCache.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/AssertsNearCache.java
@@ -6,6 +6,7 @@ import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.VersionedValue;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.NearCacheConfiguration;
+import org.infinispan.client.hotrod.configuration.NearCacheMode;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -21,12 +22,14 @@ class AssertsNearCache<K, V> {
    final Cache<byte[], ?> server;
    final BlockingQueue<MockEvent> events;
    final RemoteCacheManager manager;
+   final NearCacheMode nearCacheMode;
 
    private AssertsNearCache(RemoteCacheManager manager, Cache<byte[], ?> server, BlockingQueue<MockEvent> events) {
       this.manager = manager;
       this.remote = manager.getCache();
       this.server = server;
       this.events = events;
+      this.nearCacheMode = manager.getConfiguration().nearCache().mode();
    }
 
    static <K, V> AssertsNearCache<K, V> create(Cache<byte[], ?> server, ConfigurationBuilder builder) {
@@ -39,11 +42,6 @@ class AssertsNearCache<K, V> {
       };
 
       return new AssertsNearCache<>(manager, server, events);
-   }
-
-   static <K, V> AssertsNearCache<K, V> create(AssertsNearCache<K, V> client) {
-      final BlockingQueue<MockEvent> events = new ArrayBlockingQueue<>(128);
-      return new AssertsNearCache<>(client.manager, client.server, events);
    }
 
    AssertsNearCache<K, V> get(K key, V expected) {
@@ -116,9 +114,9 @@ class AssertsNearCache<K, V> {
 
    @SafeVarargs
    final AssertsNearCache<K, V> expectNearRemove(K key, AssertsNearCache<K, V>... affected) {
-      expectNearRemoveInClient(this, key);
+      expectLocalNearRemoveInClient(this, key);
       for (AssertsNearCache<K, V> client : affected)
-         expectNearRemoveInClient(client, key);
+         expectRemoteNearRemoveInClient(client, key);
 
       return this;
    }
@@ -141,9 +139,21 @@ class AssertsNearCache<K, V> {
       killRemoteCacheManager(manager);
    }
 
-   private static <K, V> void expectNearRemoveInClient(AssertsNearCache<K, V> client, K key) {
-      MockRemoveEvent remove = pollEvent(client.events);
-      assertEquals(key, remove.key);
+   private static <K, V> void expectLocalNearRemoveInClient(AssertsNearCache<K, V> client, K key) {
+      if (!client.nearCacheMode.eager()) {
+         // Preemptive remove
+         MockRemoveEvent preemptiveRemove = pollEvent(client.events);
+         assertEquals(key, preemptiveRemove.key);
+      }
+      // Remote event remove
+      MockRemoveEvent remoteRemove = pollEvent(client.events);
+      assertEquals(key, remoteRemove.key);
+   }
+
+   private static <K, V> void expectRemoteNearRemoveInClient(AssertsNearCache<K, V> client, K key) {
+      // Remote event remove
+      MockRemoveEvent remoteRemove = pollEvent(client.events);
+      assertEquals(key, remoteRemove.key);
    }
 
    private static <E extends MockEvent> E pollEvent(BlockingQueue<MockEvent> events) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/AvoidStaleNearCacheReadsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/AvoidStaleNearCacheReadsTest.java
@@ -1,0 +1,123 @@
+package org.infinispan.client.hotrod.near;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.VersionedValue;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.configuration.NearCacheMode;
+import org.infinispan.client.hotrod.test.SingleHotRodServerTest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+
+@Test(groups = "functional", testName = "client.hotrod.near.AvoidStaleNearCacheReadsTest")
+public class AvoidStaleNearCacheReadsTest extends SingleHotRodServerTest {
+
+   @AfterMethod(alwaysRun=true)
+   @Override
+   protected void clearContent() {
+      super.clearContent();
+      remoteCacheManager.getCache().clear(); // Clear the near cache too
+   }
+
+   @Override
+   protected RemoteCacheManager getRemoteCacheManager() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.addServer().host("127.0.0.1").port(hotrodServer.getPort());
+      builder.nearCache().mode(NearCacheMode.LAZY).maxEntries(-1);
+      return new RemoteCacheManager(builder.build());
+   }
+
+   public void testAvoidStaleReadsAfterPutRemove() {
+      repeated(new BiConsumer<Integer, RemoteCache<Integer, String>>() {
+         @Override
+         public void accept(Integer i, RemoteCache<Integer, String> remote) {
+            String value = "v" + i;
+            remote.put(1, value);
+            assertEquals(value, remote.get(1));
+            remote.remove(1);
+            assertNull(remote.get(1));
+         }
+      });
+   }
+
+   public void testAvoidStaleReadsAfterPutAll() {
+      repeated(new BiConsumer<Integer, RemoteCache<Integer, String>>() {
+         @Override
+         public void accept(Integer i, RemoteCache<Integer, String> remote) {
+            String value = "v" + i;
+            Map<Integer, String> map = new HashMap<>();
+            map.put(1, value);
+            remote.putAll(map);
+            assertEquals(value, remote.get(1));
+         }
+      });
+   }
+
+   public void testAvoidStaleReadsAfterReplace() {
+      repeated(new BiConsumer<Integer, RemoteCache<Integer, String>>() {
+         @Override
+         public void accept(Integer i, RemoteCache<Integer, String> remote) {
+            String value = "v" + i;
+            remote.replace(1, value);
+            VersionedValue<String> versioned = remote.getVersioned(1);
+            assertEquals(value, versioned.getValue());
+         }
+      });
+   }
+
+   public void testAvoidStaleReadsAfterReplaceWithVersion() {
+      repeated(new BiConsumer<Integer, RemoteCache<Integer, String>>() {
+         @Override
+         public void accept(Integer i, RemoteCache<Integer, String> remote) {
+            String value = "v" + i;
+            VersionedValue<String> versioned = remote.getVersioned(1);
+            remote.replaceWithVersion(1, value, versioned.getVersion());
+            assertEquals(value, remote.get(1));
+         }
+      });
+   }
+
+   public void testAvoidStaleReadsAfterPutAsyncRemoveVersioned() {
+      repeated(new BiConsumer<Integer, RemoteCache<Integer, String>>() {
+         @Override
+         public void accept(Integer i, RemoteCache<Integer, String> remote) {
+            String value = "v" + i;
+            await(remote.putAsync(1, value));
+            VersionedValue<String> versioned = remote.getVersioned(1);
+            assertEquals(value, versioned.getValue());
+            remote.removeWithVersion(1, versioned.getVersion());
+            assertNull(remote.get(1));
+         }
+      });
+   }
+
+   private void repeated(BiConsumer<Integer, RemoteCache<Integer, String>> c) {
+      RemoteCache<Integer, String> remote = remoteCacheManager.getCache();
+      remote.putIfAbsent(1, "v0");
+      for (int i = 1; i < 1000; i++) {
+         c.accept(i, remote);
+      }
+   }
+
+   static <T> T await(Future<T> f) {
+      try {
+         return f.get(10000, TimeUnit.SECONDS);
+      } catch (InterruptedException | ExecutionException | TimeoutException e ) {
+         throw new AssertionError(e);
+      }
+   }
+
+   interface BiConsumer<A, B> {
+      void accept(A a, B b);
+   }
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EagerNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/EagerNearCacheTest.java
@@ -19,15 +19,25 @@ public class EagerNearCacheTest extends SingleHotRodServerTest {
 
    @Override
    protected RemoteCacheManager getRemoteCacheManager() {
-      assertClient = createClient();
+      assertClient = createAssertClient();
       return assertClient.manager;
    }
 
-   protected <K, V> AssertsNearCache<K, V> createClient() {
+   protected <K, V> AssertsNearCache<K, V> createAssertClient() {
+      ConfigurationBuilder builder = clientConfiguration();
+      return AssertsNearCache.create(this.<byte[], Object>cache(), builder);
+   }
+
+   protected <K, V> RemoteCache<K, V> createClient() {
+      ConfigurationBuilder builder = clientConfiguration();
+      return new RemoteCacheManager(builder.build()).getCache();
+   }
+
+   private ConfigurationBuilder clientConfiguration() {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.addServer().host("127.0.0.1").port(hotrodServer.getPort());
       builder.nearCache().mode(getNearCacheMode()).maxEntries(-1);
-      return AssertsNearCache.create(this.<byte[], Object>cache(), builder);
+      return builder;
    }
 
    protected NearCacheMode getNearCacheMode() {
@@ -82,7 +92,7 @@ public class EagerNearCacheTest extends SingleHotRodServerTest {
       assertClient.expectNoNearEvents();
       assertClient.put(1, "v1").expectNearPut(1, "v1");
 
-      final AssertsNearCache<Integer, String> newAsserts = createClient();
+      final AssertsNearCache<Integer, String> newAsserts = createAssertClient();
       withRemoteCacheManager(new RemoteCacheManagerCallable(newAsserts.manager) {
          @Override
          public void call() {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/LazyNearCacheTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/near/LazyNearCacheTest.java
@@ -51,7 +51,7 @@ public class LazyNearCacheTest extends EagerNearCacheTest {
       assertClient.expectNoNearEvents();
       assertClient.put(1, "v1").expectNearRemove(1);
 
-      final AssertsNearCache<Integer, String> newAsserts = createClient();
+      final AssertsNearCache<Integer, String> newAsserts = createAssertClient();
       withRemoteCacheManager(new RemoteCacheManagerCallable(newAsserts.manager) {
          @Override
          public void call() {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5607

[7.2.x ONLY]

* Near cache stale reads can't be fully guaranteed since there's always
  the possibility of a read to come in when the server has already
  executed a write operation but it's in process of sending back the
  response.
* However, we can't at least guarantee that within a single
  thread, a read after a write will read the written value. The change
  proposed in this PR addresses this, by preemptively invalidating data
  after a successful write.