### PR TITLE
fix Cluster Listener document.

### DIFF
--- a/core/src/main/java/org/infinispan/notifications/Listener.java
+++ b/core/src/main/java/org/infinispan/notifications/Listener.java
@@ -217,8 +217,8 @@ public @interface Listener {
 
    /**
     * Defines whether the annotated listener is clustered or not.
-    * Important: Clustered listener can only be notified for @CacheEntryRemoved, @CacheEntryCreated
-    * and @CacheEntryModified events.
+    * Important: Clustered listener can only be notified for @CacheEntryRemoved, @CacheEntryCreated,
+    * @CacheEntryModified and @CacheEntryExpired events.
     * @return true if the expectation is that this listener is to be a cluster listener, as in it will receive
     *         all notifications for data modifications
     * @since 7.0

--- a/documentation/src/main/asciidoc/user_guide/chapter-53-Using_the_Cache_API.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-53-Using_the_Cache_API.adoc
@@ -205,7 +205,7 @@ public class MyClusterListener { .... }
 
 There are some limitations to cluster listeners from a non clustered listener.
 
-. A cluster listener can only listen to `@CacheEntryModified`, `@CacheEntryCreated` and `@CacheEntryRemoved` events.  Note this means any other type of event will not be listened to for this listener.
+. A cluster listener can only listen to `@CacheEntryModified`, `@CacheEntryCreated`, `@CacheEntryRemoved` and `@CacheEntryExpired` events.  Note this means any other type of event will not be listened to for this listener.
 . Only the post event is sent to a cluster listener, the pre event is ignored.
 
 ===== Event filtering and conversion


### PR DESCRIPTION
That the Cluster Listener supports CacheEntryExpired event was reflected in the document.