### PR TITLE
ISPN-6556 SegmentListenerNotifier.completeSegmentsNoResults is not

### DIFF
--- a/core/src/main/java/org/infinispan/stream/impl/AbstractCacheStream.java
+++ b/core/src/main/java/org/infinispan/stream/impl/AbstractCacheStream.java
@@ -522,8 +522,8 @@ public abstract class AbstractCacheStream<T, S extends BaseStream<T, S>, S2 exte
             });
             if (lastCompleted[0] != null) {
                listenerNotifier.addSegmentsForObject(lastCompleted[0], segmentsCompleted);
-               return segmentsCompleted;
             }
+            return segmentsCompleted;
          }
          return null;
       }


### PR DESCRIPTION
called for batches without values

* Made sure empty set is returned so we notify empty segments