### PR TITLE
ISPN-6488 Convert CacheRpcCommands to use a pre-computed ByteStrings

### DIFF
--- a/core/src/main/java/org/infinispan/commands/CancelCommand.java
+++ b/core/src/main/java/org/infinispan/commands/CancelCommand.java
@@ -8,12 +8,13 @@ import java.util.UUID;
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 /**
  * Command to cancel commands executing in remote VM
- * 
+ *
  * @author Vladimir Blagojevic
  * @since 5.2
  */
@@ -29,11 +30,11 @@ public class CancelCommand extends BaseRpcCommand {
       super(null);
    }
 
-   public CancelCommand(String ownerCacheName) {
+   public CancelCommand(ByteString ownerCacheName) {
       super(ownerCacheName);
    }
 
-   public CancelCommand(String ownerCacheName, UUID commandToCancel) {
+   public CancelCommand(ByteString ownerCacheName, UUID commandToCancel) {
       super(ownerCacheName);
       this.commandToCancel = commandToCancel;
    }

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -93,6 +93,7 @@ import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.transaction.xa.DldGlobalTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryManager;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.TimeService;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.logging.Log;
@@ -137,7 +138,7 @@ public class CommandsFactoryImpl implements CommandsFactory {
    private DataContainer dataContainer;
    private CacheNotifier<Object, Object> notifier;
    private Cache<Object, Object> cache;
-   private String cacheName;
+   private ByteString cacheName;
    private boolean totalOrderProtocol;
 
    private InterceptorChain interceptorChain;
@@ -209,7 +210,7 @@ public class CommandsFactoryImpl implements CommandsFactory {
    @Start(priority = 1)
    // needs to happen early on
    public void start() {
-      cacheName = cache.getName();
+      cacheName = ByteString.fromString(cache.getName());
       this.totalOrderProtocol = configuration.transaction().transactionProtocol().isTotalOrder();
    }
 
@@ -548,7 +549,7 @@ public class CommandsFactoryImpl implements CommandsFactory {
 
    @Override
    public String getCacheName() {
-      return cacheName;
+      return cacheName.toString();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/CreateCacheCommand.java
+++ b/core/src/main/java/org/infinispan/commands/CreateCacheCommand.java
@@ -9,6 +9,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.statetransfer.StateTransferLock;
 import org.infinispan.statetransfer.StateTransferManager;
 import org.infinispan.topology.CacheTopology;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.TimeService;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.logging.Log;
@@ -38,15 +39,15 @@ public class CreateCacheCommand extends BaseRpcCommand {
       super(null);
    }
 
-   public CreateCacheCommand(String ownerCacheName) {
+   public CreateCacheCommand(ByteString ownerCacheName) {
       super(ownerCacheName);
    }
 
-   public CreateCacheCommand(String ownerCacheName, String cacheNameToCreate, String cacheConfigurationName) {
+   public CreateCacheCommand(ByteString ownerCacheName, String cacheNameToCreate, String cacheConfigurationName) {
       this(ownerCacheName, cacheNameToCreate, cacheConfigurationName, 0);
    }
 
-   public CreateCacheCommand(String cacheName, String cacheNameToCreate, String cacheConfigurationName,
+   public CreateCacheCommand(ByteString cacheName, String cacheNameToCreate, String cacheConfigurationName,
                              int expectedMembers) {
       super(cacheName);
       this.cacheNameToCreate = cacheNameToCreate;

--- a/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/RemoteCommandsFactory.java
@@ -58,6 +58,7 @@ import org.infinispan.stream.impl.StreamRequestCommand;
 import org.infinispan.stream.impl.StreamResponseCommand;
 import org.infinispan.stream.impl.StreamSegmentResponseCommand;
 import org.infinispan.topology.CacheTopologyControlCommand;
+import org.infinispan.util.ByteString;
 import org.infinispan.xsite.SingleXSiteRpcCommand;
 import org.infinispan.xsite.XSiteAdminCommand;
 import org.infinispan.xsite.statetransfer.XSiteStatePushCommand;
@@ -198,7 +199,7 @@ public class RemoteCommandsFactory {
     * @param cacheName     cache name at which this command is directed
     * @return              an instance of {@link CacheRpcCommand}
     */
-   public CacheRpcCommand fromStream(byte id, byte type, String cacheName) {
+   public CacheRpcCommand fromStream(byte id, byte type, ByteString cacheName) {
       CacheRpcCommand command;
       if (type == 0) {
          switch (id) {

--- a/core/src/main/java/org/infinispan/commands/control/LockControlCommand.java
+++ b/core/src/main/java/org/infinispan/commands/control/LockControlCommand.java
@@ -12,6 +12,7 @@ import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.locks.TransactionalRemoteLockCommand;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -49,11 +50,11 @@ public class LockControlCommand extends AbstractTransactionBoundaryCommand imple
       super(null); // For command id uniqueness test
    }
 
-   public LockControlCommand(String cacheName) {
+   public LockControlCommand(ByteString cacheName) {
       super(cacheName);
    }
 
-   public LockControlCommand(Collection<?> keys, String cacheName, long flags, GlobalTransaction gtx) {
+   public LockControlCommand(Collection<?> keys, ByteString cacheName, long flags, GlobalTransaction gtx) {
       super(cacheName);
       if (keys != null) {
          //building defensive copies is here in order to support replaceKey operation
@@ -65,7 +66,7 @@ public class LockControlCommand extends AbstractTransactionBoundaryCommand imple
       this.globalTx = gtx;
    }
 
-   public LockControlCommand(Object key, String cacheName, long flags, GlobalTransaction gtx) {
+   public LockControlCommand(Object key, ByteString cacheName, long flags, GlobalTransaction gtx) {
       this(cacheName);
       this.keys = new ArrayList<>(1);
       this.keys.add(key);

--- a/core/src/main/java/org/infinispan/commands/module/ModuleCommandFactory.java
+++ b/core/src/main/java/org/infinispan/commands/module/ModuleCommandFactory.java
@@ -5,6 +5,7 @@ import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.util.ByteString;
 
 import java.util.Map;
 
@@ -46,5 +47,5 @@ public interface ModuleCommandFactory {
     * @param cacheName  cache name at which command to be created is directed
     * @return           a {@link CacheRpcCommand}
     */
-   CacheRpcCommand fromStream(byte commandId, String cacheName);
+   CacheRpcCommand fromStream(byte commandId, ByteString cacheName);
 }

--- a/core/src/main/java/org/infinispan/commands/read/DistributedExecuteCommand.java
+++ b/core/src/main/java/org/infinispan/commands/read/DistributedExecuteCommand.java
@@ -20,6 +20,7 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.distexec.DistributedCallable;
 import org.infinispan.distexec.spi.DistributedTaskLifecycleService;
 import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.util.ByteString;
 
 /**
  * DistributedExecuteCommand is used to migrate Callable and execute it in remote JVM.
@@ -43,11 +44,11 @@ public class DistributedExecuteCommand<V> extends BaseRpcCommand implements Visi
 
    private UUID uuid;
 
-   public DistributedExecuteCommand(String cacheName) {
+   public DistributedExecuteCommand(ByteString cacheName) {
       this(cacheName, null, null);
    }
 
-   public DistributedExecuteCommand(String cacheName, Collection<Object> inputKeys, Callable<V> callable) {
+   public DistributedExecuteCommand(ByteString cacheName, Collection<Object> inputKeys, Callable<V> callable) {
       super(cacheName);
       if (inputKeys == null || inputKeys.isEmpty())
          this.keys = Collections.emptySet();

--- a/core/src/main/java/org/infinispan/commands/remote/BaseRpcCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/BaseRpcCommand.java
@@ -1,18 +1,19 @@
 package org.infinispan.commands.remote;
 
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
 
 public abstract class BaseRpcCommand implements CacheRpcCommand {
-   protected final String cacheName;
+   protected final ByteString cacheName;
 
    private Address origin;
 
-   protected BaseRpcCommand(String cacheName) {
+   protected BaseRpcCommand(ByteString cacheName) {
       this.cacheName = cacheName;
    }
 
    @Override
-   public String getCacheName() {
+   public ByteString getCacheName() {
       return cacheName;
    }
 
@@ -22,12 +23,12 @@ public abstract class BaseRpcCommand implements CacheRpcCommand {
             "cacheName='" + cacheName + '\'' +
             '}';
    }
-   
+
    @Override
    public Address getOrigin() {
       return origin;
    }
-   
+
    @Override
    public void setOrigin(Address origin) {
       this.origin = origin;

--- a/core/src/main/java/org/infinispan/commands/remote/BaseRpcInvokingCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/BaseRpcInvokingCommand.java
@@ -5,6 +5,7 @@ import org.infinispan.commands.VisitableCommand;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.InvocationContextFactory;
 import org.infinispan.interceptors.InterceptorChain;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.locks.RemoteLockCommand;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -22,7 +23,7 @@ public abstract class BaseRpcInvokingCommand extends BaseRpcCommand {
    private static final Log log = LogFactory.getLog(BaseRpcInvokingCommand.class);
    private static final boolean trace = log.isTraceEnabled();
 
-   protected BaseRpcInvokingCommand(String cacheName) {
+   protected BaseRpcInvokingCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/remote/CacheRpcCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/CacheRpcCommand.java
@@ -2,6 +2,7 @@ package org.infinispan.commands.remote;
 
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
 
 /**
  * The {@link org.infinispan.remoting.rpc.RpcManager} only replicates commands wrapped in a {@link CacheRpcCommand}.
@@ -16,18 +17,18 @@ public interface CacheRpcCommand extends ReplicableCommand {
     * @return the name of the cache that produced this command.  This will also be the name of the cache this command is
     *         intended for.
     */
-   String getCacheName();
+   ByteString getCacheName();
 
    /**
     * Set the origin of the command
     * @param origin
     */
    void setOrigin(Address origin);
-   
+
    /**
     * Get the origin of the command
     * @return
     */
    Address getOrigin();
-   
+
 }

--- a/core/src/main/java/org/infinispan/commands/remote/ClusteredGetAllCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/ClusteredGetAllCommand.java
@@ -24,6 +24,7 @@ import org.infinispan.context.InvocationContextFactory;
 import org.infinispan.interceptors.InterceptorChain;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -52,12 +53,12 @@ public class ClusteredGetAllCommand<K, V> extends LocalFlagAffectedRpcCommand {
       super(null, EnumUtil.EMPTY_BIT_SET);
    }
 
-   public ClusteredGetAllCommand(String cacheName) {
+   public ClusteredGetAllCommand(ByteString cacheName) {
       super(cacheName, EnumUtil.EMPTY_BIT_SET);
    }
 
-   public ClusteredGetAllCommand(String cacheName, List<?> keys, long flags,
-         GlobalTransaction gtx, Equivalence<? super K> keyEquivalence) {
+   public ClusteredGetAllCommand(ByteString cacheName, List<?> keys, long flags,
+                                 GlobalTransaction gtx, Equivalence<? super K> keyEquivalence) {
       super(cacheName, flags);
       this.keys = keys;
       this.gtx = gtx;

--- a/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
@@ -20,6 +20,7 @@ import org.infinispan.context.InvocationContextFactory;
 import org.infinispan.interceptors.InterceptorChain;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -55,12 +56,12 @@ public class ClusteredGetCommand extends LocalFlagAffectedRpcCommand {
       super(null, EnumUtil.EMPTY_BIT_SET); // For command id uniqueness test
    }
 
-   public ClusteredGetCommand(String cacheName) {
+   public ClusteredGetCommand(ByteString cacheName) {
       super(cacheName, EnumUtil.EMPTY_BIT_SET);
    }
 
-   public ClusteredGetCommand(Object key, String cacheName, long flags,
-         boolean acquireRemoteLock, GlobalTransaction gtx, Equivalence keyEquivalence) {
+   public ClusteredGetCommand(Object key, ByteString cacheName, long flags,
+                              boolean acquireRemoteLock, GlobalTransaction gtx, Equivalence keyEquivalence) {
       super(cacheName, flags);
       this.key = key;
       this.acquireRemoteLock = acquireRemoteLock;

--- a/core/src/main/java/org/infinispan/commands/remote/LocalFlagAffectedRpcCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/LocalFlagAffectedRpcCommand.java
@@ -3,6 +3,7 @@ package org.infinispan.commands.remote;
 import org.infinispan.commands.LocalFlagAffectedCommand;
 import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.context.Flag;
+import org.infinispan.util.ByteString;
 
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
@@ -10,7 +11,7 @@ import org.infinispan.context.Flag;
 public abstract class LocalFlagAffectedRpcCommand extends BaseRpcCommand implements LocalFlagAffectedCommand {
    private long flags;
 
-   protected LocalFlagAffectedRpcCommand(String cacheName, long flagBitSet) {
+   protected LocalFlagAffectedRpcCommand(ByteString cacheName, long flagBitSet) {
       super(cacheName);
       this.flags = flagBitSet;
    }

--- a/core/src/main/java/org/infinispan/commands/remote/MultipleRpcCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/MultipleRpcCommand.java
@@ -5,6 +5,7 @@ import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.tx.TransactionBoundaryCommand;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -37,12 +38,12 @@ public class MultipleRpcCommand extends BaseRpcInvokingCommand {
       super(null); // For command id uniqueness test
    }
 
-   public MultipleRpcCommand(List<ReplicableCommand> modifications, String cacheName) {
+   public MultipleRpcCommand(List<ReplicableCommand> modifications, ByteString cacheName) {
       super(cacheName);
       commands = modifications.toArray(new ReplicableCommand[modifications.size()]);
    }
 
-   public MultipleRpcCommand(String cacheName) {
+   public MultipleRpcCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/remote/SingleRpcCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/SingleRpcCommand.java
@@ -2,6 +2,7 @@ package org.infinispan.commands.remote;
 
 import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.util.ByteString;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -22,12 +23,12 @@ public class SingleRpcCommand extends BaseRpcInvokingCommand {
       super(null); // For command id uniqueness test
    }
 
-   public SingleRpcCommand(String cacheName, ReplicableCommand command) {
+   public SingleRpcCommand(ByteString cacheName, ReplicableCommand command) {
       super(cacheName);
       this.command = command;
    }
 
-   public SingleRpcCommand(String cacheName) {
+   public SingleRpcCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/CompleteTransactionCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/CompleteTransactionCommand.java
@@ -1,6 +1,8 @@
 package org.infinispan.commands.remote.recovery;
 
 import org.infinispan.context.InvocationContext;
+import org.infinispan.util.ByteString;
+
 import javax.transaction.xa.Xid;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -30,11 +32,11 @@ public class CompleteTransactionCommand extends RecoveryCommand {
       super(null); // For command id uniqueness test
    }
 
-   public CompleteTransactionCommand(String cacheName) {
+   public CompleteTransactionCommand(ByteString cacheName) {
       super(cacheName);
    }
 
-   public CompleteTransactionCommand(String cacheName, Xid xid, boolean commit) {
+   public CompleteTransactionCommand(ByteString cacheName, Xid xid, boolean commit) {
       super(cacheName);
       this.xid = xid;
       this.commit = commit;

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/GetInDoubtTransactionsCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/GetInDoubtTransactionsCommand.java
@@ -1,6 +1,7 @@
 package org.infinispan.commands.remote.recovery;
 
 import org.infinispan.context.InvocationContext;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -27,7 +28,7 @@ public class GetInDoubtTransactionsCommand extends RecoveryCommand {
       super(null); // For command id uniqueness test
    }
 
-   public GetInDoubtTransactionsCommand(String cacheName) {
+   public GetInDoubtTransactionsCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/GetInDoubtTxInfoCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/GetInDoubtTxInfoCommand.java
@@ -1,6 +1,7 @@
 package org.infinispan.commands.remote.recovery;
 
 import org.infinispan.context.InvocationContext;
+import org.infinispan.util.ByteString;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -20,7 +21,7 @@ public class GetInDoubtTxInfoCommand extends RecoveryCommand {
       super(null); // For command id uniqueness test
    }
 
-   public GetInDoubtTxInfoCommand(String cacheName) {
+   public GetInDoubtTxInfoCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/RecoveryCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/RecoveryCommand.java
@@ -2,6 +2,7 @@ package org.infinispan.commands.remote.recovery;
 
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.transaction.xa.recovery.RecoveryManager;
+import org.infinispan.util.ByteString;
 
 /**
  * Base class for recovery-related rpc-commands.
@@ -17,7 +18,7 @@ public abstract class RecoveryCommand extends BaseRpcCommand {
       super(null); // For command id uniqueness test
    }
 
-   protected RecoveryCommand(String cacheName) {
+   protected RecoveryCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/remote/recovery/TxCompletionNotificationCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/recovery/TxCompletionNotificationCommand.java
@@ -7,6 +7,7 @@ import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryManager;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -42,7 +43,7 @@ public class TxCompletionNotificationCommand  extends RecoveryCommand implements
       super(null); // For command id uniqueness test
    }
 
-   public TxCompletionNotificationCommand(Xid xid, GlobalTransaction gtx, String cacheName) {
+   public TxCompletionNotificationCommand(Xid xid, GlobalTransaction gtx, ByteString cacheName) {
       super(cacheName);
       this.xid = xid;
       this.gtx = gtx;
@@ -56,12 +57,12 @@ public class TxCompletionNotificationCommand  extends RecoveryCommand implements
    }
 
 
-   public TxCompletionNotificationCommand(long internalId, String cacheName) {
+   public TxCompletionNotificationCommand(long internalId, ByteString cacheName) {
       super(cacheName);
       this.internalId = internalId;
    }
 
-   public TxCompletionNotificationCommand(String cacheName) {
+   public TxCompletionNotificationCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/tx/AbstractTransactionBoundaryCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/AbstractTransactionBoundaryCommand.java
@@ -9,6 +9,7 @@ import org.infinispan.remoting.transport.Address;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -29,14 +30,14 @@ public abstract class AbstractTransactionBoundaryCommand implements TransactionB
    private static boolean trace = log.isTraceEnabled();
 
    protected GlobalTransaction globalTx;
-   protected final String cacheName;
+   protected final ByteString cacheName;
    protected InterceptorChain invoker;
    protected InvocationContextFactory icf;
    protected TransactionTable txTable;
    private Address origin;
    private int topologyId = -1;
 
-   public AbstractTransactionBoundaryCommand(String cacheName) {
+   public AbstractTransactionBoundaryCommand(ByteString cacheName) {
       this.cacheName = cacheName;
    }
 
@@ -57,7 +58,7 @@ public abstract class AbstractTransactionBoundaryCommand implements TransactionB
    }
 
    @Override
-   public String getCacheName() {
+   public ByteString getCacheName() {
       return cacheName;
    }
 
@@ -156,12 +157,12 @@ public abstract class AbstractTransactionBoundaryCommand implements TransactionB
    private void markGtxAsRemote() {
       globalTx.setRemote(true);
    }
-   
+
    @Override
    public Address getOrigin() {
       return origin;
    }
-   
+
    @Override
    public void setOrigin(Address origin) {
       this.origin = origin;

--- a/core/src/main/java/org/infinispan/commands/tx/CommitCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/CommitCommand.java
@@ -1,12 +1,11 @@
 package org.infinispan.commands.tx;
 
 import org.infinispan.commands.Visitor;
-import org.infinispan.commons.CacheException;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.transaction.xa.GlobalTransaction;
-import org.infinispan.util.concurrent.TimeoutException;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -25,12 +24,12 @@ public class CommitCommand extends AbstractTransactionBoundaryCommand {
       super(null); // For command id uniqueness test
    }
 
-   public CommitCommand(String cacheName, GlobalTransaction gtx) {
+   public CommitCommand(ByteString cacheName, GlobalTransaction gtx) {
       super(cacheName);
       this.globalTx = gtx;
    }
 
-   public CommitCommand(String cacheName) {
+   public CommitCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/PrepareCommand.java
@@ -18,6 +18,7 @@ import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoveryManager;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.locks.TransactionalRemoteLockCommand;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -54,7 +55,7 @@ public class PrepareCommand extends AbstractTransactionBoundaryCommand implement
    protected RecoveryManager recoveryManager;
    private transient boolean replayEntryWrapping  = false;
    protected boolean retriedCommand;
-   
+
    private static final WriteCommand[] EMPTY_WRITE_COMMAND_ARRAY = new WriteCommand[0];
 
    public void initialize(CacheNotifier notifier, RecoveryManager recoveryManager) {
@@ -66,21 +67,21 @@ public class PrepareCommand extends AbstractTransactionBoundaryCommand implement
       super(null); // For command id uniqueness test
    }
 
-   public PrepareCommand(String cacheName, GlobalTransaction gtx, boolean onePhaseCommit, WriteCommand... modifications) {
+   public PrepareCommand(ByteString cacheName, GlobalTransaction gtx, boolean onePhaseCommit, WriteCommand... modifications) {
       super(cacheName);
       this.globalTx = gtx;
       this.modifications = modifications;
       this.onePhaseCommit = onePhaseCommit;
    }
 
-   public PrepareCommand(String cacheName, GlobalTransaction gtx, List<WriteCommand> commands, boolean onePhaseCommit) {
+   public PrepareCommand(ByteString cacheName, GlobalTransaction gtx, List<WriteCommand> commands, boolean onePhaseCommit) {
       super(cacheName);
       this.globalTx = gtx;
       this.modifications = commands == null || commands.isEmpty() ? null : commands.toArray(new WriteCommand[commands.size()]);
       this.onePhaseCommit = onePhaseCommit;
    }
 
-   public PrepareCommand(String cacheName) {
+   public PrepareCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/tx/RollbackCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/RollbackCommand.java
@@ -5,6 +5,7 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.ByteString;
 
 /**
  * Command corresponding to a transaction rollback.
@@ -19,12 +20,12 @@ public class RollbackCommand extends AbstractTransactionBoundaryCommand {
       super(null); // For command id uniqueness test
    }
 
-   public RollbackCommand(String cacheName, GlobalTransaction globalTransaction) {
+   public RollbackCommand(ByteString cacheName, GlobalTransaction globalTransaction) {
       super(cacheName);
       this.globalTx = globalTransaction;
    }
 
-   public RollbackCommand(String cacheName) {
+   public RollbackCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/tx/VersionedCommitCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/VersionedCommitCommand.java
@@ -3,6 +3,7 @@ package org.infinispan.commands.tx;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.container.versioning.EntryVersionsMap;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.ByteString;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -20,14 +21,14 @@ public class VersionedCommitCommand extends CommitCommand {
    private EntryVersionsMap updatedVersions;
 
    public VersionedCommitCommand() {
-      super("");
+      super(null);
    }
 
-   public VersionedCommitCommand(String cacheName, GlobalTransaction gtx) {
+   public VersionedCommitCommand(ByteString cacheName, GlobalTransaction gtx) {
       super(cacheName, gtx);
    }
 
-   public VersionedCommitCommand(String cacheName) {
+   public VersionedCommitCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/tx/VersionedPrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/VersionedPrepareCommand.java
@@ -4,6 +4,7 @@ import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.container.versioning.EntryVersionsMap;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.ByteString;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -23,15 +24,15 @@ public class VersionedPrepareCommand extends PrepareCommand {
    private EntryVersionsMap versionsSeen = null;
 
    public VersionedPrepareCommand() {
-      super("");
+      super(null);
    }
 
-   public VersionedPrepareCommand(String cacheName, GlobalTransaction gtx, List<WriteCommand> modifications, boolean onePhase) {
+   public VersionedPrepareCommand(ByteString cacheName, GlobalTransaction gtx, List<WriteCommand> modifications, boolean onePhase) {
       // VersionedPrepareCommands are *always* 2-phase, except when retrying a prepare.
       super(cacheName, gtx, modifications, onePhase);
    }
 
-   public VersionedPrepareCommand(String cacheName) {
+   public VersionedPrepareCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderCommitCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderCommitCommand.java
@@ -1,10 +1,9 @@
 package org.infinispan.commands.tx.totalorder;
 
 import org.infinispan.commands.tx.CommitCommand;
-import org.infinispan.context.InvocationContext;
-import org.infinispan.context.impl.RemoteTxInvocationContext;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -19,11 +18,11 @@ public class TotalOrderCommitCommand extends CommitCommand {
    public static final byte COMMAND_ID = 35;
    private static final Log log = LogFactory.getLog(TotalOrderCommitCommand.class);
 
-   public TotalOrderCommitCommand(String cacheName, GlobalTransaction gtx) {
+   public TotalOrderCommitCommand(ByteString cacheName, GlobalTransaction gtx) {
       super(cacheName, gtx);
    }
 
-   public TotalOrderCommitCommand(String cacheName) {
+   public TotalOrderCommitCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderNonVersionedPrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderNonVersionedPrepareCommand.java
@@ -4,6 +4,7 @@ import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.transaction.impl.TotalOrderRemoteTransactionState;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.ByteString;
 
 import java.util.List;
 
@@ -18,15 +19,15 @@ public class TotalOrderNonVersionedPrepareCommand extends PrepareCommand impleme
 
    public static final byte COMMAND_ID = 38;
 
-   public TotalOrderNonVersionedPrepareCommand(String cacheName, GlobalTransaction gtx, WriteCommand... modifications) {
+   public TotalOrderNonVersionedPrepareCommand(ByteString cacheName, GlobalTransaction gtx, WriteCommand... modifications) {
       super(cacheName, gtx, true, modifications);
    }
 
-   public TotalOrderNonVersionedPrepareCommand(String cacheName, GlobalTransaction gtx, List<WriteCommand> commands) {
+   public TotalOrderNonVersionedPrepareCommand(ByteString cacheName, GlobalTransaction gtx, List<WriteCommand> commands) {
       super(cacheName, gtx, commands, true);
    }
 
-   public TotalOrderNonVersionedPrepareCommand(String cacheName) {
+   public TotalOrderNonVersionedPrepareCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderRollbackCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderRollbackCommand.java
@@ -1,10 +1,9 @@
 package org.infinispan.commands.tx.totalorder;
 
 import org.infinispan.commands.tx.RollbackCommand;
-import org.infinispan.context.InvocationContext;
-import org.infinispan.context.impl.RemoteTxInvocationContext;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -20,11 +19,11 @@ public class TotalOrderRollbackCommand extends RollbackCommand {
    public static final byte COMMAND_ID = 37;
    private static final Log log = LogFactory.getLog(TotalOrderRollbackCommand.class);
 
-   public TotalOrderRollbackCommand(String cacheName, GlobalTransaction globalTransaction) {
+   public TotalOrderRollbackCommand(ByteString cacheName, GlobalTransaction globalTransaction) {
       super(cacheName, globalTransaction);
    }
 
-   public TotalOrderRollbackCommand(String cacheName) {
+   public TotalOrderRollbackCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderVersionedCommitCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderVersionedCommitCommand.java
@@ -1,10 +1,9 @@
 package org.infinispan.commands.tx.totalorder;
 
 import org.infinispan.commands.tx.VersionedCommitCommand;
-import org.infinispan.context.InvocationContext;
-import org.infinispan.context.impl.RemoteTxInvocationContext;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -19,11 +18,11 @@ public class TotalOrderVersionedCommitCommand extends VersionedCommitCommand {
    public static final byte COMMAND_ID = 36;
    private static final Log log = LogFactory.getLog(TotalOrderVersionedCommitCommand.class);
 
-   public TotalOrderVersionedCommitCommand(String cacheName, GlobalTransaction gtx) {
+   public TotalOrderVersionedCommitCommand(ByteString cacheName, GlobalTransaction gtx) {
       super(cacheName, gtx);
    }
 
-   public TotalOrderVersionedCommitCommand(String cacheName) {
+   public TotalOrderVersionedCommitCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderVersionedPrepareCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/totalorder/TotalOrderVersionedPrepareCommand.java
@@ -4,6 +4,7 @@ import org.infinispan.commands.tx.VersionedPrepareCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.transaction.impl.TotalOrderRemoteTransactionState;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.ByteString;
 
 import java.util.List;
 
@@ -19,11 +20,11 @@ public class TotalOrderVersionedPrepareCommand extends VersionedPrepareCommand i
    public static final byte COMMAND_ID = 39;
    private boolean skipWriteSkewCheck;
 
-   public TotalOrderVersionedPrepareCommand(String cacheName, GlobalTransaction gtx, List<WriteCommand> modifications, boolean onePhase) {
+   public TotalOrderVersionedPrepareCommand(ByteString cacheName, GlobalTransaction gtx, List<WriteCommand> modifications, boolean onePhase) {
       super(cacheName, gtx, modifications, onePhase);
    }
 
-   public TotalOrderVersionedPrepareCommand(String cacheName) {
+   public TotalOrderVersionedPrepareCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/GlobalComponentRegistry.java
@@ -27,6 +27,7 @@ import org.infinispan.registry.impl.InternalCacheRegistryImpl;
 import org.infinispan.remoting.transport.Transport;
 import org.infinispan.topology.ClusterTopologyManager;
 import org.infinispan.topology.LocalTopologyManager;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.ModuleProperties;
 import org.infinispan.util.TimeService;
 import org.infinispan.util.logging.Log;
@@ -83,7 +84,7 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
 
    final Collection<ModuleLifecycle> moduleLifecycles;
 
-   final ConcurrentMap<String, ComponentRegistry> namedComponents = new ConcurrentHashMap<String, ComponentRegistry>(4);
+   final ConcurrentMap<ByteString, ComponentRegistry> namedComponents = new ConcurrentHashMap<ByteString, ComponentRegistry>(4);
 
    protected final WeakReference<ClassLoader> defaultClassLoader;
 
@@ -196,15 +197,20 @@ public class GlobalComponentRegistry extends AbstractComponentRegistry {
 
    public final ComponentRegistry getNamedComponentRegistry(String name) {
       //no need so sync this method as namedComponents is thread safe and correctly published (final)
+      return getNamedComponentRegistry(ByteString.fromString(name));
+   }
+
+   public final ComponentRegistry getNamedComponentRegistry(ByteString name) {
+      //no need so sync this method as namedComponents is thread safe and correctly published (final)
       return namedComponents.get(name);
    }
 
    public synchronized final void registerNamedComponentRegistry(ComponentRegistry componentRegistry, String name) {
-      namedComponents.put(name, componentRegistry);
+      namedComponents.put(ByteString.fromString(name), componentRegistry);
    }
 
    public synchronized final void unregisterNamedComponentRegistry(String name) {
-      namedComponents.remove(name);
+      namedComponents.remove(ByteString.fromString(name));
    }
 
    public synchronized final void rewireNamedRegistries() {

--- a/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/DefaultCacheManager.java
@@ -50,6 +50,7 @@ import org.infinispan.security.impl.PrincipalRoleMapperContextImpl;
 import org.infinispan.security.impl.SecureCacheImpl;
 import org.infinispan.stats.CacheContainerStats;
 import org.infinispan.stats.impl.CacheContainerStatsImpl;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.CyclicDependencyException;
 import org.infinispan.util.DependencyGraph;
 import org.infinispan.util.logging.Log;
@@ -515,7 +516,7 @@ public class DefaultCacheManager implements EmbeddedCacheManager {
       authzHelper.checkPermission(AuthorizationPermission.ADMIN);
       ComponentRegistry cacheComponentRegistry = globalComponentRegistry.getNamedComponentRegistry(cacheName);
       if (cacheComponentRegistry != null) {
-         RemoveCacheCommand cmd = new RemoveCacheCommand(cacheName, this);
+         RemoveCacheCommand cmd = new RemoveCacheCommand(ByteString.fromString(cacheName), this);
          Transport transport = getTransport();
          try {
             CompletableFuture<?> future = null;

--- a/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/CacheRpcCommandExternalizer.java
@@ -41,6 +41,7 @@ import org.infinispan.statetransfer.StateResponseCommand;
 import org.infinispan.stream.impl.StreamRequestCommand;
 import org.infinispan.stream.impl.StreamResponseCommand;
 import org.infinispan.stream.impl.StreamSegmentResponseCommand;
+import org.infinispan.util.ByteString;
 import org.infinispan.xsite.SingleXSiteRpcCommand;
 import org.infinispan.xsite.XSiteAdminCommand;
 import org.infinispan.xsite.statetransfer.XSiteStatePushCommand;
@@ -110,8 +111,8 @@ public final class CacheRpcCommandExternalizer extends AbstractExternalizer<Cach
    public void writeObject(ObjectOutput output, CacheRpcCommand command) throws IOException {
       //header: type + method id.
       cmdExt.writeCommandHeader(output, command);
-      String cacheName = command.getCacheName();
-      output.writeUTF(cacheName);
+      ByteString cacheName = command.getCacheName();
+      ByteString.writeObject(output, cacheName);
 
       StreamingMarshaller marshaller = getCacheMarshaller(cacheName);
 
@@ -145,7 +146,7 @@ public final class CacheRpcCommandExternalizer extends AbstractExternalizer<Cach
       //header
       byte type = input.readByte();
       byte methodId = (byte) input.readShort();
-      String cacheName = input.readUTF();
+      ByteString cacheName = ByteString.readObject(input);
 
       StreamingMarshaller marshaller = getCacheMarshaller(cacheName);
 
@@ -181,7 +182,7 @@ public final class CacheRpcCommandExternalizer extends AbstractExternalizer<Cach
       return Ids.CACHE_RPC_COMMAND;
    }
 
-   private StreamingMarshaller getCacheMarshaller(String cacheName) {
+   private StreamingMarshaller getCacheMarshaller(ByteString cacheName) {
       ComponentRegistry registry = gcr.getNamedComponentRegistry(cacheName);
       if (registry == null || registry.getStatus() != ComponentStatus.RUNNING) {
          // When starting, even though the command is directed at a cache,

--- a/core/src/main/java/org/infinispan/marshall/exts/ReplicableCommandExternalizer.java
+++ b/core/src/main/java/org/infinispan/marshall/exts/ReplicableCommandExternalizer.java
@@ -24,6 +24,7 @@ import org.infinispan.manager.impl.ReplicableCommandRunnable;
 import org.infinispan.manager.impl.ReplicableCommandManagerFunction;
 import org.infinispan.marshall.core.Ids;
 import org.infinispan.topology.CacheTopologyControlCommand;
+import org.infinispan.util.ByteString;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -95,7 +96,7 @@ public class ReplicableCommandExternalizer extends AbstractExternalizer<Replicab
       }
    }
 
-   protected CacheRpcCommand fromStream(byte id, byte type, String cacheName) {
+   protected CacheRpcCommand fromStream(byte id, byte type, ByteString cacheName) {
       return cmdFactory.fromStream(id, type, cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/persistence/cluster/ClusterLoader.java
+++ b/core/src/main/java/org/infinispan/persistence/cluster/ClusterLoader.java
@@ -20,6 +20,7 @@ import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.rpc.RpcOptions;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -43,11 +44,13 @@ public class ClusterLoader implements CacheLoader, LocalOnlyCacheLoader {
 
    private ClusterLoaderConfiguration configuration;
    private InitializationContext ctx;
+   private ByteString cacheName;
 
    @Override
    public void init(InitializationContext ctx) {
       this.ctx = ctx;
       cache = ctx.getCache().getAdvancedCache();
+      cacheName = ByteString.fromString(cache.getName());
       rpcManager = cache.getRpcManager();
       this.configuration = ctx.getConfiguration();
    }
@@ -57,7 +60,7 @@ public class ClusterLoader implements CacheLoader, LocalOnlyCacheLoader {
       if (!isCacheReady()) return null;
 
       ClusteredGetCommand clusteredGetCommand = new ClusteredGetCommand(
-            key, cache.getName(), EnumUtil.EMPTY_BIT_SET, false, null,
+            key, cacheName, EnumUtil.EMPTY_BIT_SET, false, null,
             cache.getCacheConfiguration().dataContainer().keyEquivalence());
 
       Collection<Response> responses = doRemoteCall(clusteredGetCommand);

--- a/core/src/main/java/org/infinispan/remoting/inboundhandler/GlobalInboundInvocationHandler.java
+++ b/core/src/main/java/org/infinispan/remoting/inboundhandler/GlobalInboundInvocationHandler.java
@@ -16,6 +16,7 @@ import org.infinispan.remoting.responses.ExceptionResponse;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.responses.SuccessfulResponse;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.infinispan.xsite.BackupReceiver;
@@ -96,7 +97,7 @@ public class GlobalInboundInvocationHandler implements InboundInvocationHandler 
          log.tracef("Handling command %s from remote site %s", command, origin);
       }
 
-      BackupReceiver receiver = backupReceiverRepository.getBackupReceiver(origin, command.getCacheName());
+      BackupReceiver receiver = backupReceiverRepository.getBackupReceiver(origin, command.getCacheName().toString());
       Runnable runnable = create(command, receiver, reply);
       if (order.preserveOrder()) {
          runnable.run();
@@ -111,7 +112,7 @@ public class GlobalInboundInvocationHandler implements InboundInvocationHandler 
       if (trace) {
          log.tracef("Attempting to execute CacheRpcCommand: %s [sender=%s]", command, origin);
       }
-      String cacheName = command.getCacheName();
+      ByteString cacheName = command.getCacheName();
       ComponentRegistry cr = globalComponentRegistry.getNamedComponentRegistry(cacheName);
 
       if (cr == null) {

--- a/core/src/main/java/org/infinispan/statetransfer/StateRequestCommand.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateRequestCommand.java
@@ -6,6 +6,7 @@ import org.infinispan.commons.CacheException;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -48,11 +49,11 @@ public class StateRequestCommand extends BaseRpcCommand implements TopologyAffec
       super(null);  // for command id uniqueness test
    }
 
-   public StateRequestCommand(String cacheName) {
+   public StateRequestCommand(ByteString cacheName) {
       super(cacheName);
    }
 
-   public StateRequestCommand(String cacheName, Type type, Address origin, int topologyId, Set<Integer> segments) {
+   public StateRequestCommand(ByteString cacheName, Type type, Address origin, int topologyId, Set<Integer> segments) {
       super(cacheName);
       this.type = type;
       setOrigin(origin);

--- a/core/src/main/java/org/infinispan/statetransfer/StateResponseCommand.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateResponseCommand.java
@@ -4,6 +4,7 @@ import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -44,11 +45,11 @@ public class StateResponseCommand extends BaseRpcCommand {
       super(null);  // for command id uniqueness test
    }
 
-   public StateResponseCommand(String cacheName) {
+   public StateResponseCommand(ByteString cacheName) {
       super(cacheName);
    }
 
-   public StateResponseCommand(String cacheName, Address origin, int topologyId, Collection<StateChunk> stateChunks) {
+   public StateResponseCommand(ByteString cacheName, Address origin, int topologyId, Collection<StateChunk> stateChunks) {
       super(cacheName);
       setOrigin(origin);
       this.topologyId = topologyId;

--- a/core/src/main/java/org/infinispan/stream/impl/StreamRequestCommand.java
+++ b/core/src/main/java/org/infinispan/stream/impl/StreamRequestCommand.java
@@ -6,6 +6,7 @@ import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -58,11 +59,11 @@ public class StreamRequestCommand<K> extends BaseRpcCommand implements TopologyA
    // Only here for CommandIdUniquenessTest
    private StreamRequestCommand() { super(null); }
 
-   public StreamRequestCommand(String cacheName) {
+   public StreamRequestCommand(ByteString cacheName) {
       super(cacheName);
    }
 
-   public StreamRequestCommand(String cacheName, Address origin, Object id, boolean parallelStream, Type type,
+   public StreamRequestCommand(ByteString cacheName, Address origin, Object id, boolean parallelStream, Type type,
                                Set<Integer> segments, Set<K> keys, Set<K> excludedKeys, boolean includeLoader,
                                Object terminalOperation) {
       super(cacheName);

--- a/core/src/main/java/org/infinispan/stream/impl/StreamResponseCommand.java
+++ b/core/src/main/java/org/infinispan/stream/impl/StreamResponseCommand.java
@@ -4,6 +4,7 @@ import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -26,11 +27,11 @@ public class StreamResponseCommand<R> extends BaseRpcCommand {
    // Only here for CommandIdUniquenessTest
    protected StreamResponseCommand() { super(null); }
 
-   public StreamResponseCommand(String cacheName) {
+   public StreamResponseCommand(ByteString cacheName) {
       super(cacheName);
    }
 
-   public StreamResponseCommand(String cacheName, Address origin, Object id, boolean complete, R response) {
+   public StreamResponseCommand(ByteString cacheName, Address origin, Object id, boolean complete, R response) {
       super(cacheName);
       setOrigin(origin);
       this.id = id;

--- a/core/src/main/java/org/infinispan/stream/impl/StreamSegmentResponseCommand.java
+++ b/core/src/main/java/org/infinispan/stream/impl/StreamSegmentResponseCommand.java
@@ -3,6 +3,7 @@ package org.infinispan.stream.impl;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -22,11 +23,11 @@ public class StreamSegmentResponseCommand<R> extends StreamResponseCommand<R> {
    // Only here for CommandIdUniquenessTest
    protected StreamSegmentResponseCommand() { }
 
-   public StreamSegmentResponseCommand(String cacheName) {
+   public StreamSegmentResponseCommand(ByteString cacheName) {
       super(cacheName);
    }
 
-   public StreamSegmentResponseCommand(String cacheName, Address origin, Object id, boolean complete, R response,
+   public StreamSegmentResponseCommand(ByteString cacheName, Address origin, Object id, boolean complete, R response,
                                        Set<Integer> missedSegments) {
       super(cacheName, origin, id, complete, response);
       this.missedSegments = missedSegments;

--- a/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
@@ -36,6 +36,7 @@ import org.infinispan.transaction.synchronization.SynchronizationAdapter;
 import org.infinispan.transaction.xa.CacheTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.TransactionFactory;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.TimeService;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -355,7 +356,7 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
    }
 
    private void killTransaction(GlobalTransaction gtx) {
-      RollbackCommand rc = new RollbackCommand(cacheName, gtx);
+      RollbackCommand rc = new RollbackCommand(ByteString.fromString(cacheName), gtx);
       rc.init(invoker, icf, TransactionTable.this);
       try {
          rc.perform(null);

--- a/core/src/main/java/org/infinispan/util/ByteString.java
+++ b/core/src/main/java/org/infinispan/util/ByteString.java
@@ -1,0 +1,78 @@
+package org.infinispan.util;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * A simple class which encapsulates a byte[] representation of a String using a predefined encoding (currently UTF-8).
+ * This avoids repeated invocation of the expensive {@link ObjectOutput#writeUTF(String)} on marshalling
+ *
+ * @author Tristan Tarrant
+ * @since 9.0
+ */
+public class ByteString {
+   public static final Charset CHARSET = StandardCharsets.UTF_8;
+   private static final ByteString EMPTY = new ByteString(new byte[0]);
+   private final byte[] b;
+   private String s;
+   private final transient int hash;
+
+   ByteString(byte[] b) {
+      this.b = b;
+      this.hash = Arrays.hashCode(b);
+   }
+
+   public static ByteString fromString(String s) {
+      if (s.length() == 0)
+         return EMPTY;
+      else
+         return new ByteString(s.getBytes(CHARSET));
+   }
+
+   public static ByteString emptyString() {
+      return EMPTY;
+   }
+
+   @Override
+   public int hashCode() {
+      return hash;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      ByteString that = (ByteString) o;
+      return Arrays.equals(b, that.b);
+   }
+
+   @Override
+   public String toString() {
+      if (s == null) {
+         s = new String(b, CHARSET);
+      }
+      return s;
+   }
+
+
+   public static void writeObject(ObjectOutput output, ByteString object) throws IOException {
+      output.writeByte(object.b.length);
+      if (object.b.length > 0) {
+         output.write(object.b);
+      }
+   }
+
+   public static ByteString readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+      short len = input.readByte();
+      if (len == 0)
+         return EMPTY;
+
+      byte[] b = new byte[len];
+      input.readFully(b);
+      return new ByteString(b);
+   }
+}

--- a/core/src/main/java/org/infinispan/util/logging/LogFactory.java
+++ b/core/src/main/java/org/infinispan/util/logging/LogFactory.java
@@ -1,5 +1,6 @@
 package org.infinispan.util.logging;
 
+import org.infinispan.util.ByteString;
 import org.jboss.logging.Logger;
 import org.jboss.logging.NDC;
 
@@ -29,6 +30,11 @@ public class LogFactory {
    public static void pushNDC(String cacheName, boolean isTrace) {
       if (isTrace)
          NDC.push(cacheName);
+   }
+
+   public static void pushNDC(ByteString cacheName, boolean isTrace) {
+      if (isTrace)
+         NDC.push(cacheName.toString());
    }
 
    public static void popNDC(boolean isTrace) {

--- a/core/src/main/java/org/infinispan/xsite/SingleXSiteRpcCommand.java
+++ b/core/src/main/java/org/infinispan/xsite/SingleXSiteRpcCommand.java
@@ -2,6 +2,7 @@ package org.infinispan.xsite;
 
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.util.ByteString;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -18,12 +19,12 @@ public class SingleXSiteRpcCommand extends XSiteReplicateCommand {
    public static final int COMMAND_ID = 40;
    private VisitableCommand command;
 
-   public SingleXSiteRpcCommand(String cacheName, VisitableCommand command) {
+   public SingleXSiteRpcCommand(ByteString cacheName, VisitableCommand command) {
       super(cacheName);
       this.command = command;
    }
 
-   public SingleXSiteRpcCommand(String cacheName) {
+   public SingleXSiteRpcCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/xsite/XSiteAdminCommand.java
+++ b/core/src/main/java/org/infinispan/xsite/XSiteAdminCommand.java
@@ -3,6 +3,7 @@ package org.infinispan.xsite;
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.util.ByteString;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -43,11 +44,11 @@ public class XSiteAdminCommand extends BaseRpcCommand {
       super(null);// For command id uniqueness test
    }
 
-   public XSiteAdminCommand(String cacheName) {
+   public XSiteAdminCommand(ByteString cacheName) {
       super(cacheName);// For command id uniqueness test
    }
 
-   public XSiteAdminCommand(String cacheName, String siteName, AdminOperation op, Integer afterFailures, Long minTimeToWait) {
+   public XSiteAdminCommand(ByteString cacheName, String siteName, AdminOperation op, Integer afterFailures, Long minTimeToWait) {
       this(cacheName);
       this.siteName = siteName;
       this.adminOperation = op;

--- a/core/src/main/java/org/infinispan/xsite/XSiteAdminOperations.java
+++ b/core/src/main/java/org/infinispan/xsite/XSiteAdminOperations.java
@@ -13,6 +13,7 @@ import org.infinispan.remoting.responses.SuccessfulResponse;
 import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 import org.infinispan.xsite.statetransfer.XSiteStateTransferManager;
@@ -56,7 +57,7 @@ public class XSiteAdminOperations {
 
    public Map<String, SiteStatus> clusterStatus()  {
       Map<String, Boolean> localNodeStatus = backupSender.status();
-      XSiteAdminCommand command = new XSiteAdminCommand(cache.getName(), null, XSiteAdminCommand.AdminOperation.STATUS, null, null);
+      XSiteAdminCommand command = new XSiteAdminCommand(ByteString.fromString(cache.getName()), null, XSiteAdminCommand.AdminOperation.STATUS, null, null);
       Map<Address, Response> responses = invokeRemotely(command);
       List<Address> errors = checkForErrors(responses);
       if (!errors.isEmpty()) {
@@ -101,7 +102,7 @@ public class XSiteAdminOperations {
          return "Incorrect site name: " + site;
       log.tracef("This node's status is %s", offlineStatus);
 
-      XSiteAdminCommand command = new XSiteAdminCommand(cache.getName(), site, XSiteAdminCommand.AdminOperation.SITE_STATUS, null, null);
+      XSiteAdminCommand command = new XSiteAdminCommand(ByteString.fromString(cache.getName()), site, XSiteAdminCommand.AdminOperation.SITE_STATUS, null, null);
       Map<Address, Response> responses = invokeRemotely(command);
       List<Address> online = new ArrayList<>(responses.size());
       List<Address> offline = new ArrayList<>(responses.size());
@@ -147,7 +148,7 @@ public class XSiteAdminOperations {
    public String status() {
       //also consider local node
       Map<String, Boolean> localNodeStatus = backupSender.status();
-      XSiteAdminCommand command = new XSiteAdminCommand(cache.getName(), null, XSiteAdminCommand.AdminOperation.STATUS, null, null);
+      XSiteAdminCommand command = new XSiteAdminCommand(ByteString.fromString(cache.getName()), null, XSiteAdminCommand.AdminOperation.STATUS, null, null);
       Map<Address, Response> responses = invokeRemotely(command);
       List<Address> errors = checkForErrors(responses);
       if (!errors.isEmpty()) {
@@ -206,7 +207,7 @@ public class XSiteAdminOperations {
       backupSender.takeSiteOffline(site);
       log.tracef("Is site offline in node %s? %s", rpcManager.getAddress(), offlineStatus.isOffline());
 
-      XSiteAdminCommand command = new XSiteAdminCommand(cache.getName(), site, XSiteAdminCommand.AdminOperation.TAKE_OFFLINE, null, null);
+      XSiteAdminCommand command = new XSiteAdminCommand(ByteString.fromString(cache.getName()), site, XSiteAdminCommand.AdminOperation.TAKE_OFFLINE, null, null);
       Map<Address, Response> responses = invokeRemotely(command);
 
       List<Address> failed = checkForErrors(responses);
@@ -259,7 +260,7 @@ public class XSiteAdminOperations {
          return "Incorrect site name: " + site;
       backupSender.bringSiteOnline(site);
 
-      XSiteAdminCommand command = new XSiteAdminCommand(cache.getName(), site, XSiteAdminCommand.AdminOperation.BRING_ONLINE, null, null);
+      XSiteAdminCommand command = new XSiteAdminCommand(ByteString.fromString(cache.getName()), site, XSiteAdminCommand.AdminOperation.BRING_ONLINE, null, null);
       Map<Address, Response> responses = invokeRemotely(command);
 
       List<Address> failed = checkForErrors(responses);
@@ -364,7 +365,7 @@ public class XSiteAdminOperations {
       if (offlineStatus == null)
          return incorrectSiteName(site);
 
-      XSiteAdminCommand command = new XSiteAdminCommand(cache.getName(), site, XSiteAdminCommand.AdminOperation.AMEND_TAKE_OFFLINE,
+      XSiteAdminCommand command = new XSiteAdminCommand(ByteString.fromString(cache.getName()), site, XSiteAdminCommand.AdminOperation.AMEND_TAKE_OFFLINE,
                                                         afterFailures, minTimeToWait);
       Map<Address, Response> responses = invokeRemotely(command);
 

--- a/core/src/main/java/org/infinispan/xsite/XSiteReplicateCommand.java
+++ b/core/src/main/java/org/infinispan/xsite/XSiteReplicateCommand.java
@@ -1,6 +1,7 @@
 package org.infinispan.xsite;
 
 import org.infinispan.commands.remote.BaseRpcCommand;
+import org.infinispan.util.ByteString;
 
 /**
  * Abstract class to invoke RPC on the remote site.
@@ -12,7 +13,7 @@ public abstract class XSiteReplicateCommand extends BaseRpcCommand {
 
    private String originSite;
 
-   protected XSiteReplicateCommand(String cacheName) {
+   protected XSiteReplicateCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStatePushCommand.java
+++ b/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStatePushCommand.java
@@ -2,6 +2,7 @@ package org.infinispan.xsite.statetransfer;
 
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.util.ByteString;
 import org.infinispan.xsite.BackupReceiver;
 import org.infinispan.xsite.XSiteReplicateCommand;
 
@@ -22,13 +23,13 @@ public class XSiteStatePushCommand extends XSiteReplicateCommand {
    private long timeoutMillis;
    private XSiteStateConsumer consumer;
 
-   public XSiteStatePushCommand(String cacheName, XSiteState[] chunk, long timeoutMillis) {
+   public XSiteStatePushCommand(ByteString cacheName, XSiteState[] chunk, long timeoutMillis) {
       super(cacheName);
       this.chunk = chunk;
       this.timeoutMillis = timeoutMillis;
    }
 
-   public XSiteStatePushCommand(String cacheName) {
+   public XSiteStatePushCommand(ByteString cacheName) {
       super(cacheName);
    }
 

--- a/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateTransferControlCommand.java
+++ b/core/src/main/java/org/infinispan/xsite/statetransfer/XSiteStateTransferControlCommand.java
@@ -2,6 +2,7 @@ package org.infinispan.xsite.statetransfer;
 
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.util.ByteString;
 import org.infinispan.xsite.BackupReceiver;
 import org.infinispan.xsite.XSiteReplicateCommand;
 
@@ -27,13 +28,13 @@ public class XSiteStateTransferControlCommand extends XSiteReplicateCommand {
    private boolean statusOk;
    private int topologyId;
 
-   public XSiteStateTransferControlCommand(String cacheName, StateTransferControl control, String siteName) {
+   public XSiteStateTransferControlCommand(ByteString cacheName, StateTransferControl control, String siteName) {
       super(cacheName);
       this.control = control;
       this.siteName = siteName;
    }
 
-   public XSiteStateTransferControlCommand(String cacheName) {
+   public XSiteStateTransferControlCommand(ByteString cacheName) {
       super(cacheName);
    }
 
@@ -171,7 +172,7 @@ public class XSiteStateTransferControlCommand extends XSiteReplicateCommand {
 
    public XSiteStateTransferControlCommand copyForCache(String cacheName) {
       //cache name is final. we need to copy the command.
-      XSiteStateTransferControlCommand copy = new XSiteStateTransferControlCommand(cacheName);
+      XSiteStateTransferControlCommand copy = new XSiteStateTransferControlCommand(ByteString.fromString(cacheName));
       copy.control = this.control;
       copy.provider = this.provider;
       copy.consumer = this.consumer;

--- a/core/src/test/java/org/infinispan/distribution/rehash/StateResponseOrderingTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/StateResponseOrderingTest.java
@@ -22,6 +22,7 @@ import org.infinispan.test.concurrent.CommandMatcher;
 import org.infinispan.test.concurrent.StateSequencer;
 import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.ControlledConsistentHashFactory;
 import org.testng.annotations.Test;
 
@@ -107,7 +108,7 @@ public class StateResponseOrderingTest extends MultipleCacheManagersTest {
       PerCacheInboundInvocationHandler handler = TestingUtil.extractComponent(cache(0), PerCacheInboundInvocationHandler.class);
       StateChunk stateChunk0 = new StateChunk(0, Arrays.<InternalCacheEntry>asList(new ImmortalCacheEntry("k0", "v0")), true);
       StateChunk stateChunk1 = new StateChunk(1, Arrays.<InternalCacheEntry>asList(new ImmortalCacheEntry("k0", "v0")), true);
-      StateResponseCommand stateResponseCommand = new StateResponseCommand(CacheContainer.DEFAULT_CACHE_NAME,
+      StateResponseCommand stateResponseCommand = new StateResponseCommand(ByteString.fromString(CacheContainer.DEFAULT_CACHE_NAME),
             address(1), initialTopologyId, Arrays.asList(stateChunk0, stateChunk1));
       // Call with preserveOrder = true to force the execution in the same thread
       stateResponseCommand.setOrigin(address(3));

--- a/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
+++ b/core/src/test/java/org/infinispan/marshall/VersionAwareMarshallerTest.java
@@ -64,6 +64,7 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.TransactionFactory;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -83,7 +84,6 @@ import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ThreadLocalRandom;
 
 import static org.infinispan.test.TestingUtil.extractCacheMarshaller;
 import static org.infinispan.test.TestingUtil.k;
@@ -213,7 +213,7 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
    }
 
    public void testReplicableCommandsMarshalling() throws Exception {
-      String cacheName = EmbeddedCacheManager.DEFAULT_CACHE_NAME;
+      ByteString cacheName = ByteString.fromString(EmbeddedCacheManager.DEFAULT_CACHE_NAME);
       ClusteredGetCommand c2 = new ClusteredGetCommand("key", cacheName,
                                                        EnumUtil.EMPTY_BIT_SET, false, null, AnyEquivalence.getInstance());
       marshallAndAssertEquality(c2);
@@ -287,7 +287,7 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
    public void testStateTransferControlCommand() throws Exception {
       Cache<Object,Object> cache = cm.getCache();
 
-      String cacheName = EmbeddedCacheManager.DEFAULT_CACHE_NAME;
+      ByteString cacheName = ByteString.fromString(EmbeddedCacheManager.DEFAULT_CACHE_NAME);
       ImmortalCacheEntry entry1 = (ImmortalCacheEntry) TestInternalCacheEntryFactory.create("key", "value", System.currentTimeMillis() - 1000, -1, System.currentTimeMillis(), -1);
       Collection<InternalCacheEntry> state = new ArrayList<InternalCacheEntry>();
       state.add(entry1);
@@ -316,7 +316,7 @@ public class VersionAwareMarshallerTest extends AbstractInfinispanTest {
    }
 
    public void testMultiRpcCommand() throws Exception {
-      String cacheName = EmbeddedCacheManager.DEFAULT_CACHE_NAME;
+      ByteString cacheName = ByteString.fromString(EmbeddedCacheManager.DEFAULT_CACHE_NAME);
       ClusteredGetCommand c2 = new ClusteredGetCommand("key", cacheName,
             EnumUtil.EMPTY_BIT_SET, false, null, AnyEquivalence.getInstance());
       PutKeyValueCommand c5 = new PutKeyValueCommand(

--- a/core/src/test/java/org/infinispan/remoting/AsynchronousInvocationTest.java
+++ b/core/src/test/java/org/infinispan/remoting/AsynchronousInvocationTest.java
@@ -21,6 +21,7 @@ import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
 import org.infinispan.stream.impl.StreamRequestCommand;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.topology.CacheTopologyControlCommand;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.BlockingTaskAwareExecutorService;
 import org.infinispan.util.concurrent.BlockingTaskAwareExecutorServiceImpl;
 import org.jgroups.Address;
@@ -92,7 +93,7 @@ public class AsynchronousInvocationTest extends AbstractInfinispanTest {
       builder.clustering().cacheMode(CacheMode.DIST_SYNC);
       cacheManager = createClusteredCacheManager(builder);
       Cache<Object, Object> cache = cacheManager.getCache();
-      String cacheName = cache.getName();
+      ByteString cacheName = ByteString.fromString(cache.getName());
       Transport transport = extractGlobalComponent(cacheManager, Transport.class);
       if (transport instanceof JGroupsTransport) {
          commandAwareRpcDispatcher = ((JGroupsTransport) transport).getCommandAwareRpcDispatcher();

--- a/core/src/test/java/org/infinispan/remoting/TransportSenderExceptionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/remoting/TransportSenderExceptionHandlingTest.java
@@ -16,6 +16,7 @@ import org.infinispan.remoting.transport.jgroups.CommandAwareRpcDispatcher;
 import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
+import org.infinispan.util.ByteString;
 import org.jgroups.blocks.RpcDispatcher;
 import org.testng.annotations.Test;
 
@@ -50,7 +51,7 @@ public class TransportSenderExceptionHandlingTest extends MultipleCacheManagersT
          PutKeyValueCommand putCommand = new PutKeyValueCommand();
          putCommand.setKey(key);
          putCommand.setValue(value);
-         SingleRpcCommand rpcCommand = new SingleRpcCommand("replSync", putCommand);
+         SingleRpcCommand rpcCommand = new SingleRpcCommand(ByteString.fromString("replSync"), putCommand);
          when(mockMarshaller1.objectToBuffer(anyObject())).thenReturn(originalMarshaller1.objectToBuffer(rpcCommand));
          when(mockMarshaller.objectFromBuffer((byte[]) anyObject(), anyInt(), anyInt())).thenThrow(new EOFException());
          dispatcher1.setRequestMarshaller(mockMarshaller1);

--- a/core/src/test/java/org/infinispan/remoting/rpc/CustomCacheRpcCommand.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/CustomCacheRpcCommand.java
@@ -5,6 +5,7 @@ import org.infinispan.commands.Visitor;
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.util.ByteString;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -27,11 +28,11 @@ public class CustomCacheRpcCommand extends BaseRpcCommand implements VisitableCo
       super(null); // For command id uniqueness test
    }
 
-   public CustomCacheRpcCommand(String cacheName) {
+   public CustomCacheRpcCommand(ByteString cacheName) {
       super(cacheName);
    }
 
-   public CustomCacheRpcCommand(String cacheName, Object arg) {
+   public CustomCacheRpcCommand(ByteString cacheName, Object arg) {
       this(cacheName);
       this.arg = arg;
    }

--- a/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerCustomCacheRpcCommandTest.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerCustomCacheRpcCommandTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.remoting.rpc;
 
 import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.util.ByteString;
 import org.testng.annotations.Test;
 
 /**
@@ -12,6 +13,6 @@ public class RpcManagerCustomCacheRpcCommandTest extends RpcManagerCustomReplica
 
    @Override
    protected ReplicableCommand createReplicableCommandForTest(Object arg) {
-      return new CustomCacheRpcCommand(TEST_CACHE, arg);
+      return new CustomCacheRpcCommand(ByteString.fromString(TEST_CACHE), arg);
    }
 }

--- a/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerTimeoutTest.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerTimeoutTest.java
@@ -7,6 +7,7 @@ import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.transaction.TransactionProtocol;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -93,7 +94,7 @@ public class RpcManagerTimeoutTest extends MultipleCacheManagersTest {
       if (filter != null) {
          builder.responseFilter(filter);
       }
-      rpcManager.invokeRemotely(recipients, new SleepingCacheRpcCommand(CACHE_NAME, 5000), builder.build());
+      rpcManager.invokeRemotely(recipients, new SleepingCacheRpcCommand(ByteString.fromString(CACHE_NAME), 5000), builder.build());
       Assert.fail("Timeout exception wasn't thrown");
    }
 

--- a/core/src/test/java/org/infinispan/remoting/rpc/SleepingCacheRpcCommand.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/SleepingCacheRpcCommand.java
@@ -2,6 +2,7 @@ package org.infinispan.remoting.rpc;
 
 import org.infinispan.commands.remote.BaseRpcCommand;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.util.ByteString;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -20,11 +21,11 @@ public class SleepingCacheRpcCommand extends BaseRpcCommand {
       super(null);
    }
 
-   public SleepingCacheRpcCommand(String cacheName) {
+   public SleepingCacheRpcCommand(ByteString cacheName) {
       super(cacheName);
    }
 
-   public SleepingCacheRpcCommand(String cacheName, long sleepTime) {
+   public SleepingCacheRpcCommand(ByteString cacheName, long sleepTime) {
       super(cacheName);
       this.sleepTime = sleepTime;
    }

--- a/core/src/test/java/org/infinispan/remoting/rpc/TestModuleCommandExtensions.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/TestModuleCommandExtensions.java
@@ -7,6 +7,7 @@ import org.infinispan.commands.module.ModuleCommandExtensions;
 import org.infinispan.commands.module.ModuleCommandInitializer;
 import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.util.ByteString;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -43,7 +44,7 @@ public class TestModuleCommandExtensions implements ModuleCommandExtensions {
          }
 
          @Override
-         public CacheRpcCommand fromStream(byte commandId, String cacheName) {
+         public CacheRpcCommand fromStream(byte commandId, ByteString cacheName) {
             CacheRpcCommand c;
             switch (commandId) {
                case CustomCacheRpcCommand.COMMAND_ID:

--- a/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
@@ -39,6 +39,7 @@ import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.transaction.totalorder.TotalOrderManager;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.BlockingTaskAwareExecutorService;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
@@ -159,7 +160,7 @@ public class StateConsumerTest extends AbstractInfinispanTest {
       when(commandsFactory.buildStateRequestCommand(any(StateRequestCommand.Type.class), any(Address.class), anyInt(), any(Set.class))).thenAnswer(new Answer<StateRequestCommand>() {
          @Override
          public StateRequestCommand answer(InvocationOnMock invocation) {
-            return new StateRequestCommand("cache1", (StateRequestCommand.Type) invocation.getArguments()[0], (Address) invocation.getArguments()[1], (Integer) invocation.getArguments()[2], (Set) invocation.getArguments()[3]);
+            return new StateRequestCommand(ByteString.fromString("cache1"), (StateRequestCommand.Type) invocation.getArguments()[0], (Address) invocation.getArguments()[1], (Integer) invocation.getArguments()[2], (Set) invocation.getArguments()[3]);
          }
       });
 

--- a/core/src/test/java/org/infinispan/statetransfer/StateProviderTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateProviderTest.java
@@ -2,7 +2,6 @@ package org.infinispan.statetransfer;
 
 import org.infinispan.Cache;
 import org.infinispan.commands.CommandsFactory;
-import org.infinispan.commands.ReplicableCommand;
 import org.infinispan.commons.hash.MurmurHash3;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
@@ -18,13 +17,10 @@ import org.infinispan.distribution.ch.impl.DefaultConsistentHashFactory;
 import org.infinispan.notifications.cachelistener.cluster.ClusterCacheNotifier;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
-import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.rpc.RpcManager;
-import org.infinispan.remoting.rpc.RpcOptions;
 import org.infinispan.remoting.rpc.RpcOptionsBuilder;
 import org.infinispan.remoting.transport.Address;
-import org.infinispan.test.TestingUtil;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.topology.PersistentUUID;
 import org.infinispan.topology.PersistentUUIDManager;
@@ -32,6 +28,7 @@ import org.infinispan.topology.PersistentUUIDManagerImpl;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.impl.TransactionTable;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -44,11 +41,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -61,7 +56,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -251,7 +245,7 @@ public class StateProviderTest {
       when(commandsFactory.buildStateResponseCommand(any(Address.class), anyInt(), any(Collection.class))).thenAnswer(new Answer<StateResponseCommand>() {
          @Override
          public StateResponseCommand answer(InvocationOnMock invocation) {
-            return new StateResponseCommand("testCache", (Address) invocation.getArguments()[0],
+            return new StateResponseCommand(ByteString.fromString("testCache"), (Address) invocation.getArguments()[0],
                   ((Integer) invocation.getArguments()[1]).intValue(),
                   (Collection<StateChunk>) invocation.getArguments()[2]);
          }

--- a/core/src/test/java/org/infinispan/statetransfer/TxReplay2Test.java
+++ b/core/src/test/java/org/infinispan/statetransfer/TxReplay2Test.java
@@ -23,6 +23,7 @@ import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
 import org.infinispan.transaction.tm.DummyTransaction;
 import org.infinispan.transaction.tm.DummyTransactionManager;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.ControlledConsistentHashFactory;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -100,7 +101,7 @@ public class TxReplay2Test extends MultipleCacheManagersTest {
             // Wait for the commit command to block replaying the prepare on the new backup
             sequencer.advance("sim:before_extra_commit");
             // And try to run another commit command
-            CommitCommand command = new CommitCommand(newBackupOwnerCache.getName(), gtx);
+            CommitCommand command = new CommitCommand(ByteString.fromString(newBackupOwnerCache.getName()), gtx);
             command.setTopologyId(currentTopologyId);
             CommandsFactory cf = TestingUtil.extractCommandsFactory(newBackupOwnerCache);
             cf.initializeReplicableCommand(command, true);

--- a/core/src/test/java/org/infinispan/test/concurrent/DefaultCommandMatcher.java
+++ b/core/src/test/java/org/infinispan/test/concurrent/DefaultCommandMatcher.java
@@ -49,7 +49,7 @@ public class DefaultCommandMatcher implements CommandMatcher {
       if (commandClass != null && !commandClass.equals(command.getClass()))
          return false;
 
-      if (cacheName != null && !cacheName.equals(((CacheRpcCommand) command).getCacheName())) {
+      if (cacheName != null && !cacheName.equals(((CacheRpcCommand) command).getCacheName().toString())) {
          return false;
       }
 

--- a/query/src/main/java/org/infinispan/query/clustered/ClusteredQueryCommand.java
+++ b/query/src/main/java/org/infinispan/query/clustered/ClusteredQueryCommand.java
@@ -10,6 +10,7 @@ import org.infinispan.query.clustered.commandworkers.ClusteredQueryCommandWorker
 import org.infinispan.query.impl.CommandInitializer;
 import org.infinispan.query.impl.CustomQueryCommand;
 import org.infinispan.query.impl.ModuleCommandIds;
+import org.infinispan.util.ByteString;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -41,7 +42,7 @@ public class ClusteredQueryCommand extends BaseRpcCommand implements ReplicableC
    private Integer docIndex = ZERO;
 
    private ClusteredQueryCommand(ClusteredQueryCommandType type, String cacheName) {
-      super(cacheName);
+      super(ByteString.fromString(cacheName));
       commandType = type;
    }
 
@@ -49,13 +50,13 @@ public class ClusteredQueryCommand extends BaseRpcCommand implements ReplicableC
     * For CommandFactory only. To create a ClusteredQueryCommand, use createLazyIterator(),
     * destroyLazyQuery(), getResultSize() or retrieveKeyFromLazyQuery()
     */
-   public ClusteredQueryCommand(String cacheName) {
+   public ClusteredQueryCommand(ByteString cacheName) {
       super(cacheName);
    }
 
    @Override
    public void fetchExecutionContext(CommandInitializer ci) {
-      this.cache = ci.getCacheManager().getCache(cacheName);
+      this.cache = ci.getCacheManager().getCache(cacheName.toString());
    }
 
    public static ClusteredQueryCommand createLazyIterator(HSQuery query, Cache<?, ?> cache, UUID id) {

--- a/query/src/main/java/org/infinispan/query/impl/CommandFactory.java
+++ b/query/src/main/java/org/infinispan/query/impl/CommandFactory.java
@@ -9,6 +9,7 @@ import org.infinispan.commands.remote.CacheRpcCommand;
 import org.infinispan.query.clustered.ClusteredQueryCommand;
 import org.infinispan.query.indexmanager.IndexUpdateCommand;
 import org.infinispan.query.indexmanager.IndexUpdateStreamCommand;
+import org.infinispan.util.ByteString;
 
 /**
 * Remote commands factory implementation
@@ -35,7 +36,7 @@ public class CommandFactory implements ExtendedModuleCommandFactory {
    }
 
    @Override
-   public CacheRpcCommand fromStream(byte commandId, String cacheName) {
+   public CacheRpcCommand fromStream(byte commandId, ByteString cacheName) {
       CacheRpcCommand c;
       switch (commandId) {
          case ClusteredQueryCommand.COMMAND_ID:

--- a/query/src/main/java/org/infinispan/query/indexmanager/AbstractUpdateCommand.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/AbstractUpdateCommand.java
@@ -16,6 +16,7 @@ import org.infinispan.query.impl.CommandInitializer;
 import org.infinispan.query.impl.ComponentRegistryUtils;
 import org.infinispan.query.impl.CustomQueryCommand;
 import org.infinispan.query.logging.Log;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.LogFactory;
 
 import java.io.IOException;
@@ -38,7 +39,7 @@ public abstract class AbstractUpdateCommand extends BaseRpcCommand implements Re
    protected byte[] serializedModel;
    protected QueryInterceptor queryInterceptor;
 
-   protected AbstractUpdateCommand(String cacheName) {
+   protected AbstractUpdateCommand(ByteString cacheName) {
       super(cacheName);
    }
 
@@ -70,14 +71,15 @@ public abstract class AbstractUpdateCommand extends BaseRpcCommand implements Re
     */
    @Override
    public void fetchExecutionContext(CommandInitializer ci) {
-      if (ci.getCacheManager().cacheExists(cacheName)) {
-         Cache cache = ci.getCacheManager().getCache(cacheName);
+      String name = cacheName.toString();
+      if (ci.getCacheManager().cacheExists(name)) {
+         Cache cache = ci.getCacheManager().getCache(name);
          SearchManager searchManager = Search.getSearchManager(cache);
          searchFactory = searchManager.unwrap(SearchIntegrator.class);
          queryInterceptor = ComponentRegistryUtils.getQueryInterceptor(cache);
       }
       else {
-         throw new CacheException("Cache named '"+ cacheName + "' does not exist on this CacheManager, or was not started" );
+         throw new CacheException("Cache named '"+ name + "' does not exist on this CacheManager, or was not started" );
       }
    }
 

--- a/query/src/main/java/org/infinispan/query/indexmanager/IndexUpdateCommand.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/IndexUpdateCommand.java
@@ -5,6 +5,7 @@ import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.query.impl.ModuleCommandIds;
+import org.infinispan.util.ByteString;
 
 import java.util.List;
 
@@ -18,14 +19,14 @@ public class IndexUpdateCommand extends AbstractUpdateCommand {
 
    public static final byte COMMAND_ID = ModuleCommandIds.UPDATE_INDEX;
 
-   public IndexUpdateCommand(String cacheName) {
+   public IndexUpdateCommand(ByteString cacheName) {
       super(cacheName);
    }
 
    @Override
    public Object perform(InvocationContext ctx) throws Throwable {
       if (queryInterceptor.isStopping()) {
-         throw log.cacheIsStoppingNoCommandAllowed(cacheName);
+         throw log.cacheIsStoppingNoCommandAllowed(cacheName.toString());
       }
       IndexManager indexManager = searchFactory.getIndexManager(indexName);
       if (indexManager == null) {

--- a/query/src/main/java/org/infinispan/query/indexmanager/IndexUpdateStreamCommand.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/IndexUpdateStreamCommand.java
@@ -5,6 +5,7 @@ import org.hibernate.search.exception.SearchException;
 import org.hibernate.search.indexes.spi.IndexManager;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.query.impl.ModuleCommandIds;
+import org.infinispan.util.ByteString;
 
 import java.util.List;
 
@@ -18,14 +19,14 @@ public class IndexUpdateStreamCommand extends AbstractUpdateCommand {
 
    public static final byte COMMAND_ID = ModuleCommandIds.UPDATE_INDEX_STREAM;
 
-   public IndexUpdateStreamCommand(String cacheName) {
+   public IndexUpdateStreamCommand(ByteString cacheName) {
       super(cacheName);
    }
 
    @Override
    public Object perform(InvocationContext ctx) throws Throwable {
       if (queryInterceptor.isStopping()) {
-         throw log.cacheIsStoppingNoCommandAllowed(cacheName);
+         throw log.cacheIsStoppingNoCommandAllowed(cacheName.toString());
       }
       IndexManager indexManager = searchFactory.getIndexManager(indexName);
       if (indexManager == null) {

--- a/query/src/main/java/org/infinispan/query/indexmanager/RemoteIndexingBackend.java
+++ b/query/src/main/java/org/infinispan/query/indexmanager/RemoteIndexingBackend.java
@@ -16,6 +16,7 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.query.logging.Log;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.ByteString;
 import org.infinispan.util.logging.LogFactory;
 
 /**
@@ -61,7 +62,7 @@ final class RemoteIndexingBackend implements IndexingBackend {
 
    @Override
    public void applyWork(List<LuceneWork> workList, IndexingMonitor monitor, IndexManager indexManager) {
-      IndexUpdateCommand command = new IndexUpdateCommand(cacheName);
+      IndexUpdateCommand command = new IndexUpdateCommand(ByteString.fromString(cacheName));
       //Use Search's custom Avro based serializer as it includes support for back/future compatibility
       byte[] serializedModel = indexManager.getSerializer().toSerializedModel(workList);
       command.setSerializedWorkList(serializedModel);
@@ -93,7 +94,7 @@ final class RemoteIndexingBackend implements IndexingBackend {
 
    @Override
    public void applyStreamWork(LuceneWork singleOperation, IndexingMonitor monitor, IndexManager indexManager) {
-      final IndexUpdateStreamCommand streamCommand = new IndexUpdateStreamCommand(cacheName);
+      final IndexUpdateStreamCommand streamCommand = new IndexUpdateStreamCommand(ByteString.fromString(cacheName));
       final List<LuceneWork> operations = Collections.singletonList(singleOperation);
       final byte[] serializedModel = indexManager.getSerializer().toSerializedModel(operations);
       streamCommand.setSerializedWorkList(serializedModel);

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodMarshallingTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodMarshallingTest.scala
@@ -7,6 +7,7 @@ import org.infinispan.commands.remote.ClusteredGetCommand
 import org.infinispan.server.core.AbstractMarshallingTest
 import org.infinispan.commons.api.BasicCacheContainer
 import org.infinispan.commons.equivalence.ByteArrayEquivalence
+import org.infinispan.util.ByteString
 
 /**
  * Tests marshalling of Hot Rod classes.
@@ -27,7 +28,7 @@ class HotRodMarshallingTest extends AbstractMarshallingTest {
    def testMarshallingCommandWithBigByteArrayKey() {
       val cacheKey = getBigByteArray
       val command = new ClusteredGetCommand(cacheKey,
-         BasicCacheContainer.DEFAULT_CACHE_NAME, EnumUtil.EMPTY_BIT_SET, false, null,
+         ByteString.fromString(BasicCacheContainer.DEFAULT_CACHE_NAME), EnumUtil.EMPTY_BIT_SET, false, null,
          ByteArrayEquivalence.INSTANCE)
       val bytes = marshaller.objectToByteBuffer(command)
       val readCommand = marshaller.objectFromByteBuffer(bytes).asInstanceOf[ClusteredGetCommand]


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6488

WARNING: this incarnation is backwards incompatible since it changes the CacheRpcCommand to _only_ take a ByteString instead of a String. I did this to make sure I didn't miss any existing internal commands, but I will re-add the String constructors once we are happy