### PR TITLE
ISPN-6458 DistTopKeyTest.testLockLockFailed random failures

### DIFF
--- a/extended-statistics/src/test/java/org/infinispan/stats/AbstractTopKeyTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/stats/AbstractTopKeyTest.java
@@ -1,0 +1,133 @@
+package org.infinispan.stats;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.tx.PrepareCommand;
+import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.distribution.DistributionManager;
+import org.infinispan.interceptors.TxInterceptor;
+import org.infinispan.interceptors.base.CommandInterceptor;
+import org.infinispan.stats.topK.CacheUsageInterceptor;
+import org.infinispan.test.MultipleCacheManagersTest;
+
+import java.util.List;
+
+import static java.lang.String.format;
+import static org.infinispan.distribution.DistributionTestHelper.addressOf;
+
+/**
+ * @author Pedro Ruivo
+ * @since 9.0
+ */
+public abstract class AbstractTopKeyTest extends MultipleCacheManagersTest {
+
+   private static boolean isOwner(Cache<?, ?> cache, Object key) {
+      DistributionManager dm = cache.getAdvancedCache().getDistributionManager();
+      return dm == null || dm.locate(key).contains(addressOf(cache));
+   }
+
+   protected CacheUsageInterceptor getTopKey(Cache<?, ?> cache) {
+      for (CommandInterceptor interceptor : cache.getAdvancedCache().getInterceptorChain()) {
+         if (interceptor instanceof CacheUsageInterceptor) {
+            return (CacheUsageInterceptor) interceptor;
+         }
+      }
+      throw new IllegalStateException();
+   }
+
+   protected void assertTopKeyAccesses(Cache<?, ?> cache, String key, long expected, boolean readAccesses) {
+      final CacheUsageInterceptor topK = getTopKey(cache);
+      final boolean isLocal = isOwner(cache, key);
+      eventuallyEquals(format("Wrong number of accesses for key '%s' and cache '%s'.", key, addressOf(cache)),
+                       expected,
+                       () -> {
+                          if (readAccesses) {
+                             return (isLocal ? topK.getLocalTopGets() : topK.getRemoteTopGets()).getOrDefault(key, 0L);
+                          } else {
+                             return (isLocal ? topK.getLocalTopPuts() : topK.getRemoteTopPuts()).getOrDefault(key, 0L);
+                          }
+                       });
+   }
+
+   protected void assertWriteSkew(Cache<?, ?> cache, String key, long expected) {
+      final CacheUsageInterceptor topK = getTopKey(cache);
+      eventuallyEquals(format("Wrong number of write skew for key '%s' and cache '%s'.", key, addressOf(cache)),
+                       expected,
+                       () -> topK.getTopWriteSkewFailedKeys().getOrDefault(key, 0L));
+   }
+
+   private void assertTopKeyLocked(Cache<?, ?> cache, String key, long expected) {
+      final CacheUsageInterceptor topK = getTopKey(cache);
+      eventuallyEquals(format("Wrong number of locked key for key '%s' and cache '%s'.", key, addressOf(cache)),
+                       expected,
+                       () -> topK.getTopLockedKeys().getOrDefault(key, 0L));
+   }
+
+   private void assertTopKeyLockContented(Cache<?, ?> cache, String key, long expected) {
+      final CacheUsageInterceptor topK = getTopKey(cache);
+      eventuallyEquals(format("Wrong number of contented key for key '%s' and cache '%s'.", key, addressOf(cache)),
+                       expected,
+                       () -> topK.getTopContendedKeys().getOrDefault(key, 0L));
+   }
+
+   private void assertTopKeyLockFailed(Cache<?, ?> cache, String key, long expected) {
+      final CacheUsageInterceptor topK = getTopKey(cache);
+      eventuallyEquals(format("Wrong number of failed locked key for key '%s' and cache '%s'.", key, addressOf(cache)),
+                       expected,
+                       () -> topK.getTopLockFailedKeys().getOrDefault(key, 0L));
+   }
+
+   protected void assertLockInformation(Cache<?, ?> cache, String key, long locked, long contented, long failed) {
+      assertTopKeyLocked(cache, key, locked);
+      assertTopKeyLockContented(cache, key, contented);
+      assertTopKeyLockFailed(cache, key, failed);
+   }
+
+   protected PrepareCommandBlocker addPrepareBlockerIfAbsent(Cache<?, ?> cache) {
+      List<CommandInterceptor> chain = cache.getAdvancedCache().getInterceptorChain();
+
+      for (CommandInterceptor commandInterceptor : chain) {
+         if (commandInterceptor instanceof PrepareCommandBlocker) {
+            return (PrepareCommandBlocker) commandInterceptor;
+         }
+      }
+      PrepareCommandBlocker blocker = new PrepareCommandBlocker();
+      cache.getAdvancedCache().addInterceptorBefore(blocker, TxInterceptor.class);
+      return blocker;
+   }
+
+   protected class PrepareCommandBlocker extends CommandInterceptor {
+
+      private boolean unblock = false;
+      private boolean prepareBlocked = false;
+
+      @Override
+      public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
+         Object retVal = invokeNextInterceptor(ctx, command);
+         synchronized (this) {
+            prepareBlocked = true;
+            notifyAll();
+            while (!unblock) {
+               wait();
+            }
+         }
+         return retVal;
+      }
+
+      public synchronized void reset() {
+         unblock = false;
+         prepareBlocked = false;
+      }
+
+      public synchronized void unblock() {
+         unblock = true;
+         notifyAll();
+      }
+
+      public synchronized void awaitUntilPrepareBlocked() throws InterruptedException {
+         while (!prepareBlocked) {
+            wait();
+         }
+      }
+   }
+
+}

