### PR TITLE
ISPN-6559 Provide module for Infinispan Directory that satisfies the slot "for-hibernatesearch-5.5"

### DIFF
--- a/as-modules/embedded/build.xml
+++ b/as-modules/embedded/build.xml
@@ -8,6 +8,7 @@
     <major-minor version="${version.lucene}" property="lucene.slot"/>
     <major-minor version="${version.hibernate.search}" property="hibernate.search.slot"/>
     <property name="hibernate-search-directory-provider-ref" value="for-hibernatesearch-${hibernate.search.slot}"/>
+    <property name="hibernate-search-directory-wildfly-ref" value="for-hibernatesearch-5.5"/>
 
     <target name="clean">
         <delete dir="${output.dir}" />
@@ -30,6 +31,8 @@
             <filter token="lucene.slot" value="${lucene.slot}" />
             <filter token="hibernate.search.slot" value="${hibernate.search.slot}" />
             <filter token="hibernate-search-directory-provider-ref" value="${hibernate-search-directory-provider-ref}" />
+            <filter token="hibernate-search-directory-wildfly-ref" value="${hibernate-search-directory-wildfly-ref}" />
+
         </filterset>
 
         <module-def name="org.antlr.antlr-runtime" slot="${infinispan.slot}">
@@ -111,6 +114,13 @@
         </module-def>
 
         <module-def name="org.infinispan.hibernate-search.directory-provider" slot="${hibernate-search-directory-provider-ref}"  module.src="org.infinispan.for-hibernatesearch-alias"/>
+
+        <module-def name="org.infinispan.hibernate-search.directory-provider" slot="${hibernate-search-directory-wildfly-ref}" module.src="org.infinispan.for-hibernatesearch-wildfly">
+            <maven-resource group="org.infinispan" artifact="infinispan-core"/>
+            <maven-resource group="org.infinispan" artifact="infinispan-lucene-directory"/>
+            <maven-resource group="org.infinispan" artifact="infinispan-commons"/>
+            <maven-resource group="org.infinispan" artifact="infinispan-directory-provider" />
+        </module-def>
 
         <module-def name="org.infinispan.objectfilter" slot="${infinispan.slot}">
             <maven-resource group="org.infinispan" artifact="infinispan-objectfilter" />

--- a/as-modules/embedded/src/main/resources/org/infinispan/for-hibernatesearch-wildfly/main/module.xml
+++ b/as-modules/embedded/src/main/resources/org/infinispan/for-hibernatesearch-wildfly/main/module.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+This Module is meant to be used exclusively by Hibernate Search as used in combination with Hibernate ORM;
+(Not the Hibernate Search version used by Infinispan Query as an internal dependency).
+
+It is a slimmed down alternative for the combination of modules normally built by the Infinispan project:
+ - org.infinispan.lucene-directory
+ - org.infinispan
+
+As it needs to link to the classloaders of Hibernate Search without introducing possible linkage errors,
+it needs to point to the slot of module org.apache.lucene of the consuming Hibernate Search,
+and obviously needs to avoid dependencies to different versions of Hibernate Search.
+
+-->
+<module xmlns="urn:jboss:module:1.1" name="org.infinispan.hibernate-search.directory-provider"
+        slot="${hibernate-search-directory-wildfly-ref}">
+
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="org.apache.lucene" />
+        <module name="org.hibernate.search.engine"/>
+        <!-- Next dependencies are essentially a copy of those from module org.infinispan,
+             but filtering out the ones related to Apache Lucene, Infinispan Query and Hibernate Search. -->
+        <module name="javax.api"/>
+        <module name="javax.transaction.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="org.apache.xerces" services="import"/>
+        <module name="org.jboss.jandex"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.marshalling" slot="${infinispan.slot}" services="import"/>
+        <module name="org.jgroups" slot="${infinispan.slot}"/>
+        <module name="sun.jdk"/>
+    </dependencies>
+</module>

--- a/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/VersionTestHelper.java
+++ b/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/VersionTestHelper.java
@@ -32,6 +32,10 @@ public class VersionTestHelper {
       archive.add( manifestDependencies( "org.hibernate.search.orm:${hibernate-search.module.slot} services"), "META-INF/MANIFEST.MF" );
    }
 
