### PR TITLE
ISPN-5884 BlockingInterceptor causing random failures

### DIFF
--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxOriginatorBecomingPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxOriginatorBecomingPrimaryOwnerTest.java
@@ -73,12 +73,22 @@ public class NonTxOriginatorBecomingPrimaryOwnerTest extends MultipleCacheManage
             }
          });
 
-         // After the put command passed through EntryWrappingInterceptor, kill cache1
+         // Wait for the put command to pass through EntryWrappingInterceptor
          distInterceptorBarrier.await(10, TimeUnit.SECONDS);
+
+         // Stop blocking new commands, to allow state transfer to finish
+         blockingInterceptor.suspend(true);
+
+         // Kill cache1
          cache1.stop();
 
-         // Wait for the new topology to be installed and unblock the command
+         // Wait for the new topology to be installed
          TestingUtil.waitForRehashToComplete(cache0, cache2);
+
+         // Resume blocking new commands
+         blockingInterceptor.suspend(false);
+
+         // Unblock the command
          distInterceptorBarrier.await(10, TimeUnit.SECONDS);
 
          // StateTransferInterceptor retries the command, and it should block again in BlockingInterceptor.

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxStateTransferOverwritingValueTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxStateTransferOverwritingValueTest.java
@@ -152,6 +152,8 @@ public class NonTxStateTransferOverwritingValueTest extends MultipleCacheManager
 
       // Wait for the entry to be wrapped on cache1
       beforeCommitCache1Barrier.await(10, TimeUnit.SECONDS);
+      // Stop blocking, otherwise we'll block the state transfer put commands as well
+      blockingInterceptor1.suspend(true);
 
       // Allow the state to be applied on cache1 (writing the old value for our entry)
       blockingRpcManager0.stopBlocking();

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplTest.java
@@ -110,7 +110,10 @@ public class ClusterListenerReplTest extends AbstractClusterListenerNonTxTest {
       barrier.await(10, TimeUnit.SECONDS);
 
       // Remove the interceptor so the next command can proceed properly
+      cache0.getAdvancedCache().removeInterceptor(BlockingInterceptor.class);
       cache2.getAdvancedCache().removeInterceptor(BlockingInterceptor.class);
+      blockingInterceptor0.suspend(true);
+      blockingInterceptor2.suspend(true);
 
       // Kill the cache now - note this will automatically unblock the fork thread
       TestingUtil.killCacheManagers(cache1.getCacheManager());


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5884

* Introduce BlockingInterceptor.suspend(boolean)
* Always block commands unless suspended
* Fixes ClusteredListenerReplTest.testPrimaryOwnerGoesDownAfterBackupRaisesEvent

Please cherry-pick on 8.0.x as well.