### PR TITLE
ISPN-6402 Default GMS.join_timeout is too long

### DIFF
--- a/core/src/main/resources/default-configs/default-jgroups-ec2.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-ec2.xml
@@ -61,7 +61,7 @@
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"
-               join_timeout="15000"
+               join_timeout="${jgroups.join_timeout:5000}"
    />
    <MFC max_credits="2m" 
         min_threshold="0.40"

--- a/core/src/main/resources/default-configs/default-jgroups-google.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-google.xml
@@ -59,7 +59,7 @@
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"
-               join_timeout="15000"
+               join_timeout="${jgroups.join_timeout:5000}"
    />
    <MFC max_credits="2m" 
         min_threshold="0.40"

--- a/core/src/main/resources/default-configs/default-jgroups-tcp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-tcp.xml
@@ -59,7 +59,7 @@
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"
-               join_timeout="15000"
+               join_timeout="${jgroups.join_timeout:5000}"
    />
    <MFC max_credits="2m" 
         min_threshold="0.40"

--- a/core/src/main/resources/default-configs/default-jgroups-udp.xml
+++ b/core/src/main/resources/default-configs/default-jgroups-udp.xml
@@ -58,7 +58,7 @@
                   max_bytes="1M"
    />
    <pbcast.GMS print_local_addr="false"
-               join_timeout="15000"
+               join_timeout="${jgroups.join_timeout:5000}"
    />
    <UFC max_credits="2m" 
         min_threshold="0.40"

--- a/core/src/test/resources/configs/xsite/bridge.xml
+++ b/core/src/test/resources/configs/xsite/bridge.xml
@@ -61,7 +61,7 @@
 
     <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                    max_bytes="8m"/>
-    <pbcast.GMS print_local_addr="false" join_timeout="3000"
+    <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}"
                 view_bundling="false"/>
 
     <MFC max_credits="2M"

--- a/core/src/test/resources/stacks/tcp.xml
+++ b/core/src/test/resources/stacks/tcp.xml
@@ -73,7 +73,7 @@
               conn_expiry_timeout="0"/>
 
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}" view_bundling="false"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
 
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/core/src/test/resources/stacks/tcp_mping/tcp1.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp1.xml
@@ -62,7 +62,7 @@
    <RSVP />           
    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                   max_bytes="400000"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="7000" view_bundling="false"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}" view_bundling="false"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
    <FC max_credits="2m"
        min_threshold="0.40"/>

--- a/core/src/test/resources/stacks/tcp_mping/tcp2.xml
+++ b/core/src/test/resources/stacks/tcp_mping/tcp2.xml
@@ -62,7 +62,7 @@
    <RSVP />
    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                   max_bytes="400000"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="7000" view_bundling="false"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}" view_bundling="false"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
    <FC max_credits="2m"
        min_threshold="0.40"/>

--- a/core/src/test/resources/stacks/udp.xml
+++ b/core/src/test/resources/stacks/udp.xml
@@ -56,7 +56,7 @@
          conn_expiry_timeout="0"/>
 
    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}" view_bundling="false"/>
    <tom.TOA/> <!-- the Total Order Anycast is only needed for total order transactions (in distributed mode)-->
 
    <UFC max_credits="2m" min_threshold="0.40"/>

--- a/demos/distexec/src/main/release/etc/config-samples/distexec-demo/jgroups-s3_ping-aws.xml
+++ b/demos/distexec/src/main/release/etc/config-samples/distexec-demo/jgroups-s3_ping-aws.xml
@@ -11,7 +11,7 @@
                   discard_delivered_msgs="true"/>
    <UNICAST3 conn_expiry_timeout="0"/>
    <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000" max_bytes="400000"/>
-   <pbcast.GMS print_local_addr="true" join_timeout="60000" view_bundling="true"/>
+   <pbcast.GMS print_local_addr="true" join_timeout="${jgroups.join_timeout:5000}" view_bundling="true"/>
    <FC max_credits="2m" min_threshold="0.40"/>
    <FRAG2 frag_size="60000"/>
    <pbcast.STREAMING_STATE_TRANSFER/>

--- a/demos/gui/src/main/release/etc/config/jgroups-relay1.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-relay1.xml
@@ -62,7 +62,7 @@
     <UNICAST3 conn_expiry_timeout="0"/>
     <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                    max_bytes="1000000"/>