+   public static void addMainHibernateSearchManifestDependencies(Archive<?> archive) {
+      archive.add( manifestDependencies( "org.hibernate.search.orm services"), "META-INF/MANIFEST.MF" );
+   }
+
    public static Asset manifestDependencies(String moduleDependencies) {
       return manifest( injectVariables( moduleDependencies ) );
    }

--- a/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/wildfly/DirectoryProviderModuleMemberRegistrationIT.java
+++ b/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/wildfly/DirectoryProviderModuleMemberRegistrationIT.java
@@ -15,16 +15,14 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.persistence20.PersistenceDescriptor;
 import org.junit.runner.RunWith;
 
-import static org.infinispan.test.integration.as.VersionTestHelper.addHibernateSearchManifestDependencies;
 import static org.infinispan.test.integration.as.VersionTestHelper.addMainHibernateSearchManifestDependencies;
 
 /**
- * Test the Hibernate Search module combined with an Infinispan Directory usage.
- *
- * @author Sanne Grinovero
+ * Test the Hibernate Search module in Wildfly (slot "main") combined with the Infinispan directory provider
  */
 @RunWith(Arquillian.class)
-public class InfinispanModuleMemberRegistrationIT extends MemberRegistrationBase {
+public class DirectoryProviderModuleMemberRegistrationIT extends MemberRegistrationBase {
+
 
    @Deployment(name = "dep.active-1")
    @TargetsContainer("container.active-1")
@@ -40,14 +38,14 @@ public class InfinispanModuleMemberRegistrationIT extends MemberRegistrationBase
 
    private static Archive<?> createTestArchive() {
       WebArchive webArchive = ShrinkWrap
-              .create(WebArchive.class, InfinispanModuleMemberRegistrationIT.class.getSimpleName() + ".war")
+              .create(WebArchive.class, DirectoryProviderModuleMemberRegistrationIT.class.getSimpleName() + ".war")
               .addClasses(Member.class, MemberRegistration.class, MemberRegistrationBase.class)
               .addAsResource(persistenceXml(), "META-INF/persistence.xml")
               //This test is simply reusing the default configuration file, but we copy
               //this configuration into the Archive to verify that resources can be loaded from it:
-              .addAsResource("user-provided-infinispan.xml", "user-provided-infinispan.xml")
+              .addAsResource("user-provided-infinispan-persistence.xml", "user-provided-infinispan-persistence.xml")
               .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
-      addHibernateSearchManifestDependencies(webArchive);
+      addMainHibernateSearchManifestDependencies(webArchive);
       return webArchive;
    }
 
@@ -63,10 +61,6 @@ public class InfinispanModuleMemberRegistrationIT extends MemberRegistrationBase
               .value("create-drop")
               .up()
               .createProperty()
-              .name("wildfly.jpa.hibernate.search.module")
-              .value("none")
-              .up()
-              .createProperty()
               .name("hibernate.search.default.lucene_version")
               .value("LUCENE_CURRENT")
               .up()
@@ -80,12 +74,11 @@ public class InfinispanModuleMemberRegistrationIT extends MemberRegistrationBase
               .up()
               .createProperty()
               .name("hibernate.search.infinispan.configuration_resourcename")
-              .value("user-provided-infinispan.xml")
+              .value("user-provided-infinispan-persistence.xml")
               .up()
               .up()
               .up()
               .exportAsString();
       return new StringAsset(persistenceXml);
    }
-
 }

