### PR TITLE
ISPN-5954 Removed Uber Jars Weld Complains

### DIFF
--- a/all/embedded-query/pom.xml
+++ b/all/embedded-query/pom.xml
@@ -110,10 +110,15 @@
                            <pattern>org.codehaus</pattern>
                            <shadedPattern>infinispan.org.codehaus</shadedPattern>
                         </relocation>
-                        <relocation>
-                           <pattern>org.jboss.logging</pattern>
-                           <shadedPattern>infinispan.org.jboss.logging</shadedPattern>
-                        </relocation>
+                        <!-- Unfortunatelly because of https://issues.jboss.org/browse/ISPN-6093
+                             and https://bugzilla.redhat.com/show_bug.cgi?id=1266831 we cannot relocate
+                             logging module, otherwise some integration modules might miss it
+                             when both Uber jar as well as ISPN commons are on classpath
+                        -->
+                        <!--<relocation>-->
+                           <!--<pattern>org.jboss.logging</pattern>-->
+                           <!--<shadedPattern>infinispan.org.jboss.logging</shadedPattern>-->
+                        <!--</relocation>-->
                         <relocation>
                            <pattern>org.slf4j</pattern>
                            <shadedPattern>infinispan.org.slf4j</shadedPattern>

--- a/all/embedded/pom.xml
+++ b/all/embedded/pom.xml
@@ -54,24 +54,24 @@
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-cachestore-remote</artifactId>
          <optional>${uberjar.deps.optional}</optional>
-         <exclusions>
-            <exclusion>
-               <groupId>org.infinispan</groupId>
-               <artifactId>infinispan-client-hotrod</artifactId>
-            </exclusion>
-         </exclusions>
+      </dependency>
+
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-query-dsl</artifactId>
+         <optional>${uberjar.deps.optional}</optional>
+      </dependency>
+
+      <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-remote-query-client</artifactId>
+         <optional>${uberjar.deps.optional}</optional>
       </dependency>
 
       <dependency>
          <groupId>org.infinispan</groupId>
          <artifactId>infinispan-cdi-embedded</artifactId>
          <optional>${uberjar.deps.optional}</optional>
-         <exclusions>
-            <exclusion>
-               <artifactId>infinispan-client-hotrod</artifactId>
-               <groupId>org.infinispan</groupId>
-            </exclusion>
-         </exclusions>
       </dependency>
 
       <dependency>
@@ -128,9 +128,15 @@
       </dependency>
 
       <dependency>
-         <groupId>org.infinispan</groupId>
-         <artifactId>infinispan-remote</artifactId>
-         <scope>provided</scope>
+         <groupId>org.jboss.modules</groupId>
+         <artifactId>jboss-modules</artifactId>
+         <optional>${uberjar.deps.optional}</optional>
+      </dependency>
+
+      <dependency>
+         <groupId>com.mchange</groupId>
+         <artifactId>c3p0</artifactId>
+         <optional>${uberjar.deps.optional}</optional>
       </dependency>
    </dependencies>
 
@@ -165,7 +171,8 @@
                            <exclude>org.fusesource.hawtjni:hawtjni-runtime:jar:</exclude>
                            <exclude>org.fusesource.leveldbjni:leveldbjni:jar:</exclude>
                            <exclude>org.iq80.leveldb:leveldb-api:jar:</exclude>
-                           <exclude>log4j:log4j:jar:</exclude>
+                           <exclude>org.apache.logging.log4j:log4j-core:jar:*</exclude>
+                           <exclude>log4j:log4j:jar:*</exclude>
                            <exclude>net.jcip:jcip-annotations:jar:</exclude>
                            <exclude>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.1_spec:jar:</exclude>
                            <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec:jar:</exclude>
@@ -186,6 +193,12 @@
                            </excludes>
                         </filter>
                         <filter>
