### PR TITLE
ISPN-5758 Clients should find out if compatibility is enabled

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -555,8 +555,6 @@ public class RemoteCacheManager implements BasicCacheContainer {
       // Workaround for JDK6 NPE: http://bugs.sun.com/view_bug.do?bug_id=6427854
       SecurityActions.setProperty("sun.nio.ch.bugLevel", "\"\"");
 
-      codec = CodecFactory.getCodec(configuration.protocolVersion());
-
       transportFactory = Util.getInstance(configuration.transportFactory());
 
       if (marshaller == null) {
@@ -565,6 +563,8 @@ public class RemoteCacheManager implements BasicCacheContainer {
             marshaller = Util.getInstance(configuration.marshallerClass());
          }
       }
+
+      codec = CodecFactory.getCodec(configuration.protocolVersion());
 
       if (asyncExecutorService == null) {
          ExecutorFactory executorFactory = configuration.asyncExecutorFactory().factory();

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
@@ -51,6 +51,7 @@ public class ConfigurationProperties {
    public static final int DEFAULT_SO_TIMEOUT = 60000;
    public static final int DEFAULT_CONNECT_TIMEOUT = 60000;
    public static final int DEFAULT_MAX_RETRIES = 10;
+   public static final String PROTOCOL_VERSION_24 = "2.4";
    public static final String PROTOCOL_VERSION_23 = "2.3";
    public static final String PROTOCOL_VERSION_22 = "2.2";
    public static final String PROTOCOL_VERSION_21 = "2.1";
@@ -59,7 +60,7 @@ public class ConfigurationProperties {
    public static final String PROTOCOL_VERSION_12 = "1.2";
    public static final String PROTOCOL_VERSION_11 = "1.1";
    public static final String PROTOCOL_VERSION_10 = "1.0";
-   public static final String DEFAULT_PROTOCOL_VERSION = PROTOCOL_VERSION_23;
+   public static final String DEFAULT_PROTOCOL_VERSION = PROTOCOL_VERSION_24;
 
    private final TypedProperties props;
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/VersionedOperationResponse.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/VersionedOperationResponse.java
@@ -4,7 +4,7 @@ package org.infinispan.client.hotrod.impl;
 * @author Mircea.Markus@jboss.com
 * @since 4.1
 */
-public class VersionedOperationResponse {
+public class VersionedOperationResponse<V> {
 
    public enum RspCode {
       SUCCESS(true), NO_SUCH_KEY(false), MODIFIED_KEY(false);
@@ -19,17 +19,17 @@ public class VersionedOperationResponse {
       }
    }
 
-   private byte[] value;
+   private V value;
 
    private RspCode code;
 
 
-   public VersionedOperationResponse(byte[] value, RspCode code) {
+   public VersionedOperationResponse(V value, RspCode code) {
       this.value = value;
       this.code = code;
    }
 
-   public byte[] getValue() {
+   public V getValue() {
       return value;
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AddClientListenerOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AddClientListenerOperation.java
@@ -6,6 +6,7 @@ import org.infinispan.client.hotrod.annotation.ClientListener;
 import org.infinispan.client.hotrod.event.ClientEvent;
 import org.infinispan.client.hotrod.event.ClientListenerNotifier;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
+import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.commons.util.Either;
 import org.infinispan.client.hotrod.impl.protocol.HeaderParams;
 import org.infinispan.client.hotrod.impl.transport.Transport;
@@ -95,7 +96,7 @@ public class AddClientListenerOperation extends RetryOnFailureOperation<Short> {
          either = codec.readHeaderOrEvent(dedicatedTransport, params, listenerId, listenerNotifier.getMarshaller());
          switch(either.type()) {
             case LEFT:
-               if (either.left() == NO_ERROR_STATUS)
+               if (HotRodConstants.isSuccess(either.left()))
                   listenerNotifier.startClientListener(listenerId);
                else // If error, remove it
                   listenerNotifier.removeClientListener(listenerId);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ContainsKeyOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ContainsKeyOperation.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.impl.operations;
 import net.jcip.annotations.Immutable;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
+import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 
@@ -26,9 +27,9 @@ public class ContainsKeyOperation extends AbstractKeyOperation<Boolean> {
    protected Boolean executeOperation(Transport transport) {
       boolean containsKey = false;
       short status = sendKeyOperation(key, transport, CONTAINS_KEY_REQUEST, CONTAINS_KEY_RESPONSE);
-      if (status == KEY_DOES_NOT_EXIST_STATUS) {
+      if (HotRodConstants.isNotExist(status)) {
          containsKey = false;
-      } else if (status == NO_ERROR_STATUS) {
+      } else if (HotRodConstants.isSuccess(status)) {
          containsKey = true;
       }
       return containsKey;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ExecuteOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ExecuteOperation.java
@@ -18,7 +18,7 @@ import org.infinispan.client.hotrod.impl.transport.TransportFactory;
  * @author Tristan Tarrant
  * @since 7.1
  */
-public class ExecuteOperation extends RetryOnFailureOperation<byte[]> {
+public class ExecuteOperation<T> extends RetryOnFailureOperation<T> {
 
 	private final String taskName;
 	private final Map<String, byte[]> marshalledParams;
@@ -37,7 +37,7 @@ public class ExecuteOperation extends RetryOnFailureOperation<byte[]> {
 	}
 
 	@Override
-	protected byte[] executeOperation(Transport transport) {
+	protected T executeOperation(Transport transport) {
 		HeaderParams params = writeHeader(transport, EXEC_REQUEST);
 		transport.writeString(taskName);
 		transport.writeVInt(marshalledParams.size());
@@ -46,8 +46,8 @@ public class ExecuteOperation extends RetryOnFailureOperation<byte[]> {
 			transport.writeArray(entry.getValue());
 		}
 		transport.flush();
-		readHeaderAndValidate(transport, params);
-		return transport.readArray();
+		short status = readHeaderAndValidate(transport, params);
+		return codec.readUnmarshallByteArray(transport, status);
 	}
 
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetOperation.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.impl.operations;
 import net.jcip.annotations.Immutable;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
+import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 
@@ -15,7 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @since 4.1
  */
 @Immutable
-public class GetOperation extends AbstractKeyOperation<byte[]> {
+public class GetOperation<V> extends AbstractKeyOperation<V> {
 
    public GetOperation(Codec codec, TransportFactory transportFactory,
          byte[] key, byte[] cacheName, AtomicInteger topologyId, Flag[] flags) {
@@ -23,14 +24,14 @@ public class GetOperation extends AbstractKeyOperation<byte[]> {
    }
 
    @Override
-   public byte[] executeOperation(Transport transport) {
-      byte[] result = null;
+   public V executeOperation(Transport transport) {
+      V result = null;
       short status = sendKeyOperation(key, transport, GET_REQUEST, GET_RESPONSE);
-      if (status == KEY_DOES_NOT_EXIST_STATUS) {
+      if (HotRodConstants.isNotExist(status)) {
          result = null;
       } else {
-         if (status == NO_ERROR_STATUS) {
-            result = transport.readArray();
+         if (HotRodConstants.isSuccess(status)) {
+            result = codec.readUnmarshallByteArray(transport, status);
          }
       }
       return result;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetWithVersionOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetWithVersionOperation.java
@@ -8,6 +8,7 @@ import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.VersionedValue;
 import org.infinispan.client.hotrod.impl.VersionedValueImpl;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
+import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 import org.infinispan.client.hotrod.logging.Log;
@@ -22,7 +23,7 @@ import org.infinispan.client.hotrod.logging.LogFactory;
  */
 @Immutable
 @Deprecated
-public class GetWithVersionOperation extends AbstractKeyOperation<VersionedValue<byte[]>> {
+public class GetWithVersionOperation<V> extends AbstractKeyOperation<VersionedValue<V>> {
 
    private static final Log log = LogFactory.getLog(GetWithVersionOperation.class);
 
@@ -32,18 +33,18 @@ public class GetWithVersionOperation extends AbstractKeyOperation<VersionedValue
    }
 
    @Override
-   protected VersionedValue<byte[]> executeOperation(Transport transport) {
+   protected VersionedValue<V> executeOperation(Transport transport) {
       short status = sendKeyOperation(key, transport, GET_WITH_VERSION, GET_WITH_VERSION_RESPONSE);
-      VersionedValue<byte[]> result = null;
-      if (status == KEY_DOES_NOT_EXIST_STATUS) {
+      VersionedValue<V> result = null;
+      if (HotRodConstants.isNotExist(status)) {
          result = null;
-      } else if (status == NO_ERROR_STATUS) {
+      } else if (HotRodConstants.isSuccess(status)) {
          long version = transport.readLong();
          if (log.isTraceEnabled()) {
             log.tracef("Received version: %d", version);
          }
-         byte[] value = transport.readArray();
-         result = new VersionedValueImpl<byte[]>(version, value);
+         V value = codec.readUnmarshallByteArray(transport, status);
+         result = new VersionedValueImpl<V>(version, value);
       }
       return result;
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/IterationNextResponse.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/IterationNextResponse.java
@@ -6,7 +6,7 @@ import java.util.Map;
  * @author gustavonalle
  * @since 8.0
  */
-public class IterationNextResponse {
+public class IterationNextResponse<K, V> {
    private final short status;
    private final byte[] finishedSegments;
    private final Map.Entry<byte[], byte[]>[] entries;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
@@ -66,23 +66,23 @@ public class OperationsFactory implements HotRodConstants {
       return cacheNameBytes;
    }
 
-   public GetOperation newGetKeyOperation(byte[] key) {
-      return new GetOperation(
+   public <V> GetOperation<V> newGetKeyOperation(byte[] key) {
+      return new GetOperation<V>(
             codec, transportFactory, key, cacheNameBytes, topologyId, flags());
    }
 
-   public GetAllOperation newGetAllOperation(Set<byte[]> keys) {
-      return new GetAllOperation(
+   public <K, V> GetAllOperation<K, V> newGetAllOperation(Set<byte[]> keys) {
+      return new GetAllOperation<K, V>(
             codec, transportFactory, keys, cacheNameBytes, topologyId, flags());
    }
 
-   public RemoveOperation newRemoveOperation(byte[] key) {
-      return new RemoveOperation(
+   public <V> RemoveOperation<V> newRemoveOperation(byte[] key) {
+      return new RemoveOperation<V>(
             codec, transportFactory, key, cacheNameBytes, topologyId, flags());
    }
 
-   public RemoveIfUnmodifiedOperation newRemoveIfUnmodifiedOperation(byte[] key, long version) {
-      return new RemoveIfUnmodifiedOperation(
+   public <V> RemoveIfUnmodifiedOperation<V> newRemoveIfUnmodifiedOperation(byte[] key, long version) {
+      return new RemoveIfUnmodifiedOperation<V>(
             codec, transportFactory, key, cacheNameBytes, topologyId, flags(), version);
    }
 
@@ -93,13 +93,13 @@ public class OperationsFactory implements HotRodConstants {
             value, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit, version);
    }
 
-   public GetWithVersionOperation newGetWithVersionOperation(byte[] key) {
-      return new GetWithVersionOperation(
+   public <V> GetWithVersionOperation<V> newGetWithVersionOperation(byte[] key) {
+      return new GetWithVersionOperation<V>(
             codec, transportFactory, key, cacheNameBytes, topologyId, flags());
    }
 
-   public GetWithMetadataOperation newGetWithMetadataOperation(byte[] key) {
-      return new GetWithMetadataOperation(
+   public <V> GetWithMetadataOperation<V> newGetWithMetadataOperation(byte[] key) {
+      return new GetWithMetadataOperation<V>(
             codec, transportFactory, key, cacheNameBytes, topologyId, flags());
    }
 
@@ -108,9 +108,9 @@ public class OperationsFactory implements HotRodConstants {
             codec, transportFactory, cacheNameBytes, topologyId, flags());
    }
 
-   public PutOperation newPutKeyValueOperation(byte[] key, byte[] value,
+   public <V> PutOperation<V> newPutKeyValueOperation(byte[] key, byte[] value,
           long lifespan, TimeUnit lifespanTimeUnit, long maxIdle, TimeUnit maxIdleTimeUnit) {
-      return new PutOperation(
+      return new PutOperation<V>(
             codec, transportFactory, key, cacheNameBytes, topologyId, flags(),
             value, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
    }
@@ -122,16 +122,16 @@ public class OperationsFactory implements HotRodConstants {
             lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
    }
 
-   public PutIfAbsentOperation newPutIfAbsentOperation(byte[] key, byte[] value,
+   public <V> PutIfAbsentOperation<V> newPutIfAbsentOperation(byte[] key, byte[] value,
              long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
-      return new PutIfAbsentOperation(
+      return new PutIfAbsentOperation<V>(
             codec, transportFactory, key, cacheNameBytes, topologyId, flags(),
             value, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
    }
 
-   public ReplaceOperation newReplaceOperation(byte[] key, byte[] values,
+   public <V> ReplaceOperation<V> newReplaceOperation(byte[] key, byte[] values,
            long lifespan, TimeUnit lifespanTimeUnit, long maxIdle, TimeUnit maxIdleTimeUnit) {
-      return new ReplaceOperation(
+      return new ReplaceOperation<V>(
             codec, transportFactory, key, cacheNameBytes, topologyId, flags(),
             values, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
    }
@@ -146,13 +146,13 @@ public class OperationsFactory implements HotRodConstants {
             codec, transportFactory, cacheNameBytes, topologyId, flags());
    }
 
-   public BulkGetOperation newBulkGetOperation(int size) {
+   public <K, V> BulkGetOperation<K, V> newBulkGetOperation(int size) {
       return new BulkGetOperation(
             codec, transportFactory, cacheNameBytes, topologyId, flags(), size);
    }
 
-   public BulkGetKeysOperation newBulkGetKeysOperation(int scope) {
-      return new BulkGetKeysOperation(
+   public <K> BulkGetKeysOperation<K> newBulkGetKeysOperation(int scope) {
+      return new BulkGetKeysOperation<K>(
          codec, transportFactory, cacheNameBytes, topologyId, flags(), scope);
    }
 
@@ -205,8 +205,8 @@ public class OperationsFactory implements HotRodConstants {
       return new SizeOperation(codec, transportFactory, cacheNameBytes, topologyId, flags());
    }
 
-   public ExecuteOperation newExecuteOperation(String taskName, Map<String, byte[]> marshalledParams) {
-		return new ExecuteOperation(codec, transportFactory, cacheNameBytes, topologyId, flags(), taskName, marshalledParams);
+   public <T> ExecuteOperation<T> newExecuteOperation(String taskName, Map<String, byte[]> marshalledParams) {
+		return new ExecuteOperation<T>(codec, transportFactory, cacheNameBytes, topologyId, flags(), taskName, marshalledParams);
 	}
 
    public Flag[] flags() {
@@ -256,7 +256,7 @@ public class OperationsFactory implements HotRodConstants {
       return new IterationEndOperation(codec, flags(), cacheNameBytes, topologyId, iterationId, transportFactory, transport);
    }
 
-   public IterationNextOperation newIterationNextOperation(String iterationId, Transport transport) {
+   public <K, V> IterationNextOperation newIterationNextOperation(String iterationId, Transport transport) {
       return new IterationNextOperation(codec, flags(), cacheNameBytes, topologyId, iterationId, transport);
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PingOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PingOperation.java
@@ -42,7 +42,7 @@ public class PingOperation extends HotRodOperation {
          transport.flush();
 
          short respStatus = readHeaderAndValidate(transport, params);
-         if (respStatus == HotRodConstants.NO_ERROR_STATUS) {
+         if (HotRodConstants.isSuccess(respStatus)) {
             if (log.isTraceEnabled())
                log.tracef("Successfully validated transport: %s", transport);
             return PingResult.SUCCESS;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutAllOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutAllOperation.java
@@ -13,6 +13,7 @@ import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.exceptions.InvalidResponseException;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.impl.protocol.HeaderParams;
+import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 
@@ -54,7 +55,7 @@ public class PutAllOperation extends RetryOnFailureOperation<Void> {
       transport.flush();
 
       short status = readHeaderAndValidate(transport, params);
-      if (status != NO_ERROR_STATUS) {
+      if (!HotRodConstants.isSuccess(status)) {
          throw new InvalidResponseException("Unexpected response status: " + Integer.toHexString(status));
       }
       return null;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutIfAbsentOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutIfAbsentOperation.java
@@ -7,10 +7,10 @@ import net.jcip.annotations.Immutable;
 
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
+import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 import org.infinispan.commons.logging.BasicLogFactory;
-import org.infinispan.commons.util.Util;
 import org.jboss.logging.BasicLogger;
 
 /**
@@ -21,7 +21,7 @@ import org.jboss.logging.BasicLogger;
  * @since 4.1
  */
 @Immutable
-public class PutIfAbsentOperation extends AbstractKeyValueOperation<byte[]> {
+public class PutIfAbsentOperation<V> extends AbstractKeyValueOperation<V> {
 
    private static final BasicLogger log = BasicLogFactory.getLog(PutIfAbsentOperation.class);
 
@@ -32,13 +32,13 @@ public class PutIfAbsentOperation extends AbstractKeyValueOperation<byte[]> {
    }
 
    @Override
-   protected byte[] executeOperation(Transport transport) {
+   protected V executeOperation(Transport transport) {
       short status = sendPutOperation(transport, PUT_IF_ABSENT_REQUEST, PUT_IF_ABSENT_RESPONSE);
-      byte[] previousValue = null;
-      if (status == NO_ERROR_STATUS || status == NOT_PUT_REMOVED_REPLACED_STATUS || status == NOT_EXECUTED_WITH_PREVIOUS) {
+      V previousValue = null;
+      if (HotRodConstants.isNotExecuted(status)) {
          previousValue = returnPossiblePrevValue(transport, status);
          if (log.isTraceEnabled()) {
-            log.tracef("Returning from putIfAbsent: %s", Util.printArray(previousValue, false));
+            log.tracef("Returning from putIfAbsent: %s", previousValue);
          }
       }
       return previousValue;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutOperation.java
@@ -8,6 +8,7 @@ import net.jcip.annotations.Immutable;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.exceptions.InvalidResponseException;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
+import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 
@@ -18,7 +19,7 @@ import org.infinispan.client.hotrod.impl.transport.TransportFactory;
  * @since 4.1
  */
 @Immutable
-public class PutOperation extends AbstractKeyValueOperation<byte[]> {
+public class PutOperation<V> extends AbstractKeyValueOperation<V> {
 
    public PutOperation(Codec codec, TransportFactory transportFactory,
                        byte[] key, byte[] cacheName, AtomicInteger topologyId,
@@ -27,9 +28,9 @@ public class PutOperation extends AbstractKeyValueOperation<byte[]> {
    }
 
    @Override
-   protected byte[] executeOperation(Transport transport) {
+   protected V executeOperation(Transport transport) {
       short status = sendPutOperation(transport, PUT_REQUEST, PUT_RESPONSE);
-      if (status != NO_ERROR_STATUS && status != SUCCESS_WITH_PREVIOUS) {
+      if (!HotRodConstants.isSuccess(status)) {
          throw new InvalidResponseException("Unexpected response status: " + Integer.toHexString(status));
       }
       return returnPossiblePrevValue(transport, status);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveClientListenerOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveClientListenerOperation.java
@@ -4,6 +4,7 @@ import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.event.ClientListenerNotifier;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.impl.protocol.HeaderParams;
+import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 
@@ -46,7 +47,7 @@ public class RemoveClientListenerOperation extends HotRodOperation {
             transport.writeArray(listenerId);
             transport.flush();
             short status = readHeaderAndValidate(transport, params);
-            if (status == NO_ERROR_STATUS)
+            if (HotRodConstants.isSuccess(status))
                listenerNotifier.removeClientListener(listenerId);
          } finally {
             transportFactory.releaseTransport(transport);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveIfUnmodifiedOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveIfUnmodifiedOperation.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @since 4.1
  */
 @Immutable
-public class RemoveIfUnmodifiedOperation extends AbstractKeyOperation<VersionedOperationResponse> {
+public class RemoveIfUnmodifiedOperation<V> extends AbstractKeyOperation<VersionedOperationResponse<V>> {
 
    private final long version;
 
@@ -29,7 +29,7 @@ public class RemoveIfUnmodifiedOperation extends AbstractKeyOperation<VersionedO
    }
 
    @Override
-   protected VersionedOperationResponse executeOperation(Transport transport) {
+   protected VersionedOperationResponse<V> executeOperation(Transport transport) {
       // 1) write header
       HeaderParams params = writeHeader(transport, REMOVE_IF_UNMODIFIED_REQUEST);
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveOperation.java
@@ -3,6 +3,7 @@ package org.infinispan.client.hotrod.impl.operations;
 import net.jcip.annotations.Immutable;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
+import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 
@@ -16,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @since 4.1
  */
 @Immutable
-public class RemoveOperation extends AbstractKeyOperation<byte[]> {
+public class RemoveOperation<V> extends AbstractKeyOperation<V> {
 
    public RemoveOperation(Codec codec, TransportFactory transportFactory,
             byte[] key, byte[] cacheName, AtomicInteger topologyId, Flag[] flags) {
@@ -24,10 +25,10 @@ public class RemoveOperation extends AbstractKeyOperation<byte[]> {
    }
 
    @Override
-   public byte[] executeOperation(Transport transport) {
+   public V executeOperation(Transport transport) {
       short status = sendKeyOperation(key, transport, REMOVE_REQUEST, REMOVE_RESPONSE);
-      byte[] result = returnPossiblePrevValue(transport, status);
-      if (status == KEY_DOES_NOT_EXIST_STATUS)
+      V result = returnPossiblePrevValue(transport, status);
+      if (HotRodConstants.isNotExist(status))
          return null;
 
       return result; // NO_ERROR_STATUS

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceOperation.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @since 4.1
  */
 @Immutable
-public class ReplaceOperation extends AbstractKeyValueOperation<byte[]> {
+public class ReplaceOperation<V> extends AbstractKeyValueOperation<V> {
 
    public ReplaceOperation(Codec codec, TransportFactory transportFactory,
             byte[] key, byte[] cacheName, AtomicInteger topologyId,
@@ -27,10 +27,8 @@ public class ReplaceOperation extends AbstractKeyValueOperation<byte[]> {
    }
 
    @Override
-   protected byte[] executeOperation(Transport transport) {
-      byte[] result = null;
+   protected V executeOperation(Transport transport) {
       short status = sendPutOperation(transport, REPLACE_REQUEST, REPLACE_RESPONSE);
-      result = returnPossiblePrevValue(transport, status);
-      return result;
+      return returnPossiblePrevValue(transport, status);
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
@@ -45,11 +45,15 @@ public interface Codec {
 
    Either<Short, ClientEvent> readHeaderOrEvent(Transport transport, HeaderParams params, byte[] expectedListenerId, Marshaller marshaller);
 
-   byte[] returnPossiblePrevValue(Transport transport, short status, Flag[] flags);
+   Object returnPossiblePrevValue(Transport transport, short status, Flag[] flags);
 
    /**
     * Logger for Hot Rod client codec
     */
    Log getLog();
 
+   /**
+    * Read and unmarshall byte array.
+    */
+   <T> T readUnmarshallByteArray(Transport transport, short status);
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec21.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec21.java
@@ -65,25 +65,25 @@ public class Codec21 extends Codec20 {
       boolean isRetried = transport.readByte() == 1 ? true : false;
 
       if (isCustom == 1) {
-         final Object eventData = MarshallerUtil.bytes2obj(marshaller, transport.readArray());
+         final Object eventData = MarshallerUtil.bytes2obj(marshaller, transport.readArray(), status);
          return createCustomEvent(eventData, eventType, isRetried);
       } else if (isCustom == 2) { // New in 2.1, dealing with raw custom events
          return createCustomEvent(transport.readArray(), eventType, isRetried); // Raw data
       } else {
          switch (eventType) {
             case CLIENT_CACHE_ENTRY_CREATED:
-               Object createdKey = MarshallerUtil.bytes2obj(marshaller, transport.readArray());
+               Object createdKey = MarshallerUtil.bytes2obj(marshaller, transport.readArray(), status);
                long createdDataVersion = transport.readLong();
                return createCreatedEvent(createdKey, createdDataVersion, isRetried);
             case CLIENT_CACHE_ENTRY_MODIFIED:
-               Object modifiedKey = MarshallerUtil.bytes2obj(marshaller, transport.readArray());
+               Object modifiedKey = MarshallerUtil.bytes2obj(marshaller, transport.readArray(), status);
                long modifiedDataVersion = transport.readLong();
                return createModifiedEvent(modifiedKey, modifiedDataVersion, isRetried);
             case CLIENT_CACHE_ENTRY_REMOVED:
-               Object removedKey = MarshallerUtil.bytes2obj(marshaller, transport.readArray());
+               Object removedKey = MarshallerUtil.bytes2obj(marshaller, transport.readArray(), status);
                return createRemovedEvent(removedKey, isRetried);
             case CLIENT_CACHE_ENTRY_EXPIRED:
-               Object expiredKey = MarshallerUtil.bytes2obj(marshaller, transport.readArray());
+               Object expiredKey = MarshallerUtil.bytes2obj(marshaller, transport.readArray(), status);
                return createExpiredEvent(expiredKey);
             default:
                throw getLog().unknownEvent(eventTypeId);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec24.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec24.java
@@ -1,0 +1,14 @@
+package org.infinispan.client.hotrod.impl.protocol;
+
+import org.infinispan.client.hotrod.impl.transport.Transport;
+import org.infinispan.client.hotrod.logging.Log;
+import org.infinispan.client.hotrod.logging.LogFactory;
+
+public class Codec24 extends Codec23 {
+
+   @Override
+   public HeaderParams writeHeader(Transport transport, HeaderParams params) {
+      return writeHeader(transport, params, HotRodConstants.VERSION_24);
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/CodecFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/CodecFactory.java
@@ -1,5 +1,7 @@
 package org.infinispan.client.hotrod.impl.protocol;
 
+import org.infinispan.commons.marshall.Marshaller;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,6 +24,7 @@ public class CodecFactory {
    private static final Codec CODEC_21 = new Codec21();
    private static final Codec CODEC_22 = new Codec22();
    private static final Codec CODEC_23 = new Codec23();
+   private static final Codec CODEC_24 = new Codec24();
 
    static {
       codecMap = new HashMap<String, Codec>();
@@ -33,6 +36,7 @@ public class CodecFactory {
       codecMap.put(PROTOCOL_VERSION_21, CODEC_21);
       codecMap.put(PROTOCOL_VERSION_22, CODEC_22);
       codecMap.put(PROTOCOL_VERSION_23, CODEC_23);
+      codecMap.put(PROTOCOL_VERSION_24, CODEC_24);
    }
 
    public static Codec getCodec(String version) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/CodecUtils.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/CodecUtils.java
@@ -1,5 +1,9 @@
 package org.infinispan.client.hotrod.impl.protocol;
 
+import org.infinispan.client.hotrod.impl.transport.Transport;
+import org.infinispan.client.hotrod.marshall.MarshallerUtil;
+import org.infinispan.commons.marshall.Marshaller;
+
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -25,6 +29,12 @@ public final class CodecUtils {
          seconds++;
       }
       return seconds;
+   }
+
+   static <T> T readUnmarshallByteArray(Transport transport, short status) {
+      byte[] bytes = transport.readArray();
+      Marshaller marshaller = transport.getTransportFactory().getMarshaller();
+      return MarshallerUtil.bytes2obj(marshaller, bytes, status);
    }
 
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HotRodConstants.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HotRodConstants.java
@@ -21,6 +21,7 @@ public interface HotRodConstants {
    static final byte VERSION_21 = 21;
    static final byte VERSION_22 = 22;
    static final byte VERSION_23 = 23;
+   static final byte VERSION_24 = 24;
 
    //requests
    static final byte PUT_REQUEST = 0x01;
@@ -87,20 +88,23 @@ public interface HotRodConstants {
 
    //response status
    static final byte NO_ERROR_STATUS = 0x00;
+   static final byte NOT_PUT_REMOVED_REPLACED_STATUS = 0x01;
+   static final int KEY_DOES_NOT_EXIST_STATUS = 0x02;
+   static final int SUCCESS_WITH_PREVIOUS = 0x03;
+   static final int NOT_EXECUTED_WITH_PREVIOUS = 0x04;
+   static final int INVALID_ITERATION = 0x05;
+   static final byte NO_ERROR_STATUS_COMPAT = 0x06;
+   static final byte SUCCESS_WITH_PREVIOUS_COMPAT = 0x07;
+   static final byte NOT_EXECUTED_WITH_PREVIOUS_COMPAT = 0x08;
+
    static final int INVALID_MAGIC_OR_MESSAGE_ID_STATUS = 0x81;
    static final int REQUEST_PARSING_ERROR_STATUS = 0x84;
-   static final byte NOT_PUT_REMOVED_REPLACED_STATUS = 0x01;
    static final int UNKNOWN_COMMAND_STATUS = 0x82;
    static final int SERVER_ERROR_STATUS = 0x85;
-   static final int KEY_DOES_NOT_EXIST_STATUS = 0x02;
    static final int UNKNOWN_VERSION_STATUS = 0x83;
    static final int COMMAND_TIMEOUT_STATUS = 0x86;
    static final int NODE_SUSPECTED = 0x87;
    static final int ILLEGAL_LIFECYCLE_STATE = 0x88;
-   static final int SUCCESS_WITH_PREVIOUS = 0x03;
-   static final int NOT_EXECUTED_WITH_PREVIOUS = 0x04;
-   static final int INVALID_ITERATION = 0x05;
-
 
    static final byte CLIENT_INTELLIGENCE_BASIC = 0x01;
    static final byte CLIENT_INTELLIGENCE_TOPOLOGY_AWARE = 0x02;
@@ -114,4 +118,39 @@ public interface HotRodConstants {
 
    static final int DEFAULT_CACHE_TOPOLOGY = -1;
    static final int SWITCH_CLUSTER_TOPOLOGY = -2;
+
+   static boolean isSuccess(short status) {
+      return status == NO_ERROR_STATUS
+         || status == NO_ERROR_STATUS_COMPAT
+         || status == SUCCESS_WITH_PREVIOUS
+         || status == SUCCESS_WITH_PREVIOUS_COMPAT;
+   }
+
+   static boolean isNotExecuted(short status) {
+      return status == NOT_PUT_REMOVED_REPLACED_STATUS
+         || status == NOT_EXECUTED_WITH_PREVIOUS
+         || status == NOT_EXECUTED_WITH_PREVIOUS_COMPAT;
+   }
+
+   static boolean isNotExist(short status) {
+      return status == KEY_DOES_NOT_EXIST_STATUS;
+   }
+
+   static boolean hasPrevious(short status) {
+      return status == SUCCESS_WITH_PREVIOUS
+         || status == SUCCESS_WITH_PREVIOUS_COMPAT
+         || status == NOT_EXECUTED_WITH_PREVIOUS
+         || status == NOT_EXECUTED_WITH_PREVIOUS_COMPAT;
+   }
+
+   static boolean hasCompatibility(short status) {
+      return status == NO_ERROR_STATUS_COMPAT
+         || status == SUCCESS_WITH_PREVIOUS_COMPAT
+         || status == NOT_EXECUTED_WITH_PREVIOUS_COMPAT;
+   }
+
+   static boolean isInvalidIteration(short status) {
+      return status == INVALID_ITERATION;
+   }
+
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
@@ -13,6 +13,7 @@ import org.infinispan.client.hotrod.event.ClientListenerNotifier;
 import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHash;
 import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashFactory;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
+import org.infinispan.commons.marshall.Marshaller;
 
 /**
  * Transport factory for building and managing {@link org.infinispan.client.hotrod.impl.transport.Transport} objects.
@@ -67,4 +68,6 @@ public interface TransportFactory {
    void reset(byte[] cacheName);
 
    boolean trySwitchCluster(byte[] cacheName);
+
+   Marshaller getMarshaller();
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/TcpTransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/TcpTransportFactory.java
@@ -38,6 +38,7 @@ import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
 import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.equivalence.ByteArrayEquivalence;
+import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.commons.util.SslContextFactory;
 import org.infinispan.commons.util.Util;
@@ -458,6 +459,11 @@ public class TcpTransportFactory implements TransportFactory {
       }
 
       return true;
+   }
+
+   @Override
+   public Marshaller getMarshaller() {
+      return listenerNotifier.getMarshaller();
    }
 
    /**

--- a/documentation/src/main/asciidoc/user_guide/chapter-64-Hot_Rod_Protocol.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-64-Hot_Rod_Protocol.adoc
@@ -10,6 +10,7 @@ the custom TCP client/server Hot Rod protocol.
 * link:$$#_hot_rod_protocol_2_1$$[Hot Rod Protocol 2.1]
 * link:$$#_hot_rod_protocol_2_2$$[Hot Rod Protocol 2.2]
 * link:$$#_hot_rod_protocol_2_3$$[Hot Rod Protocol 2.3]
+* link:$$#_hot_rod_protocol_2_4$$[Hot Rod Protocol 2.4]
 
 ===== Hot Rod Protocol 1.0
 
@@ -1657,6 +1658,18 @@ Response format:
 +0x00+ = success, if execution completed successfully +
 +0x05+ = for non existent IterationId  +
 |==============================================================================
+
+===== Hot Rod Protocol 2.4
+
+.Infinispan versions
+TIP: This version of the protocol is implemented since Infinispan 8.1
+
+This Hot Rod protocol version adds three new status code that gives the client
+hints on whether the server has compatibility mode enabled or not:
+
+* `0x06`: Success status and compatibility mode is enabled.
+* `0x07`: Success status and return previous value, with compatibility mode is enabled.
+* `0x08`: Not executed and return previous value, with compatibility mode is enabled.
 
 ==== Hot Rod Hash Functions
 Infinispan makes use of a consistent hash function to place nodes on a hash

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestHotRodTest.java
@@ -12,6 +12,7 @@ import org.apache.commons.httpclient.methods.PutMethod;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.test.AbstractInfinispanTest;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -41,7 +42,7 @@ import static org.testng.AssertJUnit.assertEquals;
  * @since 5.3
  */
 @Test(groups = "functional", testName = "it.compatibility.EmbeddedRestHotRodTest")
-public class EmbeddedRestHotRodTest {
+public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
 
    private static final DateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
 

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ClientListenerRegistry.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ClientListenerRegistry.scala
@@ -352,7 +352,7 @@ object ClientListenerRegistry extends Constants {
    object ClientEventType {
       def apply(isCustom: Boolean, useRawData: Boolean, version: Byte): ClientEventType = {
          (isCustom, useRawData) match {
-            case (true, true) if version >= VERSION_21 => CustomRaw
+            case (true, true) if Constants.isVersionPost20(version) => CustomRaw
             case (true, _) => CustomPlain
             case (false, _) => Plain
          }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Constants.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Constants.scala
@@ -18,6 +18,7 @@ trait Constants {
    val VERSION_21: Byte = 21
    val VERSION_22: Byte = 22
    val VERSION_23: Byte = 23
+   val VERSION_24: Byte = 24
    val DEFAULT_CONSISTENT_HASH_VERSION_1x: Byte = 2
    val DEFAULT_CONSISTENT_HASH_VERSION: Byte = 3
 
@@ -29,4 +30,29 @@ trait Constants {
    val INFINITE_MAXIDLE = 0x02
 }
 
-object Constants extends Constants
+object Constants extends Constants {
+
+   def isVersion10(v: Byte): Boolean = v == VERSION_10
+   def isVersion11(v: Byte): Boolean = v == VERSION_11
+   def isVersion12(v: Byte): Boolean = v == VERSION_12
+   def isVersion13(v: Byte): Boolean = v == VERSION_13
+   def isVersion1x(v: Byte): Boolean = v >= VERSION_10 && v <= VERSION_13
+   def isVersion2x(v: Byte): Boolean = v >= VERSION_20 && v <= VERSION_24
+   def isVersionKnown(v: Byte): Boolean = isVersion1x(v) || isVersion2x(v)
+
+   /**
+    * Is version previous to, and not including, 2.2?
+    */
+   def isVersionPre22(v: Byte): Boolean = isVersion1x(v) || v == VERSION_20 || v == VERSION_21
+
+   /**
+    * Is version previous to, and not including, 2.4?
+    */
+   def isVersionPre24(v: Byte): Boolean = isVersion1x(v) || (v >= VERSION_20 && v <= VERSION_23)
+
+   /**
+    * Is version previous post, and not including, 2.0?
+    */
+   def isVersionPost20(v: Byte): Boolean = v >= VERSION_21 && v <= VERSION_24
+
+}

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
@@ -160,8 +160,8 @@ extends ReplayingDecoder[HotRodDecoderState](DECODE_HEADER) with StatsChannelHan
 
       try {
          val decoder = version match {
-            case VERSION_10 | VERSION_11 | VERSION_12 | VERSION_13 => Decoder10
-            case VERSION_20 | VERSION_21 | VERSION_22 | VERSION_23 => Decoder2x
+            case ver if Constants.isVersion1x(ver) => Decoder10
+            case ver if Constants.isVersion2x(ver) => Decoder2x
             case _ => throw new UnknownVersionException("Unknown version:" + version, version, messageId)
          }
          val endOfOp = decoder.readHeader(buffer, version, messageId, header)

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodEncoder.scala
@@ -35,7 +35,7 @@ class HotRodEncoder(cacheManager: EmbeddedCacheManager, server: HotRodServer)
                val encoder = getEncoder(r.version)
                try {
                   r.version match {
-                     case VERSION_10 | VERSION_11 | VERSION_12 | VERSION_13 | VERSION_20 | VERSION_21 | VERSION_22 | VERSION_23 =>
+                     case ver if Constants.isVersionKnown(ver) =>
                         encoder.writeHeader(r, buf, addressCache, server)
                      // if error before reading version, don't send any topology changes
                      // cos the encoding might vary from one version to the other
@@ -74,11 +74,11 @@ class HotRodEncoder(cacheManager: EmbeddedCacheManager, server: HotRodServer)
 
    private def getEncoder(version: Byte): AbstractVersionedEncoder = {
       version match {
-         case VERSION_10 => Encoders.Encoder10
-         case VERSION_11 => Encoders.Encoder11
-         case VERSION_12 => Encoders.Encoder12
-         case VERSION_13 => Encoders.Encoder13
-         case VERSION_20 | VERSION_21 | VERSION_22 | VERSION_23 => Encoder2x
+         case ver if Constants.isVersion10(ver) => Encoders.Encoder10
+         case ver if Constants.isVersion11(ver) => Encoders.Encoder11
+         case ver if Constants.isVersion12(ver) => Encoders.Encoder12
+         case ver if Constants.isVersion13(ver) => Encoders.Encoder13
+         case ver if Constants.isVersion2x(ver) => Encoder2x
          case 0 => Encoder2x
       }
    }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/OperationStatus.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/OperationStatus.scala
@@ -16,6 +16,10 @@ object OperationStatus extends Enumeration {
    val NotExecutedWithPrevious = Value(0x04)
    val InvalidIteration = Value(0x05)
 
+   val SuccessCompat = Value(0x06)
+   val SuccessWithPreviousCompat = Value(0x07)
+   val NotExecutedWithPreviousCompat = Value(0x08)
+
    val InvalidMagicOrMsgId = Value(0x81)
    val UnknownOperation = Value(0x82)
    val UnknownVersion = Value(0x83) // todo: test
@@ -25,4 +29,12 @@ object OperationStatus extends Enumeration {
    val NodeSuspected = Value(0x87)
    val IllegalLifecycleState = Value(0x88)
 
+   def withCompatibility(st: OperationStatus, isCompatibilityEnabled: Boolean): OperationStatus = {
+      st match {
+         case Success if isCompatibilityEnabled => SuccessCompat;
+         case SuccessWithPrevious if isCompatibilityEnabled => SuccessWithPreviousCompat;
+         case NotExecutedWithPrevious if isCompatibilityEnabled => NotExecutedWithPreviousCompat;
+         case _ => st
+      }
+   }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5758

* Hot Rod servers now provide different status identifiers when
  compatibility is enabled.
* A new version of the Hot Rod protocol, version 2.4, has been created
  to support the new status ids.
* Clients need to know whether compatibility is enabled or not to be
  able to apply correct unmarshalling when keys and/or values are
  returned back as part of the response.
* Version handling in both the client and server has been centralised in
  order to make it easier to do a version upgrade.