### PR TITLE
ISPN-5696 Make the javax.transaction API jar a compile dependency instead of provided

### DIFF
--- a/all/embedded/pom.xml
+++ b/all/embedded/pom.xml
@@ -95,7 +95,6 @@
       <dependency>
          <groupId>org.jboss.spec.javax.transaction</groupId>
          <artifactId>jboss-transaction-api_1.1_spec</artifactId>
-         <scope>provided</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5696