### PR TITLE
SkipOperation should use 'skip' rather than 'limit' on the stream

### DIFF
--- a/core/src/main/java/org/infinispan/stream/impl/intops/object/SkipOperation.java
+++ b/core/src/main/java/org/infinispan/stream/impl/intops/object/SkipOperation.java
@@ -16,6 +16,6 @@ public class SkipOperation<S> implements IntermediateOperation<S, Stream<S>, S, 
 
    @Override
    public Stream<S> perform(Stream<S> stream) {
-      return stream.limit(n);
+      return stream.skip(n);
    }
 }

--- a/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
@@ -1499,9 +1499,7 @@ private static class ForEachIntInjected implements IntConsumer,
       for (int i = 0; i < range; i++) {
          List<Double> res = createStream(keySet)
                  .sorted().skip(i).collect(Collectors.toList());
-         for (int j = 0; j < range - res.size(); j++) {
-            assertFalse(res.contains(j));
-         }
+         assertEquals(0, IntStream.range(0, range - res.size()).mapToDouble(v -> v).filter(res::contains).count());
       }
    }
 
@@ -1515,9 +1513,7 @@ private static class ForEachIntInjected implements IntConsumer,
       for (int i = 0; i < range; i++) {
          List<Integer> res = createStream(keySet)
                  .sorted().skip(i).collect(Collectors.toList());
-         for (int j = 0; j < range - res.size(); j++) {
-            assertFalse(res.contains(j));
-         }
+         assertEquals(0, IntStream.range(0, range - res.size()).filter(res::contains).count());
       }
    }
 
@@ -1532,9 +1528,7 @@ private static class ForEachIntInjected implements IntConsumer,
          List<Double> res = createStream(keySet)
                  .sorted().limit(i).collect(Collectors.toList());
          assertEquals(i, res.size());
-         for (int j = res.size(); j < range; j++) {
-            assertFalse(res.contains(j));
-         }
+         assertEquals(0, IntStream.range(res.size(), range).mapToDouble(v -> v).filter(res::contains).count());
       }
    }
 
@@ -1549,9 +1543,8 @@ private static class ForEachIntInjected implements IntConsumer,
          List<Integer> res = createStream(keySet)
                  .sorted().limit(i).collect(Collectors.toList());
          assertEquals(i, res.size());
-         for (int j = res.size(); j < range; j++) {
-            assertFalse(res.contains(j));
-         }
+         assertEquals(0, IntStream.range(res.size(), range).filter(res::contains).count());
+
       }
    }
 

--- a/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
@@ -1493,16 +1493,16 @@ private static class ForEachIntInjected implements IntConsumer,
       Cache<Double, String> cache = getCache(0);
       int range = 10;
       // First populate the cache with a bunch of values
-      IntStream.range(0,range).mapToDouble(value -> value).forEach(i -> cache.put(i, i + "-value"));
+      IntStream.range(0, range).mapToDouble(value -> value).forEach(i -> cache.put(i, i + "-value"));
       CacheSet<Map.Entry<Double, String>> entrySet = cache.entrySet();
 
       int cnt = range;
