### PR TITLE
ISPN-6401 Improve stability of ClientListenerLeakTest#testNoLeaksAfte…

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/event/ClientListenerNotifier.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/event/ClientListenerNotifier.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -67,7 +68,16 @@ public class ClientListenerNotifier {
    }
 
    public static ClientListenerNotifier create(Codec codec, Marshaller marshaller) {
-      return new ClientListenerNotifier(Executors.newCachedThreadPool(), codec, marshaller);
+      ExecutorService executor = Executors.newCachedThreadPool(getRestoreThreadNameThreadFactory());
+      return new ClientListenerNotifier(executor, codec, marshaller);
+   }
+
+   private static ThreadFactory getRestoreThreadNameThreadFactory() {
+      return r -> new Thread(() -> {
+         final String originalName = Thread.currentThread().getName();
+         r.run();
+         Thread.currentThread().setName(originalName);
+      });
    }
 
    public Marshaller getMarshaller() {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6401

It sometimes happens that the Thread Scheduler has not enough time to kill all the threads (Client event listener threads work in an executor). All we need to do is to give it a bit more time.

I also provided a generic waiting utility. 