### PR TITLE
Revert "[ISPN-5517] JDBCBinaryStore size method should query count directly instead of iterating"

### DIFF
--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/binary/JdbcBinaryStore.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/binary/JdbcBinaryStore.java
@@ -26,6 +26,7 @@ import org.infinispan.executors.ExecutorAllCompletionService;
 import org.infinispan.filter.KeyFilter;
 import org.infinispan.marshall.core.MarshalledEntry;
 import org.infinispan.metadata.InternalMetadata;
+import org.infinispan.persistence.PersistenceUtil;
 import org.infinispan.persistence.TaskContextImpl;
 import org.infinispan.persistence.jdbc.JdbcUtil;
 import org.infinispan.persistence.jdbc.TableManipulation;
@@ -253,31 +254,7 @@ public class JdbcBinaryStore implements AdvancedLoadWriteStore {
 
    @Override
    public int size() {
-      int count = 0;
-      Connection conn = null;
-      PreparedStatement ps = null;
-      ResultSet rs = null;
-      try {
-         String sql = tableManipulation.getLoadNonExpiredAllRowsSql();
-         conn = connectionFactory.getConnection();
-         ps = conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-         ps.setLong(1, ctx.getTimeService().wallClockTime());
-         ps.setFetchSize(tableManipulation.getFetchSize());
-         rs = ps.executeQuery();
-         while (rs.next()) {
-            InputStream binaryStream = rs.getBinaryStream(1);
-            final Bucket bucket = unmarshallBucket(binaryStream);
-            count += bucket.getStoredEntries().size();
-         }
-         return count;
-      } catch (SQLException e) {
-         log.sqlFailureFetchingAllStoredEntries(e);
-         throw new PersistenceException("SQL error while fetching all Non Expired Entries", e);
-      } finally {
-         JdbcUtil.safeClose(rs);
-         JdbcUtil.safeClose(ps);
-         connectionFactory.releaseConnection(conn);
-      }
+      return PersistenceUtil.count(this, null);
    }
 
    @Override

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/binary/JdbcBinaryStoreTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/binary/JdbcBinaryStoreTest.java
@@ -17,6 +17,7 @@ import java.io.Serializable;
 
 import static org.infinispan.test.TestingUtil.metadata;
 import static org.mockito.Mockito.mock;
+import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 
 /**
@@ -96,6 +97,22 @@ public class JdbcBinaryStoreTest extends BaseStoreTest {
       assertContains(k1, true);
       assertContains(k2, false);
       UnitTestDatabaseManager.verifyConnectionLeaks(((JdbcBinaryStore) cl).getConnectionFactory());
+   }
+
+
+   public void testCacheSize() {
+      long lifespan = 3000;
+      for (int i = 0; i < 240; i++) {
+         if (i % 2 == 0) {
+            cl.write(marshalledEntry(internalCacheEntry("key" + i, "v1", lifespan)));
+         } else {
+            cl.write(marshalledEntry(internalCacheEntry("key" + i, "v1", -1)));
+         }
+      }
+      assertEquals(cl.size(), 240);
+      timeService.advance(lifespan + 1);
+      assertEquals(cl.size(), 120);
+
    }
 
    private static final class FixedHashKey implements Serializable {

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/binary/JdbcBinaryStoreTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/binary/JdbcBinaryStoreTest.java
@@ -17,7 +17,6 @@ import java.io.Serializable;
 
 import static org.infinispan.test.TestingUtil.metadata;
 import static org.mockito.Mockito.mock;
-import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 
 /**
@@ -97,18 +96,6 @@ public class JdbcBinaryStoreTest extends BaseStoreTest {
       assertContains(k1, true);
       assertContains(k2, false);
       UnitTestDatabaseManager.verifyConnectionLeaks(((JdbcBinaryStore) cl).getConnectionFactory());
-   }
-
-   public void testCacheSize() {
-      long lifespan = 3000;
-      for (int i = 0; i < 120; i++) {
-         cl.write(marshalledEntry(internalCacheEntry("mortal" + i, "v1", lifespan)));
-         cl.write(marshalledEntry(internalCacheEntry("immortal" + i, "v1", -1)));
-      }
-
-      assertEquals(cl.size(), 240);
-      timeService.advance(lifespan + 1);
-      assertEquals(cl.size(), 120);
    }
 
    private static final class FixedHashKey implements Serializable {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5517

Need to revert the fix because it ignores the timestamp of the entries in the bucket, and so it fails when a bucket contains a mix of expired and live entries.