### PR TITLE
ISPN-6275 Avoid invalidating transport twice

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/TcpTransportFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/transport/tcp/TcpTransportFactory.java
@@ -306,14 +306,7 @@ public class TcpTransportFactory implements TransportFactory {
 
    @Override
    public void invalidateTransport(SocketAddress serverAddress, Transport transport) {
-      KeyedObjectPool<SocketAddress, TcpTransport> pool = getConnectionPool();
-      try {
-         // Transport could be null, in which case all connections
-         // to the server address will be invalidated
-         pool.invalidateObject(serverAddress, (TcpTransport) transport);
-      } catch (Exception e) {
-         log.unableToInvalidateTransport(serverAddress);
-      }
+      transport.invalidate();
    }
 
    @Override


### PR DESCRIPTION
* On invalidate simply mark transport as invalid instead of invalidating
  it from the pool. When the transport is released, if the transport is
  invalid, it'll get evicted from the pool.