### PR TITLE
ISPN-6262 Fixed parallel builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ GREP="grep"
 ROOT="/"
 MVN="mvn"
 
-MAVEN_OPTS="$MAVEN_OPTS -Xmx768M"
+MAVEN_OPTS="$MAVEN_OPTS -Xmx1G"
 export MAVEN_OPTS
 
 #  Use the maximum available, or set MAX_FD != -1 to use that

--- a/jcache/embedded/pom.xml
+++ b/jcache/embedded/pom.xml
@@ -136,40 +136,6 @@
                </execution>
             </executions>
          </plugin>
-         
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-invoker-plugin</artifactId>
-            <version>${version.maven.invoker}</version>
-            <configuration>
-               <addTestClassPath>true</addTestClassPath>
-               <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-               <pomIncludes>
-                  <pomInclude>*/pom.xml</pomInclude>
-               </pomIncludes>
-               <postBuildHookScript>verify</postBuildHookScript>
-               <streamLogs>true</streamLogs>
-               <goals>
-                  <goal>clean</goal>
-                  <goal>package</goal>
-               </goals>
-               <properties>
-                  <maven.test.skip.exec>${maven.test.skip.exec}</maven.test.skip.exec>
-                  <skipTests>${skipTests}</skipTests>
-                  <log4j.configurationFile>${log4j.configurationFile}</log4j.configurationFile>
-               </properties>
-            </configuration>
-            <executions>
-               <execution>
-                  <id>integration-test</id>
-                  <goals>
-                     <goal>install</goal>
-                     <goal>run</goal>
-                  </goals>
-               </execution>
-            </executions>
-         </plugin>
-
       </plugins>
    </build>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6262

This fix makes Maven parallel builds possible (`./build.sh clean install -DskipTests -T2C`). On my local PC it lowers build time by 1 minute:
```
./build.sh clean install -DskipTests
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 03:12 min
```

With parallel build:
```
./build.sh clean install -DskipTests -T2C (2 build threads per core)
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:20 min (Wall Clock)
```