### PR TITLE
ISPN-6410 Fix ReplicationQueueTest#testReplicationQueueMultipleThreads

### DIFF
--- a/core/src/test/java/org/infinispan/replication/ReplicationQueueTest.java
+++ b/core/src/test/java/org/infinispan/replication/ReplicationQueueTest.java
@@ -166,6 +166,8 @@ public class ReplicationQueueTest extends MultipleCacheManagersTest {
     * Test that replication queue works fine when multiple threads are putting into the queue.
     */
    public void testReplicationQueueMultipleThreads() throws Exception {
+      ReplicationQueue replicationQueue = TestingUtil.extractComponent(cache1, ReplicationQueue.class);
+
       // put 12 elements in the queue from 4 different threads
       final int numThreads = 4;
       final int numLoopsPerThread = 3;
@@ -183,13 +185,7 @@ public class ReplicationQueueTest extends MultipleCacheManagersTest {
       }, numThreads);
 
       // Now wait until values are replicated properly
-      eventually(new Condition() {
-         @Override
-         public boolean isSatisfied() throws Exception {
-            return cache2.size() == numThreads * numLoopsPerThread;
-         }
-      });
-      ReplicationQueue replicationQueue = TestingUtil.extractComponent(cache1, ReplicationQueue.class);
+      eventually(() -> cache2.size() == numThreads * numLoopsPerThread && replicationQueue.getElementsCount() == 0);
       assertEquals(0, replicationQueue.getElementsCount());
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6410

Since `ReplicationQueue` is deprecated, I fixed this test in the simplest possible way.

To master and 8.2.x please