--- a/extended-statistics/src/test/java/org/infinispan/stats/topK/LocalTopKeyTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/stats/topK/LocalTopKeyTest.java
@@ -1,17 +1,11 @@
 package org.infinispan.stats.topK;
 
-import org.infinispan.Cache;
-import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.VersioningScheme;
-import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.interceptors.TxInterceptor;
-import org.infinispan.interceptors.base.CommandInterceptor;
-import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.stats.AbstractTopKeyTest;
 import org.infinispan.test.fwk.CleanupAfterTest;
-import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -20,13 +14,13 @@ import org.testng.annotations.Test;
 import javax.transaction.RollbackException;
 import javax.transaction.Transaction;
 import java.lang.reflect.Method;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.infinispan.test.TestingUtil.k;
+import static org.testng.AssertJUnit.fail;
 
 /**
  * @author Pedro Ruivo
@@ -34,64 +28,64 @@ import static org.infinispan.test.TestingUtil.k;
  */
 @Test(groups = "functional", testName = "stats.topK.LocalTopKeyTest")
 @CleanupAfterTest
-public class LocalTopKeyTest extends SingleCacheManagerTest {
+public class LocalTopKeyTest extends AbstractTopKeyTest {
 
    @BeforeMethod(alwaysRun = true)
    public void resetBeforeTest() {
-      getTopKey().resetStatistics();
+      getTopKey(cache(0)).resetStatistics();
    }
-   
+
    public void testPut(Method method) {
       final String key1 = k(method, 1);
       final String key2 = k(method, 2);
-      
-      cache.put(key1, "value1");
-      cache.put(key2, "value2");
 
-      assertTopKeyAccesses(key1, 1, false);
-      assertTopKeyAccesses(key2, 1, false);
-      assertTopKeyAccesses(key1, 0, true);
-      assertTopKeyAccesses(key2, 0, true);
+      cache(0).put(key1, "value1");
+      cache(0).put(key2, "value2");
 
-      assertLockInformation(key1, 1, 0, 0);
-      assertLockInformation(key2, 1, 0, 0);
+      assertTopKeyAccesses(cache(0), key1, 1, false);
+      assertTopKeyAccesses(cache(0), key2, 1, false);
+      assertTopKeyAccesses(cache(0), key1, 0, true);
+      assertTopKeyAccesses(cache(0), key2, 0, true);
 
-      assertWriteSkew(key1, 0);
-      assertWriteSkew(key2, 0);
+      assertLockInformation(cache(0), key1, 1, 0, 0);
+      assertLockInformation(cache(0), key2, 1, 0, 0);
+
+      assertWriteSkew(cache(0), key1, 0);
+      assertWriteSkew(cache(0), key2, 0);
    }
 
    public void testGet(Method method) {
       final String key1 = k(method, 1);
       final String key2 = k(method, 2);
 
-      cache.get(key1);
-      cache.get(key2);
+      cache(0).get(key1);
+      cache(0).get(key2);
 
-      assertTopKeyAccesses(key1, 0, false);
-      assertTopKeyAccesses(key2, 0, false);
-      assertTopKeyAccesses(key1, 1, true);
-      assertTopKeyAccesses(key2, 1, true);
+      assertTopKeyAccesses(cache(0), key1, 0, false);
+      assertTopKeyAccesses(cache(0), key2, 0, false);
+      assertTopKeyAccesses(cache(0), key1, 1, true);
+      assertTopKeyAccesses(cache(0), key2, 1, true);
 
-      assertLockInformation(key1, 0, 0, 0);
-      assertLockInformation(key2, 0, 0, 0);
+      assertLockInformation(cache(0), key1, 0, 0, 0);
+      assertLockInformation(cache(0), key2, 0, 0, 0);
 
-      assertWriteSkew(key1, 0);
-      assertWriteSkew(key2, 0);
+      assertWriteSkew(cache(0), key1, 0);
+      assertWriteSkew(cache(0), key2, 0);
    }
 
    public void testLockFailed(Method method) throws InterruptedException, TimeoutException, ExecutionException {
       final String key = k(method, 0);
 
-      PrepareCommandBlocker blocker = addPrepareBlockerIfAbsent(cache);
+      PrepareCommandBlocker blocker = addPrepareBlockerIfAbsent(cache(0));
       blocker.reset();
       Future<Void> f = fork(() -> {
-         cache.put(key, "value");
+         cache(0).put(key, "value");
          return null;
       });
       blocker.awaitUntilPrepareBlocked();
       //at this point, the key is locked...
       try {
-         cache.put(key, "value");
+         cache(0).put(key, "value");
          Assert.fail("The key should be locked!");
       } catch (Throwable t) {
          //expected
@@ -99,45 +93,45 @@ public class LocalTopKeyTest extends SingleCacheManagerTest {
       blocker.unblock();
       f.get(30, TimeUnit.SECONDS);
 
-      assertTopKeyAccesses(key, 2, false);
-      assertTopKeyAccesses(key, 0, true);
+      assertTopKeyAccesses(cache(0), key, 2, false);
+      assertTopKeyAccesses(cache(0), key, 0, true);
 
-      assertLockInformation(key, 2, 1, 1);
+      assertLockInformation(cache(0), key, 2, 1, 1);
 
-      assertWriteSkew(key, 0);
+      assertWriteSkew(cache(0), key, 0);
    }
 
    public void testWriteSkew(Method method) throws Exception {
       final String key = k(method, 0);
 
-      cache.put(key, "init");
+      cache(0).put(key, "init");
 
-      tm().begin();
-      cache.get(key);
-      Transaction transaction = tm().suspend();
+      tm(0).begin();
+      cache(0).get(key);
+      Transaction transaction = tm(0).suspend();
 
-      cache.put(key, "value");
+      cache(0).put(key, "value");
 
       try {
-         tm().resume(transaction);
-         cache.put(key, "value1");
-         tm().commit();
-         Assert.fail("The write skew should be detected");
+         tm(0).resume(transaction);
+         cache(0).put(key, "value1");
+         tm(0).commit();
+         fail("The write skew should be detected");
       } catch (RollbackException t) {
          //expected
       }
 
-      assertTopKeyAccesses(key, 3, false);
-      assertTopKeyAccesses(key, 1, true);
+      assertTopKeyAccesses(cache(0), key, 3, false);
+      assertTopKeyAccesses(cache(0), key, 1, true);
 
       //the last put will originate an write skew
-      assertLockInformation(key, 3, 0, 0);
+      assertLockInformation(cache(0), key, 3, 0, 0);
 
-      assertWriteSkew(key, 1);
+      assertWriteSkew(cache(0), key, 1);
    }
 
    @Override
-   protected EmbeddedCacheManager createCacheManager() throws Exception {
+   protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.LOCAL, true);
       builder.customInterceptors().addInterceptor()
             .before(TxInterceptor.class)
@@ -145,97 +139,6 @@ public class LocalTopKeyTest extends SingleCacheManagerTest {
       builder.versioning().enabled(true).scheme(VersioningScheme.SIMPLE);
       builder.transaction().syncCommitPhase(true).syncRollbackPhase(true);
       builder.locking().isolationLevel(IsolationLevel.REPEATABLE_READ).writeSkewCheck(true).lockAcquisitionTimeout(100);
-      return TestCacheManagerFactory.createCacheManager(builder);
+      addClusterEnabledCacheManager(builder);
    }
-
-   private CacheUsageInterceptor getTopKey() {
-      for (CommandInterceptor interceptor : cache.getAdvancedCache().getInterceptorChain()) {
-         if (interceptor instanceof CacheUsageInterceptor) {
-            return (CacheUsageInterceptor) interceptor;
-         }
-      }
-      throw new IllegalStateException("CacheUsageInterceptor should be in the interceptor chain");
-   }
-
-   private void assertTopKeyAccesses(String key, long expected, boolean readAccesses) {
-      final CacheUsageInterceptor topK = getTopKey();
-      eventuallyEquals("Wrong number of accesses.", expected, () -> readAccesses ?
-            topK.getLocalTopGets().getOrDefault(key, 0L) :
-            topK.getLocalTopPuts().getOrDefault(key, 0L));
-   }
-
-   private void assertWriteSkew(String key, long expected) {
-      final CacheUsageInterceptor topK = getTopKey();
-      eventuallyEquals("Wrong number of write skew.", expected, () -> topK.getTopWriteSkewFailedKeys().getOrDefault(key, 0L));
-   }
-
-   private void assertTopKeyLocked(String key, long expected) {
-      final CacheUsageInterceptor topK = getTopKey();
-      eventuallyEquals("Wrong number of locked keys.", expected, () -> topK.getTopLockedKeys().getOrDefault(key, 0L));
-   }
-
-   private void assertTopKeyLockContented(String key, long expected) {
-      final CacheUsageInterceptor topK = getTopKey();
-      eventuallyEquals("Wrong number of contented keys.", expected, () -> topK.getTopContendedKeys().getOrDefault(key, 0L));
-   }
-
-   private void assertTopKeyLockFailed(String key, long expected) {
-      final CacheUsageInterceptor topK = getTopKey();
-      eventuallyEquals("Wrong number of lock failed keys.", expected, () -> topK.getTopLockFailedKeys().getOrDefault(key, 0L));
-   }
-
-   private void assertLockInformation(String key, long locked, long contented, long failed) {
-      assertTopKeyLocked(key, locked);
-      assertTopKeyLockContented(key, contented);
-      assertTopKeyLockFailed(key, failed);
-   }
-
-   private PrepareCommandBlocker addPrepareBlockerIfAbsent(Cache<?, ?> cache) {
-      List<CommandInterceptor> chain = cache.getAdvancedCache().getInterceptorChain();
-
-      for (CommandInterceptor commandInterceptor : chain) {
-         if (commandInterceptor instanceof PrepareCommandBlocker) {
-            return (PrepareCommandBlocker) commandInterceptor;
-         }
-      }
-      PrepareCommandBlocker blocker = new PrepareCommandBlocker();
-      cache.getAdvancedCache().addInterceptorBefore(blocker, TxInterceptor.class);
-      return blocker;
-   }
-
-   private class PrepareCommandBlocker extends CommandInterceptor {
-
-      private boolean unblock = false;
-      private boolean prepareBlocked = false;
-
-      @Override
-      public Object visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
-         Object retVal = invokeNextInterceptor(ctx, command);
-         synchronized (this) {
-            prepareBlocked = true;
-            notifyAll();
-            while (!unblock) {
-               wait();
-            }
-         }
-         return retVal;
-      }
-
-      private synchronized void reset() {
-         unblock = false;
-         prepareBlocked = false;
-      }
-
-      private synchronized void unblock() {
-         unblock = true;
-         notifyAll();
-      }
-
-      private synchronized void awaitUntilPrepareBlocked() throws InterruptedException {
-         while (!prepareBlocked) {
-            wait();
-         }
-      }
-   }
-
 }


### PR DESCRIPTION
* Due to async nature of top-k, use eventually for asserts

I've moved all the asserts to TestingUtil in extended stats module, to be shared between local and clustered tests.
Lets hope this would fix all the random failures in top key :)

https://issues.jboss.org/browse/ISPN-6458