### PR TITLE
ISPN-6405 Persistence configuration with clustered cache can cause

### DIFF
--- a/core/src/main/java/org/infinispan/commands/write/RemoveExpiredCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/RemoveExpiredCommand.java
@@ -118,8 +118,8 @@ public class RemoveExpiredCommand extends RemoveCommand {
    public String toString() {
       return "RemoveExpiredCommand{" +
               "key=" + key +
-              "value=" + value +
-              "lifespan=" + lifespan +
+              ", value=" + value +
+              ", lifespan=" + lifespan +
               '}';
    }
 

--- a/core/src/main/java/org/infinispan/commands/write/RemoveExpiredCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/RemoveExpiredCommand.java
@@ -128,7 +128,12 @@ public class RemoveExpiredCommand extends RemoveCommand {
       output.writeObject(commandInvocationId);
       output.writeObject(key);
       output.writeObject(value);
-      output.writeLong(lifespan);
+      if (lifespan != null) {
+         output.writeBoolean(true);
+         output.writeLong(lifespan);
+      } else {
+         output.writeBoolean(false);
+      }
    }
 
    @Override
@@ -136,7 +141,12 @@ public class RemoveExpiredCommand extends RemoveCommand {
       commandInvocationId = (CommandInvocationId) input.readObject();
       key = input.readObject();
       value = input.readObject();
-      lifespan = input.readLong();
+      boolean lifespanProvided = input.readBoolean();
+      if (lifespanProvided) {
+         lifespan = input.readLong();
+      } else {
+         lifespan = null;
+      }
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
+++ b/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
@@ -659,48 +659,42 @@ public class SingleFileStore<K, V> implements AdvancedLoadWriteStore<K, V> {
    
    @Override
    public void purge(Executor threadPool, final PurgeListener task) {
-
-      threadPool.execute(new Runnable() {
-         @Override
-         public void run() {
-            long now = timeService.wallClockTime();
-            List<KeyValuePair<Object, FileEntry>> entriesToPurge = new ArrayList<KeyValuePair<Object, FileEntry>>();
-            synchronized (entries) {
-               for (Iterator<Map.Entry<K, FileEntry>> it = entries.entrySet().iterator(); it.hasNext(); ) {
-                  Map.Entry<K, FileEntry> next = it.next();
-                  FileEntry fe = next.getValue();
-                  if (fe.isExpired(now)) {
-                     it.remove();
-                     entriesToPurge.add(new KeyValuePair<Object, FileEntry>(next.getKey(), fe));
-                  }
-               }
-            }
-
-            resizeLock.readLock().lock();
-            try {
-               for (Iterator<KeyValuePair<Object, FileEntry>> it = entriesToPurge.iterator(); it.hasNext(); ) {
-                  KeyValuePair<Object, FileEntry> next = it.next();
-                  FileEntry fe = next.getValue();
-                  if (fe.isExpired(now)) {
-                     it.remove();
-                     try {
-                        free(fe);
-                     } catch (Exception e) {
-                        throw new PersistenceException(e);
-                     }
-                     if (task != null) task.entryPurged(next.getKey());
-                  }
-               }
-               
-               // Disk space optimizations
-               synchronized (freeList) {
-                 processFreeEntries();
-               }
-            } finally {
-               resizeLock.readLock().unlock();
+      long now = timeService.wallClockTime();
+      List<KeyValuePair<Object, FileEntry>> entriesToPurge = new ArrayList<KeyValuePair<Object, FileEntry>>();
+      synchronized (entries) {
+         for (Iterator<Map.Entry<K, FileEntry>> it = entries.entrySet().iterator(); it.hasNext(); ) {
+            Map.Entry<K, FileEntry> next = it.next();
+            FileEntry fe = next.getValue();
+            if (fe.isExpired(now)) {
+               it.remove();
+               entriesToPurge.add(new KeyValuePair<Object, FileEntry>(next.getKey(), fe));
             }
          }
-      });
+      }
+
+      resizeLock.readLock().lock();
+      try {
+         for (Iterator<KeyValuePair<Object, FileEntry>> it = entriesToPurge.iterator(); it.hasNext(); ) {
+            KeyValuePair<Object, FileEntry> next = it.next();
+            FileEntry fe = next.getValue();
+            if (fe.isExpired(now)) {
+               it.remove();
+               try {
+                  free(fe);
+               } catch (Exception e) {
+                  throw new PersistenceException(e);
+               }
+               if (task != null) task.entryPurged(next.getKey());
+            }
+         }
+
+         // Disk space optimizations
+         synchronized (freeList) {
+           processFreeEntries();
+         }
+      } finally {
+         resizeLock.readLock().unlock();
+      }
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/persistence/spi/AdvancedCacheWriter.java
+++ b/core/src/main/java/org/infinispan/persistence/spi/AdvancedCacheWriter.java
@@ -23,7 +23,10 @@ public interface AdvancedCacheWriter<K, V> extends CacheWriter<K, V> {
    /**
     * Using the thread in the pool, removed all the expired data from the persistence storage. For each removed entry,
     * the supplied listener is invoked.
-    *
+    * <p>
+    * When this method returns all entries will be purged and no tasks will be running due to this loader in the
+    * provided executor.  If however an exception is thrown there could be tasks still pending or running in the
+    * executor.
     * @throws PersistenceException in case of an error, e.g. communicating with the external storage
     */
    void purge(Executor threadPool, PurgeListener<? super K> listener);

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationFunctionalTest.java
@@ -22,15 +22,19 @@ public class ExpirationFunctionalTest extends SingleCacheManagerTest {
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       ConfigurationBuilder builder = TestCacheManagerFactory.getDefaultCacheConfiguration(false);
       configure(builder);
-      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(builder);
+      EmbeddedCacheManager cm = createCacheManager(builder);
       TestingUtil.replaceComponent(cm, TimeService.class, timeService, true);
       cache = cm.getCache();
       afterCacheCreated(cm);
       return cm;
    }
 
-   protected void configure(ConfigurationBuilder config) {
+   protected EmbeddedCacheManager createCacheManager(ConfigurationBuilder builder) {
+      return TestCacheManagerFactory.createCacheManager(builder);
+   }
 
+   protected void configure(ConfigurationBuilder config) {
+      config.expiration().disableReaper();
    }
 
    protected void afterCacheCreated(EmbeddedCacheManager cm) {

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationSingleFileStoreDistListenerFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationSingleFileStoreDistListenerFunctionalTest.java
@@ -1,24 +1,60 @@
 package org.infinispan.expiration.impl;
 
+import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.util.TimeService;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.infinispan.test.TestingUtil.recursiveFileRemove;
 
 @Test(groups = "functional", testName = "expiration.impl.ExpirationSingleFileStoreDistListenerFunctionalTest")
 public class ExpirationSingleFileStoreDistListenerFunctionalTest extends ExpirationStoreListenerFunctionalTest {
+   private EmbeddedCacheManager extraManager;
+   private Cache<Object, Object> extraCache;
+
    @Override
    protected void configure(ConfigurationBuilder config) {
       config
               // Prevent the reaper from running, reaperEnabled(false) doesn't work when a store is present
               .expiration().wakeUpInterval(Long.MAX_VALUE)
               .clustering().cacheMode(CacheMode.DIST_SYNC)
-              .persistence().addSingleFileStore();
+              .persistence().addSingleFileStore().location(TestingUtil.tmpDirectory(this.getClass()));
+   }
+
+   @AfterClass(alwaysRun = true)
+   protected void clearTempDir() {
+      recursiveFileRemove(TestingUtil.tmpDirectory(this.getClass()));
+      recursiveFileRemove(TestingUtil.tmpDirectory(this.getClass().getSimpleName() + "2"));
+   }
+
+   protected void removeFromContainer(String key) {
+      super.removeFromContainer(key);
+      extraCache.getAdvancedCache().getDataContainer().remove(key);
    }
 
    @Override
    protected EmbeddedCacheManager createCacheManager(ConfigurationBuilder builder) {
-      return TestCacheManagerFactory.createClusteredCacheManager(builder);
+      extraManager = TestCacheManagerFactory.createClusteredCacheManager(builder);
+      // Inject our time service into the new CacheManager as well
+      TestingUtil.replaceComponent(extraManager, TimeService.class, timeService, true);
+      extraCache = extraManager.getCache();
+      SingleFileStoreConfigurationBuilder sfsBuilder = (SingleFileStoreConfigurationBuilder) builder.persistence().stores().get(0);
+      // Make sure each cache writes to a different location
+      sfsBuilder.location(TestingUtil.tmpDirectory(this.getClass().getSimpleName() + "2"));
+      EmbeddedCacheManager returned = TestCacheManagerFactory.createClusteredCacheManager(builder);
+      // Unfortunately we can't reinject timeservice once a cache has been started, thus we have to inject
+      // here as well, since we need the cache to verify the cluster was formed
+      TestingUtil.replaceComponent(returned, TimeService.class, timeService, true);
+      Cache<Object, Object> checkCache = returned.getCache();
+      TestingUtil.blockUntilViewReceived(checkCache, 2, TimeUnit.SECONDS.toMillis(10));
+      return returned;
    }
 }

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationSingleFileStoreDistListenerFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationSingleFileStoreDistListenerFunctionalTest.java
@@ -1,0 +1,24 @@
+package org.infinispan.expiration.impl;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "expiration.impl.ExpirationSingleFileStoreDistListenerFunctionalTest")
+public class ExpirationSingleFileStoreDistListenerFunctionalTest extends ExpirationStoreListenerFunctionalTest {
+   @Override
+   protected void configure(ConfigurationBuilder config) {
+      config
+              // Prevent the reaper from running, reaperEnabled(false) doesn't work when a store is present
+              .expiration().wakeUpInterval(Long.MAX_VALUE)
+              .clustering().cacheMode(CacheMode.DIST_SYNC)
+              .persistence().addSingleFileStore();
+   }
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager(ConfigurationBuilder builder) {
+      return TestCacheManagerFactory.createClusteredCacheManager(builder);
+   }
+}

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationSingleFileStoreListenerFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationSingleFileStoreListenerFunctionalTest.java
@@ -2,16 +2,16 @@ package org.infinispan.expiration.impl;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.persistence.file.SingleFileStore;
 import org.testng.annotations.Test;
 
-@Test(groups = "functional", testName = "expiration.impl.ExpirationStoreFunctionalTest")
-public class ExpirationStoreFunctionalTest extends ExpirationFunctionalTest {
-
+@Test(groups = "functional", testName = "expiration.impl.ExpirationSingleFileStoreListenerFunctionalTest")
+public class ExpirationSingleFileStoreListenerFunctionalTest extends ExpirationStoreListenerFunctionalTest {
    @Override
    protected void configure(ConfigurationBuilder config) {
       config
               // Prevent the reaper from running, reaperEnabled(false) doesn't work when a store is present
               .expiration().wakeUpInterval(Long.MAX_VALUE)
-              .persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class);
+              .persistence().addSingleFileStore();
    }
 }

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationStoreListenerFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationStoreListenerFunctionalTest.java
@@ -46,7 +46,7 @@ public class ExpirationStoreListenerFunctionalTest extends ExpirationStoreFuncti
    public void testExpirationOfStoreWhenDataNotInMemory() throws Exception {
       String key = "k";
       cache.put(key, "v", 10, TimeUnit.MILLISECONDS);
-      cache.getAdvancedCache().getDataContainer().remove(key);
+      removeFromContainer(key);
       // At this point data should only be in store - we assume size won't ressurect value into memory
       assertEquals(1, cache.size());
       assertEquals(0, listener.getInvocationCount());
@@ -67,6 +67,10 @@ public class ExpirationStoreListenerFunctionalTest extends ExpirationStoreFuncti
          assertEquals("v", event.getValue());
          assertNotNull(event.getMetadata());
       }
+   }
+
+   protected void removeFromContainer(String key) {
+      cache.getAdvancedCache().getDataContainer().remove(key);
    }
 
    private void assertExpiredEvents(int count) {

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpiredCacheListener.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpiredCacheListener.java
@@ -3,18 +3,23 @@ package org.infinispan.expiration.impl;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryExpired;
 import org.infinispan.notifications.cachelistener.event.CacheEntryExpiredEvent;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Listener
 public class ExpiredCacheListener {
-   List<CacheEntryExpiredEvent> events = new ArrayList<>();
-   int invocationCount;
+   private final static Log log = LogFactory.getLog(ExpiredCacheListener.class);
+   private final List<CacheEntryExpiredEvent> events = Collections.synchronizedList(new ArrayList<>());
+   private final AtomicInteger invocationCount = new AtomicInteger();
 
    public void reset() {
       events.clear();
-      invocationCount = 0;
+      invocationCount.set(0);
    }
 
    public List<CacheEntryExpiredEvent> getEvents() {
@@ -22,7 +27,7 @@ public class ExpiredCacheListener {
    }
 
    public int getInvocationCount() {
-      return invocationCount;
+      return invocationCount.get();
    }
 
 
@@ -30,8 +35,9 @@ public class ExpiredCacheListener {
 
    @CacheEntryExpired
    public void handle(CacheEntryExpiredEvent e) {
+      log.trace("Received event: " + e);
       events.add(e);
 
-      invocationCount++;
+      invocationCount.incrementAndGet();
    }
 }


### PR DESCRIPTION
duplicate expiration messages

* Fixed issue where reaper caused 2 expirations in cluster cache

https://issues.jboss.org/browse/ISPN-6405