### PR TITLE
ISPN-6210 Make the ScriptingManager use an unwrapped cache when security is enabled

### DIFF
--- a/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
+++ b/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
@@ -57,6 +57,11 @@ public final class SecureCacheImpl<K, V> implements SecureCache<K, V> {
       this.delegate = delegate;
    }
 
+   public AdvancedCache<K, V> getDelegate() {
+      authzManager.checkPermission(AuthorizationPermission.ADMIN);
+      return delegate;
+   }
+
    @Override
    public boolean startBatch() {
       authzManager.checkPermission(AuthorizationPermission.WRITE);
@@ -309,13 +314,13 @@ public final class SecureCacheImpl<K, V> implements SecureCache<K, V> {
       authzManager.checkPermission(AuthorizationPermission.WRITE);
       delegate.putForExternalRead(key, value);
    }
-   
+
    @Override
    public void putForExternalRead(K key, V value, long lifespan, TimeUnit unit) {
       authzManager.checkPermission(AuthorizationPermission.WRITE);
       delegate.putForExternalRead(key, value);
    }
-   
+
    @Override
    public void putForExternalRead(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
       authzManager.checkPermission(AuthorizationPermission.WRITE);

--- a/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingManagerImpl.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingManagerImpl.java
@@ -51,7 +51,7 @@ public class ScriptingManagerImpl implements ScriptingManager {
    private ScriptEngineManager scriptEngineManager;
    private ConcurrentMap<String, ScriptEngine> scriptEnginesByExtension = CollectionFactory.makeConcurrentMap(2);
    private ConcurrentMap<String, ScriptEngine> scriptEnginesByLanguage = CollectionFactory.makeConcurrentMap(2);
-   Cache<String, String> scriptCache;
+   private Cache<String, String> scriptCache;
    ConcurrentMap<String, CompiledScript> compiledScripts = CollectionFactory.makeConcurrentMap();
    private AuthorizationHelper globalAuthzHelper;
 
@@ -69,7 +69,7 @@ public class ScriptingManagerImpl implements ScriptingManager {
 
    Cache<String, String> getScriptCache() {
       if (scriptCache == null) {
-         scriptCache = cacheManager.getCache(SCRIPT_CACHE);
+         scriptCache = SecurityActions.getUnwrappedCache(cacheManager.getCache(SCRIPT_CACHE));
       }
       return scriptCache;
    }

--- a/scripting/src/main/java/org/infinispan/scripting/impl/SecurityActions.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/SecurityActions.java
@@ -4,6 +4,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 import org.infinispan.AdvancedCache;
+import org.infinispan.Cache;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -12,6 +13,7 @@ import org.infinispan.security.Security;
 import org.infinispan.security.actions.GetCacheAuthorizationManagerAction;
 import org.infinispan.security.actions.GetCacheEntryAction;
 import org.infinispan.security.actions.GetGlobalComponentRegistryAction;
+import org.infinispan.security.impl.SecureCacheImpl;
 
 /**
  * SecurityActions for the org.infinispan.scripting.impl package.
@@ -44,5 +46,13 @@ final class SecurityActions {
    static <K, V> CacheEntry<K, V> getCacheEntry(final AdvancedCache<K, V> cache, K key) {
       GetCacheEntryAction<K, V> action = new GetCacheEntryAction<K, V>(cache, key);
       return doPrivileged(action);
+   }
+
+   static <K, V> Cache<K, V> getUnwrappedCache(final Cache<K, V> cache) {
+      if (cache instanceof SecureCacheImpl) {
+         return doPrivileged(() ->  ((SecureCacheImpl)cache).getDelegate() );
+      } else {
+         return cache;
+      }
    }
 }

--- a/scripting/src/test/java/org/infinispan/scripting/SecureScriptingTaskManagerTest.java
+++ b/scripting/src/test/java/org/infinispan/scripting/SecureScriptingTaskManagerTest.java
@@ -107,7 +107,6 @@ public class SecureScriptingTaskManagerTest extends SingleCacheManagerTest {
         });
     }
 
-    @Test(enabled = false, description = "Is disabled until the bug ISPN-6210 is fixed.")
     public void testTask() throws Exception {
         Security.doAs(PHEIDIPPIDES, new PrivilegedExceptionAction<Void>() {
             @Override
@@ -124,7 +123,7 @@ public class SecureScriptingTaskManagerTest extends SingleCacheManagerTest {
         assertEquals(1, tasks.size());
 
         ScriptTask scriptTask = (ScriptTask) tasks.get(0);
-        assertEquals("testRole.js", scriptTask.getName());
+        assertEquals(SCRIPT_NAME, scriptTask.getName());
         assertEquals(TaskExecutionMode.ONE_NODE, scriptTask.getExecutionMode());
         assertEquals("Script", scriptTask.getType());
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6210