### PR TITLE
ISPN-5803 Extract MarshalledValues in JCache

### DIFF
--- a/jcache/commons/src/test/java/org/infinispan/jcache/util/InMemoryJCacheLoader.java
+++ b/jcache/commons/src/test/java/org/infinispan/jcache/util/InMemoryJCacheLoader.java
@@ -1,11 +1,10 @@
 package org.infinispan.jcache.util;
 
-import org.infinispan.commons.util.CollectionFactory;
-
 import javax.cache.integration.CacheLoader;
 import javax.cache.integration.CacheLoaderException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -17,9 +16,21 @@ import java.util.concurrent.atomic.LongAdder;
  */
 public class InMemoryJCacheLoader<K, V> implements CacheLoader<K, V> {
 
-   private final ConcurrentMap<K, V> store = CollectionFactory.makeConcurrentMap();
+   private final ConcurrentMap<K, V> store;
 
    private final LongAdder counter = new LongAdder();
+
+   public InMemoryJCacheLoader(ConcurrentMap<K, V> store) {
+      this.store = store;
+   }
+
+   public static <K, V> InMemoryJCacheLoader<K, V> create() {
+      return create(new ConcurrentHashMap<>());
+   }
+
+   public static <K, V> InMemoryJCacheLoader<K, V> create(ConcurrentMap<K, V> store) {
+      return new InMemoryJCacheLoader<>(store);
+   }
 
    public InMemoryJCacheLoader<K, V> store(K key, V value) {
       store.put(key, value);

--- a/jcache/commons/src/test/java/org/infinispan/jcache/util/InMemoryJCacheStore.java
+++ b/jcache/commons/src/test/java/org/infinispan/jcache/util/InMemoryJCacheStore.java
@@ -1,0 +1,53 @@
+package org.infinispan.jcache.util;
+
+import javax.cache.Cache;
+import javax.cache.integration.CacheLoader;
+import javax.cache.integration.CacheLoaderException;
+import javax.cache.integration.CacheWriter;
+import javax.cache.integration.CacheWriterException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class InMemoryJCacheStore<K, V> implements CacheLoader<K, V>, CacheWriter<K, V> {
+
+   final ConcurrentMap<K, V> store;
+
+   final InMemoryJCacheLoader<K, V> loader;
+
+   public InMemoryJCacheStore() {
+      this.store = new ConcurrentHashMap<>();
+      this.loader = InMemoryJCacheLoader.create(this.store);
+   }
+
+   @Override
+   public void write(Cache.Entry<? extends K, ? extends V> entry) throws CacheWriterException {
+      store.put(entry.getKey(), entry.getValue());
+   }
+
+   @Override
+   public void writeAll(Collection<Cache.Entry<? extends K, ? extends V>> entries) throws CacheWriterException {
+      entries.forEach(this::write);
+   }
+
+   @Override
+   public void delete(Object key) throws CacheWriterException {
+      store.remove(key);
+   }
+
+   @Override
+   public void deleteAll(Collection<?> keys) throws CacheWriterException {
+      keys.forEach(this::delete);
+   }
+
+   @Override
+   public V load(K key) throws CacheLoaderException {
+      return loader.load(key);
+   }
+
+   @Override
+   public Map<K, V> loadAll(Iterable<? extends K> keys) throws CacheLoaderException {
+      return loader.loadAll(keys);
+   }
+}

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/embedded/JCacheLoaderAdapter.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/embedded/JCacheLoaderAdapter.java
@@ -42,7 +42,7 @@ public class JCacheLoaderAdapter<K, V> implements org.infinispan.persistence.spi
 
    @Override
    public MarshalledEntry load(Object key) throws PersistenceException {
-      V value = loadKey(key);
+      V value = loadKey(MarshalledValues.extract(key));
 
       if (value != null) {
          Duration expiry = Expiration.getExpiry(expiryPolicy, Expiration.Operation.CREATION);

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/embedded/JCacheWriterAdapter.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/embedded/JCacheWriterAdapter.java
@@ -28,7 +28,9 @@ public class JCacheWriterAdapter<K, V> implements org.infinispan.persistence.spi
    @Override
    public void write(MarshalledEntry entry) {
       try {
-         delegate.write(new JCacheEntry(entry.getKey(), entry.getValue()));
+         Object key = MarshalledValues.extract(entry.getKey());
+         Object value = MarshalledValues.extract(entry.getValue());
+         delegate.write(new JCacheEntry(key, value));
       } catch (Exception e) {
          throw Exceptions.launderCacheWriterException(e);
       }
@@ -37,7 +39,7 @@ public class JCacheWriterAdapter<K, V> implements org.infinispan.persistence.spi
    @Override
    public boolean delete(Object key) {
       try {
-         delegate.delete(key);
+         delegate.delete(MarshalledValues.extract(key));
       } catch (Exception e) {
          throw Exceptions.launderCacheWriterException(e);
       }

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/embedded/MarshalledValues.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/embedded/MarshalledValues.java
@@ -1,0 +1,22 @@
+package org.infinispan.jcache.embedded;
+
+import org.infinispan.marshall.core.MarshalledValue;
+
+/**
+ * Helper class for dealing with MarshalledValues
+ */
+class MarshalledValues {
+
+   static <T> T extract(Object obj) {
+      return as((obj instanceof MarshalledValue ? ((MarshalledValue) obj).get() : obj));
+   }
+
+   @SuppressWarnings("unchecked")
+   private static <T> T as(Object obj) {
+      return (T) obj;
+   }
+
+   private MarshalledValues() {
+      // Cannot be instantiated, it's just a holder class
+   }
+}

--- a/jcache/embedded/src/test/java/org/infinispan/jcache/JCacheWriterTest.java
+++ b/jcache/embedded/src/test/java/org/infinispan/jcache/JCacheWriterTest.java
@@ -1,0 +1,87 @@
+package org.infinispan.jcache;
+
+import org.infinispan.jcache.embedded.JCacheManager;
+import org.infinispan.jcache.util.InMemoryJCacheStore;
+import org.infinispan.jcache.util.Int;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.CacheManagerCallable;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+import javax.cache.Cache;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.configuration.MutableConfiguration;
+import java.lang.reflect.Method;
+import java.net.URI;
+
+import static org.infinispan.test.TestingUtil.withCacheManager;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+
+@Test(groups = "functional", testName = "jcache.JCacheWriterTest")
+public class JCacheWriterTest extends AbstractInfinispanTest {
+
+   public void testWriteCustomKey(Method m) {
+      final String cacheName = m.getName();
+      withCacheManager(new CacheManagerCallable(
+         TestCacheManagerFactory.createCacheManager(false)) {
+         @Override
+         public void call() {
+            JCacheManager jCacheManager = createJCacheManager(cm, this);
+            InMemoryJCacheStore<Int, String> store = new InMemoryJCacheStore<>();
+
+            MutableConfiguration<Int, String> cfg = new MutableConfiguration<Int, String>();
+            cfg.setReadThrough(true);
+            cfg.setCacheLoaderFactory(new FactoryBuilder.SingletonFactory(store));
+            cfg.setCacheWriterFactory(new FactoryBuilder.SingletonFactory(store));
+            Cache<Int, String> cache = jCacheManager.createCache(cacheName, cfg);
+
+            cache.put(new Int(1), "v1");
+            assertEquals("v1", store.load(new Int(1)));
+            cache.put(new Int(2), "v2");
+            assertEquals("v2", store.load(new Int(2)));
+
+            assertEquals("v1", cache.get(new Int(1)));
+            assertEquals("v2", cache.get(new Int(2)));
+
+            cache.remove(new Int(1));
+            assertNull(store.load(new Int(1)));
+            cache.remove(new Int(2));
+            assertNull(store.load(new Int(2)));
+         }
+      });
+   }
+
+   public void testWriteCustomValue(Method m) {
+      final String cacheName = m.getName();
+      withCacheManager(new CacheManagerCallable(
+         TestCacheManagerFactory.createCacheManager(false)) {
+         @Override
+         public void call() {
+            JCacheManager jCacheManager = createJCacheManager(cm, this);
+            InMemoryJCacheStore<String, Int> store = new InMemoryJCacheStore<>();
+
+            MutableConfiguration<String, Int> cfg = new MutableConfiguration<String, Int>();
+            cfg.setReadThrough(true);
+            cfg.setCacheLoaderFactory(new FactoryBuilder.SingletonFactory(store));
+            cfg.setCacheWriterFactory(new FactoryBuilder.SingletonFactory(store));
+            Cache<String, Int> cache = jCacheManager.createCache(cacheName, cfg);
+
+            cache.put("k1", new Int(1));
+            assertEquals(new Int(1), store.load("k1"));
+            cache.put("k2", new Int(2));
+            assertEquals(new Int(2), store.load("k2"));
+
+            assertEquals(new Int(2), cache.get("k2"));
+            assertEquals(new Int(1), cache.get("k1"));
+         }
+      });
+   }
+
+
+   private static JCacheManager createJCacheManager(EmbeddedCacheManager cm, Object creator) {
+      return new JCacheManager(URI.create(creator.getClass().getName()), cm, null);
+   }
+
+}

--- a/jcache/embedded/src/test/java/org/infinispan/jcache/util/Int.java
+++ b/jcache/embedded/src/test/java/org/infinispan/jcache/util/Int.java
@@ -1,0 +1,35 @@
+package org.infinispan.jcache.util;
+
+import java.io.Serializable;
+
+/**
+ * {@link Serializable} {@link Integer} wrapper.
+ */
+public final class Int implements Serializable {
+   private final int aInt;
+
+   public Int(int aInt) {
+      this.aInt = aInt;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      Int intKey = (Int) o;
+
+      return aInt == intKey.aInt;
+
+   }
+
+   @Override
+   public int hashCode() {
+      return aInt;
+   }
+
+   @Override
+   public String toString() {
+      return "Int=" + aInt;
+   }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5803

* JCache cache store loader and writers should extract values from
  marshalled values so that cache store/writer implementations can deal
  with true types instead of wrapped ones.