### PR TITLE
ISPN-5899 ContinuousQuery tests should disable expiration reaper

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteContinuousQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteContinuousQueryTest.java
@@ -70,6 +70,7 @@ public class RemoteContinuousQueryTest extends MultiHotRodServersTest {
       cfgBuilder.indexing().index(Index.ALL)
             .addProperty("default.directory_provider", "ram")
             .addProperty("lucene_version", "LUCENE_CURRENT");
+      cfgBuilder.expiration().disableReaper();
       return cfgBuilder;
    }
 


### PR DESCRIPTION
* Disable reaper to prevent spurious failures with more than 1 event

https://issues.jboss.org/browse/ISPN-5899