### PR TITLE
ISPN-5803 Cache loaders/stores key/value params are unwrapped

### DIFF
--- a/core/src/main/java/org/infinispan/atomic/impl/AtomicHashMapProxy.java
+++ b/core/src/main/java/org/infinispan/atomic/impl/AtomicHashMapProxy.java
@@ -65,7 +65,7 @@ public class AtomicHashMapProxy<K, V> extends AutoBatchSupport implements Atomic
    // internal helper, reduces lots of casts.
    @SuppressWarnings("unchecked")
    protected AtomicHashMap<K, V> toMap(Object object) {
-      Object map = (object instanceof MarshalledValue) ? ((MarshalledValue) object).get() : object;
+      Object map = MarshalledValue.unwrap(object);
       return (AtomicHashMap<K, V>) map;
    }
 

--- a/core/src/main/java/org/infinispan/distexec/mapreduce/MapReduceCacheLoaderTask.java
+++ b/core/src/main/java/org/infinispan/distexec/mapreduce/MapReduceCacheLoaderTask.java
@@ -22,16 +22,7 @@ public class MapReduceCacheLoaderTask<KIn, VIn, KOut, VOut> implements AdvancedC
 
    @Override
    public void processEntry(MarshalledEntry<KIn, VIn> marshalledEntry, AdvancedCacheLoader.TaskContext taskContext) {
-      mapper.map(marshalledEntry.getKey(), getValue(marshalledEntry), collector);
+      mapper.map(marshalledEntry.getKey(), marshalledEntry.getValue(), collector);
    }
 
-   @SuppressWarnings("unchecked")
-   private VIn getValue(MarshalledEntry<KIn, VIn> marshalledEntry) {
-      Object loadedValue = marshalledEntry.getValue();
-      if (loadedValue instanceof MarshalledValue) {
-         return  (VIn)((MarshalledValue) loadedValue).get();
-      } else {
-         return (VIn) loadedValue;
-      }
-   }
 }

