### PR TITLE
ISPN-6311 - ExecTest.testRemoteMapReduceWithStreams test is  failing

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTest.java
@@ -117,6 +117,7 @@ public class ExecTest extends MultiHotRodServersTest {
       assertTrue(results.get("macbeth").equals(Double.valueOf(287)));
    }
 
+   @Test(enabled = false, description = "Disabling this test until the distributed scripts in DIST mode are fixed - ISPN-6173")
    public void testRemoteMapReduceWithStreams() throws Exception {
       String cacheName = "testRemoteMapReduce_Streams";
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);


### PR DESCRIPTION
Disabled as the test depends on bug ISPN-6173