--- a/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/wildfly/MemberRegistrationBase.java
+++ b/integrationtests/as-lucene-directory/src/test/java/org/infinispan/test/integration/as/wildfly/MemberRegistrationBase.java
@@ -1,0 +1,236 @@
+package org.infinispan.test.integration.as.wildfly;
+
+import org.apache.lucene.document.Document;
+import org.infinispan.test.integration.as.wildfly.controller.MemberRegistration;
+import org.infinispan.test.integration.as.wildfly.model.Member;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.InSequence;
+import org.junit.Test;
+
+import javax.ejb.EJBTransactionRolledbackException;
+import javax.inject.Inject;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@SuppressWarnings("unused")
+class MemberRegistrationBase {
+
+   private final static double GD_LATITUDE = 37.769645;
+   private final static double GD_LONGITUDE = -122.446428;
+   private final static double CH_LATITUDE = 37.780392;
+   private final static double CH_LONGITUDE = -122.513898;
+   private final static double CBGB_LATITUDE = 40.726157;
+   private final static double CBGB_LONGITUDE = -73.992116;
+   private final static double KD_LATITUDE = 40.723165;
+   private final static double KD_LONGITUDE = -73.987439;
+   private final static double BG_LATITUDE = 41.874808;
+   private final static double BG_LONGITUDE = -87.625983;
+   @Inject
+   MemberRegistration memberRegistration;
+
+   @Test
+   @InSequence(value = 1)
+   @OperateOnDeployment("dep.active-1")
+   public void
+   testRegister() throws Exception {
+      Member newMember = memberRegistration.getNewMember();
+      newMember.setName("Davide D'Alto");
+      newMember.setEmail("davide@mailinator.com");
+      newMember.setPhoneNumber("2125551234");
+      newMember.setLatitude(CH_LATITUDE);
+      newMember.setLongitude(CH_LONGITUDE);
+      memberRegistration.register();
+
+      assertNotNull(newMember.getId());
+      assertEquals("Index size isn't correct", 1, memberRegistration.indexSize());
+   }
+
+   @Test(expected = EJBTransactionRolledbackException.class)
+   @InSequence(value = 2)
+   @OperateOnDeployment("dep.active-1")
+   public void testRegisterConstraint() throws Exception {
+      Member newMember = memberRegistration.getNewMember();
+      newMember.setName("Davide D'Altoe");
+      newMember.setEmail("davide@mailinator.com");
+      newMember.setPhoneNumber("2125551235");
+      newMember.setLatitude(CH_LATITUDE);
+      newMember.setLongitude(CH_LONGITUDE);
+      memberRegistration.register();
+   }
+
+   @Test
+   @InSequence(value = 3)
+   @OperateOnDeployment("dep.active-2")
+   public void testNewMemberSearch() throws Exception {
+      Member newMember = memberRegistration.getNewMember();
+      newMember.setName("Peter O'Tall");
+      newMember.setEmail("peter@mailinator.com");
+      newMember.setPhoneNumber("4643646643");
+      newMember.setLatitude(KD_LATITUDE);
+      newMember.setLongitude(KD_LONGITUDE);
+      memberRegistration.register();
+
+      List<Member> search = memberRegistration.search("Peter");
+
+      assertFalse("Expected at least one result after the indexing", search.isEmpty());
+      assertEquals("Search hasn't found a new member", newMember.getName(), search.get(0).getName());
+      assertEquals("Index size isn't correct", 2, memberRegistration.indexSize());
+   }
+
+   @Test
+   @InSequence(value = 4)
+   @OperateOnDeployment("dep.active-2")
+   public void testNewMemberLuceneSearch() throws Exception {
+      List<Member> search = memberRegistration.luceneSearch("Peter");
+
+      assertFalse("Expected at least one result after the indexing", search.isEmpty());
+      assertEquals("Lucene search hasn't found a member", "Peter O'Tall", search.get(0).getName());
+   }
+
+   @Test
+   @InSequence(value = 5)
+   @OperateOnDeployment("dep.active-2")
+   public void testNewMemberIndexSearch() throws Exception {
+      List<Document> search = memberRegistration.indexSearch("Peter");
+
+      assertFalse("Expected at least one result after the indexing", search.isEmpty());
+      assertEquals("Lucene search hasn't found a member", "Peter O'Tall", search.get(0).get("name"));
+   }
+
+   @Test
+   @InSequence(value = 6)
+   @OperateOnDeployment("dep.active-2")
+   public void testNonExistingMember() throws Exception {
+      List<Member> search = memberRegistration.search("TotallyInventedName");
+
+      assertNotNull("Search should never return null", search);
+      assertTrue("Search results should be empty", search.isEmpty());
+   }
+
+   @Test
+   @InSequence(value = 7)
+   @OperateOnDeployment("dep.active-2")
+   public void testLuceneNonExistingMember() throws Exception {
+      List<Member> search = memberRegistration.luceneSearch("TotallyInventedName");
+
+      assertNotNull("Search should never return null", search);
+      assertTrue("Search results should be empty", search.isEmpty());
+   }
+
+   @Test
+   @InSequence(value = 8)
+   @OperateOnDeployment("dep.active-2")
+   public void testIndexNonExistingMember() throws Exception {
+      List<Document> search = memberRegistration.indexSearch("TotallyInventedName");
+
+      assertNotNull("Search should never return null", search);
+      assertTrue("Search results should be empty", search.isEmpty());
+   }
+
+   @Test
+   @InSequence(value = 9)
+   @OperateOnDeployment("dep.active-2")
+   public void testPurgeIndex() throws Exception {
+      memberRegistration.purgeMemberIndex();
+      List<Member> search = memberRegistration.search("Peter");
+
+      assertNotNull("Search should never return null", search);
+      assertTrue("Search results should be empty", search.isEmpty());
+      assertEquals("Index size isn't correct", 0, memberRegistration.indexSize());
+   }
+
+   @Test
+   @InSequence(value = 10)
+   @OperateOnDeployment("dep.active-2")
+   public void testReIndex() throws Exception {
+      memberRegistration.indexMembers();
+      List<Member> search = memberRegistration.search("Peter");
+
+      assertFalse("Expected at least one result after the indexing", search.isEmpty());
+      assertEquals("Search hasn't found a new member after reindex", "Peter O'Tall", search.get(0).getName());
+      assertEquals("Index size isn't correct", 2, memberRegistration.indexSize());
+   }
+
+   @Test
+   @InSequence(value = 11)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchNearGD() throws Exception {
+      List<Member> members = memberRegistration.spatialSearch(GD_LATITUDE, GD_LONGITUDE, 10);
+      assertEquals("Expected one result from spatial search", 1, members.size());
+      assertEquals("Spatial search did not find the correct member", "Davide D'Alto", members.get(0).getName());
+   }
+
+   @Test
+   @InSequence(value = 12)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchNearGDWithDistance() throws Exception {
+      List<Object[]> membersWithDistance = memberRegistration.spatialSearchWithDistance(GD_LATITUDE, GD_LONGITUDE, 10);
+      assertEquals("Expected one result from spatial search", 1, membersWithDistance.size());
+      assertEquals("Spatial search did not find the correct member", "Davide D'Alto",
+              ((Member) membersWithDistance.get(0)[1]).getName());
+      assertTrue("Distance was not greater than zero", (Double) membersWithDistance.get(0)[0] > 0);
+   }
+
+   @Test
+   @InSequence(value = 13)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchNearCBGB() throws Exception {
+      List<Member> members = memberRegistration.spatialSearch(CBGB_LATITUDE, CBGB_LONGITUDE, 10);
+      assertEquals("Expected one result from spatial search", 1, members.size());
+      assertEquals("Spatial search did not find the correct member", "Peter O'Tall", members.get(0).getName());
+   }
+
+   @Test
+   @InSequence(value = 14)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchNearCBGBWithDistance() throws Exception {
+      List<Object[]> membersWithDistance = memberRegistration.spatialSearchWithDistance(CBGB_LATITUDE, CBGB_LONGITUDE,
+              10);
+      assertEquals("Expected one result from spatial search", 1, membersWithDistance.size());
+      assertEquals("Spatial search did not find the correct member", "Peter O'Tall",
+              ((Member) membersWithDistance.get(0)[1]).getName());
+      assertTrue("Distance was not greater than zero", (Double) membersWithDistance.get(0)[0] > 0);
+   }
+
+   @Test
+   @InSequence(value = 15)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchNearBG() throws Exception {
+      List<Member> members = memberRegistration.spatialSearch(BG_LATITUDE, BG_LONGITUDE, 10);
+      assertEquals("Expected one result from spatial search", 0, members.size());
+   }
+
+   @Test
+   @InSequence(value = 16)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchNearBGWithDistance() throws Exception {
+      List<Object[]> membersWithDistance = memberRegistration.spatialSearchWithDistance(BG_LATITUDE, BG_LONGITUDE, 10);
+      assertEquals("Expected one result from spatial search", 0, membersWithDistance.size());
+   }
+
+   @Test
+   @InSequence(value = 17)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchLongDistance() throws Exception {
+      List<Member> members = memberRegistration.spatialSearch(GD_LATITUDE, GD_LONGITUDE, 5000);
+      assertEquals("Expected one result from spatial search", 2, members.size());
+      assertEquals("Spatial search did not find the correct member", "Davide D'Alto", members.get(0).getName());
+      assertEquals("Spatial search did not find the correct member", "Peter O'Tall", members.get(1).getName());
+   }
+
+   @Test
+   @InSequence(value = 18)
+   @OperateOnDeployment("dep.active-1")
+   public void testNewMemberSpatialSearchLongDistanceWithDistance() throws Exception {
+      List<Object[]> membersWithDistance = memberRegistration
+              .spatialSearchWithDistance(GD_LATITUDE, GD_LONGITUDE, 5000);
+      assertEquals("Expected one result from spatial search", 2, membersWithDistance.size());
+      assertEquals("Spatial search did not find the correct member", "Davide D'Alto",
+              ((Member) membersWithDistance.get(0)[1]).getName());
+      assertTrue("Distance was not greater than zero", (Double) membersWithDistance.get(0)[0] > 0);
+      assertEquals("Spatial search did not find the correct member", "Peter O'Tall",
+              ((Member) membersWithDistance.get(1)[1]).getName());
+      assertTrue("Distance was not greater than zero", (Double) membersWithDistance.get(1)[0] > 0);
+   }
+}

