### PR TITLE
ISPN-6449 DistSyncNonTxStateTransferTest.testCancelStateTransfer sometimes hangs

### DIFF
--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentWriteSkewTest.java
@@ -99,7 +99,7 @@ public class ConditionalOperationsConcurrentWriteSkewTest extends MultipleCacheM
          //await tx1 commit on cache1... the commit will be blocked!
          //tx1 has already committed in cache(0) but not in cache(1)
          //we block the remote get in order to force the tx2 to read the most recent value from cache(0)
-         controller.awaitCommit.await();
+         controller.awaitCommit.await(30, TimeUnit.SECONDS);
          controller.blockRemoteGet.close();
 
          final Future<Boolean> tx2 = fork(new Callable<Boolean>() {
@@ -172,7 +172,7 @@ public class ConditionalOperationsConcurrentWriteSkewTest extends MultipleCacheM
             getLog().debug("visit GetKeyValueCommand");
             if (!ctx.isOriginLocal() && blockRemoteGet != null) {
                getLog().debug("Remote Get Received... blocking...");
-               blockRemoteGet.await();
+               blockRemoteGet.await(30, TimeUnit.SECONDS);
             }
          }
       }
@@ -185,7 +185,7 @@ public class ConditionalOperationsConcurrentWriteSkewTest extends MultipleCacheM
             getLog().debug("visit GetCacheEntryCommand");
             if (!ctx.isOriginLocal() && blockRemoteGet != null) {
                getLog().debug("Remote Get Received... blocking...");
-               blockRemoteGet.await();
+               blockRemoteGet.await(30, TimeUnit.SECONDS);
             }
          }
       }
@@ -216,7 +216,7 @@ public class ConditionalOperationsConcurrentWriteSkewTest extends MultipleCacheM
                }
                if (blockCommit != null) {
                   getLog().debug("Commit Received... blocking...");
-                  blockCommit.await();
+                  blockCommit.await(30, TimeUnit.SECONDS);
                }
             }
          }

--- a/core/src/test/java/org/infinispan/partitionhandling/BaseTxPartitionAndMergeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BaseTxPartitionAndMergeTest.java
@@ -216,7 +216,7 @@ public abstract class BaseTxPartitionAndMergeTest extends BasePartitionHandlingT
          if (aClass.isAssignableFrom(command.getClass())) {
             notifier.open();
             try {
-               blocker.await();
+               blocker.await(30, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                Thread.currentThread().interrupt();
             }

--- a/core/src/test/java/org/infinispan/remoting/transport/ControlledTransport.java
+++ b/core/src/test/java/org/infinispan/remoting/transport/ControlledTransport.java
@@ -69,7 +69,7 @@ public class ControlledTransport extends AbstractDelegatingTransport {
 
    public void waitForCommandToBlock() throws InterruptedException {
       getLog().tracef("Waiting for at least one command to block");
-      blockingLatch.await();
+      blockingLatch.await(30, TimeUnit.SECONDS);
    }
 
    public boolean waitForCommandToBlock(long time, TimeUnit unit) throws InterruptedException {
@@ -103,7 +103,7 @@ public class ControlledTransport extends AbstractDelegatingTransport {
          }
 
          getLog().debugf("Replication trigger called, waiting for latch to open.");
-         replicationLatch.await();
+         replicationLatch.await(30, TimeUnit.SECONDS);
          getLog().trace("Replication latch opened, continuing.");
       } catch (Exception e) {
          throw new RuntimeException("Unexpected exception!", e);

--- a/core/src/test/java/org/infinispan/tx/dld/ControlledRpcManager.java
+++ b/core/src/test/java/org/infinispan/tx/dld/ControlledRpcManager.java
@@ -63,7 +63,7 @@ public class ControlledRpcManager extends AbstractControlledRpcManager {
 
    public void waitForCommandToBlock() throws InterruptedException {
       log.tracef("Waiting for at least one command to block");
-      blockingLatch.await();
+      blockingLatch.await(30, TimeUnit.SECONDS);
    }
 
    public boolean waitForCommandToBlock(long time, TimeUnit unit) throws InterruptedException {
@@ -97,7 +97,7 @@ public class ControlledRpcManager extends AbstractControlledRpcManager {
          }
 
          log.debugf("Replication trigger called, waiting for latch to open.");
-         replicationLatch.await();
+         replicationLatch.await(30, TimeUnit.SECONDS);
          log.trace("Replication latch opened, continuing.");
       } catch (Exception e) {
          throw new RuntimeException("Unexpected exception!", e);

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -80,6 +80,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -128,7 +129,7 @@ public class ControlledCommandFactory implements CommandsFactory {
          if (toBlock != null && command.getClass().isAssignableFrom(toBlock)) {
             blockTypeCommandsReceived.incrementAndGet();
             try {
-               gate.await();
+               gate.await(30, TimeUnit.SECONDS);
                log.tracef("gate is opened, processing the lock cleanup:  %s", command);
             } catch (InterruptedException e) {
                throw new RuntimeException(e);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6449

* Generate keys until the coordinator has 2 chunks
* Tests shouldn't call await() without a timeout