### PR TITLE
ISPN-5907 + ISPN-5908 + ISPN-5909

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
@@ -199,7 +199,7 @@ public class RpcManagerImpl implements RpcManager, JmxStatisticsExposer {
          throwable = throwable.getCause();
       }
       if (throwable instanceof CacheException) {
-         log.tracef("Replication exception", throwable);
+         log.trace("Replication exception", throwable);
          throw ((CacheException) throwable);
       } else {
          log.unexpectedErrorReplicating(throwable);

--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -50,6 +50,7 @@ import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
+import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -578,30 +579,27 @@ public class StateConsumerImpl implements StateConsumer {
 
             PutKeyValueCommand put = commandsFactory.buildPutKeyValueCommand(
                   e.getKey(), e.getValue(), e.getMetadata(), flags);
+            ctx.setLockOwner(put.getKeyLockOwner());
+            interceptorChain.invoke(ctx, put);
 
-            boolean success = false;
-            try {
-               ctx.setLockOwner(put.getKeyLockOwner());
-               interceptorChain.invoke(ctx, put);
-               success = true;
-            } finally {
-               if (ctx.isInTxScope()) {
-                  if (success) {
-                     try {
-                        transactionManager.commit();
-                     } catch (Throwable ex) {
-                        log.errorf(ex, "Could not commit transaction created by state transfer of key %s", e.getKey());
-                        if (transactionManager.getTransaction() != null) {
-                           transactionManager.rollback();
-                        }
-                     }
-                  } else {
-                     transactionManager.rollback();
-                  }
-               }
+            if (transactionManager != null) {
+               transactionManager.commit();
             }
          } catch (Exception ex) {
-            log.problemApplyingStateForKey(ex.getMessage(), e.getKey(), ex);
+            if (!cache.getStatus().allowInvocations()) {
+               log.debugf("Cache %s is shutting down, stopping state transfer", cacheName);
+               break;
+            } else {
+               log.problemApplyingStateForKey(ex.getMessage(), e.getKey(), ex);
+            }
+         } finally {
+            try {
+               if (transactionManager != null && transactionManager.getTransaction() != null) {
+                  transactionManager.rollback();
+               }
+            } catch (SystemException e1) {
+               log.errorRollingBack(e1);
+            }
          }
       }
       if (trace) log.tracef("Finished applying chunk of segment %d of cache %s", segmentId, cacheName);

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -382,7 +382,7 @@ public interface Log extends BasicLogger {
    void errorProcessing1pcPrepareCommand(@Cause Throwable e);
 
    @LogMessage(level = ERROR)
-   @Message(value = "Exception while rollback", id = 98)
+   @Message(value = "Exception during rollback", id = 98)
    void errorRollingBack(@Cause Throwable e);
 
    @LogMessage(level = ERROR)

--- a/core/src/test/java/org/infinispan/persistence/support/AsyncStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/support/AsyncStoreTest.java
@@ -7,30 +7,30 @@ import org.infinispan.commons.configuration.ConfigurationFor;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.configuration.cache.AsyncStoreConfiguration;
 import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 import org.infinispan.configuration.cache.SingletonStoreConfiguration;
 import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.marshall.TestObjectStreamMarshaller;
+import org.infinispan.marshall.core.MarshalledEntry;
 import org.infinispan.marshall.core.MarshalledEntryImpl;
-import org.infinispan.persistence.spi.InitializationContext;
-import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.persistence.async.AdvancedAsyncCacheLoader;
 import org.infinispan.persistence.async.AdvancedAsyncCacheWriter;
 import org.infinispan.persistence.async.State;
 import org.infinispan.persistence.dummy.DummyInMemoryStore;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfiguration;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
-import org.infinispan.persistence.spi.CacheWriter;
-import org.infinispan.marshall.core.MarshalledEntry;
-import org.infinispan.marshall.TestObjectStreamMarshaller;
-import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.persistence.modifications.Modification;
 import org.infinispan.persistence.modifications.Remove;
 import org.infinispan.persistence.modifications.Store;
-import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.persistence.spi.CacheWriter;
+import org.infinispan.persistence.spi.InitializationContext;
+import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.test.fwk.TestResourceTracker;
 import org.infinispan.util.PersistenceMockUtil;
 import org.infinispan.util.logging.Log;
@@ -52,7 +52,11 @@ import java.util.concurrent.locks.ReentrantLock;
 import static org.infinispan.test.TestingUtil.k;
 import static org.infinispan.test.TestingUtil.marshalledEntry;
 import static org.infinispan.test.TestingUtil.v;
-import static org.testng.AssertJUnit.*;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.fail;
 
 @Test(groups = "unit", testName = "persistence.support.AsyncStoreTest", sequential=true)
 public class AsyncStoreTest extends AbstractInfinispanTest {
@@ -510,8 +514,12 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
             .shutdownTimeout(50);
 
       writer = new AdvancedAsyncCacheWriter(underlying);
-      writer.init(PersistenceMockUtil.createContext(getClass().getSimpleName(), builder.build(), marshaller));
+      InitializationContext ctx =
+            PersistenceMockUtil.createContext(getClass().getSimpleName(), builder.build(), marshaller);
+      writer.init(ctx);
       writer.start();
+      underlying.init(ctx);
+      underlying.start();
       try {
          final CountDownLatch done = new CountDownLatch(1);
 

--- a/core/src/test/java/org/infinispan/persistence/support/AsyncStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/support/AsyncStoreTest.java
@@ -84,8 +84,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
             @Override
             public Object get(Object key) {
                Object result = super.get(key);
-               for (int i = 0; i < 10; i++)
-                  Thread.yield();
+               TestingUtil.sleepThread(0);
                return result;
             }
          };
@@ -146,7 +145,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
       createStore();
 
       final int number = 10;
-      final int loops = 5000;
+      final int loops = 2000;
       String key = "testRepeatedPutRemove-k-";
       String value = "testRepeatedPutRemove-v-";
 
@@ -183,7 +182,7 @@ public class AsyncStoreTest extends AbstractInfinispanTest {
       createStore();
 
       final int number = 10;
-      final int loops = 5000;
+      final int loops = 2000;
       String key = "testRepeatedPutClearPut-k-";
       String value = "testRepeatedPutClearPut-v-";
       String value2 = "testRepeatedPutClearPut-v[2]-";

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferDistSharedCacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferDistSharedCacheLoaderFunctionalTest.java
@@ -40,7 +40,7 @@ public class StateTransferDistSharedCacheLoaderFunctionalTest extends StateTrans
    };
    int id;
 
-   static final int INSERTION_COUNT = 1000;
+   static final int INSERTION_COUNT = 500;
 
    @BeforeMethod
    public void beforeEachMethod() {

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferFunctionalTest.java
@@ -65,7 +65,7 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
             .useSynchronization(false)
             .recovery().disable();
       configurationBuilder.clustering().sync().replTimeout(30000);
-      configurationBuilder.clustering().stateTransfer().fetchInMemoryState(true);
+      configurationBuilder.clustering().stateTransfer().chunkSize(50);
       configurationBuilder.locking().useLockStriping(false); // reduces the odd chance of a key collision and deadlock
    }
 
@@ -347,6 +347,7 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
       Cache<Object, Object> cache1, cache2;
       cache1 = createCacheManager().getCache(cacheName);
 
+      assertEquals(0, cache1.getAdvancedCache().getDataContainer().size());
       writeInitialData(cache1);
       // Delay the transient copy, so that we get a more thorough log test
       DelayTransfer value = new DelayTransfer();

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferLargeObjectTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferLargeObjectTest.java
@@ -6,7 +6,6 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.testng.annotations.AfterMethod;
@@ -35,7 +34,7 @@ public class StateTransferLargeObjectTest extends MultipleCacheManagersTest {
    private Cache<Integer, BigObject> c1;
    private Cache<Integer, BigObject> c2;
    private Cache<Integer, BigObject> c3;
-   private Map<Integer, BigObject> cache;
+   private Map<Integer, BigObject> expected;
 
    private final Random rnd = new Random();
 
@@ -46,7 +45,8 @@ public class StateTransferLargeObjectTest extends MultipleCacheManagersTest {
             .l1().disable()
             .clustering().stateTransfer().fetchInMemoryState(true)
             .locking().useLockStriping(false)
-            .clustering().hash().numOwners(3).numSegments(60);
+            .clustering().hash().numOwners(3).numSegments(60)
+            .stateTransfer().chunkSize(50);
       createCluster(builder, 4);
 
       c0 = cache(0);
@@ -55,34 +55,21 @@ public class StateTransferLargeObjectTest extends MultipleCacheManagersTest {
       c3 = cache(3);
       waitForClusterToForm();
       log.debug("Rehash is complete!");
-      cache = new HashMap<Integer, BigObject>();
+      expected = new HashMap<Integer, BigObject>();
    }
 
    public void testForFailure() {
-      final int num = 1000;
+      final int num = 500;
       for (int i = 0; i < num; i++) {
          BigObject bigObject = createBigObject(i, "prefix");
-         cache.put(i, bigObject);
+         expected.put(i, bigObject);
          c0.put(i, bigObject);
       }
 
-      for (int i = 0; i < num; i++) {
-         assertTrue(c0.get(i) instanceof BigObject);
-         assertTrue(c1.get(i) instanceof BigObject);
-         assertTrue(c2.get(i) instanceof BigObject);
-         assertTrue(c3.get(i) instanceof BigObject);
-      }
-
-      log.info("Before stopping a cache!");
-      fork(new Runnable() {
-         @Override
-         public void run() {
-            log.debug("About to stop " + c3.getAdvancedCache().getRpcManager().getAddress());
-            c3.stop();
-            c3.getCacheManager().stop();
-            log.debug("Cache stopped async!");
-         }
-      });
+      log.debug("About to stop " + c3.getAdvancedCache().getRpcManager().getAddress());
+      c3.stop();
+      c3.getCacheManager().stop();
+      log.debug("Cache stopped async!");
 
       for (int i = 0; i < num; i++) {
          log.debug("----Running a get on " + i);
@@ -102,7 +89,7 @@ public class StateTransferLargeObjectTest extends MultipleCacheManagersTest {
    private void assertValue(int i, Object o) {
       assertNotNull(o);
       assertTrue(o instanceof BigObject);
-      assertEquals(o, cache.get(i));
+      assertEquals(o, expected.get(i));
    }
 
    private BigObject createBigObject(int num, String prefix) {

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -98,7 +98,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
             throw new IllegalStateException("No caches registered! Use registerCacheManager(Cache... caches) to do that!");
          TestingUtil.clearContent(cacheManagers);
       } else {
-         TestingUtil.killCacheManagers(cacheManagers);
+         TestingUtil.killCacheManagers(true, cacheManagers.toArray(new EmbeddedCacheManager[cacheManagers.size()]));
          cacheManagers.clear();
       }
    }


### PR DESCRIPTION
Speed up the test suite with trace enabled

ISPN-5907 Clear the cache stores between tests
https://issues.jboss.org/browse/ISPN-5907
ISPN-5908 Stop applying state when a cache is stopping
https://issues.jboss.org/browse/ISPN-5908
ISPN-5909 Speed up StateTransferLargeObjectTest
https://issues.jboss.org/browse/ISPN-5909

Replaces https://github.com/infinispan/infinispan/pull/3803
