### PR TITLE
ISPN-6513 Updated repositories to public-jboss

### DIFF
--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -13,7 +13,7 @@
                 <repository>
                     <id>jboss-public-repository-group</id>
                     <name>JBoss Public Maven Repository Group</name>
-                    <url>https://repository.jboss.org/nexus/content/groups/public</url>
+                    <url>https://repository.jboss.org/nexus/content/groups/public-jboss</url>
                     <layout>default</layout>
                     <releases>
                         <enabled>true</enabled>
@@ -29,7 +29,7 @@
                 <pluginRepository>
                     <id>jboss-public-repository-group</id>
                     <name>JBoss Public Maven Repository Group</name>
-                    <url>https://repository.jboss.org/nexus/content/groups/public</url>
+                    <url>https://repository.jboss.org/nexus/content/groups/public-jboss</url>
                     <layout>default</layout>
                     <releases>
                         <enabled>true</enabled>


### PR DESCRIPTION
This is an additional fix to https://github.com/infinispan/infinispan/pull/4251

Some of the artifacts (like [1]) are present only in `public-jboss` repository.

[1] https://repository.jboss.org/nexus/content/groups/public-jboss/com/thoughtworks/xstream/xstream/1.4.9/