### PR TITLE
ISPN-6254 State transfer hangs after CacheNotFoundResponse

### DIFF
--- a/core/src/main/java/org/infinispan/executors/SemaphoreCompletionService.java
+++ b/core/src/main/java/org/infinispan/executors/SemaphoreCompletionService.java
@@ -60,7 +60,7 @@ public class SemaphoreCompletionService<T> implements CompletionService<T> {
     */
    public void continueTaskInBackground() {
       if (trace) log.tracef("Moving task to background, available permits %d", semaphore.availablePermits());
-      //
+      // Prevent other tasks from running with this task's permit
       semaphore.removePermit();
    }
 
@@ -158,7 +158,6 @@ public class SemaphoreCompletionService<T> implements CompletionService<T> {
             } while (next != null);
          } finally {
             semaphore.release();
-            if (trace) log.tracef("All queued tasks finished, available permits %d", semaphore.availablePermits());
 
             // In case we just got a new task between queue.poll() and semaphore.release()
             if (!queue.isEmpty()) {

--- a/core/src/main/java/org/infinispan/statetransfer/InboundTransferTask.java
+++ b/core/src/main/java/org/infinispan/statetransfer/InboundTransferTask.java
@@ -124,13 +124,14 @@ public class InboundTransferTask {
 
    /**
     * Send START_STATE_TRANSFER request to source node.
+    *
+    * @return {@code true} if the transfer was started, otherwise {@code false}
     */
    public boolean requestSegments() {
       if (!isCancelled && isStarted.compareAndSet(false, true)) {
          Set<Integer> segmentsCopy = getSegments();
          if (segmentsCopy.isEmpty()) {
             log.tracef("Segments list is empty, skipping source %s", source);
-            return true;
          }
          if (trace) {
             log.tracef("Requesting segments %s of cache %s from node %s", segmentsCopy, cacheName, source);
@@ -145,16 +146,13 @@ public class InboundTransferTask {
                if (trace) {
                   log.tracef("Successfully requested segments %s of cache %s from node %s", segmentsCopy, cacheName, source);
                }
-               return true;
             }
             log.failedToRequestSegments(segmentsCopy, cacheName, source, new CacheException(String.valueOf(response)));
          } catch (Exception e) {
             log.failedToRequestSegments(segmentsCopy, cacheName, source, e);
          }
-         return false;
-      } else {
-         return true;
       }
+      return isStartedSuccessfully;
    }
 
    /**
@@ -263,6 +261,10 @@ public class InboundTransferTask {
 
    public boolean isCompletedSuccessfully() {
       return isCompletedSuccessfully;
+   }
+
+   public boolean isStartedSuccessfully() {
+      return isStartedSuccessfully;
    }
 
    /**


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6254

Only call SemaphoreCompletionService.continueTaskInBackground() if
the START_STATE_TRANSFER command was successful.