### PR TITLE
ISPN-5981 Compatibility routing fix for clients

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -67,7 +67,6 @@ import org.infinispan.commons.util.Util;
  * <li><tt>infinispan.client.hotrod.force_return_values</tt>, default = false.  Whether or not to implicitly {@link org.infinispan.client.hotrod.Flag#FORCE_RETURN_VALUE} for all calls.</li>
  * <li><tt>infinispan.client.hotrod.tcp_no_delay</tt>, default = true.  Affects TCP NODELAY on the TCP stack.</li>
  * <li><tt>infinispan.client.hotrod.tcp_keep_alive</tt>, default = false.  Affects TCP KEEPALIVE on the TCP stack.</li>
- * <li><tt>infinispan.client.hotrod.ping_on_startup</tt>, default = true.  If true, a ping request is sent to a back end server in order to fetch cluster's topology.</li>
  * <li><tt>infinispan.client.hotrod.transport_factory</tt>, default = org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory - controls which transport to use.  Currently only the TcpTransport is supported.</li>
  * <li><tt>infinispan.client.hotrod.marshaller</tt>, default = org.infinispan.marshall.jboss.GenericJBossMarshaller.  Allows you to specify a custom {@link org.infinispan.marshall.Marshaller} implementation to serialize and deserialize user objects. For portable serialization payloads, you should configure the marshaller to be {@link org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller}</li>
  * <li><tt>infinispan.client.hotrod.async_executor_factory</tt>, default = org.infinispan.client.hotrod.impl.async.DefaultAsyncExecutorFactory.  Allows you to specify a custom asynchroous executor for async calls.</li>
@@ -318,7 +317,6 @@ public class RemoteCacheManager implements BasicCacheContainer {
       properties.setProperty(ConfigurationProperties.FORCE_RETURN_VALUES, Boolean.toString(configuration.forceReturnValues()));
       properties.setProperty(ConfigurationProperties.KEY_SIZE_ESTIMATE, Integer.toString(configuration.keySizeEstimate()));
       properties.setProperty(ConfigurationProperties.MARSHALLER, configuration.marshallerClass().getName());
-      properties.setProperty(ConfigurationProperties.PING_ON_STARTUP, Boolean.toString(configuration.pingOnStartup()));
       properties.setProperty(ConfigurationProperties.PROTOCOL_VERSION, configuration.protocolVersion());
       properties.setProperty(ConfigurationProperties.SO_TIMEOUT, Integer.toString(configuration.socketTimeout()));
       properties.setProperty(ConfigurationProperties.TCP_NO_DELAY, Boolean.toString(configuration.tcpNoDelay()));
@@ -650,15 +648,15 @@ public class RemoteCacheManager implements BasicCacheContainer {
             RemoteCacheImpl<K, V> result = createRemoteCache(cacheName);
             RemoteCacheHolder rcc = new RemoteCacheHolder(result, forceReturnValueOverride == null ? configuration.forceReturnValues() : forceReturnValueOverride);
             startRemoteCache(rcc);
-            if (configuration.pingOnStartup()) {
-               // If ping not successful assume that the cache does not exist
-               // Default cache is always started, so don't do for it
-               if (!cacheName.equals(RemoteCacheManager.DEFAULT_CACHE_NAME) &&
-                     ping(result) == PingResult.CACHE_DOES_NOT_EXIST) {
-                  return null;
-               }
+
+            PingResult pingResult = result.resolveCompatibility();
+            // If ping not successful assume that the cache does not exist
+            // Default cache is always started, so don't do for it
+            if (!cacheName.equals(RemoteCacheManager.DEFAULT_CACHE_NAME) &&
+                  pingResult == PingResult.CACHE_DOES_NOT_EXIST) {
+               return null;
             }
-            result.resolveCompatibility();
+
             result.start();
             // If ping on startup is disabled, or cache is defined in server
             cacheName2RemoteCache.put(key, rcc);
@@ -686,14 +684,6 @@ public class RemoteCacheManager implements BasicCacheContainer {
 
    protected <K, V> NearCacheService<K, V> createNearCacheService(NearCacheConfiguration cfg) {
       return NearCacheService.create(cfg, listenerNotifier);
-   }
-
-   private <K, V> PingResult ping(RemoteCacheImpl<K, V> cache) {
-      if (transportFactory == null) {
-         return PingResult.FAIL;
-      }
-
-      return cache.ping();
    }
 
    private void startRemoteCache(RemoteCacheHolder remoteCacheHolder) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -658,6 +658,7 @@ public class RemoteCacheManager implements BasicCacheContainer {
                   return null;
                }
             }
+            result.resolveCompatibility();
             result.start();
             // If ping on startup is disabled, or cache is defined in server
             cacheName2RemoteCache.put(key, rcc);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/Configuration.java
@@ -32,6 +32,7 @@ public class Configuration {
    private final int keySizeEstimate;
    private final Class<? extends Marshaller> marshallerClass;
    private final Marshaller marshaller;
+   @Deprecated
    private final boolean pingOnStartup;
    private final String protocolVersion;
    private final List<ServerConfiguration> servers;
@@ -157,6 +158,10 @@ public class Configuration {
       return nearCache;
    }
 
+   /**
+    * @deprecated No longer in effect, ping always happens on startup now.
+    */
+   @Deprecated
    public boolean pingOnStartup() {
       return pingOnStartup;
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/configuration/ConfigurationBuilder.java
@@ -205,9 +205,12 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder, Builder<
       return nearCache;
    }
 
+   /**
+    * @deprecated No longer in effect, ping always happens on startup now.
+    */
+   @Deprecated
    @Override
    public ConfigurationBuilder pingOnStartup(boolean pingOnStartup) {
-      this.pingOnStartup = pingOnStartup;
       return this;
    }
 
@@ -291,7 +294,6 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder, Builder<
       if (typed.containsKey(ConfigurationProperties.MARSHALLER)) {
          this.marshaller(typed.getProperty(ConfigurationProperties.MARSHALLER));
       }
-      this.pingOnStartup(typed.getBooleanProperty(ConfigurationProperties.PING_ON_STARTUP, pingOnStartup));
       this.protocolVersion(typed.getProperty(ConfigurationProperties.PROTOCOL_VERSION, protocolVersion));
       this.servers.clear();
       this.addServers(typed.getProperty(ConfigurationProperties.SERVER_LIST, ""));
@@ -375,7 +377,6 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder, Builder<
       this.keySizeEstimate = template.keySizeEstimate();
       this.marshaller = template.marshaller();
       this.marshallerClass = template.marshallerClass();
-      this.pingOnStartup = template.pingOnStartup();
       this.protocolVersion = template.protocolVersion();
       this.servers.clear();
       for (ServerConfiguration server : template.servers()) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
@@ -26,6 +26,7 @@ public class ConfigurationProperties {
    public static final String DEFAULT_EXECUTOR_FACTORY_POOL_SIZE = "infinispan.client.hotrod.default_executor_factory.pool_size";
    public static final String TCP_NO_DELAY = "infinispan.client.hotrod.tcp_no_delay";
    public static final String TCP_KEEP_ALIVE = "infinispan.client.hotrod.tcp_keep_alive";
+   @Deprecated
    public static final String PING_ON_STARTUP = "infinispan.client.hotrod.ping_on_startup";
    public static final String REQUEST_BALANCING_STRATEGY = "infinispan.client.hotrod.request_balancing_strategy";
    public static final String KEY_SIZE_ESTIMATE = "infinispan.client.hotrod.key_size_estimate";

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -25,7 +25,6 @@ import org.infinispan.client.hotrod.VersionedValue;
 import org.infinispan.client.hotrod.event.ClientListenerNotifier;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.client.hotrod.exceptions.RemoteCacheManagerNotStartedException;
-import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.client.hotrod.filter.Filters;
 import org.infinispan.client.hotrod.impl.operations.*;
 import org.infinispan.client.hotrod.impl.iteration.RemoteCloseableIterator;
@@ -701,14 +700,14 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
       return operationsFactory.getCacheTopologyInfo();
    }
 
-   public void resolveCompatibility() {
+   public PingOperation.PingResult resolveCompatibility() {
       if (remoteCacheManager.isStarted()) {
-         try {
-            hasCompatibility = ping().hasCompatibility();
-         } catch (TransportException e) {
-            hasCompatibility = false;
-         }
+         PingOperation.PingResult result = ping();
+         hasCompatibility = result.hasCompatibility();
+         return result;
       }
+
+      return PingOperation.PingResult.FAIL;
    }
 
    private abstract class WithFlagsCallable implements Callable<V> {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/RemoteCacheImpl.java
@@ -25,6 +25,7 @@ import org.infinispan.client.hotrod.VersionedValue;
 import org.infinispan.client.hotrod.event.ClientListenerNotifier;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.client.hotrod.exceptions.RemoteCacheManagerNotStartedException;
+import org.infinispan.client.hotrod.exceptions.TransportException;
 import org.infinispan.client.hotrod.filter.Filters;
 import org.infinispan.client.hotrod.impl.operations.*;
 import org.infinispan.client.hotrod.impl.iteration.RemoteCloseableIterator;
@@ -54,6 +55,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    protected OperationsFactory operationsFactory;
    private int estimateKeySize;
    private int estimateValueSize;
+   private volatile boolean hasCompatibility;
 
    public RemoteCacheImpl(RemoteCacheManager rcm, String name) {
       if (trace) {
@@ -83,7 +85,8 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    @Override
    public boolean removeWithVersion(K key, long version) {
       assertRemoteCacheManagerIsStarted();
-      RemoveIfUnmodifiedOperation<V> op = operationsFactory.newRemoveIfUnmodifiedOperation(obj2bytes(key, true), version);
+      RemoveIfUnmodifiedOperation<V> op = operationsFactory.newRemoveIfUnmodifiedOperation(
+         compatKeyIfNeeded(key), obj2bytes(key, true), version);
       VersionedOperationResponse<V> response = op.execute();
       return response.getCode().isUpdated();
    }
@@ -125,7 +128,8 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    @Override
    public boolean replaceWithVersion(K key, V newValue, long version, long lifespan, TimeUnit lifespanTimeUnit, long maxIdle, TimeUnit maxIdleTimeUnit) {
       assertRemoteCacheManagerIsStarted();
-      ReplaceIfUnmodifiedOperation op = operationsFactory.newReplaceIfUnmodifiedOperation(obj2bytes(key, true), obj2bytes(newValue, false), lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit, version);
+      ReplaceIfUnmodifiedOperation op = operationsFactory.newReplaceIfUnmodifiedOperation(
+         compatKeyIfNeeded(key), obj2bytes(key, true), obj2bytes(newValue, false), lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit, version);
       VersionedOperationResponse response = op.execute();
       return response.getCode().isUpdated();
    }
@@ -204,14 +208,16 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    @Override
    public VersionedValue<V> getVersioned(K key) {
       assertRemoteCacheManagerIsStarted();
-      GetWithVersionOperation<V> op = operationsFactory.newGetWithVersionOperation(obj2bytes(key, true));
+      GetWithVersionOperation<V> op = operationsFactory.newGetWithVersionOperation(
+         compatKeyIfNeeded(key), obj2bytes(key, true));
       return op.execute();
    }
 
    @Override
    public MetadataValue<V> getWithMetadata(K key) {
       assertRemoteCacheManagerIsStarted();
-      GetWithMetadataOperation<V> op = operationsFactory.newGetWithMetadataOperation(obj2bytes(key, true));
+      GetWithMetadataOperation<V> op = operationsFactory.newGetWithMetadataOperation(
+         compatKeyIfNeeded(key), obj2bytes(key, true));
       return op.execute();
    }
 
@@ -289,22 +295,28 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
       if (trace) {
          log.tracef("About to add (K,V): (%s, %s) lifespan:%d, maxIdle:%d", key, value, lifespan, maxIdleTime);
       }
-      PutOperation<V> op = operationsFactory.newPutKeyValueOperation(obj2bytes(key, true), obj2bytes(value, false), lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+      PutOperation<V> op = operationsFactory.newPutKeyValueOperation(compatKeyIfNeeded(key),
+         obj2bytes(key, true), obj2bytes(value, false), lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
       return op.execute();
    }
 
+   private K compatKeyIfNeeded(Object key) {
+      return hasCompatibility ? (K) key : null;
+   }
 
    @Override
    public V putIfAbsent(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
       assertRemoteCacheManagerIsStarted();
-      PutIfAbsentOperation<V> op = operationsFactory.newPutIfAbsentOperation(obj2bytes(key, true), obj2bytes(value, false), lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+      PutIfAbsentOperation<V> op = operationsFactory.newPutIfAbsentOperation(compatKeyIfNeeded(key),
+         obj2bytes(key, true), obj2bytes(value, false), lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
       return op.execute();
    }
 
    @Override
    public V replace(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
       assertRemoteCacheManagerIsStarted();
-      ReplaceOperation<V> op = operationsFactory.newReplaceOperation(obj2bytes(key, true), obj2bytes(value, false), lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+      ReplaceOperation<V> op = operationsFactory.newReplaceOperation(compatKeyIfNeeded(key),
+         obj2bytes(key, true), obj2bytes(value, false), lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
       return op.execute();
    }
 
@@ -461,7 +473,8 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    @Override
    public boolean containsKey(Object key) {
       assertRemoteCacheManagerIsStarted();
-      ContainsKeyOperation op = operationsFactory.newContainsKeyOperation(obj2bytes(key, true));
+      ContainsKeyOperation op = operationsFactory.newContainsKeyOperation(
+         compatKeyIfNeeded(key), obj2bytes(key, true));
       return op.execute();
    }
 
@@ -469,7 +482,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    public V get(Object key) {
       assertRemoteCacheManagerIsStarted();
       byte[] keyBytes = obj2bytes(key, true);
-      GetOperation<V> gco = operationsFactory.newGetKeyOperation(keyBytes);
+      GetOperation<V> gco = operationsFactory.newGetKeyOperation(compatKeyIfNeeded(key), keyBytes);
       V result = gco.execute();
       if (trace) {
          log.tracef("For key(%s) returning %s", key, result);
@@ -508,7 +521,7 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    @Override
    public V remove(Object key) {
       assertRemoteCacheManagerIsStarted();
-      RemoveOperation<V> removeOperation = operationsFactory.newRemoveOperation(obj2bytes(key, true));
+      RemoveOperation<V> removeOperation = operationsFactory.newRemoveOperation(compatKeyIfNeeded(key), obj2bytes(key, true));
       // TODO: It sucks that you need the prev value to see if it works...
       // We need to find a better API for RemoteCache...
       return removeOperation.execute();
@@ -686,6 +699,16 @@ public class RemoteCacheImpl<K, V> extends RemoteCacheSupport<K, V> {
    @Override
    public CacheTopologyInfo getCacheTopologyInfo() {
       return operationsFactory.getCacheTopologyInfo();
+   }
+
+   public void resolveCompatibility() {
+      if (remoteCacheManager.isStarted()) {
+         try {
+            hasCompatibility = ping().hasCompatibility();
+         } catch (TransportException e) {
+            hasCompatibility = false;
+         }
+      }
    }
 
    private abstract class WithFlagsCallable implements Callable<V> {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/TopologyInfo.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/TopologyInfo.java
@@ -93,7 +93,7 @@ public final class TopologyInfo {
       topologyIds.put(cacheName, topologyId);
    }
 
-   public Optional<SocketAddress> getHashAwareServer(byte[] key, byte[] cacheName) {
+   public Optional<SocketAddress> getHashAwareServer(Object key, byte[] cacheName) {
       Optional<SocketAddress> server = Optional.empty();
       if (isTopologyValid(cacheName)) {
          ConsistentHash consistentHash = consistentHashes.get(cacheName);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHash.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHash.java
@@ -15,7 +15,7 @@ public interface ConsistentHash {
    @Deprecated
    void init(Map<SocketAddress, Set<Integer>> servers2Hash, int numKeyOwners, int hashSpace);
 
-   SocketAddress getServer(byte[] key);
+   SocketAddress getServer(Object key);
 
    /**
     * Computes hash code of a given object, and then normalizes it to ensure a positive

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHashV1.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/ConsistentHashV1.java
@@ -78,7 +78,7 @@ public class ConsistentHashV1 implements ConsistentHash {
    }
 
    @Override
-   public SocketAddress getServer(byte[] key) {
+   public SocketAddress getServer(Object key) {
       int normalisedHashForKey;
       if (hashSpaceIsMaxInt) {
          normalisedHashForKey = getNormalizedHash(key);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/SegmentConsistentHash.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/consistenthash/SegmentConsistentHash.java
@@ -42,10 +42,10 @@ public final class SegmentConsistentHash implements ConsistentHash {
    }
 
    @Override
-   public SocketAddress getServer(byte[] key) {
+   public SocketAddress getServer(Object key) {
       int segmentId = getSegment(key);
       if (trace)
-         log.tracef("Find server in segment id %s for key %s", segmentId, Util.toHexString(key));
+         log.tracef("Find server in segment id %s for key %s", segmentId, Util.toStr(key));
 
       return segmentOwners[segmentId][0];
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AbstractKeyOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AbstractKeyOperation.java
@@ -26,18 +26,20 @@ public abstract class AbstractKeyOperation<T> extends RetryOnFailureOperation<T>
 
    private static final BasicLogger log = BasicLogFactory.getLog(AbstractKeyOperation.class);
 
-   protected final byte[] key;
+   protected final Object key;
+   protected final byte[] keyBytes;
 
    protected AbstractKeyOperation(Codec codec, TransportFactory transportFactory,
-                                  byte[] key, byte[] cacheName, AtomicInteger topologyId, int flags) {
+         Object key, byte[] keyBytes, byte[] cacheName, AtomicInteger topologyId, int flags) {
       super(codec, transportFactory, cacheName, topologyId, flags);
       this.key = key;
+      this.keyBytes = keyBytes;
    }
 
    @Override
    protected Transport getTransport(int retryCount, Set<SocketAddress> failedServers) {
       if (retryCount == 0) {
-         return transportFactory.getTransport(key, failedServers, cacheName);
+         return transportFactory.getTransport(key == null ? keyBytes : key, failedServers, cacheName);
       } else {
          return transportFactory.getTransport(failedServers, cacheName);
       }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AbstractKeyValueOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AbstractKeyValueOperation.java
@@ -28,10 +28,10 @@ public abstract class AbstractKeyValueOperation<T> extends AbstractKeyOperation<
 
    protected final TimeUnit maxIdleTimeUnit;
 
-   protected AbstractKeyValueOperation(Codec codec, TransportFactory transportFactory, byte[] key, byte[] cacheName,
+   protected AbstractKeyValueOperation(Codec codec, TransportFactory transportFactory, Object key, byte[] keyBytes, byte[] cacheName,
                                        AtomicInteger topologyId, int flags, byte[] value,
                                        long lifespan, TimeUnit lifespanTimeUnit, long maxIdle, TimeUnit maxIdleTimeUnit) {
-      super(codec, transportFactory, key, cacheName, topologyId, flags);
+      super(codec, transportFactory, key, keyBytes, cacheName, topologyId, flags);
       this.value = value;
       this.lifespan = lifespan;
       this.maxIdle = maxIdle;
@@ -45,7 +45,7 @@ public abstract class AbstractKeyValueOperation<T> extends AbstractKeyOperation<
       HeaderParams params = writeHeader(transport, opCode);
 
       // 2) write key and value
-      transport.writeArray(key);
+      transport.writeArray(keyBytes);
       codec.writeExpirationParams(transport, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
       transport.writeArray(value);
       transport.flush();

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ContainsKeyOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ContainsKeyOperation.java
@@ -18,14 +18,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ContainsKeyOperation extends AbstractKeyOperation<Boolean> {
 
    public ContainsKeyOperation(Codec codec, TransportFactory transportFactory,
-                               byte[] key, byte[] cacheName, AtomicInteger topologyId, int flags) {
-      super(codec, transportFactory, key, cacheName, topologyId, flags);
+         Object key, byte[] keyBytes, byte[] cacheName, AtomicInteger topologyId, int flags) {
+      super(codec, transportFactory, key, keyBytes,cacheName, topologyId, flags);
    }
 
    @Override
    protected Boolean executeOperation(Transport transport) {
       boolean containsKey = false;
-      short status = sendKeyOperation(key, transport, CONTAINS_KEY_REQUEST, CONTAINS_KEY_RESPONSE);
+      short status = sendKeyOperation(keyBytes, transport, CONTAINS_KEY_REQUEST, CONTAINS_KEY_RESPONSE);
       if (HotRodConstants.isNotExist(status)) {
          containsKey = false;
       } else if (HotRodConstants.isSuccess(status)) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetOperation.java
@@ -19,14 +19,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class GetOperation<V> extends AbstractKeyOperation<V> {
 
    public GetOperation(Codec codec, TransportFactory transportFactory,
-                       byte[] key, byte[] cacheName, AtomicInteger topologyId, int flags) {
-      super(codec, transportFactory, key, cacheName, topologyId, flags);
+         Object key, byte[] keyBytes, byte[] cacheName, AtomicInteger topologyId, int flags) {
+      super(codec, transportFactory, key, keyBytes, cacheName, topologyId, flags);
    }
 
    @Override
    public V executeOperation(Transport transport) {
       V result = null;
-      short status = sendKeyOperation(key, transport, GET_REQUEST, GET_RESPONSE);
+      short status = sendKeyOperation(keyBytes, transport, GET_REQUEST, GET_RESPONSE);
       if (HotRodConstants.isNotExist(status)) {
          result = null;
       } else {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetWithMetadataOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetWithMetadataOperation.java
@@ -27,13 +27,13 @@ public class GetWithMetadataOperation<V> extends AbstractKeyOperation<MetadataVa
    private static final boolean trace = log.isTraceEnabled();
 
    public GetWithMetadataOperation(Codec codec, TransportFactory transportFactory,
-                                   byte[] key, byte[] cacheName, AtomicInteger topologyId, int flags) {
-      super(codec, transportFactory, key, cacheName, topologyId, flags);
+         Object key, byte[] keyBytes, byte[] cacheName, AtomicInteger topologyId, int flags) {
+      super(codec, transportFactory, key, keyBytes, cacheName, topologyId, flags);
    }
 
    @Override
    protected MetadataValue<V> executeOperation(Transport transport) {
-      short status = sendKeyOperation(key, transport, GET_WITH_METADATA, GET_WITH_METADATA_RESPONSE);
+      short status = sendKeyOperation(keyBytes, transport, GET_WITH_METADATA, GET_WITH_METADATA_RESPONSE);
       MetadataValue<V> result = null;
       if (HotRodConstants.isNotExist(status)) {
          result = null;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetWithVersionOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/GetWithVersionOperation.java
@@ -28,13 +28,13 @@ public class GetWithVersionOperation<V> extends AbstractKeyOperation<VersionedVa
    private static final boolean trace = log.isTraceEnabled();
 
    public GetWithVersionOperation(Codec codec, TransportFactory transportFactory,
-                                  byte[] key, byte[] cacheName, AtomicInteger topologyId, int flags) {
-      super(codec, transportFactory, key, cacheName, topologyId, flags);
+         Object key, byte[] keyBytes, byte[] cacheName, AtomicInteger topologyId, int flags) {
+      super(codec, transportFactory, key, keyBytes, cacheName, topologyId, flags);
    }
 
    @Override
    protected VersionedValue<V> executeOperation(Transport transport) {
-      short status = sendKeyOperation(key, transport, GET_WITH_VERSION, GET_WITH_VERSION_RESPONSE);
+      short status = sendKeyOperation(keyBytes, transport, GET_WITH_VERSION, GET_WITH_VERSION_RESPONSE);
       VersionedValue<V> result = null;
       if (HotRodConstants.isNotExist(status)) {
          result = null;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/OperationsFactory.java
@@ -64,9 +64,9 @@ public class OperationsFactory implements HotRodConstants {
       return cacheNameBytes;
    }
 
-   public <V> GetOperation<V> newGetKeyOperation(byte[] key) {
+   public <V> GetOperation<V> newGetKeyOperation(Object key, byte[] keyBytes) {
       return new GetOperation<V>(
-            codec, transportFactory, key, cacheNameBytes, topologyId, flags());
+            codec, transportFactory, key, keyBytes, cacheNameBytes, topologyId, flags());
    }
 
    public <K, V> GetAllOperation<K, V> newGetAllOperation(Set<byte[]> keys) {
@@ -74,31 +74,31 @@ public class OperationsFactory implements HotRodConstants {
             codec, transportFactory, keys, cacheNameBytes, topologyId, flags());
    }
 
-   public <V> RemoveOperation<V> newRemoveOperation(byte[] key) {
+   public <V> RemoveOperation<V> newRemoveOperation(Object key, byte[] keyBytes) {
       return new RemoveOperation<V>(
-            codec, transportFactory, key, cacheNameBytes, topologyId, flags());
+            codec, transportFactory, key, keyBytes, cacheNameBytes, topologyId, flags());
    }
 
-   public <V> RemoveIfUnmodifiedOperation<V> newRemoveIfUnmodifiedOperation(byte[] key, long version) {
+   public <V> RemoveIfUnmodifiedOperation<V> newRemoveIfUnmodifiedOperation(Object key, byte[] keyBytes, long version) {
       return new RemoveIfUnmodifiedOperation<V>(
-            codec, transportFactory, key, cacheNameBytes, topologyId, flags(), version);
+            codec, transportFactory, key, keyBytes, cacheNameBytes, topologyId, flags(), version);
    }
 
-   public ReplaceIfUnmodifiedOperation newReplaceIfUnmodifiedOperation(byte[] key,
+   public ReplaceIfUnmodifiedOperation newReplaceIfUnmodifiedOperation(Object key, byte[] keyBytes,
             byte[] value, long lifespan, TimeUnit lifespanTimeUnit, long maxIdle, TimeUnit maxIdleTimeUnit, long version) {
       return new ReplaceIfUnmodifiedOperation(
-            codec, transportFactory, key, cacheNameBytes, topologyId, flags(lifespan, maxIdle),
+            codec, transportFactory, key, keyBytes, cacheNameBytes, topologyId, flags(lifespan, maxIdle),
             value, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit, version);
    }
 
-   public <V> GetWithVersionOperation<V> newGetWithVersionOperation(byte[] key) {
+   public <V> GetWithVersionOperation<V> newGetWithVersionOperation(Object key, byte[] keyBytes) {
       return new GetWithVersionOperation<V>(
-            codec, transportFactory, key, cacheNameBytes, topologyId, flags());
+            codec, transportFactory, key, keyBytes, cacheNameBytes, topologyId, flags());
    }
 
-   public <V> GetWithMetadataOperation<V> newGetWithMetadataOperation(byte[] key) {
+   public <V> GetWithMetadataOperation<V> newGetWithMetadataOperation(Object key, byte[] keyBytes) {
       return new GetWithMetadataOperation<V>(
-            codec, transportFactory, key, cacheNameBytes, topologyId, flags());
+            codec, transportFactory, key, keyBytes, cacheNameBytes, topologyId, flags());
    }
 
    public StatsOperation newStatsOperation() {
@@ -106,10 +106,10 @@ public class OperationsFactory implements HotRodConstants {
             codec, transportFactory, cacheNameBytes, topologyId, flags());
    }
 
-   public <V> PutOperation<V> newPutKeyValueOperation(byte[] key, byte[] value,
+   public <V> PutOperation<V> newPutKeyValueOperation(Object key, byte[] keyBytes, byte[] value,
           long lifespan, TimeUnit lifespanTimeUnit, long maxIdle, TimeUnit maxIdleTimeUnit) {
       return new PutOperation<V>(
-            codec, transportFactory, key, cacheNameBytes, topologyId, flags(lifespan, maxIdle),
+            codec, transportFactory, key, keyBytes, cacheNameBytes, topologyId, flags(lifespan, maxIdle),
             value, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
    }
 
@@ -120,23 +120,23 @@ public class OperationsFactory implements HotRodConstants {
             lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
    }
 
-   public <V> PutIfAbsentOperation<V> newPutIfAbsentOperation(byte[] key, byte[] value,
+   public <V> PutIfAbsentOperation<V> newPutIfAbsentOperation(Object key, byte[] keyBytes, byte[] value,
              long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
       return new PutIfAbsentOperation<V>(
-            codec, transportFactory, key, cacheNameBytes, topologyId, flags(lifespan, maxIdleTime),
+            codec, transportFactory, key, keyBytes, cacheNameBytes, topologyId, flags(lifespan, maxIdleTime),
             value, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
    }
 
-   public <V> ReplaceOperation<V> newReplaceOperation(byte[] key, byte[] values,
+   public <V> ReplaceOperation<V> newReplaceOperation(Object key, byte[] keyBytes, byte[] values,
            long lifespan, TimeUnit lifespanTimeUnit, long maxIdle, TimeUnit maxIdleTimeUnit) {
       return new ReplaceOperation<V>(
-            codec, transportFactory, key, cacheNameBytes, topologyId, flags(lifespan, maxIdle),
+            codec, transportFactory, key, keyBytes, cacheNameBytes, topologyId, flags(lifespan, maxIdle),
             values, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
    }
 
-   public ContainsKeyOperation newContainsKeyOperation(byte[] key) {
+   public ContainsKeyOperation newContainsKeyOperation(Object key, byte[] keyBytes) {
       return new ContainsKeyOperation(
-            codec, transportFactory, key, cacheNameBytes, topologyId, flags());
+            codec, transportFactory, key, keyBytes, cacheNameBytes, topologyId, flags());
    }
 
    public ClearOperation newClearOperation() {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PingOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PingOperation.java
@@ -46,7 +46,9 @@ public class PingOperation extends HotRodOperation {
          if (HotRodConstants.isSuccess(respStatus)) {
             if (trace)
                log.tracef("Successfully validated transport: %s", transport);
-            return PingResult.SUCCESS;
+            return HotRodConstants.hasCompatibility(respStatus)
+               ? PingResult.SUCCESS_WITH_COMPAT
+               : PingResult.SUCCESS;
          } else {
             String hexStatus = Integer.toHexString(respStatus);
             if (trace)
@@ -67,9 +69,19 @@ public class PingOperation extends HotRodOperation {
    public static enum PingResult {
       // Success if the ping request was responded correctly
       SUCCESS,
+      // Success with compatibility enabled
+      SUCCESS_WITH_COMPAT,
       // When the ping request fails due to non-existing cache
       CACHE_DOES_NOT_EXIST,
       // For any other type of failures
-      FAIL,
+      FAIL;
+
+      public boolean isSuccess() {
+         return this == SUCCESS || this == SUCCESS_WITH_COMPAT;
+      }
+
+      public boolean hasCompatibility() {
+         return this == SUCCESS_WITH_COMPAT;
+      }
    }
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutIfAbsentOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutIfAbsentOperation.java
@@ -27,9 +27,9 @@ public class PutIfAbsentOperation<V> extends AbstractKeyValueOperation<V> {
    private static final boolean trace = log.isTraceEnabled();
 
    public PutIfAbsentOperation(Codec codec, TransportFactory transportFactory,
-                               byte[] key, byte[] cacheName, AtomicInteger topologyId,
-                               int flags, byte[] value, long lifespan, TimeUnit lifespanTimeUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
-      super(codec, transportFactory, key, cacheName, topologyId, flags, value, lifespan, lifespanTimeUnit, maxIdleTime, maxIdleTimeUnit);
+                               Object key, byte[] keyBytes, byte[] cacheName, AtomicInteger topologyId,
+                               int flags, byte[] value, long lifespan,TimeUnit lifespanTimeUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+      super(codec, transportFactory, key, keyBytes, cacheName, topologyId, flags, value, lifespan, lifespanTimeUnit, maxIdleTime, maxIdleTimeUnit);
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/PutOperation.java
@@ -22,9 +22,10 @@ import org.infinispan.client.hotrod.impl.transport.TransportFactory;
 public class PutOperation<V> extends AbstractKeyValueOperation<V> {
 
    public PutOperation(Codec codec, TransportFactory transportFactory,
-                       byte[] key, byte[] cacheName, AtomicInteger topologyId,
+                       Object key, byte[] keyBytes, byte[] cacheName, AtomicInteger topologyId,
                        int flags, byte[] value, long lifespan, TimeUnit lifespanTimeUnit, long maxIdle, TimeUnit maxIdleTimeUnit) {
-      super(codec, transportFactory, key, cacheName, topologyId, flags, value, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
+      super(codec, transportFactory, key, keyBytes, cacheName, topologyId,
+         flags, value, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveIfUnmodifiedOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveIfUnmodifiedOperation.java
@@ -22,8 +22,8 @@ public class RemoveIfUnmodifiedOperation<V> extends AbstractKeyOperation<Version
    private final long version;
 
    public RemoveIfUnmodifiedOperation(Codec codec, TransportFactory transportFactory,
-                                      byte[] key, byte[] cacheName, AtomicInteger topologyId, int flags, long version) {
-      super(codec, transportFactory, key, cacheName, topologyId, flags);
+         Object key, byte[] keyBytes, byte[] cacheName, AtomicInteger topologyId, int flags, long version) {
+      super(codec, transportFactory, key, keyBytes, cacheName, topologyId, flags);
       this.version = version;
    }
 
@@ -33,7 +33,7 @@ public class RemoveIfUnmodifiedOperation<V> extends AbstractKeyOperation<Version
       HeaderParams params = writeHeader(transport, REMOVE_IF_UNMODIFIED_REQUEST);
 
       //2) write message body
-      transport.writeArray(key);
+      transport.writeArray(keyBytes);
       transport.writeLong(version);
       transport.flush();
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/RemoveOperation.java
@@ -19,13 +19,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class RemoveOperation<V> extends AbstractKeyOperation<V> {
 
    public RemoveOperation(Codec codec, TransportFactory transportFactory,
-                          byte[] key, byte[] cacheName, AtomicInteger topologyId, int flags) {
-      super(codec, transportFactory, key, cacheName, topologyId, flags);
+         Object key, byte[] keyBytes, byte[] cacheName, AtomicInteger topologyId, int flags) {
+      super(codec, transportFactory, key, keyBytes, cacheName, topologyId, flags);
    }
 
    @Override
    public V executeOperation(Transport transport) {
-      short status = sendKeyOperation(key, transport, REMOVE_REQUEST, REMOVE_RESPONSE);
+      short status = sendKeyOperation(keyBytes, transport, REMOVE_REQUEST, REMOVE_RESPONSE);
       V result = returnPossiblePrevValue(transport, status);
       if (HotRodConstants.isNotExist(status))
          return null;

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceIfUnmodifiedOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceIfUnmodifiedOperation.java
@@ -20,10 +20,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ReplaceIfUnmodifiedOperation extends AbstractKeyValueOperation<VersionedOperationResponse> {
    private final long version;
 
-   public ReplaceIfUnmodifiedOperation(Codec codec, TransportFactory transportFactory, byte[] key, byte[] cacheName,
+   public ReplaceIfUnmodifiedOperation(Codec codec, TransportFactory transportFactory, Object key, byte[] keyBytes, byte[] cacheName,
                                        AtomicInteger topologyId, int flags, byte[] value,
                                        long lifespan, TimeUnit lifespanTimeUnit, long maxIdle, TimeUnit maxIdleTimeUnit, long version) {
-      super(codec, transportFactory, key, cacheName, topologyId, flags, value, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
+      super(codec, transportFactory, key, keyBytes, cacheName, topologyId, flags, value, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
       this.version = version;
    }
 
@@ -33,7 +33,7 @@ public class ReplaceIfUnmodifiedOperation extends AbstractKeyValueOperation<Vers
       HeaderParams params = writeHeader(transport, REPLACE_IF_UNMODIFIED_REQUEST);
 
       //2) write message body
-      transport.writeArray(key);
+      transport.writeArray(keyBytes);
       codec.writeExpirationParams(transport, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
       transport.writeLong(version);
       transport.writeArray(value);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/ReplaceOperation.java
@@ -21,9 +21,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ReplaceOperation<V> extends AbstractKeyValueOperation<V> {
 
    public ReplaceOperation(Codec codec, TransportFactory transportFactory,
-                           byte[] key, byte[] cacheName, AtomicInteger topologyId,
-                           int flags, byte[] value, long lifespan, TimeUnit lifespanTimeUnit, long maxIdle, TimeUnit maxIdleTimeUnit) {
-      super(codec, transportFactory, key, cacheName, topologyId, flags, value, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
+            Object key, byte[] keyBytes, byte[] cacheName, AtomicInteger topologyId,
+            int flags, byte[] value, long lifespan, TimeUnit lifespanTimeUnit, long maxIdle, TimeUnit maxIdleTimeUnit) {
+      super(codec, transportFactory, key, keyBytes, cacheName, topologyId, flags, value, lifespan, lifespanTimeUnit, maxIdle, maxIdleTimeUnit);
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/TransportFactory.java
@@ -53,7 +53,7 @@ public interface TransportFactory {
 
    ConsistentHashFactory getConsistentHashFactory();
 
-   Transport getTransport(byte[] key, Set<SocketAddress> failedServers, byte[] cacheName);
+   Transport getTransport(Object key, Set<SocketAddress> failedServers, byte[] cacheName);
 
    boolean isTcpNoDelay();
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/TransportObjectFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/TransportObjectFactory.java
@@ -58,7 +58,7 @@ public class TransportObjectFactory
    @Override
    public boolean validateObject(SocketAddress address, TcpTransport transport) {
       try {
-         boolean valid = ping(transport, defaultCacheTopologyId) == PingOperation.PingResult.SUCCESS;
+         boolean valid = ping(transport, defaultCacheTopologyId).isSuccess();
          if (trace) log.tracef("Is connection %s valid? %s", transport, valid);
          return valid;
       } catch (Throwable e) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CompatRoutingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CompatRoutingTest.java
@@ -1,0 +1,58 @@
+package org.infinispan.client.hotrod;
+
+import org.infinispan.Cache;
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.remoting.rpc.RpcManagerImpl;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+@Test(testName = "client.hotrod.CompatRoutingTest", groups = "functional")
+public class CompatRoutingTest extends MultiHotRodServersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createHotRodServers(2, getCacheConfiguration());
+   }
+
+   private ConfigurationBuilder getCacheConfiguration() {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      builder.clustering().hash().numOwners(1).compatibility().enabled(true);
+      builder.jmxStatistics().enable();
+      return builder;
+   }
+
+   public void testGetWithCompatibility() {
+      RemoteCache<String, String> client = client(0).getCache();
+      HashMap<String, String> cachedValues = new HashMap<>();
+      for (int i = 0; i < 100; i++) {
+         String key = String.format("key-%d", i);
+         String value = String.format("value-%d", i);
+         client.put(key, value);
+         cachedValues.put(key, value);
+      }
+
+      int startRpcs = 0;
+      for (Cache cache : caches()) {
+         startRpcs += ((RpcManagerImpl) cache.getAdvancedCache().getRpcManager()).getReplicationCount();
+      }
+      assertTrue(startRpcs > 0);
+      for (Map.Entry<String, String> entry : cachedValues.entrySet()) {
+         String value = client.get(entry.getKey());
+         assertEquals(entry.getValue(), value);
+      }
+      int endRpcs = 0;
+      for (Cache cache : caches()) {
+         endRpcs += ((RpcManagerImpl) cache.getAdvancedCache().getRpcManager()).getReplicationCount();
+      }
+      assertEquals(startRpcs, endRpcs);
+   }
+
+
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashComparisonTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashComparisonTest.java
@@ -152,7 +152,7 @@ public class ConsistentHashComparisonTest {
       }
 
       @Override
-      public SocketAddress getServer(byte[] key) {
+      public SocketAddress getServer(Object key) {
          int keyHashCode = getNormalizedHash(key);
          if (keyHashCode == Integer.MIN_VALUE) keyHashCode += 1;
          int hash = Math.abs(keyHashCode);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/PingOnStartupTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/PingOnStartupTest.java
@@ -59,38 +59,6 @@ public class PingOnStartupTest extends MultiHotRodServersTest {
       });
    }
 
-   public void testTopologyNotFetched() {
-      Properties props = new Properties();
-      HotRodServer hotRodServer2 = server(1);
-      props.put("infinispan.client.hotrod.server_list",
-            "localhost:" + hotRodServer2.getPort());
-      props.put("infinispan.client.hotrod.ping_on_startup", "false");
-
-      withRemoteCacheManager(new RemoteCacheManagerCallable(
-            new InternalRemoteCacheManager(props)) {
-         @Override
-         public void call() {
-            TcpTransportFactory tcpTransportFactory =
-                  (TcpTransportFactory) ((InternalRemoteCacheManager) rcm).getTransportFactory();
-            assertEquals(1, tcpTransportFactory.getServers().size());
-         }
-      });
-   }
-
-   public void testGetCacheWithPingOnStartupDisabledSingleNode() {
-      Properties props = new Properties();
-      props.put("infinispan.client.hotrod.server_list", "boomoo:12345");
-      props.put("infinispan.client.hotrod.ping_on_startup", "false");
-
-      withRemoteCacheManager(new RemoteCacheManagerCallable(
-            new RemoteCacheManager(props)) {
-         @Override
-         public void call() {
-            rcm.getCache();
-         }
-      });
-   }
-
    public void testGetCacheWithPingOnStartupDisabledMultipleNodes() {
       Properties props = new Properties();
       HotRodServer hotRodServer2 = server(1);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/configuration/ConfigurationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/configuration/ConfigurationTest.java
@@ -176,7 +176,7 @@ public class ConfigurationTest {
       assertEquals(100, configuration.socketTimeout());
       assertFalse(configuration.tcpNoDelay());
       assertTrue(configuration.tcpKeepAlive());
-      assertFalse(configuration.pingOnStartup());
+      assertTrue(configuration.pingOnStartup());
       assertEquals(128, configuration.keySizeEstimate());
       assertEquals(1024, configuration.valueSizeEstimate());
       assertEquals(0, configuration.maxRetries());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
@@ -57,8 +57,7 @@ public abstract class MultiHotRodServersTest extends MultipleCacheManagersTest {
       clientBuilder.addServer()
             .host("localhost")
             .port(serverPort)
-            .maxRetries(maxRetries())
-            .pingOnStartup(false);
+            .maxRetries(maxRetries());
       return clientBuilder;
    }
 

--- a/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-48-Using_Hot_Rod_Server.adoc
@@ -45,7 +45,6 @@ infinispan.client.hotrod.default_executor_factory.pool_size = 1
 infinispan.client.hotrod.default_executor_factory.queue_size = 10000
 infinispan.client.hotrod.hash_function_impl.1 = org.infinispan.client.hotrod.impl.consistenthash.ConsistentHashV1
 infinispan.client.hotrod.tcp_no_delay = true
-infinispan.client.hotrod.ping_on_startup = true
 infinispan.client.hotrod.request_balancing_strategy = org.infinispan.client.hotrod.impl.transport.tcp.RoundRobinBalancingStrategy
 infinispan.client.hotrod.key_size_estimate = 64
 infinispan.client.hotrod.value_size_estimate = 512


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-5981

* When compatibility is enabled, servers store data in POJO mode, hence
  clients should be routing based on the POJO version instead of the
  byte[] version.