-    <pbcast.GMS print_local_addr="true" join_timeout="5000"
+    <pbcast.GMS print_local_addr="true" join_timeout="${jgroups.join_timeout:5000}"
                 max_bundling_time="200"
                 view_bundling="true"/>
     <FC max_credits="2M"

--- a/demos/gui/src/main/release/etc/config/jgroups-relay2.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-relay2.xml
@@ -63,7 +63,7 @@
     <UNICAST3 conn_expiry_timeout="0"/>
     <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                    max_bytes="1000000"/>
-    <pbcast.GMS print_local_addr="true" join_timeout="5000"
+    <pbcast.GMS print_local_addr="true" join_timeout="${jgroups.join_timeout:5000}"
                 max_bundling_time="200"
                 view_bundling="true"/>
     <FC max_credits="2M"

--- a/demos/gui/src/main/release/etc/config/jgroups-tcp.xml
+++ b/demos/gui/src/main/release/etc/config/jgroups-tcp.xml
@@ -63,7 +63,7 @@
 
     <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
                    max_bytes="10m"/>
-    <pbcast.GMS print_local_addr="true" join_timeout="5000"
+    <pbcast.GMS print_local_addr="true" join_timeout="${jgroups.join_timeout:5000}"
                 max_bundling_time="30"
                 view_bundling="true"/>
     <MFC max_credits="2M"

--- a/integrationtests/all-remote-it/src/test/resources/arquillian.xml
+++ b/integrationtests/all-remote-it/src/test/resources/arquillian.xml
@@ -9,14 +9,21 @@
             <configuration>
                 <property name="jbossHome">${project.build.directory}/node1/infinispan-server-${project.version}</property>
                 <property name="serverConfig">clustered.xml</property>
-                <property name="javaVmArguments">-Xmx512m -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1 -Djboss.server.default.config=clustered.xml -Djboss.node.name=node1</property>
+                <property name="javaVmArguments">-Xmx512m -Djava.net.preferIPv4Stack=true
+                    -Djgroups.bind_addr=127.0.0.1 -Djboss.server.default.config=clustered.xml
+                    -Djboss.node.name=node1 -Djgroups.join_timeout=2000
+                </property>
             </configuration>
         </container>
         <container qualifier="container-2" mode="manual">
             <configuration>
                 <property name="jbossHome">${project.build.directory}/node2/infinispan-server-${project.version}</property>
                 <property name="serverConfig">clustered.xml</property>
-                <property name="javaVmArguments">-Xmx512m -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1 -Djboss.server.default.config=clustered.xml -Djboss.node.name=node2 -Djboss.socket.binding.port-offset=10000</property>
+                <property name="javaVmArguments">-Xmx512m -Djava.net.preferIPv4Stack=true
+                    -Djgroups.bind_addr=127.0.0.1 -Djboss.server.default.config=clustered.xml
+                    -Djboss.node.name=node2 -Djboss.socket.binding.port-offset=10000
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">19990</property>
             </configuration>
         </container>

--- a/integrationtests/as-integration-client/src/test/resources/arquillian.xml
+++ b/integrationtests/as-integration-client/src/test/resources/arquillian.xml
@@ -18,7 +18,9 @@
             <property name="serverConfig">standalone-test.xml</property>
             <!-- To debug the Arquillian managed application server: -->
             <!-- property name="javaVmArguments">-Djboss.node.name=remote-client -Djboss.socket.binding.port-offset=100 -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=y -Xmx512m</property -->
-            <property name="javaVmArguments">-Djboss.node.name=remote-client -Djboss.socket.binding.port-offset=100 -Xmx512m</property>
+            <property name="javaVmArguments">-Djboss.node.name=remote-client
+                -Djboss.socket.binding.port-offset=100 -Xmx512m -Djgroups.join_timeout=2000
+            </property>
             <property name="managementPort">10090</property>
         </configuration>
     </container>

--- a/integrationtests/as-integration-embedded/src/test/resources/arquillian.xml
+++ b/integrationtests/as-integration-embedded/src/test/resources/arquillian.xml
@@ -10,7 +10,9 @@
         <container qualifier="container.active-1" default="true">
             <configuration>
                 <property name="jbossHome">${basedir}/target/node1/wildfly-${version.org.wildfly}</property>