-      for(int i = 0;i<cnt;i++){
-         List<Map.Entry<Double,String>> res = createStream(entrySet)
+      for (int i = 0; i < cnt; i++) {
+         List<Map.Entry<Double, String>> res = createStream(entrySet)
                  .sorted((o1, o2) -> o1.getKey().compareTo(o2.getKey()))
                  .skip(i).collect(Collectors.toList());
-         for(int j = 0;j< cnt - res.size();j++){
-            String targetValue = (double)j + "-value";
+         for (int j = 0; j < cnt - res.size(); j++) {
+            String targetValue = (double) j + "-value";
             assertFalse(res.stream().anyMatch(v -> v.getValue().equals(targetValue)));
          }
       }
@@ -1512,20 +1512,17 @@ private static class ForEachIntInjected implements IntConsumer,
       Cache<Double, String> cache = getCache(0);
       int range = 10;
       // First populate the cache with a bunch of values
-      IntStream.range(0,range).mapToDouble(value -> value).forEach(i -> cache.put(i, i + "-value"));
+      IntStream.range(0, range).mapToDouble(value -> value).forEach(i -> cache.put(i, i + "-value"));
       CacheSet<Map.Entry<Double, String>> entrySet = cache.entrySet();
-      List<Map.Entry<Double,String>> total = createStream(entrySet)
-              .sorted((o1, o2) -> o1.getKey().compareTo(o2.getKey()))
-              .collect(Collectors.toList());
 
       int cnt = range;
-      for(int i = 1;i<cnt;i++){
-         List<Map.Entry<Double,String>> res = createStream(entrySet)
+      for (int i = 1; i < cnt; i++) {
+         List<Map.Entry<Double, String>> res = createStream(entrySet)
                  .sorted((o1, o2) -> o1.getKey().compareTo(o2.getKey()))
                  .limit(i).collect(Collectors.toList());
-         assertEquals(i,res.size());
-         for(int j = res.size();j< cnt;j++){
-            String targetValue = (double)j + "-value";
+         assertEquals(i, res.size());
+         for (int j = res.size(); j < cnt; j++) {
+            String targetValue = (double) j + "-value";
             assertFalse(res.stream().anyMatch(v -> v.getValue().equals(targetValue)));
          }
       }

--- a/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
@@ -1499,6 +1499,7 @@ private static class ForEachIntInjected implements IntConsumer,
       for (int i = 0; i < range; i++) {
          List<Double> res = createStream(keySet)
                  .sorted().skip(i).collect(Collectors.toList());
+         assertEquals(range - i, res.size());
          assertEquals(0, IntStream.range(0, range - res.size()).mapToDouble(v -> v).filter(res::contains).count());
       }
    }
@@ -1513,6 +1514,7 @@ private static class ForEachIntInjected implements IntConsumer,
       for (int i = 0; i < range; i++) {
          List<Integer> res = createStream(keySet)
                  .sorted().skip(i).collect(Collectors.toList());
+         assertEquals(range - i, res.size());
          assertEquals(0, IntStream.range(0, range - res.size()).filter(res::contains).count());
       }
    }

--- a/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
@@ -1489,39 +1489,68 @@ private static class ForEachIntInjected implements IntConsumer,
       assertFalse(createStream(entrySet).mapToDouble(toDouble).allMatch(i -> Math.floor(i) == i));
    }
 
-   public void testSkip() {
+   public void testDoubleSkip() {
       Cache<Double, String> cache = getCache(0);
       int range = 10;
       // First populate the cache with a bunch of values
       IntStream.range(0, range).mapToDouble(value -> value).forEach(i -> cache.put(i, i + "-value"));
-      CacheSet<Map.Entry<Double, String>> entrySet = cache.entrySet();
+      CacheSet<Double> keySet = cache.keySet();
 
       for (int i = 0; i < range; i++) {
-         List<Map.Entry<Double, String>> res = createStream(entrySet)
-                 .sorted((o1, o2) -> o1.getKey().compareTo(o2.getKey()))
-                 .skip(i).collect(Collectors.toList());
+         List<Double> res = createStream(keySet)
+                 .sorted().skip(i).collect(Collectors.toList());
          for (int j = 0; j < range - res.size(); j++) {
-            String targetValue = (double) j + "-value";
-            assertFalse(res.stream().anyMatch(v -> v.getValue().equals(targetValue)));
+            assertFalse(res.contains(j));
          }
       }
    }
 
-   public void testLimit() {
+   public void testIntegerSkip() {
+      Cache<Integer, String> cache = getCache(0);
+      int range = 10;
+      // First populate the cache with a bunch of values
+      IntStream.range(0, range).forEach(i -> cache.put(i, i + "-value"));
+      CacheSet<Integer> keySet = cache.keySet();
+
+      for (int i = 0; i < range; i++) {
+         List<Integer> res = createStream(keySet)
+                 .sorted().skip(i).collect(Collectors.toList());
+         for (int j = 0; j < range - res.size(); j++) {
+            assertFalse(res.contains(j));
+         }
+      }
+   }
+
+   public void testDoubleLimit() {
       Cache<Double, String> cache = getCache(0);
       int range = 10;
       // First populate the cache with a bunch of values
       IntStream.range(0, range).mapToDouble(value -> value).forEach(i -> cache.put(i, i + "-value"));
-      CacheSet<Map.Entry<Double, String>> entrySet = cache.entrySet();
+      CacheSet<Double> keySet = cache.keySet();
 
       for (int i = 1; i < range; i++) {
-         List<Map.Entry<Double, String>> res = createStream(entrySet)
-                 .sorted((o1, o2) -> o1.getKey().compareTo(o2.getKey()))
-                 .limit(i).collect(Collectors.toList());
+         List<Double> res = createStream(keySet)
+                 .sorted().limit(i).collect(Collectors.toList());
          assertEquals(i, res.size());
          for (int j = res.size(); j < range; j++) {
-            String targetValue = (double) j + "-value";
-            assertFalse(res.stream().anyMatch(v -> v.getValue().equals(targetValue)));
+            assertFalse(res.contains(j));
+         }
+      }
+   }
+
+   public void testIntegerLimit() {
+      Cache<Integer, String> cache = getCache(0);
+      int range = 10;
+      // First populate the cache with a bunch of values
+      IntStream.range(0, range).forEach(i -> cache.put(i, i + "-value"));
+      CacheSet<Integer> keySet = cache.keySet();
+
+      for (int i = 1; i < range; i++) {
+         List<Integer> res = createStream(keySet)
+                 .sorted().limit(i).collect(Collectors.toList());
+         assertEquals(i, res.size());
+         for (int j = res.size(); j < range; j++) {
+            assertFalse(res.contains(j));
          }
       }
    }

--- a/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
@@ -1496,12 +1496,11 @@ private static class ForEachIntInjected implements IntConsumer,
       IntStream.range(0, range).mapToDouble(value -> value).forEach(i -> cache.put(i, i + "-value"));
       CacheSet<Map.Entry<Double, String>> entrySet = cache.entrySet();
 
-      int cnt = range;
-      for (int i = 0; i < cnt; i++) {
+      for (int i = 0; i < range; i++) {
          List<Map.Entry<Double, String>> res = createStream(entrySet)
                  .sorted((o1, o2) -> o1.getKey().compareTo(o2.getKey()))
                  .skip(i).collect(Collectors.toList());
-         for (int j = 0; j < cnt - res.size(); j++) {
+         for (int j = 0; j < range - res.size(); j++) {
             String targetValue = (double) j + "-value";
             assertFalse(res.stream().anyMatch(v -> v.getValue().equals(targetValue)));
          }
@@ -1515,13 +1514,12 @@ private static class ForEachIntInjected implements IntConsumer,
       IntStream.range(0, range).mapToDouble(value -> value).forEach(i -> cache.put(i, i + "-value"));
       CacheSet<Map.Entry<Double, String>> entrySet = cache.entrySet();
 
-      int cnt = range;
-      for (int i = 1; i < cnt; i++) {
+      for (int i = 1; i < range; i++) {
          List<Map.Entry<Double, String>> res = createStream(entrySet)
                  .sorted((o1, o2) -> o1.getKey().compareTo(o2.getKey()))
                  .limit(i).collect(Collectors.toList());
          assertEquals(i, res.size());
-         for (int j = res.size(); j < cnt; j++) {
+         for (int j = res.size(); j < range; j++) {
             String targetValue = (double) j + "-value";
             assertFalse(res.stream().anyMatch(v -> v.getValue().equals(targetValue)));
          }

--- a/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
+++ b/core/src/test/java/org/infinispan/stream/BaseStreamTest.java
@@ -1489,6 +1489,48 @@ private static class ForEachIntInjected implements IntConsumer,
       assertFalse(createStream(entrySet).mapToDouble(toDouble).allMatch(i -> Math.floor(i) == i));
    }
 
+   public void testSkip() {
+      Cache<Double, String> cache = getCache(0);
+      int range = 10;
+      // First populate the cache with a bunch of values
+      IntStream.range(0,range).mapToDouble(value -> value).forEach(i -> cache.put(i, i + "-value"));
+      CacheSet<Map.Entry<Double, String>> entrySet = cache.entrySet();
+
+      int cnt = range;
+      for(int i = 0;i<cnt;i++){
+         List<Map.Entry<Double,String>> res = createStream(entrySet)
+                 .sorted((o1, o2) -> o1.getKey().compareTo(o2.getKey()))
+                 .skip(i).collect(Collectors.toList());
+         for(int j = 0;j< cnt - res.size();j++){
+            String targetValue = (double)j + "-value";
+            assertFalse(res.stream().anyMatch(v -> v.getValue().equals(targetValue)));
+         }
+      }
+   }
+
+   public void testLimit() {
+      Cache<Double, String> cache = getCache(0);
+      int range = 10;
+      // First populate the cache with a bunch of values
+      IntStream.range(0,range).mapToDouble(value -> value).forEach(i -> cache.put(i, i + "-value"));
+      CacheSet<Map.Entry<Double, String>> entrySet = cache.entrySet();
+      List<Map.Entry<Double,String>> total = createStream(entrySet)
+              .sorted((o1, o2) -> o1.getKey().compareTo(o2.getKey()))
+              .collect(Collectors.toList());
+
+      int cnt = range;
+      for(int i = 1;i<cnt;i++){
+         List<Map.Entry<Double,String>> res = createStream(entrySet)
+                 .sorted((o1, o2) -> o1.getKey().compareTo(o2.getKey()))
+                 .limit(i).collect(Collectors.toList());
+         assertEquals(i,res.size());
+         for(int j = res.size();j< cnt;j++){
+            String targetValue = (double)j + "-value";
+            assertFalse(res.stream().anyMatch(v -> v.getValue().equals(targetValue)));
+         }
+      }
+   }
+
    public void testDoubleAnyMatch() {
       Cache<Double, String> cache = getCache(0);
       int range = 10;


### PR DESCRIPTION
Perhaps I misunderstood the idea here but probably SkipOperation should use skip rather than limit on the stream at hand.