### PR TITLE
ISPN-4851 Make SyncConsistentHashFactory the default CH factory

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/HashConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/HashConfiguration.java
@@ -21,9 +21,9 @@ public class HashConfiguration {
    public static final AttributeDefinition<ConsistentHashFactory> CONSISTENT_HASH_FACTORY  = AttributeDefinition.builder("consistentHashFactory", null, ConsistentHashFactory.class).immutable().build();
    public static final AttributeDefinition<Hash> HASH = AttributeDefinition.builder("hash", (Hash)MurmurHash3.getInstance()).copier(IdentityAttributeCopier.INSTANCE).immutable().build();
    public static final AttributeDefinition<Integer> NUM_OWNERS = AttributeDefinition.builder("numOwners" , 2).immutable().build();
-   // With the default consistent hash factory, this default gives us an even spread for clusters
-   // up to 6 members and the difference between nodes stays under 20% up to 12 members.
-   public static final AttributeDefinition<Integer> NUM_SEGMENTS = AttributeDefinition.builder("numSegments" , 60).immutable().build();
+   // Because it assigns owners randomly, SyncConsistentHashFactory doesn't work very well with a low number
+   // of segments. (With DefaultConsistentHashFactory, 60 segments was ok up to 6 nodes.)
+   public static final AttributeDefinition<Integer> NUM_SEGMENTS = AttributeDefinition.builder("numSegments", 256).immutable().build();
    public static final AttributeDefinition<Float> CAPACITY_FACTOR= AttributeDefinition.builder("capacityFactor", 1.0f).immutable().build();
    public static final AttributeDefinition<KeyPartitioner> KEY_PARTITIONER = AttributeDefinition
          .builder("keyPartitioner", new HashFunctionPartitioner(), KeyPartitioner.class)

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/DefaultConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/DefaultConsistentHash.java
@@ -21,6 +21,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Default {@link ConsistentHash} implementation. This object is immutable.
@@ -350,6 +352,23 @@ public class DefaultConsistentHash implements ConsistentHash {
          capacityFactorsMap.put(members.get(i), capacityFactors[i]);
       }
       return capacityFactorsMap;
+   }
+
+   public String prettyPrintOwnership() {
+      StringBuilder sb = new StringBuilder();
+      for (Address member : getMembers()) {
+         sb.append("\n").append(member).append(":");
+         for (int segment = 0; segment < segmentOwners.length; segment++) {
+            int index = segmentOwners[segment].indexOf(member);
+            if (index >= 0) {
+               sb.append(' ').append(segment);
+               if (index == 0) {
+                  sb.append('\'');
+               }
+            }
+         }
+      }
+      return sb.toString();
    }
 
    public static class Externalizer extends InstanceReusingAdvancedExternalizer<DefaultConsistentHash> {

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/OwnershipStatistics.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/OwnershipStatistics.java
@@ -100,6 +100,14 @@ public class OwnershipStatistics {
       owned[i]--;
    }
 
+   public int sumPrimaryOwned() {
+      int segmentsWithPrimaryOwners = 0;
+      for (int ownedCount : primaryOwned) {
+         segmentsWithPrimaryOwners += ownedCount;
+      }
+      return segmentsWithPrimaryOwners;
+   }
+
    public int sumOwned() {
       int allOwnersCount = 0;
       for (int ownedCount : owned) {

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHash.java
@@ -50,6 +50,32 @@ public class ReplicatedConsistentHash implements ConsistentHash {
       segmentSize = Util.getSegmentSize(primaryOwners.length);
    }
 
+   public ReplicatedConsistentHash union(ReplicatedConsistentHash ch2) {
+      if (!this.getHashFunction().equals(ch2.getHashFunction())) {
+         throw new IllegalArgumentException("The consistent hash objects must have the same hash function");
+      }
+      if (this.getNumSegments() != ch2.getNumSegments()) {
+         throw new IllegalArgumentException("The consistent hash objects must have the same number of segments");
+
+      }
+
+      List<Address> unionMembers = new ArrayList<Address>(this.getMembers());
+      for (Address member : ch2.getMembers()) {
+         if (!unionMembers.contains(member)) {
+            unionMembers.add(member);
+         }
+      }
+
+      int[] primaryOwners = new int[this.getNumSegments()];
+      for (int segmentId = 0; segmentId < primaryOwners.length; segmentId++) {
+         Address primaryOwner = this.locatePrimaryOwnerForSegment(segmentId);
+         int primaryOwnerIndex = unionMembers.indexOf(primaryOwner);
+         primaryOwners[segmentId] = primaryOwnerIndex;
+      }
+
+      return new ReplicatedConsistentHash(this.getHashFunction(), unionMembers, primaryOwners);
+   }
+
    @Override
    public int getNumSegments() {
       return primaryOwners.length;

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/ReplicatedConsistentHashFactory.java
@@ -9,7 +9,6 @@ import org.infinispan.remoting.transport.Address;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -124,28 +123,7 @@ public class ReplicatedConsistentHashFactory implements ConsistentHashFactory<Re
 
    @Override
    public ReplicatedConsistentHash union(ReplicatedConsistentHash ch1, ReplicatedConsistentHash ch2) {
-      if (!ch1.getHashFunction().equals(ch2.getHashFunction())) {
-         throw new IllegalArgumentException("The consistent hash objects must have the same hash function");
-      }
-      if (ch1.getNumSegments() != ch2.getNumSegments()) {
-         throw new IllegalArgumentException("The consistent hash objects must have the same number of segments");
-      }
-
-      List<Address> unionMembers = new ArrayList<Address>(ch1.getMembers());
-      for (Address member : ch2.getMembers()) {
-         if (!unionMembers.contains(member)) {
-            unionMembers.add(member);
-         }
-      }
-
-      int[] primaryOwners = new int[ch1.getNumSegments()];
-      for (int segmentId = 0; segmentId < primaryOwners.length; segmentId++) {
-         Address primaryOwner = ch1.locatePrimaryOwnerForSegment(segmentId);
-         int primaryOwnerIndex = unionMembers.indexOf(primaryOwner);
-         primaryOwners[segmentId] = primaryOwnerIndex;
-      }
-
-      return new ReplicatedConsistentHash(ch1.getHashFunction(), unionMembers, primaryOwners);
+      return ch1.union(ch2);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/SyncReplicatedConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/SyncReplicatedConsistentHashFactory.java
@@ -1,0 +1,100 @@
+package org.infinispan.distribution.ch.impl;
+
+import org.infinispan.commons.hash.Hash;
+import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.distribution.ch.ConsistentHashFactory;
+import org.infinispan.marshall.core.Ids;
+import org.infinispan.remoting.transport.Address;
+
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * {@link SyncConsistentHashFactory} adapted for replicated caches, so that the primary owner of a key
+ * is the same in replicated and distributed caches.
+ *
+ * @author Dan Berindei
+ * @since 8.2
+ */
+public class SyncReplicatedConsistentHashFactory implements ConsistentHashFactory<ReplicatedConsistentHash> {
+
+   public static final float OWNED_SEGMENTS_ALLOWED_VARIATION = 1.10f;
+   public static final float PRIMARY_SEGMENTS_ALLOWED_VARIATION = 1.20f;
+
+   private static final SyncConsistentHashFactory syncCHF = new SyncConsistentHashFactory();
+
+   @Override
+   public ReplicatedConsistentHash create(Hash hashFunction, int numOwners, int numSegments,
+         List<Address> members, Map<Address, Float> capacityFactors) {
+      DefaultConsistentHash dch = syncCHF.create(hashFunction, 1, numSegments, members, null);
+      return replicatedFromDefault(dch);
+   }
+
+   private ReplicatedConsistentHash replicatedFromDefault(DefaultConsistentHash dch) {
+      int numSegments = dch.getNumSegments();
+      List<Address> members = dch.getMembers();
+      int[] primaryOwners = new int[numSegments];
+      for (int segment = 0; segment < numSegments; segment++) {
+         primaryOwners[segment] = members.indexOf(dch.locatePrimaryOwnerForSegment(segment));
+      }
+      return new ReplicatedConsistentHash(dch.getHashFunction(), members, primaryOwners);
+   }
+
+   @Override
+   public ReplicatedConsistentHash updateMembers(ReplicatedConsistentHash baseCH, List<Address> newMembers,
+         Map<Address, Float> actualCapacityFactors) {
+      DefaultConsistentHash baseDCH = defaultFromReplicated(baseCH);
+      DefaultConsistentHash dch = syncCHF.updateMembers(baseDCH, newMembers, null);
+      return replicatedFromDefault(dch);
+   }
+
+   private DefaultConsistentHash defaultFromReplicated(ReplicatedConsistentHash baseCH) {
+      int numSegments = baseCH.getNumSegments();
+      List<Address>[] baseSegmentOwners = new List[numSegments];
+      for (int segment = 0; segment < numSegments; segment++) {
+         baseSegmentOwners[segment] = Collections.singletonList(baseCH.locatePrimaryOwnerForSegment(segment));
+      }
+      return new DefaultConsistentHash(baseCH.getHashFunction(), 1,
+            numSegments, baseCH.getMembers(), null, baseSegmentOwners);
+   }
+
+   @Override
+   public ReplicatedConsistentHash rebalance(ReplicatedConsistentHash baseCH) {
+      DefaultConsistentHash baseDCH = defaultFromReplicated(baseCH);
+      DefaultConsistentHash dch = syncCHF.rebalance(baseDCH);
+      return replicatedFromDefault(dch);
+   }
+
+   @Override
+   public ReplicatedConsistentHash union(ReplicatedConsistentHash ch1, ReplicatedConsistentHash ch2) {
+      return ch1.union(ch2);
+   }
+
+   public static class Externalizer extends AbstractExternalizer<SyncReplicatedConsistentHashFactory> {
+
+      @Override
+      public void writeObject(ObjectOutput output, SyncReplicatedConsistentHashFactory chf) {
+      }
+
+      @Override
+      @SuppressWarnings("unchecked")
+      public SyncReplicatedConsistentHashFactory readObject(ObjectInput unmarshaller) {
+         return new SyncReplicatedConsistentHashFactory();
+      }
+
+      @Override
+      public Integer getId() {
+         return Ids.SYNC_REPLICATED_CONSISTENT_HASH_FACTORY;
+      }
+
+      @Override
+      public Set<Class<? extends SyncReplicatedConsistentHashFactory>> getTypeClasses() {
+         return Collections.<Class<? extends SyncReplicatedConsistentHashFactory>>singleton(
+               SyncReplicatedConsistentHashFactory.class);
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/distribution/ch/impl/TopologyAwareSyncConsistentHashFactory.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/impl/TopologyAwareSyncConsistentHashFactory.java
@@ -63,7 +63,7 @@ public class TopologyAwareSyncConsistentHashFactory extends SyncConsistentHashFa
       }
 
       @Override
-      protected void addOwner(int segment, Address candidate) {
+      protected boolean addBackupOwner(int segment, Address candidate) {
          List<Address> owners = segmentOwners[segment];
          if (owners.size() < actualNumOwners && !locationAlreadyAdded(candidate, owners, currentLevel)) {
             if (!ignoreMaxSegments) {
@@ -71,19 +71,23 @@ public class TopologyAwareSyncConsistentHashFactory extends SyncConsistentHashFa
                   long maxSegments = Math.round(computeExpectedSegmentsForNode(candidate, 1) * PRIMARY_SEGMENTS_ALLOWED_VARIATION);
                   if (stats.getPrimaryOwned(candidate) < maxSegments) {
                      addOwnerNoCheck(segment, candidate);
+                     return true;
                   }
                } else {
                   long maxSegments = Math.round(computeExpectedSegmentsForNode(candidate, actualNumOwners) * OWNED_SEGMENTS_ALLOWED_VARIATION);
                   if (stats.getOwned(candidate) < maxSegments) {
                      addOwnerNoCheck(segment, candidate);
+                     return true;
                   }
                }
             } else {
                if (!capacityFactors.get(candidate).equals(0f)) {
                   addOwnerNoCheck(segment, candidate);
+                  return true;
                }
             }
          }
+         return false;
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/interceptors/DeadlockDetectingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/DeadlockDetectingInterceptor.java
@@ -7,6 +7,7 @@ import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.commons.util.InfinispanCollections;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Start;
@@ -68,7 +69,8 @@ public class DeadlockDetectingInterceptor extends CommandInterceptor {
          globalTransaction.setRemoteLockIntention(command.getKeys());
          //in the case of DIST we need to propagate the list of keys. In all other situations in can be determined
          // based on the actual command
-         if (cacheConfiguration.clustering().cacheMode().isDistributed()) {
+         CacheMode cacheMode = cacheConfiguration.clustering().cacheMode();
+         if (cacheMode.isDistributed() || cacheMode.isReplicated()) {
             if (trace) log.tracef("Locks as seen at origin are: %s", ctx.getLockedKeys());
             ((DldGlobalTransaction) ctx.getGlobalTransaction()).setLocksHeldAtOrigin(ctx.getLockedKeys());
          }

--- a/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
+++ b/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
@@ -49,6 +49,7 @@ import org.infinispan.distribution.ch.impl.HashFunctionPartitioner;
 import org.infinispan.distribution.ch.impl.ReplicatedConsistentHash;
 import org.infinispan.distribution.ch.impl.ReplicatedConsistentHashFactory;
 import org.infinispan.distribution.ch.impl.SyncConsistentHashFactory;
+import org.infinispan.distribution.ch.impl.SyncReplicatedConsistentHashFactory;
 import org.infinispan.distribution.ch.impl.TopologyAwareConsistentHashFactory;
 import org.infinispan.distribution.ch.impl.TopologyAwareSyncConsistentHashFactory;
 import org.infinispan.factories.GlobalComponentRegistry;
@@ -318,6 +319,7 @@ public class ExternalizerTable implements ObjectTable {
       addInternalExternalizer(new DefaultConsistentHashFactory.Externalizer());
       addInternalExternalizer(new ReplicatedConsistentHashFactory.Externalizer());
       addInternalExternalizer(new SyncConsistentHashFactory.Externalizer());
+      addInternalExternalizer(new SyncReplicatedConsistentHashFactory.Externalizer());
       addInternalExternalizer(new TopologyAwareConsistentHashFactory.Externalizer());
       addInternalExternalizer(new TopologyAwareSyncConsistentHashFactory.Externalizer());
       addInternalExternalizer(new CacheTopology.Externalizer());

--- a/core/src/main/java/org/infinispan/marshall/core/Ids.java
+++ b/core/src/main/java/org/infinispan/marshall/core/Ids.java
@@ -166,4 +166,5 @@ public interface Ids extends org.infinispan.commons.marshall.Ids {
    int VALUE_MATCHER = 162;
 
    int HASH_FUNCTION_PARTITIONER = 163;
+   int SYNC_REPLICATED_CONSISTENT_HASH_FACTORY = 164;
 }

--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -628,6 +628,7 @@ public class StateConsumerImpl implements StateConsumer {
                   ((RemoteTransaction) tx).setLookedUpEntriesTopology(topologyId - 1);
                }
             }
+            // TODO Shouldn't this be done for transactions originated locally as well?
             transactionInfo.getLockedKeys().forEach(tx::addBackupLockForKey);
          }
       }

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferManagerImpl.java
@@ -9,9 +9,9 @@ import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.distribution.ch.ConsistentHashFactory;
 import org.infinispan.distribution.ch.KeyPartitioner;
-import org.infinispan.distribution.ch.impl.DefaultConsistentHashFactory;
-import org.infinispan.distribution.ch.impl.ReplicatedConsistentHashFactory;
-import org.infinispan.distribution.ch.impl.TopologyAwareConsistentHashFactory;
+import org.infinispan.distribution.ch.impl.SyncConsistentHashFactory;
+import org.infinispan.distribution.ch.impl.SyncReplicatedConsistentHashFactory;
+import org.infinispan.distribution.ch.impl.TopologyAwareSyncConsistentHashFactory;
 import org.infinispan.distribution.group.PartitionerConsistentHash;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
@@ -134,13 +134,13 @@ public class StateTransferManagerImpl implements StateTransferManager {
          if (cacheMode.isClustered()) {
             if (cacheMode.isDistributed()) {
                if (globalConfiguration.transport().hasTopologyInfo()) {
-                  factory = new TopologyAwareConsistentHashFactory();
+                  factory = new TopologyAwareSyncConsistentHashFactory();
                } else {
-                  factory = new DefaultConsistentHashFactory();
+                  factory = new SyncConsistentHashFactory();
                }
             } else {
                // this is also used for invalidation mode
-               factory = new ReplicatedConsistentHashFactory();
+               factory = new SyncReplicatedConsistentHashFactory();
             }
          }
       }

--- a/core/src/main/resources/schema/infinispan-config-8.2.xsd
+++ b/core/src/main/resources/schema/infinispan-config-8.2.xsd
@@ -1126,10 +1126,9 @@
             </xs:annotation>
           </xs:element>
         </xs:sequence>
-        <xs:attribute name="segments" type="xs:int" default="80">
+        <xs:attribute name="segments" type="xs:int" default="256">
           <xs:annotation>
-            <xs:documentation>Number of hash space segments (per cluster). The recommended value is 10 *
-              cluster size. The default value is 80
+            <xs:documentation>Number of hash space segments (per cluster). The default value is 256, and should be at least 20 * cluster size.
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
@@ -1179,9 +1178,9 @@
             <xs:documentation>Number of cluster-wide replicas for each cache entry.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="segments" type="xs:int" default="60">
+        <xs:attribute name="segments" type="xs:int" default="256">
           <xs:annotation>
-            <xs:documentation>Number of hash space segments (per cluster). The recommended value is 10 * cluster size. The default value is 80</xs:documentation>
+            <xs:documentation>Number of hash space segments (per cluster). The default value is 256, and should be at least 20 * cluster size.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="capacity-factor" type="xs:double" default="1">

--- a/core/src/test/java/org/infinispan/api/flags/FlagsEnabledTest.java
+++ b/core/src/test/java/org/infinispan/api/flags/FlagsEnabledTest.java
@@ -50,8 +50,7 @@ public class FlagsEnabledTest extends MultipleCacheManagersTest {
             .locking().writeSkewCheck(true).isolationLevel(IsolationLevel.REPEATABLE_READ)
             .versioning().enable().scheme(VersioningScheme.SIMPLE)
             .persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class)
-            .transaction().syncCommitPhase(true)
-            .clustering().hash().numSegments(2);
+            .transaction().syncCommitPhase(true);
       createClusteredCaches(2, cacheName, builder);
    }
 
@@ -120,12 +119,12 @@ public class FlagsEnabledTest extends MultipleCacheManagersTest {
    }
 
    public void testReplicateSkipCacheLoad(Method m) {
-      final AdvancedCache<String, String> cache1 = advancedCache(0, cacheName);
-      final AdvancedCache<String, String> cache2 = advancedCache(1, cacheName);
+      final AdvancedCache<Object, String> cache1 = advancedCache(0, cacheName);
+      final AdvancedCache<Object, String> cache2 = advancedCache(1, cacheName);
       assertLoadsAndReset(cache1, 0, cache2, 0);
 
       final String v = v(m, 1);
-      final String k = k(m, 1);
+      final Object k = getKeyForCache(0, cacheName);
       cache1.withFlags(Flag.SKIP_CACHE_LOAD).put(k, v);
       // The write-skew check tries to load it from persistence.
       assertLoadsAndReset(cache1, isTxCache() ? 1 : 0, cache2, 0);

--- a/core/src/test/java/org/infinispan/api/flags/NonTxFlagsEnabledTest.java
+++ b/core/src/test/java/org/infinispan/api/flags/NonTxFlagsEnabledTest.java
@@ -56,8 +56,7 @@ public class NonTxFlagsEnabledTest extends FlagsEnabledTest {
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
       builder
-            .persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class)
-            .clustering().hash().numSegments(2);
+            .persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class);
       createClusteredCaches(2, cacheName, builder);
    }
 
@@ -65,8 +64,7 @@ public class NonTxFlagsEnabledTest extends FlagsEnabledTest {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
       builder
             .persistence().addStore(UnnecessaryLoadingTest.CountingStoreConfigurationBuilder.class)
-            .persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class)
-            .clustering().hash().numSegments(2);
+            .persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class);
       return builder;
    }
 }

--- a/core/src/test/java/org/infinispan/atomic/FineGrainedAtomicMapAPITest.java
+++ b/core/src/test/java/org/infinispan/atomic/FineGrainedAtomicMapAPITest.java
@@ -1,12 +1,14 @@
 package org.infinispan.atomic;
 
 import org.infinispan.Cache;
+import org.infinispan.distribution.MagicKey;
 import org.testng.annotations.Test;
 
 import java.util.Map;
 
 import static org.infinispan.atomic.AtomicMapLookup.getAtomicMap;
 import static org.infinispan.atomic.AtomicMapLookup.getFineGrainedAtomicMap;
+import static org.testng.AssertJUnit.fail;
 
 /**
  * @author Vladimir Blagojevic (C) 2011 Red Hat Inc.
@@ -16,13 +18,34 @@ import static org.infinispan.atomic.AtomicMapLookup.getFineGrainedAtomicMap;
 @Test(groups = "functional", testName = "atomic.FineGrainedAtomicMapAPITest")
 public class FineGrainedAtomicMapAPITest extends BaseAtomicHashMapAPITest {
 
-   @SuppressWarnings("UnusedDeclaration")
-   @Test(expectedExceptions = {IllegalArgumentException.class})
-   public void testFineGrainedMapAfterAtomicMap() throws Exception {
-      Cache<String, Object> cache1 = cache(0, "atomic");
+   public void testFineGrainedMapAfterAtomicMapPrimary() throws Exception {
+      Cache<MagicKey, Object> cache1 = cache(0, "atomic");
 
-      AtomicMap<String, String> map = getAtomicMap(cache1, "testReplicationRemoveCommit");
-      FineGrainedAtomicMap<String, String> map2 = getFineGrainedAtomicMap(cache1, "testReplicationRemoveCommit");
+      MagicKey key = new MagicKey("key", cache1);
+      getAtomicMap(cache1, key);
+
+      try {
+         getFineGrainedAtomicMap(cache1, key);
+         fail("Should have failed with an IllegalArgumentException");
+      } catch (IllegalArgumentException e) {
+         // Expected
+      }
+   }
+
+   @Test(enabled = false, description = "Doesn't work when the originator isn't the primary owner, see ISPN-5988")
+   public void testFineGrainedMapAfterAtomicMapBackup() throws Exception {
+      Cache<MagicKey, Object> cache1 = cache(0, "atomic");
+      Cache<MagicKey, Object> cache2 = cache(1, "atomic");
+
+      MagicKey key = new MagicKey("key", cache2);
+      getAtomicMap(cache1, key);
+
+      try {
+         getFineGrainedAtomicMap(cache1, key);
+         fail("Should have failed with an IllegalArgumentException");
+      } catch (IllegalArgumentException e) {
+         // Expected
+      }
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/distribution/MagicKey.java
+++ b/core/src/test/java/org/infinispan/distribution/MagicKey.java
@@ -4,6 +4,7 @@ import org.infinispan.Cache;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Random;
 
 import static org.infinispan.distribution.DistributionTestHelper.addressOf;
@@ -96,7 +97,8 @@ public class MagicKey implements Serializable {
 
       MagicKey magicKey = (MagicKey) o;
 
-      return hashcode == magicKey.hashcode && address.equals(magicKey.address);
+      return hashcode == magicKey.hashcode && address.equals(magicKey.address) &&
+            Objects.equals(name, magicKey.name);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/distribution/rehash/BaseTxStateTransferOverwriteTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/BaseTxStateTransferOverwriteTest.java
@@ -196,15 +196,15 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
 
    protected void doStateTransferInBetweenPrepareCommit(final TestWriteOperation op,
                                                       final boolean additionalValueOnNonOwner) throws Exception {
-      final String key = getClass().getName() + "-key";
       // Test scenario:
       // cache0,1,2 are in the cluster, an owner leaves
       // Key k is in the cache, and is transferred to the non owner
       // A user operation also modifies key k causing an invalidation
       // on the non owner which is getting the state transfer
-      final AdvancedCache<Object, Object> primaryOwnerCache = getFirstOwner(key).getAdvancedCache();
-      final AdvancedCache<Object, Object> backupOwnerCache = getOwners(key)[1].getAdvancedCache();
-      final AdvancedCache<Object, Object> nonOwnerCache = getFirstNonOwner(key).getAdvancedCache();
+      final AdvancedCache<Object, Object> primaryOwnerCache = advancedCache(0, cacheName);
+      final AdvancedCache<Object, Object> backupOwnerCache = advancedCache(1, cacheName);
+      final AdvancedCache<Object, Object> nonOwnerCache = advancedCache(2, cacheName);
+      final MagicKey key = new MagicKey(op + "-key", cache(0, cacheName), cache(1, cacheName));
 
       // Prepare for replace/remove: put a previous value in cache0
       final Object previousValue = op.getPreviousValue();
@@ -265,7 +265,6 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
 
          // let state transfer go
          checkPoint.trigger("pre_state_apply_release_for_" + nonOwnerCache);
-
          TestingUtil.waitForRehashToComplete(primaryOwnerCache, nonOwnerCache);
 
          switch (op) {
@@ -304,7 +303,6 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
       final AdvancedCache<Object, Object> primaryOwnerCache = cache(0, cacheName).getAdvancedCache();
       final AdvancedCache<Object, Object> backupOwnerCache = cache(1, cacheName).getAdvancedCache();
       final AdvancedCache<Object, Object> nonOwnerCache = cache(2, cacheName).getAdvancedCache();
-
       final MagicKey key = new MagicKey(primaryOwnerCache, backupOwnerCache);
 
       // Prepare for replace/remove: put a previous value in cache0
@@ -410,15 +408,15 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
    }
 
    private void doL1InvalidationOldTopologyComesAfterRebalance(final TestWriteOperation op) throws Exception {
-      final String key = getClass().getName() + "-key";
       // Test scenario:
       // cache0,1,2 are in the cluster, an owner leaves
       // Key k is in the cache, and is transferred to the non owner
       // A user operation also modifies key k causing an invalidation
       // on the non owner which is getting the state transfer
-      final AdvancedCache<Object, Object> primaryOwnerCache = getFirstOwner(key).getAdvancedCache();
-      final AdvancedCache<Object, Object> backupOwnerCache = getOwners(key)[1].getAdvancedCache();
-      final AdvancedCache<Object, Object> nonOwnerCache = getFirstNonOwner(key).getAdvancedCache();
+      final AdvancedCache<Object, Object> primaryOwnerCache = advancedCache(0, cacheName);
+      final AdvancedCache<Object, Object> backupOwnerCache = advancedCache(1, cacheName);
+      final AdvancedCache<Object, Object> nonOwnerCache = advancedCache(2, cacheName);
+      final MagicKey key = new MagicKey(op + "-key", cache(0, cacheName), cache(1, cacheName));
 
       // Prepare for replace/remove: put a previous value in cache0
       final Object previousValue = op.getPreviousValue();

--- a/core/src/test/java/org/infinispan/lock/APITest.java
+++ b/core/src/test/java/org/infinispan/lock/APITest.java
@@ -14,6 +14,7 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.LockingMode;
+import org.infinispan.util.ReplicatedControlledConsistentHashFactory;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.testng.annotations.Test;
 
@@ -39,6 +40,8 @@ public class APITest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder cfg = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
+      cfg.clustering().hash().numSegments(1)
+            .consistentHashFactory(new ReplicatedControlledConsistentHashFactory(0));
       cfg.transaction().lockingMode(LockingMode.PESSIMISTIC)
             .cacheStopTimeout(0)
             .locking().lockAcquisitionTimeout(100);

--- a/core/src/test/java/org/infinispan/lock/CheckNoRemoteCallForLocalKeyTest.java
+++ b/core/src/test/java/org/infinispan/lock/CheckNoRemoteCallForLocalKeyTest.java
@@ -2,8 +2,10 @@ package org.infinispan.lock;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.MagicKey;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.transaction.LockingMode;
+import org.infinispan.util.ReplicatedControlledConsistentHashFactory;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -19,7 +21,7 @@ public class CheckNoRemoteCallForLocalKeyTest extends MultipleCacheManagersTest 
 
    protected CheckRemoteLockAcquiredOnlyOnceTest.ControlInterceptor controlInterceptor;
    protected CacheMode mode = CacheMode.REPL_SYNC;
-   protected Object key = "k";
+   protected Object key;
 
    @Override
    protected void createCacheManagers() throws Throwable {
@@ -27,6 +29,7 @@ public class CheckNoRemoteCallForLocalKeyTest extends MultipleCacheManagersTest 
       c.transaction().lockingMode(LockingMode.PESSIMISTIC);
       createCluster(c, 2);
       waitForClusterToForm();
+      key = new MagicKey(cache(0));
       controlInterceptor = new CheckRemoteLockAcquiredOnlyOnceTest.ControlInterceptor();
       cache(1).getAdvancedCache().addInterceptor(controlInterceptor, 1);
    }

--- a/core/src/test/java/org/infinispan/lock/CheckRemoteLockAcquiredOnlyOnceTest.java
+++ b/core/src/test/java/org/infinispan/lock/CheckRemoteLockAcquiredOnlyOnceTest.java
@@ -4,6 +4,7 @@ import org.infinispan.commands.control.LockControlCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.distribution.MagicKey;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.transaction.LockingMode;
@@ -35,7 +36,7 @@ public class CheckRemoteLockAcquiredOnlyOnceTest extends MultipleCacheManagersTe
       waitForClusterToForm();
       controlInterceptor = new ControlInterceptor();
       cache(0).getAdvancedCache().addInterceptor(controlInterceptor, 1);
-      key = "k";
+      key = new MagicKey("k", cache(0));
    }
 
    public void testLockThenLock() throws Exception {

--- a/core/src/test/java/org/infinispan/lock/singlelock/AbstractNoCrashTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/AbstractNoCrashTest.java
@@ -7,6 +7,7 @@ import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
 import org.infinispan.transaction.tm.DummyTransaction;
 import org.infinispan.tx.recovery.RecoveryDummyTransactionManagerLookup;
+import org.infinispan.util.ReplicatedControlledConsistentHashFactory;
 import org.testng.annotations.Test;
 
 import java.util.Collections;

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/BasicSingleLockRepPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/BasicSingleLockRepPessimisticTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.lock.singlelock.replicated.pessimistic;
 
 import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.distribution.MagicKey;
 import org.infinispan.lock.singlelock.AbstractNoCrashTest;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.transaction.LockingMode;
@@ -19,63 +20,65 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
    }
 
    protected void testTxAndLockOnDifferentNodes(AbstractNoCrashTest.Operation operation, boolean addFirst, boolean removed) throws Exception {
-
+      Object k = new MagicKey("k", cache(0));
       if (addFirst)
-         cache(0).put("k", "v_initial");
-      assertNotLocked("k");
+         cache(0).put(k, "v_initial");
+      assertNotLocked(k);
       tm(0).begin();
-      operation.perform("k", 0);
+      operation.perform(k, 0);
 
-      assert lockManager(0).isLocked("k");
-      assert !lockManager(1).isLocked("k");
-      assert !lockManager(2).isLocked("k");
+      assert lockManager(0).isLocked(k);
+      assert !lockManager(1).isLocked(k);
+      assert !lockManager(2).isLocked(k);
 
       tm(0).commit();
 
-      assertNotLocked("k");
-      assertValue("k", removed);
+      assertNotLocked(k);
+      assertValue(k, removed);
    }
 
    public void testMultipleLocksInSameTx() throws Exception {
+      Object k1 = new MagicKey("k1", cache(0));
+      Object k2 = new MagicKey("k2", cache(0));
 
       tm(0).begin();
-      cache(0).put("k1", "v");
-      cache(0).put("k2", "v");
+      cache(0).put(k1, "v");
+      cache(0).put(k2, "v");
 
-      assert lockManager(0).isLocked("k1");
-      assert lockManager(0).isLocked("k2");
-      assert !lockManager(1).isLocked("k1");
-      assert !lockManager(1).isLocked("k2");
-      assert !lockManager(1).isLocked("k2");
-      assert !lockManager(2).isLocked("k2");
+      assert lockManager(0).isLocked(k1);
+      assert lockManager(0).isLocked(k2);
+      assert !lockManager(1).isLocked(k1);
+      assert !lockManager(1).isLocked(k2);
+      assert !lockManager(1).isLocked(k2);
+      assert !lockManager(2).isLocked(k2);
 
       tm(0).commit();
 
-      assertNotLocked("k1");
-      assertNotLocked("k2");
-      assertValue("k1", false);
-      assertValue("k2", false);
+      assertNotLocked(k1);
+      assertNotLocked(k2);
+      assertValue(k1, false);
+      assertValue(k2, false);
    }
 
    public void testTxAndLockOnSameNode() throws Exception {
-
+      Object k0 = new MagicKey("k0", cache(0));
       tm(0).begin();
-      cache(0).put("k0", "v");
+      cache(0).put(k0, "v");
 
-      assert lockManager(0).isLocked("k0");
-      assert !lockManager(1).isLocked("k0");
-      assert !lockManager(2).isLocked("k0");
+      assert lockManager(0).isLocked(k0);
+      assert !lockManager(1).isLocked(k0);
+      assert !lockManager(2).isLocked(k0);
 
       tm(0).commit();
 
-      assertNotLocked("k0");
-      assertValue("k0", false);
+      assertNotLocked(k0);
+      assertValue(k0, false);
    }
 
    public void testSecondTxCannotPrepare1() throws Exception {
-
+      Object k0 = new MagicKey("k0", cache(0));
       tm(0).begin();
-      cache(0).put("k0", "v");
+      cache(0).put(k0, "v");
       DummyTransaction dtm = (DummyTransaction) tm(0).suspend();
 
       assert checkTxCount(0, 1, 0);
@@ -84,7 +87,7 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
 
       tm(0).begin();
       try {
-         cache(0).put("k0", "other");
+         cache(0).put(k0, "other");
          assert false;
       } catch (Throwable e) {
          tm(0).rollback();
@@ -100,7 +103,7 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
 
       tm(1).begin();
       try {
-         cache(1).put("k0", "other");
+         cache(1).put(k0, "other");
          assert false;
       } catch (Throwable e) {
          tm(0).rollback();
@@ -117,7 +120,7 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
       tm(0).resume(dtm);
       tm(0).commit();
 
-      assertValue("k0", false);
+      assertValue(k0, false);
 
       eventually(new AbstractInfinispanTest.Condition() {
          @Override
@@ -128,9 +131,9 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
    }
 
    public void testSecondTxCannotPrepare2() throws Exception {
-
+      Object k0 = new MagicKey("k0", cache(0));
       tm(1).begin();
-      cache(1).put("k0", "v");
+      cache(1).put(k0, "v");
       DummyTransaction dtm = (DummyTransaction) tm(1).suspend();
 
       assert checkTxCount(0, 0, 1);
@@ -139,7 +142,7 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
 
       tm(0).begin();
       try {
-         cache(0).put("k0", "other");
+         cache(0).put(k0, "other");
          assert false;
       } catch (Throwable e) {
          tm(0).rollback();
@@ -155,7 +158,7 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
 
       tm(1).begin();
       try {
-         cache(1).put("k0", "other");
+         cache(1).put(k0, "other");
          assert false;
       } catch (Throwable e) {
          tm(0).rollback();
@@ -172,7 +175,7 @@ public class BasicSingleLockRepPessimisticTest extends AbstractNoCrashTest {
       tm(0).resume(dtm);
       tm(0).commit();
 
-      assertValue("k0", false);
+      assertValue(k0, false);
 
       eventually(new AbstractInfinispanTest.Condition() {
          @Override

--- a/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/LockOwnerCrashPessimisticReplTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/replicated/pessimistic/LockOwnerCrashPessimisticReplTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.lock.singlelock.replicated.pessimistic;
 
 import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.distribution.MagicKey;
 import org.infinispan.lock.singlelock.AbstractLockOwnerCrashTest;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.LockingMode;
@@ -16,10 +17,5 @@ public class LockOwnerCrashPessimisticReplTest extends AbstractLockOwnerCrashTes
 
    public LockOwnerCrashPessimisticReplTest() {
       super(CacheMode.REPL_SYNC, LockingMode.PESSIMISTIC, false);
-   }
-
-   @Override
-   protected Object getKeyForCache(int nodeIndex) {
-      return "k" + nodeIndex;
    }
 }

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplInitialTransferDistTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplInitialTransferDistTest.java
@@ -391,6 +391,11 @@ public class CacheNotifierImplInitialTransferDistTest extends MultipleCacheManag
       for (K key : keys) {
          boolean isPrimaryOwner = hash.locatePrimaryOwner(key).equals(address);
          if (isPrimaryOwner == shouldBePrimaryOwner) {
+            if (shouldBePrimaryOwner) {
+               log.debugf("Found key %s with primary owner %s", key, address);
+            } else {
+               log.debugf("Found key %s with primary owner != %s", key, address);
+            }
             return key;
          }
       }

--- a/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
@@ -379,7 +379,7 @@ public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
       return partitionHandlingManager(advancedCache(index));
    }
 
-   private PartitionHandlingManager partitionHandlingManager(Cache cache) {
+   protected PartitionHandlingManager partitionHandlingManager(Cache cache) {
       return cache.getAdvancedCache().getComponentRegistry().getComponent(PartitionHandlingManager.class);
    }
 

--- a/core/src/test/java/org/infinispan/partitionhandling/BaseTxPartitionAndMergeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BaseTxPartitionAndMergeTest.java
@@ -85,6 +85,10 @@ public abstract class BaseTxPartitionAndMergeTest extends BasePartitionHandlingT
       getLog().debugf("Merging cluster");
       partition(0).merge(partition(1));
       waitForRehashToComplete(caches(cacheName));
+      for (int i = 0; i < numMembersInCluster; i++) {
+         PartitionHandlingManager phmI = partitionHandlingManager(cache(i, cacheName));
+         eventually(() -> AvailabilityMode.AVAILABLE == phmI.getAvailabilityMode());
+      }
       getLog().debugf("Cluster merged");
    }
 

--- a/core/src/test/java/org/infinispan/partitionhandling/NumOwnersNodeCrashInSequenceTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/NumOwnersNodeCrashInSequenceTest.java
@@ -183,7 +183,7 @@ public class NumOwnersNodeCrashInSequenceTest extends MultipleCacheManagersTest 
       LocalTopologyManager ltm = TestingUtil.extractGlobalComponent(manager(a0), LocalTopologyManager.class);
       ltm.setCacheAvailability(CacheContainer.DEFAULT_CACHE_NAME, AvailabilityMode.AVAILABLE);
       TestingUtil.waitForRehashToComplete(cache(a0), cache(a1));
-      assertEquals(AvailabilityMode.AVAILABLE, phm0.getAvailabilityMode());
+      eventually(() -> AvailabilityMode.AVAILABLE == phm0.getAvailabilityMode());
    }
 
    private void installNewView(List<Address> members, Address missing, EmbeddedCacheManager... where) {

--- a/core/src/test/java/org/infinispan/replication/ForceSyncAsyncFlagsTest.java
+++ b/core/src/test/java/org/infinispan/replication/ForceSyncAsyncFlagsTest.java
@@ -15,6 +15,7 @@ import org.infinispan.remoting.transport.Transport;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.util.ReplicatedControlledConsistentHashFactory;
 import org.testng.annotations.Test;
 
 import static org.mockito.Matchers.anyBoolean;
@@ -39,6 +40,7 @@ public class ForceSyncAsyncFlagsTest extends MultipleCacheManagersTest {
 
    public void testForceAsyncFlagUsage() throws Exception {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
+      builder.clustering().hash().numSegments(1).consistentHashFactory(new ReplicatedControlledConsistentHashFactory(0));
       createClusteredCaches(2, "replSync", builder);
 
       AdvancedCache<String, String> cache1 = this.<String, String>cache(0, "replSync").getAdvancedCache();
@@ -67,6 +69,7 @@ public class ForceSyncAsyncFlagsTest extends MultipleCacheManagersTest {
 
    public void testForceSyncFlagUsage() throws Exception {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_ASYNC, false);
+      builder.clustering().hash().numSegments(1).consistentHashFactory(new ReplicatedControlledConsistentHashFactory(0));
       createClusteredCaches(2, "replAsync", builder);
 
       AdvancedCache<String, String> cache1 = this.<String, String>cache(0, "replAsync").getAdvancedCache();

--- a/core/src/test/java/org/infinispan/replication/SyncReplTest.java
+++ b/core/src/test/java/org/infinispan/replication/SyncReplTest.java
@@ -14,6 +14,7 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.Transport;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.util.ReplicatedControlledConsistentHashFactory;
 import org.testng.annotations.Test;
 
 import static org.mockito.Matchers.anyBoolean;
@@ -38,6 +39,7 @@ public class SyncReplTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder replSync = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
+      replSync.clustering().hash().numSegments(1).consistentHashFactory(new ReplicatedControlledConsistentHashFactory(0));
       createClusteredCaches(2, "replSync", replSync);
    }
 
@@ -142,6 +144,7 @@ public class SyncReplTest extends MultipleCacheManagersTest {
       try {
          ConfigurationBuilder asyncCache = getDefaultClusteredCacheConfig(CacheMode.REPL_ASYNC, false);
          asyncCache.clustering().async().asyncMarshalling(true);
+         asyncCache.clustering().hash().numSegments(1).consistentHashFactory(new ReplicatedControlledConsistentHashFactory(0));
          defineConfigurationOnAllManagers("asyncCache", asyncCache);
          Cache<String, String> asyncCache1 = manager(0).getCache("asyncCache");
          manager(1).getCache("asyncCache");

--- a/core/src/test/java/org/infinispan/statetransfer/DataRehashedEventTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/DataRehashedEventTest.java
@@ -116,7 +116,7 @@ public class DataRehashedEventTest extends MultipleCacheManagersTest {
 
    public void testPostOnlyEvent() {
       Cache<Object, Object> c1 = cache(0);
-      rehashListener = new DataRehashedListenrPostOnly();
+      rehashListener = new DataRehashedListenerPostOnly();
       c1.addListener(rehashListener);
 
       ConsistentHash ch1Node = advancedCache(0).getDistributionManager().getReadConsistentHash();
@@ -127,8 +127,7 @@ public class DataRehashedEventTest extends MultipleCacheManagersTest {
       cache(1);
       TestingUtil.waitForRehashToComplete(cache(0), cache(1));
 
-      List<DataRehashedEvent<Object, Object>> events = rehashListener.removeEvents();
-      assertEquals(1, events.size());
+      rehashListener.waitForEvents(1);
    }
 
    @Listener
@@ -158,7 +157,7 @@ public class DataRehashedEventTest extends MultipleCacheManagersTest {
    }
 
    @Listener(observation = Listener.Observation.POST)
-   public class DataRehashedListenrPostOnly extends DataRehashedListener {
+   public class DataRehashedListenerPostOnly extends DataRehashedListener {
 
    }
 }

--- a/core/src/test/java/org/infinispan/statetransfer/JoiningNode.java
+++ b/core/src/test/java/org/infinispan/statetransfer/JoiningNode.java
@@ -8,6 +8,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.testng.AssertJUnit.assertTrue;
+
 /**
  * Represents a joining node, designed for state transfer related tests.
  *
@@ -38,17 +40,13 @@ public class JoiningNode {
    public void waitForJoin(long timeout, Cache... caches) throws InterruptedException {
       // Wait for either a merge or view change to happen
       latch.await(timeout, TimeUnit.MILLISECONDS);
+      assertTrue(isStateTransferred());
+
       // Wait for the state transfer to end
       TestingUtil.waitForRehashToComplete(caches);
    }
 
-   private boolean isStateTransferred() {
+   public boolean isStateTransferred() {
       return !listener.merged;
    }
-
-   void verifyStateTransfer(Callable<Void> verify) throws Exception {
-      if (isStateTransferred())
-         verify.call();
-   }
-
 }

--- a/core/src/test/java/org/infinispan/statetransfer/OrphanTransactionsCleanupTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/OrphanTransactionsCleanupTest.java
@@ -8,6 +8,7 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.topology.LocalTopologyManager;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.impl.TransactionTable;
+import org.infinispan.util.ReplicatedControlledConsistentHashFactory;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.testng.annotations.Test;
@@ -31,6 +32,8 @@ public class OrphanTransactionsCleanupTest extends MultipleCacheManagersTest {
    protected void createCacheManagers() throws Throwable {
       configurationBuilder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
       configurationBuilder.transaction().lockingMode(LockingMode.PESSIMISTIC);
+      // Make the coordinator the primary owner of the only segment
+      configurationBuilder.clustering().hash().numSegments(1).consistentHashFactory(new ReplicatedControlledConsistentHashFactory(0));
       configurationBuilder.clustering().stateTransfer().awaitInitialTransfer(false);
 
       addClusterEnabledCacheManager(configurationBuilder);

--- a/core/src/test/java/org/infinispan/statetransfer/ReplCommandForwardingTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ReplCommandForwardingTest.java
@@ -18,6 +18,8 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.CheckPoint;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.topology.CacheTopology;
+import org.infinispan.util.ControlledConsistentHashFactory;
+import org.infinispan.util.ReplicatedControlledConsistentHashFactory;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.BrokenBarrierException;
@@ -50,9 +52,10 @@ public class ReplCommandForwardingTest extends MultipleCacheManagersTest {
 
    private ConfigurationBuilder buildConfig(boolean transactional, boolean onePhase, Class<?> commandToBlock) {
       CacheMode mode = (transactional && !onePhase) ? CacheMode.REPL_SYNC : CacheMode.REPL_ASYNC;
-      // The coordinator will always be the primary owner
       ConfigurationBuilder configurationBuilder = getDefaultClusteredCacheConfig(mode, transactional);
       if (mode.isSynchronous()) configurationBuilder.clustering().sync().replTimeout(15000);
+      // The coordinator will always be the primary owner
+      configurationBuilder.clustering().hash().numSegments(1).consistentHashFactory(new ReplicatedControlledConsistentHashFactory(0));
       configurationBuilder.clustering().stateTransfer().fetchInMemoryState(true);
       configurationBuilder.transaction().syncCommitPhase(false);
       // We must block after the commit was replicated, but before the entries are committed

--- a/core/src/test/java/org/infinispan/statetransfer/ReplCommandRetryTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ReplCommandRetryTest.java
@@ -20,6 +20,7 @@ import org.infinispan.test.fwk.CheckPoint;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.transaction.LockingMode;
+import org.infinispan.util.ReplicatedControlledConsistentHashFactory;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.BrokenBarrierException;
@@ -52,9 +53,11 @@ public class ReplCommandRetryTest extends MultipleCacheManagersTest {
    }
 
    private ConfigurationBuilder buildConfig(LockingMode lockingMode, Class<?> commandToBlock, boolean isOriginator) {
-      // The coordinator will always be the primary owner
       ConfigurationBuilder configurationBuilder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, lockingMode != null);
       configurationBuilder.transaction().lockingMode(lockingMode);
+      // The coordinator will always be the primary owner
+      configurationBuilder.clustering().hash().numSegments(1)
+            .consistentHashFactory(new ReplicatedControlledConsistentHashFactory(0));
       configurationBuilder.clustering().sync().replTimeout(15000);
       configurationBuilder.clustering().stateTransfer().fetchInMemoryState(true);
       if (commandToBlock == LockControlCommand.class && !isOriginator) {

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferFunctionalTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Future;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 @Test(groups = "functional", testName = "statetransfer.StateTransferFunctionalTest")
 public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
@@ -163,7 +164,7 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
       JoiningNode node = new JoiningNode(createCacheManager());
       cache2 = node.getCache(cacheName);
       node.waitForJoin(60000, cache1, cache2);
-      node.verifyStateTransfer(new CacheVerifier(cache2));
+      verifyInitialData(cache2);
 
       logTestEnd(m);
    }
@@ -179,7 +180,7 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
       JoiningNode node = new JoiningNode(createCacheManager());
       cache2 = node.getCache(cacheName);
       node.waitForJoin(60000, cache1, cache2);
-      node.verifyStateTransfer(new CacheVerifier(cache2));
+      verifyInitialData(cache2);
 
       cacheManager1.defineConfiguration("otherCache", configurationBuilder.build());
       cacheManager1.getCache("otherCache");
@@ -199,7 +200,7 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
       cache1.put("delay", new DelayTransfer());
 
       node2.waitForJoin(60000, cache1, cache2);
-      node2.verifyStateTransfer(new CacheVerifier(cache2));
+      verifyInitialData(cache2);
 
       final JoiningNode node3 = new JoiningNode(createCacheManager());
       final JoiningNode node4 = new JoiningNode(createCacheManager());
@@ -229,8 +230,8 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
       node3.waitForJoin(120000, cache1, cache2, cache3, cache4);
       node4.waitForJoin(120000, cache1, cache2, cache3, cache4);
 
-      node3.verifyStateTransfer(new CacheVerifier(cache3));
-      node4.verifyStateTransfer(new CacheVerifier(cache4));
+      verifyInitialData(cache3);
+      verifyInitialData(cache4);
 
       logTestEnd(m);
    }
@@ -275,7 +276,7 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
       JoiningNode node2 = new JoiningNode(createCacheManager());
       cache2 = node2.getCache(cacheName);
       node2.waitForJoin(60000, cache1, cache2);
-      node2.verifyStateTransfer(new CacheVerifier(cache2));
+      verifyInitialData(cache2);
 
       cache2.stop();
       cache2.start();
@@ -320,7 +321,7 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
       writingTask.stop();
       int count = future.get(60, SECONDS);
 
-      node2.verifyStateTransfer(new CacheVerifier(cache2));
+      verifyInitialData(cache2);
 
       for (int c = 0; c < count; c++) {
          assertEquals(c, cache2.get("test" + c));
@@ -366,26 +367,10 @@ public class StateTransferFunctionalTest extends MultipleCacheManagersTest {
       int count = future.get(60, SECONDS);
 
       verifyInitialData(cache1);
-      node2.verifyStateTransfer(new CacheVerifier(cache2));
+      verifyInitialData(cache2);
 
       for (int c = 0; c < count; c++) {
          assertEquals(c, cache2.get("test" + c));
       }
    }
-
-   public class CacheVerifier implements Callable<Void> {
-
-      private final Cache<Object, Object> cache;
-
-      public CacheVerifier(Cache<Object, Object> cache) {
-         this.cache = cache;
-      }
-
-      @Override
-      public Void call() {
-         verifyInitialData(cache);
-         return null;
-      }
-   }
-
 }

--- a/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedStreamIteratorTest.java
@@ -323,7 +323,8 @@ public class DistributedStreamIteratorTest extends BaseClusteredStreamIteratorTe
 
       Map<Integer, Set<Map.Entry<Object, String>>> entriesPerSegment = generateEntriesPerSegment(ch, entries.entrySet());
 
-      assertEquals(segmentsCache0, entriesPerSegment.keySet());
+      // We should not see keys from other segments, but there may be segments without any keys
+      assertTrue(segmentsCache0.containsAll(entriesPerSegment.keySet()));
       verify(clusterStreamManager, never()).awaitCompletion(any(UUID.class), anyLong(), any(TimeUnit.class));
    }
 

--- a/core/src/test/java/org/infinispan/test/AbstractCacheTest.java
+++ b/core/src/test/java/org/infinispan/test/AbstractCacheTest.java
@@ -3,10 +3,13 @@ package org.infinispan.test;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.ch.ConsistentHashFactory;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.CleanupAfterTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.util.ControlledConsistentHashFactory;
+import org.infinispan.util.ReplicatedControlledConsistentHashFactory;
 
 import java.util.concurrent.TimeUnit;
 
@@ -61,11 +64,6 @@ public class AbstractCacheTest extends AbstractInfinispanTest {
          builder.clustering().sync();
       else
          builder.clustering().async();
-
-      if (mode.isReplicated()) {
-         // only one segment is supported for REPL tests now because some old tests still expect a single primary owner
-         builder.clustering().hash().numSegments(1);
-      }
 
       return builder;
    }

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -514,10 +514,11 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
 
    protected <K, V> Cache<K, V> getLockOwner(Object key, String cacheName) {
       Configuration c = getCache(0, cacheName).getCacheConfiguration();
-      if (c.clustering().cacheMode().isReplicated() || c.clustering().cacheMode().isInvalidation()) {
+      if (c.clustering().cacheMode().isInvalidation()) {
          return getCache(0, cacheName); //for replicated caches only the coordinator acquires lock
-      }  else {
-         if (!c.clustering().cacheMode().isDistributed()) throw new IllegalStateException("This is not a clustered cache!");
+      }  else if (!c.clustering().cacheMode().isClustered()) {
+         throw new IllegalStateException("This is not a clustered cache!");
+      } else {
          final Address address = getCache(0, cacheName).getAdvancedCache().getDistributionManager().locate(key).get(0);
          for (Cache<K, V> cache : this.<K, V>caches(cacheName)) {
             if (cache.getAdvancedCache().getRpcManager().getTransport().getAddress().equals(address)) {

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -94,6 +94,7 @@ import static java.io.File.separator;
 import static org.infinispan.commons.api.BasicCacheContainer.DEFAULT_CACHE_NAME;
 import static org.infinispan.persistence.manager.PersistenceManager.AccessMode.BOTH;
 import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.fail;
 
 public class TestingUtil {
    private static final Log log = LogFactory.getLog(TestingUtil.class);
@@ -1492,6 +1493,12 @@ public class TestingUtil {
          AssertJUnit.assertArrayEquals((byte[]) expected, (byte[]) actual);
       else
          AssertJUnit.assertEquals(expected, actual);
+   }
+
+   public static void assertBetween(double lowerBound, double upperBound, double actual) {
+      if (actual < lowerBound || upperBound < actual) {
+         fail("Expected between:<" + lowerBound + "> and:<" + upperBound + "> but was:<" + actual + ">");
+      }
    }
 
    public static class TestPrincipal implements Principal, Serializable {

--- a/core/src/test/java/org/infinispan/tx/dld/DldPessimisticLockingDistributedTest.java
+++ b/core/src/test/java/org/infinispan/tx/dld/DldPessimisticLockingDistributedTest.java
@@ -17,23 +17,6 @@ import javax.transaction.SystemException;
 @Test (groups = "functional", testName = "tx.dld.DldPessimisticLockingDistributedTest")
 public class DldPessimisticLockingDistributedTest extends BaseDldPessimisticLockingTest {
 
-   private Object k0;
-   private Object k1;
-
-   @Override
-   protected void createCacheManagers() throws Throwable {
-      ConfigurationBuilder config = createConfiguration();
-
-      EmbeddedCacheManager cm1 = TestCacheManagerFactory.createClusteredCacheManager(config);
-      EmbeddedCacheManager cm2 = TestCacheManagerFactory.createClusteredCacheManager(config);
-      registerCacheManager(cm1);
-      registerCacheManager(cm2);
-      waitForClusterToForm();
-
-      k0 = new MagicKey(cache(0));
-      k1 = new MagicKey(cache(1));
-   }
-
    protected ConfigurationBuilder createConfiguration() {
       ConfigurationBuilder config = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
       config
@@ -44,7 +27,4 @@ public class DldPessimisticLockingDistributedTest extends BaseDldPessimisticLock
       return config;
    }
 
-   public void testSymmetricDeadlock() throws SystemException {
-      testSymmetricDld(k0, k1);
-   }
 }

--- a/core/src/test/java/org/infinispan/tx/dld/DldPessimisticLockingReplicationTest.java
+++ b/core/src/test/java/org/infinispan/tx/dld/DldPessimisticLockingReplicationTest.java
@@ -3,6 +3,7 @@ package org.infinispan.tx.dld;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.Flag;
+import org.infinispan.distribution.MagicKey;
 import org.infinispan.test.PerCacheExecutorThread;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.transaction.LockingMode;
@@ -15,48 +16,11 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "tx.dld.DldPessimisticLockingReplicationTest")
 public class DldPessimisticLockingReplicationTest extends BaseDldPessimisticLockingTest {
-
-   @Override
-   protected void createCacheManagers() {
-      ConfigurationBuilder configuration = getConfigurationBuilder();
-      createClusteredCaches(2, configuration);
-      TestingUtil.blockUntilViewsReceived(1000, cache(0), cache(1));
-   }
-
-   protected ConfigurationBuilder getConfigurationBuilder() {
+   protected ConfigurationBuilder createConfiguration() {
       ConfigurationBuilder configuration = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
       configuration.transaction().lockingMode(LockingMode.PESSIMISTIC)
             .locking().useLockStriping(false)
             .deadlockDetection().enable();
       return configuration;
-   }
-
-   public void testDeadlock() throws Exception {
-      testSymmetricDld("k1", "k2");
-   }
-
-   /**
-    * On eager locking, remote locks are being acquired at first, and then local locks. This is for specifying the
-    * behavior whe remote acquisition succeeds and local fails.
-    */
-   public void testDeadlockFailedToAcquireLocalLocks() throws Exception {
-      //first acquire a local lock on k1
-      tm(0).begin();
-      cache(0).getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).put("k1","v1");
-      assert lm0.isLocked("k1");
-      assert !lm1.isLocked("k1");
-      try {
-         ex0.execute(PerCacheExecutorThread.Operations.BEGIN_TX);
-         ex0.setKeyValue("k1", "v1_1");
-         ex0.execute(PerCacheExecutorThread.Operations.PUT_KEY_VALUE);
-         assert ex0.lastResponse() instanceof TimeoutException : "received " + ex0.lastResponse();
-         eventually(new Condition() {
-            public boolean isSatisfied() throws Exception {
-               return !lm1.isLocked("k1");
-            }
-         });
-      } finally {
-         tm(0).rollback();
-      }
    }
 }

--- a/core/src/test/java/org/infinispan/tx/locking/OptimisticDistTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/OptimisticDistTxTest.java
@@ -12,10 +12,4 @@ public class OptimisticDistTxTest extends OptimisticReplTxTest {
    public OptimisticDistTxTest() {
       this.cacheMode = CacheMode.DIST_SYNC;
    }
-
-   @Override
-   protected void createCacheManagers() throws Throwable {
-      super.createCacheManagers();
-      k = getKeyForCache(0);
-   }
 }

--- a/core/src/test/java/org/infinispan/tx/locking/OptimisticReplTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/OptimisticReplTxTest.java
@@ -46,13 +46,13 @@ public class OptimisticReplTxTest extends AbstractClusteredTxTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      k = "k";
       final ConfigurationBuilder conf = getDefaultClusteredCacheConfig(cacheMode, true);
       conf.transaction()
             .lockingMode(LockingMode.OPTIMISTIC)
             .transactionManagerLookup(new DummyTransactionManagerLookup());
       createCluster(conf, 2);
       waitForClusterToForm();
+      k = getKeyForCache(0);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/tx/locking/PessimisticDistTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/PessimisticDistTxTest.java
@@ -19,10 +19,4 @@ public class PessimisticDistTxTest extends PessimisticReplTxTest {
             .hash().numOwners(1);
       return builder;
    }
-
-   @Override
-   protected void createCacheManagers() throws Throwable {
-      super.createCacheManagers();
-      k = getKeyForCache(0);
-   }
 }

