### PR TITLE
Fixed javadoc to point to correct common dependency

### DIFF
--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -91,7 +91,7 @@
 
       <dependency>
          <groupId>${project.groupId}</groupId>
-         <artifactId>infinispan-spring4-commons</artifactId>
+         <artifactId>infinispan-spring4-common</artifactId>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Fixed javadoc issue that was pointing to commons erroneously.