### PR TITLE
ISPN-5889 Deal with merge views in Hot Rod

### DIFF
--- a/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
@@ -76,7 +76,7 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
    public static class PartitionDescriptor {
       int[] nodes;
 
-      PartitionDescriptor(int... nodes) {
+      public PartitionDescriptor(int... nodes) {
          this.nodes = nodes;
       }
 
@@ -89,7 +89,7 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
       }
    }
 
-   class Partition {
+   public class Partition {
 
       private final List<Address> allMembers;
       List<Channel> channels = new ArrayList<>();

--- a/server/core/src/main/scala/org/infinispan/server/core/logging/JavaLog.java
+++ b/server/core/src/main/scala/org/infinispan/server/core/logging/JavaLog.java
@@ -109,4 +109,8 @@ public interface JavaLog extends org.infinispan.util.logging.Log {
    @Message(value = "Request to encode unexpected message %s", id = 5024)
    void errorUnexpectedMessage(Object msg);
 
+   @LogMessage(level = WARN)
+   @Message(value = "Merged member '%s' can't be found and so can't be added to topology. This node should be restarted to join topology.", id = 5025)
+   void mergedMemberCantBeFound(String member);
+
 }

--- a/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
@@ -90,4 +90,6 @@ trait Log {
    def logErrorEncodingMessage(msg: Any, t: Throwable) = log.errorEncodingMessage(msg, t)
 
    def logErrorUnexpectedMessage(msg: Any) = log.errorUnexpectedMessage(msg)
+
+   def logMergedMemberCantBeFound(member: String) = log.mergedMemberCantBeFound(member)
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/CrashedMemberDetectorListener.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/CrashedMemberDetectorListener.scala
@@ -2,20 +2,22 @@ package org.infinispan.server.hotrod
 
 import logging.Log
 import org.infinispan.notifications.Listener
-import org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged
+import org.infinispan.notifications.cachemanagerlistener.annotation.{Merged, ViewChanged}
 import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent
 import scala.collection.JavaConversions._
 import org.infinispan.context.Flag
 
 /**
- * Listener that detects crashed or stopped members and removes them from
- * the address cache.
+ * Listener that detects crashed, stopped and merged members. When
+ * crashed/stopped members are detected, these are removed from the address
+ * cache but they're temporarily cached locally in case the nodes get merged
+ * back.
  *
  * @author Galder Zamarreño
  * @since 5.1
  */
 @Listener(sync = false) // Use a separate thread to avoid blocking the view handler thread
-class CrashedMemberDetectorListener(cache: AddressCache, server: HotRodServer) extends Log {
+class CrashedMemberDetectorListener(cache: AddressCache, backupCache: AddressCache, server: HotRodServer) extends Log {
 
    // Let all nodes remove the address from their own cache locally. By doing
    // this, we can guarantee that transport view id has been updated before
@@ -38,11 +40,39 @@ class CrashedMemberDetectorListener(cache: AddressCache, server: HotRodServer) e
          if (!goneMembers.isEmpty) {
             // Consider doing removeAsync and then waiting for all removals...
             if (addressCache.getStatus.allowInvocations()) {
-               goneMembers.foreach(addressCache.remove(_))
+               goneMembers.foreach(addr => {
+                  val serverAddr = addressCache.get(addr)
+                  backupCache.put(addr, serverAddr)
+                  addressCache.remove(addr)
+               })
             }
          }
       } catch {
          case t: Throwable => logErrorDetectingCrashedMember(t)
+      }
+   }
+
+   @Merged
+   def handleViewMerged(e: ViewChangedEvent) {
+      trace("Merge view change received: %s", e)
+      val newMembers = collectionAsScalaIterable(e.getNewMembers)
+      val oldMembers = collectionAsScalaIterable(e.getOldMembers)
+      val addedMembers = newMembers.filterNot(oldMembers contains _)
+      if (addressCache.getStatus.allowInvocations()) {
+         trace("Added members are: %s", addedMembers)
+         if (addedMembers.nonEmpty) {
+            addedMembers.foreach(added => {
+               val serverAddr = backupCache.get(added)
+               if (serverAddr != null)
+                  addressCache.put(added, serverAddr)
+               else
+                  logMergedMemberCantBeFound(added.toString)
+            })
+         }
+         val removedMembers = oldMembers.filterNot(newMembers contains _)
+         trace("Removed members are: %s", removedMembers)
+         if (removedMembers.nonEmpty)
+            removedMembers.foreach(removed => addressCache.remove(removed))
       }
    }
 

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/CrashedMemberDetectorTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/CrashedMemberDetectorTest.scala
@@ -24,11 +24,12 @@ class CrashedMemberDetectorTest extends SingleCacheManagerTest {
 
    def testDetectCrashedMembers() {
       val cache = cacheManager.getCache[Address, ServerAddress]()
+      val backup = cacheManager.getCache[Address, ServerAddress]("backup")
       cache.put(new TestAddress(1), new ServerAddress("a", 123))
       cache.put(new TestAddress(2), new ServerAddress("b", 456))
       cache.put(new TestAddress(3), new ServerAddress("c", 789))
 
-      val detector = new CrashedMemberDetectorListener(cache, null)
+      val detector = new CrashedMemberDetectorListener(cache, backup, null)
 
       val oldMembers = new ArrayList[Address]()
       oldMembers.add(new TestAddress(1))
@@ -46,6 +47,8 @@ class CrashedMemberDetectorTest extends SingleCacheManagerTest {
 
       assertTrue(cache.containsKey(new TestAddress(1)))
       assertTrue(cache.containsKey(new TestAddress(2)))
+      assertFalse(cache.containsKey(new TestAddress(3)))
+      assertTrue(backup.containsKey(new TestAddress(3)))
    }
 
 }

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodMultiNodeTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodMultiNodeTest.scala
@@ -23,11 +23,14 @@ abstract class HotRodMultiNodeTest extends MultipleCacheManagersTest {
    @Test(enabled=false) // Disable explicitly to avoid TestNG thinking this is a test!!
    override def createCacheManagers() {
       for (i <- 0 until nodeCount) {
-         val cm = TestCacheManagerFactory.createClusteredCacheManager(hotRodCacheConfiguration())
+         val cm = createCacheManager()
          cacheManagers.add(cm)
       }
       defineCaches(cacheName)
    }
+
+   protected def createCacheManager(): EmbeddedCacheManager =
+      TestCacheManagerFactory.createClusteredCacheManager(hotRodCacheConfiguration())
 
    protected def defineCaches(cacheName: String): Unit = {
       cacheManagers.foreach(cm => cm.defineConfiguration(cacheName, createCacheConfig.build()))

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodViewMergeTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodViewMergeTest.scala
@@ -1,0 +1,89 @@
+package org.infinispan.server.hotrod
+
+import java.lang.reflect.Method
+
+import org.infinispan.configuration.cache.{ConfigurationBuilder, CacheMode}
+import org.infinispan.partitionhandling.{AvailabilityMode, BasePartitionHandlingTest}
+import org.infinispan.partitionhandling.BasePartitionHandlingTest.PartitionDescriptor
+import org.infinispan.server.core.test.ServerTestingUtil._
+import org.infinispan.server.hotrod.Constants._
+import org.infinispan.server.hotrod.OperationStatus._
+import org.infinispan.server.hotrod.test.{HotRodClient, HotRodTestingUtil}
+import org.infinispan.server.hotrod.test.HotRodTestingUtil._
+import org.infinispan.test.AbstractCacheTest.CleanupPhase
+import org.infinispan.test.TestingUtil
+import org.infinispan.test.fwk.TransportFlags
+import org.testng.Assert._
+import org.testng.annotations.{AfterClass, BeforeClass, Test}
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable.ListBuffer
+
+@Test(groups = Array("functional"), testName = "server.hotrod.HotRodViewMergeTest")
+class HotRodViewMergeTest extends BasePartitionHandlingTest {
+
+   numMembersInCluster = 2
+   cacheMode = CacheMode.DIST_SYNC
+   cleanup = CleanupPhase.AFTER_TEST
+
+   private[this] val servers = new ListBuffer[HotRodServer]()
+   private[this] var client: HotRodClient = _
+
+   @BeforeClass(alwaysRun = true)
+   @Test(enabled=false) // Disable explicitly to avoid TestNG thinking this is a test!!
+   override def createBeforeClass() {
+      super.createBeforeClass()
+
+      var nextServerPort = serverPort
+      for (i <- 0 until numMembersInCluster) {
+         servers += HotRodTestingUtil.startHotRodServer(cacheManagers.get(i), nextServerPort)
+         nextServerPort += 50
+      }
+
+      client = new HotRodClient("127.0.0.1", servers.head.getPort, "", 60, 21)
+      TestingUtil.waitForRehashToComplete(cache(0, ""), cache(1, ""))
+   }
+
+   @AfterClass(alwaysRun = true)
+   override protected def destroy(): Unit = {
+      try {
+         killClient(client)
+         servers.foreach(killServer(_))
+      } finally {
+         super.destroy()
+      }
+   }
+
+   @Test(enabled=false) // to avoid TestNG picking it up as a test
+   override protected def createCacheManagers(): Unit = {
+      val dcc = hotRodCacheConfiguration(new ConfigurationBuilder())
+      dcc.clustering.cacheMode(cacheMode).hash().numOwners(1)
+      createClusteredCaches(numMembersInCluster, dcc, new TransportFlags().withFD(true).withMerge(true))
+      waitForClusterToForm()
+   }
+
+   def testNewTopologySentAfterViewMerge(m: Method) {
+      expectCompleteTopology(client, 2)
+      val p0 = new PartitionDescriptor(0)
+      val p1 = new PartitionDescriptor(1)
+      splitCluster(p0.getNodes, p1.getNodes)
+      TestingUtil.waitForRehashToComplete(cache(p1.node(0)))
+      TestingUtil.waitForRehashToComplete(cache(p0.node(0)))
+      expectPartialTopology(client)
+      partition(0).merge(partition(1))
+      expectCompleteTopology(client, 8)
+   }
+
+   private def expectCompleteTopology(c: HotRodClient, expectedTopologyId: Int): Unit = {
+      val resp = c.ping(INTELLIGENCE_HASH_DISTRIBUTION_AWARE, 0)
+      assertStatus(resp, Success)
+      assertHashTopology20Received(resp.topologyResponse.get, servers.toList, "", expectedTopologyId)
+   }
+
+   private def expectPartialTopology(c: HotRodClient): Unit = {
+      val resp = c.ping(INTELLIGENCE_HASH_DISTRIBUTION_AWARE, 2)
+      assertStatus(resp, Success)
+      assertHashTopology20Received(resp.topologyResponse.get, List(servers.head), "", 3)
+   }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5889

* Hot Rod address cache needs to be updated when a merge happens and new
  nodes return back to the cluster, or other nodes are removed.
* The problem is that a merge is the result of a previous installed view
  where a node is removed, and if it's removed from the address cache,
  its endpoint address is also removed. So, to be able to restore a
  node's endpoint address if and when a merge happens, after removing it
  from the address cache, it needs to be kept around in a backup cache
  in case the node comes back as a result of a merge.
* Obviously, this backup address cache needs to be purged so it has been
  configured with expiration timeout of one day, so a merge can still be
  dealt with within that time.
* The backup address cache is a simple cache to reduce its footprint
  since it's just a concurrent hash map that supports expiration.