### PR TITLE
ISPN-5875 Server must unwrap PriviledgedActionExceptions

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/SecureServerFailureRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/SecureServerFailureRetryTest.java
@@ -1,0 +1,46 @@
+package org.infinispan.client.hotrod.retry;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
+import org.infinispan.client.hotrod.test.InternalRemoteCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.core.security.simple.SimpleServerAuthenticationProvider;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder;
+import org.infinispan.server.hotrod.test.HotRodTestingUtil;
+import org.infinispan.server.hotrod.test.TestCallbackHandler;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "client.hotrod.retry.SecureServerFailureRetryTest")
+public class SecureServerFailureRetryTest extends ServerFailureRetryTest {
+
+   @Override
+   protected HotRodServer createStartHotRodServer(EmbeddedCacheManager manager) {
+      HotRodServerConfigurationBuilder serverBuilder = new HotRodServerConfigurationBuilder();
+      SimpleServerAuthenticationProvider sap = new SimpleServerAuthenticationProvider();
+      sap.addUser("user", "realm", "password".toCharArray(), null);
+      serverBuilder.authentication()
+         .enable()
+         .serverName("localhost")
+         .addAllowedMech("CRAM-MD5")
+         .serverAuthenticationProvider(sap);
+      return HotRodClientTestingUtil.startHotRodServer(manager, serverBuilder);
+   }
+
+   @Override
+   protected RemoteCacheManager createRemoteCacheManager(int port) {
+      ConfigurationBuilder clientBuilder = new ConfigurationBuilder();
+      clientBuilder
+         .security().authentication()
+            .enable()
+            .saslMechanism("CRAM-MD5")
+            .callbackHandler(new TestCallbackHandler("user", "realm", "password".toCharArray()))
+         .forceReturnValues(true)
+         .connectionTimeout(5)
+         .connectionPool().maxActive(1)
+         .addServer().host("127.0.0.1").port(port);
+      return new InternalRemoteCacheManager(clientBuilder.build());
+   }
+
+}

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
@@ -25,11 +25,10 @@ import scala.collection.JavaConverters._
 import javax.security.sasl.Sasl
 import io.netty.channel.ChannelHandlerContext
 import javax.security.auth.Subject
-import java.security.PrivilegedAction
+import java.security.{PrivilegedActionException, PrivilegedAction, Principal}
 import javax.security.sasl.SaslServer
 import io.netty.handler.ssl.SslHandler
 import java.util.ArrayList
-import java.security.Principal
 import org.infinispan.server.core.security.InetAddressPrincipal
 import java.net.InetSocketAddress
 import org.infinispan.server.core.security.simple.SimpleUserPrincipal
@@ -524,6 +523,7 @@ object Decoder2x extends AbstractVersionedDecoder with ServerConstants with Log 
             case _ : IllegalLifecycleStateException => createIllegalLifecycleStateErrorResponse(h, t)
             case _ => createServerErrorResponse(h, t)
          }
+         case p: PrivilegedActionException => createErrorResponse(h, p.getCause)
          case t: Throwable => createServerErrorResponse(h, t)
       }
    }


### PR DESCRIPTION
* Unwrapping is necessary to discover the real cause and propagate that
  back to the client.