### PR TITLE
ISPN-6306 Distributed Streams should also be used for Replication Cache

### DIFF
--- a/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
+++ b/core/src/main/java/org/infinispan/factories/InterceptorChainFactory.java
@@ -115,7 +115,7 @@ public class InterceptorChainFactory extends AbstractNamedCacheComponentFactory 
       boolean isTotalOrder = configuration.transaction().transactionProtocol().isTotalOrder();
       CacheMode cacheMode = configuration.clustering().cacheMode();
 
-      if (configuration.clustering().cacheMode().isDistributed()) {
+      if (cacheMode.isDistributed() || cacheMode.isReplicated()) {
          interceptorChain.appendInterceptor(createInterceptor(new DistributionBulkInterceptor<>(),
                  DistributionBulkInterceptor.class), false);
       }

--- a/core/src/main/java/org/infinispan/factories/StreamManagerFactory.java
+++ b/core/src/main/java/org/infinispan/factories/StreamManagerFactory.java
@@ -1,5 +1,6 @@
 package org.infinispan.factories;
 
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
 import org.infinispan.stream.impl.ClusterStreamManager;
 import org.infinispan.stream.impl.LocalStreamManager;
@@ -18,7 +19,8 @@ import org.infinispan.stream.impl.PartitionAwareClusterStreamManager;
 public class StreamManagerFactory extends AbstractNamedCacheComponentFactory implements AutoInstantiableFactory {
    @Override
    public <T> T construct(Class<T> componentType) {
-      if (configuration.clustering().cacheMode().isDistributed()) {
+      CacheMode cacheMode = configuration.clustering().cacheMode();
+      if (cacheMode.isDistributed() || cacheMode.isReplicated()) {
          if (componentType.equals(LocalStreamManager.class)) {
             return componentType.cast(new LocalStreamManagerImpl<>());
          }

--- a/core/src/main/java/org/infinispan/interceptors/distribution/DistributionBulkInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/DistributionBulkInterceptor.java
@@ -39,8 +39,8 @@ import java.util.function.Function;
 import static org.infinispan.factories.KnownComponentNames.ASYNC_OPERATIONS_EXECUTOR;
 
 /**
- * Interceptor that handles bulk entrySet and keySet commands when using in a distributed environment.  This
- * interceptor produces backing collections for either method and a distributed stream for either which leverages
+ * Interceptor that handles bulk entrySet and keySet commands when using in a distributed/replicated environment.
+ * This interceptor produces backing collections for either method and a distributed stream for either which leverages
  * distributed processing through the cluster.
  * @param <K> The key type of entries
  * @param <V> The value type of entries
@@ -108,16 +108,6 @@ public class DistributionBulkInterceptor<K, V> extends CommandInterceptor {
             return cache.remove(entry.getKey(), entry.getValue());
          }
          return false;
-      }
-
-      @Override
-      public boolean add(CacheEntry<K, V> internalCacheEntry) {
-         V value = cache.put(internalCacheEntry.getKey(), internalCacheEntry.getValue());
-         // If the value was already there we can treat as if it wasn't added
-         if (value != null && value.equals(internalCacheEntry.getValue())) {
-            return false;
-         }
-         return true;
       }
 
       private Map.Entry<K, V> toEntry(Object obj) {

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferCacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferCacheLoaderFunctionalTest.java
@@ -3,6 +3,7 @@ package org.infinispan.statetransfer;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.context.Flag;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.persistence.spi.CacheLoader;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -94,7 +95,9 @@ public class StateTransferCacheLoaderFunctionalTest extends StateTransferFunctio
          verifyInitialData(c1);
 
          verifyNoDataOnLoader(c2);
-         verifyNoData(c2);
+         // There shouldn't be any data locally since there was no entries in memory and the shared loader doesn't
+         // actually share entries
+         verifyNoData(c2.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL));
       } finally {
          sharedCacheLoader.set(false);
       }

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferFileCacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferFileCacheLoaderFunctionalTest.java
@@ -4,6 +4,7 @@ import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder;
+import org.infinispan.context.Flag;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.MultipleCacheManagersTest;
@@ -112,7 +113,9 @@ public class StateTransferFileCacheLoaderFunctionalTest extends MultipleCacheMan
          verifyInitialData(c1);
 
          verifyNoDataOnLoader(c2);
-         verifyNoData(c2);
+         // There shouldn't be any data locally since there was no entries in memory and the shared loader doesn't
+         // actually share entries
+         verifyNoData(c2.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL));
       } finally {
          if (cm1 != null) cm1.stop();
          if (cm2 != null) cm2.stop();

--- a/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
@@ -36,7 +36,7 @@ import static org.testng.AssertJUnit.*;
  * Base test class for streams to verify proper behavior of all of the terminal operations for all of the various
  * stream classes
  */
-@Test
+@Test(groups="functional")
 public abstract class BaseStreamTest extends MultipleCacheManagersTest {
    protected final String CACHE_NAME = getClass().getName();
    protected ConfigurationBuilder builderUsed;

--- a/core/src/test/java/org/infinispan/stream/DistributedNonRehashStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedNonRehashStreamTest.java
@@ -7,7 +7,7 @@ import org.testng.annotations.Test;
 /**
  * Verifies stream tests work when rehash is disabled
  */
-@Test(groups = "functional", testName = "streams.DistributedStreamTest")
+@Test(groups = "functional", testName = "streams.DistributedNonRehashStreamTest")
 public class DistributedNonRehashStreamTest extends DistributedStreamTest {
    @Override
    protected <E> CacheStream<E> createStream(CacheCollection<E> entries) {

--- a/core/src/test/java/org/infinispan/stream/DistributedParallelNonRehashStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedParallelNonRehashStreamTest.java
@@ -7,7 +7,7 @@ import org.testng.annotations.Test;
 /**
  * Verifies stream tests work when rehash is disabled on a parallel stream with parallel distribution
  */
-@Test(groups = "functional", testName = "streams.DistributedParallelStreamTest")
+@Test(groups = "functional", testName = "streams.DistributedParallelNonRehashStreamTest")
 public class DistributedParallelNonRehashStreamTest extends DistributedStreamTest {
    @Override
    protected <E> CacheStream<E> createStream(CacheCollection<E> entries) {

--- a/core/src/test/java/org/infinispan/stream/DistributedSequentialNonRehashStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedSequentialNonRehashStreamTest.java
@@ -7,7 +7,7 @@ import org.testng.annotations.Test;
 /**
  * Verifies stream tests work when rehash is disabled on a sequential stream
  */
-@Test(groups = "functional", testName = "streams.DistributedSequentialStreamTest")
+@Test(groups = "functional", testName = "streams.DistributedSequentialNonRehashStreamTest")
 public class DistributedSequentialNonRehashStreamTest extends DistributedStreamTest {
    @Override
    protected <E> CacheStream<E> createStream(CacheCollection<E> entries) {

--- a/core/src/test/java/org/infinispan/stream/LocalParallelStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/LocalParallelStreamTest.java
@@ -9,11 +9,7 @@ import org.testng.annotations.Test;
  * Verifies stream tests work on a local parallel stream
  */
 @Test(groups = "functional", testName = "streams.LocalParallelStreamTest")
-public class LocalParallelStreamTest extends BaseStreamTest {
-   public LocalParallelStreamTest() {
-      super(false, CacheMode.LOCAL);
-   }
-
+public class LocalParallelStreamTest extends LocalStreamTest {
    @Override
    protected <E> CacheStream<E> createStream(CacheCollection<E> entries) {
       return entries.parallelStream();

--- a/core/src/test/java/org/infinispan/stream/LocalStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/LocalStreamTest.java
@@ -18,4 +18,10 @@ public class LocalStreamTest extends BaseStreamTest {
    protected <E> CacheStream<E> createStream(CacheCollection<E> entries) {
       return entries.stream();
    }
+
+   @Test(enabled = false)
+   @Override
+   public void testKeySegmentFilter() {
+
+   }
 }

--- a/core/src/test/java/org/infinispan/stream/SimpleParallelStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/SimpleParallelStreamTest.java
@@ -9,19 +9,10 @@ import org.testng.annotations.Test;
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
-@Test(groups = "functional", testName = "streams.LocalStreamTest")
-public class SimpleParallelStreamTest extends BaseStreamTest {
-   public SimpleParallelStreamTest() {
-      super(false, CacheMode.LOCAL);
-   }
-
+@Test(groups = "functional", testName = "streams.SimpleParallelStreamTest")
+public class SimpleParallelStreamTest extends LocalParallelStreamTest {
    @Override
    protected void enhanceConfiguration(ConfigurationBuilder builder) {
       builder.simpleCache(true);
-   }
-
-   @Override
-   protected <E> CacheStream<E> createStream(CacheCollection<E> cacheCollection) {
-      return cacheCollection.parallelStream();
    }
 }

--- a/core/src/test/java/org/infinispan/stream/SimpleStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/SimpleStreamTest.java
@@ -10,18 +10,9 @@ import org.infinispan.stream.BaseStreamTest;import org.testng.annotations.Test;i
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
 @Test(groups = "functional", testName = "streams.LocalStreamTest")
-public class SimpleStreamTest extends BaseStreamTest {
-   public SimpleStreamTest() {
-      super(false, CacheMode.LOCAL);
-   }
-
+public class SimpleStreamTest extends LocalStreamTest {
    @Override
    protected void enhanceConfiguration(ConfigurationBuilder builder) {
       builder.simpleCache(true);
-   }
-
-   @Override
-   protected <E> CacheStream<E> createStream(CacheCollection<E> cacheCollection) {
-      return cacheCollection.stream();
    }
 }

--- a/documentation/src/main/asciidoc/user_guide/chapter-63-Streams.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-63-Streams.adoc
@@ -51,9 +51,9 @@ The segments can be filtered by invoking
 link:https://docs.jboss.org/infinispan/{infinispanversion}/apidocs/org/infinispan/CacheStream.html#filterKeySegments-java.util.Set-[filterKeySegments]
 method on the `CacheStream`.  This is applied after the key filter but before any intermediate operations are performed.
 
-=== Local/Invalidation/Replication Cache
+=== Local/Invalidation
 
-A stream used with a local, invalidation or replication cache can be used just the same way you would use a stream on a
+A stream used with a local or invalidation cache can be used just the same way you would use a stream on a
 regular collection. Infinispan handles all of the translations if necessary behind the scenes and works with all
 of the more interesting options (ie. storeAsBinary, compatibility mode, and a cache loader).
 
@@ -67,7 +67,7 @@ Map<Object, String> jbossValues = cache.entrySet().stream()
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 ----
 
-=== Distribution Cache
+=== Distribution/Replication
 
 This is where streams come into their stride.  When a stream operation is performed it will
 send the various intermediate and terminal operations to each node that has pertinent data.
@@ -281,6 +281,13 @@ link:https://docs.jboss.org/infinispan/8.2/apidocs/org/infinispan/CacheStream.ht
 method on the `CacheStream`.  This value will default to the `chunkSize` configured in state transfer.
 Unfortunately this value is a tradeoff with memory usage vs performance vs at least once and your
 mileage may vary.
+
+===== Using `iterator` with a replication cache
+
+Currently if you are using a replicated cache the `iterator` or `spliterator`
+terminal operations will not perform any of the operations remotely
+and will instead perform everythign on the local node. This is for performance as doing a
+remote iteration process is very costly.
 
 ==== Intermediate operation exceptions
 


### PR DESCRIPTION
* Replication now uses distributed streams by default
** Iterator/Spliterator method will always be local
* Cleaned up tests a bit

https://issues.jboss.org/browse/ISPN-6306