-                <property name="javaVmArguments">-Xmx512m -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1</property>
+                <property name="javaVmArguments">-Xmx512m -Djava.net.preferIPv4Stack=true
+                    -Djgroups.bind_addr=127.0.0.1 -Djgroups.join_timeout=2000
+                </property>
                 <!-- To debug the Arquillian managed application server: -->
                 <!-- property name="javaVmArguments">-Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=y -Xmx512m -Dorg.jboss.remoting-jmx.timeout=300  -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1</property-->
             </configuration>
@@ -18,7 +20,9 @@
         <container qualifier="container.active-2">
             <configuration>
                 <property name="jbossHome">${basedir}/target/node2/wildfly-${version.org.wildfly}</property>
-                <property name="javaVmArguments">-Djboss.socket.binding.port-offset=10000 -Xmx512m -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1</property>
+                <property name="javaVmArguments">-Djboss.socket.binding.port-offset=10000 -Xmx512m
+                    -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1 -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">19990</property>
             </configuration>
         </container>

--- a/integrationtests/as-lucene-directory/src/test/resources/arquillian.xml
+++ b/integrationtests/as-lucene-directory/src/test/resources/arquillian.xml
@@ -12,7 +12,9 @@
                 <property name="jbossHome">${basedir}/target/node1/wildfly-${version.org.wildfly}</property>
                 <!-- Needed for JMS tests -->
                 <property name="serverConfig">standalone-full-testqueues.xml</property>
-                <property name="javaVmArguments">-Xmx512m -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1 -XX:+IgnoreUnrecognizedVMOptions</property>
+                <property name="javaVmArguments">-Xmx512m -Djava.net.preferIPv4Stack=true
+                    -Djgroups.bind_addr=127.0.0.1 -Djgroups.join_timeout=2000 -XX:+IgnoreUnrecognizedVMOptions
+                </property>
                 <!-- To debug the Arquillian managed application server: -->
                 <!--<property name="javaVmArguments">-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y -Xmx512m -Dorg.jboss.remoting-jmx.timeout=300  -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1</property>-->
             </configuration>
@@ -23,7 +25,10 @@
                 <property name="jbossHome">${basedir}/target/node2/wildfly-${version.org.wildfly}</property>
                 <!-- Needed for JMS tests -->
                 <property name="serverConfig">standalone-full-testqueues.xml</property>
-                <property name="javaVmArguments">-Djboss.socket.binding.port-offset=10000 -Xmx512m -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1 -XX:+IgnoreUnrecognizedVMOptions</property>
+                <property name="javaVmArguments">-Djboss.socket.binding.port-offset=10000 -Xmx512m
+                    -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1
+                    -Djgroups.join_timeout=2000 -XX:+IgnoreUnrecognizedVMOptions
+                </property>
                 <property name="managementPort">19990</property>
                 <!--<property name="javaVmArguments">-Xrunjdwp:transport=dt_socket,address=5006,server=y,suspend=y -Xmx512m -Dorg.jboss.remoting-jmx.timeout=300  -Djava.net.preferIPv4Stack=true -Djgroups.bind_addr=127.0.0.1</property>-->
             </configuration>

--- a/integrationtests/security-it/src/test/resources/arquillian.xml
+++ b/integrationtests/security-it/src/test/resources/arquillian.xml
@@ -17,7 +17,7 @@
             <!--Needed for security domain configuration-->
             <property name="serverConfig">standalone.xml</property>
             <property name="javaVmArguments">
-                -Djboss.node.name=testnode
+                -Djboss.node.name=testnode -Djgroups.join_timeout=2000
             </property>
             <property name="managementPort">9990</property>
          </configuration>
@@ -33,10 +33,11 @@
             <property name="serverConfig">standalone-ha.xml</property>
             <property name="javaVmArguments">-Djboss.node.name=node0
                                              -Djboss.socket.binding.port-offset=100 
-                                             -Djava.net.preferIPv4Stack=true 
-                                             -Dsasl.username=test_user 
+                                             -Djava.net.preferIPv4Stack=true
+                                             -Dsasl.username=test_user
                                              -Dsasl.password=test_password
                                              -Dsasl.realm=test_realm
