### PR TITLE
ISPN-6352 ClusterExecutor.submitConsumer swallows exceptions thrown by

### DIFF
--- a/core/src/test/java/org/infinispan/manager/ClusterExecutorTest.java
+++ b/core/src/test/java/org/infinispan/manager/ClusterExecutorTest.java
@@ -332,7 +332,7 @@ public class ClusterExecutorTest extends AbstractInfinispanTest {
             EmbeddedCacheManager cm1 = cms[0];
 
             CompletableFuture<Void> future =
-                    cm1.executor().timeout(10, TimeUnit.MILLISECONDS).submitConsumer(m -> null,
+                    cm1.executor().submitConsumer(m -> null,
                             (a, i, t) -> {
                                throw new NullPointerException();
                             });


### PR DESCRIPTION
the consumer

* Make sure we don't set timeout for test

https://issues.jboss.org/browse/ISPN-6352