### PR TITLE
ISPN-6276 AdvancedAsyncCacheLoader is now threadsafe

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/async/AdvancedAsyncCacheLoader.java
+++ b/core/src/main/java/org/infinispan/persistence/async/AdvancedAsyncCacheLoader.java
@@ -3,13 +3,14 @@ package org.infinispan.persistence.async;
 import org.infinispan.executors.ExecutorAllCompletionService;
 import org.infinispan.filter.KeyFilter;
 import org.infinispan.marshall.core.MarshalledEntry;
-import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.persistence.TaskContextImpl;
 import org.infinispan.persistence.modifications.Modification;
 import org.infinispan.persistence.modifications.Remove;
 import org.infinispan.persistence.modifications.Store;
 import org.infinispan.persistence.spi.AdvancedCacheLoader;
 import org.infinispan.persistence.spi.CacheLoader;
+import org.infinispan.persistence.spi.PersistenceException;
+import org.infinispan.util.concurrent.ConcurrentHashSet;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -74,14 +75,14 @@ public class AdvancedAsyncCacheLoader extends AsyncCacheLoader implements Advanc
       ExecutorAllCompletionService eacs = new ExecutorAllCompletionService(executor);
       final TaskContext taskContext = new TaskContextImpl();
 
-      Set<Object> allKeys = new HashSet<Object>(batchSize);
+      Set<Object> allKeys = new ConcurrentHashSet<>();
       Set<Object> batch = new HashSet<Object>();
       loadAllKeys(state.get(), allKeys, keyFilter, executor);
       for (Iterator it = allKeys.iterator(); it.hasNext(); ) {
          batch.add(it.next());
          if (batch.size() == batchSize) {
             final Set<Object> toHandle = batch;
-            batch = new HashSet<Object>(batchSize);
+            batch = new HashSet<>(batchSize);
             submitProcessTask(cacheLoaderTask, eacs, taskContext, toHandle);
          }
       }

--- a/core/src/test/java/org/infinispan/persistence/PreloadingWithWriteBehindTest.java
+++ b/core/src/test/java/org/infinispan/persistence/PreloadingWithWriteBehindTest.java
@@ -2,21 +2,39 @@ package org.infinispan.persistence;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.filter.KeyFilter;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.persistence.async.AdvancedAsyncCacheLoader;
 import org.infinispan.persistence.dummy.DummyInMemoryStore;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.persistence.spi.AdvancedCacheLoader;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
+import java.io.Serializable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import static org.testng.AssertJUnit.assertEquals;
 
 @Test(groups = "functional", testName = "persistence.PreloadingWithWriteBehindTest")
 public class PreloadingWithWriteBehindTest extends SingleCacheManagerTest {
+
+   /**
+    * This key will generate a lot of collisions (hashcode = const). Hopefully this will make
+    * the race condition from AdvancedCacheLoader#process to appear more ffrequently
+    */
+   static class KeyWithCollisions implements Serializable {
+
+      @Override
+      public int hashCode() {
+         return 1;
+      }
+   }
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
@@ -31,16 +49,45 @@ public class PreloadingWithWriteBehindTest extends SingleCacheManagerTest {
       return TestCacheManagerFactory.createCacheManager(dccc);
    }
 
-   public void testPreload() {
+   public void testIfPreloadWorkCorrectly() {
+      //given
       cache.put("k1","v1");
       cache.put("k2","v2");
       cache.put("k3","v3");
+
+      //when
       getDummyLoader().clearStats();
       cache.stop();
       cache.start();
-      assertEquals(3, cache.size());
+
       Integer loads = getDummyLoader().stats().get("load");
+
+      //then
+      assertEquals(3, cache.size());
       assertEquals((Integer)0, loads);
+   }
+
+   @Test(timeOut = 10_000)
+   public void testIfCanLoadKeysConcurrently() throws Exception {
+      final int numberOfEntriesTested = 1_000;
+      final int numberOfConcurrentThreads = 16;
+
+      IntStream
+              .range(0, numberOfEntriesTested)
+              .forEach(i -> cache.put(new KeyWithCollisions(), "value: " + i));
+
+      AdvancedCacheLoader.CacheLoaderTask<Object, String> task = (marshalledEntry, taskContext) -> {};
+      KeyFilter<Object> keyFilter = KeyFilter.ACCEPT_ALL_FILTER;
+      ExecutorService executeInManyThreads = Executors.newFixedThreadPool(numberOfConcurrentThreads);
+
+
+      AdvancedAsyncCacheLoader cacheLoader = (AdvancedAsyncCacheLoader) TestingUtil.getCacheLoader(cache);
+
+      //when
+      cacheLoader.process(keyFilter, task, executeInManyThreads, true, true);
+
+      //then
+      assertEquals(numberOfEntriesTested, cacheLoader.size());
    }
 
    private DummyInMemoryStore getDummyLoader() {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-3938

Highlights:
* `ConcurrentHashSet` is used as a container for all loaded keys