### PR TITLE
[master] ISPN-6192 Memory leak caused by RPCs that complete prior to their timeout

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/executors/CachedThreadPoolExecutorFactory.java
+++ b/commons/src/main/java/org/infinispan/commons/executors/CachedThreadPoolExecutorFactory.java
@@ -7,13 +7,9 @@ import java.util.concurrent.ThreadFactory;
 /**
  * @author Galder Zamarreño
  */
-public class CachedThreadPoolExecutorFactory implements ThreadPoolExecutorFactory<ExecutorService> {
+public enum CachedThreadPoolExecutorFactory implements ThreadPoolExecutorFactory<ExecutorService> {
 
-   private static final CachedThreadPoolExecutorFactory INSTANCE = new CachedThreadPoolExecutorFactory();
-
-   private CachedThreadPoolExecutorFactory() {
-      // singleton
-   }
+   INSTANCE;
 
    @Override
    public ExecutorService createExecutor(ThreadFactory factory) {
@@ -28,5 +24,4 @@ public class CachedThreadPoolExecutorFactory implements ThreadPoolExecutorFactor
    public static CachedThreadPoolExecutorFactory create() {
       return INSTANCE;
    }
-
 }

--- a/commons/src/main/java/org/infinispan/commons/executors/ScheduledThreadPoolExecutorFactory.java
+++ b/commons/src/main/java/org/infinispan/commons/executors/ScheduledThreadPoolExecutorFactory.java
@@ -1,23 +1,21 @@
 package org.infinispan.commons.executors;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 
 /**
  * @author Galder Zamarreño
  */
-public class ScheduledThreadPoolExecutorFactory implements ThreadPoolExecutorFactory<ScheduledExecutorService> {
+public enum ScheduledThreadPoolExecutorFactory implements ThreadPoolExecutorFactory<ScheduledExecutorService> {
 
-   private static final ScheduledThreadPoolExecutorFactory INSTANCE = new ScheduledThreadPoolExecutorFactory();
-
-   private ScheduledThreadPoolExecutorFactory() {
-      // singleton
-   }
+   INSTANCE;
 
    @Override
    public ScheduledExecutorService createExecutor(ThreadFactory factory) {
-      return Executors.newSingleThreadScheduledExecutor(factory);
+      ScheduledThreadPoolExecutor result = new ScheduledThreadPoolExecutor(1, factory);
+      result.setRemoveOnCancelPolicy(true);
+      return result;
    }
 
    @Override
@@ -28,5 +26,4 @@ public class ScheduledThreadPoolExecutorFactory implements ThreadPoolExecutorFac
    public static ScheduledThreadPoolExecutorFactory create() {
       return INSTANCE;
    }
-
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6192

Re-instrument singleton pattern using enum.