### PR TITLE
ISPN-6048 Add sun.jdk dependency to Scala lang

### DIFF
--- a/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/scala-lang/library/main/module.xml
+++ b/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/scala-lang/library/main/module.xml
@@ -6,5 +6,6 @@
     </resources>
 
     <dependencies>
+       <module name="sun.jdk"/>
     </dependencies>
 </module>


### PR DESCRIPTION
* This avoids potential problems with Scala lang if using Scala futures
  for async computation.