### PR TITLE
ISPN-6406 Null exec return is empty byte[]

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/marshall/MarshallerUtil.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/marshall/MarshallerUtil.java
@@ -23,7 +23,7 @@ public final class MarshallerUtil {
 
    @SuppressWarnings("unchecked")
    public static <T> T bytes2obj(Marshaller marshaller, byte[] bytes, short status) {
-      if (bytes == null) return null;
+      if (bytes == null || bytes.length == 0) return null;
       try {
          Object ret = marshaller.objectFromByteBuffer(bytes);
          if (HotRodConstants.hasCompatibility(status)) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTest.java
@@ -161,6 +161,14 @@ public class ExecTest extends MultiHotRodServersTest {
       });
    }
 
+   @Test(dataProvider = "CacheNameProvider")
+   public void testExecReturnNull(String cacheName) throws IOException {
+      withScript(manager(0), "/test-null-return.js", scriptName -> {
+         Object result = clients.get(0).getCache(cacheName).execute(scriptName, new HashMap<>());
+         assertEquals(null, result);
+      });
+   }
+
    @DataProvider(name = "CacheNameProvider")
    private static Object[][] provideCacheMode() {
       return new Object[][] {{REPL_CACHE}, {DIST_CACHE}};

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTypedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTypedTest.java
@@ -73,6 +73,16 @@ public class ExecTypedTest extends MultiHotRodServersTest {
       });
    }
 
+   public void testPutGetEmptyString() throws Exception {
+      withScript(addScriptClient.getCache(SCRIPT_CACHE), "/typed-put-get.js", scriptName -> {
+         Map<String, String> params = new HashMap<>();
+         params.put("k", "empty-key");
+         params.put("v", "");
+         String result = clients.get(0).getCache().execute(scriptName, params);
+         assertEquals("", result);
+      });
+   }
+
    public void testRemoteTypedScriptSizeExecute() throws Exception {
       withScript(addScriptClient.getCache(SCRIPT_CACHE), "/typed-size.js", scriptName -> {
          clients.get(0).getCache().clear();
@@ -85,6 +95,13 @@ public class ExecTypedTest extends MultiHotRodServersTest {
       withScript(addScriptClient.getCache(SCRIPT_CACHE), "/typed-cachemanager-put-get.js", scriptName -> {
          String result = execClient.getCache().execute(scriptName, new HashMap<>());
          assertEquals("a", result);
+      });
+   }
+
+   public void testRemoteTypedScriptNullReturnExecute() throws Exception {
+      withScript(addScriptClient.getCache(SCRIPT_CACHE), "/typed-null-return.js", scriptName -> {
+         String result = clients.get(0).getCache().execute(scriptName, new HashMap<>());
+         assertEquals(null, result);
       });
    }
 

--- a/client/hotrod-client/src/test/resources/typed-null-return.js
+++ b/client/hotrod-client/src/test/resources/typed-null-return.js
@@ -1,0 +1,2 @@
+// mode=local,language=javascript,datatype='text/plain; charset=utf-8'
+cache.get('key-not-present');

--- a/scripting/src/main/java/org/infinispan/scripting/impl/DataType.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/DataType.java
@@ -6,6 +6,7 @@ import org.infinispan.commons.util.Immutables;
 
 import java.nio.charset.Charset;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -47,7 +48,8 @@ public enum DataType {
 
       @Override
       public Object fromDataType(Object obj, Optional<Marshaller> marshaller) {
-         return obj instanceof String
+         return Objects.isNull(obj)
+               ? null : obj instanceof String
                ? ((String) obj).getBytes(CHARSET_UTF8)
                : obj.toString().getBytes(CHARSET_UTF8);
       }

--- a/scripting/src/test/resources/test-null-return.js
+++ b/scripting/src/test/resources/test-null-return.js
@@ -1,0 +1,2 @@
+// mode=local,language=javascript,datatype='text/plain; charset=utf-8'
+cache.get('key-not-present');

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/ContextHandler.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/ContextHandler.java
@@ -99,7 +99,8 @@ public class ContextHandler extends SimpleChannelInboundHandler<CacheDecodeConte
             byte[] result = (byte[]) taskManager.runTask(execContext.name(),
                     new TaskContext().marshaller(marshaller).cache(msg.cache()).parameters(execContext.params())).get();
             writeResponse(msg, ctx.channel(),
-                    new ExecResponse(h.version(), h.messageId(), h.cacheName(), h.clientIntel(), h.topologyId(), result));
+                    new ExecResponse(h.version(), h.messageId(), h.cacheName(), h.clientIntel(), h.topologyId(),
+                          result == null ? new byte[]{} : result));
             break;
          case BulkGetRequest:
             int size = (int) msg.operationDecodeContext();


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6406

* A Java client will return null when encountering byte[].