### PR TITLE
ISPN-6043 Log the stacktrace if a listener fails

### DIFF
--- a/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/CacheManagerNotifierImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachemanagerlistener/CacheManagerNotifierImpl.java
@@ -133,7 +133,7 @@ public class CacheManagerNotifierImpl extends AbstractListenerImpl<Event, Listen
       } catch (Exception x) {
          // Only cache entry-related listeners should be able to throw an exception to veto the operation.
          // Just log the exception thrown by the invoker, it should contain all the relevant information.
-         log.error(x);
+         log.failedInvokingCacheManagerListener(x);
       }
    }
 

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1408,4 +1408,8 @@ public interface Log extends BasicLogger {
 
    @Message(value = "The configured entity class %s is not indexable. Please remove it from the indexing configuration.", id = 404)
    CacheConfigurationException classNotIndexable(String className);
+
+   @LogMessage(level = ERROR)
+   @Message(value = "Caught exception while invoking a cache manager listener!", id = 405)
+   void failedInvokingCacheManagerListener(@Cause Exception e);
 }


### PR DESCRIPTION
Having only the exception message in the log is often not enough, i.e.

```
ERROR [org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifierImpl] (sc-main) org.infinispan.commons.CacheListenerException: ISPN000280: Caught exception [java.lang.NullPointerException] while invoking method [public synchronized void org.radargun.service.InfinispanClustered.viewChanged(org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent)] on listener instance: org.radargun.service.InfinispanClustered@78338b0a
```
