### PR TITLE
ISPN-6452 Use JBoss Marshaller OSGi in client EAP module

### DIFF
--- a/as-modules/client/build.xml
+++ b/as-modules/client/build.xml
@@ -49,6 +49,10 @@
         <module-def name="org.infinispan.commons" slot="${infinispan.slot}">
             <maven-resource group="org.infinispan" artifact="infinispan-commons" />
         </module-def>
+
+        <module-def name="org.jboss.marshalling" slot="${infinispan.slot}">
+            <maven-resource group="org.jboss.marshalling" artifact="jboss-marshalling-osgi" />
+        </module-def>
     </target>
 
     <target name="all" depends="clean, copy-files, modules" />

--- a/as-modules/client/pom.xml
+++ b/as-modules/client/pom.xml
@@ -38,6 +38,11 @@
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-query-dsl</artifactId>
       </dependency>
+
+      <dependency>
+         <groupId>org.jboss.marshalling</groupId>
+         <artifactId>jboss-marshalling-osgi</artifactId>
+      </dependency>
    </dependencies>
 
    <build>

--- a/as-modules/client/src/main/resources/org/infinispan/commons/main/module.xml
+++ b/as-modules/client/src/main/resources/org/infinispan/commons/main/module.xml
@@ -8,8 +8,7 @@
         <module name="javax.transaction.api"/>
         <module name="javax.xml.bind.api"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.marshalling"/>
-        <module name="org.jboss.marshalling.river" services="import"/>
+        <module name="org.jboss.marshalling" slot="${slot}" services="import"/>
         <module name="sun.jdk"/>
     </dependencies>
 </module>

--- a/as-modules/client/src/main/resources/org/jboss/marshalling/main/module.xml
+++ b/as-modules/client/src/main/resources/org/jboss/marshalling/main/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.marshalling" slot="${slot}">
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.modules"/>
+    </dependencies>
+</module>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6452

Since we use JBoss Marshaller OSGi as a runtime/compiletime dependency - we should also use it in EAP modules.