### PR TITLE
ISPN-5788 Add more tests for query grouping and aggregations

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -59,7 +59,7 @@
       
       <version.maven-compiler-plugin>3.1</version.maven-compiler-plugin>
       
-      <version.protostream>3.0.2.Final</version.protostream>
+      <version.protostream>3.0.3.Final</version.protostream>
       <version.aesh>0.33.14</version.aesh>
       <version.antlr>3.5.2</version.antlr>
       <version.c3p0>0.9.5</version.c3p0>

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
@@ -180,8 +180,8 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
    //todo [anistor] the original exception gets wrapped in HotRodClientException
    @Override
    @Test(expectedExceptions = HotRodClientException.class, expectedExceptionsMessageRegExp = "org.hibernate.hql.ParsingException: The expression 'surname' must be part of an aggregate function or it should be included in the GROUP BY clause")
-   public void testGroupBy3() throws Exception {
-      super.testGroupBy3();
+   public void testGroupBy2() throws Exception {
+      super.testGroupBy2();
    }
 
    //todo [anistor] null numbers do not seem to work in remote mode
@@ -193,6 +193,18 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
 
    //todo [anistor] the original exception gets wrapped in HotRodClientException
    @Test(expectedExceptions = HotRodClientException.class, expectedExceptionsMessageRegExp = "org.hibernate.hql.ParsingException: Queries containing grouping and aggregation functions must use projections.")
+   @Override
+   public void testGroupBy3() {
+      super.testGroupBy3();
+   }
+
+   @Test(expectedExceptions = HotRodClientException.class, expectedExceptionsMessageRegExp = "java.lang.IllegalStateException: Aggregation SUM cannot be applied to property of type java.lang.String")
+   @Override
+   public void testGroupBy4() {
+      super.testGroupBy4();
+   }
+
+   @Test(expectedExceptions = HotRodClientException.class, expectedExceptionsMessageRegExp = "org.hibernate.hql.ParsingException: HQL000009: Cannot have aggregate functions in WHERE clause : SUM.")
    @Override
    public void testGroupBy5() {
       super.testGroupBy5();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/AddressPB.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/AddressPB.java
@@ -10,6 +10,7 @@ public class AddressPB implements Address {
 
    private String street;
    private String postCode;
+   private int number;
 
    public String getStreet() {
       return street;
@@ -28,10 +29,21 @@ public class AddressPB implements Address {
    }
 
    @Override
+   public int getNumber() {
+      return number;
+   }
+
+   @Override
+   public void setNumber(int number) {
+      this.number = number;
+   }
+
+   @Override
    public String toString() {
       return "AddressPB{" +
             "street='" + street + '\'' +
             ", postCode='" + postCode + '\'' +
+            ", number='" + number + '\'' +
             '}';
    }
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/marshallers/AddressMarshaller.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/testdomain/protobuf/marshallers/AddressMarshaller.java
@@ -25,10 +25,12 @@ public class AddressMarshaller implements MessageMarshaller<AddressPB> {
    public AddressPB readFrom(ProtoStreamReader reader) throws IOException {
       String street = reader.readString("street");
       String postCode = reader.readString("postCode");
+      int number = reader.readInt("number");
 
       AddressPB address = new AddressPB();
       address.setStreet(street);
       address.setPostCode(postCode);
+      address.setNumber(number);
       return address;
    }
 
@@ -36,6 +38,7 @@ public class AddressMarshaller implements MessageMarshaller<AddressPB> {
    public void writeTo(ProtoStreamWriter writer, AddressPB address) throws IOException {
       writer.writeString("street", address.getStreet());
       writer.writeString("postCode", address.getPostCode());
+      writer.writeInt("number", address.getNumber());
    }
 }
 

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/testdomain/Address.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/testdomain/Address.java
@@ -13,4 +13,8 @@ public interface Address {
    String getPostCode();
 
    void setPostCode(String postCode);
+
+   int getNumber();
+
+   void setNumber(int number);
 }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/testdomain/hsearch/AddressHS.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/testdomain/hsearch/AddressHS.java
@@ -19,6 +19,9 @@ public class AddressHS implements Address, Serializable {
    @Field(store = Store.YES, analyze = Analyze.NO)
    private String postCode;
 
+   @Field(store = Store.YES, analyze = Analyze.NO)
+   private int number;
+
    public String getStreet() {
       return street;
    }
@@ -35,6 +38,14 @@ public class AddressHS implements Address, Serializable {
       this.postCode = postCode;
    }
 
+   public int getNumber() {
+      return number;
+   }
+
+   public void setNumber(int number) {
+      this.number = number;
+   }
+
    @Override
    public boolean equals(Object o) {
       if (this == o) return true;
@@ -44,6 +55,7 @@ public class AddressHS implements Address, Serializable {
 
       if (postCode != null ? !postCode.equals(other.postCode) : other.postCode != null) return false;
       if (street != null ? !street.equals(other.street) : other.street != null) return false;
+      if (number != other.number) return false;
 
       return true;
    }
@@ -52,6 +64,7 @@ public class AddressHS implements Address, Serializable {
    public int hashCode() {
       int result = street != null ? street.hashCode() : 0;
       result = 31 * result + (postCode != null ? postCode.hashCode() : 0);
+      result = 31 * result + number;
       return result;
    }
 
@@ -60,6 +73,7 @@ public class AddressHS implements Address, Serializable {
       return "AddressHS{" +
             "street='" + street + '\'' +
             ", postCode='" + postCode + '\'' +
+            ", number='" + number + '\'' +
             '}';
    }
 }


### PR DESCRIPTION
This PR depends on https://github.com/infinispan/protostream/pull/24.

Several tests fail:
testAggregateDate
testComplexQuery
testComplexQuery2
testDateFilteringWithGroupBy
testEmbeddedAvg
testEmbeddedCount1
testEmbeddedCount2
testEmbeddedGlobalAvg
testEmbeddedGlobalCount
testEmbeddedGlobalMax
testEmbeddedGlobalSum
testEmbeddedMax
testEmbeddedSum

The first 4 fail because of https://issues.jboss.org/browse/ISPN-5787 , the rest is caused by https://issues.jboss.org/browse/ISPN-5682 (the issue is really about using aggregations on embedded entities).