### PR TITLE
ISPN-6290 Upgrade to Log4j2 2.5

### DIFF
--- a/core/src/test/java/org/infinispan/util/logging/log4j/CompressedFileManager.java
+++ b/core/src/test/java/org/infinispan/util/logging/log4j/CompressedFileManager.java
@@ -34,8 +34,8 @@ import org.apache.logging.log4j.core.appender.ManagerFactory;
  */
 public class CompressedFileManager extends FileManager {
 
-   protected CompressedFileManager(String fileName, OutputStream os, boolean append, boolean locking, String advertiseURI, Layout<? extends Serializable> layout, int bufferSize) {
-      super(fileName, os, append, locking, advertiseURI, layout, bufferSize);
+   protected CompressedFileManager(String fileName, OutputStream os, boolean append, boolean locking, String advertiseURI, Layout<? extends Serializable> layout, int bufferSize, boolean writerHeader) {
+      super(fileName, os, append, locking, advertiseURI, layout, bufferSize, writerHeader);
    }
 
    private static final CompressedFileManagerFactory FACTORY = new CompressedFileManagerFactory();
@@ -141,7 +141,8 @@ public class CompressedFileManager extends FileManager {
                   bufferSize = -1; // signals to RollingFileManager not to use BufferedOutputStream
                }
             }
-            return new CompressedFileManager(name, os, data.append, data.locking, data.advertiseURI, data.layout, bufferSize);
+            boolean writeHeader = !data.append || !file.exists();
+            return new CompressedFileManager(name, os, data.append, data.locking, data.advertiseURI, data.layout, bufferSize, writeHeader);
          } catch (final IOException ex) {
             LOGGER.error("FileManager (" + name + ") " + ex);
          }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -148,7 +148,7 @@
       <version.junit>4.11</version.junit>
       <version.leveldb>0.7</version.leveldb>
       <version.leveldbjni>1.7</version.leveldbjni>
-      <version.log4j>2.3</version.log4j>
+      <version.log4j>2.5</version.log4j>
       <version.lucene>5.4.1</version.lucene>
       <version.mc4j>1.2.6</version.mc4j>
       <version.mockito>1.9.5</version.mockito>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6290
https://issues.jboss.org/browse/ISPN-6289