### PR TITLE
ISPN-5879 Avoid concurrent cluster switches

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/CacheTopologyInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/CacheTopologyInfo.java
@@ -22,4 +22,5 @@ public interface CacheTopologyInfo {
     */
    Map<SocketAddress, Set<Integer>> getSegmentsPerServer();
 
+   Integer getTopologyId();
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -580,7 +580,7 @@ public class RemoteCacheManager implements BasicCacheContainer {
 
       synchronized (cacheName2RemoteCache) {
          for (RemoteCacheHolder rcc : cacheName2RemoteCache.values()) {
-            startRemoteCache(rcc, defaultCacheTopologyId);
+            startRemoteCache(rcc);
          }
       }
 
@@ -649,8 +649,7 @@ public class RemoteCacheManager implements BasicCacheContainer {
          if (!cacheName2RemoteCache.containsKey(key)) {
             RemoteCacheImpl<K, V> result = createRemoteCache(cacheName);
             RemoteCacheHolder rcc = new RemoteCacheHolder(result, forceReturnValueOverride == null ? configuration.forceReturnValues() : forceReturnValueOverride);
-            AtomicInteger topologyId = cacheName.isEmpty() ? defaultCacheTopologyId : new AtomicInteger(-1);
-            startRemoteCache(rcc, topologyId);
+            startRemoteCache(rcc);
             if (configuration.pingOnStartup()) {
                // If ping not successful assume that the cache does not exist
                // Default cache is always started, so don't do for it
@@ -696,10 +695,10 @@ public class RemoteCacheManager implements BasicCacheContainer {
       return cache.ping();
    }
 
-   private void startRemoteCache(RemoteCacheHolder remoteCacheHolder, AtomicInteger topologyId) {
+   private void startRemoteCache(RemoteCacheHolder remoteCacheHolder) {
       RemoteCacheImpl<?, ?> remoteCache = remoteCacheHolder.remoteCache;
       OperationsFactory operationsFactory = new OperationsFactory(
-            transportFactory, remoteCache.getName(), topologyId, remoteCacheHolder.forceReturnValue,
+            transportFactory, remoteCache.getName(), remoteCacheHolder.forceReturnValue,
             codec, listenerNotifier);
       remoteCache.init(marshaller, asyncExecutorService, operationsFactory, configuration.keySizeEstimate(), configuration.valueSizeEstimate());
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/CacheTopologyInfoImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/CacheTopologyInfoImpl.java
@@ -26,6 +26,7 @@ public class CacheTopologyInfoImpl implements CacheTopologyInfo {
       return numSegments;
    }
 
+   @Override
    public Integer getTopologyId() {
       return topologyId;
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/HotRodOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/HotRodOperation.java
@@ -45,7 +45,8 @@ public abstract class HotRodOperation implements HotRodConstants {
       HeaderParams params = new HeaderParams()
             .opCode(operationCode).cacheName(cacheName).flags(flags)
             .clientIntel(CLIENT_INTELLIGENCE_HASH_DISTRIBUTION_AWARE)
-            .topologyId(topologyId).txMarker(NO_TX);
+            .topologyId(topologyId).txMarker(NO_TX)
+            .topologyAge(transport.getTransportFactory().getTopologyAge());
       return codec.writeHeader(transport, params);
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
@@ -47,12 +47,14 @@ public class OperationsFactory implements HotRodConstants {
    private final String cacheName;
 
    public OperationsFactory(TransportFactory transportFactory, String cacheName,
-                            AtomicInteger topologyId, boolean forceReturnValue, Codec codec,
+                            boolean forceReturnValue, Codec codec,
                             ClientListenerNotifier listenerNotifier) {
       this.transportFactory = transportFactory;
       this.cacheNameBytes = RemoteCacheManager.cacheNameBytes(cacheName);
       this.cacheName = cacheName;
-      this.topologyId = topologyId;
+      this.topologyId = transportFactory != null
+         ? transportFactory.createTopologyId(cacheNameBytes)
+         : new AtomicInteger(-1);
       this.forceReturnValue = forceReturnValue;
       this.codec = codec;
       this.listenerNotifier = listenerNotifier;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
@@ -245,8 +245,9 @@ public class Codec10 implements Codec {
             hashFunctionVersion, hashSpace, clusterSize);
 
       Set<SocketAddress> socketAddresses = servers2Hash.keySet();
+      int topologyAge = transport.getTransportFactory().getTopologyAge();
       if (localLog.isInfoEnabled()) {
-         localLog.newTopology(transport.getRemoteSocketAddress(), newTopologyId,
+         localLog.newTopology(transport.getRemoteSocketAddress(), newTopologyId, topologyAge,
                socketAddresses.size(), socketAddresses);
       }
       transport.getTransportFactory().updateServers(socketAddresses, cacheName, false);
@@ -254,7 +255,7 @@ public class Codec10 implements Codec {
          localLog.trace("Not using a consistent hash function (hash function version == 0).");
       } else {
          transport.getTransportFactory().updateHashFunction(
-               servers2Hash, numKeyOwners, hashFunctionVersion, hashSpace, cacheName);
+               servers2Hash, numKeyOwners, hashFunctionVersion, hashSpace, cacheName, topologyId);
       }
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HeaderParams.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HeaderParams.java
@@ -20,6 +20,7 @@ public class HeaderParams {
    byte txMarker;
    AtomicInteger topologyId;
    long messageId;
+   int topologyAge;
 
    public HeaderParams opCode(short opCode) {
       this.opCode = opCode;
@@ -54,6 +55,11 @@ public class HeaderParams {
 
    public HeaderParams messageId(long messageId) {
       this.messageId = messageId;
+      return this;
+   }
+
+   public HeaderParams topologyAge(int topologyAge) {
+      this.topologyAge = topologyAge;
       return this;
    }
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
@@ -13,6 +13,8 @@ import org.infinispan.client.hotrod.event.ClientListenerNotifier;
 import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHash;
 import org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashFactory;
 import org.infinispan.client.hotrod.impl.protocol.Codec;
+import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory;
+import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory.ClusterSwitchStatus;
 import org.infinispan.commons.marshall.Marshaller;
 
 /**
@@ -41,9 +43,11 @@ public interface TransportFactory {
     * @deprecated Only called for Hot Rod 1.x protocol.
     */
    @Deprecated
-   void updateHashFunction(Map<SocketAddress, Set<Integer>> servers2Hash, int numKeyOwners, short hashFunctionVersion, int hashSpace, byte[] cacheName);
+   void updateHashFunction(Map<SocketAddress, Set<Integer>> servers2Hash, int numKeyOwners, short hashFunctionVersion, int hashSpace,
+      byte[] cacheName, AtomicInteger topologyId);
 
-   void updateHashFunction(SocketAddress[][] segmentOwners, int numSegments, short hashFunctionVersion, byte[] cacheName);
+   void updateHashFunction(SocketAddress[][] segmentOwners, int numSegments, short hashFunctionVersion,
+      byte[] cacheName, AtomicInteger topologyId);
 
    ConsistentHash getConsistentHash(byte[] cacheName);
 
@@ -67,10 +71,17 @@ public interface TransportFactory {
 
    void reset(byte[] cacheName);
 
-   boolean trySwitchCluster(byte[] cacheName);
+   AtomicInteger createTopologyId(byte[] cacheName);
+
+   int getTopologyId(byte[] cacheName);
+
+   ClusterSwitchStatus trySwitchCluster(String failedClusterName, byte[] cacheName);
 
    Marshaller getMarshaller();
 
    boolean switchToCluster(String clusterName);
 
+   String getCurrentClusterName();
+
+   int getTopologyAge();
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
@@ -53,8 +53,8 @@ public interface Log extends BasicLogger {
    void errorFromServer(String message);
 
    @LogMessage(level = INFO)
-   @Message(value = "%s sent new topology view (id=%d) containing %d addresses: %s", id = 4006)
-   void newTopology(SocketAddress address, int viewId, int topologySize, Set<SocketAddress> topology);
+   @Message(value = "%s sent new topology view (id=%d, age=%d) containing %d addresses: %s", id = 4006)
+   void newTopology(SocketAddress address, int viewId, int age, int topologySize, Set<SocketAddress> topology);
 
    @LogMessage(level = ERROR)
    @Message(value = "Exception encountered. Retry %d out of %d", id = 4007)

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/RetryOnFailureUnitTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/RetryOnFailureUnitTest.java
@@ -7,6 +7,8 @@ import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 import org.infinispan.client.hotrod.impl.operations.RetryOnFailureOperation;
 import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
+import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory;
+import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory.ClusterSwitchStatus;
 import org.mockito.Mockito;
 import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
@@ -53,6 +55,7 @@ public class RetryOnFailureUnitTest {
    private void doRetryTest(int maxRetry, boolean failOnTransport) {
       TransportFactory mockTransport = Mockito.mock(TransportFactory.class);
       Mockito.when(mockTransport.getMaxRetries()).thenReturn(maxRetry);
+      Mockito.when(mockTransport.trySwitchCluster(Mockito.anyObject(), Mockito.anyObject())).thenReturn(ClusterSwitchStatus.NOT_SWITCHED);
       MockOperation mockOperation = new MockOperation(mockTransport, failOnTransport);
       try {
          mockOperation.execute();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/SiteDownFailoverTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/SiteDownFailoverTest.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 
-@Test(groups = "functional", testName = "xsite.SiteDownFailoverTest")
+@Test(groups = "functional", testName = "client.hotrod.xsite.SiteDownFailoverTest")
 public class SiteDownFailoverTest extends AbstractHotRodSiteFailoverTest {
 
    public void testFailoverAfterSiteShutdown() {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/SiteManualSwitchTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/xsite/SiteManualSwitchTest.java
@@ -10,7 +10,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 
-@Test(groups = "functional", testName = "xsite.SiteDownFailoverTest")
+@Test(groups = "functional", testName = "client.hotrod.xsite.SiteDownFailoverTest")
 public class SiteManualSwitchTest extends AbstractHotRodSiteFailoverTest {
 
    @Override


### PR DESCRIPTION
Matej and I have been testing manually but I didn't have time to create a unit test for it. I'll create a JIRA for this.

* When switching clusters, update topology id of the cache involved. To
  do so, enhance TopologyInfo to deal with multiple topology ids.
* Instead of relying on individual requests to check failover validity,
  add a step in the failover cluster switch logic to check the servers
  to which it is going to failover. If none of those are available
  consider cluster switch not achieved. If any succeed, switch the
  cluster and apply new topology.
* Cluster switches can happen while clients are hammering the server, in
  which case there's a possibility that after a cluster switch old
  topology updates are received. To avoid these being applied, the
  concept of topology age has been added which is increased every time
  there's a cluster switch. When new topologies are received, the
  topology age is verified and it's from a previous cluster, this is ignored.