### PR TITLE
ISPN-6542 Subclasses of AbstractWriteKeyCommand don't marshal the Par…

### DIFF
--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -485,10 +485,10 @@ public interface CommandsFactory {
    <K, V> WriteOnlyKeyValueCommand<K, V> buildWriteOnlyKeyValueCommand(
       K key, V value, BiConsumer<V, WriteEntryView<V>> f, Params params);
 
-   <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Set<? extends K> keys, Consumer<WriteEntryView<V>> f);
+   <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Set<? extends K> keys, Consumer<WriteEntryView<V>> f, Params params);
 
-   <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Set<? extends K> keys, Function<ReadWriteEntryView<K,V>, R> f);
+   <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Set<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f, Params params);
 
-   <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K,V>, R> f);
+   <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f, Params params);
 
 }

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -686,13 +686,13 @@ public class CommandsFactoryImpl implements CommandsFactory {
    }
 
    @Override
-   public <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Set<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f) {
-      return new ReadWriteManyCommand<>(keys, f);
+   public <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Set<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f, Params params) {
+      return new ReadWriteManyCommand<>(keys, f, params);
    }
 
    @Override
-   public <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f) {
-      return new ReadWriteManyEntriesCommand<>(entries, f);
+   public <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f, Params params) {
+      return new ReadWriteManyEntriesCommand<>(entries, f, params);
    }
 
    @Override
@@ -708,16 +708,14 @@ public class CommandsFactoryImpl implements CommandsFactory {
    }
 
    @Override
-   public <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Set<? extends K> keys, Consumer<WriteEntryView<V>> f) {
-      return new WriteOnlyManyCommand<>(keys, f);
+   public <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Set<? extends K> keys, Consumer<WriteEntryView<V>> f, Params params) {
+      return new WriteOnlyManyCommand<>(keys, f, params);
    }
 
    @Override
    public <K, V> WriteOnlyManyEntriesCommand<K, V> buildWriteOnlyManyEntriesCommand(
          Map<? extends K, ? extends V> entries, BiConsumer<V, WriteEntryView<V>> f, Params params) {
-      WriteOnlyManyEntriesCommand<K, V> cmd = new WriteOnlyManyEntriesCommand<>(entries, f);
-      cmd.setParams(params);
-      return cmd;
+      return new WriteOnlyManyEntriesCommand<>(entries, f, params);
    }
 
    private ValueMatcher getValueMatcher(Object o) {

--- a/core/src/main/java/org/infinispan/commands/functional/AbstractWriteManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/AbstractWriteManyCommand.java
@@ -5,7 +5,6 @@ import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.functional.impl.FunctionalNotifier;
 import org.infinispan.functional.impl.Params;
 import org.infinispan.metadata.Metadata;
 

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyCommand.java
@@ -44,6 +44,7 @@ public final class ReadWriteKeyCommand<K, V, R> extends AbstractWriteKeyCommand<
       output.writeObject(key);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
       output.writeLong(Flag.copyWithoutRemotableFlags(getFlagsBitSet()));
       output.writeObject(commandInvocationId);
    }
@@ -53,6 +54,7 @@ public final class ReadWriteKeyCommand<K, V, R> extends AbstractWriteKeyCommand<
       key = input.readObject();
       f = (Function<ReadWriteEntryView<K, V>, R>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
+      params = Params.Externalizer.INSTANCE.readObject(input);
       setFlagsBitSet(input.readLong());
       commandInvocationId = (CommandInvocationId) input.readObject();
    }

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyValueCommand.java
@@ -55,6 +55,7 @@ public final class ReadWriteKeyValueCommand<K, V, R> extends AbstractWriteKeyCom
       output.writeObject(value);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
       output.writeLong(Flag.copyWithoutRemotableFlags(getFlagsBitSet()));
       output.writeObject(commandInvocationId);
       output.writeObject(prevValue);