+                                             -Djgroups.join_timeout=2000
             </property>
             <property name="managementAddress">${node0.mgmt.addr:127.0.0.1}</property>
             <property name="managementPort">10090</property>
@@ -71,10 +72,11 @@
             <property name="serverConfig">standalone-ha.xml</property>
             <property name="javaVmArguments">-Djboss.node.name=node1 
                                              -Djboss.socket.binding.port-offset=200 
-                                             -Djava.net.preferIPv4Stack=true 
-                                             -Dsasl.username=test_user 
-                                             -Dsasl.password=wrong_password 
+                                             -Djava.net.preferIPv4Stack=true
+                                             -Dsasl.username=test_user
+                                             -Dsasl.password=wrong_password
                                              -Dsasl.realm=test_realm
+                                             -Djgroups.join_timeout=2000
             </property>
             <property name="managementPort">10190</property>
          </configuration>
@@ -90,10 +92,11 @@
             <property name="serverConfig">standalone-ha.xml</property>
             <property name="javaVmArguments">-Djboss.node.name=node0
                                              -Djboss.socket.binding.port-offset=100 
-                                             -Djava.net.preferIPv4Stack=true 
+                                             -Djava.net.preferIPv4Stack=true
                                              -Dsasl.credentials.properties=${basedir}/target/test-classes/jgroups-simple-auth.properties
                                              -Dsasl.local.principal=test_user
                                              -Dsasl.realm=test_realm
+                                             -Djgroups.join_timeout=2000
             </property>
             <property name="managementPort">10090</property>
          </configuration>
@@ -108,10 +111,11 @@
             <property name="serverConfig">standalone-ha.xml</property>
             <property name="javaVmArguments">-Djboss.node.name=node1 
                                              -Djboss.socket.binding.port-offset=200 
-                                             -Djava.net.preferIPv4Stack=true 
+                                             -Djava.net.preferIPv4Stack=true
                                              -Dsasl.credentials.properties=${basedir}/target/test-classes/jgroups-simple-auth.properties
                                              -Dsasl.local.principal=joining_test_user
                                              -Dsasl.realm=test_realm
+                                             -Djgroups.join_timeout=2000
             </property>
             <property name="managementPort">10190</property>
          </configuration>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node0.xml
@@ -66,7 +66,7 @@
          server_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" />
          
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}" view_bundling="false"/>
 
    <UFC max_credits="2m" min_threshold="0.40"/>
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1-fail.xml
@@ -65,7 +65,7 @@
          login_module_name="krb-node1-fail" />
 
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}" view_bundling="false"/>
    
 
    <UFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-krb-node1.xml
@@ -65,7 +65,7 @@
          login_module_name="krb-node1" />
 
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}" view_bundling="false"/>
    
 
    <UFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node0.xml
@@ -68,7 +68,7 @@
          sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
          
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}" view_bundling="false"/>
 
    <UFC max_credits="2m" min_threshold="0.40"/>
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-node1.xml
@@ -64,7 +64,7 @@
          client_callback_handler_class="org.infinispan.test.integration.security.utils.SaslPropCallbackHandler" />
 
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}" view_bundling="false"/>
    
 
    <UFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-md5-user-node0.xml
@@ -68,7 +68,7 @@
          sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
          
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}" view_bundling="false"/>
 
    <UFC max_credits="2m" min_threshold="0.40"/>
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node0.xml
@@ -66,7 +66,7 @@
          sasl_props="com.sun.security.sasl.digest.realm=test_realm" />
          
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}" view_bundling="false"/>
 
    <UFC max_credits="2m" min_threshold="0.40"/>
    <MFC max_credits="2m" min_threshold="0.40"/>

--- a/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
+++ b/integrationtests/security-it/src/test/resources/jgroups-tcp-sasl-prop-handler-node1.xml
@@ -64,7 +64,7 @@
          client_callback_handler_class="org.jgroups.auth.sasl.SimpleAuthorizingCallbackHandler" />
 
    <pbcast.STABLE stability_delay="500" desired_avg_gossip="5000" max_bytes="1m"/>
-   <pbcast.GMS print_local_addr="false" join_timeout="3000" view_bundling="false"/>
+   <pbcast.GMS print_local_addr="false" join_timeout="${jgroups.join_timeout:2000}" view_bundling="false"/>
    
 
    <UFC max_credits="2m" min_threshold="0.40"/>

