### PR TITLE
ISPN-5677 RemoteCache async methods use flags [7.2.x]

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
@@ -209,7 +209,7 @@ public class OperationsFactory implements HotRodConstants {
 		return new ExecuteOperation(codec, transportFactory, cacheNameBytes, topologyId, flags(), taskName, marshalledParams);
 	}
 
-   private Flag[] flags() {
+   public Flag[] flags() {
       List<Flag> flags = this.flagsMap.get();
       this.flagsMap.remove();
       if (forceReturnValue) {
@@ -237,7 +237,6 @@ public class OperationsFactory implements HotRodConstants {
       }
       for(Flag flag : flags)
          list.add(flag);
-
    }
 
    public boolean hasFlag(Flag flag) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteAsyncAPIForceReturnPerCallTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteAsyncAPIForceReturnPerCallTest.java
@@ -1,0 +1,18 @@
+package org.infinispan.client.hotrod;
+
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "client.hotrod.RemoteAsyncAPIForceReturnPerCallTest")
+public class RemoteAsyncAPIForceReturnPerCallTest extends RemoteAsyncAPITest {
+
+   @Override
+   protected boolean isForceReturnValuesViaConfiguration() {
+      return false;
+   }
+
+   @Override
+   protected RemoteCache<String, String> remote() {
+      return super.remote().withFlags(Flag.FORCE_RETURN_VALUE);
+   }
+
+}


### PR DESCRIPTION
* They were previously being ignored as a result of not sending from the
  main thread to the thread executing the async operation.