### PR TITLE
ISPN-5903 BZ1266831 Fix logging exception when both infinispan-remote uber-jar and infinispan-commons on classpath

### DIFF
--- a/all/remote/pom.xml
+++ b/all/remote/pom.xml
@@ -127,10 +127,15 @@
                            <pattern>com.google</pattern>
                            <shadedPattern>infinispan.com.google</shadedPattern>
                         </relocation>
-                        <relocation>
+                        <!-- Unfortunatelly because of https://issues.jboss.org/browse/ISPN-5903
+                             and https://bugzilla.redhat.com/show_bug.cgi?id=1266831 we cannot relocate
+                             logging module, otherwise some integration modules might miss it
+                             when both Uber jar as well as ISPN commons are on classpath
+                          -->
+                        <!--<relocation>
                            <pattern>org.jboss.logging</pattern>
                            <shadedPattern>infinispan.org.jboss.logging</shadedPattern>
-                        </relocation>
+                        </relocation> -->
                      </relocations>
                      <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/ISPN-5903
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1266831

This issue was already fixed, the problem is that when the infinispan-remote package is used with infinispan-spring4-remote package, there is an exception:

    java.lang.NoSuchMethodError: org.infinispan.commons.logging.BasicLogFactory.getLog(Ljava/lang/Class;)Linfinispan/org/jboss/logging/BasicLogger;

This happens because two versions of BasicLogFactory are loaded, one from infinispan-remote that is "shaded" by maven-shade-plugin, one from infinispan-commons (transitive dependency of infinispan-spring4-remote) which is not "shaded", both have the same fully qualified names and when the hotrod-client is loaded, it picks up one of those classes, when it picks up the infinispan-commons version, it fails with the above error as method that returns  infinispan.org.jboss.logging.BasicLogger is not found. The infinispan-remote version is picked up if it's loaded first, which can be achieved by defining the package before infinispan-spring4-remote in a pom.xml. Another solution is to exclude infinispan-commons from infinispan-spring4-remote, which gets rid of the later version of BasicLogFactory altogether. See the linked BZ for more information.

This fix disables "shading" of the org.jboss.logging package, which makes the above workaround unecessary.