--- a/jcache/tck-runner/pom.xml
+++ b/jcache/tck-runner/pom.xml
@@ -212,6 +212,7 @@
                   <org.jsr107.tck.management.agentId>${tck.mbean.server}</org.jsr107.tck.management.agentId>
                   <log4j.configurationFile>${log4j.configurationFile}</log4j.configurationFile>
                   <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+                  <jgroups.join_timeout>2000</jgroups.join_timeout>
                </systemPropertyVariables>
                <properties>
                   <property>
@@ -237,6 +238,7 @@
                         <ExcludeList>ExcludeList_embedded</ExcludeList>
                         <javax.cache.Cache>${embedded.CacheImpl}</javax.cache.Cache>
                         <javax.cache.Cache.Entry>${embedded.CacheEntryImpl}</javax.cache.Cache.Entry>
+                        <jgroups.join_timeout>2000</jgroups.join_timeout>
                      </systemPropertyVariables>
                   </configuration>
                </execution>
@@ -267,6 +269,7 @@
                         <ExcludeList>ExcludeList_remote</ExcludeList>
                         <javax.cache.Cache>${remote.CacheImpl}</javax.cache.Cache>
                         <javax.cache.Cache.Entry>${remote.CacheEntryImpl}</javax.cache.Cache.Entry>
+                        <jgroups.join_timeout>2000</jgroups.join_timeout>
                      </systemPropertyVariables>
                   </configuration>
                </execution>
@@ -322,6 +325,7 @@
                      </excludes>
                      <systemPropertyVariables>
                         <domainJar>${domain-lib-dir}/${domain-jar}</domainJar>
+                        <jgroups.join_timeout>2000</jgroups.join_timeout>
                      </systemPropertyVariables>
                   </configuration>
                </plugin>

--- a/lucene/directory-provider/src/test/resources/testing-flush-loopback.xml
+++ b/lucene/directory-provider/src/test/resources/testing-flush-loopback.xml
@@ -29,7 +29,7 @@
 			conn_expiry_timeout="0"/>
 	<pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
 		max_bytes="400000" />
-	<pbcast.GMS print_local_addr="true" join_timeout="500"
+	<pbcast.GMS print_local_addr="true" join_timeout="${jgroups.join_timeout:500}"
 		view_bundling="false" />
 	<RSVP resend_interval="20" timeout="10000" ack_on_delivery="false" />
 </config>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1587,6 +1587,7 @@
                <systemPropertyVariables>
                   <infinispan.test.jgroups.protocol>${infinispan.test.jgroups.protocol}</infinispan.test.jgroups.protocol>
                   <jgroups.bind_addr>127.0.0.1</jgroups.bind_addr>
+                  <jgroups.join_timeout>2000</jgroups.join_timeout>
                   <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
                   <log4j.configurationFile>${log4j.configurationFile}</log4j.configurationFile>
                   <build.directory>${project.build.directory}</build.directory>

--- a/server/integration/jgroups/src/main/resources/jgroups-defaults.xml
+++ b/server/integration/jgroups/src/main/resources/jgroups-defaults.xml
@@ -88,7 +88,7 @@
       max_bytes="1M"/>
    <pbcast.GMS 
       print_local_addr="false"
-      join_timeout="${jgroups.join_timeout:15000}"/>
+      join_timeout="${jgroups.join_timeout:5000}"/>
    <UFC 
       max_credits="2m" 
       min_threshold="0.40"/>

--- a/server/integration/testsuite/src/test/resources/arquillian.xml
+++ b/server/integration/testsuite/src/test/resources/arquillian.xml
@@ -11,7 +11,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">examples/standalone-hotrod-rolling-upgrade.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -24,8 +26,9 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">standalone.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -38,7 +41,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">examples/standalone-rest-rolling-upgrade.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -64,7 +70,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">examples/clustered-jdbc.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
             </configuration>
         </container>
@@ -74,7 +83,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">clustered.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -86,7 +98,8 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">examples/clustered-storage-only.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
                     -Djboss.socket.binding.port-offset=100
                 </property>
                 <property name="managementPort">10090</property>
@@ -101,7 +114,10 @@
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="managementPort">9990</property>
                 <property name="serverConfig">examples/clustered-topology.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
             </configuration>
