### PR TITLE
ISPN-5917 + ISPN-5918 Transaction table leaks

### DIFF
--- a/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
@@ -105,6 +105,7 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
    private ConcurrentMap<GlobalTransaction, RemoteTransaction> remoteTransactions;
    private Lock minTopologyRecalculationLock;
    protected boolean clustered = false;
+   protected volatile boolean running = false;
 
    @Inject
    public void initialize(RpcManager rpcManager, Configuration configuration,
@@ -182,6 +183,8 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
             }, interval, interval, TimeUnit.MILLISECONDS);
          }
       }
+
+      running = true;
    }
 
    @Override
@@ -206,6 +209,7 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
    @Stop
    @SuppressWarnings("unused")
    private void stop() {
+      running = false;
       cacheManagerNotifier.removeListener(this);
       if (executorService != null)
          executorService.shutdownNow();
@@ -377,6 +381,12 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
       RemoteTransaction remoteTransaction = remoteTransactions.get(globalTx);
       if (remoteTransaction != null)
          return remoteTransaction;
+
+      if (!running) {
+         // Assume that we wouldn't get this far if the cache was already stopped
+         throw log.cacheIsStopping(cacheName);
+      }
+
       remoteTransaction = modifications == null ? txFactory.newRemoteTransaction(globalTx, topologyId)
             : txFactory.newRemoteTransaction(modifications, globalTx, topologyId);
       RemoteTransaction existing = remoteTransactions.putIfAbsent(globalTx, remoteTransaction);
@@ -400,6 +410,10 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
    public LocalTransaction getOrCreateLocalTransaction(Transaction transaction, boolean implicitTransaction) {
       LocalTransaction current = localTransactions.get(transaction);
       if (current == null) {
+         if (!running) {
+            // Assume that we wouldn't get this far if the cache was already stopped
+            throw log.cacheIsStopping(cacheName);
+         }
          Address localAddress = rpcManager != null ? rpcManager.getTransport().getAddress() : null;
          GlobalTransaction tx = txFactory.newGlobalTransaction(localAddress, false);
          current = txFactory.newLocalTransaction(transaction, tx, implicitTransaction, currentTopologyId);

--- a/core/src/main/java/org/infinispan/transaction/xa/XaTransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/XaTransactionTable.java
@@ -56,7 +56,9 @@ public class XaTransactionTable extends TransactionTable {
 
    private void removeXidTxMapping(LocalXaTransaction localTx) {
       final Xid xid = localTx.getXid();
-      xid2LocalTx.remove(xid);
+      if (xid != null) {
+         xid2LocalTx.remove(xid);
+      }
    }
 
    public LocalXaTransaction getLocalTransaction(Xid xid) {

--- a/core/src/test/java/org/infinispan/tx/TerminatedCacheWhileInTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/TerminatedCacheWhileInTxTest.java
@@ -11,25 +11,28 @@ import org.testng.annotations.Test;
 
 import javax.transaction.TransactionManager;
 import java.lang.reflect.Method;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.infinispan.test.TestingUtil.k;
 import static org.infinispan.test.TestingUtil.v;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.fail;
 
 /**
  * Test that verifies that Cache.stop() waits for on-going transactions to
  * finish before making the cache unavailable.
  *
+ * Also verifies that new transactions started while the cache is stopping
+ * are not accepted.
+ *
  * @author Galder Zamarreño
+ * @author Dan Berindei
  * @since 4.2
- * @since 5.0
  */
 @Test(groups = "functional", testName = "tx.TerminatedCacheWhileInTxTest")
 public class TerminatedCacheWhileInTxTest extends SingleCacheManagerTest {
@@ -37,11 +40,8 @@ public class TerminatedCacheWhileInTxTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder c = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+      c.transaction().cacheStopTimeout(10000);
       return TestCacheManagerFactory.createCacheManager(c);
-   }
-
-   public void testStopWhileInTx(Method m) throws Throwable {
-      stopCacheCalls(m, false);
    }
 
    /**
@@ -49,60 +49,45 @@ public class TerminatedCacheWhileInTxTest extends SingleCacheManagerTest {
     * on-going transactions or non-transactional invocations are not allowed
     * once the cache is in stopping mode.
     */
-   @Test(expectedExceptions = IllegalLifecycleStateException.class)
-   public void testNotAllowCallsWhileStopping(Method m) throws Throwable {
-      stopCacheCalls(m, true);
-   }
-
-   private void stopCacheCalls(final Method m, boolean withCallStoppingCache) throws Throwable {
-      final Cache<String, String> cache = cacheManager.getCache("cache-" + m.getName());
-      final ExecutorService executorService = Executors.newCachedThreadPool();
+   public void testNotAllowCallsWhileStopping(final Method m) throws Throwable {
+      final Cache<String, String> cache1 = cacheManager.getCache("cache-" + m.getName());
       final CyclicBarrier barrier = new CyclicBarrier(2);
       final CountDownLatch latch = new CountDownLatch(1);
-      final TransactionManager tm = TestingUtil.getTransactionManager(cache);
+      final TransactionManager tm = TestingUtil.getTransactionManager(cache1);
 
-      Callable<Void> waitAfterModCallable = new Callable<Void>() {
-         @Override
-         public Void call() throws Exception {
-            log.debug("Wait for all executions paths to be ready to perform calls.");
-            tm.begin();
-            cache.put(k(m, 1), v(m, 1));
-            log.debug("Cache modified, wait for cache to be stopped.");
-            barrier.await();
-            latch.await(10, TimeUnit.SECONDS);
-            tm.commit();
-            return null;
-         }
-      };
-      Future<Void> waitAfterModFuture = executorService.submit(waitAfterModCallable);
+      Future<Void> waitAfterModFuture = fork(() -> {
+         log.debug("Wait for all executions paths to be ready to perform calls.");
+         tm.begin();
+         cache1.put(k(m, 1), v(m, 1));
+         log.debug("Cache modified, wait for cache to be stopped.");
+         barrier.await();
+         // Delay the commit, but it must still happen while cache.stop() is waiting for transactions
+         assertFalse(latch.await(5, TimeUnit.SECONDS));
+         tm.commit();
+         return null;
+      });
 
-      barrier.await(); // wait for all threads to have done their modifications
-      Future<Void> callStoppingCacheFuture = null;
-      if (withCallStoppingCache) {
-         Callable<Void> callStoppingCache = new Callable<Void>() {
-            @Override
-            public Void call() throws Exception {
-               log.debug("Wait very briefly and then make call.");
-               Thread.sleep(30000);
-               cache.put(k(m, 2), v(m, 2));
-               return null;
-            }
-         };
-         callStoppingCacheFuture = executorService.submit(callStoppingCache);
-      }
-      cache.stop(); // now stop the cache
+      // wait for the transaction to have started
+      barrier.await();
+
+      Future<Void> callStoppingCacheFuture = fork(() -> {
+         log.debug("Wait very briefly and then make call.");
+         Thread.sleep(2000);
+         cache1.put(k(m, 2), v(m, 2));
+         return null;
+      });
+
+      cache1.stop(); // now stop the cache
       latch.countDown(); // now that cache has been stopped, let the thread continue
 
-      log.debug("All threads finished, let's shutdown the executor and check whether any exceptions were reported");
       waitAfterModFuture.get();
       if (callStoppingCacheFuture != null) {
          try {
             callStoppingCacheFuture.get();
+            fail("Should have thrown an IllegalLifecycleStateException");
          } catch (ExecutionException e) {
-            throw e.getCause();
+            assertTrue(e.toString(), e.getCause() instanceof IllegalLifecycleStateException);
          }
       }
-
-      executorService.shutdownNow();
    }
 }


### PR DESCRIPTION
ISPN-5917 Transactions rolled back early are never removed
https://issues.jboss.org/browse/ISPN-5917
ISPN-5918 Remote transactions can be registered after cache stop
https://issues.jboss.org/browse/ISPN-5918