### PR TITLE
ISPN-6089 Distributed Stream doesn't operate in parllel locally

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/distribution/DistributionBulkInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/DistributionBulkInterceptor.java
@@ -152,7 +152,7 @@ public class DistributionBulkInterceptor<K, V> extends CommandInterceptor {
          AdvancedCache<K, V> advancedCache = cache.getAdvancedCache();
          ComponentRegistry registry = advancedCache.getComponentRegistry();
          CacheStream<CacheEntry<K, V>> cacheStream = new DistributedCacheStream<>(cache.getCacheManager().getAddress(),
-                 true, advancedCache.getDistributionManager(), () -> entrySet.stream(),
+                 true, advancedCache.getDistributionManager(), () -> entrySet.parallelStream(),
                  registry.getComponent(ClusterStreamManager.class), !command.hasFlag(Flag.SKIP_CACHE_LOAD),
                  cache.getCacheConfiguration().clustering().stateTransfer().chunkSize(),
                  registry.getComponent(Executor.class, ASYNC_OPERATIONS_EXECUTOR), registry);
@@ -193,7 +193,7 @@ public class DistributionBulkInterceptor<K, V> extends CommandInterceptor {
          TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx, dm.getConsistentHash());
 
          CacheStream<CacheEntry<K, V>> cacheStream = new TxDistributedCacheStream<>(cache.getCacheManager().getAddress(),
-                 true, dm, () -> entrySet.stream(), txManager, !command.hasFlag(Flag.SKIP_CACHE_LOAD),
+                 true, dm, () -> entrySet.parallelStream(), txManager, !command.hasFlag(Flag.SKIP_CACHE_LOAD),
                  cache.getCacheConfiguration().clustering().stateTransfer().chunkSize(),
                  registry.getComponent(Executor.class, ASYNC_OPERATIONS_EXECUTOR), registry, ctx);
          return applyTimeOut(cacheStream, cache);
@@ -303,7 +303,7 @@ public class DistributionBulkInterceptor<K, V> extends CommandInterceptor {
          AdvancedCache<K, V> advancedCache = cache.getAdvancedCache();
          ComponentRegistry registry = advancedCache.getComponentRegistry();
          return new DistributedCacheStream<>(cache.getCacheManager().getAddress(), true,
-                 advancedCache.getDistributionManager(), () -> entrySet.stream(),
+                 advancedCache.getDistributionManager(), () -> entrySet.parallelStream(),
                  registry.getComponent(ClusterStreamManager.class), !command.hasFlag(Flag.SKIP_CACHE_LOAD),
                  cache.getCacheConfiguration().clustering().stateTransfer().chunkSize(),
                  registry.getComponent(Executor.class, ASYNC_OPERATIONS_EXECUTOR), registry,
@@ -344,7 +344,7 @@ public class DistributionBulkInterceptor<K, V> extends CommandInterceptor {
          TxClusterStreamManager<K> txManager = new TxClusterStreamManager<>(realManager, ctx, dm.getConsistentHash());
 
          return new TxDistributedCacheStream<>(cache.getCacheManager().getAddress(), true,
-                 dm, () -> entrySet.stream(), txManager, !command.hasFlag(Flag.SKIP_CACHE_LOAD),
+                 dm, () -> entrySet.parallelStream(), txManager, !command.hasFlag(Flag.SKIP_CACHE_LOAD),
                  cache.getCacheConfiguration().clustering().stateTransfer().chunkSize(),
                  registry.getComponent(Executor.class, ASYNC_OPERATIONS_EXECUTOR), registry,
                  StreamMarshalling.entryToKeyFunction(), ctx);

--- a/core/src/main/java/org/infinispan/stream/impl/AbstractCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/AbstractCacheStream.java
@@ -656,7 +656,8 @@ public abstract class AbstractCacheStream<T, S extends BaseStream<T, S>, T_CONS>
          if (excludedKeys != null) {
             return stream.filter(e -> !excludedKeys.contains(e.getKey()));
          }
-         return stream;
+         // Make sure the stream is set to be parallel or not
+         return parallel ? stream.parallel() : stream.sequential();
       };
    }
 


### PR DESCRIPTION
* Set the stream to parallel right away if a parallel stream was invoked
* Set the stream parallel or sequential when retrieving

https://issues.jboss.org/browse/ISPN-6089