### PR TITLE
ISPN-6307 Add datatype script parameter

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTypedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTypedTest.java
@@ -1,0 +1,51 @@
+package org.infinispan.client.hotrod;
+
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.commons.equivalence.AnyEquivalence;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.scripting.ScriptingManager;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+@Test(groups = "functional", testName = "client.hotrod.ExecTypedTest")
+public class ExecTypedTest extends MultiHotRodServersTest {
+
+   private static final String SCRIPT_CACHE = "___script_cache";
+   private static final int NUM_SERVERS = 2;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
+      builder.dataContainer()
+            .keyEquivalence(AnyEquivalence.getInstance())
+            .valueEquivalence(AnyEquivalence.getInstance());
+      createHotRodServers(NUM_SERVERS, builder);
+   }
+
+   public void testRemoteTypedScriptPutGetExecute() throws Exception {
+      loadScript("testRemoteTypedScriptPutGetExecute.js", "/typed-put-get.js");
+      Map<String, String> params = new HashMap<>();
+      params.put("k", "typed-key");
+      params.put("v", "typed-value");
+      String result = clients.get(0).getCache().execute("testRemoteTypedScriptPutGetExecute.js", params);
+      assertEquals("typed-value", result);
+   }
+
+   private void loadScript(String name, String scriptName) throws IOException {
+      try (InputStream is = this.getClass().getResourceAsStream(scriptName)) {
+         String script = TestingUtil.loadFileAsString(is);
+         ScriptingManager scriptingManager = manager(0)
+               .getGlobalComponentRegistry().getComponent(ScriptingManager.class);
+         scriptingManager.addScript(name, script);
+      }
+   }
+
+}

--- a/client/hotrod-client/src/test/resources/typed-put-get.js
+++ b/client/hotrod-client/src/test/resources/typed-put-get.js
@@ -1,0 +1,4 @@
+// mode=local,language=javascript,parameters=[k, v],datatype='text/plain; charset=utf-8'
+var cache = cacheManager.getCache();
+cache.put(k, v);
+cache.get(k);

--- a/commons/src/main/java/org/infinispan/commons/util/Immutables.java
+++ b/commons/src/main/java/org/infinispan/commons/util/Immutables.java
@@ -7,17 +7,8 @@ import java.io.ObjectOutput;
 import java.io.Reader;
 import java.io.Serializable;
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.InvalidPropertiesFormatException;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import org.infinispan.commons.marshall.AbstractExternalizer;
 import org.infinispan.commons.marshall.Ids;
@@ -226,6 +217,17 @@ public class Immutables {
       return new ImmutableEntry<K, V>(entry);
    }
 
+   /**
+    * Wraps a key and value with an immutable {@link Map.Entry}}. There is no copying involved.
+    *
+    * @param key the key to wrap.
+    * @param value the value to wrap.
+    * @return an immutable {@link Map.Entry}} wrapper that delegates to the original mapping.
+    */
+   public static <K, V> Map.Entry<K, V> immutableEntry(K key, V value) {
+      return new ImmutableEntry<K, V>(key, value);
+   }
+
    public interface  Immutable {
    }
 
@@ -361,6 +363,12 @@ public class Immutables {
          this.key = entry.getKey();
          this.value = entry.getValue();
          this.hash = entry.hashCode();
+      }
+
+      ImmutableEntry(K key, V value) {
+         this.key = key;
+         this.value = value;
+         this.hash = Objects.hashCode(key) ^ Objects.hashCode(value);
       }
 
       @Override

--- a/documentation/src/main/asciidoc/user_guide/chapter-78-Scripting.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-78-Scripting.adoc
@@ -41,6 +41,13 @@ The following metadata property keys are available
 * collator: this property is only valid for +mapper+ scripts, and specifies the name of another script that will be used for the collation phase of a map/reduce job. This property will be removed in Infinispan 9.
 * combiner: this property is only valid for +mapper+ scripts, and specifies the name of another script that will be used for the combine phase of a map/reduce job. This property will be removed in Infinispan 9.
 * parameters: an array of valid parameter names for this script. Invocations which specify parameter names not included in this list will cause an exception.