@@ -120,6 +136,7 @@
                     -Djboss.jgroups.topology.rack=r1
                     -Djboss.jgroups.topology.machine=m2
                     -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djgroups.join_timeout=2000
                 </property>
                 <property name="waitForPorts">11311 11322 8180</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -139,6 +156,7 @@
                     -Djboss.jgroups.topology.rack=r2
                     -Djboss.jgroups.topology.machine=m2
                     -Djboss.bind.address.management=${node2.ip} -Djboss.bind.address=${node2.ip}
+                    -Djgroups.join_timeout=2000
                 </property>
                 <property name="waitForPorts">11411 11422 8280</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -150,7 +168,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/clustered-1.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -162,8 +183,9 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">testsuite/clustered-2.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -176,7 +198,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">examples/clustered-xsite.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -188,8 +213,9 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">examples/clustered-xsite2.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -202,8 +228,9 @@
                 <property name="jbossHome">${server3.dist}</property>
                 <property name="managementAddress">${node2.ip}</property>
                 <property name="serverConfig">examples/clustered-xsite3.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node2 -Djboss.bind.address.management=${node2.ip} -Djboss.bind.address=${node2.ip}
-                    -Djboss.socket.binding.port-offset=200
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node2
+                    -Djboss.bind.address.management=${node2.ip} -Djboss.bind.address=${node2.ip}
+                    -Djboss.socket.binding.port-offset=200 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10190</property>
                 <property name="waitForPorts">11411 11422 8280</property>
@@ -216,7 +243,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">examples/standalone-fcs-local.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args}
+                    -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip}
+                    -Djboss.bind.address=${node0.ip} -Djgroups.join_timeout=2000
+                </property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
             </configuration>
@@ -227,7 +257,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">examples/standalone-hotrod-multiple.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="waitForPorts">11222 11223 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
             </configuration>
@@ -239,7 +272,10 @@
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="managementPort">9990</property>
                 <property name="serverConfig">examples/standalone-rcs-local.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
             </configuration>
@@ -251,8 +287,9 @@
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="managementPort">10090</property>
                 <property name="serverConfig">standalone.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="waitForPorts">11311 11322 8180</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -264,7 +301,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">examples/standalone-hotrod-ssl.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="waitForPorts">11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
             </configuration>
@@ -275,7 +315,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">examples/standalone-leveldb-cs-local.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
             </configuration>
@@ -286,7 +329,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">examples/standalone-compatibility-mode.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="waitForPorts">11222 8080 11211</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
             </configuration>
@@ -297,7 +343,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/clustered-jmx.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -309,8 +358,9 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">testsuite/clustered-jmx.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -323,8 +373,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/standalone-leveldb-local.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -337,7 +388,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/clustered-asymmetric-1.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -349,8 +403,9 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">testsuite/clustered-asymmetric-2.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -363,8 +418,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/rest-sec-basic-wr.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -376,8 +432,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/rest-sec-cert-wr.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -390,8 +447,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/rest-sec-digest-wr.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -404,8 +462,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/standalone-rcs-local.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -418,9 +477,10 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">testsuite/standalone-rcs-remote.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
                     -Djboss.socket.binding.port-offset=100
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -434,7 +494,9 @@
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="managementPort">9990</property>
                 <property name="serverConfig">testsuite/clustered-with-encrypt.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
                 </property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -447,8 +509,9 @@
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="managementPort">10090</property>
                 <property name="serverConfig">testsuite/clustered-with-encrypt.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="waitForPorts">11311 11322 8180</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -460,7 +523,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/clustered-suppress-state-transfer.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -472,8 +538,9 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">testsuite/clustered-suppress-state-transfer.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -486,8 +553,9 @@
                 <property name="jbossHome">${server3.dist}</property>
                 <property name="managementAddress">${node2.ip}</property>
                 <property name="serverConfig">testsuite/clustered-suppress-state-transfer.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node2 -Djboss.bind.address.management=${node2.ip} -Djboss.bind.address=${node2.ip}
-                    -Djboss.socket.binding.port-offset=200
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node2
+                    -Djboss.bind.address.management=${node2.ip} -Djboss.bind.address=${node2.ip}
+                    -Djboss.socket.binding.port-offset=200 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10190</property>
                 <property name="waitForPorts">11411 11422 8280</property>
