### PR TITLE
ISPN-6260 Add example configurations to domain config

### DIFF
--- a/cdi/embedded/src/test/java/org/infinispan/cdi/test/cachemanager/registration/CacheRegistrationTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/test/cachemanager/registration/CacheRegistrationTest.java
@@ -32,7 +32,7 @@ public class CacheRegistrationTest extends Arquillian {
 
    @Inject
    private EmbeddedCacheManager defaultCacheManager;
-   
+
    @Inject
    private Cache<String, String> cache;
 
@@ -43,8 +43,8 @@ public class CacheRegistrationTest extends Arquillian {
    public void testCacheRegistrationInDefaultCacheManager() {
        // Make sure the cache is registered
       cache.put("foo", "bar");
-      
-      final Set<String> cacheNames = defaultCacheManager.getCacheNames();
+
+      final Set<String> cacheNames = defaultCacheManager.getCacheConfigurationNames();
 
       assertEquals(cacheNames.size(), 2);
       assertTrue(cacheNames.contains("small"));
@@ -54,7 +54,7 @@ public class CacheRegistrationTest extends Arquillian {
    public void testCacheRegistrationInSpecificCacheManager() {
       // Make sure the cache is registered
       cache.put("foo", "bar");
-      final Set<String> cacheNames = specificCacheManager.getCacheNames();
+      final Set<String> cacheNames = specificCacheManager.getCacheConfigurationNames();
 
       assertEquals(cacheNames.size(), 1);
       assertTrue(cacheNames.contains("very-large"));

--- a/cdi/remote/src/test/java/org/infinispan/cdi/test/cache/remote/NamedCacheTest.java
+++ b/cdi/remote/src/test/java/org/infinispan/cdi/test/cache/remote/NamedCacheTest.java
@@ -56,6 +56,7 @@ public class NamedCacheTest extends Arquillian {
             hotRodCacheConfiguration(TestCacheManagerFactory
                   .getDefaultCacheConfiguration(false)));
       embeddedCacheManager.defineConfiguration("small", embeddedCacheManager.getDefaultCacheConfiguration());
+      embeddedCacheManager.getCache("small");
       hotRodServer = startHotRodServer(embeddedCacheManager);
    }
 

--- a/cdi/remote/src/test/java/org/infinispan/cdi/test/cache/remote/SpecificCacheManagerTest.java
+++ b/cdi/remote/src/test/java/org/infinispan/cdi/test/cache/remote/SpecificCacheManagerTest.java
@@ -51,6 +51,7 @@ public class SpecificCacheManagerTest extends Arquillian {
             hotRodCacheConfiguration(TestCacheManagerFactory
                   .getDefaultCacheConfiguration(false)));
       embeddedCacheManager.defineConfiguration("small", embeddedCacheManager.getDefaultCacheConfiguration());
+      embeddedCacheManager.getCache("small");
       hotRodServer = startHotRodServer(embeddedCacheManager);
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheManagerStoppedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/CacheManagerStoppedTest.java
@@ -32,6 +32,7 @@ public class CacheManagerStoppedTest extends SingleCacheManagerTest {
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       cacheManager = TestCacheManagerFactory.createCacheManager(hotRodCacheConfiguration());
       cacheManager.defineConfiguration(CACHE_NAME, hotRodCacheConfiguration().build());
+      cacheManager.getCache(CACHE_NAME);
       hotrodServer = HotRodClientTestingUtil.startHotRodServer(cacheManager);
       remoteCacheManager = new RemoteCacheManager("localhost:" + hotrodServer.getPort(), true);
       return cacheManager;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientAsymmetricClusterTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ClientAsymmetricClusterTest.java
@@ -28,6 +28,7 @@ public class ClientAsymmetricClusterTest extends MultiHotRodServersTest {
 
       // Define replicated cache in only one of the nodes
       manager(0).defineConfiguration(CACHE_NAME, builder.build());
+      manager(0).getCache(CACHE_NAME);
    }
 
    public void testAsymmetricCluster() {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodIntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/HotRodIntegrationTest.java
@@ -52,6 +52,7 @@ public class HotRodIntegrationTest extends SingleCacheManagerTest {
       EmbeddedCacheManager cm = TestCacheManagerFactory
             .createCacheManager(hotRodCacheConfiguration());
       cm.defineConfiguration(CACHE_NAME, builder.build());
+      cm.getCache(CACHE_NAME);
       return cm;
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/LockingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/LockingTest.java
@@ -60,6 +60,7 @@ public class LockingTest extends SingleCacheManagerTest {
       for (CacheName cacheName : CacheName.values()) {
          cacheName.configure(builder);
          cacheManager.defineConfiguration(cacheName.name(), builder.build());
+         cacheManager.getCache(cacheName.name());
       }
       return cacheManager;
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerLeakTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerLeakTest.java
@@ -22,6 +22,7 @@ public class ClientListenerLeakTest extends SingleHotRodServerTest {
       ConfigurationBuilder cfg = hotRodCacheConfiguration();
       cacheName = this.getClass().getSimpleName();
       cm.defineConfiguration(cacheName, cfg.build());
+      cm.getCache(cacheName);
       return cm;
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultiHotRodServerIspnDirQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultiHotRodServerIspnDirQueryTest.java
@@ -30,6 +30,7 @@ public class MultiHotRodServerIspnDirQueryTest extends MultiHotRodServerQueryTes
 
       for (EmbeddedCacheManager cm : cacheManagers) {
          cm.defineConfiguration(TEST_CACHE, builder.build());
+         cm.getCache(TEST_CACHE);
       }
 
       waitForClusterToForm();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultiHotRodServerIspnDirReplQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultiHotRodServerIspnDirReplQueryTest.java
@@ -28,6 +28,7 @@ public class MultiHotRodServerIspnDirReplQueryTest extends MultiHotRodServerIspn
 
       for (EmbeddedCacheManager cm : cacheManagers) {
          cm.defineConfiguration(TEST_CACHE, builder.build());
+         cm.getCache(TEST_CACHE);
       }
 
       waitForClusterToForm();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/MultiHotRodServersTest.java
@@ -116,7 +116,9 @@ public abstract class MultiHotRodServersTest extends MultipleCacheManagersTest {
    }
 
    protected void defineInAll(String cacheName, ConfigurationBuilder builder) {
-      for (HotRodServer server : servers)
+      for (HotRodServer server : servers) {
          server.getCacheManager().defineConfiguration(cacheName, builder.build());
+         server.getCacheManager().getCache(cacheName);
+      }
    }
 }

--- a/core/src/main/java/org/infinispan/configuration/ConfigurationManager.java
+++ b/core/src/main/java/org/infinispan/configuration/ConfigurationManager.java
@@ -8,9 +8,11 @@ import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 import static org.infinispan.commons.api.BasicCacheContainer.DEFAULT_CACHE_NAME;
 
@@ -85,6 +87,14 @@ public class ConfigurationManager {
    }
 
    public Collection<String> getDefinedCaches() {
+      List<String> cacheNames = namedConfiguration.entrySet().stream()
+            .filter(entry -> !entry.getValue().isTemplate())
+            .map(entry -> entry.getKey())
+            .collect(Collectors.toList());
+      return Collections.unmodifiableCollection(cacheNames);
+   }
+
+   public Collection<String> getDefinedConfigurations() {
       return Collections.unmodifiableCollection(namedConfiguration.keySet());
    }
 }

--- a/core/src/main/java/org/infinispan/factories/RecoveryManagerFactory.java
+++ b/core/src/main/java/org/infinispan/factories/RecoveryManagerFactory.java
@@ -45,7 +45,7 @@ public class RecoveryManagerFactory extends AbstractNamedCacheComponentFactory i
          //if use a defined cache
          if (!useDefaultCache) {
             // check to see that the cache is defined
-            if (!cm.getCacheNames().contains(recoveryCacheName)) {
+            if (!cm.getCacheConfigurationNames().contains(recoveryCacheName)) {
                throw new CacheConfigurationException("Recovery cache (" + recoveryCacheName + ") does not exist!!");
             }
          } else {

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -757,7 +757,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
    @Override
    public Set<String> getCacheNames() {
       // Get the XML/programmatically defined caches
-      Set<String> names = new HashSet<>(); //configurationManager.getDefinedCaches());
+      Set<String> names = new HashSet<>(configurationManager.getDefinedCaches());
       // Add the caches created dynamically without explicit config
       // Since caches could be modified dynamically, make a safe copy of keys
       names.addAll(Immutables.immutableSetConvert(caches.keySet()));

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -381,6 +381,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
          builder.read(defaultConfigIfNotPresent);
       }
       builder.read(configOverride);
+      builder.template(configOverride.isTemplate());
       return configurationManager.putConfiguration(cacheName, builder);
    }
 
@@ -756,10 +757,23 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
    @Override
    public Set<String> getCacheNames() {
       // Get the XML/programmatically defined caches
-      Set<String> names = new HashSet<>(configurationManager.getDefinedCaches());
+      Set<String> names = new HashSet<>(); //configurationManager.getDefinedCaches());
       // Add the caches created dynamically without explicit config
       // Since caches could be modified dynamically, make a safe copy of keys
       names.addAll(Immutables.immutableSetConvert(caches.keySet()));
+      names.remove(DEFAULT_CACHE_NAME);
+      InternalCacheRegistry internalCacheRegistry = globalComponentRegistry.getComponent(InternalCacheRegistry.class);
+      internalCacheRegistry.filterPrivateCaches(names);
+      if (names.isEmpty())
+         return Collections.emptySet();
+      else
+         return Immutables.immutableSetWrap(names);
+   }
+
+   @Override
+   public Set<String> getCacheConfigurationNames() {
+      // Get the XML/programmatically defined caches
+      Set<String> names = new HashSet<>(configurationManager.getDefinedConfigurations());
       names.remove(DEFAULT_CACHE_NAME);
       InternalCacheRegistry internalCacheRegistry = globalComponentRegistry.getComponent(InternalCacheRegistry.class);
       internalCacheRegistry.filterPrivateCaches(names);
@@ -800,7 +814,22 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
       return result.toString();
    }
 
-   @ManagedAttribute(description = "The total number of defined caches, excluding the default cache.", displayName = "Number of caches defined", displayType = DisplayType.SUMMARY)
+   @ManagedAttribute(description = "The defined cache configuration names.", displayName = "List of defined cache configurations", dataType = DataType.TRAIT, displayType = DisplayType.SUMMARY)
+   public String getDefinedCacheConfigurationNames() {
+      StringBuilder result = new StringBuilder("[");
+      boolean comma = false;
+      for (String cacheName : getCacheConfigurationNames()) {
+         if (comma)
+            result.append(",");
+         else
+            comma = true;
+         result.append(cacheName);
+      }
+      result.append("]");
+      return result.toString();
+   }
+
+   @ManagedAttribute(description = "The total number of defined cache configurations.", displayName = "Number of caches defined", displayType = DisplayType.SUMMARY)
    public String getDefinedCacheCount() {
       return String.valueOf(configurationManager.getDefinedCaches().size());
    }

--- a/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
@@ -155,12 +155,31 @@ public interface EmbeddedCacheManager extends CacheContainer, Listenable {
     *
     * If no named caches are registered or no caches have been created, this
     * method returns an empty set.  The default cache is never included in this
-    * set of cache names.
+    * set of cache names, as well a caches for internal-only use {@link org.infinispan.registry.InternalCacheRegistry}
     *
     * @return an immutable set of non-default named caches registered or
     * created with this cache manager.
     */
    Set<String> getCacheNames();
+
+   /**
+    * This method returns a collection of cache configuration names which contains the
+    * cache configurations that have been defined via XML or programmatically, and the
+    * cache configurations that have been defined at runtime via this cache manager
+    * instance.
+    *
+    * If no cache configurations are registered or no caches have been created, this
+    * method returns an empty set.  The default cache is never included in this
+    * set of cache names, as well a caches for internal-only use {@link org.infinispan.registry.InternalCacheRegistry}
+    *
+    * @return an immutable set of non-default named caches registered or
+    * created with this cache manager.
+    *
+    * @since 8.2
+    */
+   default Set<String> getCacheConfigurationNames() {
+      throw new UnsupportedOperationException();
+   }
 
    /**
     * Tests whether a named cache is running.
@@ -216,7 +235,7 @@ public interface EmbeddedCacheManager extends CacheContainer, Listenable {
     * the same configuration.
     *
     * @param cacheName name of cache to retrieve
-    * @param configurationTemplate name of the configuration template to use
+    * @param configurationName name of the configuration template to use
     * @return null if no configuration exists as per rules set above, otherwise
     *         returns a cache instance identified by cacheName
     */

--- a/core/src/main/java/org/infinispan/manager/impl/AbstractDelegatingEmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/impl/AbstractDelegatingEmbeddedCacheManager.java
@@ -4,6 +4,7 @@ import org.infinispan.Cache;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.manager.ClusterExecutor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.Transport;
@@ -95,6 +96,16 @@ public class AbstractDelegatingEmbeddedCacheManager implements EmbeddedCacheMana
    @Override
    public Set<String> getCacheNames() {
       return cm.getCacheNames();
+   }
+
+   @Override
+   public Set<String> getCacheConfigurationNames() {
+      return cm.getCacheConfigurationNames();
+   }
+
+   @Override
+   public ClusterExecutor executor() {
+      return cm.executor();
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/jmx/CacheManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheManagerMBeanTest.java
@@ -75,7 +75,7 @@ public class CacheManagerMBeanTest extends SingleCacheManagerTest {
       attribute = (String) server.getAttribute(name, "DefinedCacheNames");
       assertTrue(attribute.contains("a("));
       assertTrue(attribute.contains("b("));
-      assertFalse(attribute.contains("c("));
+      assertTrue(attribute.contains("c("));
    }
 
    public void testJmxOperationMetadata() throws Exception {

--- a/core/src/test/java/org/infinispan/jmx/CacheManagerMBeanTest.java
+++ b/core/src/test/java/org/infinispan/jmx/CacheManagerMBeanTest.java
@@ -1,8 +1,10 @@
 package org.infinispan.jmx;
 
+import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.assertFalse;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import org.infinispan.Cache;
@@ -58,21 +60,22 @@ public class CacheManagerMBeanTest extends SingleCacheManagerTest {
       assert server.getAttribute(name, "CreatedCacheCount").equals("1");
       assert server.getAttribute(name, "DefinedCacheCount").equals("3");
       assert server.getAttribute(name, "RunningCacheCount").equals("1");
-      String attribute = (String) server.getAttribute(name, "DefinedCacheNames");
-      assert attribute.contains("a(");
-      assert attribute.contains("b(");
-      assert attribute.contains("c(");
+      String attribute = (String) server.getAttribute(name, "DefinedCacheConfigurationNames");
+      String names[] = attribute.substring(1, attribute.length()-1).split(",");
+      assertTrue(Arrays.binarySearch(names, "a") >= 0);
+      assertTrue(Arrays.binarySearch(names, "b") >= 0);
+      assertTrue(Arrays.binarySearch(names, "c") >= 0);
 
       //now start some caches
       server.invoke(name, "startCache", new Object[]{"a"}, new String[]{String.class.getName()});
       server.invoke(name, "startCache", new Object[]{"b"}, new String[]{String.class.getName()});
-      assert server.getAttribute(name, "CreatedCacheCount").equals("3");
-      assert server.getAttribute(name, "DefinedCacheCount").equals("3");
-      assert server.getAttribute(name, "RunningCacheCount").equals("3");
+      assertEquals("3", server.getAttribute(name, "CreatedCacheCount"));
+      assertEquals("3", server.getAttribute(name, "DefinedCacheCount"));
+      assertEquals("3", server.getAttribute(name, "RunningCacheCount"));
       attribute = (String) server.getAttribute(name, "DefinedCacheNames");
-      assert attribute.contains("a(");
-      assert attribute.contains("b(");
-      assert attribute.contains("c(");
+      assertTrue(attribute.contains("a("));
+      assertTrue(attribute.contains("b("));
+      assertFalse(attribute.contains("c("));
    }
 
    public void testJmxOperationMetadata() throws Exception {

--- a/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
@@ -218,9 +218,9 @@ public class CacheManagerTest extends AbstractInfinispanTest {
          cm.defineConfiguration("two", new ConfigurationBuilder().build());
          cm.getCache("three");
          Set<String> cacheNames = cm.getCacheNames();
-         assertEquals(1, cacheNames.size());
-         assertFalse(cacheNames.contains("one"));
-         assertFalse(cacheNames.contains("two"));
+         assertEquals(3, cacheNames.size());
+         assertTrue(cacheNames.contains("one"));
+         assertTrue(cacheNames.contains("two"));
          assertTrue(cacheNames.contains("three"));
       } finally {
          cm.stop();

--- a/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerTest.java
@@ -218,10 +218,10 @@ public class CacheManagerTest extends AbstractInfinispanTest {
          cm.defineConfiguration("two", new ConfigurationBuilder().build());
          cm.getCache("three");
          Set<String> cacheNames = cm.getCacheNames();
-         assert 3 == cacheNames.size();
-         assert cacheNames.contains("one");
-         assert cacheNames.contains("two");
-         assert cacheNames.contains("three");
+         assertEquals(1, cacheNames.size());
+         assertFalse(cacheNames.contains("one"));
+         assertFalse(cacheNames.contains("two"));
+         assertTrue(cacheNames.contains("three"));
       } finally {
          cm.stop();
       }

--- a/scripting/src/main/java/org/infinispan/scripting/impl/LifecycleCallbacks.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/LifecycleCallbacks.java
@@ -27,4 +27,10 @@ public class LifecycleCallbacks extends AbstractModuleLifecycle {
       Map<Integer,AdvancedExternalizer<?>> externalizerMap = gc.serialization().advancedExternalizers();
       externalizerMap.put(ExternalizerIds.SCRIPT_METADATA, new ScriptMetadata.Externalizer());
    }
+
+   @Override
+   public void cacheManagerStarted(GlobalComponentRegistry gcr) {
+      ScriptingManagerImpl scriptingManager = (ScriptingManagerImpl) gcr.getComponent(ScriptingManager.class);
+      scriptingManager.getScriptCache(); // Initialize the cache
+   }
 }

--- a/server/integration/feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/server/integration/feature-pack/src/main/resources/configuration/domain/template.xml
@@ -49,13 +49,7 @@
     </socket-binding-groups>
 
     <server-groups>
-        <server-group name="main-server-group" profile="clustered">
-            <jvm name="default">
-                <heap size="64m" max-size="512m"/>
-            </jvm>
-            <socket-binding-group ref="clustered-sockets"/>
-        </server-group>
-        <server-group name="other-server-group" profile="clustered">
+        <server-group name="cluster" profile="clustered">
             <jvm name="default">
                 <heap size="64m" max-size="512m"/>
             </jvm>

--- a/server/integration/feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/server/integration/feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -90,8 +90,8 @@
     </jvms>
 
     <servers>
-        <server name="server-one" group="main-server-group"/>
-        <server name="server-two" group="other-server-group">
+        <server name="server-one" group="cluster"/>
+        <server name="server-two" group="cluster">
             <!-- server-two avoids port conflicts by incrementing the ports in
                  the default socket-group declared in the server-group -->
             <socket-bindings port-offset="150"/>
@@ -102,3 +102,4 @@
         <?SUBSYSTEMS socket-binding-group="standard-sockets"?>
     </profile>
 </host>
+

--- a/server/integration/feature-pack/src/main/resources/configuration/host/host.xml
+++ b/server/integration/feature-pack/src/main/resources/configuration/host/host.xml
@@ -86,7 +86,7 @@
     </jvms>
 
     <servers>
-        <server name="server-one" group="main-server-group">
+        <server name="server-one" group="cluster">
             <!-- Remote JPDA debugging for a specific server
             <jvm name="default">
               <jvm-options>
@@ -95,15 +95,10 @@
            </jvm>
            -->
         </server>
-        <server name="server-two" group="main-server-group" auto-start="true">
+        <server name="server-two" group="cluster" auto-start="true">
             <!-- server-two avoids port conflicts by incrementing the ports in
                  the default socket-group declared in the server-group -->
             <socket-bindings port-offset="150"/>
-        </server>
-        <server name="server-three" group="other-server-group" auto-start="false">
-            <!-- server-three avoids port conflicts by incrementing the ports in
-                 the default socket-group declared in the server-group -->
-            <socket-bindings port-offset="250"/>
         </server>
     </servers>
     
@@ -111,3 +106,4 @@
         <?SUBSYSTEMS socket-binding-group="standard-sockets"?>
     </profile>
 </host>
+

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationAdd.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationAdd.java
@@ -223,6 +223,7 @@ public abstract class CacheConfigurationAdd extends AbstractAddStepHandler imple
         List<Dependency<?>> dependencies = new LinkedList<>();
         // Infinispan Configuration to hold the operation data
         ConfigurationBuilder builder = new ConfigurationBuilder().read(getDefaultConfiguration(this.mode));
+        builder.template(CacheConfigurationResource.TEMPLATE.resolveModelAttribute(context, cacheModel).asBoolean());
 
         // process cache configuration ModelNode describing overrides to defaults
         processModelNode(context, containerName, cacheModel, builder, dependencies);

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationResource.java
@@ -150,6 +150,12 @@ public class CacheConfigurationResource extends SimpleResourceDefinition impleme
                .setDefaultValue(new ModelNode().set(true))
                .build();
 
+   static final SimpleAttributeDefinition TEMPLATE =
+         new SimpleAttributeDefinitionBuilder(ModelKeys.TEMPLATE, ModelType.BOOLEAN, false)
+               .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+               .setDefaultValue(new ModelNode().set(false))
+               .build();
+
     static final SimpleAttributeDefinition REMOTE_CACHE =
             new SimpleAttributeDefinitionBuilder(ModelKeys.REMOTE_CACHE, ModelType.STRING, true)
                    .setXmlName(Attribute.REMOTE_CACHE.getLocalName())
@@ -164,7 +170,7 @@ public class CacheConfigurationResource extends SimpleResourceDefinition impleme
                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                    .build();
 
-    static final AttributeDefinition[] ATTRIBUTES = {BATCHING, CACHE_MODULE, CONFIGURATION, INDEXING, INDEXING_AUTO_CONFIG, INDEXING_PROPERTIES, JNDI_NAME, SIMPLE_CACHE, START, STATISTICS, STATISTICS_AVAILABLE, REMOTE_CACHE, REMOTE_SITE};
+    static final AttributeDefinition[] ATTRIBUTES = {BATCHING, CACHE_MODULE, CONFIGURATION, INDEXING, INDEXING_AUTO_CONFIG, INDEXING_PROPERTIES, JNDI_NAME, SIMPLE_CACHE, START, STATISTICS, STATISTICS_AVAILABLE, REMOTE_CACHE, REMOTE_SITE, TEMPLATE};
 
     // here for legacy purposes only
     static final SimpleAttributeDefinition NAME =

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationService.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationService.java
@@ -68,7 +68,10 @@ public class CacheConfigurationService extends AbstractCacheConfigurationService
         if (templateConfiguration != null) {
             builder.read(templateConfiguration);
         }
-        builder.read(this.builder.build());
+        Configuration configuration = this.builder.build();
+        builder.read(configuration);
+        builder.template(configuration.isTemplate());
+
         builder.jmxStatistics().enabled(this.dependencies.getCacheContainer().getCacheManagerConfiguration().globalJmxStatistics().enabled());
         TransactionManager tm = this.dependencies.getTransactionManager();
         if (tm != null) {

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanResourceDescriptionResolver.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanResourceDescriptionResolver.java
@@ -160,6 +160,7 @@ public class InfinispanResourceDescriptionResolver extends SubsystemResourceDesc
         sharedAttributeResolver.put(ModelKeys.START, "cache");
         sharedAttributeResolver.put(ModelKeys.STATISTICS, "cache");
         sharedAttributeResolver.put(ModelKeys.STATISTICS_AVAILABLE, "cache");
+        sharedAttributeResolver.put(ModelKeys.TEMPLATE, "cache");
 
         sharedAttributeResolver.put(ModelKeys.ASYNC_MARSHALLING, "clustered-cache");
         sharedAttributeResolver.put(ModelKeys.CACHE_AVAILABILITY, "clustered-cache");

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader.java
@@ -726,6 +726,7 @@ public final class InfinispanSubsystemXMLReader implements XMLElementReader<List
     private void addCacheConfiguration(String cacheType, PathAddress containerAddress, Map<PathAddress, ModelNode> operations,
             boolean configurationOnly, ModelNode cacheConfiguration,
             Map<PathAddress, ModelNode> additionalConfigurationOperations, PathAddress cacheConfigurationAddress) {
+        cacheConfiguration.get(CacheConfigurationResource.TEMPLATE.getName()).set(configurationOnly);
         if (configurationOnly) {
             // just create the configuration
             operations.put(cacheConfigurationAddress, cacheConfiguration);

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
@@ -225,6 +225,7 @@ public class ModelKeys {
     static final String TAKE_BACKUP_OFFLINE_MIN_WAIT = "min-wait";
     static final String TAKE_OFFLINE = "take-offline";
     static final String TCP_NO_DELAY = "tcp-no-delay";
+    static final String TEMPLATE = "template";
     static final String TEMPORARY_LOCATION = "temporary-location";
     static final String THREAD_POOL_SIZE = "thread-pool-size";
     static final String TIMEOUT = "timeout";

--- a/server/integration/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/server/integration/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -154,6 +154,7 @@ datagrid-infinispan.cache.indexing-properties=Properties to control indexing beh
 datagrid-infinispan.cache.remove=Remove a cache from this container.
 datagrid-infinispan.cache.remote-cache=The name of the remote cache that backups data here.
 datagrid-infinispan.cache.remote-site=The name of the remote site containing the cache that backups data here.
+datagrid-infinispan.cache.template=Whether the configuration is a template or for a concrete cache.
 # cache operations
 datagrid-infinispan.cache.clear-cache=Clears the cache contents.
 datagrid-infinispan.cache.flush-cache=Flushes the cache contents.

--- a/server/integration/infinispan/src/main/resources/subsystem-templates/infinispan-core.xml
+++ b/server/integration/infinispan/src/main/resources/subsystem-templates/infinispan-core.xml
@@ -27,6 +27,63 @@
       <replacement placeholder="CACHE-CONTAINERS">
          <cache-container name="clustered" default-cache="default" statistics="true">
             <transport lock-timeout="60000" />
+            
+            <distributed-cache-configuration name="transactional" mode="SYNC" start="EAGER">
+               <transaction mode="NON_XA" locking="PESSIMISTIC"/>
+            </distributed-cache-configuration>
+            
+            <replicated-cache-configuration name="replicated" mode="SYNC" start="EAGER" />
+
+            <distributed-cache-configuration name="persistent-file-store" mode="SYNC" start="EAGER">
+               <file-store shared="false" fetch-state="true" passivation="false"/>
+            </distributed-cache-configuration>
+            
+            <distributed-cache-configuration name="indexed" mode="SYNC" start="EAGER">
+               <indexing index="LOCAL" auto-config="true"/>
+            </distributed-cache-configuration>
+            
+            <distributed-cache-configuration name="memory-bounded" mode="SYNC" start="EAGER">
+               <eviction strategy="LRU" size="10000000" type="MEMORY"/>
+            </distributed-cache-configuration>
+            
+            <distributed-cache-configuration name="persistent-file-store-passivation" mode="SYNC" start="EAGER">
+               <eviction strategy="LRU" size="10000" type="COUNT"/>
+               <file-store shared="false" fetch-state="true" passivation="true">
+                  <write-behind flush-lock-timeout="1" modification-queue-size="1024" shutdown-timeout="25000" thread-pool-size="1" />
+               </file-store>
+            </distributed-cache-configuration>
+            
+            <distributed-cache-configuration name="persistent-file-store-write-behind" mode="SYNC" start="EAGER">
+               <file-store shared="false" fetch-state="true" passivation="false">
+                  <write-behind flush-lock-timeout="1" modification-queue-size="1024" shutdown-timeout="25000" thread-pool-size="1" />
+               </file-store>
+            </distributed-cache-configuration>
+            
+            <distributed-cache-configuration name="persistent-leveldb-store" mode="SYNC" start="EAGER">
+               <leveldb-store shared="false" fetch-state="true" passivation="false"/>
+            </distributed-cache-configuration>
+            
+            <distributed-cache-configuration name="persistent-jdbc-string-keyed" mode="SYNC" owners="2" start="EAGER">
+               <string-keyed-jdbc-store datasource="java:jboss/datasources/ExampleDS" fetch-state="true" preload="false" purge="false" shared="false" passivation="false">
+                  <string-keyed-table prefix="ISPN">
+                     <id-column name="id" type="VARCHAR" />
+                     <data-column name="datum" type="BINARY" />
+                     <timestamp-column name="version" type="BIGINT" />
+                  </string-keyed-table>
+                  <write-behind flush-lock-timeout="1" modification-queue-size="1024" shutdown-timeout="25000" thread-pool-size="1" />
+               </string-keyed-jdbc-store>
+            </distributed-cache-configuration>
+
+            <distributed-cache-configuration name="persistent-jdbc-binary-keyed" mode="SYNC" owners="2" start="EAGER">
+               <binary-keyed-jdbc-store datasource="java:jboss/datasources/ExampleDS" fetch-state="true" preload="true" purge="false" shared="false" passivation="false">
+                  <binary-keyed-table prefix="ISPN">
+                     <id-column name="id" type="VARCHAR" />
+                     <data-column name="datum" type="BINARY" />
+                     <timestamp-column name="version" type="BIGINT" />
+                  </binary-keyed-table>
+               </binary-keyed-jdbc-store>
+            </distributed-cache-configuration>
+            
             <distributed-cache name="default" mode="SYNC" segments="20" owners="2" remote-timeout="30000" start="EAGER">
                <locking acquire-timeout="30000" concurrency-level="1000" striping="false" />
                <transaction mode="NONE" />
@@ -37,11 +94,7 @@
                <transaction mode="NONE" />
             </distributed-cache>
 
-            <distributed-cache name="namedCache" mode="SYNC" start="EAGER" />
-
-            <distributed-cache name="transactionalCache" mode="SYNC" start="EAGER">
-               <transaction mode="NON_XA" locking="PESSIMISTIC"/>
-            </distributed-cache>
+            
          </cache-container>
       </replacement>
    </supplement>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6259
https://issues.jboss.org/browse/ISPN-6260

ISPN-6259 Distinguish between caches and configuration
ISPN-6260 Add example configurations to domain config 

I've reduced the number of caches in the OOTB domain configuration to two: default and memcachedCache
I've also created a bunch of templates for a variety of common use-cases
I had to fix a "misunderstanding" (ISPN-6259) because otherwise the hotrod server would start the bare configurations as caches...