### PR TITLE
ISPN-5719 Add a default log4j2 configuration in parent POM

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -81,7 +81,8 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
       <defaultTestGroup>functional,unit,arquillian</defaultTestGroup>
-      
+
+      <log4j.configurationFile>log4j2.xml</log4j.configurationFile>
       <defaultExcludedTestGroup>unstable,stress,unstable_xsite</defaultExcludedTestGroup>
       <forkJvmArgs>-Xmx2G</forkJvmArgs>
       <testNGListener>org.infinispan.test.fwk.UnitTestTestNGListener</testNGListener>


### PR DESCRIPTION
The fix for ISPN-5719 introduced this warning when `log4j.configurationFile` is not defined on the command line:

```
[01:18:52]ERROR StatusLogger Cannot locate file  java.io.FileNotFoundException: /mnt/persistent_storage/cloud-user/ispn/buildAgent/work/64255532d1f9a010/query (Is a directory)
[01:18:52]	at java.io.FileInputStream.open0(Native Method)
[01:18:52]	at java.io.FileInputStream.open(FileInputStream.java:195)
[01:18:52]	at java.io.FileInputStream.<init>(FileInputStream.java:138)
[01:18:52]	at org.apache.logging.log4j.core.config.ConfigurationFactory.getInputFromUri(ConfigurationFactory.java:278)
[01:18:52]	at org.apache.logging.log4j.core.config.ConfigurationFactory$Factory.getConfiguration(ConfigurationFactory.java:395)
[01:18:52]	at org.apache.logging.log4j.core.config.ConfigurationFactory.getConfiguration(ConfigurationFactory.java:254)
[01:18:52]	at org.apache.logging.log4j.core.LoggerContext.reconfigure(LoggerContext.java:425)
[01:18:52]	at org.apache.logging.log4j.core.LoggerContext.reconfigure(LoggerContext.java:442)
[01:18:52]	at org.apache.logging.log4j.core.LoggerContext.start(LoggerContext.java:138)
[01:18:52]	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:207)
[01:18:52]	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:41)
```