### PR TITLE
ISPN-5871 FlagsEnabledTest.testWithFlagsSemantics always fails

### DIFF
--- a/core/src/test/java/org/infinispan/api/flags/NonTxFlagsEnabledTest.java
+++ b/core/src/test/java/org/infinispan/api/flags/NonTxFlagsEnabledTest.java
@@ -56,7 +56,6 @@ public class NonTxFlagsEnabledTest extends FlagsEnabledTest {
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
       builder
-            .persistence().addStore(UnnecessaryLoadingTest.CountingStoreConfigurationBuilder.class)
             .persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class)
             .clustering().hash().numSegments(2);
       createClusteredCaches(2, cacheName, builder);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5871

* Make the assertions more fine-grained
* Use MagicKey to ensure stable key locations