### PR TITLE
ISPN-6249 Streams filter key segments with using count can cause

### DIFF
--- a/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
@@ -7,6 +7,8 @@ import org.infinispan.CacheStream;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.entries.ImmortalCacheEntry;
+import org.infinispan.distribution.DistributionManager;
+import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
@@ -1968,5 +1970,30 @@ public abstract class BaseStreamTest extends MultipleCacheManagersTest {
       }
       assertEquals(range + 1, halfCount);
       assertEquals(range * 2, pos);
+   }
+
+   public void testKeySegmentFilter() {
+      Cache<Integer, String> cache = getCache(0);
+      int range = 12;
+      // First populate the cache with a bunch of values
+      IntStream.range(0, range).boxed().forEach(i -> cache.put(i, i + "-value"));
+
+      assertEquals(range, cache.size());
+      CacheSet<Map.Entry<Integer, String>> entrySet = cache.entrySet();
+
+      // Take the first half of the segments
+      int segments = cache.getCacheConfiguration().clustering().hash().numSegments() / 2;
+      AtomicInteger realCount = new AtomicInteger();
+
+      DistributionManager dm = cache.getAdvancedCache().getComponentRegistry().getComponent(DistributionManager.class);
+      ConsistentHash ch = dm.getConsistentHash();
+      cache.forEach((k, v) -> {
+         if (segments >= ch.getSegment(k)) {
+            realCount.incrementAndGet();
+         }
+      });
+
+      assertEquals(realCount.get(), createStream(entrySet).filterKeySegments(
+              IntStream.range(0, segments).boxed().collect(Collectors.toSet())).count());
    }
 }


### PR DESCRIPTION
deadlock issues

* Make sure processed segments are checked when completing

https://issues.jboss.org/browse/ISPN-6249