### PR TITLE
ISPN-6468 Ignore SyncReplExtendedStatisticTest

### DIFF
--- a/extended-statistics/src/test/java/org/infinispan/stats/simple/SyncReplExtendedStatisticTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/stats/simple/SyncReplExtendedStatisticTest.java
@@ -8,7 +8,7 @@ import org.testng.annotations.Test;
  * @author Pedro Ruivo
  * @since 6.0
  */
-@Test(groups = "functional", testName = "stats.simple.SyncReplExtendedStatisticTest")
+@Test(groups = "functional", testName = "stats.simple.SyncReplExtendedStatisticTest", enabled = false, description = "To be fixed by ISPN-6468")
 public class SyncReplExtendedStatisticTest extends BaseNonTotalOrderClusteredExtendedStatisticsTest {
 
    public SyncReplExtendedStatisticTest() {


### PR DESCRIPTION
To be fixed by https://issues.jboss.org/browse/ISPN-6468