### PR TITLE
ISPN-5821 Add manual cluster switch in Java client

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -26,6 +26,7 @@ import org.infinispan.client.hotrod.impl.protocol.Codec;
 import org.infinispan.client.hotrod.impl.protocol.CodecFactory;
 import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
+import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.client.hotrod.logging.LogFactory;
 import org.infinispan.client.hotrod.near.NearCacheService;
@@ -606,6 +607,29 @@ public class RemoteCacheManager implements BasicCacheContainer {
 
    public boolean isStarted() {
       return started;
+   }
+
+   /**
+    * Switch remote cache manager to a different cluster, previously
+    * declared via configuration. If the switch was completed successfully,
+    * this method returns {@code true}, otherwise it returns {@code false}.
+    *
+    * @param clusterName name of the cluster to which to switch to
+    * @return {@code true} if the cluster was switched, {@code false} otherwise
+    */
+   public boolean switchToCluster(String clusterName) {
+      return transportFactory.switchToCluster(clusterName);
+   }
+
+   /**
+    * Switch remote cache manager to a the default cluster, previously
+    * declared via configuration. If the switch was completed successfully,
+    * this method returns {@code true}, otherwise it returns {@code false}.
+    *
+    * @return {@code true} if the cluster was switched, {@code false} otherwise
+    */
+   public boolean switchToDefaultCluster() {
+      return transportFactory.switchToCluster(TcpTransportFactory.DEFAULT_CLUSTER_NAME);
    }
 
    private Properties loadFromStream(InputStream stream) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
@@ -70,4 +70,7 @@ public interface TransportFactory {
    boolean trySwitchCluster(byte[] cacheName);
 
    Marshaller getMarshaller();
+
+   boolean switchToCluster(String clusterName);
+
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
@@ -209,4 +209,12 @@ public interface Log extends BasicLogger {
    @LogMessage(level = INFO)
    @Message(value = "Switched back to main cluster", id = 4051)
    void switchedBackToMainCluster();
+
+   @LogMessage(level = INFO)
+   @Message(value = "Manually switched to cluster '%s'", id = 4052)
+   void manuallySwitchedToCluster(String clusterName);
+
+   @LogMessage(level = INFO)
+   @Message(value = "Manually switched back to main cluster", id = 4053)
+   void manuallySwitchedBackToMainCluster();
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/SiteManualSwitchTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/SiteManualSwitchTest.java
@@ -1,0 +1,51 @@
+package org.infinispan.client.hotrod.xsite;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+@Test(groups = "functional", testName = "xsite.SiteDownFailoverTest")
+public class SiteManualSwitchTest extends AbstractHotRodSiteFailoverTest {
+
+   @Override
+   protected void createSites() {
+      super.createSites();
+      addHitCountInterceptors();
+   }
+
+   public void testManualClusterSwitch() {
+      RemoteCacheManager clientA = client(SITE_A, Optional.of(SITE_B));
+      RemoteCacheManager clientB = client(SITE_B, Optional.empty());
+
+      RemoteCache<Integer, String> cacheA = clientA.getCache();
+      RemoteCache<Integer, String> cacheB = clientB.getCache();
+
+      assertNoHits();
+
+      assertSingleSiteHit(SITE_A, SITE_B, () -> assertNull(cacheA.put(1, "v1")));
+      assertSingleSiteHit(SITE_A, SITE_B, () -> assertEquals("v1", cacheA.get(1)));
+      assertSingleSiteHit(SITE_B, SITE_A, () -> assertNull(cacheB.put(2, "v2")));
+      assertSingleSiteHit(SITE_B, SITE_A, () -> assertEquals("v2", cacheB.get(2)));
+
+      assertTrue(clientA.switchToCluster(SITE_B));
+      assertSingleSiteHit(SITE_B, SITE_A, () -> assertNull(cacheA.put(3, "v3")));
+      assertSingleSiteHit(SITE_B, SITE_A, () -> assertEquals("v3", cacheA.get(3)));
+
+      assertTrue(clientA.switchToDefaultCluster());
+      assertSingleSiteHit(SITE_A, SITE_B, () -> assertNull(cacheA.put(4, "v4")));
+      assertSingleSiteHit(SITE_A, SITE_B, () -> assertEquals("v4", cacheA.get(4)));
+   }
+
+   private void assertSingleSiteHit(String siteHit, String siteNotHit, Runnable r) {
+      r.run();
+      assertSiteHit(siteHit, 1);
+      assertSiteNotHit(siteNotHit);
+   }
+
+}

--- a/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
@@ -928,6 +928,17 @@ NOTE: Remember that regardless of the cluster definitions, the initial
 server(s) configuration must be provided unless the initial servers can
 be resolved using the default server host and port details.
 
+====== Manual Site Cluster Switch
+
+As well as supporting automatic site cluster failover, Java Hot Rod clients
+can also switch between site clusters manually by calling RemoteCacheManager's
+`switchToCluster(clusterName)` and `switchToDefaultCluster()`.
+
+Using `switchToCluster(clusterName)`, users can force a client to switch
+to one of the clusters pre-defined in the Hot Rod client configuration.
+To switch to the initial servers defined in the client configuration, call
+`switchToDefaultCluster()`.
+
 ====  Consistent Concurrent Updates With Hot Rod Versioned Operations
 Data structures, such as Infinispan link:http://docs.jboss.org/infinispan/{infinispanversion}/apidocs/org/infinispan/Cache.html[Cache] , that are accessed and modified concurrently can suffer from data consistency issues unless there're mechanisms to guarantee data correctness. Infinispan Cache, since it implements link:http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ConcurrentMap.html[ConcurrentMap] , provides operations such as link:http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ConcurrentMap.html#replace(K, V, V)[conditional replace] , link:http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ConcurrentMap.html#putIfAbsent(K, V)[putIfAbsent] , and link:http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ConcurrentMap.html#remove(java.lang.Object, java.lang.Object)[conditional remove] to its clients in order to guarantee data correctness. It even allows clients to operate against cache instances within JTA transactions, hence providing the necessary data consistency guarantees.
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5821

* Java Hot Rod client can manually switch between pre-defined clusters
  via `switchToCluster` and `switchToDefaultCluster` methods.