### PR TITLE
ISPN-6306 Distributed Streams should also be used for Replication Cache

### DIFF
--- a/core/src/main/java/org/infinispan/distribution/ch/ConsistentHash.java
+++ b/core/src/main/java/org/infinispan/distribution/ch/ConsistentHash.java
@@ -158,14 +158,14 @@ public interface ConsistentHash {
     * Returns the segments owned by a cache member.
     *
     * @param owner the address of the member
-    * @return a non-null set of segment IDs
+    * @return a non-null set of segment IDs, may or may not be unmodifiable, which shouldn't be modified by caller
     */
    Set<Integer> getSegmentsForOwner(Address owner);
 
    /**
     * Returns the segments that this cache member is the primary owner for.
     * @param owner the address of the member
-    * @return a non-null set of segment IDs
+    * @return a non-null set of segment IDs, may or may not be unmodifiable, which shouldn't be modified by caller
     */
    Set<Integer> getPrimarySegmentsForOwner(Address owner);
 

--- a/core/src/main/java/org/infinispan/stream/impl/DistributedCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/DistributedCacheStream.java
@@ -526,8 +526,8 @@ public class DistributedCacheStream<R> extends AbstractCacheStream<R, Stream<R>,
                   if (stayLocal) {
                      segments = segmentsToProcess;
                   } else {
-                     segments = ch.getPrimarySegmentsForOwner(localAddress);
-                     segments.retainAll(segmentsToProcess);
+                     segments = ch.getPrimarySegmentsForOwner(localAddress).stream()
+                             .filter(segmentsToProcess::contains).collect(Collectors.toSet());
                   }
 
                   excludedKeys = segments.stream().flatMap(s -> results.referenceArray.get(s).stream())
@@ -608,9 +608,9 @@ public class DistributedCacheStream<R> extends AbstractCacheStream<R, Stream<R>,
          results.onCompletion(null, segments, localValue);
       } else {
          Set<Integer> ourSegments = ownedSegmentsSupplier.get();
-         ourSegments.retainAll(segmentsToProcess);
-         log.tracef("CH changed - making %s segments suspect for identifier %s", ourSegments, id);
-         results.onSegmentsLost(ourSegments);
+         Set<Integer> lostSegments = ourSegments.stream().filter(segmentsToProcess::contains).collect(Collectors.toSet());
+         log.tracef("CH changed - making %s segments suspect for identifier %s", lostSegments, id);
+         results.onSegmentsLost(lostSegments);
       }
    }
 

--- a/core/src/test/java/org/infinispan/stream/stress/ReplicatedStreamRehashStressTest.java
+++ b/core/src/test/java/org/infinispan/stream/stress/ReplicatedStreamRehashStressTest.java
@@ -1,0 +1,18 @@
+package org.infinispan.stream.stress;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.testng.annotations.Test;
+
+/**
+ * Stress test designed to test to verify that distributed stream works properly when constant rehashes occur in
+ * a replicated cache
+ *
+ * @author wburns
+ * @since 8.2
+ */
+@Test(groups = "stress", testName = "stream.stress.ReplicatedStreamRehashStressTest")
+public class ReplicatedStreamRehashStressTest extends DistributedStreamRehashStressTest {
+   public ReplicatedStreamRehashStressTest() {
+      super(CacheMode.REPL_SYNC);
+   }
+}


### PR DESCRIPTION
* Fixed issue with filterBySegment / REPL cache and failover

https://issues.jboss.org/browse/ISPN-6306