### PR TITLE
ISPN-6300 Add missing bindings to dist remote exec

### DIFF
--- a/client/hotrod-client/src/test/resources/typed-put-get-dist.js
+++ b/client/hotrod-client/src/test/resources/typed-put-get-dist.js
@@ -1,0 +1,4 @@
+// mode=distributed,language=javascript,parameters=[k, v],datatype='text/plain; charset=utf-8'
+var cache = cacheManager.getCache();
+cache.put(k, v);
+cache.get(k);

--- a/scripting/src/main/java/org/infinispan/scripting/impl/DataType.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/DataType.java
@@ -5,6 +5,7 @@ import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.Immutables;
 
 import java.nio.charset.Charset;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -47,11 +48,15 @@ public enum DataType {
       }
 
       @Override
+      @SuppressWarnings("unchecked")
       public Object fromDataType(Object obj, Optional<Marshaller> marshaller) {
-         return Objects.isNull(obj)
-               ? null : obj instanceof String
-               ? ((String) obj).getBytes(CHARSET_UTF8)
-               : obj.toString().getBytes(CHARSET_UTF8);
+         if (obj instanceof List)
+            return ((List) obj).stream()
+                  .map(Object::toString)
+                  .collect(Collectors.joining("\", \"", "[\"", "\"]"))
+                  .toString().getBytes(CHARSET_UTF8);
+
+         return Objects.isNull(obj) ? null : obj.toString().getBytes(CHARSET_UTF8);
       }
 
       private static String asString(Object v) {

--- a/scripting/src/main/java/org/infinispan/scripting/impl/DistributedScript.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/DistributedScript.java
@@ -1,6 +1,7 @@
 package org.infinispan.scripting.impl;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Set;
 
 import javax.script.Bindings;
@@ -18,11 +19,13 @@ import org.infinispan.scripting.ScriptingManager;
  */
 class DistributedScript<T> implements DistributedCallable<Object, Object, T>, Serializable {
    private final ScriptMetadata metadata;
+   private final Map<String, ?> ctxParams;
    private transient ScriptingManagerImpl scriptManager;
    private transient Bindings bindings;
 
-   DistributedScript(ScriptMetadata metadata) {
+   DistributedScript(ScriptMetadata metadata, Map<String, ?> ctxParams) {
       this.metadata = metadata;
+      this.ctxParams = ctxParams;
    }
 
    @Override
@@ -36,5 +39,7 @@ class DistributedScript<T> implements DistributedCallable<Object, Object, T>, Se
       bindings = new SimpleBindings();
       bindings.put("inputKeys", inputKeys);
       bindings.put("cache", cache);
+      bindings.put("cacheManager", cache.getCacheManager());
+      ctxParams.entrySet().stream().forEach(e -> bindings.put(e.getKey(), e.getValue()));
    }
 }

--- a/scripting/src/test/resources/test-put-get-dist.js
+++ b/scripting/src/test/resources/test-put-get-dist.js
@@ -1,0 +1,4 @@
+// mode=distributed,language=javascript,parameters=[k, v]
+var cache = cacheManager.getCache();
+cache.put(k, v);
+cache.get(k);

--- a/scripting/src/test/resources/test-put-get.js
+++ b/scripting/src/test/resources/test-put-get.js
@@ -1,0 +1,4 @@
+// mode=local,language=javascript,parameters=[k, v]
+var cache = cacheManager.getCache();
+cache.put(k, v);
+cache.get(k);


### PR DESCRIPTION
* Added cacheManager and context parameters as bindings for distributed
  remote task execution.
* Marshaller not currently passed since the marshaller in the context
  can't easily be initialised in the distributed tasks.
* Added tests to verify that bindings are correctly set for normal
  remote execution and typed remote execution.

Q. Plugging in Marshaller for dist script execution is tricky, any ideas?