### PR TITLE
ISPN-6353 REST service fails to start during remote query server inte…

### DIFF
--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/configs/ExampleConfigsIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/configs/ExampleConfigsIT.java
@@ -25,7 +25,6 @@ import org.infinispan.arquillian.core.RemoteInfinispanServer;
 import org.infinispan.arquillian.core.RemoteInfinispanServers;
 import org.infinispan.arquillian.core.RunningServer;
 import org.infinispan.arquillian.core.WithRunningServer;
-import org.infinispan.arquillian.utils.MBeanObjectsProvider;
 import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.RemoteCache;

--- a/server/integration/testsuite/src/test/resources/config/infinispan/customcs.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/customcs.xml
@@ -1,9 +1,10 @@
-        <subsystem xmlns="urn:infinispan:server:core:8.0">
+        <subsystem xmlns="urn:infinispan:server:core:8.2">
             <cache-container name="local" default-cache="default">
                 <local-cache name="default" start="EAGER">
                     <store name="customStore" class="org.infinispan.persistence.cluster.MyCustomCacheStore">
                         <property name="customProperty">10</property>
                     </store>
                 </local-cache>
+                <replicated-cache name="memcachedCache" mode="SYNC"/>
             </cache-container>
         </subsystem>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/customtask.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/customtask.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:infinispan:server:core:8.0" >
+<subsystem xmlns="urn:infinispan:server:core:8.2" >
     <cache-container
             name="local"
             default-cache="taskAccessible">
@@ -13,6 +13,7 @@
             <transaction mode="NONE" />
             <compatibility enabled="true"/>
         </local-cache>
+        <replicated-cache name="memcachedCache" mode="SYNC"/>
     </cache-container>
 </subsystem>
 

--- a/server/integration/testsuite/src/test/resources/config/infinispan/eviction.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/eviction.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:8.0">
+        <subsystem xmlns="urn:infinispan:server:core:8.2">
              <cache-container name="local" default-cache="none">
                  <local-cache name="none" start="EAGER">
                      <eviction strategy="NONE" />
@@ -13,5 +13,6 @@
                  <local-cache name="lru" start="EAGER">
                      <eviction strategy="LRU" max-entries="3"/>
                  </local-cache>
+                 <replicated-cache name="memcachedCache" mode="SYNC"/>
              </cache-container>
         </subsystem>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/expiration.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/expiration.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:8.0">
+        <subsystem xmlns="urn:infinispan:server:core:8.2">
             <cache-container name="clustered" default-cache="default">
                 <transport lock-timeout="240000"/>
                 <replicated-cache name="hotrodExpiration" start="EAGER" mode="SYNC" batching="false" remote-timeout="30000">
@@ -9,5 +9,6 @@
                     <file-store name="expirationCacheStore" passivation="false" path="rest-expiration-cache-store" purge="true" />
                     <expiration lifespan="2000" max-idle="2000" />
                 </replicated-cache>
+                <replicated-cache name="memcachedCache" mode="SYNC"/>
             </cache-container>
         </subsystem>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/filecachestore.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/filecachestore.xml
@@ -1,8 +1,9 @@
-        <subsystem xmlns="urn:infinispan:server:core:8.0">
+        <subsystem xmlns="urn:infinispan:server:core:8.2">
             <cache-container name="local" default-cache="default">
                 <local-cache name="default" start="EAGER">
                     <file-store name="myFileStore" passivation="false" purge="false" max-entries="2" />
                 </local-cache>
+                <replicated-cache name="memcachedCache" mode="SYNC"/>
             </cache-container>
             <cache-container name="security"/>
         </subsystem>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/indexing-secured.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/indexing-secured.xml
@@ -2,6 +2,7 @@
 
             <cache-container name="clustered" default-cache="test_cache_not_indexed">
                 <transport lock-timeout="240000"/>
+
                 <security>
                     <authorization>
                         <identity-role-mapper/>