@@ -67,6 +68,7 @@ public final class ReadWriteKeyValueCommand<K, V, R> extends AbstractWriteKeyCom
       value = (V) input.readObject();
       f = (BiFunction<V, ReadWriteEntryView<K, V>, R>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
+      params = Params.Externalizer.INSTANCE.readObject(input);
       setFlagsBitSet(input.readLong());
       commandInvocationId = (CommandInvocationId) input.readObject();
       prevValue = (V) input.readObject();

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyCommand.java
@@ -1,17 +1,13 @@
 package org.infinispan.commands.functional;
 
 import org.infinispan.commands.Visitor;
-import org.infinispan.commands.write.ValueMatcher;
-import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.api.functional.EntryView.ReadWriteEntryView;
 import org.infinispan.commons.marshall.MarshallUtil;
-import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.functional.impl.EntryViews;
+import org.infinispan.functional.impl.Params;
 import org.infinispan.lifecycle.ComponentStatus;
-import org.infinispan.metadata.Metadata;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -24,7 +20,7 @@ import java.util.function.Function;
 
 import static org.infinispan.functional.impl.EntryViews.snapshot;
 
-public final class ReadWriteManyCommand<K, V, R> implements WriteCommand {
+public final class ReadWriteManyCommand<K, V, R> extends AbstractWriteManyCommand {
 
    public static final byte COMMAND_ID = 52;
 
@@ -35,14 +31,16 @@ public final class ReadWriteManyCommand<K, V, R> implements WriteCommand {
    boolean isForwarded = false;
    private List<R> remoteReturns = new ArrayList<>();
 
-   public ReadWriteManyCommand(Set<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f) {
+   public ReadWriteManyCommand(Set<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f, Params params) {
       this.keys = keys;
       this.f = f;
+      this.params = params;
    }
 
    public ReadWriteManyCommand(ReadWriteManyCommand command) {
       this.keys = command.keys;
       this.f = command.f;
+      this.params = command.params;
    }
 
    public ReadWriteManyCommand() {
@@ -66,6 +64,7 @@ public final class ReadWriteManyCommand<K, V, R> implements WriteCommand {
       MarshallUtil.marshallCollection(keys, output);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
    }
 
    @Override
@@ -73,6 +72,7 @@ public final class ReadWriteManyCommand<K, V, R> implements WriteCommand {
       keys = MarshallUtil.unmarshallCollection(input, size -> new HashSet<>());
       f = (Function<ReadWriteEntryView<K, V>, R>) input.readObject();
       isForwarded = input.readBoolean();
+      params = Params.Externalizer.INSTANCE.readObject(input);
    }
 
    public boolean isForwarded() {
@@ -105,16 +105,6 @@ public final class ReadWriteManyCommand<K, V, R> implements WriteCommand {
    @Override
    public void setTopologyId(int topologyId) {
       this.topologyId = topologyId;
-   }
-
-   @Override
-   public ValueMatcher getValueMatcher() {
-      return ValueMatcher.MATCH_ALWAYS;
-   }
-
-   @Override
-   public void setValueMatcher(ValueMatcher valueMatcher) {
-      // No-op
    }
 
    @Override
@@ -180,45 +170,4 @@ public final class ReadWriteManyCommand<K, V, R> implements WriteCommand {
    public boolean alwaysReadsExistingValues() {
       return false;
    }
-
-   @Override
-   public Set<Flag> getFlags() {
-      return null;  // TODO: Customise this generated block
-   }
-
-   @Override
-   public long getFlagsBitSet() {
-      return EnumUtil.EMPTY_BIT_SET;
-   }
-
-   @Override
-   public void setFlags(Set<Flag> flags) {
-      // TODO: Customise this generated block
-   }
-
-   @Override
-   public void setFlagsBitSet(long bitSet) {
-      // TODO: Customise this generated block
-   }
-
-   @Override
-   public void setFlags(Flag... flags) {
-      // TODO: Customise this generated block
-   }
-
-   @Override
-   public boolean hasFlag(Flag flag) {
-      return false;  // TODO: Customise this generated block
-   }
-
-   @Override
-   public Metadata getMetadata() {
-      return null;  // TODO: Customise this generated block
-   }
-
-   @Override
-   public void setMetadata(Metadata metadata) {
-      // TODO: Customise this generated block
-   }
-
 }

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyEntriesCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyEntriesCommand.java
@@ -1,16 +1,12 @@
 package org.infinispan.commands.functional;
 
 import org.infinispan.commands.Visitor;
-import org.infinispan.commands.write.ValueMatcher;
-import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.api.functional.EntryView.ReadWriteEntryView;
-import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.functional.impl.EntryViews;
+import org.infinispan.functional.impl.Params;
 import org.infinispan.lifecycle.ComponentStatus;
-import org.infinispan.metadata.Metadata;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -23,7 +19,7 @@ import java.util.function.BiFunction;
 
 import static org.infinispan.functional.impl.EntryViews.snapshot;
 
-public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand {
+public final class ReadWriteManyEntriesCommand<K, V, R> extends AbstractWriteManyCommand {
 
    public static final byte COMMAND_ID = 53;
 
@@ -34,9 +30,10 @@ public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand 
    boolean isForwarded = false;
    private List<R> remoteReturns = new ArrayList<>();
 
-   public ReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f) {
+   public ReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f, Params params) {
       this.entries = entries;
       this.f = f;
+      this.params = params;
    }
 
    public ReadWriteManyEntriesCommand() {
@@ -45,6 +42,7 @@ public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand 
    public ReadWriteManyEntriesCommand(ReadWriteManyEntriesCommand command) {
       this.entries = command.entries;
       this.f = command.f;
+      this.params = command.params;
    }
 
    public Map<? extends K, ? extends V> getEntries() {
@@ -65,6 +63,7 @@ public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand 
       output.writeObject(entries);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
    }
 
    @Override
@@ -72,6 +71,7 @@ public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand 
       entries = (Map<? extends K, ? extends V>) input.readObject();
       f = (BiFunction<V, ReadWriteEntryView<K, V>, R>) input.readObject();
       isForwarded = input.readBoolean();
+      params = Params.Externalizer.INSTANCE.readObject(input);
    }
 
    public boolean isForwarded() {
@@ -141,16 +141,6 @@ public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand 
    }
 
    @Override
-   public ValueMatcher getValueMatcher() {
-      return ValueMatcher.MATCH_ALWAYS;
-   }
-
-   @Override
-   public void setValueMatcher(ValueMatcher valueMatcher) {
-      // No-op
-   }
-
-   @Override
    public Set<Object> getAffectedKeys() {
       return null;  // TODO: Customise this generated block
    }
@@ -170,7 +160,6 @@ public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand 
       return false;  // TODO: Customise this generated block
    }
 
-   @Override
    public boolean readsExistingValues() {
       return true;
    }
@@ -180,44 +169,7 @@ public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand 
       return false;
    }
 
-   @Override
-   public Set<Flag> getFlags() {
-      return null;  // TODO: Customise this generated block
+   public Set<? extends K> getKeys() {
+      return entries.keySet();
    }
-
-   @Override
-   public long getFlagsBitSet() {
-      return EnumUtil.EMPTY_BIT_SET;
-   }
-
-   @Override
-   public void setFlags(Set<Flag> flags) {
-      // TODO: Customise this generated block
-   }
-
-   @Override
-   public void setFlagsBitSet(long bitSet) {
-      // TODO: Customise this generated block
-   }
-
-   @Override
-   public void setFlags(Flag... flags) {
-      // TODO: Customise this generated block
-   }
-
-   @Override
-   public boolean hasFlag(Flag flag) {
-      return false;  // TODO: Customise this generated block
-   }
-
-   @Override
-   public Metadata getMetadata() {
-      return null;  // TODO: Customise this generated block
-   }
-
-   @Override
-   public void setMetadata(Metadata metadata) {
-      // TODO: Customise this generated block
-   }
-
 }

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyCommand.java
@@ -41,6 +41,7 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K> 
       output.writeObject(key);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
       output.writeLong(Flag.copyWithoutRemotableFlags(getFlagsBitSet()));
       output.writeObject(commandInvocationId);
    }
@@ -50,6 +51,7 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K> 
       key = input.readObject();
       f = (Consumer<WriteEntryView<V>>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
+      params = Params.Externalizer.INSTANCE.readObject(input);
       setFlagsBitSet(input.readLong());
       commandInvocationId = (CommandInvocationId) input.readObject();
    }

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyValueCommand.java
@@ -45,6 +45,7 @@ public final class WriteOnlyKeyValueCommand<K, V> extends AbstractWriteKeyComman
       output.writeObject(value);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
       output.writeLong(Flag.copyWithoutRemotableFlags(getFlagsBitSet()));
       output.writeObject(commandInvocationId);
    }
@@ -55,6 +56,7 @@ public final class WriteOnlyKeyValueCommand<K, V> extends AbstractWriteKeyComman
       value = (V) input.readObject();
       f = (BiConsumer<V, WriteEntryView<V>>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
+      params = Params.Externalizer.INSTANCE.readObject(input);
       setFlagsBitSet(input.readLong());
       commandInvocationId = (CommandInvocationId) input.readObject();
    }

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyCommand.java
@@ -6,6 +6,7 @@ import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.functional.impl.EntryViews;
+import org.infinispan.functional.impl.Params;
 import org.infinispan.lifecycle.ComponentStatus;
 
 import java.io.IOException;
@@ -24,14 +25,16 @@ public final class WriteOnlyManyCommand<K, V> extends AbstractWriteManyCommand<K
    private Set<? extends K> keys;
    private Consumer<WriteEntryView<V>> f;
 
-   public WriteOnlyManyCommand(Set<? extends K> keys, Consumer<WriteEntryView<V>> f) {
+   public WriteOnlyManyCommand(Set<? extends K> keys, Consumer<WriteEntryView<V>> f, Params params) {
       this.keys = keys;
       this.f = f;
+      this.params = params;
    }
 
    public WriteOnlyManyCommand(WriteOnlyManyCommand<K, V> command) {
       this.keys = command.getKeys();
       this.f = command.f;
+      this.params = command.params;
    }
 
    public WriteOnlyManyCommand() {
@@ -55,6 +58,7 @@ public final class WriteOnlyManyCommand<K, V> extends AbstractWriteManyCommand<K
       MarshallUtil.marshallCollection(keys, output);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
    }
 
    @Override
@@ -62,6 +66,7 @@ public final class WriteOnlyManyCommand<K, V> extends AbstractWriteManyCommand<K
       keys = MarshallUtil.unmarshallCollectionUnbounded(input, HashSet::new);
       f = (Consumer<WriteEntryView<V>>) input.readObject();
       isForwarded = input.readBoolean();
+      params = Params.Externalizer.INSTANCE.readObject(input);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyEntriesCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyEntriesCommand.java
@@ -5,6 +5,7 @@ import org.infinispan.commons.api.functional.EntryView.WriteEntryView;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.functional.impl.EntryViews;
+import org.infinispan.functional.impl.Params;
 import org.infinispan.lifecycle.ComponentStatus;
 
 import java.io.IOException;
@@ -21,14 +22,16 @@ public final class WriteOnlyManyEntriesCommand<K, V> extends AbstractWriteManyCo
    private Map<? extends K, ? extends V> entries;
    private BiConsumer<V, WriteEntryView<V>> f;
 
-   public WriteOnlyManyEntriesCommand(Map<? extends K, ? extends V> entries, BiConsumer<V, WriteEntryView<V>> f) {
+   public WriteOnlyManyEntriesCommand(Map<? extends K, ? extends V> entries, BiConsumer<V, WriteEntryView<V>> f, Params params) {
       this.entries = entries;
       this.f = f;
+      this.params = params;
    }
 
    public WriteOnlyManyEntriesCommand(WriteOnlyManyEntriesCommand<K, V> command) {
       this.entries = command.entries;
       this.f = command.f;
+      this.params = command.params;
    }
 
    public WriteOnlyManyEntriesCommand() {
@@ -52,6 +55,7 @@ public final class WriteOnlyManyEntriesCommand<K, V> extends AbstractWriteManyCo
       output.writeObject(entries);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
    }
 
    @Override
@@ -59,6 +63,7 @@ public final class WriteOnlyManyEntriesCommand<K, V> extends AbstractWriteManyCo
       entries = (Map<? extends K, ? extends V>) input.readObject();
       f = (BiConsumer<V, WriteEntryView<V>>) input.readObject();
       isForwarded = input.readBoolean();
+      params = Params.Externalizer.INSTANCE.readObject(input);
    }
 
    @Override
@@ -119,4 +124,7 @@ public final class WriteOnlyManyEntriesCommand<K, V> extends AbstractWriteManyCo
       return true;
    }
 
+   public Set<? extends K> getKeys() {
+      return entries.keySet();
+   }
 }

--- a/core/src/main/java/org/infinispan/functional/impl/Params.java
+++ b/core/src/main/java/org/infinispan/functional/impl/Params.java
@@ -3,10 +3,17 @@ package org.infinispan.functional.impl;
 import org.infinispan.commons.api.functional.Param;
 import org.infinispan.commons.api.functional.Param.FutureMode;
 import org.infinispan.commons.api.functional.Param.PersistenceMode;
+import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.util.Experimental;
+import org.infinispan.marshall.core.Ids;
 
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
@@ -31,6 +38,10 @@ public final class Params {
       FutureMode.defaultValue(),
       PersistenceMode.defaultValue(),
    };
+   // TODO: as Params are immutable and there's only limited number of them,
+   // there could be a table with all the possible combinations and we
+   // wouldn't have to allocate at all
+   private static final Params DEFAULT_INSTANCE = new Params(DEFAULTS);
 
    final Param<?>[] params;
 
@@ -77,7 +88,7 @@ public final class Params {
    }
 
    public static Params create() {
-      return new Params(DEFAULTS);
+      return DEFAULT_INSTANCE;
    }
 
    public static Params from(Param<?>... ps) {
@@ -108,4 +119,35 @@ public final class Params {
       }
    }
 
+   public static class Externalizer implements AdvancedExternalizer<Params> {
+      public static Externalizer INSTANCE = new Externalizer();
+
+      @Override
+      public Set<Class<? extends Params>> getTypeClasses() {
+         return Collections.singleton(Params.class);
+      }
+
+      @Override
+      public Integer getId() {
+         return Ids.PARAMS;
+      }
+
+      @Override
+      public void writeObject(ObjectOutput output, Params params) throws IOException {
+         // There's no point in sending FutureMode over wire
+         output.writeInt(((PersistenceMode) params.get(PersistenceMode.ID).get()).ordinal());
+      }
+
+      @Override
+      public Params readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+         PersistenceMode persistenceMode = PersistenceMode.values()[input.readInt()];
+         if (persistenceMode == PersistenceMode.defaultValue()) {
+            return DEFAULT_INSTANCE;
+         } else {
+            Param[] params = Arrays.copyOf(DEFAULTS, DEFAULTS.length);
+            params[PersistenceMode.ID] = persistenceMode;
+            return new Params(params);
+         }
+      }
+   }
 }

--- a/core/src/main/java/org/infinispan/functional/impl/ReadWriteMapImpl.java
+++ b/core/src/main/java/org/infinispan/functional/impl/ReadWriteMapImpl.java
@@ -71,8 +71,7 @@ public final class ReadWriteMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    @Override
    public <R> Traversable<R> evalMany(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f) {
       log.tracef("Invoked evalMany(entries=%s, %s)", entries, params);
-      Param<FutureMode> futureMode = params.get(FutureMode.ID);
-      ReadWriteManyEntriesCommand cmd = fmap.cmdFactory().buildReadWriteManyEntriesCommand(entries, f);
+      ReadWriteManyEntriesCommand cmd = fmap.cmdFactory().buildReadWriteManyEntriesCommand(entries, f, params);
       InvocationContext ctx = fmap.invCtxFactory().createInvocationContext(true, entries.size());
       return Traversables.of(((List<R>) fmap.chain().invoke(ctx, cmd)).stream());
    }
@@ -80,8 +79,7 @@ public final class ReadWriteMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    @Override
    public <R> Traversable<R> evalMany(Set<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f) {
       log.tracef("Invoked evalMany(keys=%s, %s)", keys, params);
-      Param<FutureMode> futureMode = params.get(FutureMode.ID);
-      ReadWriteManyCommand cmd = fmap.cmdFactory().buildReadWriteManyCommand(keys, f);
+      ReadWriteManyCommand cmd = fmap.cmdFactory().buildReadWriteManyCommand(keys, f, params);
       InvocationContext ctx = fmap.invCtxFactory().createInvocationContext(true, keys.size());
       return Traversables.of(((List<R>) fmap.chain().invoke(ctx, cmd)).stream());
    }
@@ -89,9 +87,8 @@ public final class ReadWriteMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    @Override
    public <R> Traversable<R> evalAll(Function<ReadWriteEntryView<K, V>, R> f) {
       log.tracef("Invoked evalAll(%s)", params);
-      Param<FutureMode> futureMode = params.get(FutureMode.ID);
       CloseableIteratorSet<K> keys = fmap.cache.keySet();
-      ReadWriteManyCommand cmd = fmap.cmdFactory().buildReadWriteManyCommand(keys, f);
+      ReadWriteManyCommand cmd = fmap.cmdFactory().buildReadWriteManyCommand(keys, f, params);
       InvocationContext ctx = fmap.invCtxFactory().createInvocationContext(true, keys.size());
       return Traversables.of(((List<R>) fmap.chain().invoke(ctx, cmd)).stream());
    }

--- a/core/src/main/java/org/infinispan/functional/impl/WriteOnlyMapImpl.java
+++ b/core/src/main/java/org/infinispan/functional/impl/WriteOnlyMapImpl.java
@@ -80,7 +80,7 @@ public final class WriteOnlyMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    public CompletableFuture<Void> evalMany(Set<? extends K> keys, Consumer<WriteEntryView<V>> f) {
       log.tracef("Invoked evalMany(keys=%s, %s)", keys, params);
       Param<FutureMode> futureMode = params.get(FutureMode.ID);
-      WriteOnlyManyCommand cmd = fmap.cmdFactory().buildWriteOnlyManyCommand(keys, f);
+      WriteOnlyManyCommand cmd = fmap.cmdFactory().buildWriteOnlyManyCommand(keys, f, params);
       InvocationContext ctx = fmap.invCtxFactory().createInvocationContext(true, keys.size());
       return futureVoid(futureMode, ctx, cmd);
    }
@@ -90,7 +90,7 @@ public final class WriteOnlyMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
       log.tracef("Invoked evalAll(%s)", params);
       Param<FutureMode> futureMode = params.get(FutureMode.ID);
       CloseableIteratorSet<K> keys = fmap.cache.keySet();
-      WriteOnlyManyCommand cmd = fmap.cmdFactory().buildWriteOnlyManyCommand(keys, f);
+      WriteOnlyManyCommand cmd = fmap.cmdFactory().buildWriteOnlyManyCommand(keys, f, params);
       InvocationContext ctx = fmap.invCtxFactory().createInvocationContext(true, keys.size());
       return futureVoid(futureMode, ctx, cmd);
    }

--- a/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
+++ b/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
@@ -67,6 +67,7 @@ import org.infinispan.filter.KeyValueFilterAsKeyFilter;
 import org.infinispan.filter.NullValueConverter;
 import org.infinispan.functional.impl.EntryViews;
 import org.infinispan.functional.impl.MetaParams;
+import org.infinispan.functional.impl.Params;
 import org.infinispan.marshall.exts.*;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.metadata.impl.InternalMetadataImpl;
@@ -384,6 +385,8 @@ public class ExternalizerTable implements ObjectTable {
       addInternalExternalizer(new MarshallableFunctionExternalizers.LambdaWithMetasExternalizer());
       addInternalExternalizer(new MarshallableFunctionExternalizers.SetValueIfEqualsReturnBooleanExternalizer());
       addInternalExternalizer(new PersistentUUID.Externalizer());
+
+      addInternalExternalizer(Params.Externalizer.INSTANCE);
    }
 
    void addInternalExternalizer(AdvancedExternalizer<?> ext) {

--- a/core/src/main/java/org/infinispan/marshall/core/Ids.java
+++ b/core/src/main/java/org/infinispan/marshall/core/Ids.java
@@ -174,4 +174,6 @@ public interface Ids extends org.infinispan.commons.marshall.Ids {
    int AFFINITY_FUNCTION_PARTITIONER = 165;
 
    int PERSISTENT_UUID = 166;
+
+   int PARAMS = 167;
 }

--- a/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
@@ -3,6 +3,7 @@ package org.infinispan.functional;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.functional.impl.FunctionalMapImpl;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.testng.annotations.BeforeClass;
 
@@ -25,14 +26,18 @@ abstract class AbstractFunctionalTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       // Create local caches as default in a cluster of 2
-      createClusteredCaches(2, new ConfigurationBuilder());
+      ConfigurationBuilder localBuilder = new ConfigurationBuilder();
+      localBuilder.persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class);
+      createClusteredCaches(2, localBuilder);
       // Create distributed caches
       ConfigurationBuilder distBuilder = new ConfigurationBuilder();
       distBuilder.clustering().cacheMode(CacheMode.DIST_SYNC).hash().numOwners(1);
+      distBuilder.persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class);
       cacheManagers.stream().forEach(cm -> cm.defineConfiguration(DIST, distBuilder.build()));
       // Create replicated caches
       ConfigurationBuilder replBuilder = new ConfigurationBuilder();
       replBuilder.clustering().cacheMode(CacheMode.REPL_SYNC);
