### PR TITLE
ISPN-5993 ClassCastException in ProtobufMetadataManagerInterceptor fo…

### DIFF
--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptor.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptor.java
@@ -401,10 +401,6 @@ final class ProtobufMetadataManagerInterceptor extends BaseCustomInterceptor imp
 
    @Override
    public Object visitClearCommand(InvocationContext ctx, ClearCommand command) throws Throwable {
-      // lock .errors key
-      VisitableCommand cmd = commandsFactory.buildLockControlCommand(ERRORS_KEY_SUFFIX, null, null);
-      invoker.invoke(ctx, cmd);
-
       for (String fileName : serializationContext.getFileDescriptors().keySet()) {
          serializationContext.unregisterProtoFile(fileName);
       }


### PR DESCRIPTION
…r clear

Since clear is now non-tx we can just remove the lines of code that attempt to lock .errors key and the issue is gone.

Jira: https://issues.jboss.org/browse/ISPN-5993