### PR TITLE
ISPN-6014 DebuggingUnitTestNGListener handles threadTestName incorrectly

### DIFF
--- a/core/src/test/java/org/infinispan/test/fwk/DebuggingUnitTestNGListener.java
+++ b/core/src/test/java/org/infinispan/test/fwk/DebuggingUnitTestNGListener.java
@@ -3,6 +3,7 @@ package org.infinispan.test.fwk;
 import java.util.Set;
 
 import org.infinispan.manager.CacheContainer;
+import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.util.concurrent.ConcurrentHashSet;
 import org.infinispan.util.logging.Log;
@@ -28,7 +29,11 @@ public class DebuggingUnitTestNGListener extends UnitTestTestNGListener {
 
    @Override
    public void onFinish(ITestContext testCxt) {
-      super.onFinish(testCxt);
+      Class testClass = testCxt.getCurrentXmlTest().getXmlClasses().get(0).getSupportClass();
+      if (!AbstractInfinispanTest.class.isAssignableFrom(testClass)) {
+         //do not null the threadTestName as it is required during cleanup check
+         TestResourceTracker.testFinished(testClass.getName(), false);
+      }
       checkCleanedUp(testCxt);
    }
 
@@ -45,6 +50,7 @@ public class DebuggingUnitTestNGListener extends UnitTestTestNGListener {
          }
       }
       finally {
+         TestResourceTracker.setThreadTestName(null);
          TestingUtil.killCacheManagers(cm);
       }
    }

--- a/core/src/test/java/org/infinispan/test/fwk/TestResourceTracker.java
+++ b/core/src/test/java/org/infinispan/test/fwk/TestResourceTracker.java
@@ -95,13 +95,18 @@ public class TestResourceTracker {
     * Called on the "main" test thread, after any configuration method.
     */
    public static void testFinished(String testName) {
+      testFinished(testName, true);
+   }
+
+   public static void testFinished(String testName, boolean unsetThreadTestName) {
       cleanUpResources(testName);
       if (!testName.equals(getCurrentTestName())) {
          cleanUpResources(getCurrentTestName());
          throw new IllegalArgumentException("Current thread name was not set correctly: " + getCurrentTestName() +
-               ", should have been " + testName);
+                 ", should have been " + testName);
       }
-      setThreadTestName(null);
+      if (unsetThreadTestName)
+         setThreadTestName(null);
    }
 
    /**


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6014