--- a/core/src/main/java/org/infinispan/distexec/mapreduce/MapReduceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/distexec/mapreduce/MapReduceManagerImpl.java
@@ -387,11 +387,7 @@ public class MapReduceManagerImpl implements MapReduceManager {
       @SuppressWarnings("unchecked")
       protected V getValue(InternalCacheEntry<K,V> entry){
          if (entry != null && !entry.isExpired(timeService.wallClockTime())) {
-            Object value = entry.getValue();
-            if (value instanceof MarshalledValue) {
-               value = ((MarshalledValue) value).get();
-            }
-            return  (V)value;
+            return MarshalledValue.unwrap(entry.getValue());
          } else {
             return null;
          }
@@ -446,18 +442,14 @@ public class MapReduceManagerImpl implements MapReduceManager {
 
       @Override
       public void processEntry(MarshalledEntry<K, V> marshalledEntry, TaskContext taskContext) throws InterruptedException {
-         executeMapWithCollector(marshalledEntry.getKey(), getValue(marshalledEntry));
+         executeMapWithCollector(marshalledEntry.getKey(), marshalledEntry.getValue());
       }
 
       @Override
       @SuppressWarnings("unchecked")
       protected V getValue(InternalCacheEntry<K, V> entry){
          if (entry != null) {
-            Object value = entry.getValue();
-            if (value instanceof MarshalledValue) {
-               value = ((MarshalledValue) value).get();
-            }
-            return  (V)value;
+            return MarshalledValue.unwrap(entry.getValue());
          } else {
             return null;
          }
@@ -502,15 +494,6 @@ public class MapReduceManagerImpl implements MapReduceManager {
          }
       }
 
-      @SuppressWarnings("unchecked")
-      private V getValue(MarshalledEntry<K, V> marshalledEntry) {
-         Object loadedValue = marshalledEntry.getValue();
-         if (loadedValue instanceof MarshalledValue) {
-            return  (V) ((MarshalledValue) loadedValue).get();
-         } else {
-            return (V) loadedValue;
-         }
-      }
    }
 
    private static final class IntermediateKeyFilter<T> implements KeyFilter<IntermediateKey<T>> {

--- a/core/src/main/java/org/infinispan/filter/CollectionKeyFilter.java
+++ b/core/src/main/java/org/infinispan/filter/CollectionKeyFilter.java
@@ -3,6 +3,7 @@ package org.infinispan.filter;
 import org.infinispan.commons.marshall.AbstractExternalizer;
 import org.infinispan.commons.util.Util;
 import org.infinispan.marshall.core.Ids;
+import org.infinispan.marshall.core.MarshalledValue;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -33,7 +34,11 @@ public class CollectionKeyFilter<K> implements KeyFilter<K> {
 
    @Override
    public boolean accept(K key) {
-      return accept ? keys.contains(key) : !keys.contains(key);
+      // This filter is provided as callback to cache stores, so it should be
+      // able to take normal keys and verify them against seen keys which
+      // might be MarshalledValues.
+      boolean contains = keys.stream().filter(k -> k.equals(key) || MarshalledValue.unwrap(k).equals(key)).count() > 0;
+      return accept ? contains : !contains;
    }
 
    public static class Externalizer extends AbstractExternalizer<CollectionKeyFilter> {

--- a/core/src/main/java/org/infinispan/interceptors/MarshalledValueInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/MarshalledValueInterceptor.java
@@ -231,12 +231,11 @@ public class MarshalledValueInterceptor<K, V> extends CommandInterceptor {
    }
 
    protected <R> R processRetVal(R retVal, InvocationContext ctx) {
-      if (retVal instanceof MarshalledValue) {
-         if (ctx == null || ctx.isOriginLocal()) {
-            if (trace) log.tracef("Return is a marshall value, so extract instance from: %s", retVal);
-            retVal = (R) ((MarshalledValue) retVal).get();
-         }
+      if (ctx == null || ctx.isOriginLocal()) {
+         if (trace) log.tracef("Return is a marshall value, so extract instance from: %s", retVal);
+         return MarshalledValue.unwrap(retVal);
       }
+
       return retVal;
    }
 

--- a/core/src/main/java/org/infinispan/iteration/impl/LocalEntryRetriever.java
+++ b/core/src/main/java/org/infinispan/iteration/impl/LocalEntryRetriever.java
@@ -702,9 +702,6 @@ public class LocalEntryRetriever<K, V> implements EntryRetriever<K, V> {
    }
 
    protected static <T> T unwrapMarshalledvalue(T value) {
-      if (value instanceof MarshalledValue) {
-         return (T) ((MarshalledValue) value).get();
-      }
-      return value;
+      return MarshalledValue.unwrap(value);
    }
 }

--- a/core/src/main/java/org/infinispan/marshall/core/MarshalledEntryImpl.java
+++ b/core/src/main/java/org/infinispan/marshall/core/MarshalledEntryImpl.java
@@ -52,6 +52,10 @@ public class MarshalledEntryImpl<K,V> implements MarshalledEntry<K,V> {
       if (key == null) {
          key = unmarshall(keyBytes);
       }
+
+      if (key instanceof MarshalledValue)
+         key = MarshalledValue.unwrap(key);
+
       return key;
    }
 
@@ -60,6 +64,10 @@ public class MarshalledEntryImpl<K,V> implements MarshalledEntry<K,V> {
       if (value == null) {
          value = unmarshall(valueBytes);
       }
+
+      if (value instanceof MarshalledValue)
+         value = MarshalledValue.unwrap(value);
+
       return value;
    }
 

--- a/core/src/main/java/org/infinispan/marshall/core/MarshalledValue.java
+++ b/core/src/main/java/org/infinispan/marshall/core/MarshalledValue.java
@@ -191,6 +191,15 @@ public final class MarshalledValue implements Externalizable {
       marshaller = new GenericJBossMarshaller();
    }
 
+   public static <T> T unwrap(Object obj) {
+      return as((obj instanceof MarshalledValue ? ((MarshalledValue) obj).get() : obj));
+   }
+
+   @SuppressWarnings("unchecked")
+   private static <T> T as(Object obj) {
+      return (T) obj;
+   }
+
    public static class Externalizer extends AbstractExternalizer<MarshalledValue> {
       private final StreamingMarshaller globalMarshaller;
 

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/event/impl/EventImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/event/impl/EventImpl.java
@@ -72,8 +72,6 @@ public class EventImpl<K, V> implements CacheEntryActivatedEvent, CacheEntryCrea
    @Override
    @SuppressWarnings("unchecked")
    public K getKey() {
-      if (key instanceof MarshalledValue)
-         key = (K) ((MarshalledValue) key).get();
       return key;
    }
 
@@ -99,7 +97,7 @@ public class EventImpl<K, V> implements CacheEntryActivatedEvent, CacheEntryCrea
    }
 
    public void setKey(K key) {
-      this.key = key;
+      this.key = MarshalledValue.unwrap(key);
    }
 
    public void setTransactionId(GlobalTransaction transaction) {
@@ -150,8 +148,6 @@ public class EventImpl<K, V> implements CacheEntryActivatedEvent, CacheEntryCrea
    @Override
    @SuppressWarnings("unchecked")
    public V getValue() {
-      if (value instanceof MarshalledValue)
-         value = (V) ((MarshalledValue) value).get();
       return value;
    }
 
@@ -175,7 +171,7 @@ public class EventImpl<K, V> implements CacheEntryActivatedEvent, CacheEntryCrea
    }
 
    public void setValue(V value) {
-      this.value = value;
+      this.value = MarshalledValue.unwrap(value);
    }
 
    public void setEntries(Map<? extends K, ? extends V> entries) {

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -26,6 +26,7 @@ import org.infinispan.interceptors.InterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.marshall.core.MarshalledEntry;
 import org.infinispan.marshall.core.MarshalledEntryFactory;
+import org.infinispan.marshall.core.MarshalledValue;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.metadata.impl.InternalMetadataImpl;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
@@ -411,7 +412,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
          boolean removed = false;
          for (CacheWriter w : writers) {
             if (mode.canPerform(configMap.get(w))) {
-               removed |= w.delete(key);
+               removed |= w.delete(MarshalledValue.unwrap(key));
             }
          }
          return removed;
@@ -459,7 +460,7 @@ public class PersistenceManagerImpl implements PersistenceManager {
             if (!context.isOriginLocal() && isLocalOnlyLoader(l))
                continue;
 
-            MarshalledEntry load = l.load(key);
+            MarshalledEntry load = l.load(MarshalledValue.unwrap(key));
             if (load != null)
                return load;
          }

--- a/core/src/test/java/org/infinispan/persistence/BaseStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/BaseStoreTest.java
@@ -499,12 +499,13 @@ public abstract class BaseStoreTest extends AbstractInfinispanTest {
    public void testLoadAndStoreMarshalledValues() throws PersistenceException {
       assertIsEmpty();
 
-      MarshalledValue key = new MarshalledValue(new Pojo().role("key"), getMarshaller());
-      MarshalledValue key2 = new MarshalledValue(new Pojo().role("key2"), getMarshaller());
-      MarshalledValue value = new MarshalledValue(new Pojo().role("value"), getMarshaller());
+      Pojo key = new Pojo().role("key");
+      MarshalledValue mvKey = new MarshalledValue(key, getMarshaller());
+      Pojo value = new Pojo().role("value");
+      MarshalledValue mvValue = new MarshalledValue(value, getMarshaller());
 
       assertFalse(cl.contains(key));
-      cl.write(new MarshalledEntryImpl<Object, Object>(key, value, null, getMarshaller()));
+      cl.write(new MarshalledEntryImpl<Object, Object>(mvKey, mvValue, null, getMarshaller()));
 
       assertEquals(value, cl.load(key).getValue());
       MarshalledEntry entry = cl.load(key);
@@ -512,6 +513,7 @@ public abstract class BaseStoreTest extends AbstractInfinispanTest {
                  entry.getMetadata() == null || entry.getMetadata().expiryTime() == -1 || entry.getMetadata().maxIdle() == -1);
       assertContains(key, true);
 
+      Pojo key2 = new Pojo().role("key2");
       assertFalse(cl.delete(key2));
       assertTrue(cl.delete(key));
    }

--- a/core/src/test/java/org/infinispan/util/Int.java
+++ b/core/src/test/java/org/infinispan/util/Int.java
@@ -1,0 +1,35 @@
+package org.infinispan.util;
+
+import java.io.Serializable;
+
+/**
+ * {@link Serializable} {@link Integer} wrapper.
+ */
+public final class Int implements Serializable {
+   private final int aInt;
+
+   public Int(int aInt) {
+      this.aInt = aInt;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      Int intKey = (Int) o;
+
+      return aInt == intKey.aInt;
+
+   }
+
+   @Override
+   public int hashCode() {
+      return aInt;
+   }
+
+   @Override
+   public String toString() {
+      return "Int=" + aInt;
+   }
+}

--- a/jcache/commons/src/test/java/org/infinispan/jcache/util/InMemoryJCacheLoader.java
+++ b/jcache/commons/src/test/java/org/infinispan/jcache/util/InMemoryJCacheLoader.java
@@ -1,11 +1,10 @@
 package org.infinispan.jcache.util;
 
-import org.infinispan.commons.util.CollectionFactory;
-
 import javax.cache.integration.CacheLoader;
 import javax.cache.integration.CacheLoaderException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -17,9 +16,21 @@ import java.util.concurrent.atomic.LongAdder;
  */
 public class InMemoryJCacheLoader<K, V> implements CacheLoader<K, V> {
 
-   private final ConcurrentMap<K, V> store = CollectionFactory.makeConcurrentMap();
+   private final ConcurrentMap<K, V> store;
 
    private final LongAdder counter = new LongAdder();
+
+   public InMemoryJCacheLoader(ConcurrentMap<K, V> store) {
+      this.store = store;
+   }
+
+   public static <K, V> InMemoryJCacheLoader<K, V> create() {
+      return create(new ConcurrentHashMap<>());
+   }
+
+   public static <K, V> InMemoryJCacheLoader<K, V> create(ConcurrentMap<K, V> store) {
+      return new InMemoryJCacheLoader<>(store);
+   }
 
    public InMemoryJCacheLoader<K, V> store(K key, V value) {
       store.put(key, value);

--- a/jcache/commons/src/test/java/org/infinispan/jcache/util/InMemoryJCacheStore.java
+++ b/jcache/commons/src/test/java/org/infinispan/jcache/util/InMemoryJCacheStore.java
@@ -1,0 +1,53 @@
+package org.infinispan.jcache.util;
+
+import javax.cache.Cache;
+import javax.cache.integration.CacheLoader;
+import javax.cache.integration.CacheLoaderException;
+import javax.cache.integration.CacheWriter;
+import javax.cache.integration.CacheWriterException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class InMemoryJCacheStore<K, V> implements CacheLoader<K, V>, CacheWriter<K, V> {
+
+   final ConcurrentMap<K, V> store;
+
+   final InMemoryJCacheLoader<K, V> loader;
+
+   public InMemoryJCacheStore() {
+      this.store = new ConcurrentHashMap<>();
+      this.loader = InMemoryJCacheLoader.create(this.store);
+   }
+
+   @Override
+   public void write(Cache.Entry<? extends K, ? extends V> entry) throws CacheWriterException {
+      store.put(entry.getKey(), entry.getValue());
+   }
+
+   @Override
+   public void writeAll(Collection<Cache.Entry<? extends K, ? extends V>> entries) throws CacheWriterException {
+      entries.forEach(this::write);
+   }
+
+   @Override
+   public void delete(Object key) throws CacheWriterException {
+      store.remove(key);
+   }
+
+   @Override
+   public void deleteAll(Collection<?> keys) throws CacheWriterException {
+      keys.forEach(this::delete);
+   }
+
+   @Override
+   public V load(K key) throws CacheLoaderException {
+      return loader.load(key);
+   }
+
+   @Override
+   public Map<K, V> loadAll(Iterable<? extends K> keys) throws CacheLoaderException {
+      return loader.loadAll(keys);
+   }
+}

--- a/jcache/embedded/src/test/java/org/infinispan/jcache/JCacheLoaderTest.java
+++ b/jcache/embedded/src/test/java/org/infinispan/jcache/JCacheLoaderTest.java
@@ -14,6 +14,7 @@ import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.util.ControlledTimeService;
+import org.infinispan.util.Int;
 import org.infinispan.util.TimeService;
 import org.testng.annotations.Test;
 
@@ -53,7 +54,7 @@ public class JCacheLoaderTest extends AbstractInfinispanTest {
          public void call() {
             JCacheManager jCacheManager = createJCacheManager(cm, this);
 
-            InMemoryJCacheLoader<Integer, String> cacheLoader = new InMemoryJCacheLoader<Integer, String>();
+            InMemoryJCacheLoader<Integer, String> cacheLoader = InMemoryJCacheLoader.create();
             cacheLoader.store(1, "v1").store(2, "v2");
 
             MutableConfiguration<Integer, String> cfg = new MutableConfiguration<Integer, String>();
@@ -122,7 +123,7 @@ public class JCacheLoaderTest extends AbstractInfinispanTest {
             TestingUtil.replaceComponent(cm, TimeService.class, timeService, true);
             JCacheManager jCacheManager = createJCacheManager(cm, this);
 
-            InMemoryJCacheLoader<Integer, String> cacheLoader = new InMemoryJCacheLoader<Integer, String>();
+            InMemoryJCacheLoader<Integer, String> cacheLoader = InMemoryJCacheLoader.create();
             cacheLoader.store(1, "v1").store(2, "v2");
 
             MutableConfiguration<Integer, String> cfg = new MutableConfiguration<Integer, String>();
@@ -162,6 +163,27 @@ public class JCacheLoaderTest extends AbstractInfinispanTest {
 
             assertEquals(null, dc.get(2));
             assertEquals(null, dc.get(1));
+         }
+      });
+   }
+
+   public void testLoadCustomKey(Method m) {
+      final String cacheName = m.getName();
+      withCacheManager(new CacheManagerCallable(
+         TestCacheManagerFactory.createCacheManager(false)) {
+         @Override
+         public void call() {
+            JCacheManager jCacheManager = createJCacheManager(cm, this);
+            InMemoryJCacheLoader<Int, String> cacheLoader = InMemoryJCacheLoader.create();
+            cacheLoader.store(new Int(1), "v1").store(new Int(2), "v2");
+
+            MutableConfiguration<Int, String> cfg = new MutableConfiguration<Int, String>();
+            cfg.setReadThrough(true);
+            cfg.setCacheLoaderFactory(new FactoryBuilder.SingletonFactory(cacheLoader));
+            Cache<Int, String> cache = jCacheManager.createCache(cacheName, cfg);
+
+            assertEquals("v2", cache.get(new Int(2)));
+            assertEquals("v1", cache.get(new Int(1)));
          }
       });
    }

--- a/jcache/embedded/src/test/java/org/infinispan/jcache/JCacheWriterTest.java
+++ b/jcache/embedded/src/test/java/org/infinispan/jcache/JCacheWriterTest.java
@@ -1,0 +1,87 @@
+package org.infinispan.jcache;
+
+import org.infinispan.jcache.embedded.JCacheManager;
+import org.infinispan.jcache.util.InMemoryJCacheStore;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.infinispan.test.CacheManagerCallable;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.util.Int;
+import org.testng.annotations.Test;
+
+import javax.cache.Cache;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.configuration.MutableConfiguration;
+import java.lang.reflect.Method;
+import java.net.URI;
+
+import static org.infinispan.test.TestingUtil.withCacheManager;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
+
+@Test(groups = "functional", testName = "jcache.JCacheWriterTest")
+public class JCacheWriterTest extends AbstractInfinispanTest {
+
+   public void testWriteCustomKey(Method m) {
+      final String cacheName = m.getName();
+      withCacheManager(new CacheManagerCallable(
+         TestCacheManagerFactory.createCacheManager(false)) {
+         @Override
+         public void call() {
+            JCacheManager jCacheManager = createJCacheManager(cm, this);
+            InMemoryJCacheStore<Int, String> store = new InMemoryJCacheStore<>();
+
+            MutableConfiguration<Int, String> cfg = new MutableConfiguration<Int, String>();
+            cfg.setReadThrough(true);
+            cfg.setCacheLoaderFactory(new FactoryBuilder.SingletonFactory(store));
+            cfg.setCacheWriterFactory(new FactoryBuilder.SingletonFactory(store));
+            Cache<Int, String> cache = jCacheManager.createCache(cacheName, cfg);
+
+            cache.put(new Int(1), "v1");
+            assertEquals("v1", store.load(new Int(1)));
+            cache.put(new Int(2), "v2");
+            assertEquals("v2", store.load(new Int(2)));
+
+            assertEquals("v1", cache.get(new Int(1)));
+            assertEquals("v2", cache.get(new Int(2)));
+
+            cache.remove(new Int(1));
+            assertNull(store.load(new Int(1)));
+            cache.remove(new Int(2));
+            assertNull(store.load(new Int(2)));
+         }
+      });
+   }
+
+   public void testWriteCustomValue(Method m) {
+      final String cacheName = m.getName();
+      withCacheManager(new CacheManagerCallable(
+         TestCacheManagerFactory.createCacheManager(false)) {
+         @Override
+         public void call() {
+            JCacheManager jCacheManager = createJCacheManager(cm, this);
+            InMemoryJCacheStore<String, Int> store = new InMemoryJCacheStore<>();
+
+            MutableConfiguration<String, Int> cfg = new MutableConfiguration<String, Int>();
+            cfg.setReadThrough(true);
+            cfg.setCacheLoaderFactory(new FactoryBuilder.SingletonFactory(store));
+            cfg.setCacheWriterFactory(new FactoryBuilder.SingletonFactory(store));
+            Cache<String, Int> cache = jCacheManager.createCache(cacheName, cfg);
+
+            cache.put("k1", new Int(1));
+            assertEquals(new Int(1), store.load("k1"));
+            cache.put("k2", new Int(2));
+            assertEquals(new Int(2), store.load("k2"));
+
+            assertEquals(new Int(2), cache.get("k2"));
+            assertEquals(new Int(1), cache.get("k1"));
+         }
+      });
+   }
+
+
+   private static JCacheManager createJCacheManager(EmbeddedCacheManager cm, Object creator) {
+      return new JCacheManager(URI.create(creator.getClass().getName()), cm, null);
+   }
+
+}

--- a/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
+++ b/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
@@ -256,10 +256,7 @@ public final class QueryInterceptor extends CommandInterceptor {
    }
 
    private Object extractValue(Object wrappedValue) {
-      if (wrappedValue instanceof MarshalledValue)
-         return ((MarshalledValue) wrappedValue).get();
-      else
-         return wrappedValue;
+      return MarshalledValue.unwrap(wrappedValue);
    }
 
    public void enableClasses(Class[] classes) {

--- a/query/src/main/java/org/infinispan/query/impl/massindex/IndexWorker.java
+++ b/query/src/main/java/org/infinispan/query/impl/massindex/IndexWorker.java
@@ -63,12 +63,6 @@ public class IndexWorker implements DistributedCallable<Object, Object, Void> {
       return replicated ? AcceptAllKeyValueFilter.getInstance() : new PrimaryOwnersKeyValueFilter();
    }
 
-   private Object extractValue(Object wrappedValue) {
-      if (wrappedValue instanceof MarshalledValue)
-         return ((MarshalledValue) wrappedValue).get();
-      return wrappedValue;
-   }
-
    @Override
    @SuppressWarnings("unchecked")
    public Void call() throws Exception {
@@ -79,7 +73,7 @@ public class IndexWorker implements DistributedCallable<Object, Object, Void> {
          Iterator<CacheEntry<Object, Object>> iterator = stream.filter(CacheFilters.predicate(filter)).iterator();
          while (iterator.hasNext()) {
             CacheEntry<Object, Object> next = iterator.next();
-            Object value = extractValue(next.getValue());
+            Object value = MarshalledValue.unwrap(next.getValue());
             if (value != null && value.getClass().equals(entity))
                indexUpdater.updateIndex(next.getKey(), value);
          }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5803

* Instead of having the JCache loader/writer adapters deal with
  MarshalledValue handling, make the persistence manager and
  MarshalledEntryImpl deal with the complexity of providing cache store
  implementations with the expected key/value types.
* Key instances passed directly to cache stores are now user types as
  opposed to: user types or marshalled values.
* MarshalledEntryImpl now unwraps key/value instances from
  MarshalledValue if callin getKey()/getValue() but such operations
  should normally not be called by cache stores since they normally
  should deal with byte array format, which is accessible via
  getKeyBytes()/getValueBytes and those do no
  unwrapping.
* DummyCacheStore has been fixed to avoid unnecessary
  serialization/deserialization by calling getValueBytes() in
  MarshalledEntry instead of getValue().