### PR TITLE
ISPN-5699 Simplify entry wrapping

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/FastCopyHashMap.java
+++ b/commons/src/main/java/org/infinispan/commons/util/FastCopyHashMap.java
@@ -583,9 +583,6 @@ public class FastCopyHashMap<K, V> extends AbstractMap<K, V> implements Map<K, V
       @Override
       public Map.Entry<K, V> next() {
          Entry<K, V> e = nextEntry();
-         if (trace)
-            log.tracef("Next entry: key=%s, value=%s", e.key, e.value);
-
          return new WriteThroughEntry(e.key, e.value);
       }
    }

--- a/core/src/main/java/org/infinispan/commands/write/ApplyDeltaCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/ApplyDeltaCommand.java
@@ -4,6 +4,8 @@ import org.infinispan.atomic.Delta;
 import org.infinispan.atomic.DeltaCompositeKey;
 import org.infinispan.commands.CommandInvocationId;
 import org.infinispan.commands.Visitor;
+import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.container.entries.DeltaAwareCacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.lifecycle.ComponentStatus;
@@ -50,7 +52,11 @@ public class ApplyDeltaCommand extends AbstractDataWriteCommand {
     */
    @Override
    public Object perform(InvocationContext ctx) throws Throwable {
-      //nothing to do here
+      CacheEntry contextEntry = ctx.lookupEntry(key);
+      if (contextEntry instanceof DeltaAwareCacheEntry) {
+         DeltaAwareCacheEntry deltaAwareCacheEntry = (DeltaAwareCacheEntry) contextEntry;
+         deltaAwareCacheEntry.appendDelta(delta);
+      }
       return null;
    }
 

--- a/core/src/main/java/org/infinispan/commands/write/ReplaceCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/ReplaceCommand.java
@@ -9,6 +9,7 @@ import org.infinispan.container.entries.MVCCEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.metadata.Metadata;
+import org.infinispan.metadata.Metadatas;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 
 import java.util.Set;
@@ -74,6 +75,7 @@ public class ReplaceCommand extends AbstractDataWriteCommand implements Metadata
       if (e != null && valueMatcher.matches(e, oldValue, newValue, valueEquivalence)) {
          e.setChanged(true);
          Object old = e.setValue(newValue);
+         Metadatas.updateMetadata(e, metadata);
          if (valueMatcher != ValueMatcher.MATCH_EXPECTED_OR_NEW) {
             return returnValue(old, e.getMetadata(), true, ctx);
          } else {
@@ -83,14 +85,6 @@ public class ReplaceCommand extends AbstractDataWriteCommand implements Metadata
       }
 
       return returnValue(null, null, false, ctx);
-   }
-
-   @SuppressWarnings("unchecked")
-   private boolean isValueEquals(Object oldValue, Object newValue) {
-      if (valueEquivalence != null)
-         return valueEquivalence.equals(oldValue, newValue);
-
-      return oldValue.equals(newValue);
    }
 
    private Object returnValue(Object beingReplaced, Metadata previousMetadata, boolean successful,

--- a/core/src/main/java/org/infinispan/container/DefaultDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/DefaultDataContainer.java
@@ -221,7 +221,7 @@ public class DefaultDataContainer<K, V> implements DataContainer<K, V> {
       }
 
       if (trace)
-         log.tracef("Store %s in container", e);
+         log.tracef("Store %s in container", copy);
 
       entries.compute(copy.getKey(), (key, entry) -> {
          activator.onUpdate(key, entry == null);

--- a/core/src/main/java/org/infinispan/container/EntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/EntryFactoryImpl.java
@@ -1,8 +1,5 @@
 package org.infinispan.container;
 
-import org.infinispan.commands.write.PutKeyValueCommand;
-import org.infinispan.commands.write.PutMapCommand;
-import org.infinispan.configuration.cache.VersioningScheme;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.atomic.Delta;
@@ -17,12 +14,9 @@ import org.infinispan.container.entries.MVCCEntry;
 import org.infinispan.container.entries.ReadCommittedEntry;
 import org.infinispan.container.entries.RepeatableReadEntry;
 import org.infinispan.container.entries.StateChangingEntry;
-import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
-import org.infinispan.metadata.Metadatas;
-import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -40,27 +34,21 @@ public class EntryFactoryImpl implements EntryFactory {
    
    protected boolean useRepeatableRead;
    private DataContainer container;
-   protected boolean clusterModeWriteSkewCheck;
    private boolean isL1Enabled; //cache the value
    private Configuration configuration;
-   private CacheNotifier notifier;
    private DistributionManager distributionManager;//is null for non-clustered caches
 
    @Inject
-   public void injectDependencies(DataContainer dataContainer, Configuration configuration, CacheNotifier notifier,
+   public void injectDependencies(DataContainer dataContainer, Configuration configuration,
                                   DistributionManager distributionManager) {
       this.container = dataContainer;
       this.configuration = configuration;
-      this.notifier = notifier;
       this.distributionManager = distributionManager;
    }
 
    @Start (priority = 8)
    public void init() {
       useRepeatableRead = configuration.locking().isolationLevel() == IsolationLevel.REPEATABLE_READ;
-      clusterModeWriteSkewCheck = useRepeatableRead && configuration.locking().writeSkewCheck() &&
-            configuration.clustering().cacheMode().isClustered() && configuration.versioning().scheme() == VersioningScheme.SIMPLE &&
-            configuration.versioning().enabled();
       isL1Enabled = configuration.clustering().l1().enabled();
    }
 
@@ -68,190 +56,189 @@ public class EntryFactoryImpl implements EntryFactory {
    public final CacheEntry wrapEntryForReading(InvocationContext ctx, Object key, CacheEntry existing) {
       CacheEntry cacheEntry = getFromContext(ctx, key);
       if (cacheEntry == null) {
-         cacheEntry = existing == null ? getFromContainer(key, false) : existing;
+         cacheEntry = existing != null ? existing : getFromContainer(key, false);
 
-         // do not bother wrapping though if this is not in a tx.  repeatable read etc are all meaningless unless there is a tx.
+         // With repeatable read, we need to create a RepeatableReadEntry
+         // Otherwise we can store the InternalCacheEntry directly in the context
          if (useRepeatableRead) {
-            MVCCEntry mvccEntry;
-            if (cacheEntry == null) {
-               mvccEntry = createWrappedEntry(key, null, ctx, null, false, false, false);
-            } else {
-               mvccEntry = createWrappedEntry(key, cacheEntry, ctx, null, false, false, false);
-               // If the original entry has changeable state, copy state flags to the new MVCC entry.
-               if (cacheEntry instanceof StateChangingEntry && mvccEntry != null)
-                  mvccEntry.copyStateFlagsFrom((StateChangingEntry) cacheEntry);
-            }
-
-            if (mvccEntry != null) ctx.putLookedUpEntry(key, mvccEntry);
-            if (trace) {
-               log.tracef("Wrap %s for read. Entry=%s", key, mvccEntry);
-            }
-            return mvccEntry;
-         } else if (cacheEntry != null) { // if not in transaction and repeatable read, or simply read committed (regardless of whether in TX or not), do not wrap
+            cacheEntry = createWrappedEntry(key, cacheEntry, ctx, false);
+         }
+         if (cacheEntry != null) {
             ctx.putLookedUpEntry(key, cacheEntry);
          }
-         if (trace) {
-            log.tracef("Wrap %s for read. Entry=%s", key, cacheEntry);
-         }
-         return cacheEntry;
       }
+
       if (trace) {
          log.tracef("Wrap %s for read. Entry=%s", key, cacheEntry);
       }
       return cacheEntry;
    }
 
+   @Deprecated
    @Override
    public final  MVCCEntry wrapEntryForClear(InvocationContext ctx, Object key) throws InterruptedException {
-      //skipRead == true because the keys values are not read during the ClearOperation (neither by application)
-      MVCCEntry mvccEntry = wrapEntry(ctx, key, null, true);
-      if (trace) {
-         log.tracef("Wrap %s for clear. Entry=%s", key, mvccEntry);
-      }
-      return mvccEntry;
+      return null;
    }
 
    @Override
    public final  MVCCEntry wrapEntryForReplace(InvocationContext ctx, ReplaceCommand cmd) throws InterruptedException {
-      Object key = cmd.getKey();
-      MVCCEntry mvccEntry = wrapEntry(ctx, key, cmd.getMetadata(), false);
-      if (mvccEntry == null) {
-         // make sure we record this! Null value since this is a forced lock on the key
-         ctx.putLookedUpEntry(key, null);
-      }
-      if (trace) {
-         log.tracef("Wrap %s for replace. Entry=%s", key, mvccEntry);
-      }
-      return mvccEntry;
+      return wrapEntryForWriting(ctx, cmd.getKey(), Wrap.WRAP_NON_NULL, false, false);
    }
 
    @Override
    public final  MVCCEntry wrapEntryForRemove(InvocationContext ctx, Object key, boolean skipRead,
                                               boolean forInvalidation, boolean forceWrap) throws InterruptedException {
-      CacheEntry cacheEntry = getFromContext(ctx, key);
-      MVCCEntry mvccEntry = null;
-      if (cacheEntry != null) {
-         if (cacheEntry instanceof MVCCEntry) {
-            mvccEntry = (MVCCEntry) cacheEntry;
-         } else {
-            //skipRead == true because the key already exists in the context that means the key was previous accessed.
-            mvccEntry = wrapMvccEntryForRemove(ctx, key, cacheEntry, true);
-         }
-      } else {
-         InternalCacheEntry ice = getFromContainer(key, forInvalidation);
-         if (ice != null || clusterModeWriteSkewCheck || forceWrap) {
-            mvccEntry = wrapInternalCacheEntryForPut(ctx, key, ice, null, skipRead);
-         }
-      }
-      if (mvccEntry == null) {
-         // make sure we record this! Null value since this is a forced lock on the key
-         ctx.putLookedUpEntry(key, null);
-      } else {
-         mvccEntry.copyForUpdate(container);
-      }
-      if (trace) {
-         log.tracef("Wrap %s for remove. Entry=%s", key, mvccEntry);
-      }
-      return mvccEntry;
+      Wrap wrap = forceWrap ? Wrap.WRAP_ALL : Wrap.WRAP_NON_NULL;
+      return wrapEntryForWriting(ctx, key, wrap, skipRead, forInvalidation);
    }
 
    @Override
-   //removed final modifier to allow mock this method
    public MVCCEntry wrapEntryForPut(InvocationContext ctx, Object key, InternalCacheEntry icEntry,
-         boolean undeleteIfNeeded, FlagAffectedCommand cmd, boolean skipRead) {
-      CacheEntry cacheEntry = getFromContext(ctx, key);
+                                    boolean undeleteIfNeeded, FlagAffectedCommand cmd, boolean skipRead) {
+      if (icEntry != null) {
+         throw new IllegalArgumentException("Only addMissingValue can handle external entries");
+      }
+      return wrapEntryForWriting(ctx, key, Wrap.WRAP_ALL, skipRead, false);
+   }
+
+   @Override
+   public MVCCEntry wrapEntryForWriting(InvocationContext ctx, Object key, Wrap wrap, boolean skipRead,
+                                        boolean ignoreOwnership) {
+      if (wrap == Wrap.STORE) {
+         throw new IllegalStateException("wrapEntryForWriting must create a MVCCEntry");
+      }
+      if (useRepeatableRead) {
+         wrap = Wrap.WRAP_ALL;
+      }
+      CacheEntry contextEntry = getFromContext(ctx, key);
       MVCCEntry mvccEntry;
-      if (cacheEntry != null && cacheEntry.isNull() && !useRepeatableRead) cacheEntry = null;
-      Metadata providedMetadata = cmd.getMetadata();
-      if (cacheEntry != null) {
-         if (useRepeatableRead) {
-            //sanity check. In repeatable read, we only deal with RepeatableReadEntry and ClusteredRepeatableReadEntry
-            if (cacheEntry instanceof RepeatableReadEntry) {
-               mvccEntry = (MVCCEntry) cacheEntry;
-            } else {
-               throw new IllegalStateException("Cache entry stored in context should be a RepeatableReadEntry instance " +
-                                                     "but it is " + cacheEntry.getClass().getCanonicalName());
-            }
-            //if the icEntry is not null, then this is a remote get. We need to update the value and the metadata.
-            if (!mvccEntry.isRemoved() && !mvccEntry.skipLookup() && icEntry != null) {
-               mvccEntry.setValue(icEntry.getValue());
-               updateVersion(mvccEntry, icEntry.getMetadata());
-            }
-            if (!mvccEntry.isRemoved() && mvccEntry.isNull()) {
-               //new entry
+      if (contextEntry instanceof MVCCEntry) {
+         // Nothing to do, already wrapped.
+         mvccEntry = assertRepeatableReadEntry(contextEntry);
+      } else if (contextEntry != null) {
+         // Already in the context as an InternalCacheEntry or DeltaAwareCacheEntry.
+         // Need to wrap it in a MVCCEntry.
+         mvccEntry = createWrappedEntry(key, contextEntry, ctx, skipRead);
+         ctx.putLookedUpEntry(key, mvccEntry);
+         if (trace)
+            log.tracef("Updated context entry %s", contextEntry);
+      } else {
+         // Not in the context yet.
+         InternalCacheEntry ice = getFromContainer(key, ignoreOwnership);
+         if (ice == null && wrap == Wrap.WRAP_NON_NULL) {
+            mvccEntry = null;
+         } else {
+            mvccEntry = createWrappedEntry(key, ice, ctx, skipRead);
+            // TODO This will also wrap entries not owned by the local node, maybe we can avoid it for non-tx
+            if (ice == null) {
                mvccEntry.setCreated(true);
             }
-            //always update the metadata if needed.
-            updateMetadata(mvccEntry, providedMetadata);
-
-         } else {
-            //skipRead == true because the key already exists in the context that means the key was previous accessed.
-            mvccEntry = wrapMvccEntryForPut(ctx, key, cacheEntry, providedMetadata, true);
+            ctx.putLookedUpEntry(key, mvccEntry);
+            if (trace)
+               log.tracef("Updated context entry %s", mvccEntry);
          }
-         mvccEntry.undelete(undeleteIfNeeded);
-      } else {
-         InternalCacheEntry ice = (icEntry == null ? getFromContainer(key, false) : icEntry);
-         // A putForExternalRead is putIfAbsent, so if key present, do nothing
-         if (ice != null && cmd.hasFlag(Flag.PUT_FOR_EXTERNAL_READ)) {
-            // make sure we record this! Null value since this is a forced lock on the key
-            ctx.putLookedUpEntry(key, null);
-            if (trace) {
-               log.tracef("Wrap %s for put. Entry=null", key);
-            }
-            return null;
-         }
-
-         mvccEntry = ice != null ?
-             wrapInternalCacheEntryForPut(ctx, key, ice, providedMetadata, skipRead) :
-             newMvccEntryForPut(ctx, key, cmd, providedMetadata, skipRead);
       }
-      mvccEntry.copyForUpdate(container);
-      if (trace) {
-         log.tracef("Wrap %s for put. Entry=%s", key, mvccEntry);
+      if (mvccEntry != null) {
+         mvccEntry.copyForUpdate();
       }
       return mvccEntry;
    }
-   
+
    @Override
-   public CacheEntry wrapEntryForDelta(InvocationContext ctx, Object deltaKey, Delta delta ) {
-      CacheEntry cacheEntry = getFromContext(ctx, deltaKey);
-      DeltaAwareCacheEntry deltaAwareEntry = null;
-      if (cacheEntry != null) {        
-         deltaAwareEntry = wrapEntryForDelta(ctx, deltaKey, cacheEntry);
-      } else {                     
-         InternalCacheEntry ice = getFromContainer(deltaKey, false);
-         if (ice != null){
-            deltaAwareEntry = newDeltaAwareCacheEntry(ctx, deltaKey, (DeltaAware)ice.getValue());
+   public boolean wrapExternalEntry(InvocationContext ctx, Object key, CacheEntry externalEntry, Wrap wrap,
+                                    boolean skipRead) {
+      // For a write operation, the entry is always already wrapped. For a read operation, the entry may be
+      // in the context as an InternalCacheEntry, as null, or missing altogether.
+      CacheEntry contextEntry = getFromContext(ctx, key);
+      if (contextEntry instanceof MVCCEntry) {
+         // Already wrapped for a write. Update the value and the metadata.
+         if (!contextEntry.isNull() || contextEntry.skipLookup()) {
+            // This can happen during getGroup() invocations, which request the whole group from remote nodes
+            // even if some keys are already in the context.
+            if (trace)
+               log.tracef("Ignored update for context entry %s", contextEntry);
+            return false;
          }
+         contextEntry.setValue(externalEntry.getValue());
+         contextEntry.setMetadata(externalEntry.getMetadata());
+         if (trace)
+            log.tracef("Updated context entry %s", contextEntry);
+         return true;
+      } else if (contextEntry instanceof DeltaAwareCacheEntry) {
+         // Already wrapped for an ApplyDeltaCommand. Update the value.
+         if (contextEntry.getValue() != null) {
+            if (trace)
+               log.tracef("Ignored update for context entry %s", contextEntry);
+            return false;
+         }
+         contextEntry.setValue(externalEntry.getValue());
+         contextEntry.setMetadata(externalEntry.getMetadata());
+         if (trace)
+            log.tracef("Updated context entry %s", contextEntry);
+         return true;
+      } else if (contextEntry == null || contextEntry.isNull()) {
+         // Not in the context yet (or NullCacheEntry in context).
+         // This shouldn't be necessary: with repeatable read, we never reach this branch, because we already have an MVCCEntry.
+         if (useRepeatableRead) {
+            wrap = Wrap.WRAP_ALL;
+         }
+         if (externalEntry == null && wrap != Wrap.WRAP_ALL) {
+            // TODO We only need the wrap != WRAP_ALL check for getAll, we should remove it
+            if (trace)
+               log.tracef("Skipping update with null value for key %s", key);
+            return false;
+         }
+         if (wrap == Wrap.STORE) {
+            // This is a read operation, store the external entry in the context directly.
+            ctx.putLookedUpEntry(key, externalEntry);
+         } else {
+            // This is a write (or getAll) operation, wrap it.
+            MVCCEntry mvccEntry = createWrappedEntry(key, externalEntry, ctx, skipRead);
+            ctx.putLookedUpEntry(key, mvccEntry);
+         }
+         if (trace)
+            log.tracef("Updated context entry %s", externalEntry);
+         return true;
+      } else {
+         // Already in the context as an InternalCacheEntry
+         if (trace)
+            log.tracef("Skipping update with null value for key %s", key);
+         return false;
       }
-      if (deltaAwareEntry != null)
-         deltaAwareEntry.appendDelta(delta);
-      if (trace) {
-         log.tracef("Wrap %s for delta. Entry=%s", deltaKey, deltaAwareEntry);
+   }
+
+   @Override
+   public CacheEntry wrapEntryForDelta(InvocationContext ctx, Object deltaKey, Delta delta) {
+      CacheEntry cacheEntry = getFromContext(ctx, deltaKey);
+      DeltaAwareCacheEntry deltaAwareEntry;
+      if (cacheEntry instanceof DeltaAwareCacheEntry) {
+         // Already delta-aware, nothing to do.
+         deltaAwareEntry = (DeltaAwareCacheEntry) cacheEntry;
+      } else if (cacheEntry != null) {
+         // Wrap the existing context entry inside a DeltaAwareCacheEntry
+         deltaAwareEntry = createWrappedDeltaEntry(deltaKey, (DeltaAware) cacheEntry.getValue(), cacheEntry);
+         ctx.putLookedUpEntry(deltaKey, deltaAwareEntry);
+      } else {
+         // Read the value from the container and wrap it
+         InternalCacheEntry ice = getFromContainer(deltaKey, false);
+         DeltaAwareCacheEntry deltaEntry =
+               createWrappedDeltaEntry(deltaKey, ice != null ? (DeltaAware) ice.getValue() : null, null);
+
+         ctx.putLookedUpEntry(deltaKey, deltaEntry);
+         deltaAwareEntry = deltaEntry;
       }
+      if (trace) log.tracef("Wrap %s for delta. Entry=%s", deltaKey, deltaAwareEntry);
       return deltaAwareEntry;
    }
-   
-   private DeltaAwareCacheEntry wrapEntryForDelta(InvocationContext ctx, Object key, CacheEntry cacheEntry) {
-      if (cacheEntry instanceof DeltaAwareCacheEntry) return (DeltaAwareCacheEntry) cacheEntry;
-      return wrapInternalCacheEntryForDelta(ctx, key, cacheEntry);
-   }
-   
-   private DeltaAwareCacheEntry wrapInternalCacheEntryForDelta(InvocationContext ctx, Object key, CacheEntry cacheEntry) {
-      DeltaAwareCacheEntry e;
-      if(cacheEntry instanceof MVCCEntry){
-         e = createWrappedDeltaEntry(key, (DeltaAware) cacheEntry.getValue(), cacheEntry);
-      }
-      else if (cacheEntry instanceof InternalCacheEntry) {
-         cacheEntry = wrapInternalCacheEntryForPut(ctx, key, (InternalCacheEntry) cacheEntry, null, false);
-         e = createWrappedDeltaEntry(key, (DeltaAware) cacheEntry.getValue(), cacheEntry);
-      }
-      else {
-         e = createWrappedDeltaEntry(key, (DeltaAware) cacheEntry.getValue(), null);
-      }
-      ctx.putLookedUpEntry(key, e);
-      return e;
 
+   private MVCCEntry assertRepeatableReadEntry(CacheEntry cacheEntry) {
+      // Sanity check. In repeatable read, we only use RepeatableReadEntry and ClusteredRepeatableReadEntry
+      if (useRepeatableRead && !(cacheEntry instanceof RepeatableReadEntry)) {
+         throw new IllegalStateException(
+               "Cache entry stored in context should be a RepeatableReadEntry instance " +
+                     "but it is " + cacheEntry.getClass().getCanonicalName());
+      }
+      return (MVCCEntry) cacheEntry;
    }
 
    private CacheEntry getFromContext(InvocationContext ctx, Object key) {
@@ -260,11 +247,13 @@ public class EntryFactoryImpl implements EntryFactory {
       return cacheEntry;
    }
 
-   private InternalCacheEntry getFromContainer(Object key, boolean forceFetch) {
+   private InternalCacheEntry getFromContainer(Object key, boolean ignoreOwnership) {
       final boolean isLocal = distributionManager == null || distributionManager.getLocality(key).isLocal();
-      if (isLocal || forceFetch) {
+      if (isLocal || ignoreOwnership) {
          final InternalCacheEntry ice = container.get(key);
-         if (trace) log.tracef("Retrieved from container %s (forceFetch=%s, isLocal=%s)", ice, forceFetch, isLocal);
+         if (trace)
+            log.tracef("Retrieved from container %s (ignoreOwnership=%s, isLocal=%s)", ice, ignoreOwnership,
+                       isLocal);
          return ice;
       } else if (isL1Enabled) {
          final InternalCacheEntry ice = container.get(key);
@@ -276,91 +265,28 @@ public class EntryFactoryImpl implements EntryFactory {
       return null;
    }
 
-   private MVCCEntry newMvccEntryForPut(
-         InvocationContext ctx, Object key, FlagAffectedCommand cmd, Metadata providedMetadata, boolean skipRead) {
-      MVCCEntry mvccEntry;
-      if (trace) log.trace("Creating new entry.");
-      Object newValue;
-      if (cmd instanceof PutKeyValueCommand) {
-         newValue = ((PutKeyValueCommand)cmd).getValue();
-      } else if (cmd instanceof PutMapCommand) {
-         newValue = ((PutMapCommand)cmd).getMap().get(key);
-      } else {
-         newValue = null;
-      }
-
-      notifier.notifyCacheEntryCreated(key, newValue, providedMetadata, true, ctx, cmd);
-      mvccEntry = createWrappedEntry(key, null, ctx, providedMetadata, true, false, skipRead);
-      mvccEntry.setCreated(true);
-      ctx.putLookedUpEntry(key, mvccEntry);
-      return mvccEntry;
-   }
-
-   private MVCCEntry wrapMvccEntryForPut(InvocationContext ctx, Object key, CacheEntry cacheEntry, Metadata providedMetadata, boolean skipRead) {
-      if (cacheEntry instanceof MVCCEntry) {
-         MVCCEntry mvccEntry = (MVCCEntry) cacheEntry;
-         updateMetadata(mvccEntry, providedMetadata);
-         return mvccEntry;
-      }
-      return wrapInternalCacheEntryForPut(ctx, key, (InternalCacheEntry) cacheEntry, providedMetadata, skipRead);
-   }
-
-   private MVCCEntry wrapInternalCacheEntryForPut(InvocationContext ctx, Object key, InternalCacheEntry cacheEntry, Metadata providedMetadata, boolean skipRead) {
-      MVCCEntry mvccEntry = createWrappedEntry(key, cacheEntry, ctx, providedMetadata, true, false, skipRead);
-      ctx.putLookedUpEntry(key, mvccEntry);
-      return mvccEntry;
-   }
-
-   private MVCCEntry wrapMvccEntryForRemove(InvocationContext ctx, Object key, CacheEntry cacheEntry, boolean skipRead) {
-      MVCCEntry mvccEntry = createWrappedEntry(key, cacheEntry, ctx, null, false, true, skipRead);
-      // If the original entry has changeable state, copy state flags to the new MVCC entry.
-      if (cacheEntry instanceof StateChangingEntry)
-         mvccEntry.copyStateFlagsFrom((StateChangingEntry) cacheEntry);
-
-      ctx.putLookedUpEntry(key, mvccEntry);
-      return mvccEntry;
-   }
-
-   private MVCCEntry wrapEntry(InvocationContext ctx, Object key, Metadata providedMetadata, boolean skipRead) {
-      CacheEntry cacheEntry = getFromContext(ctx, key);
-      MVCCEntry mvccEntry = null;
-      if (cacheEntry != null) {
-         //already wrapped. set skip read to true to avoid replace the current version.
-         mvccEntry = wrapMvccEntryForPut(ctx, key, cacheEntry, providedMetadata, true);
-      } else {
-         InternalCacheEntry ice = getFromContainer(key, false);
-         if (ice != null || clusterModeWriteSkewCheck) {
-            mvccEntry = wrapInternalCacheEntryForPut(ctx, key, ice, providedMetadata, skipRead);
-         }
-      }
-      if (mvccEntry != null)
-         mvccEntry.copyForUpdate(container);
-      return mvccEntry;
-   }
-
    protected MVCCEntry createWrappedEntry(Object key, CacheEntry cacheEntry, InvocationContext context,
-                                          Metadata providedMetadata, boolean isForInsert, boolean forRemoval, boolean skipRead) {
-      Object value = cacheEntry != null ? cacheEntry.getValue() : null;
-      Metadata metadata = providedMetadata != null
-            ? providedMetadata
-            : cacheEntry != null ? cacheEntry.getMetadata() : null;
+                                          boolean skipRead) {
+      Object value = null;
+      Metadata metadata = null;
+      if (cacheEntry != null) {
+         value = cacheEntry.getValue();
+         metadata = cacheEntry.getMetadata();
+      }
 
-      if (value == null && !isForInsert && !useRepeatableRead)
-         return null;
+      if (trace) log.tracef("Creating new entry for key %s", key);
+      MVCCEntry mvccEntry = useRepeatableRead ? new RepeatableReadEntry(key, value, metadata) :
+            new ReadCommittedEntry(key, value, metadata);
 
-      return useRepeatableRead
-            ? new RepeatableReadEntry(key, value, metadata)
-            : new ReadCommittedEntry(key, value, metadata);
+      // If the original entry has changeable state, copy state flags to the new MVCC entry.
+      if (cacheEntry instanceof StateChangingEntry) {
+         mvccEntry.copyStateFlagsFrom((StateChangingEntry) cacheEntry);
+      }
+      return mvccEntry;
    }
-   
-   private DeltaAwareCacheEntry newDeltaAwareCacheEntry(InvocationContext ctx, Object key, DeltaAware deltaAware){
-      DeltaAwareCacheEntry deltaEntry = createWrappedDeltaEntry(key, deltaAware, null);
-      ctx.putLookedUpEntry(key, deltaEntry);
-      return deltaEntry;
-   }
-   
+
    private DeltaAwareCacheEntry createWrappedDeltaEntry(Object key, DeltaAware deltaAware, CacheEntry entry) {
-      DeltaAwareCacheEntry deltaAwareCacheEntry = new DeltaAwareCacheEntry(key,deltaAware, entry);
+      DeltaAwareCacheEntry deltaAwareCacheEntry = new DeltaAwareCacheEntry(key, deltaAware, entry);
       // Set the delta aware entry to created so it ignores the previous value and only merges new deltas when it is
       // committed
       if (entry != null && entry.isCreated()) {
@@ -368,29 +294,4 @@ public class EntryFactoryImpl implements EntryFactory {
       }
       return deltaAwareCacheEntry;
    }
-
-   private void updateMetadata(MVCCEntry entry, Metadata providedMetadata) {
-      if (trace) {
-         log.tracef("Update metadata for %s. Provided metadata is %s", entry, providedMetadata);
-      }
-      if (providedMetadata == null || entry == null || entry.getMetadata() != null) {
-         return;
-      }
-      entry.setMetadata(providedMetadata);
-   }
-
-   private void updateVersion(MVCCEntry entry, Metadata providedMetadata) {
-      if (trace) {
-         log.tracef("Update metadata for %s. Provided metadata is %s", entry, providedMetadata);
-      }
-      if (providedMetadata == null || entry == null) {
-         return;
-      } else if (entry.getMetadata() == null) {
-         entry.setMetadata(providedMetadata);
-         return;
-      }
-
-      entry.setMetadata(Metadatas.applyVersion(entry.getMetadata(), providedMetadata));
-   }
-
 }

--- a/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
@@ -49,8 +49,9 @@ public interface CacheEntry<K, V> extends Cloneable, Map.Entry<K, V>, MetadataAw
    boolean isValid();
 
    /**
-    * @return true if the entry was loaded from a cache store.
+    * @deprecated Always returns false.
     */
+   @Deprecated
    boolean isLoaded();
 
    /**
@@ -115,6 +116,10 @@ public interface CacheEntry<K, V> extends Cloneable, Map.Entry<K, V>, MetadataAw
 
    void setValid(boolean valid);
 
+   /**
+    * @deprecated Does nothing.
+    */
+   @Deprecated
    void setLoaded(boolean loaded);
 
    /**
@@ -127,6 +132,7 @@ public interface CacheEntry<K, V> extends Cloneable, Map.Entry<K, V>, MetadataAw
     * If the entry is marked as removed and doUndelete==true then the "valid" flag is set to true and "removed"
     * flag is set to false.
     */
+   @Deprecated
    boolean undelete(boolean doUndelete);
 
    public CacheEntry<K, V> clone();

--- a/core/src/main/java/org/infinispan/container/entries/MVCCEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/MVCCEntry.java
@@ -9,13 +9,18 @@ import org.infinispan.container.DataContainer;
  * @since 4.0
  */
 public interface MVCCEntry<K, V> extends CacheEntry<K, V>, StateChangingEntry {
+   /**
+    * @deprecated Since 8.0, use {@link #copyForUpdate()} instead.
+    */
+   @Deprecated
+   default void copyForUpdate(DataContainer<? super K, ? super V> container) {
+      copyForUpdate();
+   }
 
    /**
     * Makes internal copies of the entry for updates
-    *
-    * @param container      data container
     */
-   void copyForUpdate(DataContainer<? super K, ? super V> container);
+   void copyForUpdate();
 
    void setChanged(boolean isChanged);
 

--- a/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/ReadCommittedEntry.java
@@ -49,7 +49,7 @@ public class ReadCommittedEntry implements MVCCEntry {
    // more space-efficient.  Note that this value will be stored in a byte, which means up to 8 flags can be stored in
    // a single byte.  Always start shifting with 0, the last shift cannot be greater than 7.
    protected enum Flags {
-      CHANGED(1), // same as 1 << 0
+      CHANGED(1 << 0),
       CREATED(1 << 1),
       REMOVED(1 << 2),
       VALID(1 << 3),
@@ -127,7 +127,7 @@ public class ReadCommittedEntry implements MVCCEntry {
    }
 
    @Override
-   public void copyForUpdate(DataContainer container) {
+   public void copyForUpdate() {
       if (isFlagSet(COPIED)) return; // already copied
 
       setFlag(COPIED); //mark as copied
@@ -141,10 +141,10 @@ public class ReadCommittedEntry implements MVCCEntry {
       // TODO: No tombstones for now!!  I'll only need them for an eventually consistent cache
 
       // only do stuff if there are changes.
-      if (isChanged() || isLoaded()) {
+      if (isChanged()) {
          if (trace)
-            log.tracef("Updating entry (key=%s removed=%s valid=%s changed=%s created=%s loaded=%s value=%s metadata=%s, providedMetadata=%s)",
-                  toStr(getKey()), isRemoved(), isValid(), isChanged(), isCreated(), isLoaded(), toStr(value), getMetadata(), providedMetadata);
+            log.tracef("Updating entry (key=%s removed=%s valid=%s changed=%s created=%s value=%s metadata=%s, providedMetadata=%s)",
+                  toStr(getKey()), isRemoved(), isValid(), isChanged(), isCreated(), toStr(value), getMetadata(), providedMetadata);
 
          // Ugh!
          if (value instanceof AtomicHashMap) {
@@ -279,11 +279,13 @@ public class ReadCommittedEntry implements MVCCEntry {
    }
 
    @Override
+   @Deprecated
    public boolean isLoaded() {
       return false;
    }
 
    @Override
+   @Deprecated
    public void setLoaded(boolean loaded) {
    }
 

--- a/core/src/main/java/org/infinispan/container/entries/RepeatableReadEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/RepeatableReadEntry.java
@@ -23,7 +23,7 @@ public class RepeatableReadEntry extends ReadCommittedEntry {
    }
 
    @Override
-   public void copyForUpdate(DataContainer container) {
+   public void copyForUpdate() {
       if (isFlagSet(COPIED)) return; // already copied
 
       setFlag(COPIED); //mark as copied

--- a/core/src/main/java/org/infinispan/context/InvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/InvocationContext.java
@@ -2,6 +2,8 @@ package org.infinispan.context;
 
 import java.util.Set;
 
+import org.infinispan.container.EntryFactory;
+import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.remoting.transport.Address;
 
@@ -21,8 +23,7 @@ public interface InvocationContext extends EntryLookup, Cloneable {
    boolean isOriginLocal();
    
    /**
-    * Get the origin of the command, or null if the command originated locally
-    * @return
+    * @return the origin of the command, or null if the command originated locally
     */
    Address getOrigin();
 
@@ -65,8 +66,6 @@ public interface InvocationContext extends EntryLookup, Cloneable {
 
    /**
     * Sets the class loader associated for this invocation
-    *
-    * @param classLoader
     */
    void setClassLoader(ClassLoader classLoader);
 
@@ -83,11 +82,12 @@ public interface InvocationContext extends EntryLookup, Cloneable {
    boolean hasLockedKey(Object key);
 
    /**
-    * Tries to replace the value of the wrapped entry associated with the given key in the context, if one exists.
-    *
-    * @return true if the context already contained a wrapped entry for which this value was changed, false otherwise.
+    * @deprecated Since 8.1, use {@link EntryFactory#wrapExternalEntry(InvocationContext, Object, CacheEntry, EntryFactory.Wrap, boolean)} instead.
     */
-   boolean replaceValue(Object key, InternalCacheEntry cacheEntry);
+   @Deprecated
+   default boolean replaceValue(Object key, InternalCacheEntry cacheEntry) {
+      return false;
+   }
 
    boolean isEntryRemovedInContext(Object key);
 }

--- a/core/src/main/java/org/infinispan/context/SingleKeyNonTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/SingleKeyNonTxInvocationContext.java
@@ -3,7 +3,6 @@ package org.infinispan.context;
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.util.InfinispanCollections;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.remoting.transport.Address;
 
 import java.util.Collections;
@@ -148,20 +147,6 @@ public final class SingleKeyNonTxInvocationContext implements InvocationContext 
    @Override
    public boolean hasLockedKey(final Object key) {
       return isLocked && keyEquivalence.equals(this.key, key);
-   }
-
-   @Override
-   public boolean replaceValue(final Object key, final InternalCacheEntry cacheEntry) {
-      CacheEntry ce = lookupEntry(key);
-      if (ce == null || ce.isNull() || ce.getValue() == null) {
-         if (ce != null) {
-            ce.setValue(cacheEntry.getValue());
-            ce.setMetadata(cacheEntry.getMetadata());
-         } else {
-            return false;
-         }
-      }
-      return true;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/context/impl/AbstractInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/AbstractInvocationContext.java
@@ -56,27 +56,15 @@ public abstract class AbstractInvocationContext implements InvocationContext {
    }
 
    @Override
-   public boolean replaceValue(final Object key, final InternalCacheEntry cacheEntry) {
-      CacheEntry ce = lookupEntry(key);
-      if (ce == null || ce.isNull() || ce.getValue() == null) {
-         if (ce != null) {
-            ce.setValue(cacheEntry.getValue());
-            ce.setMetadata(cacheEntry.getMetadata());
-            onEntryValueReplaced(key, cacheEntry);
-         } else {
-            return false;
-         }
-      }
-      return true;
-   }
-
-   @Override
    public boolean isEntryRemovedInContext(final Object key) {
       CacheEntry ce = lookupEntry(key);
       return ce != null && ce.isRemoved() && ce.isChanged();
    }
 
+   /**
+    * @deprecated Since 8.1, no longer used.
+    */
+   @Deprecated
    protected void onEntryValueReplaced(final Object key, final InternalCacheEntry cacheEntry) {
-      //no-op. used in tx mode with write skew check.
    }
 }

--- a/core/src/main/java/org/infinispan/context/impl/AbstractTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/AbstractTxInvocationContext.java
@@ -2,7 +2,6 @@ package org.infinispan.context.impl;
 
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.transaction.impl.AbstractCacheTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
@@ -115,12 +114,6 @@ public abstract class AbstractTxInvocationContext<T extends AbstractCacheTransac
    @Override
    public final void clearLockedKeys() {
       cacheTransaction.clearLockedKeys();
-   }
-
-   @Override
-   protected final void onEntryValueReplaced(Object key, InternalCacheEntry cacheEntry) {
-      //the value to be returned was read from remote node. We need to update the version seen.
-      cacheTransaction.replaceVersionRead(key, cacheEntry.getMetadata().version());
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/context/impl/ClearInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/ClearInvocationContext.java
@@ -2,7 +2,6 @@ package org.infinispan.context.impl;
 
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.ClearCacheEntry;
-import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.remoting.transport.Address;
 
 import java.util.Collections;
@@ -63,11 +62,6 @@ public class ClearInvocationContext extends AbstractInvocationContext implements
    public boolean hasLockedKey(Object key) {
       //ClearCommand does not acquire locks
       return false;
-   }
-
-   @Override
-   public boolean replaceValue(Object key, InternalCacheEntry cacheEntry) {
-      return true;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/context/impl/ImmutableContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/ImmutableContext.java
@@ -3,7 +3,6 @@ package org.infinispan.context.impl;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.util.InfinispanCollections;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.remoting.transport.Address;
 
@@ -108,11 +107,6 @@ public final class ImmutableContext implements InvocationContext {
 
    @Override
    public void clearLockedKeys() {
-      throw newUnsupportedMethod();
-   }
-
-   @Override
-   public boolean replaceValue(Object key, InternalCacheEntry cacheEntry) {
       throw newUnsupportedMethod();
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
@@ -21,6 +21,7 @@ import org.infinispan.commands.write.DataWriteCommand;
 import org.infinispan.commands.write.ValueMatcher;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.CacheException;
+import org.infinispan.container.EntryFactory;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.InternalCacheValue;
@@ -114,7 +115,7 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
             //noinspection unchecked
             List<CacheEntry> cacheEntries = (List<CacheEntry>) ((SuccessfulResponse) response).getResponseValue();
             for (CacheEntry entry : cacheEntries) {
-               entryFactory.wrapEntryForReading(ctx, entry.getKey(), entry);
+               entryFactory.wrapExternalEntry(ctx, entry.getKey(), entry, EntryFactory.Wrap.STORE, false);
             }
          }
       }
@@ -459,7 +460,7 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
                            toStr(key), rpcManager.getAddress(), ch.locateOwners(key));
                   }
                   // Force a map entry to be created, because we know this entry is local
-                  entryFactory.wrapEntryForPut(ctx, key, null, false, command, false);
+                  entryFactory.wrapExternalEntry(ctx, key, null, EntryFactory.Wrap.WRAP_ALL, false);
                }
             }
          }
@@ -482,7 +483,9 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
                if (!justRetrieved.containsKey(key)) {
                   missingRemoteValues = true;
                } else {
-                  entryFactory.wrapEntryForPut(ctx, key, justRetrieved.get(key), false, command, false);
+                  InternalCacheEntry remoteEntry = justRetrieved.get(key);
+                  entryFactory.wrapExternalEntry(ctx, key, remoteEntry, EntryFactory.Wrap.WRAP_NON_NULL,
+                                                 false);
                }
             }
          }
@@ -507,7 +510,7 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
                            toStr(key), rpcManager.getAddress(), ch.locateOwners(key));
                   }
                   // Force a map entry to be created, because we know this entry is local
-                  entryFactory.wrapEntryForPut(ctx, key, null, false, command, false);
+                  entryFactory.wrapExternalEntry(ctx, key, null, EntryFactory.Wrap.WRAP_ALL, false);
                }
             }
          }
@@ -520,8 +523,7 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
    public Object visitReadOnlyManyCommand(InvocationContext ctx, ReadOnlyManyCommand command) throws Throwable {
       // TODO: Can we reimplement GetAll in terms of ReadOnlyManyCommand?
       if (command.hasFlag(Flag.CACHE_MODE_LOCAL)
-         || command.hasFlag(Flag.SKIP_REMOTE_LOOKUP)
-         || command.hasFlag(Flag.IGNORE_RETURN_VALUES)) {
+         || command.hasFlag(Flag.SKIP_REMOTE_LOOKUP)) {
          return invokeNextInterceptor(ctx, command);
       }
 
@@ -553,7 +555,7 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
                         toStr(key), rpcManager.getAddress(), ch.locateOwners(key));
                   }
                   // Force a map entry to be created, because we know this entry is local
-                  entryFactory.wrapEntryForPut(ctx, key, null, false, command, false);
+                  entryFactory.wrapExternalEntry(ctx, key, null, EntryFactory.Wrap.WRAP_ALL, false);
                }
             }
          }
@@ -576,7 +578,9 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
                if (!justRetrieved.containsKey(key)) {
                   missingRemoteValues = true;
                } else {
-                  entryFactory.wrapEntryForPut(ctx, key, justRetrieved.get(key), false, command, false);
+                  InternalCacheEntry remoteEntry = justRetrieved.get(key);
+                  entryFactory.wrapExternalEntry(ctx, key, remoteEntry, EntryFactory.Wrap.WRAP_NON_NULL,
+                                                 false);
                }
             }
          }
@@ -601,21 +605,11 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
                         toStr(key), rpcManager.getAddress(), ch.locateOwners(key));
                   }
                   // Force a map entry to be created, because we know this entry is local
-                  entryFactory.wrapEntryForPut(ctx, key, null, false, command, false);
+                  entryFactory.wrapExternalEntry(ctx, key, null, EntryFactory.Wrap.WRAP_ALL, false);
                }
             }
          }
          return invokeNextInterceptor(ctx, command);
-      }
-   }
-
-   protected void wrapInternalCacheEntry(InternalCacheEntry ice, InvocationContext ctx, Object key,
-                                         boolean isWrite, FlagAffectedCommand command) {
-      if (!ctx.replaceValue(key, ice))  {
-         if (isWrite)
-            entryFactory.wrapEntryForPut(ctx, key, ice, false, command, true);
-         else
-            ctx.putLookedUpEntry(key, ice);
       }
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
@@ -254,7 +254,7 @@ public class L1NonTxInterceptor extends BaseRpcInterceptor {
          // may not have the value - if so we need to add it then now that we know we waited for the get response
          // to complete
          if (ctx.lookupEntry(key) == null) {
-            entryFactory.wrapEntryForRemove(ctx, key, true, true, false);
+            entryFactory.wrapEntryForWriting(ctx, key, EntryFactory.Wrap.WRAP_NON_NULL, true, true);
          }
       }
       return super.visitInvalidateL1Command(ctx, invalidateL1Command);
@@ -317,7 +317,7 @@ public class L1NonTxInterceptor extends BaseRpcInterceptor {
       }
       abortL1UpdateOrWait(key);
       ctx.removeLookedUpEntry(key);
-      entryFactory.wrapEntryForRemove(ctx, key, true, true, false);
+      entryFactory.wrapEntryForWriting(ctx, key, EntryFactory.Wrap.WRAP_NON_NULL, true, true);
 
       InvalidateCommand command = commandsFactory.buildInvalidateFromL1Command(null, Collections.singleton(key));
       invokeNextInterceptor(ctx, command);

--- a/core/src/main/java/org/infinispan/metadata/Metadatas.java
+++ b/core/src/main/java/org/infinispan/metadata/Metadatas.java
@@ -1,5 +1,7 @@
 package org.infinispan.metadata;
 
+import org.infinispan.container.entries.CacheEntry;
+
 /**
  * Utility method for Metadata classes.
  *
@@ -31,4 +33,20 @@ public class Metadatas {
       return target;
    }
 
+   /**
+    * Set the {@code providedMetadata} on the cache entry.
+    *
+    * If the entry already has a version, copy the version in the new metadata.
+    */
+   public static void updateMetadata(CacheEntry entry, Metadata providedMetadata) {
+      if (entry != null && providedMetadata != null) {
+         Metadata mergedMetadata;
+         if (entry.getMetadata() == null) {
+            mergedMetadata = providedMetadata;
+         } else {
+            mergedMetadata = applyVersion(entry.getMetadata(), providedMetadata);
+         }
+         entry.setMetadata(mergedMetadata);
+      }
+   }
 }

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationPrimaryOwnerFailTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationPrimaryOwnerFailTest.java
@@ -78,9 +78,8 @@ public class ConditionalOperationPrimaryOwnerFailTest extends MultipleCacheManag
             assertFalse("Entry should not be wrapped!", context.isOriginLocal());
             return invocation.callRealMethod();
          }
-      }).when(spyEntryFactory).wrapEntryForPut(any(InvocationContext.class), anyObject(),
-                                               any(InternalCacheEntry.class), anyBoolean(),
-                                               any(FlagAffectedCommand.class), anyBoolean());
+      }).when(spyEntryFactory).wrapEntryForWriting(any(InvocationContext.class), anyObject(),
+                                                   any(EntryFactory.Wrap.class), anyBoolean(), anyBoolean());
 
       Future<?> killMemberResult = fork(new Runnable() {
          @Override

--- a/core/src/test/java/org/infinispan/notifications/CacheListenerCacheLoaderTest.java
+++ b/core/src/test/java/org/infinispan/notifications/CacheListenerCacheLoaderTest.java
@@ -33,7 +33,7 @@ public class CacheListenerCacheLoaderTest extends AbstractInfinispanTest {
          .storeName("no_passivation");
       cm.defineConfiguration("no_passivation", c.build());
 
-      new ConfigurationBuilder();
+      c = new ConfigurationBuilder();
       c.persistence().passivation(true).addStore(DummyInMemoryStoreConfigurationBuilder.class)
          .storeName("passivation");
       cm.defineConfiguration("passivation", c.build());

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
-import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.*;
 
 import java.util.Collections;


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5699

 * Unify the wrapping for write commands in a single method,
   EntryFactory.wrapEntryForWriting
 * Add a separate method to update the value from loaders
   or remote nodes, EntryFactory.wrapExternalEntry
 * Remove entry creation notification from EntryFactoryImpl
 * Remove provided metadata handling from EntryFactoryImpl
 * Deprecate CacheEntry.isLoaded
 * Deprecate EntryFactory.wrapEntryForClear
 * Deprecate InvocationContext.replaceValue
 * Always wrap for putForExternalRead, not just when the
   entry does not exist in the data container