+      replBuilder.persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class);
       cacheManagers.stream().forEach(cm -> cm.defineConfiguration(REPL, replBuilder.build()));
       // Wait for cluster to form
       waitForClusterToForm(DIST, REPL);

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -434,18 +434,18 @@ public class ControlledCommandFactory implements CommandsFactory {
    }
 
    @Override
-   public <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Set<? extends K> keys, Consumer<EntryView.WriteEntryView<V>> f) {
-      return actual.buildWriteOnlyManyCommand(keys, f);
+   public <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Set<? extends K> keys, Consumer<EntryView.WriteEntryView<V>> f, Params params) {
+      return actual.buildWriteOnlyManyCommand(keys, f, params);
    }
 
    @Override
-   public <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Set<? extends K> keys, Function<EntryView.ReadWriteEntryView<K, V>, R> f) {
-      return actual.buildReadWriteManyCommand(keys, f);
+   public <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Set<? extends K> keys, Function<EntryView.ReadWriteEntryView<K, V>, R> f, Params params) {
+      return actual.buildReadWriteManyCommand(keys, f, params);
    }
 
    @Override
-   public <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, EntryView.ReadWriteEntryView<K, V>, R> f) {
-      return actual.buildReadWriteManyEntriesCommand(entries, f);
+   public <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, EntryView.ReadWriteEntryView<K, V>, R> f, Params params) {
+      return actual.buildReadWriteManyEntriesCommand(entries, f, params);
    }
 
 }


### PR DESCRIPTION
…ams params field

* marshall params
* pass params to all write/read-write functional commands
* don't ignore some commands in CacheWriterInterceptor
* add Dummy store to functional API tests