### PR TITLE
ISPN-6238 TxInterceptor won't enlist a tx with Status.STATUS_MARKED_ROLLBACK

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/TxInterceptor.java
@@ -400,9 +400,15 @@ public class TxInterceptor<K, V> extends CommandInterceptor implements JmxStatis
    }
 
    private boolean isNotValid(int status) {
-      return status != Status.STATUS_ACTIVE
-            && status != Status.STATUS_PREPARING
-            && status != Status.STATUS_COMMITTING;
+      switch (status) {
+         case Status.STATUS_ACTIVE:
+         case Status.STATUS_MARKED_ROLLBACK:
+         case Status.STATUS_PREPARING:
+         case Status.STATUS_COMMITTING:
+            return false;
+         default:
+            return true;
+      }
    }
 
    private static boolean shouldEnlist(InvocationContext ctx) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6238

A cache should still be able to enlist a tx marked as rollback-only to perform reads.

Please cherry-pick into 8.1.x.