### PR TITLE
ISPN-6549 The query-dsl bundle does not export required packages for …

### DIFF
--- a/query-dsl/pom.xml
+++ b/query-dsl/pom.xml
@@ -55,7 +55,7 @@
             <configuration>
                <instructions>
                   <Export-Package>
-                     !${project.groupId}.query.dsl.impl.*,
+                     !${project.groupId}.query.dsl.impl.logging.*,
                      ${project.groupId}.query.api.*;version=${project.version};-split-package:=error,
                      ${project.groupId}.query.dsl.*;version=${project.version};-split-package:=error
                   </Export-Package>


### PR DESCRIPTION
…OSGi

JIRA: https://issues.jboss.org/browse/ISPN-6549

This reverts the issue introduced by ISPN-6069. We still skip from exporting org.infinispan.query.dsl.impl.logging.*