### PR TITLE
[ISPN-6415] Allow duplicate JMX domains in JPA cache store testsuite

### DIFF
--- a/persistence/jpa/src/test/resources/config/jpa-config.xml
+++ b/persistence/jpa/src/test/resources/config/jpa-config.xml
@@ -8,6 +8,8 @@
    >
 
   <cache-container default-cache="default">
+    <jmx duplicate-domains="true" />
+
     <local-cache name="default">
       <locking isolation="REPEATABLE_READ"
                acquire-timeout="20000" write-skew="false"


### PR DESCRIPTION
See: https://issues.jboss.org/browse/ISPN-6415