### PR TITLE
No need to set query parameters again after construction

### DIFF
--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
@@ -290,6 +290,22 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    }
 
    @Test
+   public void testEqHybridQueryWithParam() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .having("notes").eq("Lorem ipsum dolor sit amet")
+            .and().having("surname").eq(Expression.param("surnameParam"))
+            .toBuilder().build();
+
+      q.setParameter("surnameParam", "Doe");
+
+      List<User> list = q.list();
+      assertEquals(1, list.size());
+      assertEquals(1, list.get(0).getId());
+   }
+
+   @Test
    public void testEqHybridQueryWithPredicateOptimisation() throws Exception {
       QueryFactory qf = getQueryFactory();
 

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryEngine.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryEngine.java
@@ -377,11 +377,7 @@ public class QueryEngine {
       // some fields are indexed, run a hybrid query
       String expandedJpaOut = JPATreePrinter.printTree(parsingResult.getTargetEntityName(), expansion, null);
       Query expandedQuery = new EmbeddedLuceneQuery(this, queryFactory, expandedJpaOut, namedParameters, parsingResult.getProjections(), -1, -1);
-      HybridQuery hybridQuery = new HybridQuery(queryFactory, cache, jpqlString, namedParameters, getObjectFilter(getSecondPhaseMatcher(), jpqlString, namedParameters), startOffset, maxResults, expandedQuery);
-      if (namedParameters != null) {
-         hybridQuery.setParameters(namedParameters);
-      }
-      return hybridQuery;
+      return new HybridQuery(queryFactory, cache, jpqlString, namedParameters, getObjectFilter(getSecondPhaseMatcher(), jpqlString, namedParameters), startOffset, maxResults, expandedQuery);
    }
 
    protected BaseMatcher getFirstPhaseMatcher() {
@@ -496,7 +492,7 @@ public class QueryEngine {
    }
 
    protected LuceneProcessingChain makeProcessingChain(Map<String, Object> namedParameters) {
-      EntityNamesResolver entityNamesResolver = new EntityNamesResolver() {
+      final EntityNamesResolver entityNamesResolver = new EntityNamesResolver() {
          @Override
          public Class<?> getClassFromName(String entityName) {
             try {

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
@@ -276,6 +276,21 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       assertEquals(1, list.get(0).getId());
    }
 
+   public void testEqHybridQueryWithParam() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.from(getModelFactory().getUserImplClass())
+            .having("notes").eq("Lorem ipsum dolor sit amet")
+            .and().having("surname").eq(Expression.param("surnameParam"))
+            .toBuilder().build();
+
+      q.setParameter("surnameParam", "Doe");
+
+      List<User> list = q.list();
+      assertEquals(1, list.size());
+      assertEquals(1, list.get(0).getId());
+   }
+
    public void testEqHybridQueryWithPredicateOptimisation() throws Exception {
       QueryFactory qf = getQueryFactory();
 


### PR DESCRIPTION
This was a leftover from an earlier version which did not take the params in the constructor.
Add test for hybrid query with parameter.