@@ -500,8 +568,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/clustered-transport-stack.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Djboss.default.jgroups.stack=tcp</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djboss.default.jgroups.stack=tcp -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -513,8 +583,10 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">testsuite/clustered-transport-stack.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
                     -Djboss.socket.binding.port-offset=100 -Djboss.default.jgroups.stack=udp
+                    -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -527,7 +599,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/standalone-filecs.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
             </configuration>
@@ -538,7 +613,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/standalone-eviction.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -550,7 +628,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/standalone-customtask.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -563,7 +644,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/standalone-customcs.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -575,7 +659,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/clustered-expiration.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -587,8 +674,9 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">testsuite/clustered-expiration.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -602,7 +690,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/jdbc.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -615,7 +706,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/jdbc-string-invalidation.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -627,8 +721,9 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">testsuite/jdbc-string-invalidation.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -641,7 +736,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/clustered-with-l1.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -653,8 +751,9 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">testsuite/clustered-with-l1.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -667,7 +766,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/standalone-cachecontainer.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11222 11223 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -679,7 +781,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/clustered-clusteredcache.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -691,8 +796,10 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">testsuite/clustered-clusteredcache.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -704,8 +811,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/hotrod-auth-clustered.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -717,8 +825,10 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">testsuite/hotrod-auth-clustered.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -731,8 +841,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/hotrod-auth-krb.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -745,8 +856,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/hotrod-auth-qop.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -759,8 +871,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/hotrod-auth-ldap.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -773,8 +886,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/hotrod-auth-ldap-ssl.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -787,8 +901,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/hotrod-authz-ldap.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -815,8 +930,10 @@
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="managementPort">10090</property>
                 <property name="serverConfig">testsuite/clustered-with-sasl-md5-1.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip} -Dsasl.username=test -Dsasl.password=heslo -Dsasl.realm=testRealm
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Dsasl.username=test -Dsasl.password=heslo -Dsasl.realm=testRealm
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="waitForPorts">11311 11322 8180</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -829,7 +946,9 @@
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="managementPort">9990</property>
                 <property name="serverConfig">testsuite/clustered-with-sasl-krb-0.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000 -Djgroups.join_timeout=2000
                 </property>
                 <property name="waitForPorts">11211 11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -842,8 +961,9 @@
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="managementPort">10090</property>
                 <property name="serverConfig">testsuite/clustered-with-sasl-krb-1.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="waitForPorts">11311 11322 8180</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -868,8 +988,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/hotrod-auth.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -885,7 +1006,10 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">testsuite/clustered-indexing.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11222 8080</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -897,8 +1021,9 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">testsuite/clustered-indexing.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -911,7 +1036,11 @@
                 <property name="jbossHome">${server3.dist}</property>
                 <property name="managementAddress">${node2.ip}</property>
                 <property name="serverConfig">testsuite/clustered-indexing-secured.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node2 -Djboss.bind.address.management=${node2.ip} -Djboss.bind.address=${node2.ip} -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djboss.socket.binding.port-offset=200</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node2
