### PR TITLE
Adding class- and method-names to the key so there are no collissions.

### DIFF
--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/DefaultCacheKeyGenerator.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/DefaultCacheKeyGenerator.java
@@ -12,11 +12,12 @@ import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Default {@link javax.cache.annotation.CacheKeyGenerator} implementation.
- * By default all key parameters of the intercepted method compose the
+ * By default all key parameters including the intercepted method and class names compose the
  * {@link javax.cache.annotation.CacheKey}.
  *
  * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
  * @author Galder Zamarreño
+ * @author <a href="mailto:daniel@pfeifer.io">Daniel Pfeifer</a>
  */
 @ApplicationScoped
 public class DefaultCacheKeyGenerator implements CacheKeyGenerator {
@@ -26,7 +27,12 @@ public class DefaultCacheKeyGenerator implements CacheKeyGenerator {
       assertNotNull(cacheKeyInvocationContext, "cacheKeyInvocationContext parameter must not be null");
 
       final CacheInvocationParameter[] keyParameters = cacheKeyInvocationContext.getKeyParameters();
-      final Object[] keyValues = new Object[keyParameters.length];
+      final Object[] keyValues = new Object[keyParameters.length + 2]; // make space for class- and method-name 
+
+      final String methodName = cacheKeyInvocationContext.getMethod().getName();
+      final String className = cacheKeyInvocationContext.getMethod().getDeclaringClass().getSimpleName(); 
+      keyValues[keyValues.length - 1] = methodName;
+      keyValues[keyValues.length - 2] = className;
 
       for (int i = 0 ; i < keyParameters.length ; i++) {
          keyValues[i] = keyParameters[i].getValue();


### PR DESCRIPTION
When using JCache-annotations the DefaultCacheKeyGenerator exclusively looks at parameter values to form the cache key. Therefore it will be very likely that collissions occur (resulting in difficult to find ClassCastExceptions). The provided patch uses the method- and class names as additionally values to make the cache key more unique.

Might also add that I am aware that by spec this should not be an issue when no cachename is given (as it should generate a cache using the class-name), but when a cache name is given collissions may occur.