### PR TITLE
ISPN-6353 REST service fails to start during remote query server inte…

### DIFF
--- a/server/integration/testsuite/src/test/resources/config/infinispan/customcs.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/customcs.xml
@@ -5,6 +5,6 @@
                         <property name="customProperty">10</property>
                     </store>
                 </local-cache>
-                <replicated-cache name="memcachedCache" mode="SYNC"/>
+                <local-cache name="memcachedCache"/>
             </cache-container>
         </subsystem>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/customtask.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/customtask.xml
@@ -13,7 +13,7 @@
             <transaction mode="NONE" />
             <compatibility enabled="true"/>
         </local-cache>
-        <replicated-cache name="memcachedCache" mode="SYNC"/>
+        <local-cache name="memcachedCache"/>
     </cache-container>
 </subsystem>
 

--- a/server/integration/testsuite/src/test/resources/config/infinispan/eviction.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/eviction.xml
@@ -5,14 +5,14 @@
                  </local-cache>
                  <local-cache name="unordered" start="EAGER">
                      <!-- UNORDERED is deprecated and uses LRU instead -->
-                     <eviction strategy="UNORDERED" max-entries="3"/>
+                     <eviction strategy="UNORDERED" size="3"/>
                  </local-cache>
                  <local-cache name="lirs" start="EAGER">
-                     <eviction strategy="LIRS" max-entries="5"/>
+                     <eviction strategy="LIRS" size="5"/>
                  </local-cache>
                  <local-cache name="lru" start="EAGER">
-                     <eviction strategy="LRU" max-entries="3"/>
+                     <eviction strategy="LRU" size="3"/>
                  </local-cache>
-                 <replicated-cache name="memcachedCache" mode="SYNC"/>
+                 <local-cache name="memcachedCache"/>
              </cache-container>
         </subsystem>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/filecachestore.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/filecachestore.xml
@@ -3,7 +3,7 @@
                 <local-cache name="default" start="EAGER">
                     <file-store name="myFileStore" passivation="false" purge="false" max-entries="2" />
                 </local-cache>
-                <replicated-cache name="memcachedCache" mode="SYNC"/>
+                <local-cache name="memcachedCache"/>
             </cache-container>
             <cache-container name="security"/>
         </subsystem>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/indexing.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/indexing.xml
@@ -48,8 +48,8 @@
                 <local-cache name="localnotindexed" start="EAGER" />
 
                 <!-- Keep REST and Memcached services happy by providing the needed caches -->
-                <replicated-cache name="rest" mode="SYNC"/>
-                <replicated-cache name="memcachedCache" mode="SYNC"/>
+                <replicated-cache name="rest" mode="SYNC" start="EAGER"/>
+                <replicated-cache name="memcachedCache" mode="SYNC" start="EAGER"/>
             </cache-container>
 
             <cache-container name="security"/>

--- a/server/integration/testsuite/src/test/resources/config/infinispan/rcs-remote.xml
+++ b/server/integration/testsuite/src/test/resources/config/infinispan/rcs-remote.xml
@@ -13,6 +13,6 @@
                         striping="false" />
                     <transaction mode="NONE" />
                 </local-cache>
-                <replicated-cache name="memcachedCache" mode="SYNC"/>
+                <local-cache name="memcachedCache"/>
             </cache-container>
         </subsystem>


### PR DESCRIPTION
…gration tests

* make the rest cache startup eager to avoid CNFE
* fix max-entries vs size
* use local caches for REST and memcached if the cache container is local

jira: https://issues.jboss.org/browse/ISPN-6353

This is take 2. The previous PR for this issue has introduced a failure in EvictionStrategyIT and also did not really solve the problem of the missing rest or memcached caches because the newly added ones failed to start anyway since they were replicated and the container was local.