### PR TITLE
ISPN-5801 JCache metadata expiry should be absolute

### DIFF
--- a/jcache/embedded/src/main/java/org/infinispan/jcache/embedded/JCacheLoaderAdapter.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/embedded/JCacheLoaderAdapter.java
@@ -47,11 +47,11 @@ public class JCacheLoaderAdapter<K, V> implements org.infinispan.persistence.spi
       if (value != null) {
          Duration expiry = Expiration.getExpiry(expiryPolicy, Expiration.Operation.CREATION);
          long now = ctx.getTimeService().wallClockTime(); // ms
-         if (expiry.isEternal()) {
+         if (expiry == null || expiry.isEternal()) {
             return ctx.getMarshalledEntryFactory().newMarshalledEntry(value, value, null);
          } else {
-            JCacheInternalMetadata meta = new JCacheInternalMetadata(now,
-                  expiry.getTimeUnit().toMillis(expiry.getDurationAmount()));
+            long exp = now + expiry.getTimeUnit().toMillis(expiry.getDurationAmount());
+            JCacheInternalMetadata meta = new JCacheInternalMetadata(now, exp);
             return ctx.getMarshalledEntryFactory().newMarshalledEntry(value, value, meta);
          }
       }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5801

* As indicated in the JCache internal metadata instance variable
  comments, both expiry and created should be absolute, so fix expiry
  parameter which until now was being passed as relative.