### PR TITLE
Fix XSD schema's state-transfer timeout to be 4 minutes (as opposed t…

### DIFF
--- a/core/src/main/resources/schema/infinispan-config-8.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-8.0.xsd
@@ -1332,7 +1332,7 @@
         <xs:documentation>If enabled, this will cause the cache to ask neighboring caches for state when it starts up, so the cache starts 'warm', although it will impact startup time.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="timeout" type="xs:long" default="60000">
+    <xs:attribute name="timeout" type="xs:long" default="240000">
       <xs:annotation>
         <xs:documentation>The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.</xs:documentation>
       </xs:annotation>


### PR DESCRIPTION
…o legacy default of 1 minute)

See org.infinispan.configuration.cache.StateTransferConfiguration#TIMEOUT for the actual value of the default.

Oh, XSD, you liar!