### PR TITLE
ISPN-6408 Support non-String returns

### DIFF
--- a/client/hotrod-client/src/test/resources/typed-size.js
+++ b/client/hotrod-client/src/test/resources/typed-size.js
@@ -1,0 +1,2 @@
+// mode=local,language=javascript,datatype='text/plain; charset=utf-8'
+cache.size();

--- a/commons/src/main/java/org/infinispan/commons/marshall/StringMarshaller.java
+++ b/commons/src/main/java/org/infinispan/commons/marshall/StringMarshaller.java
@@ -1,0 +1,33 @@
+package org.infinispan.commons.marshall;
+
+import org.infinispan.commons.io.ByteBuffer;
+import org.infinispan.commons.io.ByteBufferImpl;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+public final class StringMarshaller extends AbstractMarshaller {
+
+   final Charset charset;
+
+   public StringMarshaller(Charset charset) {
+      this.charset = charset;
+   }
+
+   @Override
+   protected ByteBuffer objectToBuffer(Object o, int estimatedSize) throws IOException, InterruptedException {
+      byte[] bytes = ((String) o).getBytes(charset);
+      return new ByteBufferImpl(bytes, 0, bytes.length);
+   }
+
+   @Override
+   public Object objectFromByteBuffer(byte[] buf, int offset, int length) throws IOException, ClassNotFoundException {
+      return new String(buf, charset);
+   }
+
+   @Override
+   public boolean isMarshallable(Object o) throws Exception {
+      return o instanceof String;
+   }
+
+}

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/CustomMemcachedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/CustomMemcachedHotRodTest.java
@@ -5,6 +5,7 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.commons.io.ByteBuffer;
 import org.infinispan.commons.io.ByteBufferImpl;
 import org.infinispan.commons.marshall.AbstractMarshaller;
+import org.infinispan.commons.marshall.StringMarshaller;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.testng.annotations.AfterClass;
@@ -39,7 +40,7 @@ public class CustomMemcachedHotRodTest extends AbstractInfinispanTest {
    @BeforeClass
    protected void setup() throws Exception {
       cacheFactory = new CompatibilityCacheFactory<String, String>(
-            CACHE_NAME, new StringMarshaller(), CacheMode.LOCAL).setup();
+            CACHE_NAME, new StringMarshaller(Charset.forName("UTF-8")), CacheMode.LOCAL).setup();
    }
 
    @AfterClass
@@ -186,28 +187,6 @@ public class CustomMemcachedHotRodTest extends AbstractInfinispanTest {
       public void close() throws IOException {
          socket.close();
       }
-   }
-
-   static class StringMarshaller extends AbstractMarshaller {
-
-      private static final Charset DEFAULT_ENCODING = Charset.forName("UTF-8");
-
-      @Override
-      protected ByteBuffer objectToBuffer(Object o, int estimatedSize) {
-         byte[] bytes = ((String) o).getBytes(DEFAULT_ENCODING);
-         return new ByteBufferImpl(bytes, 0, bytes.length);
-      }
-
-      @Override
-      public Object objectFromByteBuffer(byte[] buf, int offset, int length) {
-         return new String(buf, DEFAULT_ENCODING);
-      }
-
-      @Override
-      public boolean isMarshallable(Object o) throws Exception {
-         return o instanceof String;
-      }
-
    }
 
 }

--- a/scripting/src/main/java/org/infinispan/scripting/impl/DataType.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/DataType.java
@@ -48,7 +48,9 @@ public enum DataType {
 
       @Override
       public Object fromDataType(Object obj, Optional<Marshaller> marshaller) {
-         return obj instanceof String ? ((String) obj).getBytes(CHARSET_UTF8) : obj;
+         return obj instanceof String
+               ? ((String) obj).getBytes(CHARSET_UTF8)
+               : obj.toString().getBytes(CHARSET_UTF8);
       }
 
       private static String asString(Object v) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6408
* Transform return values to its String form and send that back.
* Refactored StringMarshaller to commons so that it can easily be used
  by multiple consumers.