### PR TITLE
ISPN-6125 JMX attribute evictions is always zero

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/CacheMgmtInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheMgmtInterceptor.java
@@ -82,7 +82,6 @@ public class CacheMgmtInterceptor extends JmxStatsCommandInterceptor {
       Object returnValue = invokeNextInterceptor(ctx, command);
       if (getStatisticsEnabled(command))
          evictions.increment();
-
       return returnValue;
    }
 
@@ -440,5 +439,8 @@ public class CacheMgmtInterceptor extends JmxStatsCommandInterceptor {
       return super.getStatisticsEnabled() && !cmd.hasFlag(Flag.SKIP_STATISTICS);
    }
 
+   public void addEvictions(long numEvictions) {
+      evictions.add(numEvictions);
+   }
 }
 

--- a/server/integration/testsuite/src/test/resources/config/infinispan/jmx.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/jmx.xml
@@ -20,7 +20,10 @@
                     enabled="true"
                     timeout="600000"/>
         </distributed-cache>
-        <distributed-cache name="memcachedCache" start="EAGER" mode="SYNC" />
+        <distributed-cache name="memcachedCache" start="EAGER" mode="SYNC">
+            <eviction strategy="LRU" size="1" type="COUNT"/>
+            <file-store passivation="true" path="dc" purge="true" shared="false"/>
+        </distributed-cache>
     </cache-container>
     <cache-container name="security"/>
 </subsystem>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6125

I also had another solution which would add new MBean called Eviction, similar to already existing Passivation and Activation. But we would end up with two MBeans for eviction: the already existing which still partially works and the new one). I think the current solution is less invasive and just fixes behaviour of the "evictions" attribute on Statistics MBean. So far it was registering only evictions performed explicitly by cache.evict(). Now it counts all evictions.