@@ -11,7 +12,8 @@
                         <role name="supervisor" permissions="READ WRITE EXEC BULK_READ"/>
                     </authorization>
                 </security>
-                <distributed-cache name="test_cache_indexed" mode="SYNC" start="EAGER" module="org.infinispan.remote-query.server">
+
+                <distributed-cache name="test_cache_indexed" mode="SYNC" start="EAGER">
                     <indexing index="ALL">
                         <property name="default.directory_provider">ram</property>
                     </indexing>
@@ -19,11 +21,14 @@
                         <authorization roles="admin reader writer supervisor" enabled="true"/>
                     </security>
                 </distributed-cache>
-                <distributed-cache name="test_cache_not_indexed" mode="SYNC" start="EAGER" module="org.infinispan.remote-query.server">
+
+                <distributed-cache name="test_cache_not_indexed" mode="SYNC" start="EAGER">
                     <security>
                         <authorization roles="admin reader writer supervisor" enabled="true"/>
                     </security>
                 </distributed-cache>
+
+                <replicated-cache name="memcachedCache" mode="SYNC"/>
             </cache-container>
 
             <cache-container name="security"/>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/indexing.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/indexing.xml
@@ -2,6 +2,7 @@
 
             <cache-container name="clustered" default-cache="repltestcache">
                 <transport lock-timeout="240000"/>
+
                 <replicated-cache name="repltestcache" mode="SYNC" start="EAGER" module="org.infinispan.remote-query.server">
                     <indexing index="ALL">
                         <property name="default.indexmanager">org.infinispan.query.indexmanager.InfinispanIndexManager</property>
@@ -22,18 +23,19 @@
 
                 <replicated-cache name="repl_descriptor" start="EAGER" mode="SYNC" />
 
-                <distributed-cache name="disttestcache" mode="SYNC" start="EAGER" module="org.infinispan.remote-query.server">
+                <distributed-cache name="disttestcache" mode="SYNC" start="EAGER">
                     <indexing index="ALL">
                         <property name="default.directory_provider">ram</property>
                     </indexing>
                 </distributed-cache>
 
-                <local-cache name="localtestcache" start="EAGER" module="org.infinispan.remote-query.server">
+                <local-cache name="localtestcache" start="EAGER">
                     <indexing index="ALL">
                         <property name="default.directory_provider">ram</property>
                         <property name="lucene_version">LUCENE_CURRENT</property>
                     </indexing>
                 </local-cache>
+
                 <local-cache name="localtestcache_manual" start="EAGER">
                     <indexing index="ALL">
                         <property name="default.directory_provider">ram</property>
@@ -42,7 +44,12 @@
                         <property name="hibernate.search.jmx_enabled">true</property>
                     </indexing>
                 </local-cache>
+
                 <local-cache name="localnotindexed" start="EAGER" />
+
+                <!-- Keep REST and Memcached services happy by providing the needed caches -->
+                <replicated-cache name="rest" mode="SYNC"/>
+                <replicated-cache name="memcachedCache" mode="SYNC"/>
             </cache-container>
 
             <cache-container name="security"/>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/rcs-remote.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/rcs-remote.xml
@@ -1,4 +1,4 @@
-        <subsystem xmlns="urn:infinispan:server:core:8.0" >
+        <subsystem xmlns="urn:infinispan:server:core:8.2" >
             <cache-container 
                 name="local"
                 default-cache="default">
@@ -13,5 +13,6 @@
                         striping="false" />
                     <transaction mode="NONE" />
                 </local-cache>
+                <replicated-cache name="memcachedCache" mode="SYNC"/>
             </cache-container>
         </subsystem>


### PR DESCRIPTION
…gration tests

* define rest and memcachedCache to avoid being created based on the default config (which would fail due to classloading of InfinispanIndexManager)
* remove module attribute from cache definitions that do not need it

Jira: https://issues.jboss.org/browse/ISPN-6353