### PR TITLE
ISPN-6322 Infinispan can miss incoming commands with JGroupsChannelLokup

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -626,7 +626,7 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
          return singleResponseFuture.thenApply(rsp -> {
             if (trace) log.tracef("Response: %s", rsp);
             Address sender = fromJGroupsAddress(rsp.getSender());
-            Response response = checkRsp(rsp, sender, responseFilter != null, ignoreLeavers);
+            Response response = checkRsp(rsp, sender, ignoreTimeout(responseFilter), ignoreLeavers);
             return Collections.singletonMap(sender, response);
          });
       } else if (rspListFuture != null) {
@@ -639,7 +639,7 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
             for (Rsp<Response> rsp : rsps.values()) {
                hasResponses |= rsp.wasReceived();
                Address sender = fromJGroupsAddress(rsp.getSender());
-               Response response = checkRsp(rsp, sender, responseFilter != null, ignoreLeavers);
+               Response response = checkRsp(rsp, sender, ignoreTimeout(responseFilter), ignoreLeavers);
                if (response != null) {
                   hasValidResponses = true;
                   retval.put(sender, response);
@@ -669,6 +669,10 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
       } else {
          throw new IllegalStateException("Should have one remote invocation future");
       }
+   }
+
+   private boolean ignoreTimeout(ResponseFilter responseFilter) {
+      return responseFilter != null && !responseFilter.needMoreResponses();
    }
 
    @Override
@@ -725,7 +729,7 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
       boolean hasResponses = false;
       for (Rsp<Response> rsp : rsps) {
          Address sender = fromJGroupsAddress(rsp.getSender());
-         Response response = checkRsp(rsp, sender, responseFilter != null, ignoreLeavers);
+         Response response = checkRsp(rsp, sender, ignoreTimeout(responseFilter), ignoreLeavers);
          if (response != null) {
             retval.put(sender, response);
             hasResponses = true;
@@ -794,7 +798,9 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
       } else if (rsp.wasSuspected()) {
          response = checkResponse(CacheNotFoundResponse.INSTANCE, sender, ignoreLeavers);
       } else {
-         if (!ignoreTimeout) throw new TimeoutException("Replication timeout for " + sender);
+         if (!ignoreTimeout) {
+            throw new TimeoutException("Replication timeout for " + sender);
+         }
          response = null;
       }
 

--- a/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterTopologyManagerImpl.java
@@ -33,6 +33,7 @@ import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.Transport;
 import org.infinispan.remoting.transport.jgroups.SuspectException;
+import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -47,6 +48,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
@@ -66,6 +68,10 @@ import static org.infinispan.util.logging.events.Messages.MESSAGES;
  * @since 5.2
  */
 public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
+
+   public static final int INITIAL_CONNECTION_ATTEMPTS = 10;
+   public static final int CLUSTER_RECOVERY_ATTEMPTS = 10;
+
    private enum ClusterManagerStatus {
       INITIALIZING,
       REGULAR_MEMBER,
@@ -139,20 +145,33 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
 
    protected void fetchRebalancingStatusFromCoordinator() {
       if (!transport.isCoordinator()) {
+         // Assume any timeout is because the coordinator doesn't have a CommandAwareRpcDispatcher yet
+         // (possible with a JGroupsChannelLookup and shouldConnect = false), and retry.
          ReplicableCommand command = new CacheTopologyControlCommand(null,
                CacheTopologyControlCommand.Type.POLICY_GET_STATUS, transport.getAddress(), -1);
-         Address coordinator = transport.getCoordinator();
-         try {
-            Map<Address, Response> responseMap = transport.invokeRemotely(Collections.singleton(coordinator),
-                  command, ResponseMode.SYNCHRONOUS, getGlobalTimeout(), null, DeliverOrder.NONE, false);
-            Response response = responseMap.get(coordinator);
-            if (response instanceof SuccessfulResponse) {
-               globalRebalancingEnabled = ((Boolean) ((SuccessfulResponse) response).getResponseValue());
-            } else {
-               log.errorReadingRebalancingStatus(coordinator, null);
+         Address coordinator = null;
+         Response response = null;
+         for (int i = INITIAL_CONNECTION_ATTEMPTS - 1; i >= 0; i--) {
+            try {
+               coordinator = transport.getCoordinator();
+               Map<Address, Response> responseMap = transport
+                     .invokeRemotely(Collections.singleton(coordinator), command, ResponseMode.SYNCHRONOUS,
+                           getGlobalTimeout() / INITIAL_CONNECTION_ATTEMPTS, null, DeliverOrder.NONE, false);
+               response = responseMap.get(coordinator);
+               break;
+            } catch (Exception e) {
+               if (i == 0 || !(e instanceof TimeoutException)) {
+                  log.errorReadingRebalancingStatus(coordinator, e);
+                  response = SuccessfulResponse.create(Boolean.TRUE);
+               }
+               log.debug("Timed out waiting for rebalancing status from coordinator, trying again");
             }
-         } catch (Exception e) {
-            log.errorReadingRebalancingStatus(coordinator, e);
+         }
+
+         if (response instanceof SuccessfulResponse) {
+            globalRebalancingEnabled = ((Boolean) ((SuccessfulResponse) response).getResponseValue());
+         } else {
+            log.errorReadingRebalancingStatus(coordinator, new CacheException(response.toString()));
          }
       }
    }
@@ -407,8 +426,21 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
       log.debugf("Recovering cluster status for view %d", newViewId);
       ReplicableCommand command = new CacheTopologyControlCommand(null,
             CacheTopologyControlCommand.Type.GET_STATUS, transport.getAddress(), newViewId);
-      Map<Address, Object> statusResponses = executeOnClusterSync(command, getGlobalTimeout(), false, false,
-            new CacheTopologyFilterReuser());
+      Map<Address, Object> statusResponses = null;
+      // Assume any timeout is because one of the nodes didn't have a CommandAwareRpcDispatcher
+      // installed at the time (possible with JGroupsChannelLookup and shouldConnect == false), and retry.
+      for (int i = CLUSTER_RECOVERY_ATTEMPTS - 1; i >= 0; i--) {
+         try {
+            statusResponses =
+                  executeOnClusterSync(command, getGlobalTimeout() / CLUSTER_RECOVERY_ATTEMPTS, false, false,
+                        new CacheTopologyFilterReuser());
+            break;
+         } catch (ExecutionException e) {
+            if (i == 0 || !(e.getCause() instanceof TimeoutException))
+               throw e;
+            log.debug("Timed out waiting for cluster status responses, trying again");
+         }
+      }
 
       log.debugf("Got %d status responses. members are %s", statusResponses.size(), clusterMembers);
       Map<String, Map<Address, CacheStatusResponse>> responsesByCache = new HashMap<>();
@@ -521,7 +553,7 @@ public class ClusterTopologyManagerImpl implements ClusterTopologyManager {
          throw new Exception(throwable);
       }
 
-      return extractResponseValues(remoteFuture.get(timeout, TimeUnit.MILLISECONDS), localResponse);
+      return extractResponseValues(CompletableFutures.await(remoteFuture), localResponse);
    }
 
    private int getGlobalTimeout() {

--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartChanelLookupTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartChanelLookupTest.java
@@ -1,0 +1,125 @@
+package org.infinispan.statetransfer;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.JGroupsConfigBuilder;
+import org.infinispan.test.fwk.TestResourceTracker;
+import org.infinispan.test.fwk.TransportFlags;
+import org.jgroups.JChannel;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Future;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.infinispan.test.TestingUtil.blockUntilViewsReceived;
+import static org.infinispan.test.TestingUtil.extractGlobalComponentRegistry;
+import static org.infinispan.test.TestingUtil.waitForRehashToComplete;
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Tests concurrent startup of cache managers when the channel is started externally
+ * and injected with a JGroupsChannelLookup.
+ *
+ * @author Dan Berindei
+ * @since 8.2
+ */
+@Test(testName = "statetransfer.ConcurrentStartTest", groups = "functional")
+@CleanupAfterMethod
+public class ConcurrentStartChanelLookupTest extends MultipleCacheManagersTest {
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      // The test method will create the cache managers
+   }
+
+   @DataProvider(name = "startOrder")
+   public Object[][] startOrder() {
+      return new Object[][]{{0, 1}, {1, 0}};
+   }
+
+   @Test(timeOut = 60000, dataProvider = "startOrder")
+   public void testConcurrentStart(int eagerManager, int lazyManager) throws Exception {
+      TestResourceTracker.testThreadStarted(this);
+      String name1 = TestResourceTracker.getNextNodeName();
+      String name2 = TestResourceTracker.getNextNodeName();
+
+      // Create and connect both channels beforehand
+      // We need both nodes in the view when the coordinator's ClusterTopologyManagerImpl starts
+      // in order to reproduce the ISPN-5106 deadlock
+      JChannel ch1 = createChannel(name1, 0);
+      JChannel ch2 = createChannel(name2, 1);
+
+      // Use a JGroupsChannelLookup to pass the created channels to the transport
+      EmbeddedCacheManager cm1 = createCacheManager(name1, ch1);
+      EmbeddedCacheManager cm2 = createCacheManager(name2, ch2);
+
+      try {
+         assertEquals(ComponentStatus.INSTANTIATED, extractGlobalComponentRegistry(cm1).getStatus());
+         assertEquals(ComponentStatus.INSTANTIATED, extractGlobalComponentRegistry(cm2).getStatus());
+
+         log.debugf("Channels created. Starting the caches");
+         Future<Object> repl1Future = fork(() -> manager(eagerManager).getCache("repl"));
+
+         // If eagerManager == 0, the coordinator broadcasts a GET_STATUS command.
+         // If eagerManager == 1, the non-coordinator sends a POLICY_GET_STATUS command to the coordinator.
+         // We want to start the lazyManager without receiving these commands, then the eagerManager should
+         // retry and succeed.
+         // Bundling and retransmission in NAKACK2 mean we need an extra wait after lazyManager sent its
+         // command, so we don't try to wait for a precise amount of time.
+         Thread.sleep(500);
+
+         Future<Object> repl2Future = fork(() -> manager(lazyManager).getCache("repl"));
+
+         repl1Future.get(10, SECONDS);
+         repl2Future.get(10, SECONDS);
+
+         Cache<String, String> c1r = cm1.getCache("repl");
+         Cache<String, String> c2r = cm2.getCache("repl");
+
+         blockUntilViewsReceived(10000, cm1, cm2);
+         waitForRehashToComplete(c1r, c2r);
+
+         c1r.put("key", "value");
+         assertEquals("value", c2r.get("key"));
+      } finally {
+         cm1.stop();
+         cm2.stop();
+
+         ch1.close();
+         ch2.close();
+      }
+   }
+
+   private EmbeddedCacheManager createCacheManager(String name1, JChannel ch1) {
+      GlobalConfigurationBuilder gcb1 = new GlobalConfigurationBuilder();
+      gcb1.transport().nodeName(ch1.getName()).distributedSyncTimeout(10, SECONDS);
+      gcb1.globalJmxStatistics().allowDuplicateDomains(true);
+      CustomChannelLookup.registerChannel(gcb1, ch1, name1, false);
+
+      ConfigurationBuilder replCfg = new ConfigurationBuilder();
+      replCfg.clustering().cacheMode(CacheMode.REPL_SYNC);
+      replCfg.clustering().stateTransfer().timeout(10, SECONDS);
+
+      EmbeddedCacheManager cm1 = new DefaultCacheManager(gcb1.build(), replCfg.build(), false);
+      registerCacheManager(cm1);
+      return cm1;
+   }
+
+   private JChannel createChannel(String name, int portRange) throws Exception {
+      JChannel channel = new JChannel(JGroupsConfigBuilder
+            .getJGroupsConfig(ConcurrentStartChanelLookupTest.class.getName(),
+                  new TransportFlags().withPortRange(portRange)));
+      channel.setName(name);
+      channel.connect(ConcurrentStartChanelLookupTest.class.getSimpleName());
+      log.tracef("Channel %s connected: %s", channel, channel.getViewAsString());
+      return channel;
+   }
+}

--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartForkChannelTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartForkChannelTest.java
@@ -150,7 +150,7 @@ public class ConcurrentStartForkChannelTest extends MultipleCacheManagersTest {
       });
       channel.getProtocolStack().addProtocol(fork);
       ForkChannel fch = new ForkChannel(channel, "stack1", "channel1");
-      CustomChannelLookup.registerChannel(name, fch, gcb, true);
+      CustomChannelLookup.registerChannel(gcb, fch, name, true);
 
       EmbeddedCacheManager cm = new DefaultCacheManager(gcb.build(), cacheCfg.build(), false);
       registerCacheManager(cm);

--- a/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ConcurrentStartTest.java
@@ -116,7 +116,7 @@ public class ConcurrentStartTest extends MultipleCacheManagersTest {
       GlobalConfigurationBuilder gcb = new GlobalConfigurationBuilder();
       gcb.transport().nodeName(name);
       gcb.globalJmxStatistics().allowDuplicateDomains(true);
-      CustomChannelLookup.registerChannel(channel.getName(), channel, gcb, false);
+      CustomChannelLookup.registerChannel(gcb, channel, channel.getName(), false);
       EmbeddedCacheManager cm = new DefaultCacheManager(gcb.build(), false);
       Configuration replCfg = new ConfigurationBuilder().clustering().cacheMode(CacheMode.REPL_SYNC).build();
       cm.defineConfiguration(REPL_CACHE_NAME, replCfg);

--- a/core/src/test/java/org/infinispan/statetransfer/CustomChannelLookup.java
+++ b/core/src/test/java/org/infinispan/statetransfer/CustomChannelLookup.java
@@ -21,8 +21,8 @@ public class CustomChannelLookup implements JGroupsChannelLookup {
    private static final Map<String, JChannel> channelMap = CollectionFactory.makeConcurrentMap();
    private boolean connect;
 
-   public static void registerChannel(String nodeName, JChannel channel,
-         GlobalConfigurationBuilder gcb, boolean connect) {
+   public static void registerChannel(GlobalConfigurationBuilder gcb, JChannel channel, String nodeName,
+         boolean connect) {
       TransportConfigurationBuilder tcb = gcb.transport();
       tcb.defaultTransport();
       tcb.addProperty(JGroupsTransport.CHANNEL_LOOKUP, CustomChannelLookup.class.getName());


### PR DESCRIPTION
Also fixes ISPN-6384 Fix JGroupsTransport.invokeRemotelyAsync timeout handling.
The ISPN-6322 commit adds a new test for JGroupsChannelLookup concurrent start, so there's another commit to stop using JGroupsChannelLookup in ConcurrentStartTest.

https://issues.jboss.org/browse/ISPN-6322
https://issues.jboss.org/browse/ISPN-6384
https://issues.jboss.org/browse/ISPN-5495

Please cherry-pick to 8.2.x as well.