+                    -Djboss.bind.address.management=${node2.ip} -Djboss.bind.address=${node2.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                    -Djboss.socket.binding.port-offset=200 -Djgroups.join_timeout=2000
+                </property>
                 <property name="managementPort">10190</property>
                 <property name="waitForPorts">11422 8280</property>
                 <property name="jmxDomain">${server.jmx.domain}</property>
@@ -926,8 +1055,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">${suite.client.local.config}</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -940,8 +1070,9 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">${suite.client.local.config}</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -956,8 +1087,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">${suite.client.dist.config}</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -970,9 +1102,10 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">${suite.client.dist.config}</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
                     -Djboss.socket.binding.port-offset=100
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -987,8 +1120,9 @@
                 <property name="jbossHome">${server1.dist}</property>
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="serverConfig">${suite.client.repl.config}</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -1001,9 +1135,10 @@
                 <property name="jbossHome">${server2.dist}</property>
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="serverConfig">${suite.client.repl.config}</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
                     -Djboss.socket.binding.port-offset=100
-                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -1020,7 +1155,9 @@
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="serverConfig">examples/standalone-hotrod-rolling-upgrade.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -1033,8 +1170,9 @@
                 <property name="jbossHome">${server.old.dist}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="serverConfig">standalone.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
-                    -Djboss.socket.binding.port-offset=100
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -1049,7 +1187,7 @@
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="serverConfig">examples/standalone-rest-rolling-upgrade.xml</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
-                -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+                    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -1061,7 +1199,7 @@
                 <property name="jbossHome">${server.old.dist}</property>
                 <property name="serverConfig">standalone.xml</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
-                -Djboss.socket.binding.port-offset=100
+                    -Djboss.socket.binding.port-offset=100 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -1093,8 +1231,10 @@
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="serverConfig">examples/clustered-hotrod-rolling-upgrade.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
                     -Djboss.socket.binding.port-offset=100 -Dremote.destination.port=11522
+                    -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -1106,8 +1246,9 @@
                 <property name="javaHome">${server.jvm}</property>
                 <property name="jbossHome">${server2.old.dist}</property>
                 <property name="serverConfig">clustered.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node2 -Djboss.bind.address.management=${node2.ip} -Djboss.bind.address=${node2.ip}
-                    -Djboss.socket.binding.port-offset=200
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node2
+                    -Djboss.bind.address.management=${node2.ip} -Djboss.bind.address=${node2.ip}
+                    -Djboss.socket.binding.port-offset=200 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10190</property>
                 <property name="waitForPorts">11411 11422 8280</property>
@@ -1119,8 +1260,9 @@
                 <property name="javaHome">${server.jvm}</property>
                 <property name="jbossHome">${server3.old.dist}</property>
                 <property name="serverConfig">clustered.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node3 -Djboss.bind.address.management=${node3.ip} -Djboss.bind.address=${node3.ip}
-                    -Djboss.socket.binding.port-offset=300
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node3
+                    -Djboss.bind.address.management=${node3.ip} -Djboss.bind.address=${node3.ip}
+                    -Djboss.socket.binding.port-offset=300 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10290</property>
                 <property name="waitForPorts">11511 11522 8380</property>
@@ -1136,8 +1278,9 @@
                 <property name="managementAddress">${node0.ip}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="serverConfig">examples/clustered-rest-rolling-upgrade.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0 -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
-                    -Dremote.destination.port=8280
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                    -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                    -Dremote.destination.port=8280 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">9990</property>
                 <property name="waitForPorts">11211 11222 8080</property>
@@ -1151,8 +1294,10 @@
                 <property name="managementAddress">${node1.ip}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="serverConfig">examples/clustered-rest-rolling-upgrade.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1 -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node1
+                    -Djboss.bind.address.management=${node1.ip} -Djboss.bind.address=${node1.ip}
                     -Djboss.socket.binding.port-offset=100 -Dremote.destination.port=8380
+                    -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10090</property>
                 <property name="waitForPorts">11311 11322 8180</property>
@@ -1164,8 +1309,9 @@
                 <property name="javaHome">${server.jvm}</property>
                 <property name="jbossHome">${server2.old.dist}</property>
                 <property name="serverConfig">clustered.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node2 -Djboss.bind.address.management=${node2.ip} -Djboss.bind.address=${node2.ip}
-                    -Djboss.socket.binding.port-offset=200
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node2
+                    -Djboss.bind.address.management=${node2.ip} -Djboss.bind.address=${node2.ip}
+                    -Djboss.socket.binding.port-offset=200 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10190</property>
                 <property name="waitForPorts">11411 11422 8280</property>
@@ -1177,8 +1323,9 @@
                 <property name="javaHome">${server.jvm}</property>
                 <property name="jbossHome">${server3.old.dist}</property>
                 <property name="serverConfig">clustered.xml</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node3 -Djboss.bind.address.management=${node3.ip} -Djboss.bind.address=${node3.ip}
-                    -Djboss.socket.binding.port-offset=300
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node3
+                    -Djboss.bind.address.management=${node3.ip} -Djboss.bind.address=${node3.ip}
+                    -Djboss.socket.binding.port-offset=300 -Djgroups.join_timeout=2000
                 </property>
                 <property name="managementPort">10290</property>
                 <property name="waitForPorts">11511 11522 8380</property>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6402

* Change the production default to 5000ms, and the tests to 2000ms.
* Set the jgroups.join_timeout property for Arquillian/JCache tests