### PR TITLE
ISPN-6320 Improve stability of ClientEventsOOMTest

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientEventsOOMTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientEventsOOMTest.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 import static org.junit.Assert.assertEquals;
@@ -64,6 +65,8 @@ public class ClientEventsOOMTest extends MultiHotRodServersTest {
    private ConfigurationBuilder getConfigurationBuilder() {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
       builder.clustering().hash().numOwners(NUM_OWNERS);
+      //playing with OOM - weird things might happen when JVM will struggle for life
+      builder.clustering().sync().replTimeout(5, TimeUnit.MINUTES);
       return hotRodCacheConfiguration(builder);
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6320

My local runs shows that sometimes this test takes pretty long (since JVM struggles for life in this test, such things might happen). I think this is the root cause why it fails [1].

[1] http://ci.infinispan.org/project.html?projectId=Infinispan&testNameId=5048793009923214371&tab=testDetails