### PR TITLE
ISPN-5790 AuthorizationManager rework

### DIFF
--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -1821,4 +1821,5 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    public Properties getConfigurationAsProperties() {
       return new PropertyFormatter().format(config);
    }
+
 }

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalSecurityConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalSecurityConfigurationBuilder.java
@@ -1,5 +1,7 @@
 package org.infinispan.configuration.global;
 
+import java.util.concurrent.TimeUnit;
+
 import org.infinispan.commons.configuration.Builder;
 
 /**
@@ -24,7 +26,12 @@ public class GlobalSecurityConfigurationBuilder extends AbstractGlobalConfigurat
 
    @Override
    public GlobalSecurityConfigurationBuilder securityCacheTimeout(long securityCacheTimeout) {
-      this.securityCacheTimeout = securityCacheTimeout;
+      return securityCacheTimeout(securityCacheTimeout, TimeUnit.MILLISECONDS);
+   }
+
+   @Override
+   public GlobalSecurityConfigurationBuilder securityCacheTimeout(long securityCacheTimeout, TimeUnit unit) {
+      this.securityCacheTimeout = unit.toMillis(securityCacheTimeout);
       return this;
    }
 

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalSecurityConfigurationChildBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalSecurityConfigurationChildBuilder.java
@@ -1,5 +1,7 @@
 package org.infinispan.configuration.global;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * GlobalSecurityConfigurationChildBuilder.
  *
@@ -12,9 +14,21 @@ public interface GlobalSecurityConfigurationChildBuilder extends GlobalConfigura
     */
    GlobalAuthorizationConfigurationBuilder authorization();
    /**
-    * Defines the timeout in milliseconds for which to cache user access roles
+    * Defines the timeout in milliseconds for which to cache user access roles. A value of -1 means the entries
+    * never expire. A value of 0 will disable the cache.
     *
     * @param securityCacheTimeout
+    * @deprecated Use {@link #securityCacheTimeout(long, TimeUnit)} instead
     */
+   @Deprecated
    GlobalSecurityConfigurationBuilder securityCacheTimeout(long securityCacheTimeout);
+
+   /**
+    * Defines the timeout for which to cache user access roles. A value of -1 means the entries
+    * never expire. A value of 0 will disable the cache.
+    *
+    * @param securityCacheTimeout the timeout
+    * @param unit the {@link TimeUnit}
+    */
+   GlobalSecurityConfigurationBuilder securityCacheTimeout(long securityCacheTimeout, TimeUnit unit);
 }

--- a/core/src/main/java/org/infinispan/factories/EmptyConstructorFactory.java
+++ b/core/src/main/java/org/infinispan/factories/EmptyConstructorFactory.java
@@ -10,10 +10,6 @@ import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.marshall.core.ExternalizerTable;
 import org.infinispan.remoting.inboundhandler.GlobalInboundInvocationHandler;
 import org.infinispan.remoting.inboundhandler.InboundInvocationHandler;
-import org.infinispan.topology.ClusterTopologyManager;
-import org.infinispan.topology.ClusterTopologyManagerImpl;
-import org.infinispan.topology.LocalTopologyManager;
-import org.infinispan.topology.LocalTopologyManagerImpl;
 import org.infinispan.util.DefaultTimeService;
 import org.infinispan.util.TimeService;
 import org.infinispan.xsite.BackupReceiverRepository;
@@ -27,31 +23,26 @@ import org.infinispan.xsite.BackupReceiverRepositoryImpl;
  * @since 4.0
  */
 
