### PR TITLE
ISPN-5755 Expose clustered stats via Hot Rod

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodStatisticsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodStatisticsTest.java
@@ -5,6 +5,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.AfterMethod;
@@ -23,7 +24,7 @@ import static org.testng.AssertJUnit.assertTrue;
  * @since 4.1
  */
 @Test(groups = "functional", testName = "client.hotrod.HotRodStatisticsTest")
-public class HotRodStatisticsTest {
+public class HotRodStatisticsTest extends AbstractInfinispanTest {
 
    private HotRodServer hotrodServer;
    private CacheContainer cacheContainer;

--- a/documentation/src/main/asciidoc/user_guide/chapter-64-Hot_Rod_Protocol.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-64-Hot_Rod_Protocol.adoc
@@ -1722,6 +1722,25 @@ Response format:
 |... continues until entry count is reached ||
 |==============================================================================
 
+. Stats:
+
+Statistics returned by previous Hot Rod protocol versions were local to the node
+where the Hot Rod operation had been called. Starting with 2.4, new statistics
+have been added which provide global counts for the statistics returned
+previously. If the Hot Rod is running in local mode, these statistics are not
+returned:
+
+[options="header"]
+|===============
+|Name|Explanation
+| globalCurrentNumberOfEntries |Number of entries currently across the Hot Rod cluster.
+| globalStores |Total number of put operations across the Hot Rod cluster.
+| globalRetrievals |Total number of get operations across the Hot Rod cluster.
+| globalHits |Total number of get hits across the Hot Rod cluster.
+| globalMisses |Total number of get misses across the Hot Rod cluster.
+| globalRemoveHits |Total number of removal hits across the Hot Rod cluster.
+| globalRemoveMisses |Total number of removal misses across the Hot Rod cluster.
+|===============
 
 ==== Hot Rod Hash Functions
 Infinispan makes use of a consistent hash function to place nodes on a hash

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/AbstractVersionedDecoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/AbstractVersionedDecoder.scala
@@ -8,7 +8,6 @@ import io.netty.channel.ChannelHandlerContext
 import org.infinispan.configuration.cache.Configuration
 import org.infinispan.container.entries.CacheEntry
 import org.infinispan.server.core.transport.NettyTransport
-import org.infinispan.stats.Stats
 
 /**
  * This class represents the work to be done by a decoder of a particular Hot Rod protocol version.
@@ -74,7 +73,7 @@ abstract class AbstractVersionedDecoder {
    /**
     * Create a response for the stats command.
     */
-   def createStatsResponse(header: HotRodHeader, stats: Stats, t: NettyTransport): StatsResponse
+   def createStatsResponse(hrCtx: CacheDecodeContext, t: NettyTransport): StatsResponse
 
    /**
     * Create an error response based on the Throwable instance received.

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/CacheDecodeContext.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/CacheDecodeContext.scala
@@ -245,6 +245,8 @@ class CacheDecodeContext(server: HotRodServer) extends ServerConstants with Log 
 
    def createMultiGetResponse(pairs: Map[Bytes, CacheEntry[Bytes, Bytes]]): AnyRef = null
 
+   def getCacheRegistry(cacheName: String): ComponentRegistry =
+      server.getCacheRegistry(cacheName)
 }
 
 case class ExpirationParam(duration: Long, unit: TimeUnitValue) {

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder10.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder10.scala
@@ -238,7 +238,9 @@ object Decoder10 extends AbstractVersionedDecoder with ServerConstants with Log 
    override def customReadValue(decoder: HotRodDecoder, header: HotRodHeader,
        hrCtx: CacheDecodeContext, buffer: ByteBuf, cache: Cache): AnyRef = null
 
-   override def createStatsResponse(h: HotRodHeader, cacheStats: Stats, t: NettyTransport): StatsResponse = {
+   override def createStatsResponse(hrCtx: CacheDecodeContext, t: NettyTransport): StatsResponse = {
+      val h = hrCtx.header
+      val cacheStats = hrCtx.cache.getStats
       val stats = mutable.Map.empty[String, String]
       stats += ("timeSinceStart" -> cacheStats.getTimeSinceStart.toString)
       stats += ("currentNumberOfEntries" -> cacheStats.getCurrentNumberOfEntries.toString)

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/HotRodDecoder.scala
@@ -197,7 +197,7 @@ extends ReplayingDecoder[HotRodDecoderState](DECODE_HEADER) with StatsChannelHan
       writeResponse(ctx.channel, decodeCtx.decoder.customReadValue(this, decodeCtx.header, decodeCtx, buffer, decodeCtx.cache))
 
    def createStatsResponse: Response =
-      decodeCtx.decoder.createStatsResponse(decodeCtx.header, decodeCtx.cache.getStats, transport)
+      decodeCtx.decoder.createStatsResponse(decodeCtx, transport)
 
    private def wrapSecurity(block: => Unit) = {
       if (secure) Security.doAs(subject, new PrivilegedExceptionAction[Unit] {

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodStatsClusterTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodStatsClusterTest.scala
@@ -1,0 +1,86 @@
+package org.infinispan.server.hotrod
+
+import java.lang.reflect.Method
+
+import org.infinispan.configuration.cache.{CacheMode, ConfigurationBuilder}
+import org.infinispan.server.hotrod.Constants._
+import org.infinispan.server.hotrod.OperationStatus._
+import org.infinispan.server.hotrod.test.{HotRodMagicKeyGenerator, HotRodClient}
+import org.infinispan.server.hotrod.test.HotRodTestingUtil._
+import org.infinispan.stats.impl.ClusterCacheStatsImpl
+import org.infinispan.test.AbstractCacheTest._
+import org.infinispan.test.TestingUtil
+import org.testng.Assert._
+import org.testng.annotations.Test
+
+@Test(groups = Array("functional"), testName = "server.hotrod.HotRodStatsClusterTest")
+class HotRodStatsClusterTest extends HotRodMultiNodeTest {
+
+   override protected def protocolVersion: Byte = 24
+
+   override protected def cacheName: String = "hotRodClusterStats"
+
+   override protected def createCacheConfig: ConfigurationBuilder = {
+      val config = hotRodCacheConfiguration(
+         getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false))
+      config.jmxStatistics().enable()
+      config.clustering().hash().numOwners(1)
+      config
+   }
+
+   def testClusterStats(m: Method): Unit = {
+      val client1 = clients.head
+      val client2 = clients.tail.head
+
+      val key1 = HotRodMagicKeyGenerator.newKey(cache(0, cacheName))
+      val value = v(m, "v1-")
+      val resp = client1.put(key1, 0, 0, value, INTELLIGENCE_HASH_DISTRIBUTION_AWARE, 0)
+      assertStatus(resp, Success)
+      assertSuccess(client1.get(key1, 0), value)
+      client1.remove(k(m))
+
+      var stats1 = client1.stats
+      assertEquals(stats1.get("currentNumberOfEntries").get, "1")
+      assertEquals(stats1.get("totalNumberOfEntries").get, "1")
+      assertEquals(stats1.get("stores").get, "1")
+      assertEquals(stats1.get("hits").get, "1")
+      assertEquals(stats1.get("retrievals").get, "1")
+      assertEquals(stats1.get("removeMisses").get, "1")
+      assertEquals(stats1.get("globalCurrentNumberOfEntries").get, "1")
+      assertEquals(stats1.get("globalStores").get, "1")
+      assertEquals(stats1.get("globalHits").get, "1")
+      assertEquals(stats1.get("globalRetrievals").get, "1")
+      assertEquals(stats1.get("globalRemoveMisses").get, "1")
+
+      var stats2 = client2.stats
+      assertEquals(stats2.get("currentNumberOfEntries").get, "0")
+      assertEquals(stats2.get("totalNumberOfEntries").get, "0")
+      assertEquals(stats2.get("stores").get, "0")
+      assertEquals(stats2.get("hits").get, "0")
+      assertEquals(stats2.get("retrievals").get, "0")
+      assertEquals(stats2.get("removeMisses").get, "0")
+      assertEquals(stats2.get("globalCurrentNumberOfEntries").get, "1")
+      assertEquals(stats2.get("globalStores").get, "1")
+      assertEquals(stats2.get("globalHits").get, "1")
+      assertEquals(stats2.get("globalRetrievals").get, "1")
+      assertEquals(stats2.get("globalRemoveMisses").get, "1")
+
+      TestingUtil.sleepThread(ClusterCacheStatsImpl.DEFAULT_STALE_STATS_THRESHOLD + 2000)
+
+      client1.remove(key1)
+      assertKeyDoesNotExist(client1.get(key1, 0))
+
+      stats1 = client1.stats
+      assertEquals(stats1.get("misses").get, "1")
+      assertEquals(stats1.get("removeHits").get, "1")
+      assertEquals(stats1.get("globalMisses").get, "1")
+      assertEquals(stats1.get("globalRemoveHits").get, "1")
+
+      stats2 = client2.stats
+      assertEquals(stats2.get("misses").get, "0")
+      assertEquals(stats2.get("removeHits").get, "0")
+      assertEquals(stats2.get("globalMisses").get, "1")
+      assertEquals(stats2.get("globalRemoveHits").get, "1")
+   }
+
+}

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodStatsTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodStatsTest.scala
@@ -13,7 +13,7 @@ import org.infinispan.manager.EmbeddedCacheManager
  * @author Galder Zamarreño
  * @since 4.1
  */
-@Test(groups = Array("functional"), testName = "server.hotrod.FunctionalTest")
+@Test(groups = Array("functional"), testName = "server.hotrod.HotRodStatsTest")
 class HotRodStatsTest extends HotRodSingleNodeTest {
 
    override def createTestCacheManager: EmbeddedCacheManager = {

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodClient.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/test/HotRodClient.scala
@@ -339,8 +339,18 @@ private class Encoder(protocolVersion: Byte) extends MessageToByteEncoder[Object
                writeRangedBytes(op.key, buffer) // key length + key
                if (op.value != null) {
                   if (op.code != 0x0D) { // If it's not removeIfUnmodified...
-                     writeUnsignedInt(op.lifespan, buffer) // lifespan
-                     writeUnsignedInt(op.maxIdle, buffer) // maxIdle
+                     if (protocolVersion >= 22) {
+                        if (op.lifespan > 0 || op.maxIdle > 0) {
+                           buffer.writeByte(0) // seconds for both
+                           writeUnsignedInt(op.lifespan, buffer) // lifespan
+                           writeUnsignedInt(op.maxIdle, buffer) // maxIdle
+                        } else {
+                           buffer.writeByte(0x88)
+                        }
+                     } else {
+                        writeUnsignedInt(op.lifespan, buffer) // lifespan
+                        writeUnsignedInt(op.maxIdle, buffer) // maxIdle
+                     }
                   }
                   if (op.code == 0x09 || op.code == 0x0D) {
                      buffer.writeLong(op.dataVersion)


### PR DESCRIPTION
* Added new set of statistics that return global, across the cluster,
  counts for the statistics currently exposed.
* These statistics are only available for clients talking Hot Rod
  protocol 2.4.
* New statistics maintain previous names but with a 'global' prefix in
  front of them.