### PR TITLE
ISPN-5467 Deprecate existing interceptors

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/ActivationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/ActivationInterceptor.java
@@ -6,6 +6,10 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
+/**
+ * @deprecated Since 8.2, no longer public API.
+ */
+@Deprecated
 public class ActivationInterceptor extends CacheLoaderInterceptor {
 
    private static final Log log = LogFactory.getLog(ActivationInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/BatchingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/BatchingInterceptor.java
@@ -18,8 +18,9 @@ import javax.transaction.TransactionManager;
  * Interceptor that captures batched calls and attaches contexts.
  *
  * @author Manik Surtani (<a href="mailto:manik@jboss.org">manik@jboss.org</a>)
- * @since 4.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class BatchingInterceptor extends CommandInterceptor {
    private BatchContainer batchContainer;
    private TransactionManager transactionManager;

--- a/core/src/main/java/org/infinispan/interceptors/CacheLoaderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheLoaderInterceptor.java
@@ -76,6 +76,10 @@ import org.infinispan.util.TimeService;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
+/**
+ * @deprecated Since 8.2, no longer public API.
+ */
+@Deprecated
 @MBean(objectName = "CacheLoader", description = "Component that handles loading entries from a CacheStore into memory.")
 public class CacheLoaderInterceptor<K, V> extends JmxStatsCommandInterceptor {
    private final AtomicLong cacheLoads = new AtomicLong(0);

--- a/core/src/main/java/org/infinispan/interceptors/CacheMgmtInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheMgmtInterceptor.java
@@ -37,8 +37,9 @@ import org.infinispan.util.logging.LogFactory;
  * Captures cache management statistics
  *
  * @author Jerry Gauthier
- * @since 4.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 @MBean(objectName = "Statistics", description = "General statistics such as timings, hit/miss ratio, etc.")
 public class CacheMgmtInterceptor extends JmxStatsCommandInterceptor {
    private final LongAdder hitTimes = new LongAdder();

--- a/core/src/main/java/org/infinispan/interceptors/CacheWriterInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheWriterInterceptor.java
@@ -64,8 +64,9 @@ import static org.infinispan.persistence.manager.PersistenceManager.AccessMode.P
  * @author Bela Ban
  * @author Dan Berindei
  * @author Mircea Markus
- * @since 4.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 @MBean(objectName = "CacheStore", description = "Component that handles storing of entries to a CacheStore from memory.")
 public class CacheWriterInterceptor extends JmxStatsCommandInterceptor {
    private final boolean trace = getLog().isTraceEnabled();

--- a/core/src/main/java/org/infinispan/interceptors/CallInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CallInterceptor.java
@@ -29,8 +29,9 @@ import org.infinispan.util.logging.LogFactory;
  *
  * @author Bela Ban
  * @author Mircea.Markus@jboss.com
- * @since 4.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class CallInterceptor extends CommandInterceptor {
 
    private static final Log log = LogFactory.getLog(CallInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/ClusteredActivationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/ClusteredActivationInterceptor.java
@@ -15,8 +15,9 @@ import org.infinispan.util.logging.LogFactory;
  * cache loader if needed on a remote node, in certain conditions.
  *
  * @author Manik Surtani
- * @since 5.1
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class ClusteredActivationInterceptor extends ActivationInterceptor {
 
    private static final Log log = LogFactory.getLog(ClusteredActivationInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/ClusteredCacheLoaderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/ClusteredCacheLoaderInterceptor.java
@@ -15,8 +15,9 @@ import org.infinispan.util.logging.LogFactory;
  * cache loader if needed on a remote node, in certain conditions.
  *
  * @author Manik Surtani
- * @since 5.1
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class ClusteredCacheLoaderInterceptor extends CacheLoaderInterceptor {
 
    private static final Log log = LogFactory.getLog(ClusteredActivationInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/ClusteringInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/ClusteringInterceptor.java
@@ -12,8 +12,9 @@ import org.infinispan.util.concurrent.locks.LockManager;
  * Base class for replication and distribution interceptors.
  *
  * @author anistor@redhat.com
- * @since 5.2
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public abstract class ClusteringInterceptor extends BaseRpcInterceptor {
 
    protected CommandsFactory cf;

--- a/core/src/main/java/org/infinispan/interceptors/DeadlockDetectingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/DeadlockDetectingInterceptor.java
@@ -25,8 +25,9 @@ import org.infinispan.util.logging.LogFactory;
  * Note: for local caches, deadlock detection dos NOT work for aggregate operations (clear, putAll).
  *
  * @author Mircea.Markus@jboss.com
- * @since 4.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class DeadlockDetectingInterceptor extends CommandInterceptor {
 
    private static final Log log = LogFactory.getLog(DeadlockDetectingInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/DistCacheWriterInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/DistCacheWriterInterceptor.java
@@ -35,8 +35,9 @@ import static org.infinispan.persistence.manager.PersistenceManager.AccessMode.P
  *
  * @author Galder Zamarreño
  * @author Dan Berindei
- * @since 4.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class DistCacheWriterInterceptor extends CacheWriterInterceptor {
    private DistributionManager dm;
    private Transport transport;

--- a/core/src/main/java/org/infinispan/interceptors/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/EntryWrappingInterceptor.java
@@ -51,8 +51,9 @@ import org.infinispan.xsite.statetransfer.XSiteStateConsumer;
  *
  * @author Mircea Markus
  * @author Pedro Ruivo
- * @since 5.1
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class EntryWrappingInterceptor extends CommandInterceptor {
 
    private EntryFactory entryFactory;

--- a/core/src/main/java/org/infinispan/interceptors/GroupingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/GroupingInterceptor.java
@@ -28,8 +28,9 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * added/removed during the processing of a {@link org.infinispan.commands.remote.GetKeysInGroupCommand}
  *
  * @author Pedro Ruivo
- * @since 7.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class GroupingInterceptor extends CommandInterceptor {
 
    private CacheNotifier<?, ?> cacheNotifier;

--- a/core/src/main/java/org/infinispan/interceptors/InvalidationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/InvalidationInterceptor.java
@@ -52,8 +52,9 @@ import org.infinispan.util.logging.LogFactory;
  * @author Manik Surtani
  * @author Galder Zamarreño
  * @author Mircea.Markus@jboss.com
- * @since 4.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 @MBean(objectName = "Invalidation", description = "Component responsible for invalidating entries on remote caches when entries are written to locally.")
 public class InvalidationInterceptor extends BaseRpcInterceptor implements JmxStatisticsExposer {
    private final AtomicLong invalidations = new AtomicLong(0);

--- a/core/src/main/java/org/infinispan/interceptors/InvocationContextInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/InvocationContextInterceptor.java
@@ -37,7 +37,9 @@ import java.util.Collections;
 /**
  * @author Mircea.Markus@jboss.com
  * @author Galder Zamarreño
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class InvocationContextInterceptor extends CommandInterceptor {
 
    private TransactionManager tm;

--- a/core/src/main/java/org/infinispan/interceptors/IsMarshallableInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/IsMarshallableInterceptor.java
@@ -38,8 +38,9 @@ import org.infinispan.util.logging.LogFactory;
  * with the original request thread.
  *
  * @author Galder Zamarreño
- * @since 4.2
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class IsMarshallableInterceptor extends CommandInterceptor {
 
    private StreamingMarshaller marshaller;

--- a/core/src/main/java/org/infinispan/interceptors/MarshalledValueInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/MarshalledValueInterceptor.java
@@ -60,8 +60,9 @@ import org.infinispan.util.logging.LogFactory;
  * @author Mircea.Markus@jboss.com
  * @author Galder Zamarreño
  * @see org.infinispan.marshall.core.MarshalledValue
- * @since 4.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class MarshalledValueInterceptor<K, V> extends CommandInterceptor {
    private StreamingMarshaller marshaller;
    private boolean wrapKeys = true;

--- a/core/src/main/java/org/infinispan/interceptors/NotificationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/NotificationInterceptor.java
@@ -14,8 +14,9 @@ import org.infinispan.util.logging.LogFactory;
  * The interceptor in charge of firing off notifications to cache listeners
  *
  * @author <a href="mailto:manik@jboss.org">Manik Surtani</a>
- * @since 4.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class NotificationInterceptor extends CommandInterceptor {
    private CacheNotifier notifier;
 

--- a/core/src/main/java/org/infinispan/interceptors/TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/TxInterceptor.java
@@ -80,8 +80,9 @@ import org.infinispan.util.logging.LogFactory;
  * @author <a href="mailto:manik@jboss.org">Manik Surtani (manik@jboss.org)</a>
  * @author Mircea.Markus@jboss.com
  * @see org.infinispan.transaction.xa.TransactionXaAdapter
- * @since 4.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 @MBean(objectName = "Transactions", description = "Component that manages the cache's participation in JTA transactions.")
 public class TxInterceptor<K, V> extends CommandInterceptor implements JmxStatisticsExposer {
 

--- a/core/src/main/java/org/infinispan/interceptors/VersionedEntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/VersionedEntryWrappingInterceptor.java
@@ -22,8 +22,9 @@ import org.infinispan.util.logging.LogFactory;
  * Interceptor in charge with wrapping entries and add them in caller's context.
  *
  * @author Mircea Markus
- * @since 5.1
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class VersionedEntryWrappingInterceptor extends EntryWrappingInterceptor {
 
    protected VersionGenerator versionGenerator;

--- a/core/src/main/java/org/infinispan/interceptors/base/BaseRpcInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/base/BaseRpcInterceptor.java
@@ -28,8 +28,9 @@ import java.util.Set;
  *
  * @author <a href="mailto:manik@jboss.org">Manik Surtani (manik@jboss.org)</a>
  * @author Mircea.Markus@jboss.com
- * @since 4.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public abstract class BaseRpcInterceptor extends CommandInterceptor {
    protected boolean trace = getLog().isTraceEnabled();
 

--- a/core/src/main/java/org/infinispan/interceptors/base/BaseStateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/base/BaseStateTransferInterceptor.java
@@ -25,8 +25,9 @@ import java.util.concurrent.TimeUnit;
  * Also, it has some utilities methods with the most common logic.
  *
  * @author Pedro Ruivo
- * @since 7.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public abstract class BaseStateTransferInterceptor extends CommandInterceptor {
    private final boolean trace = getLog().isTraceEnabled();
 

--- a/core/src/main/java/org/infinispan/interceptors/base/JmxStatsCommandInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/base/JmxStatsCommandInterceptor.java
@@ -9,8 +9,9 @@ import org.infinispan.jmx.annotations.ManagedOperation;
  * Base class for all the interceptors exposing management statistics.
  *
  * @author Mircea.Markus@jboss.com
- * @since 4.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public abstract class JmxStatsCommandInterceptor extends CommandInterceptor implements JmxStatisticsExposer {
    @ManagedAttribute(description = "Enables or disables the gathering of statistics by this component", writable = true)
    private boolean statisticsEnabled = false;

--- a/core/src/main/java/org/infinispan/interceptors/compat/BaseTypeConverterInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/compat/BaseTypeConverterInterceptor.java
@@ -51,8 +51,9 @@ import java.util.stream.StreamSupport;
  * to provide a suitable TypeConverter.
  *
  * @author Galder Zamarreño
- * @since 6.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public abstract class BaseTypeConverterInterceptor<K, V> extends CommandInterceptor {
 
    private InternalEntryFactory entryFactory;

--- a/core/src/main/java/org/infinispan/interceptors/compat/TypeConverterInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/compat/TypeConverterInterceptor.java
@@ -18,8 +18,9 @@ import org.infinispan.util.logging.LogFactory;
  * An interceptor that applies type conversion to the data stored in the cache.
  *
  * @author Galder Zamarreño
- * @since 5.3
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class TypeConverterInterceptor<K, V> extends BaseTypeConverterInterceptor<K, V> {
 
    // No need for a REST type converter since the REST server itself does

--- a/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
@@ -65,8 +65,9 @@ import static org.infinispan.commons.util.Util.toStr;
  * @author Mircea.Markus@jboss.com
  * @author Pete Muir
  * @author Dan Berindei <dan@infinispan.org>
- * @since 4.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public abstract class BaseDistributionInterceptor extends ClusteringInterceptor {
 
    protected DistributionManager dm;

--- a/core/src/main/java/org/infinispan/interceptors/distribution/DistributionBulkInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/DistributionBulkInterceptor.java
@@ -44,7 +44,9 @@ import static org.infinispan.factories.KnownComponentNames.ASYNC_OPERATIONS_EXEC
  * distributed processing through the cluster.
  * @param <K> The key type of entries
  * @param <V> The value type of entries
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class DistributionBulkInterceptor<K, V> extends CommandInterceptor {
    private Cache<K, V> cache;
 

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1LastChanceInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1LastChanceInterceptor.java
@@ -35,8 +35,9 @@ import java.util.concurrent.Future;
  * container
  *
  * @author wburns
- * @since 6.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class L1LastChanceInterceptor extends BaseRpcInterceptor {
 
    private static final Log log = LogFactory.getLog(L1NonTxInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1NonTxInterceptor.java
@@ -44,8 +44,9 @@ import java.util.concurrent.TimeoutException;
  *
  * @author Mircea Markus
  * @author William Burns
- * @since 5.2
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class L1NonTxInterceptor extends BaseRpcInterceptor {
 
    private static final Log log = LogFactory.getLog(L1NonTxInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/distribution/L1TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/L1TxInterceptor.java
@@ -19,8 +19,9 @@ import static org.infinispan.commons.util.Util.toStr;
  * Interceptor that handles L1 logic for transactional caches.
  *
  * @author William Burns
- * @since 6.0
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class L1TxInterceptor extends L1NonTxInterceptor {
 
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/distribution/NonTxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/NonTxDistributionInterceptor.java
@@ -54,8 +54,9 @@ import java.util.concurrent.TimeoutException;
  * consistent-hash aware hotrod clients which connect directly to the lock owner.
  *
  * @author Mircea Markus
- * @since 5.2
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class NonTxDistributionInterceptor extends BaseDistributionInterceptor {
 
    private static Log log = LogFactory.getLog(NonTxDistributionInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -55,8 +55,9 @@ import static org.infinispan.util.DeltaCompositeKeyUtil.getAffectedKeysFromConte
  * Handles the distribution of the transactional caches.
  *
  * @author Mircea Markus
- * @since 5.2
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class TxDistributionInterceptor extends BaseDistributionInterceptor {
 
    private static Log log = LogFactory.getLog(TxDistributionInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/distribution/VersionedDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/VersionedDistributionInterceptor.java
@@ -18,8 +18,9 @@ import static org.infinispan.transaction.impl.WriteSkewHelper.readVersionsFromRe
  * A version of the {@link TxDistributionInterceptor} that adds logic to handling prepares when entries are versioned.
  *
  * @author Manik Surtani
- * @since 5.1
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class VersionedDistributionInterceptor extends TxDistributionInterceptor {
 
    private static final Log log = LogFactory.getLog(VersionedDistributionInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/locking/AbstractLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/AbstractLockingInterceptor.java
@@ -35,8 +35,9 @@ import java.util.stream.Stream;
  * Base class for various locking interceptors in this package.
  *
  * @author Mircea Markus
- * @since 5.1
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public abstract class AbstractLockingInterceptor extends CommandInterceptor {
    private boolean trace = getLog().isTraceEnabled();
 

--- a/core/src/main/java/org/infinispan/interceptors/locking/AbstractTxLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/AbstractTxLockingInterceptor.java
@@ -26,8 +26,9 @@ import java.util.concurrent.TimeUnit;
  * Base class for transaction based locking interceptors.
  *
  * @author Mircea.Markus@jboss.com
- * @since 5.1
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public abstract class AbstractTxLockingInterceptor extends AbstractLockingInterceptor {
    private boolean trace = getLog().isTraceEnabled();
 

--- a/core/src/main/java/org/infinispan/interceptors/locking/NonTransactionalLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/NonTransactionalLockingInterceptor.java
@@ -13,8 +13,9 @@ import org.infinispan.util.logging.LogFactory;
  * Locking interceptor to be used for non-transactional caches.
  *
  * @author Mircea Markus
- * @since 5.1
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class NonTransactionalLockingInterceptor extends AbstractLockingInterceptor {
 
    private static final Log log = LogFactory.getLog(NonTransactionalLockingInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/locking/OptimisticLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/OptimisticLockingInterceptor.java
@@ -26,8 +26,9 @@ import java.util.Collection;
  * Locking interceptor to be used by optimistic transactional caches.
  *
  * @author Mircea Markus
- * @since 5.1
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class OptimisticLockingInterceptor extends AbstractTxLockingInterceptor {
 
    private boolean needToMarkReads;

--- a/core/src/main/java/org/infinispan/interceptors/locking/PessimisticLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/PessimisticLockingInterceptor.java
@@ -41,8 +41,9 @@ import java.util.Set;
  * in the case of keys being locked.
  *
  * @author Mircea Markus
- * @since 5.1
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class PessimisticLockingInterceptor extends AbstractTxLockingInterceptor {
 
    private CommandsFactory cf;

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderDistributionInterceptor.java
@@ -17,8 +17,9 @@ import java.util.Collection;
  * order based protocol is enabled
  *
  * @author Pedro Ruivo
- * @since 5.3
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class TotalOrderDistributionInterceptor extends TxDistributionInterceptor {
 
    private static final Log log = LogFactory.getLog(TotalOrderDistributionInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderInterceptor.java
@@ -30,8 +30,9 @@ import java.util.Collection;
  *
  * @author Pedro Ruivo
  * @author Mircea.Markus@jboss.com
- * @since 5.3
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class TotalOrderInterceptor extends CommandInterceptor {
 
    private static final Log log = LogFactory.getLog(TotalOrderInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderStateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderStateTransferInterceptor.java
@@ -12,8 +12,9 @@ import org.infinispan.util.logging.LogFactory;
  * Synchronizes the incoming totally ordered transactions with the state transfer.
  *
  * @author Pedro Ruivo
- * @since 5.3
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class TotalOrderStateTransferInterceptor extends BaseStateTransferInterceptor {
 
    private static final Log log = LogFactory.getLog(TotalOrderStateTransferInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedDistributionInterceptor.java
@@ -21,8 +21,9 @@ import java.util.Collection;
  * (i.e., the write skew check passes in all keys owners)
  *
  * @author Pedro Ruivo
- * @since 5.3
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class TotalOrderVersionedDistributionInterceptor extends VersionedDistributionInterceptor {
 
    private static final Log log = LogFactory.getLog(TotalOrderVersionedDistributionInterceptor.class);

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedEntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderVersionedEntryWrappingInterceptor.java
@@ -26,8 +26,9 @@ import java.util.ArrayList;
  *
  * @author Mircea.Markus@jboss.com
  * @author Pedro Ruivo
- * @since 5.3
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class TotalOrderVersionedEntryWrappingInterceptor extends VersionedEntryWrappingInterceptor {
 
    private static final Log log = LogFactory.getLog(TotalOrderVersionedEntryWrappingInterceptor.class);

--- a/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateTransferInterceptor.java
@@ -58,8 +58,9 @@ import java.util.function.Consumer;
  *
  * @author anistor@redhat.com
  * @author Dan Berindei
- * @since 5.2
+ * @deprecated Since 8.2, no longer public API.
  */
+@Deprecated
 public class StateTransferInterceptor extends BaseStateTransferInterceptor {
 
    private static final Log log = LogFactory.getLog(StateTransferInterceptor.class);

--- a/core/src/main/java/org/infinispan/statetransfer/package-info.java
+++ b/core/src/main/java/org/infinispan/statetransfer/package-info.java
@@ -1,4 +1,6 @@
 /**
  * Transfer of state to new caches in a cluster.
+ *
+ * @private
  */
 package org.infinispan.statetransfer;


### PR DESCRIPTION
The ISPN-5467 pull request is not quite ready, performance-wise.

This pull request only deprecates the interceptors, to alert users that the implementation may change at any time. We will still allow custom interceptors after ISPN-5467/ISPN-5468, but users depending on an existing interceptor (e.g. for positioning their custom interceptor) may need to change their code.