### PR TITLE
ISPN-5948 ClusterListenerDistTxTest.testSimpleExpirationFilterNotOwner

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TransactionConfigurationBuilder.java
@@ -301,6 +301,9 @@ public class TransactionConfigurationBuilder extends AbstractConfigurationChildB
             throw log.invalidLockingModeForTotalOrder(lockingMode());
          }
       }
+      if (!attributes.attribute(NOTIFICATIONS).get()) {
+         log.transactionNotificationsDisabled();
+      }
       recovery.validate();
    }
 

--- a/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
@@ -185,11 +185,6 @@ public class InterceptorChainFactory extends AbstractNamedCacheComponentFactory 
          interceptorChain.appendInterceptor(interceptor, false);
       }
 
-      // NotificationInterceptor is used only for Prepare/Commit/Rollback notifications
-      if (transactionMode.isTransactional() && configuration.transaction().notifications()) {
-         interceptorChain.appendInterceptor(createInterceptor(new NotificationInterceptor(), NotificationInterceptor.class), false);
-      }
-
       if (configuration.transaction().useEagerLocking()) {
          configuration.transaction().lockingMode(LockingMode.PESSIMISTIC);
       }
@@ -205,6 +200,12 @@ public class InterceptorChainFactory extends AbstractNamedCacheComponentFactory 
          } else {
             interceptorChain.appendInterceptor(createInterceptor(new NonTransactionalLockingInterceptor(), NonTransactionalLockingInterceptor.class), false);
          }
+      }
+
+      // NotificationInterceptor is used only for Prepare/Commit/Rollback notifications
+      // This needs to be after locking interceptor to guarantee that locks are still held when raising notifications
+      if (transactionMode.isTransactional() && configuration.transaction().notifications()) {
+         interceptorChain.appendInterceptor(createInterceptor(new NotificationInterceptor(), NotificationInterceptor.class), false);
       }
 
       if (configuration.sites().hasEnabledBackups() && !configuration.sites().disableBackups()) {

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/RemoteClusterListener.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/RemoteClusterListener.java
@@ -106,7 +106,7 @@ public class RemoteClusterListener {
       }  else {
          // Send event back to origin who has the cluster listener
          if (trace) {
-            log.tracef("Submitting Event %s to cluster listener to %s", event, origin);
+            log.tracef("Passing Event to manager %s to send to %s", event, origin);
          }
          eventManager.addEvents(origin, id, Collections.singleton(ClusterEvent.fromEvent(event)), sync);
       }
@@ -121,7 +121,7 @@ public class RemoteClusterListener {
             eventsToSend.add(ClusterEvent.fromEvent(cacheEvent));
             // Send event back to origin who has the cluster listener
             if (trace) {
-               log.tracef("Submitting Event(s) %s to cluster listener to %s", eventsToSend, origin);
+               log.tracef("Passing Event(s) to manager %s to send to %s", eventsToSend, origin);
             }
          }
          eventManager.addEvents(origin, id, eventsToSend, sync);

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1408,5 +1408,9 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Recovery not supported with asynchronous commit phase", id = 394)
    CacheConfigurationException recoveryNotSupportedWithAsyncCommit();
+
+   @LogMessage(level = INFO)
+   @Message(value = "Transaction notifications are disabled.  This prevents cluster listeners from working properly!", id = 395)
+   void transactionNotificationsDisabled();
 }
 


### PR DESCRIPTION
and ClusterListenerDistTxTest.testSimpleExpirationConverterNotOwner fail
with assertion error

* Moved notification interceptor to be below locking
* Makes sure tx notifications are properly ordered

https://issues.jboss.org/browse/ISPN-5948