### PR TITLE
ISPN-5520 Hot Rod client XSite failover support

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/AbstractConfigurationChildBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/AbstractConfigurationChildBuilder.java
@@ -27,6 +27,11 @@ public abstract class AbstractConfigurationChildBuilder implements Configuration
    }
 
    @Override
+   public ClusterConfigurationBuilder addCluster(String clusterName) {
+      return builder.addCluster(clusterName);
+   }
+
+   @Override
    public ConfigurationBuilder addServers(String servers) {
       return builder.addServers(servers);
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ClusterConfiguration.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ClusterConfiguration.java
@@ -1,0 +1,24 @@
+package org.infinispan.client.hotrod.configuration;
+
+import java.util.List;
+
+/**
+ * @since 8.1
+ */
+public class ClusterConfiguration {
+   private final List<ServerConfiguration> serverCluster;
+   private final String clusterName;
+
+   public ClusterConfiguration(List<ServerConfiguration> serverCluster, String clusterName) {
+      this.serverCluster = serverCluster;
+      this.clusterName = clusterName;
+   }
+
+   public List<ServerConfiguration> getCluster() {
+      return serverCluster;
+   }
+
+   public String getClusterName() {
+      return clusterName;
+   }
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ClusterConfigurationBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ClusterConfigurationBuilder.java
@@ -1,0 +1,45 @@
+package org.infinispan.client.hotrod.configuration;
+
+import org.infinispan.commons.configuration.Builder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @since 8.1
+ */
+public class ClusterConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<ClusterConfiguration> {
+
+   private final List<ServerConfigurationBuilder> servers = new ArrayList<ServerConfigurationBuilder>();
+   private final String clusterName;
+
+   protected ClusterConfigurationBuilder(ConfigurationBuilder builder, String clusterName) {
+      super(builder);
+      this.clusterName = clusterName;
+   }
+
+   public ClusterConfigurationBuilder addClusterNode(String host, int port) {
+      ServerConfigurationBuilder serverBuilder = new ServerConfigurationBuilder(builder);
+      servers.add(serverBuilder.host(host).port(port));
+      return this;
+   }
+
+   @Override
+   public void validate() {
+   }
+
+   @Override
+   public ClusterConfiguration create() {
+      List<ServerConfiguration> serverCluster = servers.stream()
+         .map(ServerConfigurationBuilder::create).collect(Collectors.toList());
+      return new ClusterConfiguration(serverCluster, clusterName);
+   }
+
+   @Override
+   public Builder<?> read(ClusterConfiguration template) {
+      template.getCluster().stream()
+         .forEach(server -> this.addClusterNode(server.host(), server.port()));
+      return this;
+   }
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
@@ -43,11 +43,13 @@ public class Configuration {
    private final int valueSizeEstimate;
    private final int maxRetries;
    private final NearCacheConfiguration nearCache;
+   private final List<ClusterConfiguration> clusters;
 
    Configuration(ExecutorFactoryConfiguration asyncExecutorFactory, Class<? extends RequestBalancingStrategy> balancingStrategyClass, FailoverRequestBalancingStrategy balancingStrategy, ClassLoader classLoader,
          ConnectionPoolConfiguration connectionPool, int connectionTimeout, Class<? extends ConsistentHash>[] consistentHashImpl, boolean forceReturnValues, int keySizeEstimate, Class<? extends Marshaller> marshallerClass,
          boolean pingOnStartup, String protocolVersion, List<ServerConfiguration> servers, int socketTimeout, SecurityConfiguration security, boolean tcpNoDelay, boolean tcpKeepAlive,
-         Class<? extends TransportFactory> transportFactory, int valueSizeEstimate, int maxRetries, NearCacheConfiguration nearCache) {
+         Class<? extends TransportFactory> transportFactory, int valueSizeEstimate, int maxRetries, NearCacheConfiguration nearCache,
+         List<ClusterConfiguration> clusters) {
       this.asyncExecutorFactory = asyncExecutorFactory;
       this.balancingStrategyClass = balancingStrategyClass;
       this.balancingStrategy = balancingStrategy;
@@ -70,12 +72,14 @@ public class Configuration {
       this.transportFactory = transportFactory;
       this.valueSizeEstimate = valueSizeEstimate;
       this.nearCache = nearCache;
+      this.clusters = clusters;
    }
 
    Configuration(ExecutorFactoryConfiguration asyncExecutorFactory, Class<? extends RequestBalancingStrategy> balancingStrategyClass, FailoverRequestBalancingStrategy balancingStrategy, ClassLoader classLoader,
          ConnectionPoolConfiguration connectionPool, int connectionTimeout, Class<? extends ConsistentHash>[] consistentHashImpl, boolean forceReturnValues, int keySizeEstimate, Marshaller marshaller,
          boolean pingOnStartup, String protocolVersion, List<ServerConfiguration> servers, int socketTimeout, SecurityConfiguration security, boolean tcpNoDelay, boolean tcpKeepAlive,
-         Class<? extends TransportFactory> transportFactory, int valueSizeEstimate, int maxRetries, NearCacheConfiguration nearCache) {
+         Class<? extends TransportFactory> transportFactory, int valueSizeEstimate, int maxRetries, NearCacheConfiguration nearCache,
+         List<ClusterConfiguration> clusters) {
       this.asyncExecutorFactory = asyncExecutorFactory;
       this.balancingStrategyClass = balancingStrategyClass;
       this.balancingStrategy = balancingStrategy;
@@ -98,6 +102,7 @@ public class Configuration {
       this.transportFactory = transportFactory;
       this.valueSizeEstimate = valueSizeEstimate;
       this.nearCache = nearCache;
+      this.clusters = clusters;
    }
 
    public ExecutorFactoryConfiguration asyncExecutorFactory() {
@@ -162,6 +167,10 @@ public class Configuration {
 
    public List<ServerConfiguration> servers() {
       return servers;
+   }
+
+   public List<ClusterConfiguration> clusters() {
+      return clusters;
    }
 
    public int socketTimeout() {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationChildBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationChildBuilder.java
@@ -24,6 +24,11 @@ public interface ConfigurationChildBuilder {
    ServerConfigurationBuilder addServer();
 
    /**
+    * Adds a new remote server cluster
+    */
+   ClusterConfigurationBuilder addCluster(String clusterName);
+
+   /**
     * Adds a list of remote servers in the form: host1[:port][;host2[:port]]...
     */
    ConfigurationBuilder addServers(String servers);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/TopologyInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/TopologyInfo.java
@@ -5,6 +5,7 @@ import org.infinispan.client.hotrod.configuration.Configuration;
 import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHash;
 import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashFactory;
 import org.infinispan.client.hotrod.impl.consistenthash.SegmentConsistentHash;
+import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
 import org.infinispan.commons.equivalence.AnyEquivalence;
@@ -90,15 +91,22 @@ public final class TopologyInfo {
    }
 
    public Optional<SocketAddress> getHashAwareServer(byte[] key, byte[] cacheName) {
-      Optional<SocketAddress> server = Optional.empty();
-      ConsistentHash consistentHash = consistentHashes.get(cacheName);
-      if (consistentHash != null) {
-         server = Optional.of(consistentHash.getServer(key));
-         if (log.isTraceEnabled()) {
-            log.tracef("Using consistent hash for determining the server: " + server);
+      if (isTopologyValid()) {
+         ConsistentHash consistentHash = consistentHashes.get(cacheName);
+         if (consistentHash != null) {
+            Optional<SocketAddress> server = Optional.of(consistentHash.getServer(key));
+            if (log.isTraceEnabled()) {
+               log.tracef("Using consistent hash for determining the server: " + server);
+            }
+            return server;
          }
       }
-      return server;
+
+      return Optional.empty();
+   }
+
+   private boolean isTopologyValid() {
+      return topologyId.get() > HotRodConstants.DEFAULT_CACHE_TOPOLOGY;
    }
 
    public void updateServers(Collection<SocketAddress> updatedServers) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RetryOnFailureOperation.java
@@ -112,6 +112,10 @@ public abstract class RetryOnFailureOperation<T> extends HotRodOperation {
             transportFactory.reset(cacheName);
             triedCompleteRestart = true;
             return -1; // reset retry count
+         } else if (transportFactory.trySwitchCluster(cacheName)){
+            log.debug("Switched to a different cluster");
+            triedCompleteRestart = true;
+            return -1; // reset retry count
          } else {
             log.exceptionAndNoRetriesLeft(i,transportFactory.getMaxRetries(), e);
             throw e;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
@@ -65,4 +65,6 @@ public interface TransportFactory {
    SSLContext getSSLContext();
 
    void reset(byte[] cacheName);
+
+   boolean trySwitchCluster(byte[] cacheName);
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/configuration/ConfigurationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/configuration/ConfigurationTest.java
@@ -4,12 +4,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
-import java.io.IOException;
-
 import javax.security.auth.Subject;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.UnsupportedCallbackException;
 
 import org.infinispan.client.hotrod.SomeAsyncExecutorFactory;
 import org.infinispan.client.hotrod.SomeCustomConsistentHashV1;
@@ -111,6 +106,18 @@ public class ConfigurationTest {
       ConfigurationBuilder builder = new ConfigurationBuilder();
       builder.security().authentication().enable().saslMechanism("PLAIN").callbackHandler(SaslTransportObjectFactory.NoOpCallbackHandler.INSTANCE);
       builder.build();
+   }
+
+   public void testClusters() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.addServers("1.1.1.1:9999");
+      builder.addCluster("my-cluster").addClusterNode("localhost", 8382);
+      Configuration cfg = builder.build();
+      assertEquals(1, cfg.servers().size());
+      assertServer("1.1.1.1", 9999, cfg.servers().get(0));
+      assertEquals(1, cfg.clusters().size());
+      assertEquals(1, cfg.clusters().get(0).getCluster().size());
+      assertServer("localhost", 8382, cfg.clusters().get(0).getCluster().get(0));
    }
 
    private void assertServer(String host, int port, ServerConfiguration serverCfg) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/AbstractHotRodSiteFailoverTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/AbstractHotRodSiteFailoverTest.java
@@ -1,0 +1,94 @@
+package org.infinispan.client.hotrod.xsite;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.client.hotrod.test.InternalRemoteCacheManager;
+import org.infinispan.configuration.cache.BackupConfiguration.BackupStrategy;
+import org.infinispan.configuration.cache.BackupConfigurationBuilder;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.xsite.AbstractXSiteTest;
+import org.testng.annotations.AfterClass;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+
+abstract class AbstractHotRodSiteFailoverTest extends AbstractXSiteTest {
+
+   static String SITE_A = "LON";
+   static String SITE_B = "NYC";
+   static Random R = new Random();
+   static int NODES_PER_SITE = 2;
+
+   Map<String, List<HotRodServer>> siteServers = new HashMap<>();
+
+   RemoteCacheManager client(String siteName, Optional<String> backupSiteName) {
+      HotRodServer server = siteServers.get(siteName).get(R.nextInt(NODES_PER_SITE));
+      org.infinispan.client.hotrod.configuration.ConfigurationBuilder clientBuilder =
+         new org.infinispan.client.hotrod.configuration.ConfigurationBuilder();
+      clientBuilder
+         .addServer().host("localhost").port(server.getPort())
+         .maxRetries(0);
+
+      backupSiteName.ifPresent(name -> {
+         HotRodServer backupServer = siteServers.get(name).get(R.nextInt(NODES_PER_SITE));
+         clientBuilder.addCluster(name).addClusterNode("localhost", backupServer.getPort());
+      });
+      return new InternalRemoteCacheManager(clientBuilder.build());
+   }
+
+   int findServerPort(String siteName) {
+      return siteServers.get(siteName).get(0).getPort();
+   }
+
+   void killSite(String siteName) {
+      siteServers.get(siteName).forEach(HotRodClientTestingUtil::killServers);
+      site(siteName).cacheManagers().forEach(TestingUtil::killCacheManagers);
+   }
+
+   @Override
+   protected void createSites() {
+      createHotRodSite(SITE_A, SITE_B, Optional.empty());
+      createHotRodSite(SITE_B, SITE_A, Optional.empty());
+   }
+
+   @AfterClass(alwaysRun = true) // run even if the test failed
+   protected void destroy() {
+      try {
+         siteServers.values().stream().forEach(servers ->
+            servers.forEach(HotRodClientTestingUtil::killServers));
+      } finally {
+         super.destroy();
+      }
+   }
+
+   protected void createHotRodSite(String siteName, String backupSiteName, Optional<Integer> serverPort) {
+      ConfigurationBuilder builder = hotRodCacheConfiguration(
+         getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
+      BackupConfigurationBuilder backup = builder.sites().addBackup();
+      backup.site(backupSiteName).strategy(BackupStrategy.SYNC);
+
+      GlobalConfigurationBuilder globalBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      globalBuilder.globalJmxStatistics().allowDuplicateDomains(true);
+      globalBuilder.site().localSite(siteName);
+      TestSite site = createSite(siteName, NODES_PER_SITE, globalBuilder, builder);
+      Collection<EmbeddedCacheManager> cacheManagers = site.cacheManagers();
+      List<HotRodServer> servers = cacheManagers.stream().map(cm -> serverPort
+         .map(port -> HotRodClientTestingUtil.startHotRodServer(cm, port, new HotRodServerConfigurationBuilder()))
+         .orElseGet(() -> HotRodClientTestingUtil.startHotRodServer(cm))).collect(Collectors.toList());
+      siteServers.put(siteName, servers);
+   }
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/SiteDownFailoverTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/SiteDownFailoverTest.java
@@ -1,0 +1,46 @@
+package org.infinispan.client.hotrod.xsite;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+
+@Test(groups = "functional", testName = "xsite.SiteDownFailoverTest")
+public class SiteDownFailoverTest extends AbstractHotRodSiteFailoverTest {
+
+   public void testFailoverAfterSiteShutdown() {
+      RemoteCacheManager clientA = client(SITE_A, Optional.of(SITE_B));
+      RemoteCacheManager clientB = client(SITE_B, Optional.empty());
+      RemoteCache<Integer, String> cacheA = clientA.getCache();
+      RemoteCache<Integer, String> cacheB = clientB.getCache();
+
+      assertNull(cacheA.put(1, "v1"));
+      assertEquals("v1", cacheA.get(1));
+      assertEquals("v1", cacheB.get(1));
+
+      int portServerSiteA = findServerPort(SITE_A);
+      killSite(SITE_A);
+
+      // Client connected with surviving site should find data
+      assertEquals("v1", cacheB.get(1));
+
+      // Client connected to crashed site should failover
+      assertEquals("v1", cacheA.get(1));
+
+      // Restart previously shut down site
+      createHotRodSite(SITE_A, SITE_B, Optional.of(portServerSiteA));
+
+      killSite(SITE_B);
+
+      // Client that had details for site A should failover back
+      // There is no data in original site since state transfer is not enabled
+      assertNull(cacheA.get(1));
+      assertNull(cacheA.put(2, "v2"));
+      assertEquals("v2", cacheA.get(2));
+   }
+
+}

--- a/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
@@ -899,6 +899,35 @@ use conditional operations, or operations whose previous value is required,
 it's important that the cache is configured to be transactional in order to
 avoid incorrect conditional operations or return values.
 
+===== Site Cluster Failover
+
+On top of the in-cluster failover, Hot Rod clients are also able to failover
+to different clusters, which could be represented as an independent site.
+
+NOTE: This feature was introduced in Infinispan 8.1.
+
+The way site cluster failover works is that if all the main cluster nodes
+are not available, the client checks to see if any other clusters have been
+defined in which cases it tries to failover to the alternative cluster.
+If the failover succeeds, the client will remain connected to the alternative
+cluster until this becomes unavailable, in which case it'll try any other
+clusters defined, and ultimately, it'll try the original server settings.
+
+To configure a cluster in the Hot Rod client, one host/port pair details
+must be provided for each of the clusters configured. For example:
+
+[source,java]
+----
+org.infinispan.client.hotrod.configuration.ConfigurationBuilder cb
+      = new org.infinispan.client.hotrod.configuration.ConfigurationBuilder();
+cb.addCluster().addClusterNode("remote-cluster-host", 11222);
+RemoteCacheManager rmc = new RemoteCacheManager(cb.build());
+----
+
+NOTE: Remember that regardless of the cluster definitions, the initial
+server(s) configuration must be provided unless the initial servers can
+be resolved using the default server host and port details.
+
 ====  Consistent Concurrent Updates With Hot Rod Versioned Operations
 Data structures, such as Infinispan link:http://docs.jboss.org/infinispan/{infinispanversion}/apidocs/org/infinispan/Cache.html[Cache] , that are accessed and modified concurrently can suffer from data consistency issues unless there're mechanisms to guarantee data correctness. Infinispan Cache, since it implements link:http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ConcurrentMap.html[ConcurrentMap] , provides operations such as link:http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ConcurrentMap.html#replace(K, V, V)[conditional replace] , link:http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ConcurrentMap.html#putIfAbsent(K, V)[putIfAbsent] , and link:http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ConcurrentMap.html#remove(java.lang.Object, java.lang.Object)[conditional remove] to its clients in order to guarantee data correctness. It even allows clients to operate against cache instances within JTA transactions, hence providing the necessary data consistency guarantees.
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5520

* This initial implementation supports dealing with entire clusters
  failing, and falling back on cluster information defined in Hot Rod
  configuration.
* It's necessary for at least a single server's IP address to be
  provided in the cluster definition, and from that the rest of the
  topology can be deduced.
* Once a node has connected to a different site cluster, it remains
  connected to that site until the cluster becomes unavailable, in which
  case it failovers to next cluster.
* If all cluster sites become unavailable, as a last resort the initial
  server configuration is tried.