### PR TITLE
ISPN-6100 L1 entries not always stored as L1InternalCacheEntry

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/locking/ClusteringDependentLogic.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/ClusteringDependentLogic.java
@@ -26,6 +26,7 @@ import org.infinispan.functional.impl.EntryViews;
 import org.infinispan.functional.impl.FunctionalNotifier;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.metadata.Metadata;
+import org.infinispan.metadata.impl.L1Metadata;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.remoting.rpc.RpcManager;
@@ -516,6 +517,7 @@ public interface ClusteringDependentLogic {
                      metadata = builder
                            .lifespan(configuration.clustering().l1().lifespan())
                            .build();
+                     metadata = new L1Metadata(metadata);
                   }
                } else {
                   doCommit = false;

--- a/core/src/test/java/org/infinispan/distribution/MagicKey.java
+++ b/core/src/test/java/org/infinispan/distribution/MagicKey.java
@@ -103,6 +103,6 @@ public class MagicKey implements Serializable {
 
    @Override
    public String toString() {
-      return "MagicKey#" + name + '{' + Integer.toHexString(hashcode) + '@' + address + '/' + segment + '}';
+      return "MagicKey#" + name + '{' + Integer.toHexString(hashcode) + '/' + segment + '@' + address + '}';
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6100

DistributedClusteringLogic.commitSingleEntry wasn't using L1Metadata
for entries that should have been stored as L1 entries.