### PR TITLE
ISPN-6399 Timeout updating the JGroups view after killing one node

### DIFF
--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -62,7 +62,7 @@
     <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                    max_bytes="8m"/>
     <pbcast.GMS print_local_addr="false" join_timeout="3000"
-                view_bundling="true"/>
+                view_bundling="false"/>
 
     <MFC max_credits="2M"
          min_threshold="0.40"/>

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -73,7 +73,7 @@
               conn_expiry_timeout="0"/>
 
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
 
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -62,7 +62,7 @@
    <RSVP />           
    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                   max_bytes="400000"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="7000" view_bundling="true"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="7000" view_bundling="false"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
    <FC max_credits="2m"
        min_threshold="0.40"/>

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -62,7 +62,7 @@
    <RSVP />
    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                   max_bytes="400000"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="7000" view_bundling="true"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="7000" view_bundling="false"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
    <FC max_credits="2m"
        min_threshold="0.40"/>

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -56,7 +56,7 @@
          conn_expiry_timeout="0"/>
 
    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
 
    <UFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
@@ -66,7 +66,7 @@
          server_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" />
          
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
 
    <UFC max_credits="2m" min_threshold="0.40"/>
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
@@ -65,7 +65,7 @@
          login_module_name="krb-node1-fail" />
 
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
    
 
    <UFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
@@ -65,7 +65,7 @@
          login_module_name="krb-node1" />
 
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
    
 
    <UFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
@@ -68,7 +68,7 @@
          sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
          
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
 
    <UFC max_credits="2m" min_threshold="0.40"/>
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
@@ -64,7 +64,7 @@
          client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" />
 
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
    
 
    <UFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
@@ -68,7 +68,7 @@
          sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
          
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
 
    <UFC max_credits="2m" min_threshold="0.40"/>
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
@@ -66,7 +66,7 @@
          sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
          
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
 
    <UFC max_credits="2m" min_threshold="0.40"/>
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
@@ -64,7 +64,7 @@
          client_callback_handler_class="org.jgroups.auth.sasl.SimpleAuthorizingCallbackHandler" />
 
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="true"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
    
 
    <UFC max_credits="2m" min_threshold="0.40"/>

--- a/lucene/directory-provider/src/test/resources/testing-flush-loopback.xml
+++ b/lucene/directory-provider/src/test/resources/testing-flush-loopback.xml
@@ -30,6 +30,6 @@
 	<pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
 		max_bytes="400000" />
 	<pbcast.GMS print_local_addr="true" join_timeout="500"
-		view_bundling="true" />
+		view_bundling="false" />
 	<RSVP resend_interval="20" timeout="10000" ack_on_delivery="false" />
 </config>


### PR DESCRIPTION
Work around JGRP-2028 by disabling view bundling.

https://issues.jboss.org/browse/ISPN-6399
