### PR TITLE
ISPN-5924 and ISPN-5925 GlobalStateManager and PersistentUUID

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/global/GlobalConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalConfiguration.java
@@ -42,7 +42,7 @@ public class GlobalConfiguration {
    private final GlobalSecurityConfiguration security;
    private final SerializationConfiguration serialization;
    private final ShutdownConfiguration shutdown;
-   private final GlobalStateConfiguration statePersistence;
+   private final GlobalStateConfiguration globalState;
    private final Map<Class<?>, ?> modules;
    private final SiteConfiguration site;
    private final WeakReference<ClassLoader> cl;
@@ -62,7 +62,7 @@ public class GlobalConfiguration {
          GlobalJmxStatisticsConfiguration globalJmxStatistics,
          TransportConfiguration transport, GlobalSecurityConfiguration security,
          SerializationConfiguration serialization, ShutdownConfiguration shutdown,
-         GlobalStateConfiguration statePersistence,
+         GlobalStateConfiguration globalState,
          List<?> modules, SiteConfiguration site,ClassLoader cl) {
       this.evictionThreadPool = evictionThreadPool;
       this.listenerThreadPool = listenerThreadPool;
@@ -75,7 +75,7 @@ public class GlobalConfiguration {
       this.security = security;
       this.serialization = serialization;
       this.shutdown = shutdown;
-      this.statePersistence = statePersistence;
+      this.globalState = globalState;
       Map<Class<?>, Object> moduleMap = new HashMap<Class<?>, Object>();
       for(Object module : modules) {
          moduleMap.put(module.getClass(), module);
@@ -185,8 +185,8 @@ public class GlobalConfiguration {
       return shutdown;
    }
 
-   public GlobalStateConfiguration statePersistence() {
-      return statePersistence;
+   public GlobalStateConfiguration globalState() {
+      return globalState;
    }
 
    @SuppressWarnings("unchecked")
@@ -222,7 +222,7 @@ public class GlobalConfiguration {
             ", security=" + security +
             ", serialization=" + serialization +
             ", shutdown=" + shutdown +
-            ", statePersistence=" + statePersistence +
+            ", globalState=" + globalState +
             ", modules=" + modules +
             ", site=" + site +
             ", cl=" + cl +

--- a/core/src/main/java/org/infinispan/configuration/global/GlobalConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/global/GlobalConfigurationBuilder.java
@@ -245,7 +245,7 @@ public class GlobalConfigurationBuilder implements GlobalConfigurationChildBuild
       security.read(template.security());
       serialization.read(template.serialization());
       shutdown.read(template.shutdown());
-      globalState.read(template.statePersistence());
+      globalState.read(template.globalState());
       transport.read(template.transport());
       site.read(template.sites());
       return this;

--- a/core/src/main/java/org/infinispan/factories/GlobalStateManagerFactory.java
+++ b/core/src/main/java/org/infinispan/factories/GlobalStateManagerFactory.java
@@ -1,0 +1,24 @@
+package org.infinispan.factories;
+
+import org.infinispan.factories.annotations.DefaultFactoryFor;
+import org.infinispan.globalstate.GlobalStateManager;
+import org.infinispan.globalstate.impl.GlobalStateManagerImpl;
+
+/**
+ * GlobalStateManagerFactory.
+ *
+ * @author Tristan Tarrant
+ * @since 8.1
+ */
+@DefaultFactoryFor(classes = GlobalStateManager.class)
+public class GlobalStateManagerFactory extends AbstractComponentFactory implements AutoInstantiableFactory {
+
+   @Override
+   public <T> T construct(Class<T> componentType) {
+      if (globalConfiguration.globalState().enabled())
+         return componentType.cast(new GlobalStateManagerImpl());
+      else
+         return null;
+   }
+
+}

--- a/core/src/main/java/org/infinispan/globalstate/GlobalStateManager.java
+++ b/core/src/main/java/org/infinispan/globalstate/GlobalStateManager.java
@@ -1,0 +1,38 @@
+package org.infinispan.globalstate;
+
+import java.util.Optional;
+
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+
+/**
+ * GlobalStateManager.
+ *
+ * @author Tristan Tarrant
+ * @since 8.1
+ */
+@Scope(Scopes.GLOBAL)
+public interface GlobalStateManager {
+
+   /**
+    * Registers a state provider within this state manager
+    *
+    * @param provider
+    */
+   void registerStateProvider(GlobalStateProvider provider);
+
+   /**
+    * Reads the persistent state for the specified scope.
+    */
+   Optional<ScopedPersistentState> readScopedState(String scope);
+
+   /**
+    * Persists the specified scoped state
+    */
+   void writeScopedState(ScopedPersistentState state);
+
+   /**
+    * Persists the global state by contacting all registered scope providers
+    */
+   void writeGlobalState();
+}

--- a/core/src/main/java/org/infinispan/globalstate/GlobalStateProvider.java
+++ b/core/src/main/java/org/infinispan/globalstate/GlobalStateProvider.java
@@ -1,0 +1,23 @@
+package org.infinispan.globalstate;
+
+/**
+ * GlobalStateProvider. Implementors who need to register with the {@link GlobalStateManager}
+ * because they contribute to/are interested in the contents of the global persistent state.
+ *
+ * @author Tristan Tarrant
+ * @since 8.1
+ */
+public interface GlobalStateProvider {
+
+   /**
+    * This method is invoked by the {@link GlobalStateManager} just before
+    * persisting the global state
+    */
+   void prepareForPersist(ScopedPersistentState globalState);
+
+   /**
+    * This method is invoked by the {@link GlobalStateManager} after starting up to notify
+    * that global state has been restored.
+    */
+   void prepareForRestore(ScopedPersistentState globalState);
+}

--- a/core/src/main/java/org/infinispan/globalstate/ScopedPersistentState.java
+++ b/core/src/main/java/org/infinispan/globalstate/ScopedPersistentState.java
@@ -1,0 +1,33 @@
+package org.infinispan.globalstate;
+
+import java.util.function.BiConsumer;
+
+/**
+ * ScopedPersistentState.
+ *
+ * @author Tristan Tarrant
+ * @since 8.1
+ */
+public interface ScopedPersistentState {
+   public static final String GLOBAL_SCOPE = "___global";
+
+   /**
+    * Returns the name of this persistent state's scope
+    */
+   String getScope();
+
+   /**
+    * Sets a state property. Values will be unicode-escaped when written
+    */
+   void setProperty(String key, String value);
+
+   /**
+    * Retrieves a state property
+    */
+   String getProperty(String key);
+
+   /**
+    * Performs the specified action on every entry of the state
+    */
+   void forEach(BiConsumer<String, String> action);
+}

--- a/core/src/main/java/org/infinispan/globalstate/impl/GlobalStateManagerImpl.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/GlobalStateManagerImpl.java
@@ -1,0 +1,140 @@
+package org.infinispan.globalstate.impl;
+
+import static org.infinispan.globalstate.ScopedPersistentState.GLOBAL_SCOPE;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.infinispan.Version;
+import org.infinispan.commons.util.Util;
+import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.Stop;
+import org.infinispan.globalstate.GlobalStateManager;
+import org.infinispan.globalstate.GlobalStateProvider;
+import org.infinispan.globalstate.ScopedPersistentState;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.util.TimeService;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+/**
+ * GlobalStateManagerImpl. This global component manages persistent state across restarts. The
+ * information is stored in a Properties file. On a graceful shutdown it persists the following
+ * information:
+ *
+ * version = full version (e.g. major.minor.micro.qualifier) timestamp = timestamp using ISO-8601
+ *
+ * as well as any additional information contributed by registered {@link GlobalStateProvider}s
+ *
+ * @author Tristan Tarrant
+ * @since 8.1
+ */
+public class GlobalStateManagerImpl implements GlobalStateManager {
+   private static Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+   private GlobalConfiguration globalConfiguration;
+   private List<GlobalStateProvider> stateProviders = new ArrayList<>();
+   private TimeService timeService;
+
+   @Inject
+   public void inject(GlobalConfiguration globalConfiguration, TimeService timeService,
+         EmbeddedCacheManager cacheManager) {
+      this.globalConfiguration = globalConfiguration;
+      this.timeService = timeService;
+   }
+
+   @Start(priority = 1) // Must start before everything else
+   public void start() {
+      File stateFile = getStateFile(GLOBAL_SCOPE);
+      Optional<ScopedPersistentState> globalState = readScopedState(GLOBAL_SCOPE);
+      if (globalState.isPresent()) {
+         ScopedPersistentState state = globalState.get();
+         // We proceed only if we can write to the file
+         if (!stateFile.canWrite()) {
+            throw log.nonWritableStateFile(stateFile);
+         }
+         // Validate the state before proceeding
+         log.globalStateLoad(state.getProperty("version"), state.getProperty("timestamp"));
+
+         stateProviders.forEach(provider -> provider.prepareForRestore(state));
+      } else {
+         // Clean slate. Try to create an empty state file before proceeding
+         try {
+            stateFile.getParentFile().mkdirs();
+            stateFile.createNewFile();
+         } catch (IOException e) {
+            throw log.nonWritableStateFile(stateFile);
+         }
+      }
+   }
+
+   @Stop(priority = 1)
+   public void stop() {
+      writeGlobalState();
+   }
+
+   @Override
+   public void writeGlobalState() {
+      ScopedPersistentState state = new ScopedPersistentStateImpl(GLOBAL_SCOPE);
+      state.setProperty("version", Version.getVersion());
+      state.setProperty("timestamp", timeService.instant().toString());
+      // ask any state providers to contribute to the global state
+      stateProviders.forEach(provider -> provider.prepareForPersist(state));
+      writeScopedState(state);
+      log.globalStateWrite(state.getProperty("version"), state.getProperty("timestamp"));
+   }
+
+   @Override
+   public void writeScopedState(ScopedPersistentState state) {
+      File stateFile = getStateFile(state.getScope());
+      try (PrintWriter w = new PrintWriter(stateFile)) {
+         state.forEach((key, value) -> {
+            w.printf("%s=%s%n", Util.unicodeEscapeString(key), Util.unicodeEscapeString(value));
+         });
+      } catch (IOException e) {
+         throw log.failedWritingGlobalState(e, stateFile);
+      }
+   }
+
+   @Override
+   public Optional<ScopedPersistentState> readScopedState(String scope) {
+      File stateFile = getStateFile(scope);
+      if (!stateFile.exists())
+         return Optional.empty();
+      try (BufferedReader r = new BufferedReader(new FileReader(stateFile))) {
+         ScopedPersistentState state = new ScopedPersistentStateImpl(scope);
+         for (String line = r.readLine(); line != null; line = r.readLine()) {
+            if (!line.startsWith("#")) { // Skip comment lines
+               int eq = line.indexOf('=');
+               while (eq > 0 && line.charAt(eq-1) == '\\') {
+                  eq = line.indexOf('=', eq + 1);
+               }
+               if (eq > 0) {
+                  state.setProperty(Util.unicodeUnescapeString(line.substring(0, eq).trim()),
+                        Util.unicodeUnescapeString(line.substring(eq + 1).trim()));
+               }
+            }
+         }
+         return Optional.of(state);
+      } catch (IOException e) {
+         throw log.failedReadingPersistentState(e, stateFile);
+      }
+   }
+
+   private File getStateFile(String scope) {
+      return new File(globalConfiguration.globalState().persistentLocation(), scope + ".state");
+   }
+
+   @Override
+   public void registerStateProvider(GlobalStateProvider provider) {
+      this.stateProviders.add(provider);
+   }
+}

--- a/core/src/main/java/org/infinispan/globalstate/impl/ScopedPersistentStateImpl.java
+++ b/core/src/main/java/org/infinispan/globalstate/impl/ScopedPersistentStateImpl.java
@@ -1,0 +1,44 @@
+package org.infinispan.globalstate.impl;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.infinispan.globalstate.ScopedPersistentState;
+
+/**
+ * ScopedPersistentStateImpl.
+ *
+ * @author Tristan Tarrant
+ * @since 8.1
+ */
+public class ScopedPersistentStateImpl implements ScopedPersistentState {
+   private final String scope;
+   private final Map<String, String> state;
+
+   public ScopedPersistentStateImpl(String scope) {
+      this.scope = scope;
+      this.state = new LinkedHashMap<>(); // to preserve order
+   }
+
+   @Override
+   public String getScope() {
+      return scope;
+   }
+
+   @Override
+   public void setProperty(String key, String value) {
+      state.put(key, value);
+   }
+
+   @Override
+   public String getProperty(String key) {
+      return state.get(key);
+   }
+
+   @Override
+   public void forEach(BiConsumer<String, String> action) {
+      state.forEach(action);
+   }
+
+}

--- a/core/src/main/java/org/infinispan/registry/impl/InternalCacheRegistryImpl.java
+++ b/core/src/main/java/org/infinispan/registry/impl/InternalCacheRegistryImpl.java
@@ -56,8 +56,8 @@ public class InternalCacheRegistryImpl implements InternalCacheRegistry {
       ConfigurationBuilder builder = new ConfigurationBuilder().read(configuration);
       builder.jmxStatistics().disable(); // Internal caches must not be included in stats counts
       GlobalConfiguration globalConfiguration = cacheManager.getCacheManagerConfiguration();
-      if (flags.contains(Flag.PERSISTENT) && globalConfiguration.statePersistence().enabled()) {
-         builder.persistence().addSingleFileStore().location(globalConfiguration.statePersistence().persistentLocation()).purgeOnStartup(false).preload(true);
+      if (flags.contains(Flag.PERSISTENT) && globalConfiguration.globalState().enabled()) {
+         builder.persistence().addSingleFileStore().location(globalConfiguration.globalState().persistentLocation()).purgeOnStartup(false).preload(true);
       }
       SecurityActions.defineConfiguration(cacheManager, name, builder.build());
       internalCaches.add(name);

--- a/core/src/main/java/org/infinispan/topology/LocalTopologyManager.java
+++ b/core/src/main/java/org/infinispan/topology/LocalTopologyManager.java
@@ -117,4 +117,10 @@ public interface LocalTopologyManager {
     * Updates the availability state of a cache (for the entire cluster).
     */
    void setCacheAvailability(String cacheName, AvailabilityMode availabilityMode) throws Exception;
+
+   /**
+    * Returns the local UUID of this node. If global state persistence is enabled, this UUID will be saved and reused
+    * across restarts
+    */
+   PersistentUUID getPersistentUUID();
 }

--- a/core/src/main/java/org/infinispan/topology/PersistentUUID.java
+++ b/core/src/main/java/org/infinispan/topology/PersistentUUID.java
@@ -1,0 +1,76 @@
+package org.infinispan.topology;
+
+import java.util.UUID;
+
+import org.infinispan.remoting.transport.Address;
+
+/**
+ * PersistentUUID. A special {@link Address} UUID whose purpose is to remain unchanged across node
+ * restarts when using global state.
+ *
+ * @author Tristan Tarrant
+ * @since 8.1
+ */
+public class PersistentUUID implements Address {
+   final UUID uuid;
+   final int hashCode;
+
+   private PersistentUUID(UUID uuid) {
+      this.uuid = uuid;
+      this.hashCode = uuid.hashCode();
+   }
+
+   public PersistentUUID(long msb, long lsb) {
+      this(new UUID(msb, lsb));
+   }
+
+   public static PersistentUUID randomUUID() {
+      return new PersistentUUID(UUID.randomUUID());
+   }
+
+   public static PersistentUUID fromString(String name) {
+      return new PersistentUUID(UUID.fromString(name));
+   }
+
+
+   public long getMostSignificantBits() {
+      return uuid.getMostSignificantBits();
+   }
+
+   public long getLeastSignificantBits() {
+      return uuid.getLeastSignificantBits();
+   }
+
+   @Override
+   public int compareTo(Address o) {
+      PersistentUUID other = (PersistentUUID) o;
+      return uuid.compareTo(other.uuid);
+   }
+
+   @Override
+   public int hashCode() {
+      return hashCode;
+   }
+
+   @Override
+   public String toString() {
+      return uuid.toString();
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+      PersistentUUID other = (PersistentUUID) obj;
+      if (uuid == null) {
+         if (other.uuid != null)
+            return false;
+      } else if (!uuid.equals(other.uuid))
+         return false;
+      return true;
+   }
+}

--- a/core/src/main/java/org/infinispan/util/AbstractControlledLocalTopologyManager.java
+++ b/core/src/main/java/org/infinispan/util/AbstractControlledLocalTopologyManager.java
@@ -10,6 +10,7 @@ import org.infinispan.topology.CacheTopology;
 import org.infinispan.topology.CacheTopologyHandler;
 import org.infinispan.topology.LocalTopologyManager;
 import org.infinispan.topology.LocalTopologyManagerImpl;
+import org.infinispan.topology.PersistentUUID;
 import org.infinispan.topology.ManagerStatusResponse;
 import org.infinispan.topology.RebalancingStatus;
 
@@ -146,4 +147,10 @@ public abstract class AbstractControlledLocalTopologyManager implements LocalTop
    protected void beforeConfirmRebalance(String cacheName, int topologyId, Throwable throwable) {
       //no-op by default
    }
+
+   @Override
+   public PersistentUUID getPersistentUUID() {
+      return delegate.getPersistentUUID();
+   }
+
 }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1380,5 +1380,22 @@ public interface Log extends BasicLogger {
    @Message(value = "The data container class configuration has been deprecated.  This has no current replacement", id = 385)
    void dataContainerConfigurationDeprecated();
 
+   @Message(value = "Failed to read persisted state from file %s. Aborting.", id = 386)
+   CacheConfigurationException failedReadingPersistentState(@Cause IOException e, File stateFile);
+
+   @Message(value = "Failed to write state to file %s.", id = 387)
+   CacheConfigurationException failedWritingGlobalState(@Cause IOException e, File stateFile);
+
+   @Message(value = "The state file %s is not writable. Aborting.", id = 388)
+   CacheConfigurationException nonWritableStateFile(File stateFile);
+
+   @LogMessage(level = INFO)
+   @Message(value = "Loaded global state, version=%s timestamp=%s", id = 389)
+   void globalStateLoad(String version, String timestamp);
+
+   @LogMessage(level = INFO)
+   @Message(value = "Persisted state, version=%s timestamp=%s", id = 390)
+   void globalStateWrite(String version, String timestamp);
+
 }
 

--- a/core/src/test/java/org/infinispan/configuration/parsing/UnifiedXmlFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/parsing/UnifiedXmlFileParsingTest.java
@@ -81,9 +81,9 @@ public class UnifiedXmlFileParsingTest extends AbstractInfinispanTest {
    private static void configurationCheck81(EmbeddedCacheManager cm) {
       configurationCheck80(cm);
       GlobalConfiguration globalConfiguration = cm.getCacheManagerConfiguration();
-      assertTrue(globalConfiguration.statePersistence().enabled());
-      assertEquals("persistentPath", globalConfiguration.statePersistence().persistentLocation());
-      assertEquals("tmpPath", globalConfiguration.statePersistence().temporaryLocation());
+      assertTrue(globalConfiguration.globalState().enabled());
+      assertEquals("persistentPath", globalConfiguration.globalState().persistentLocation());
+      assertEquals("tmpPath", globalConfiguration.globalState().temporaryLocation());
    }
 
    private static void configurationCheck80(EmbeddedCacheManager cm) {

--- a/core/src/test/java/org/infinispan/globalstate/GlobalStateRestartTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/GlobalStateRestartTest.java
@@ -1,0 +1,71 @@
+package org.infinispan.globalstate;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.io.File;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.topology.LocalTopologyManager;
+import org.infinispan.topology.PersistentUUID;
+import org.testng.annotations.Test;
+
+@Test(testName = "globalstate.GlobalStateRestartTest", groups = "functional")
+public class GlobalStateRestartTest extends MultipleCacheManagersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createStatefulCacheManager("A", true);
+      createStatefulCacheManager("B", true);
+   }
+
+   private void createStatefulCacheManager(String id, boolean clear) {
+      String stateDirectory = TestingUtil.tmpDirectory(GlobalStateRestartTest.class.getSimpleName() + "_" + id);
+      if (clear)
+         TestingUtil.recursiveFileRemove(stateDirectory);
+      GlobalConfigurationBuilder global = GlobalConfigurationBuilder.defaultClusteredBuilder();
+      global.globalState().enable().persistentLocation(stateDirectory);
+
+      ConfigurationBuilder config = new ConfigurationBuilder();
+      config.clustering().cacheMode(CacheMode.DIST_SYNC).hash().numOwners(1);
+      config.persistence().addSingleFileStore().location(stateDirectory);
+      addClusterEnabledCacheManager(global, config);
+   }
+
+   public void testGracefulShutdownAndRestart() {
+      waitForClusterToForm();
+      LocalTopologyManager ltm1 = TestingUtil.extractGlobalComponent(manager(0), LocalTopologyManager.class);
+      LocalTopologyManager ltm2 = TestingUtil.extractGlobalComponent(manager(1), LocalTopologyManager.class);
+      PersistentUUID uuid1 = ltm1.getPersistentUUID();
+      assertNotNull(uuid1);
+      PersistentUUID uuid2 = ltm2.getPersistentUUID();
+      assertNotNull(uuid2);
+      String gsp0_location = manager(0).getCacheManagerConfiguration().globalState().persistentLocation();
+      String gsp1_location = manager(1).getCacheManagerConfiguration().globalState().persistentLocation();
+
+      TestingUtil.killCacheManagers(this.cacheManagers);
+      checkStateDirNotEmpty(gsp0_location);
+      checkStateDirNotEmpty(gsp1_location);
+      this.cacheManagers.clear();
+
+      // Recreate the cluster
+      createStatefulCacheManager("A", false);
+      createStatefulCacheManager("B", false);
+      waitForClusterToForm();
+      ltm1 = TestingUtil.extractGlobalComponent(manager(0), LocalTopologyManager.class);
+      ltm2 = TestingUtil.extractGlobalComponent(manager(1), LocalTopologyManager.class);
+      assertEquals(uuid1, ltm1.getPersistentUUID());
+      assertEquals(uuid2, ltm2.getPersistentUUID());
+   }
+
+   private void checkStateDirNotEmpty(String gsp0_location) {
+      File[] listFiles = new File(gsp0_location).listFiles();
+      assertTrue(listFiles.length > 0);
+   }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5924
https://issues.jboss.org/browse/ISPN-5925

Before I come along with the actual graceful cache shutdown / start, here are two building blocks.

The GlobalStateManager sits in the GCR lifecycle and manages global and per-cache state persistence.

The LocalUUID is the unique node identifier which survives restarts.