### PR TITLE
ISPN-6271 Stream filterKeys reads keys not owned remotely when it

### DIFF
--- a/core/src/main/java/org/infinispan/stream/impl/local/EntryStreamSupplier.java
+++ b/core/src/main/java/org/infinispan/stream/impl/local/EntryStreamSupplier.java
@@ -4,6 +4,7 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.context.Flag;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.stream.impl.RemovableCloseableIterator;
 import org.infinispan.util.logging.Log;
@@ -34,7 +35,8 @@ public class EntryStreamSupplier<K, V> implements AbstractLocalCacheStream.Strea
    public Stream<CacheEntry<K, V>> buildStream(Set<Integer> segmentsToFilter, Set<?> keysToFilter) {
       Stream<CacheEntry<K, V>> stream;
       if (keysToFilter != null) {
-         AdvancedCache<K, V> advancedCache = cache.getAdvancedCache();
+         // Make sure we aren't going remote to retrieve these
+         AdvancedCache<K, V> advancedCache = cache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL);
          log.tracef("Applying key filtering %s", keysToFilter);
          stream = keysToFilter.stream().map(advancedCache::getCacheEntry).filter(e -> e != null);
       } else {

--- a/core/src/main/java/org/infinispan/stream/impl/local/KeyStreamSupplier.java
+++ b/core/src/main/java/org/infinispan/stream/impl/local/KeyStreamSupplier.java
@@ -1,8 +1,10 @@
 package org.infinispan.stream.impl.local;
 
+import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.container.entries.CacheEntry;
+import org.infinispan.context.Flag;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.stream.impl.RemovableCloseableIterator;
 import org.infinispan.util.logging.Log;
@@ -36,7 +38,9 @@ public class KeyStreamSupplier<K, V> implements AbstractLocalCacheStream.StreamS
       Stream<K> stream;
       if (keysToFilter != null) {
          log.tracef("Applying key filtering %s", keysToFilter);
-         stream = (Stream<K>) keysToFilter.stream().filter(k -> cache.containsKey(k));
+         // Make sure we aren't going remote to retrieve these
+         AdvancedCache<K, V> advancedCache = cache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL);
+         stream = (Stream<K>) keysToFilter.stream().filter(k -> advancedCache.containsKey(k));
       } else {
          stream = supplier.get();
       }

--- a/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
@@ -1996,4 +1996,17 @@ public abstract class BaseStreamTest extends MultipleCacheManagersTest {
       assertEquals(realCount.get(), createStream(entrySet).filterKeySegments(
               IntStream.range(0, segments).boxed().collect(Collectors.toSet())).count());
    }
+
+   public void testKeyFilter() {
+      Cache<Integer, String> cache = getCache(0);
+      int range = 12;
+      // First populate the cache with a bunch of values
+      IntStream.range(0, range).boxed().forEach(i -> cache.put(i, i + "-value"));
+
+      assertEquals(range, cache.size());
+      CacheSet<Map.Entry<Integer, String>> entrySet = cache.entrySet();
+
+      Set<Integer> keys = IntStream.of(2, 5, 8, 3, 1, range + 2).boxed().collect(Collectors.toSet());
+      assertEquals(keys.size() - 1, createStream(entrySet).filterKeys(keys).count());
+   }
 }


### PR DESCRIPTION
shouldn't

* Make sure key filter uses local cache to look up on each node

https://issues.jboss.org/browse/ISPN-6271