--- a/core/src/test/java/org/infinispan/tx/locking/PessimisticReplTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/locking/PessimisticReplTxTest.java
@@ -4,6 +4,7 @@ import javax.transaction.Transaction;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.distribution.MagicKey;
 import org.infinispan.remoting.RemoteException;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
@@ -24,6 +25,8 @@ public class PessimisticReplTxTest extends AbstractClusteredTxTest {
       final ConfigurationBuilder conf = buildConfiguration();
       createCluster(conf, 2);
       waitForClusterToForm();
+
+      k = new MagicKey(cache(0));
    }
 
    protected ConfigurationBuilder buildConfiguration() {
@@ -33,10 +36,6 @@ public class PessimisticReplTxTest extends AbstractClusteredTxTest {
             .transactionManagerLookup(new DummyTransactionManagerLookup())
          .locking().lockAcquisitionTimeout(10L); //fail fast
       return conf;
-   }
-
-   public PessimisticReplTxTest() {
-      k = "k";
    }
 
    public void testTxInProgress1() throws Exception {

--- a/core/src/test/java/org/infinispan/tx/lockreordering/DistLockReorderingTest.java
+++ b/core/src/test/java/org/infinispan/tx/lockreordering/DistLockReorderingTest.java
@@ -19,7 +19,7 @@ import static org.infinispan.tx.lockreordering.LocalLockReorderingTest.runTest;
 @Test (groups = "functional", testName = "tx.lockreordering.DistLockReorderingTest")
 public class DistLockReorderingTest extends MultipleCacheManagersTest {
 
-   protected List keys;
+   protected List<Object> keys;
    protected CacheMode cacheMode = CacheMode.DIST_SYNC;
 
    @Override
@@ -36,7 +36,7 @@ public class DistLockReorderingTest extends MultipleCacheManagersTest {
       int node = (int) (System.nanoTime() % 2);
       /** this is what's used for inducing ordering */
       MurmurHash3 hashFunction = MurmurHash3.getInstance();
-      keys = new ArrayList<Integer>(2);
+      keys = new ArrayList<>(2);
       final Object firstKey = getKeyForCache(node);
       keys.add(firstKey);
       while (keys.size() < 2) {

--- a/core/src/test/java/org/infinispan/tx/lockreordering/LocalLockReorderingTest.java
+++ b/core/src/test/java/org/infinispan/tx/lockreordering/LocalLockReorderingTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.CyclicBarrier;
 @Test (groups = "functional", testName = "tx.lockreordering.LocalLockReorderingTest")
 public class LocalLockReorderingTest extends SingleCacheManagerTest {
 
-   private List<Integer> keys;
+   private List<Object> keys;
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
@@ -48,11 +48,11 @@ public class LocalLockReorderingTest extends SingleCacheManagerTest {
       runTest(StresserThread.MIXED_OPS_PERFORMER, cache, cache, keys, getThreadName(m));
    }
 
-   static void runTest(StresserThread.OperationsPerformer ops, Cache c1, Cache c2, List<Integer> keys, String threadNamePrefix) throws InterruptedException {
+   static void runTest(StresserThread.OperationsPerformer ops, Cache c1, Cache c2, List<Object> keys, String threadNamePrefix) throws InterruptedException {
       CyclicBarrier beforeCommit = new CyclicBarrier(2);
 
       StresserThread st1 = new StresserThread(c1, keys, "t1", ops, beforeCommit, threadNamePrefix + "-1");
-      final ArrayList<Integer> reversedKeys = new ArrayList<Integer>(keys);
+      final ArrayList<Object> reversedKeys = new ArrayList<>(keys);
       Collections.reverse(reversedKeys);
       StresserThread st2 = new StresserThread(c2, reversedKeys, "t2", ops, beforeCommit, threadNamePrefix+"-2");
 
@@ -66,11 +66,10 @@ public class LocalLockReorderingTest extends SingleCacheManagerTest {
       assert !st2.isError();
    }
 
-   static List<Integer> generateKeys() {
-      List<Integer> keys;
+   static List<Object> generateKeys() {
+      List<Object> keys = new ArrayList<>(2);
       /** this is what's used for inducing ordering */
       MurmurHash2 hashFunction = new MurmurHash2();
-      keys = new ArrayList<Integer>(2);
       int count = 0;
       keys.add(count);
       while (keys.size() < 2) {

--- a/core/src/test/java/org/infinispan/tx/lockreordering/ReplicatedLockReorderingTest.java
+++ b/core/src/test/java/org/infinispan/tx/lockreordering/ReplicatedLockReorderingTest.java
@@ -15,9 +15,4 @@ public class ReplicatedLockReorderingTest extends DistLockReorderingTest {
    public ReplicatedLockReorderingTest() {
       cacheMode = CacheMode.REPL_SYNC;
    }
-
-   @Override
-   void buildKeys() {
-      keys = generateKeys();
-   }
 }

--- a/core/src/test/java/org/infinispan/tx/recovery/DldEagerLockingAndRecoveryReplicationTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/DldEagerLockingAndRecoveryReplicationTest.java
@@ -10,8 +10,8 @@ import org.testng.annotations.Test;
 @Test (groups = "functional", testName = "tx.recovery.DldEagerLockingAndRecoveryReplicationTest")
 public class DldEagerLockingAndRecoveryReplicationTest extends DldPessimisticLockingReplicationTest {
 
-   protected ConfigurationBuilder getConfigurationBuilder() {
-      ConfigurationBuilder configurationBuilder = super.getConfigurationBuilder();
+   protected ConfigurationBuilder createConfiguration() {
+      ConfigurationBuilder configurationBuilder = super.createConfiguration();
       configurationBuilder.transaction().recovery().enable();
       return configurationBuilder;
    }

--- a/core/src/test/java/org/infinispan/tx/synchronisation/DldEagerLockingReplicationWithSyncTest.java
+++ b/core/src/test/java/org/infinispan/tx/synchronisation/DldEagerLockingReplicationWithSyncTest.java
@@ -12,8 +12,8 @@ import org.testng.annotations.Test;
 public class DldEagerLockingReplicationWithSyncTest extends DldPessimisticLockingReplicationTest {
 
    @Override
-   protected ConfigurationBuilder getConfigurationBuilder() {
-      ConfigurationBuilder config = super.getConfigurationBuilder();
+   protected ConfigurationBuilder createConfiguration() {
+      ConfigurationBuilder config = super.createConfiguration();
       config.transaction().useSynchronization(true);
       return config;
    }

--- a/core/src/test/java/org/infinispan/util/ReplicatedControlledConsistentHashFactory.java
+++ b/core/src/test/java/org/infinispan/util/ReplicatedControlledConsistentHashFactory.java
@@ -1,0 +1,91 @@
+package org.infinispan.util;
+
+import org.infinispan.commons.hash.Hash;
+import org.infinispan.distribution.ch.ConsistentHashFactory;
+import org.infinispan.distribution.ch.impl.ReplicatedConsistentHash;
+import org.infinispan.remoting.transport.Address;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+/**
+ * ConsistentHashFactory implementation that allows the user to control who the owners are.
+ *
+ * @author Dan Berindei
+ * @since 7.0
+ */
+public class ReplicatedControlledConsistentHashFactory
+      implements ConsistentHashFactory<ReplicatedConsistentHash>, Serializable {
+   private volatile List<Address> membersToUse;
+   private int[] primaryOwnerIndices;
+
+   /**
+    * Create a consistent hash factory with a single segment.
+    */
+   public ReplicatedControlledConsistentHashFactory(int primaryOwner1, int... otherPrimaryOwners) {
+      setOwnerIndexes(primaryOwner1, otherPrimaryOwners);
+   }
+
+   public void setOwnerIndexes(int primaryOwner1, int... otherPrimaryOwners) {
+      primaryOwnerIndices = concatOwners(primaryOwner1, otherPrimaryOwners);
+   }
+
+   @Override
+   public ReplicatedConsistentHash create(Hash hashFunction, int numOwners, int numSegments,
+         List<Address> members, Map<Address, Float> capacityFactors) {
+      int[] thePrimaryOwners = new int[primaryOwnerIndices.length];
+      for (int i = 0; i < primaryOwnerIndices.length; i++) {
+         if (membersToUse != null) {
+            int membersToUseIndex = Math.min(primaryOwnerIndices[i], membersToUse.size() - 1);
+            int membersIndex = members.indexOf(membersToUse.get(membersToUseIndex));
+            thePrimaryOwners[i] = membersIndex > 0 ? membersIndex : members.size() - 1;
+         } else {
+            thePrimaryOwners[i] = Math.min(primaryOwnerIndices[i], members.size() - 1);
+         }
+      }
+      return new ReplicatedConsistentHash(hashFunction, members, thePrimaryOwners);
+   }
+
+   @Override
+   public ReplicatedConsistentHash updateMembers(ReplicatedConsistentHash baseCH, List<Address> newMembers,
+         Map<Address, Float> capacityFactors) {
+      return create(baseCH.getHashFunction(), baseCH.getNumOwners(), baseCH.getNumSegments(), newMembers,
+            null);
+   }
+
+   @Override
+   public ReplicatedConsistentHash rebalance(ReplicatedConsistentHash baseCH) {
+      return create(baseCH.getHashFunction(), baseCH.getNumOwners(), baseCH.getNumSegments(),
+            baseCH.getMembers(), null);
+   }
+
+   @Override
+   public ReplicatedConsistentHash union(ReplicatedConsistentHash ch1, ReplicatedConsistentHash ch2) {
+      return ch1.union(ch2);
+   }
+
+   private int[] concatOwners(int head, int[] tail) {
+      int[] firstSegmentOwners;
+      if (tail == null || tail.length == 0) {
+         firstSegmentOwners = new int[]{head};
+      } else {
+         firstSegmentOwners = new int[tail.length + 1];
+         firstSegmentOwners[0] = head;
+         for (int i = 0; i < tail.length; i++) {
+            firstSegmentOwners[i + 1] = tail[i];
+         }
+      }
+      return firstSegmentOwners;
+   }
+
+   /**
+    * @param membersToUse Owner indexes will be in this list, instead of the current list of members
+    */
+   public void setMembersToUse(List<Address> membersToUse) {
+      this.membersToUse = membersToUse;
+   }
+}

--- a/extended-statistics/src/test/java/org/infinispan/stats/BaseTxClusterExtendedStatisticLogicTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/stats/BaseTxClusterExtendedStatisticLogicTest.java
@@ -333,7 +333,7 @@ public abstract class BaseTxClusterExtendedStatisticLogicTest extends MultipleCa
 
          }
       }
-      assertTxSeen(txExecutor, numOfLocalWriteTx, replicated ? numOfLocalWriteTx : numOfRemoteWriteTx, numOfReadOnlyTx, abort);
+      assertTxSeen(txExecutor, numOfLocalWriteTx, numOfRemoteWriteTx, numOfReadOnlyTx, abort);
 
       EnumSet<ExtendedStatistic> statsToValidate = getStatsToValidate();
 
@@ -380,19 +380,19 @@ public abstract class BaseTxClusterExtendedStatisticLogicTest extends MultipleCa
    }
 
    private boolean isRemote(Object key, Cache cache) {
-      return !replicated && !DistributionTestHelper.isOwner(cache, key);
+      return !DistributionTestHelper.isOwner(cache, key);
    }
 
    private boolean isLockOwner(Object key, Cache cache) {
-      return replicated ? address(0).equals(address(cache)) : DistributionTestHelper.isFirstOwner(cache, key);
+      return DistributionTestHelper.isFirstOwner(cache, key);
    }
 
    private Object getKey(int i) {
       if (i < 0) {
-         return replicated ? "KEY_" + i : new MagicKey("KEY_" + i, cache(0));
+         return new MagicKey("KEY_" + i, cache(0));
       }
       for (int j = keys.size(); j < i; ++j) {
-         keys.add(replicated ? "KEY_" + (j + 1) : new MagicKey("KEY_" + (j + 1), cache(0)));
+         keys.add(new MagicKey("KEY_" + (j + 1), cache(0)));
       }
       return keys.get(i - 1);
    }

--- a/extended-statistics/src/test/java/org/infinispan/stats/logic/PessimisticLockingTxClusterExtendedStatisticLogicTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/stats/logic/PessimisticLockingTxClusterExtendedStatisticLogicTest.java
@@ -15,6 +15,7 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.tx.dld.ControlledRpcManager;
 import org.infinispan.util.DefaultTimeService;
+import org.infinispan.util.ReplicatedControlledConsistentHashFactory;
 import org.infinispan.util.TimeService;
 import org.infinispan.util.TransactionTrackInterceptor;
 import org.infinispan.util.concurrent.IsolationLevel;
@@ -119,6 +120,7 @@ public class PessimisticLockingTxClusterExtendedStatisticLogicTest extends Multi
    protected void createCacheManagers() throws Throwable {
       for (int i = 0; i < NUM_NODES; ++i) {
          ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true);
+         builder.clustering().hash().numSegments(1).consistentHashFactory(new ReplicatedControlledConsistentHashFactory(0));
          builder.locking().isolationLevel(IsolationLevel.REPEATABLE_READ)//.writeSkewCheck(true)
                .lockAcquisitionTimeout(60000); //the timeout are triggered by the TimeService!
          builder.transaction().recovery().disable();

--- a/extended-statistics/src/test/java/org/infinispan/stats/topK/DistTopKeyTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/stats/topK/DistTopKeyTest.java
@@ -14,20 +14,7 @@ import static org.infinispan.distribution.DistributionTestHelper.addressOf;
  */
 @Test(groups = "functional", testName = "stats.topK.DistTopKeyTest")
 public class DistTopKeyTest extends BaseClusterTopKeyTest {
-
    public DistTopKeyTest() {
       super(CacheMode.DIST_SYNC, 2);
-   }
-
-   @Override
-   protected boolean isOwner(Cache<?, ?> cache, Object key) {
-      DistributionManager dm = cache.getAdvancedCache().getDistributionManager();
-      return dm.locate(key).contains(addressOf(cache));
-   }
-
-   @Override
-   protected boolean isPrimaryOwner(Cache<?, ?> cache, Object key) {
-      DistributionManager dm = cache.getAdvancedCache().getDistributionManager();
-      return dm.getPrimaryLocation(key).equals(addressOf(cache));
    }
 }

--- a/extended-statistics/src/test/java/org/infinispan/stats/topK/ReplTopKeyTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/stats/topK/ReplTopKeyTest.java
@@ -2,6 +2,7 @@ package org.infinispan.stats.topK;
 
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.distribution.DistributionManager;
 import org.infinispan.stats.BaseClusterTopKeyTest;
 import org.testng.annotations.Test;
 
@@ -13,18 +14,7 @@ import static org.infinispan.distribution.DistributionTestHelper.addressOf;
  */
 @Test(groups = "functional", testName = "stats.topK.ReplTopKeyTest")
 public class ReplTopKeyTest extends BaseClusterTopKeyTest {
-
    public ReplTopKeyTest() {
       super(CacheMode.REPL_SYNC, 2);
-   }
-
-   @Override
-   protected boolean isOwner(Cache<?, ?> cache, Object key) {
-      return true;
-   }
-
-   @Override
-   protected boolean isPrimaryOwner(Cache<?, ?> cache, Object key) {
-      return cache.getAdvancedCache().getRpcManager().getTransport().getCoordinator().equals(addressOf(cache));
    }
 }

--- a/server/integration/infinispan/src/main/resources/schema/jboss-infinispan-core_8_2.xsd
+++ b/server/integration/infinispan/src/main/resources/schema/jboss-infinispan-core_8_2.xsd
@@ -748,7 +748,7 @@
                         <xs:documentation>Number of cluster-wide replicas for each cache entry.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="segments" type="xs:int" default="80">
+                <xs:attribute name="segments" type="xs:int" default="256">
                     <xs:annotation>
                         <xs:documentation>Number of hash space segments (per cluster). The recommended value is 10 * cluster size. The default value is 80</xs:documentation>
                     </xs:annotation>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-4851

* Also create SyncReplicatedConsistentHashFactory, to match the primary
  owners in replicated and distributed caches.
* Change the default number of segments to 256.
* Remove the special default of 1 segment for replicated tests.
* Improve handling of capacity factors in SyncConsistentHashFactory.
* Fix random test failures caused by the CH and segments changes.