### PR TITLE
ISPN-6323 Cluster startup hangs indefinitely in client-server mode

### DIFF
--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/LifecycleManager.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/LifecycleManager.java
@@ -112,7 +112,7 @@ public final class LifecycleManager extends AbstractModuleLifecycle {
    @Override
    public void cacheStarting(ComponentRegistry cr, Configuration cfg, String cacheName) {
       InternalCacheRegistry icr = cr.getGlobalComponentRegistry().getComponent(InternalCacheRegistry.class);
-      if (!icr.isInternalCache(cacheName) || icr.internalCacheHasFlag(cacheName, InternalCacheRegistry.Flag.QUERYABLE)) {
+      if (!icr.isInternalCache(cacheName)) {
          ProtobufMetadataManagerImpl protobufMetadataManager = (ProtobufMetadataManagerImpl) cr.getGlobalComponentRegistry().getComponent(ProtobufMetadataManager.class);
          SerializationContext serCtx = protobufMetadataManager.getSerializationContext();
          cr.registerComponent(new ProtobufMatcher(serCtx), ProtobufMatcher.class);


### PR DESCRIPTION
* avoid creation of remote query components for internal caches because the starting of __protobuf_metadata cache may lead to deadlock

Jira: https://issues.jboss.org/browse/ISPN-6323