### PR TITLE
ISPN-6445 Fix ParallelIterationTest

### DIFF
--- a/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
+++ b/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
@@ -531,9 +531,6 @@ public class SingleFileStore<K, V> implements AdvancedLoadWriteStore<K, V> {
          eacs.submit(new Callable<Void>() {
             @Override
             public Void call() throws Exception {
-               if (taskContext.isStopped())
-                  return null;
-
                try {
                   final MarshalledEntry marshalledEntry = _load(key, fetchValue, fetchMetadata);
                   if (marshalledEntry != null) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6445

* Broken by https://github.com/infinispan/infinispan/pull/4191, which added an executor queue
* Revert the extra TaskContext.isStopped() check in SingleFileStore