### PR TITLE
ISPN-6095 TransportStackConfigurationIT fails with JGroups 3.6.7.Final

### DIFF
--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/transport/TransportStackConfigurationIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/transport/TransportStackConfigurationIT.java
@@ -75,11 +75,11 @@ public class TransportStackConfigurationIT {
 
         assertEquals(true, Boolean.parseBoolean(getAttribute(provider, protocolMBean, "thread_pool.enabled")));
         assertEquals(false, Boolean.parseBoolean(getAttribute(provider, protocolMBean, "thread_pool.queue_enabled")));
-        assertEquals("Discard", getAttribute(provider, protocolMBean, "thread_pool.rejection_policy"));
+        assertEquals("abort", getAttribute(provider, protocolMBean, "thread_pool.rejection_policy"));
 
         assertEquals(true, Boolean.parseBoolean(getAttribute(provider, protocolMBean, "oob_thread_pool.enabled")));
         assertEquals(false, Boolean.parseBoolean(getAttribute(provider, protocolMBean, "oob_thread_pool.queue_enabled")));
-        assertEquals("discard", getAttribute(provider, protocolMBean, "oob_thread_pool.rejection_policy"));
+        assertEquals("abort", getAttribute(provider, protocolMBean, "oob_thread_pool.rejection_policy"));
     }
 
     /*


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6095