### PR TITLE
ISPN-5889 Re-add node to topology cache with overlapping partitions

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/TransportObjectFactoryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/TransportObjectFactoryTest.java
@@ -31,6 +31,6 @@ public class TransportObjectFactoryTest {
             .when(codec).writeHeader(any(Transport.class), any(HeaderParams.class));
 
       InetSocketAddress address = new InetSocketAddress(123);
-      assertFalse("Exception shouldn't be thrown here", objectFactory.validateObject(address, any(TcpTransport.class)));
+      assertFalse("Exception shouldn't be thrown here", objectFactory.validateObject(address, null));
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5889

Use a distributed task to check if any other member removed this node's
address, instead of relying on a CacheEntryInvalidatedEvent.