-@DefaultFactoryFor(classes = {InboundInvocationHandler.class, RemoteCommandsFactory.class, ExternalizerTable.class,
-                              BackupReceiverRepository.class, CancellationService.class, TimeService.class})
+@DefaultFactoryFor(classes = {BackupReceiverRepository.class, CancellationService.class, ExternalizerTable.class,
+                              InboundInvocationHandler.class, RemoteCommandsFactory.class, TimeService.class})
 @Scope(Scopes.GLOBAL)
 public class EmptyConstructorFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
 
    @Override
    @SuppressWarnings("unchecked")
    public <T> T construct(Class<T> componentType) {
-      if (componentType.equals(RemoteCommandsFactory.class))
-         return (T) new RemoteCommandsFactory();
-      else if (componentType.equals(ExternalizerTable.class))
-         return (T) new ExternalizerTable();
-      else if (componentType.equals(LocalTopologyManager.class))
-         return (T) new LocalTopologyManagerImpl();
-      else if (componentType.equals(ClusterTopologyManager.class))
-         return (T) new ClusterTopologyManagerImpl();
-      else if (componentType.equals(BackupReceiverRepository.class))
+      if (componentType.equals(BackupReceiverRepository.class))
          return (T) new BackupReceiverRepositoryImpl();
       else if (componentType.equals(CancellationService.class))
          return (T) new CancellationServiceImpl();
-      else if (componentType.equals(TimeService.class)) {
-         return (T) new DefaultTimeService();
-      } else if (componentType.equals(InboundInvocationHandler.class)) {
+      else if (componentType.equals(ExternalizerTable.class))
+         return (T) new ExternalizerTable();
+      else if (componentType.equals(InboundInvocationHandler.class))
          return (T) new GlobalInboundInvocationHandler();
-      }
+      else if (componentType.equals(RemoteCommandsFactory.class))
+         return (T) new RemoteCommandsFactory();
+      else if (componentType.equals(TimeService.class))
+         return (T) new DefaultTimeService();
 
       throw new CacheConfigurationException("Don't know how to create a " + componentType.getName());
    }

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -36,7 +36,6 @@ import org.infinispan.jmx.annotations.Parameter;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifier;
 import org.infinispan.registry.InternalCacheRegistry;
-import org.infinispan.registry.impl.ClusterRegistryImpl;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.transport.Address;
@@ -676,7 +675,8 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
                }
                cachesToStop.addAll(caches.keySet());
                // will be stopped by the GCR