--- a/integrationtests/as-lucene-directory/src/test/resources/user-provided-infinispan-persistence.xml
+++ b/integrationtests/as-lucene-directory/src/test/resources/user-provided-infinispan-persistence.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="urn:infinispan:config:8.2 http://www.infinispan.org/schemas/infinispan-config-8.2.xsd"
+            xmlns="urn:infinispan:config:8.2">
+
+    <jgroups>
+        <stack-file name="default-jgroups-tcp" path="default-configs/default-jgroups-tcp.xml"/>
+    </jgroups>
+
+    <cache-container name="HibernateSearch" default-cache="default" statistics="false" shutdown-hook="DONT_REGISTER">
+        <transport stack="default-jgroups-tcp"/>
+        <jmx duplicate-domains="true"/>
+
+        <replicated-cache name="LuceneIndexesMetadata" mode="SYNC" remote-timeout="25000">
+            <persistence passivation="false">
+                <file-store preload="true" purge="true" path="${jboss.server.temp.dir}/indexes"/>
+            </persistence>
+            <indexing index="NONE"/>
+        </replicated-cache>
+
+        <distributed-cache name="LuceneIndexesData" mode="SYNC" remote-timeout="25000">
+            <persistence passivation="false">
+                <file-store preload="true" purge="true" path="${jboss.server.temp.dir}/indexes"/>
+            </persistence>
+            <indexing index="NONE"/>
+        </distributed-cache>
+
+        <replicated-cache name="LuceneIndexesLocking" mode="SYNC" remote-timeout="25000">
+            <persistence passivation="false">
+                <file-store preload="true" purge="true" path="${jboss.server.temp.dir}/indexes"/>
+            </persistence>
+            <indexing index="NONE"/>
+        </replicated-cache>
+    </cache-container>
+
+</infinispan>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6559

**8.2.x only!**


This PR adds a new module supposed to be used with Hibernate Search applications running on Wildfly 10 that want to store Lucene indexes on Infinispan.

Currently the distributed modules include the Infinispan directory provider slot ```ispn-8.2``` but this module depends on hibernate search ```ispn-8.2``` causing incompatibilities with the hibernate search version present in Wildfly.
