### PR TITLE
ISPN-6389 Classloader correction

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/uberjar/ManifestUberJarDuplicatedJarsWarner.java
+++ b/commons/src/main/java/org/infinispan/commons/util/uberjar/ManifestUberJarDuplicatedJarsWarner.java
@@ -48,7 +48,7 @@ public class ManifestUberJarDuplicatedJarsWarner implements UberJarDuplicatedJar
     List<String> getBundleSymbolicNames() {
         List<String> symbolicNames = new ArrayList<>();
         try {
-            Enumeration<URL> resources = Thread.currentThread().getContextClassLoader().getResources(MANIFEST_LOCATION);
+            Enumeration<URL> resources = getClass().getClassLoader().getResources(MANIFEST_LOCATION);
             while (resources.hasMoreElements()) {
                 URL manifestUrl = resources.nextElement();
                 try (InputStream is = manifestUrl.openStream()) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6389

A really nice explanation which classloader to use I found in [Module Compatible Classloading Guide](https://developer.jboss.org/wiki/ModuleCompatibleClassloadingGuide):

> FRAMEWORKS, NEVER LOAD YOUR CLASSES FROM THE TCCL!!
If you expect portability between different classloading environments, it is always wrong for a framework to load its classes from the TCCL. Instead use the right classloader, which is most often the defining classloader. If the defining classloader is not the right classloader, then look for a way to get the right loader and use it to load classes. Even if you have an inheritance model with a hierarchy that sees the classes you want, it is always more correct to pick the classloader that "owns" the classes.