+* datatype: optional property providing information, in the form of
+Media Types (also known as MIME) about the type of the data stored in the
+caches, as well as parameter and return values. Currently it only accepts a
+single value which is `text/plain; charset=utf-8`, indicating that data is
+String UTF-8 format. This metadata parameter is designed for remote clients
+that only support a particular type of data, making it easy for them to
+retrieve, store and work with parameters.
 
 Since the execution mode is a characteristic of the script, nothing special needs to be done on the client to invoke scripts in different modes.
 

--- a/scripting/src/main/java/org/infinispan/scripting/impl/DataType.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/DataType.java
@@ -1,0 +1,100 @@
+package org.infinispan.scripting.impl;
+
+import org.infinispan.commons.CacheException;
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.util.Immutables;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public enum DataType {
+   UTF8(new Utf8Transformer()),
+   DEFAULT(new DefaultTransformer());
+
+   public final Transformer transformer;
+
+   DataType(Transformer transformer) {
+      this.transformer = transformer;
+   }
+
+   public static DataType fromMime(String mime) {
+      switch (mime) {
+         case "text/plain; charset=utf-8":
+            return UTF8;
+         default:
+            return DEFAULT;
+      }
+   }
+
+   interface Transformer {
+      Map<String, ?> toDataType(Map<String, ?> objs, Optional<Marshaller> marshaller);
+      Object fromDataType(Object obj, Optional<Marshaller> marshaller);
+   }
+
+   static final class Utf8Transformer implements Transformer {
+      public static final Charset CHARSET_UTF8 = Charset.forName("UTF-8");
+
+      @Override
+      public Map<String, ?> toDataType(Map<String, ?> objs, Optional<Marshaller> marshaller) {
+         return objs.entrySet().stream().map(e -> {
+            Object v = e.getValue();
+            Object entryValue = v instanceof byte[] ? asString(v) : v;
+            return Immutables.immutableEntry(e.getKey(), entryValue);
+         }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+      }
+
+      @Override
+      public Object fromDataType(Object obj, Optional<Marshaller> marshaller) {
+         return obj instanceof String ? ((String) obj).getBytes(CHARSET_UTF8) : obj;
+      }
+
+      private static String asString(Object v) {
+         return new String((byte[]) v, CHARSET_UTF8);
+      }
+   }
+
+   static final class DefaultTransformer implements Transformer {
+      @Override
+      public Map<String, ?> toDataType(Map<String, ?> objs, Optional<Marshaller> marshaller) {
+         if (marshaller.isPresent()) {
+            Marshaller m = marshaller.get();
+            return objs.entrySet().stream().map(e -> {
+               Object v = e.getValue();
+               Object entryValue = v instanceof byte[] ? fromBytes(v, m) : v;
+               return Immutables.immutableEntry(e.getKey(), entryValue);
+            }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+         }
+
+         return objs;
+      }
+
+      private static Object fromBytes(Object obj, Marshaller marshaller) {
+         try {
+            return marshaller.objectFromByteBuffer((byte[]) obj);
+         } catch (Exception e) {
+            throw new CacheException(e);
+         }
+      }
+
+      @Override
+      public Object fromDataType(Object obj, Optional<Marshaller> marshaller) {
+         try {
+            return marshaller.map(m -> toBytes(obj, m)).orElse(obj);
+         } catch (Exception e) {
+            throw new CacheException(e);
+         }
+      }
+
+      private static Object toBytes(Object obj, Marshaller marshaller) {
+         try {
+            return marshaller.objectToByteBuffer(obj);
+         } catch (Exception e) {
+            throw new CacheException(e);
+         }
+      }
+   }
+
+}

--- a/scripting/src/main/java/org/infinispan/scripting/impl/ScriptMetadata.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/ScriptMetadata.java
@@ -31,9 +31,11 @@ public class ScriptMetadata implements Metadata {
    private final Optional<String> reducer;
    private final Optional<String> collator;
    private final Optional<String> combiner;
+   private final DataType dataType;
 
    ScriptMetadata(String name, Optional<String> language, String extension, ExecutionMode mode, Set<String> parameters,
-         Optional<String> role, Optional<String> reducer, Optional<String> collator, Optional<String> combiner) {
+         Optional<String> role, Optional<String> reducer, Optional<String> collator, Optional<String> combiner,
+         DataType dataType) {
       this.name = name;
       this.language = language;
       this.extension = extension;
@@ -43,6 +45,7 @@ public class ScriptMetadata implements Metadata {
       this.reducer = reducer;
       this.collator = collator;
       this.combiner = combiner;
+      this.dataType = dataType;
    }
 
    public Optional<String> language() {
@@ -79,6 +82,10 @@ public class ScriptMetadata implements Metadata {
 
    public Optional<String> collator() {
       return collator;
+   }
+
+   public DataType dataType() {
+      return dataType;
    }
 
    @Override
@@ -118,6 +125,7 @@ public class ScriptMetadata implements Metadata {
       Optional<String> combiner = Optional.empty();
       Optional<String> collator = Optional.empty();
       Optional<String> reducer = Optional.empty();
+      DataType dataType = DataType.DEFAULT;
 
       public ScriptMetadata.Builder name(String name) {
          this.name = name;
@@ -164,6 +172,11 @@ public class ScriptMetadata implements Metadata {
          return this;
       }
 
+      public ScriptMetadata.Builder dataType(DataType dataType) {
+         this.dataType = dataType;
+         return this;
+      }
+
       @Override
       public ScriptMetadata.Builder lifespan(long time, TimeUnit unit) {
          return this;
@@ -191,7 +204,7 @@ public class ScriptMetadata implements Metadata {
 
       @Override
       public ScriptMetadata build() {
-         return new ScriptMetadata(name, language, extension, mode, parameters, role, reducer, collator, combiner);
+         return new ScriptMetadata(name, language, extension, mode, parameters, role, reducer, collator, combiner, dataType);
       }
 
       @Override
@@ -230,6 +243,7 @@ public class ScriptMetadata implements Metadata {
          output.writeObject(object.reducer);
          output.writeObject(object.collator);
          output.writeObject(object.combiner);
+         output.writeObject(object.dataType);
       }
 
       @Override
@@ -244,8 +258,9 @@ public class ScriptMetadata implements Metadata {
          Optional<String> reducer = (Optional<String>) input.readObject();
          Optional<String> collator = (Optional<String>) input.readObject();
          Optional<String> combiner = (Optional<String>) input.readObject();
+         DataType dataType = (DataType) input.readObject();
 
-         return new ScriptMetadata(name, language, extension, mode, parameters, role, reducer, collator, combiner);
+         return new ScriptMetadata(name, language, extension, mode, parameters, role, reducer, collator, combiner, dataType);
       }
    }
 }

--- a/scripting/src/main/java/org/infinispan/scripting/impl/ScriptMetadataParser.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/ScriptMetadataParser.java
@@ -67,6 +67,9 @@ public class ScriptMetadataParser {
                case "collator":
                   metadataBuilder.collator(value);
                   break;
+               case "datatype":
+                  metadataBuilder.dataType(DataType.fromMime(value));
+                  break;
                default:
                   throw log.unknownScriptProperty(key);
                }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
@@ -315,12 +315,12 @@ object Decoder2x extends AbstractVersionedDecoder with ServerConstants with Log 
             val params = new HashMap[String, Object]
             for (i <- 0 until paramCount) {
                val paramName = readString(buffer)
-               val paramValue = marshaller.objectFromByteBuffer(readRangedBytes(buffer))
+               val paramValue = readRangedBytes(buffer)
                params.put(paramName, paramValue)
             }
             val taskManager = SecurityActions.getCacheGlobalComponentRegistry(cache).getComponent(classOf[TaskManager])
-            val result: Any = taskManager.runTask(name, new TaskContext().marshaller(marshaller).cache(cache).parameters(params)).get
-            new ExecResponse(h.version, h.messageId, h.cacheName, h.clientIntel, h.topologyId, marshaller.objectToByteBuffer(result))
+            val result: Array[Byte] = taskManager.runTask(name, new TaskContext().marshaller(marshaller).cache(cache).parameters(params)).get.asInstanceOf[Array[Byte]]
+            new ExecResponse(h.version, h.messageId, h.cacheName, h.clientIntel, h.topologyId, result)
       }
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6307

* Datatype script metadata parameter is designed for remote clients
  working purely with data in a particular format, e.g. JS clients
  with UTF-8 Strings.