-               cachesToStop.remove(ClusterRegistryImpl.GLOBAL_REGISTRY_CACHE_NAME);
+               InternalCacheRegistry internalCacheRegistry = globalComponentRegistry.getComponent(InternalCacheRegistry.class);
+               internalCacheRegistry.filterPrivateCaches(cachesToStop);
                // make sure we stop the default cache LAST!
                if(!defaultCacheHasDependency) {
                   cachesToStop.add(DEFAULT_CACHE_NAME);
@@ -757,7 +757,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
       names.addAll(Immutables.immutableSetConvert(caches.keySet()));
       names.remove(DEFAULT_CACHE_NAME);
       InternalCacheRegistry internalCacheRegistry = globalComponentRegistry.getComponent(InternalCacheRegistry.class);
-      internalCacheRegistry.filterInternalCaches(names);
+      internalCacheRegistry.filterPrivateCaches(names);
       if (names.isEmpty())
          return InfinispanCollections.emptySet();
       else

--- a/core/src/main/java/org/infinispan/registry/InternalCacheRegistry.java
+++ b/core/src/main/java/org/infinispan/registry/InternalCacheRegistry.java
@@ -18,17 +18,45 @@ import org.infinispan.factories.scopes.Scopes;
 public interface InternalCacheRegistry {
    enum Flag {
       EXCLUSIVE, // means that the cache must be declared only once
-      USER,  // means that this cache is visible to users
+      USER, // means that this cache is visible to users
       PERSISTENT, // means the cache should be made persistent across restarts if global state persistence is enabled
    }
 
+   /**
+    * Registers an internal cache. The cache will be marked as private and volatile
+    *
+    * @param name
+    *           The name of the cache
+    * @param configuration
+    *           The configuration for the cache
+    */
    void registerInternalCache(String name, Configuration configuration);
 
+   /**
+    * Registers an internal cache with the specified flags.
+    *
+    * @param name
+    *           The name of the cache
+    * @param configuration
+    *           The configuration for the cache
+    * @param flags
+    *           The flags which determine the behaviour of the cache. See {@link Flag}
+    */
    void registerInternalCache(String name, Configuration configuration, EnumSet<Flag> flags);
 
+   /**
+    * Returns whether the cache is internal, i.e. it has been registered using the
+    * {@link #registerInternalCache(String, Configuration)} method
+    */
    boolean isInternalCache(String name);
 
+   /**
+    * Retrieves the names of all the internal caches
+    */
    Set<String> getInternalCacheNames();
 
-   void filterInternalCaches(Set<String> names);
+   /**
+    * Removes the private caches from the specified set of cache names
+    */
+   void filterPrivateCaches(Set<String> names);
 }

--- a/core/src/main/java/org/infinispan/registry/impl/ClusterRegistryImpl.java
+++ b/core/src/main/java/org/infinispan/registry/impl/ClusterRegistryImpl.java
@@ -60,9 +60,6 @@ public class ClusterRegistryImpl<S, K, V> implements ClusterRegistry<S, K, V> {
 
    @Stop(priority=1)
    public void stop() {
-      if (clusterRegistryCache != null) {
-         clusterRegistryCache.stop();
-      }
       clusterRegistryCache = null;
    }
 

--- a/core/src/main/java/org/infinispan/registry/impl/InternalCacheRegistryImpl.java
+++ b/core/src/main/java/org/infinispan/registry/impl/InternalCacheRegistryImpl.java
@@ -4,10 +4,12 @@ import java.lang.invoke.MethodHandles;
 import java.util.EnumSet;
 import java.util.Set;
 
+import org.infinispan.Cache;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Stop;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.registry.InternalCacheRegistry;
 import org.infinispan.util.concurrent.ConcurrentHashSet;
@@ -29,6 +31,15 @@ public class InternalCacheRegistryImpl implements InternalCacheRegistry {
    @Inject
    public void init(EmbeddedCacheManager cacheManager) {
       this.cacheManager = cacheManager;
+   }
+
+   @Stop(priority = 1)
+   public void stop() {
+      for (String cacheName : internalCaches) {
+         Cache<Object, Object> cache = cacheManager.getCache(cacheName, false);
+         if (cache != null)
+            cache.stop();
+      }
    }
 
    @Override
@@ -66,7 +77,7 @@ public class InternalCacheRegistryImpl implements InternalCacheRegistry {
    }
 
    @Override
-   public void filterInternalCaches(Set<String> names) {
+   public void filterPrivateCaches(Set<String> names) {
       names.removeAll(privateCaches);
    }
 }

--- a/core/src/main/java/org/infinispan/security/AuthorizationManager.java
+++ b/core/src/main/java/org/infinispan/security/AuthorizationManager.java
@@ -16,5 +16,15 @@ import org.infinispan.factories.scopes.Scopes;
  */
 @Scope(Scopes.NAMED_CACHE)
 public interface AuthorizationManager {
-   void checkPermission(AuthorizationPermission permissions);
+   /**
+    * Verifies that the {@link Subject} associated with the current {@link AccessControlContext}
+    * has the requested permission. A {@link SecurityException} is thrown otherwise.
+    */
+   void checkPermission(AuthorizationPermission permission);
+
+   /**
+    * Verifies that the {@link Subject} associated with the current {@link AccessControlContext}
+    * has the requested permission and role. A {@link SecurityException} is thrown otherwise.
+    */
+   void checkPermission(AuthorizationPermission permission, String role);
 }

--- a/core/src/main/java/org/infinispan/security/GlobalSecurityManager.java
+++ b/core/src/main/java/org/infinispan/security/GlobalSecurityManager.java
@@ -1,0 +1,26 @@
+package org.infinispan.security;
+
+import org.infinispan.Cache;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+
+/**
+ * GlobalSecurityManager.
+ *
+ * @author Tristan Tarrant
+ * @since 8.1
+ */
+@Scope(Scopes.GLOBAL)
+public interface GlobalSecurityManager {
+
+   /**
+    * Returns the global ACL cache
+    */
+   Cache<?, ?> globalACLCache();
+
+   /**
+    * Flushes the ACL cache for this node
+    */
+   void flushGlobalACLCache();
+
+}

--- a/core/src/main/java/org/infinispan/security/impl/AuthorizationManagerImpl.java
+++ b/core/src/main/java/org/infinispan/security/impl/AuthorizationManagerImpl.java
@@ -1,30 +1,25 @@
 package org.infinispan.security.impl;
 
-import java.security.Principal;
-
-import javax.security.auth.Subject;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentMap;
 
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.AuthorizationConfiguration;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.global.GlobalConfiguration;
-import org.infinispan.configuration.global.GlobalSecurityConfiguration;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.registry.ClusterRegistry;
 import org.infinispan.security.AuditContext;
 import org.infinispan.security.AuthorizationManager;
 import org.infinispan.security.AuthorizationPermission;
+import org.infinispan.security.GlobalSecurityManager;
 
 /**
- * AuthorizationManagerImpl. An implementation of the {@link AuthorizationManager} interface. In
- * order to increase performance, the access mask computed from the {@link Subject}'s
- * {@link Principal}s is cached for future uses.
+ * AuthorizationManagerImpl. An implementation of the {@link AuthorizationManager} interface.
  *
  * @author Tristan Tarrant
  * @since 7.0
  */
 public class AuthorizationManagerImpl implements AuthorizationManager {
-   private GlobalSecurityConfiguration globalConfiguration;
    private AuthorizationConfiguration configuration;
    private AuthorizationHelper authzHelper;
 
@@ -32,15 +27,19 @@ public class AuthorizationManagerImpl implements AuthorizationManager {
    }
 
    @Inject
-   public void init(Cache<?, ?> cache, GlobalConfiguration globalConfiguration, Configuration configuration,
-         ClusterRegistry<String, Subject, Integer> clusterRegistry) {
-      this.globalConfiguration = globalConfiguration.security();
+   public void init(Cache<?, ?> cache, GlobalConfiguration globalConfiguration, Configuration configuration, GlobalSecurityManager globalSecurityManager) {
       this.configuration = configuration.security().authorization();
-      this.authzHelper = new AuthorizationHelper(this.globalConfiguration, AuditContext.CACHE, cache.getName(), clusterRegistry);
+      this.authzHelper = new AuthorizationHelper(globalConfiguration.security(), AuditContext.CACHE, cache.getName(),
+            (ConcurrentMap<CachePrincipalPair, SubjectACL>) globalSecurityManager.globalACLCache());
    }
 
    @Override
    public void checkPermission(AuthorizationPermission perm) {
-      authzHelper.checkPermission(configuration, perm);
+      authzHelper.checkPermission(configuration, perm, null);
+   }
+
+   @Override
+   public void checkPermission(AuthorizationPermission perm, String role) {
+      authzHelper.checkPermission(configuration, perm, role);
    }
 }

--- a/core/src/main/java/org/infinispan/security/impl/CachePrincipalPair.java
+++ b/core/src/main/java/org/infinispan/security/impl/CachePrincipalPair.java
@@ -1,0 +1,50 @@
+package org.infinispan.security.impl;
+
+import java.security.Principal;
+
+/**
+ * CachePrincipalPair.
+ *
+ * @author Tristan Tarrant
+ * @since 8.1
+ */
+final public class CachePrincipalPair {
+   private final String principalName;
+   private final String cacheName;
+   private final int hashCode;
+
+   CachePrincipalPair(Principal userPrincipal, String cacheName) {
+      this.principalName = userPrincipal.getName();
+      this.cacheName = cacheName;
+      this.hashCode = computeHashCode();
+   }
+
+   private int computeHashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((cacheName == null) ? 0 : cacheName.hashCode());
+      result = prime * result + ((principalName == null) ? 0 : principalName.hashCode());
+      return result;
+   }
+
+   @Override
+   public int hashCode() {
+      return hashCode;
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+      CachePrincipalPair other = (CachePrincipalPair) obj;
+      if (!cacheName.equals(other.cacheName))
+         return false;
+      if (!principalName.equals(other.principalName))
+         return false;
+      return true;
+   }
+}

--- a/core/src/main/java/org/infinispan/security/impl/GlobalSecurityManagerFactory.java
+++ b/core/src/main/java/org/infinispan/security/impl/GlobalSecurityManagerFactory.java
@@ -1,0 +1,27 @@
+package org.infinispan.security.impl;
+
+import org.infinispan.factories.AbstractComponentFactory;
+import org.infinispan.factories.AutoInstantiableFactory;
+import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.security.GlobalSecurityManager;
+
+/**
+ * Factory for GlobalSecurityManager implementations
+ *
+ * @author Tristan Tarrant
+ * @since 8.1
+ */
+@Scope(Scopes.GLOBAL)
+@DefaultFactoryFor(classes = GlobalSecurityManager.class)
+public class GlobalSecurityManagerFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
+
+   @Override
+   public <T> T construct(Class<T> componentType) {
+      if (globalConfiguration.security().authorization().enabled())
+         return componentType.cast(new GlobalSecurityManagerImpl());
+      else
+         return null;
+   }
+}

--- a/core/src/main/java/org/infinispan/security/impl/GlobalSecurityManagerImpl.java
+++ b/core/src/main/java/org/infinispan/security/impl/GlobalSecurityManagerImpl.java
@@ -1,0 +1,61 @@
+package org.infinispan.security.impl;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.jmx.annotations.MBean;
+import org.infinispan.jmx.annotations.ManagedOperation;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.registry.InternalCacheRegistry;
+import org.infinispan.security.GlobalSecurityManager;
+
+/**
+ * GlobalSecurityManagerImpl. Initialize the global ACL cache.
+ *
+ * @author Tristan Tarrant
+ * @since 8.1
+ */
+@MBean(objectName = "GlobalSecurityManager", description = "Controls global ACL caches")
+public class GlobalSecurityManagerImpl implements GlobalSecurityManager {
+   private static final String ACL_CACHE = "___acl_cache";
+   private EmbeddedCacheManager cacheManager;
+   private boolean cacheEnabled;
+
+   @Inject
+   public void init(EmbeddedCacheManager cacheManager, GlobalConfiguration globalConfiguration, InternalCacheRegistry internalCacheRegistry) {
+      this.cacheManager = cacheManager;
+      registerGlobalACLCacheConfiguration(globalConfiguration, internalCacheRegistry);
+   }
+
+   private void registerGlobalACLCacheConfiguration(GlobalConfiguration globalConfiguration, InternalCacheRegistry internalCacheRegistry) {
+      long timeout = globalConfiguration.security().securityCacheTimeout();
+      if (timeout != 0) {
+         ConfigurationBuilder cfg = new ConfigurationBuilder();
+         cfg.simpleCache(true);
+         if (timeout > 0)
+            cfg.expiration().lifespan(timeout);
+         internalCacheRegistry.registerInternalCache(ACL_CACHE, cfg.build());
+         cacheEnabled = true;
+      } else {
+         cacheEnabled = false;
+      }
+   }
+
+   @Override
+   public Cache<?, ?> globalACLCache() {
+      if (cacheEnabled) {
+         return cacheManager.getCache(ACL_CACHE);
+      } else {
+         return null;
+      }
+   }
+
+   @ManagedOperation(name="Flush ACL Cache", displayName="Flush ACL Cache", description="Flushes the global ACL cache for this node")
+   @Override
+   public void flushGlobalACLCache() {
+      if (cacheEnabled) {
+         globalACLCache().clear();
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/security/impl/SubjectACL.java
+++ b/core/src/main/java/org/infinispan/security/impl/SubjectACL.java
@@ -1,0 +1,41 @@
+package org.infinispan.security.impl;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * SubjectACL.
+ *
+ * @author Tristan Tarrant
+ * @since 8.1
+ */
+public class SubjectACL {
+   private final Set<String> roles;
+   private final int mask;
+
+   public SubjectACL(Set<String> roles, int mask) {
+      this.roles = Collections.unmodifiableSet(roles);
+      this.mask = mask;
+   }
+
+   public int getMask() {
+      return mask;
+   }
+
+   public Set<String> getRoles() {
+      return roles;
+   }
+
+   public boolean containsRole(String role) {
+      return roles.contains(role);
+   }
+
+   public boolean matches(int permissionMask) {
+      return (mask & permissionMask) == permissionMask;
+   }
+
+   @Override
+   public String toString() {
+      return "SubjectACL [roles=" + roles + ", mask=" + mask + "]";
+   }
+}

--- a/core/src/test/java/org/infinispan/security/RolePermissionNoACLCacheTest.java
+++ b/core/src/test/java/org/infinispan/security/RolePermissionNoACLCacheTest.java
@@ -1,0 +1,32 @@
+package org.infinispan.security;
+
+import java.util.concurrent.TimeUnit;
+
+import org.infinispan.configuration.cache.AuthorizationConfigurationBuilder;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalAuthorizationConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.security.impl.IdentityRoleMapper;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+@Test(groups="functional", testName="security.RolePermissionNoACLCacheTest")
+public class RolePermissionNoACLCacheTest extends RolePermissionTest {
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
+      GlobalAuthorizationConfigurationBuilder globalRoles = global.security().securityCacheTimeout(0, TimeUnit.SECONDS).authorization().enable()
+            .principalRoleMapper(new IdentityRoleMapper());
+      ConfigurationBuilder config = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+      AuthorizationConfigurationBuilder authConfig = config.security().authorization().enable();
+
+      globalRoles
+         .role("role1").permission(AuthorizationPermission.EXEC)
+         .role("role2").permission(AuthorizationPermission.EXEC)
+         .role("admin").permission(AuthorizationPermission.ALL);
+      authConfig.role("role1").role("role2").role("admin");
+      return TestCacheManagerFactory.createCacheManager(global, config);
+   }
+}

--- a/core/src/test/java/org/infinispan/security/RolePermissionTest.java
+++ b/core/src/test/java/org/infinispan/security/RolePermissionTest.java
@@ -1,0 +1,145 @@
+package org.infinispan.security;
+
+import java.security.PrivilegedAction;
+import java.security.PrivilegedExceptionAction;
+
+import javax.security.auth.Subject;
+
+import org.infinispan.configuration.cache.AuthorizationConfigurationBuilder;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalAuthorizationConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.security.impl.IdentityRoleMapper;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+@Test(groups="functional", testName="security.RolePermissionTest")
+public class RolePermissionTest extends SingleCacheManagerTest {
+   static final Subject ADMIN = TestingUtil.makeSubject("admin");
+   static final Subject SUBJECT_A = TestingUtil.makeSubject("A", "role1");
+   AuthorizationManager authzManager;
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      GlobalConfigurationBuilder global = new GlobalConfigurationBuilder();
+      GlobalAuthorizationConfigurationBuilder globalRoles = global.security().authorization().enable()
+            .principalRoleMapper(new IdentityRoleMapper());
+      ConfigurationBuilder config = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+      AuthorizationConfigurationBuilder authConfig = config.security().authorization().enable();
+
+      globalRoles
+         .role("role1").permission(AuthorizationPermission.EXEC)
+         .role("role2").permission(AuthorizationPermission.EXEC)
+         .role("admin").permission(AuthorizationPermission.ALL);
+      authConfig.role("role1").role("role2").role("admin");
+      return TestCacheManagerFactory.createCacheManager(global, config);
+   }
+
+   @Override
+   protected void setup() throws Exception {
+      authzManager = Security.doAs(ADMIN, new PrivilegedExceptionAction<AuthorizationManager>() {
+
+         @Override
+         public AuthorizationManager run() throws Exception {
+            cacheManager = createCacheManager();
+            if (cache == null) cache = cacheManager.getCache();
+            return cache.getAdvancedCache().getAuthorizationManager();
+         }
+      });
+   }
+
+   public void testPermissionAndRole() {
+      Security.doAs(SUBJECT_A, new PrivilegedAction<Void>() {
+
+         @Override
+         public Void run() {
+            authzManager.checkPermission(AuthorizationPermission.EXEC, "role1");
+            return null;
+         }
+      });
+   }
+
+   public void testPermissionAndNoRole() {
+      Security.doAs(SUBJECT_A, new PrivilegedAction<Void>() {
+
+         @Override
+         public Void run() {
+            authzManager.checkPermission(AuthorizationPermission.EXEC);
+            return null;
+         }
+      });
+   }
+
+   @Test(expectedExceptions=SecurityException.class)
+   public void testWrongPermissionAndNoRole() {
+      Security.doAs(SUBJECT_A, new PrivilegedAction<Void>() {
+
+         @Override
+         public Void run() {
+            authzManager.checkPermission(AuthorizationPermission.LISTEN);
+            return null;
+         }
+      });
+   }
+
+   @Test(expectedExceptions=SecurityException.class)
+   public void testWrongPermissionAndRole() {
+      Security.doAs(SUBJECT_A, new PrivilegedAction<Void>() {
+
+         @Override
+         public Void run() {
+            authzManager.checkPermission(AuthorizationPermission.LISTEN, "role1");
+            return null;
+         }
+      });
+   }
+
+   @Test(expectedExceptions=SecurityException.class)
+   public void testPermissionAndWrongRole() {
+      Security.doAs(SUBJECT_A, new PrivilegedAction<Void>() {
+
+         @Override
+         public Void run() {
+            authzManager.checkPermission(AuthorizationPermission.EXEC, "role2");
+            return null;
+         }
+      });
+   }
+
+   @Test(expectedExceptions=SecurityException.class)
+   public void testWrongPermissionAndWrongRole() {
+      Security.doAs(SUBJECT_A, new PrivilegedAction<Void>() {
+
+         @Override
+         public Void run() {
+            authzManager.checkPermission(AuthorizationPermission.LISTEN, "role2");
+            return null;
+         }
+      });
+   }
+
+   @Override
+   protected void teardown() {
+      Security.doAs(ADMIN, new PrivilegedAction<Void>() {
+         @Override
+         public Void run() {
+            RolePermissionTest.super.teardown();
+            return null;
+         }
+      });
+   }
+
+   @Override
+   protected void clearContent() {
+      Security.doAs(ADMIN, new PrivilegedAction<Void>() {
+         @Override
+         public Void run() {
+            cacheManager.getCache().clear();
+            return null;
+         }
+      });
+   }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5790

- use an internal cache instead of the Cluster Registry
- add a GlobalSecurityManager with the ability to flush acl caches
- don't cache per-cache acl masks
- add a role check in addition to the existing permission check