### PR TITLE
ISPN-6389 Warn when duplicated classes are found

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -24,6 +24,8 @@ import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.FileLookupFactory;
 import org.infinispan.commons.util.TypedProperties;
 import org.infinispan.commons.util.Util;
+import org.infinispan.commons.util.uberjar.UberJarDuplicatedJarsWarner;
+import org.infinispan.commons.util.uberjar.ManifestUberJarDuplicatedJarsWarner;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -104,6 +106,7 @@ public class RemoteCacheManager implements RemoteCacheContainer {
    public Configuration getConfiguration() {
       return configuration;
    }
+
 
    /**
     * @since 4.2
@@ -272,7 +275,18 @@ public class RemoteCacheManager implements RemoteCacheContainer {
       // Print version to help figure client version run
       log.version(RemoteCacheManager.class.getPackage().getImplementationVersion());
 
+      warnAboutUberJarDuplicates();
+
       started = true;
+   }
+
+   private final void warnAboutUberJarDuplicates() {
+      UberJarDuplicatedJarsWarner scanner = new ManifestUberJarDuplicatedJarsWarner();
+      scanner.isClasspathCorrectAsync()
+              .thenAcceptAsync(isClasspathCorrect -> {
+                 if(!isClasspathCorrect)
+                    log.warnAboutUberJarDuplicates();
+              });
    }
 
    /**

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
@@ -256,4 +256,8 @@ public interface Log extends BasicLogger {
    @Message(value = "Tracking key %s belonging to segment %d, already tracked? = %b", id = 4064)
    void trackingSegmentKey(String key, int segment, boolean isTracked);
 
+   @LogMessage(level = WARN)
+   @Message(value = "Classpath does not look correct. Make sure you are not mixing uber and jars", id = 4065)
+   void warnAboutUberJarDuplicates();
+
 }

--- a/commons/src/main/java/org/infinispan/commons/util/uberjar/ManifestUberJarDuplicatedJarsWarner.java
+++ b/commons/src/main/java/org/infinispan/commons/util/uberjar/ManifestUberJarDuplicatedJarsWarner.java
@@ -1,0 +1,81 @@
+package org.infinispan.commons.util.uberjar;
+
+import org.infinispan.commons.logging.Log;
+import org.infinispan.commons.logging.LogFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.jar.Manifest;
+
+/**
+ * Manifest based implementation of a {@link UberJarDuplicatedJarsWarner}.
+ * <p>
+ *     Incorrect combinations:
+ *     <ul>
+ *         <li>Commons + any of the Uber Jars</li>
+ *         <li>Embedded + Remote Uber Jar</li>
+ *         <li>Commons + Embedded + Remote Uber Jar</li>
+ *     </ul>
+ * </p>
+ *
+ * @author slaskawi
+ */
+public class ManifestUberJarDuplicatedJarsWarner implements UberJarDuplicatedJarsWarner {
+
+    private static final Log logger = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+
+    private static final String MANIFEST_LOCATION = "META-INF/MANIFEST.MF";
+    private final String SYMBOLIC_NAME_MANIFEST_ENTRY = "Bundle-SymbolicName";
+
+    @Override
+    public boolean isClasspathCorrect() {
+        List<String> bundleNames = getBundleSymbolicNames();
+        long numberOfMatches = bundleNames.stream()
+                .filter(hasRemoteUberJar()
+                        .or(hasEmbeddedUberJar())
+                        .or(hasCommons()))
+                .count();
+        return numberOfMatches < 2;
+    }
+
+    List<String> getBundleSymbolicNames() {
+        List<String> symbolicNames = new ArrayList<>();
+        try {
+            Enumeration<URL> resources = Thread.currentThread().getContextClassLoader().getResources(MANIFEST_LOCATION);
+            while (resources.hasMoreElements()) {
+                URL manifestUrl = resources.nextElement();
+                try (InputStream is = manifestUrl.openStream()) {
+                    Manifest manifest = new Manifest(is);
+                    symbolicNames.add(manifest.getMainAttributes().getValue(SYMBOLIC_NAME_MANIFEST_ENTRY));
+                }
+            }
+        } catch (IOException e) {
+            logger.warn("Can not extract jar manifest from the classpath. Uber Jar classpath check is skipped.");
+        }
+        return symbolicNames;
+    }
+
+    Predicate<String> hasCommons() {
+        return jarSymbolicName -> "org.infinispan.commons".equals(jarSymbolicName);
+    }
+
+    Predicate<String> hasEmbeddedUberJar() {
+        return jarSymbolicName -> "org.infinispan.embedded".equals(jarSymbolicName);
+    }
+
+    Predicate<String> hasRemoteUberJar() {
+        return jarSymbolicName -> "org.infinispan.remote".equals(jarSymbolicName);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> isClasspathCorrectAsync() {
+        return CompletableFuture.supplyAsync(() -> isClasspathCorrect());
+    }
+}

--- a/commons/src/main/java/org/infinispan/commons/util/uberjar/UberJarDuplicatedJarsWarner.java
+++ b/commons/src/main/java/org/infinispan/commons/util/uberjar/UberJarDuplicatedJarsWarner.java
@@ -1,0 +1,25 @@
+package org.infinispan.commons.util.uberjar;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Checks if classpath contains proper configuration for Uber Jars and warns if it does not.
+ *
+ * @author slaskawi
+ */
+public interface UberJarDuplicatedJarsWarner {
+
+    /**
+     * Synchronously checks if classpath looks correct for Uber Jar usage.
+     *
+     * @return <code>true</code> if duplicate is found.
+     */
+    boolean isClasspathCorrect();
+
+    /**
+     * Asynchronously checks if classpath looks correct for Uber Jar usage.
+     *
+     * @return {@link CompletableFuture} with the result.
+     */
+    CompletableFuture<Boolean> isClasspathCorrectAsync();
+}

--- a/commons/src/test/java/org/infinispan/commons/util/uberjar/ManifestUberJarDuplicatedJarsWarnerTest.java
+++ b/commons/src/test/java/org/infinispan/commons/util/uberjar/ManifestUberJarDuplicatedJarsWarnerTest.java
@@ -1,0 +1,74 @@
+package org.infinispan.commons.util.uberjar;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ManifestUberJarDuplicatedJarsWarnerTest {
+
+    @Test
+    public void shouldDetectBothUberJars() throws Exception {
+        //given
+        ManifestUberJarDuplicatedJarsWarner scanner = new ManifestUberJarDuplicatedJarsWarner() {
+            @Override
+            List<String> getBundleSymbolicNames() {
+                return Arrays.asList("org.infinispan.embedded", "org.infinispan.remote");
+            }
+        };
+
+        //when
+        Boolean isClasspathCorrect = scanner.isClasspathCorrect();
+
+        //then
+        assertFalse(isClasspathCorrect);
+    }
+
+    @Test
+    public void shouldDetectCommonsAndUberJar() throws Exception {
+        //given
+        ManifestUberJarDuplicatedJarsWarner scanner = new ManifestUberJarDuplicatedJarsWarner() {
+            @Override
+            List<String> getBundleSymbolicNames() {
+                return Arrays.asList("org.infinispan.embedded", "org.infinispan.commons");
+            }
+        };
+
+        //when
+        Boolean isClasspathCorrect = scanner.isClasspathCorrect();
+
+        //then
+        assertFalse(isClasspathCorrect);
+    }
+
+    @Test
+    public void shouldNotThrowExceptionOnEmptyClasspath() throws Exception {
+        new ManifestUberJarDuplicatedJarsWarner() {
+            @Override
+            List<String> getBundleSymbolicNames() {
+                return Arrays.asList("org.infinispan.embedded", "org.infinispan.commons");
+            }
+        }.isClasspathCorrect();
+    }
+
+    @Test
+    public void shouldPassOnNormalClasspath() throws Exception {
+        //given
+        ManifestUberJarDuplicatedJarsWarner scanner = new ManifestUberJarDuplicatedJarsWarner() {
+            @Override
+            List<String> getBundleSymbolicNames() {
+                return Arrays.asList("org.infinispan.embedded", "org.acme.DonaldDuck");
+            }
+        };
+
+        //when
+        Boolean isClasspathCorrect = scanner.isClasspathCorrect();
+
+        //then
+        assertTrue(isClasspathCorrect);
+    }
+
+}

--- a/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
@@ -6,6 +6,8 @@ import org.infinispan.Version;
 import org.infinispan.commands.module.ModuleCommandFactory;
 import org.infinispan.commands.module.ModuleCommandInitializer;
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.util.uberjar.ManifestUberJarDuplicatedJarsWarner;
+import org.infinispan.commons.util.uberjar.UberJarDuplicatedJarsWarner;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.global.ShutdownHookBehavior;
 import org.infinispan.factories.annotations.SurvivesRestarts;
@@ -239,6 +241,7 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
                l.cacheManagerStarted(this);
             }
          }
+         warnAboutUberJarDuplicates();
       } catch (RuntimeException rte) {
          EmbeddedCacheManagerStartupException exception = new EmbeddedCacheManagerStartupException(rte);
          state = ComponentStatus.FAILED;
@@ -250,6 +253,15 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
          }
          throw exception;
       }
+   }
+
+   private final void warnAboutUberJarDuplicates() {
+      UberJarDuplicatedJarsWarner scanner = new ManifestUberJarDuplicatedJarsWarner();
+      scanner.isClasspathCorrectAsync()
+              .thenAcceptAsync(isClasspathCorrect -> {
+                 if(!isClasspathCorrect)
+                    log.warnAboutUberJarDuplicates();
+              });
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1408,4 +1408,8 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Node %s attempting to join cache %s with incompatible state", id = 410)
    CacheJoinException nodeWithIncompatibleStateJoiningCache(Address joiner, String cacheName);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Classpath does not look correct. Make sure you are not mixing uber and jars", id = 411)
+   void warnAboutUberJarDuplicates();
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6389

Performs an async "fire and forget" check if there are duplicated classes found on the classpath. If so - prints out a warning.