### PR TITLE
ISPN-5727 Stop client listener executor on shutdown

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AddClientListenerOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AddClientListenerOperation.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod.impl.operations;
 
 import org.infinispan.client.hotrod.Flag;
+import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.annotation.ClientListener;
 import org.infinispan.client.hotrod.event.ClientEvent;
 import org.infinispan.client.hotrod.event.ClientListenerNotifier;
@@ -27,6 +28,7 @@ public class AddClientListenerOperation extends RetryOnFailureOperation<Short> {
    private static final Log log = LogFactory.getLog(AddClientListenerOperation.class, Log.class);
 
    public final byte[] listenerId;
+   private final String cacheNameString;
 
    /**
     * Decicated transport instance for adding client listener. This transport
@@ -41,15 +43,16 @@ public class AddClientListenerOperation extends RetryOnFailureOperation<Short> {
    public final byte[][] converterFactoryParams;
 
    protected AddClientListenerOperation(Codec codec, TransportFactory transportFactory,
-         byte[] cacheName, AtomicInteger topologyId, Flag[] flags,
+         String cacheName, AtomicInteger topologyId, Flag[] flags,
          ClientListenerNotifier listenerNotifier, Object listener,
          byte[][] filterFactoryParams, byte[][] converterFactoryParams) {
-      super(codec, transportFactory, cacheName, topologyId, flags);
+      super(codec, transportFactory, RemoteCacheManager.cacheNameBytes(cacheName), topologyId, flags);
       this.listenerId = generateListenerId();
       this.listenerNotifier = listenerNotifier;
       this.listener = listener;
       this.filterFactoryParams = filterFactoryParams;
       this.converterFactoryParams = converterFactoryParams;
+      this.cacheNameString = cacheName;
    }
 
    private byte[] generateListenerId() {
@@ -113,4 +116,7 @@ public class AddClientListenerOperation extends RetryOnFailureOperation<Short> {
       return l;
    }
 
+   public String getCacheName() {
+      return cacheNameString;
+   }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
@@ -44,11 +44,14 @@ public class OperationsFactory implements HotRodConstants {
 
    private final ClientListenerNotifier listenerNotifier;
 
+   private final String cacheName;
+
    public OperationsFactory(TransportFactory transportFactory, String cacheName,
                             AtomicInteger topologyId, boolean forceReturnValue, Codec codec,
                             ClientListenerNotifier listenerNotifier) {
       this.transportFactory = transportFactory;
       this.cacheNameBytes = RemoteCacheManager.cacheNameBytes(cacheName);
+      this.cacheName = cacheName;
       this.topologyId = topologyId;
       this.forceReturnValue = forceReturnValue;
       this.codec = codec;
@@ -155,14 +158,14 @@ public class OperationsFactory implements HotRodConstants {
 
    public AddClientListenerOperation newAddClientListenerOperation(Object listener) {
       return new AddClientListenerOperation(codec, transportFactory,
-            cacheNameBytes, topologyId, flags(), listenerNotifier,
+            cacheName, topologyId, flags(), listenerNotifier,
             listener, null, null);
    }
 
    public AddClientListenerOperation newAddClientListenerOperation(
          Object listener, byte[][] filterFactoryParams, byte[][] converterFactoryParams) {
       return new AddClientListenerOperation(codec, transportFactory,
-            cacheNameBytes, topologyId, flags(), listenerNotifier,
+            cacheName, topologyId, flags(), listenerNotifier,
             listener, filterFactoryParams, converterFactoryParams);
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerLeakTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerLeakTest.java
@@ -1,0 +1,43 @@
+package org.infinispan.client.hotrod.event;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.test.RemoteCacheManagerCallable;
+import org.infinispan.client.hotrod.test.SingleHotRodServerTest;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.testng.annotations.Test;
+
+import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.withRemoteCacheManager;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+import static org.infinispan.test.TestingUtil.detectThreadLeaks;
+
+@Test(groups = "functional", testName = "client.hotrod.event.ClientListenerLifecycleTest")
+public class ClientListenerLeakTest extends SingleHotRodServerTest {
+
+   private String cacheName;
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      EmbeddedCacheManager cm = super.createCacheManager();
+      ConfigurationBuilder cfg = hotRodCacheConfiguration();
+      cacheName = this.getClass().getSimpleName();
+      cm.defineConfiguration(cacheName, cfg.build());
+      return cm;
+   }
+
+   public void testNoLeaksAfterShutdown() {
+      withRemoteCacheManager(new RemoteCacheManagerCallable(getRemoteCacheManager()) {
+         @Override
+         public void call() {
+            RemoteCache<Integer, String> remote = rcm.getCache(cacheName);
+            EventLogListener<Integer> eventListener = new EventLogListener<>();
+            remote.addClientListener(eventListener);
+            eventListener.expectNoEvents();
+            remote.put(1, "one");
+            eventListener.expectOnlyCreatedEvent(1, cache(cacheName));
+         }
+      });
+      detectThreadLeaks(".*Client-Listener-ClientListenerLeakTest-.*");
+   }
+
+}

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -84,19 +84,7 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.security.Principal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Properties;
-import java.util.Random;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
@@ -1590,6 +1578,17 @@ public class TestingUtil {
             t = cause;
          }
       }
+   }
+
+   public static void detectThreadLeaks(String regexp) {
+      List<Thread> leakedThreads = new ArrayList<>();
+      for (Map.Entry<Thread, StackTraceElement[]> s : Thread.getAllStackTraces().entrySet()) {
+         Thread thread = s.getKey();
+         if (thread.getName().matches(regexp)) leakedThreads.add(thread);
+      }
+
+      if (!leakedThreads.isEmpty())
+         throw new AssertionError("Leaked threads: " + leakedThreads);
    }
 
 }


### PR DESCRIPTION
* Make sure also that when a client listener is removed, the task is
  cancelled.
* Added a test helper method to detect thread leaks given a regular
  expression.