### PR TITLE
ISPN-6068 Upgrade to JGroups 3.6.7.Final

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -72,7 +72,7 @@
       <version.cdi>1.0-SP4</version.cdi>
       <version.jboss.marshalling>1.4.10.Final</version.jboss.marshalling>
       <version.jboss.logging>3.3.0.Final</version.jboss.logging>
-      <version.jgroups>3.6.4.Final</version.jgroups>
+      <version.jgroups>3.6.7.Final</version.jgroups>
       <version.jta>1.0.1.Final</version.jta>
       <version.netty>4.0.25.Final</version.netty>
       <version.osgi>4.3.1</version.osgi>

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
@@ -52,11 +52,7 @@ import static org.infinispan.remoting.transport.jgroups.JGroupsTransport.fromJGr
 public class CommandAwareRpcDispatcher extends RpcDispatcher {
    public static final RspList<Response> EMPTY_RESPONSES_LIST = new RspList<>();
 
-   static class LogWrapper {
-      // Dummy class to workaround JGRP-1942
-   }
-
-   private static final Log log = LogFactory.getLog(CommandAwareRpcDispatcher.LogWrapper.class);
+   private static final Log log = LogFactory.getLog(CommandAwareRpcDispatcher.class);
    private static final boolean trace = log.isTraceEnabled();
    private static final boolean FORCE_MCAST = Boolean.getBoolean("infinispan.unsafe.force_multicast");
 

--- a/core/src/test/java/org/infinispan/test/fwk/JGroupsConfigBuilder.java
+++ b/core/src/test/java/org/infinispan/test/fwk/JGroupsConfigBuilder.java
@@ -5,6 +5,7 @@ import org.jgroups.conf.ConfiguratorFactory;
 import org.jgroups.conf.ProtocolConfiguration;
 import org.jgroups.conf.ProtocolStackConfigurator;
 import org.jgroups.conf.XmlConfigurator;
+import org.jgroups.protocols.TCP_NIO;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -20,6 +21,7 @@ import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.FD_SOCK;
 import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.MERGE3;
 import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.RELAY2;
 import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.TCP;
+import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.TCP_NIO2;
 import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.TEST_PING;
 import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.UDP;
 import static org.infinispan.test.fwk.JGroupsConfigBuilder.ProtocolType.VERIFY_SUSPECT;
@@ -171,7 +173,8 @@ public class JGroupsConfigBuilder {
    }
 
    private static String replaceTcpStartPort(JGroupsProtocolCfg jgroupsCfg, TransportFlags transportFlags) {
-      Map<String, String> props = jgroupsCfg.getProtocol(TCP).getProperties();
+      ProtocolType transportProtocol = jgroupsCfg.containsProtocol(TCP_NIO2) ? TCP_NIO2 : TCP;
+      Map<String, String> props = jgroupsCfg.getProtocol(transportProtocol).getProperties();
       Integer startPort = threadTcpStartPort.get();
       int portRange = TCP_PORT_RANGE_PER_THREAD;
       if (transportFlags.isSiteIndexSpecified()) {
@@ -185,7 +188,7 @@ public class JGroupsConfigBuilder {
       props.put("bind_port", startPort.toString());
       // In JGroups, the port_range is inclusive
       props.put("port_range", String.valueOf(portRange - 1));
-      return replaceProperties(jgroupsCfg, props, TCP);
+      return replaceProperties(jgroupsCfg, props, transportProtocol);
    }
 
    private static String replaceProperties(
@@ -290,7 +293,7 @@ public class JGroupsConfigBuilder {
    }
 
    enum ProtocolType {
-      TCP, UDP, SHARED_LOOPBACK,
+      TCP, TCP_NIO2, UDP, SHARED_LOOPBACK,
       MPING, PING, TCPPING, TEST_PING, SHARED_LOOPBACK_PING,
       MERGE2, MERGE3,
       FD_SOCK, FD, VERIFY_SUSPECT, FD_ALL, FD_ALL2,

--- a/core/src/test/resources/stacks/broken-tcp.xml
+++ b/core/src/test/resources/stacks/broken-tcp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
    <TCP
          bind_addr="${jgroups.tcp.address:127.0.0.1}"
          bind_port="${jgroups.tcp.port:7800}"

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -1,7 +1,8 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
-   <TCP
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
+   <!-- Disable the regular thread pool queue for tests so we can set a lower min_threads -->
+   <TCP_NIO2
          bind_addr="${jgroups.tcp.address:127.0.0.1}"
          bind_port="${jgroups.tcp.port:7800}"
          port_range="30"
@@ -16,10 +17,10 @@
          thread_naming_pattern="pl"
 
          thread_pool.enabled="true"
-         thread_pool.min_threads="2"
-         thread_pool.max_threads="2"
+         thread_pool.min_threads="1"
+         thread_pool.max_threads="5"
          thread_pool.keep_alive_time="60000"
-         thread_pool.queue_enabled="true"
+         thread_pool.queue_enabled="false"
          thread_pool.queue_max_size="100"
          thread_pool.rejection_policy="Discard"
 

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
    <TCP bind_port="7800"
         port_range="30"
         recv_buf_size="20000000"

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
    <TCP bind_port="7800"
         port_range="30"
         recv_buf_size="20000000"

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
    <UDP
          mcast_addr="${jgroups.udp.mcast_addr:228.6.7.8}"
          mcast_port="${jgroups.udp.mcast_port:46655}"
@@ -20,7 +20,7 @@
          thread_pool.min_threads="1"
          thread_pool.max_threads="5"
          thread_pool.keep_alive_time="60000"
-         thread_pool.queue_enabled="true"
+         thread_pool.queue_enabled="false"
          thread_pool.queue_max_size="100"
          thread_pool.rejection_policy="Discard"
 

--- a/demos/gui/src/main/release/etc/config/jgroups-relay1.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-relay1.xml
@@ -10,7 +10,7 @@
 
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
     <UDP mcast_addr="239.1.1.1"
          mcast_port="${jgroups.udp.mcast_port:45111}"
          tos="8"

--- a/demos/gui/src/main/release/etc/config/jgroups-relay2.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-relay2.xml
@@ -10,7 +10,7 @@
 
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
     <UDP mcast_addr="239.2.2.2"
          mcast_port="${jgroups.udp.mcast_port:45222}"
          tos="8"

--- a/demos/gui/src/main/release/etc/config/jgroups-tcp.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-tcp.xml
@@ -10,7 +10,7 @@
 
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
     <TCP bind_port="7800" port_range="10"
          recv_buf_size="20000000"
          send_buf_size="640000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
  
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
 
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
 
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
 
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
    
    <TCP bind_port="7800" port_range="10"
          recv_buf_size="20000000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
    
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
 
    <TCP  bind_port="7800" port_range="10"
          recv_buf_size="20000000"

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
@@ -1,6 +1,6 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.4.xsd">
+        xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/JGroups-3.6.xsd">
    
    <TCP bind_port="7800" port_range="10"
          recv_buf_size="20000000"

--- a/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/JChannelFactory.java
+++ b/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/JChannelFactory.java
@@ -175,11 +175,11 @@ public class JChannelFactory implements ChannelFactory, ProtocolStackConfigurato
             private Object handle(Message message) {
                 Header header = (Header) message.getHeader(this.id);
                 // If this is a request expecting a response, don't leave the requester hanging - send an identifiable response on which it can filter
-                if ((header != null) && (header.type == Header.REQ) && header.rsp_expected) {
+                if ((header != null) && (header.type == Header.REQ) && header.rspExpected()) {
                     Message response = message.makeReply().setFlag(message.getFlags()).clearFlag(Message.Flag.RSVP, Message.Flag.SCOPED);
 
                     response.putHeader(FORK.ID, message.getHeader(FORK.ID));
-                    response.putHeader(this.id, new Header(Header.RSP, header.id, false, this.id));
+                    response.putHeader(this.id, new Header(Header.RSP, header.req_id, this.id));
                     response.setBuffer(UNKNOWN_FORK_RESPONSE.array());
 
                     channel.down(new Event(Event.MSG, response));


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6068

* Use TCP_NIO2 in the test suite.
* Remove the log4j2 workaround in CommandAwareRpcDispatcher

The test suite seems to much faster with the new version of TCP_NIO2 (and about the same speed as with regular TCP).