+                           <artifact>org.infinispan.protostream:protostream</artifact>
+                           <excludes>
+                              <exclude>protostream/javassist/util/HotSwapper*.class</exclude>
+                           </excludes>
+                        </filter>
+                        <filter>
                            <artifact>org.jgroups:jgroups</artifact>
                            <includes>
                               <include>org/jgroups/**</include>
@@ -196,10 +209,30 @@
                            </includes>
                         </filter>
                         <filter>
+                           <artifact>org.jboss.logging:jboss-logging</artifact>
+                           <excludes>
+                              <exclude>org/jboss/logging/JBossLogManagerLogger*.class</exclude>
+                              <exclude>org/jboss/logging/JBossLogManagerProvider*.class</exclude>
+                           </excludes>
+                        </filter>
+                        <filter>
+                           <artifact>org.infinispan:infinispan-commons</artifact>
+                           <excludes>
+                              <exclude>org/infinispan/commons/util/OsgiClassLoader*.class</exclude>
+                           </excludes>
+                        </filter>
+                        <filter>
+                           <artifact>com.mchange:mchange-commons-java</artifact>
+                           <excludes>
+                              <exclude>com/mchange/v3/hocon/*</exclude>
+                           </excludes>
+                        </filter>
+                        <filter>
                            <artifact>*:*</artifact>
                            <excludes>
                               <exclude>INSTALL.html</exclude>
                               <exclude>LICENSE</exclude>
+                              <exclude>XPP3-LICENSE.txt</exclude>
                               <exclude>README</exclude>
                               <exclude>META-INF/*.SF</exclude>
                               <exclude>META-INF/*.DSA</exclude>
@@ -211,6 +244,8 @@
                               <exclude>META-INF/LICENSE.txt</exclude>
                               <exclude>META-INF/NOTICE</exclude>
                               <exclude>META-INF/NOTICE.txt</exclude>
+                              <exclude>schema/*.xsd</exclude>
+                              <exclude>__redirected/*</exclude>
                            </excludes>
                         </filter>
                      </filters>
@@ -221,13 +256,22 @@
                            <shadedPattern>infinispan.com.google</shadedPattern>
                         </relocation>
                         <relocation>
+                           <pattern>com.mchange</pattern>
+                           <shadedPattern>infinispan.com.mchange</shadedPattern>
+                        </relocation>
+                        <relocation>
                            <pattern>org.iq80</pattern>
                            <shadedPattern>infinispan.org.iq80</shadedPattern>
                         </relocation>
-                        <relocation>
+                        <!-- Unfortunatelly because of https://issues.jboss.org/browse/ISPN-6093
+                             and https://bugzilla.redhat.com/show_bug.cgi?id=1266831 we cannot relocate
+                             logging module, otherwise some integration modules might miss it
+                             when both Uber jar as well as ISPN commons are on classpath
+                          -->
+                        <!-- <relocation>
                            <pattern>org.jboss.logging</pattern>
                            <shadedPattern>infinispan.org.jboss.logging</shadedPattern>
-                        </relocation>
+                        </relocation> -->
                      </relocations>
                      <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
@@ -261,13 +305,11 @@
                   </goals>
                   <configuration>
                      <instructions>
-                        
                         <Include-Resource>
                            @${intermediary_jar_path},
                            /OSGI-INF/blueprint/blueprint.xml=${project.basedir}/target/classes/OSGI-INF/blueprint/blueprint.xml,
                            /features.xml=${project.basedir}/target/classes/features.xml
                         </Include-Resource>
-                        
                         <_exportcontents>
                            org.infinispan.*,
                            org.jboss.marshalling.*;version=${version.jboss.marshalling},
@@ -299,6 +341,7 @@
                            *
                         </Import-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
+                        <Dependencies>org.hibernate</Dependencies>
                      </instructions>
                   </configuration>
                </execution>

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -3,9 +3,9 @@
    <modelVersion>4.0.0</modelVersion>
    <parent>
       <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-bom</artifactId>
+      <artifactId>infinispan-parent</artifactId>
       <version>8.2.0-SNAPSHOT</version>
-      <relativePath>../bom/pom.xml</relativePath>
+      <relativePath>../parent/pom.xml</relativePath>
    </parent>
    <artifactId>infinispan-all-parent</artifactId>
    <name>Parent pom for uberjar modules</name>

--- a/all/remote/pom.xml
+++ b/all/remote/pom.xml
@@ -52,10 +52,37 @@
       </dependency>
 
       <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-jcache-remote</artifactId>
+         <optional>${uberjar.deps.optional}</optional>
+      </dependency>
+
+
+      <dependency>
          <groupId>org.jboss.marshalling</groupId>
          <artifactId>jboss-marshalling-osgi</artifactId>
          <optional>${uberjar.deps.optional}</optional>
       </dependency>
+
+      <!-- Needed by JCache Remote -->
+      <dependency>
+         <groupId>org.wildfly.core</groupId>
+         <artifactId>wildfly-controller-client</artifactId>
+         <optional>${uberjar.deps.optional}</optional>
+      </dependency>
+      <dependency>
+         <groupId>org.jboss.modules</groupId>
+         <artifactId>jboss-modules</artifactId>
+         <optional>${uberjar.deps.optional}</optional>
+      </dependency>
+
+      <dependency>
+         <groupId>org.slf4j</groupId>
+         <artifactId>slf4j-api</artifactId>
+         <optional>${uberjar.deps.optional}</optional>
+         <scope>compile</scope>
+      </dependency>
+
    </dependencies>
 
    <build>
@@ -64,9 +91,6 @@
          <resource>
             <directory>${project.basedir}/src/main/resources</directory>
             <filtering>true</filtering>
-            <includes>
-               <include>features.xml</include>
-            </includes>
          </resource>
       </resources>
       <plugins>
@@ -84,25 +108,61 @@
                      <finalName>${intermediary_jar_name}</finalName>
                      <artifactSet>
                         <excludes>
-                           <exclude>org.infinispan:infinispan-remote</exclude>
-                           <exclude>log4j:log4j:jar:</exclude>
-                           <exclude>net.jcip:jcip-annotations:jar:</exclude>
-                           <exclude>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.1_spec:jar:</exclude>
-                           <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec:jar:</exclude>
-                           <exclude>javax.annotation:jsr250-api:jar:</exclude>
-                           <exclude>javax.cache:cache-api:jar:</exclude>
-                           <exclude>javax.enterprise:cdi-api:jar:</exclude>
-                           <exclude>javax.inject:javax.inject:jar:</exclude>
-                           <exclude>org.osgi:org.osgi.core:jar:</exclude>
-                           <exclude>org.osgi:org.osgi.compendium:jar:</exclude>
+                           <exclude>org.apache.logging.log4j:log4j-core:jar:*</exclude>
+                           <exclude>log4j:log4j:jar:*</exclude>
+                           <exclude>net.jcip:jcip-annotations:jar:*</exclude>
+                           <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec:*</exclude>
+                           <exclude>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.1_spec:*</exclude>
+                           <exclude>javax.cache:cache-api:*</exclude>
+                           <exclude>javax.enterprise:cdi-api:*</exclude>
+                           <exclude>org.jboss.spec.javax.annotation:jboss-annotations-api_1.1_spec:*</exclude>
+                           <exclude>javax.inject:javax.inject:*</exclude>
+                           <exclude>org.jgroups:jgroups:*</exclude>
+                           <exclude>org.osgi:org.osgi.core:*</exclude>
+                           <exclude>org.osgi:org.osgi.compendium:*</exclude>
                         </excludes>
                      </artifactSet>
                      <filters>
+                        <filter>
+                           <artifact>org.infinispan:infinispan-commons</artifact>
+                           <excludes>
+                              <exclude>org/infinispan/commons/util/OsgiClassLoader*.class</exclude>
+                           </excludes>
+                        </filter>
+                        <filter>
+                           <artifact>org.infinispan.protostream:protostream</artifact>
+                           <excludes>
+                              <exclude>protostream/javassist/util/HotSwapper*.class</exclude>
+                           </excludes>
+                        </filter>
+                        <filter>
+                           <artifact>org.jboss.marshalling:jboss-marshalling</artifact>
+                           <excludes>
+                              <exclude>org/jboss/marshalling/ModularClassTable*.class</exclude>
+                           </excludes>
+                        </filter>
+                        <filter>
+                           <artifact>org.apache.logging.log4j:log4j-api</artifact>
+                           <excludes>
+                              <exclude>org/apache/logging/log4j/util/Activator*.class</exclude>
+                           </excludes>
+                        </filter>
+                        <filter>
+                           <artifact>org.jboss.logging:jboss-logging</artifact>
+                           <excludes>
+                              <exclude>org/jboss/logging/JBossLogManagerLogger*.class</exclude>
+                              <exclude>org/jboss/logging/JBossLogManagerProvider*.class</exclude>
+                              <exclude>org/jboss/logging/Slf4jLogger*.class</exclude>
+                              <exclude>org/jboss/logging/Log4jLogger*.class</exclude>
+                              <exclude>org/jboss/logging/Slf4jLocationAwareLogger*.class</exclude>
+                           </excludes>
+                        </filter>
                         <filter>
                            <artifact>*:*</artifact>
                            <excludes>
                               <exclude>INSTALL.html</exclude>
                               <exclude>LICENSE</exclude>
+                              <exclude>XPP3-LICENSE.txt</exclude>
                               <exclude>README</exclude>
                               <exclude>META-INF/*.SF</exclude>
                               <exclude>META-INF/*.DSA</exclude>
@@ -114,34 +174,69 @@
                               <exclude>META-INF/LICENSE.txt</exclude>
                               <exclude>META-INF/NOTICE</exclude>
                               <exclude>META-INF/NOTICE.txt</exclude>
+                              <exclude>jboss-as-checkstyle/checkstyle.xml</exclude>
+                              <exclude>schema/*.xsd</exclude>
+                              <exclude>__redirected/*</exclude>
                            </excludes>
                         </filter>
                      </filters>
                      <createSourcesJar>true</createSourcesJar>
                      <relocations>
                         <relocation>
-                           <pattern>org.apache</pattern>
-                           <shadedPattern>infinispan.org.apache</shadedPattern>
+                           <pattern>org.apache.commons</pattern>
+                           <shadedPattern>infinispan.org.apache.commons</shadedPattern>
+                        </relocation>
+                        <relocation>
+                           <pattern>org.slf4j</pattern>
+                           <shadedPattern>infinispan.org.slf4j</shadedPattern>
                         </relocation>
                         <relocation>
                            <pattern>com.google</pattern>
                            <shadedPattern>infinispan.com.google</shadedPattern>
                         </relocation>
-                        <!-- Unfortunatelly because of https://issues.jboss.org/browse/ISPN-5903
-                             and https://bugzilla.redhat.com/show_bug.cgi?id=1266831 we cannot relocate
-                             logging module, otherwise some integration modules might miss it
-                             when both Uber jar as well as ISPN commons are on classpath
-                          -->
-                        <!--<relocation>
+                        <relocation>
+                           <pattern>org.xnio</pattern>
+                           <shadedPattern>infinispan.org.xnio</shadedPattern>
+                        </relocation>
+                        <relocation>
+                           <pattern>org.jboss.threads</pattern>
+                           <shadedPattern>infinispan.org.jboss.threads</shadedPattern>
+                        </relocation>
+                        <relocation>
+                           <pattern>org.jboss.remoting3</pattern>
+                           <shadedPattern>infinispan.org.jboss.remoting3</shadedPattern>
+                        </relocation>
+                        <relocation>
                            <pattern>org.jboss.logging</pattern>
                            <shadedPattern>infinispan.org.jboss.logging</shadedPattern>
-                        </relocation> -->
+                        </relocation>
+                        <relocation>
+                           <pattern>org.jboss.modules</pattern>
+                           <shadedPattern>infinispan.org.jboss.modules</shadedPattern>
+                        </relocation>
+                        <relocation>
+                           <pattern>org.jboss.dmr</pattern>
+                           <shadedPattern>infinispan.org.jboss.dmr</shadedPattern>
+                        </relocation>
+                        <relocation>
+                           <pattern>org.jboss.as</pattern>
+                           <shadedPattern>infinispan.org.jboss.as</shadedPattern>
+                        </relocation>
+                        <relocation>
+                           <pattern>com.squareup</pattern>
+                           <shadedPattern>infinispan.com.squareup</shadedPattern>
+                        </relocation>
+                        <!-- Unfortunately because of https://issues.apache.org/jira/browse/MSHADE-182 -->
+                        <!-- we can not relocate marshalling module. Even when trying manual fixes it still fails -->
+                        <!--<relocation>-->
+                           <!--<pattern>org.jboss.marshalling</pattern>-->
+                           <!--<shadedPattern>infinispan.org.jboss.marshalling</shadedPattern>-->
+                        <!--</relocation>-->
                      </relocations>
                      <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                            <resources>
                               <resource>blueprint.xml</resource>
-                              <resource>features.xml</resource>
                            </resources>
                         </transformer>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
@@ -162,7 +257,6 @@
                   <id>default-bundle</id>
                   <phase>none</phase>
                </execution>
-
                <execution>
                   <id>bundle-package</id>
                   <phase>package</phase>
@@ -171,12 +265,10 @@
                   </goals>
                   <configuration>
                      <instructions>
-                        
                         <Include-Resource>
                            @${intermediary_jar_path},
                            /features.xml=${project.basedir}/target/classes/features.xml
                         </Include-Resource>
-                        
                         <_exportcontents>
                            org.infinispan.client.hotrod.*,
                            org.infinispan.commons.*,
@@ -192,9 +284,11 @@
                            !javax.*,
                            !sun.misc,
                            !sun.reflect,
+                           !com.sun.jmx.*,
                            !com.sun.jdi.*,
                            !net.jcip.annotations,
                            !org.jboss.logmanager,
+                           !org.jboss.logging.annotations.*,
                            !org.jboss.modules,
                            *
                         </Import-Package>

--- a/cdi/remote/pom.xml
+++ b/cdi/remote/pom.xml
@@ -26,6 +26,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-cdi-common</artifactId>
         </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -603,11 +603,6 @@
             <scope>test</scope>
          </dependency>
          <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-controller</artifactId>
-            <version>${version.org.wildfly.core}</version>
-         </dependency>
-         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-weld-ee-embedded-1.1</artifactId>
             <version>${version.arquillian.container.weld}</version>
@@ -1110,6 +1105,13 @@
                       <artifactId>xapool</artifactId>
                   </exclusion>
               </exclusions>
+          </dependency>
+          <dependency>
+             <groupId>org.wildfly.core</groupId>
+             <artifactId>wildfly-core-parent</artifactId>
+             <version>${version.org.wildfly.core}</version>
+             <scope>import</scope>
+             <type>pom</type>
           </dependency>
       </dependencies>
    </dependencyManagement>


### PR DESCRIPTION
Hey!

Please take a look at proposed solution for https://issues.jboss.org/browse/ISPN-5954

Highlights:
* Remote Uber Jar now contains `RemoteCacheManager` & friends (required for RemoteStore)
* Added missing jars which were causing Class Loading Exceptions
* Added dependencies to `org.hinernate` for embedded and `sun.jdk`
* Added CDI Extensions which eliminate unwanted `EmbeddedCacheManager` and `RemoteCacheManager` beans. Their lifecycle should be handles by CDI extensions (and they should not be autodiscovered by Weld).