### PR TITLE
ISPN-6574 Implement JCache remote getCache()

### DIFF
--- a/jcache/commons/src/test/java/org/infinispan/jcache/util/JCacheTestingUtil.java
+++ b/jcache/commons/src/test/java/org/infinispan/jcache/util/JCacheTestingUtil.java
@@ -67,4 +67,8 @@ public class JCacheTestingUtil {
       return manager.createCache(cacheName, new MutableConfiguration());
    }
 
+   public static CacheManager createCacheManager(CachingProvider provider, Class invoker, String cacheName, Properties properties) {
+      return provider.getCacheManager(URI.create(invoker.getName()), new TestClassLoader(Thread.currentThread().getContextClassLoader()), properties);
+   }
+
 }

--- a/jcache/remote/src/main/java/org/infinispan/jcache/remote/JCacheManager.java
+++ b/jcache/remote/src/main/java/org/infinispan/jcache/remote/JCacheManager.java
@@ -1,8 +1,10 @@
 package org.infinispan.jcache.remote;
 
 import java.net.URI;
+import java.util.Objects;
 import java.util.Properties;
 
+import javax.cache.Cache;
 import javax.cache.configuration.Configuration;
 import javax.cache.spi.CachingProvider;
 
@@ -64,17 +66,49 @@ public class JCacheManager extends AbstractJCacheManager {
          throw log.cacheCreationFailed(cacheName, ex);
       }
 
+      return createJCache(cacheName, adapter);
+   }
+
+   private <K, V> AbstractJCache<K, V> createJCache(String cacheName, ConfigurationAdapter<K, V> adapter) {
+      RemoteCache<K, V> ispnCache = getRemoteCache(cm, cacheName);
+      RemoteCache<K, V> ispnCacheForceReturnValue = getRemoteCache(cmForceReturnValue, cacheName);
+      return new JCache<K, V>(ispnCache, ispnCacheForceReturnValue, this, adapter);
+   }
+
+   private <K, V> RemoteCache<K, V> getRemoteCache(RemoteCacheManager cm, String cacheName) {
       RemoteCache<K, V> ispnCache = cm.getCache(cacheName);
       if (ispnCache == null) {
          throw log.cacheNotFound(cacheName);
       }
+      return ispnCache;
+   }
 
+   @Override
+   public <K, V> Cache<K, V> getCache(String cacheName) {
+      Cache<K, V> cache = super.getCache(cacheName);
+      return Objects.isNull(cache)
+            ? createRegisterJCache(cacheName)
+            : cache;
+   }
+
+   public <K, V> Cache<K, V> createRegisterJCache(String cacheName) {
+      RemoteCache<K, V> ispnCache = cm.getCache(cacheName);
       RemoteCache<K, V> ispnCacheForceReturnValue = cmForceReturnValue.getCache(cacheName);
-      if (ispnCacheForceReturnValue == null) {
-         throw log.cacheNotFound(cacheName);
+      if (ispnCache != null && cmForceReturnValue != null) {
+         ConfigurationAdapter<K, V> adapter = ConfigurationAdapter.create();
+         JCache<K, V> jcache = new JCache<>(ispnCache, ispnCacheForceReturnValue, this, adapter);
+         registerPredefinedCache(cacheName, jcache);
+         return jcache;
       }
+      return null;
+   }
 
-      return new JCache<K, V>(ispnCache, ispnCacheForceReturnValue, this, adapter);
+   @Override
+   public <K, V> Cache<K, V> getCache(String cacheName, Class<K> keyType, Class<V> valueType) {
+      Cache<K, V> cache = super.getCache(cacheName, keyType, valueType);
+      return Objects.isNull(cache)
+            ? createRegisterJCache(cacheName)
+            : cache;
    }
 
    @Override

--- a/jcache/remote/src/test/java/org/infinispan/jcache/JCacheTwoCachesBasicOpsTest.java
+++ b/jcache/remote/src/test/java/org/infinispan/jcache/JCacheTwoCachesBasicOpsTest.java
@@ -4,36 +4,35 @@ import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.jcache.util.JCacheTestingUtil;
 import org.infinispan.server.hotrod.HotRodServer;
-import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import javax.cache.Cache;
+import javax.cache.CacheManager;
 import javax.cache.Caching;
 import java.lang.reflect.Method;
 import java.util.Properties;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
-import static org.infinispan.jcache.util.JCacheTestingUtil.createCacheWithProperties;
+import static org.infinispan.jcache.util.JCacheTestingUtil.createCacheManager;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 
 /**
  * @author Matej Cimbora
  */
 @Test(testName = "org.infinispan.jcache.JCacheTwoCachesBasicOpsTest", groups = "functional")
-@CleanupAfterMethod
 public class JCacheTwoCachesBasicOpsTest extends AbstractTwoCachesBasicOpsTest {
 
+   public static final String CACHE_NAME = "jcache-remote-cache";
    private HotRodServer hotRodServer1;
    private HotRodServer hotRodServer2;
-   private Cache cache1;
-   private Cache cache2;
+   private CacheManager cm1;
+   private CacheManager cm2;
    private ClassLoader testSpecificClassLoader;
 
    @Override
    protected void createCacheManagers() throws Throwable {
-
-      createClusteredCaches(2, "default", hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC)));
+      createClusteredCaches(2, CACHE_NAME, hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC)));
 
       hotRodServer1 = HotRodClientTestingUtil.startHotRodServer(cacheManagers.get(0));
       hotRodServer2 = HotRodClientTestingUtil.startHotRodServer(cacheManagers.get(1));
@@ -41,11 +40,11 @@ public class JCacheTwoCachesBasicOpsTest extends AbstractTwoCachesBasicOpsTest {
 
       Properties properties = new Properties();
       properties.put("infinispan.client.hotrod.server_list", hotRodServer1.getHost() + ":" + hotRodServer1.getPort());
-      cache1 = createCacheWithProperties(Caching.getCachingProvider(testSpecificClassLoader), JCacheTwoCachesBasicOpsTest.class, "default", properties);
+      cm1 = createCacheManager(Caching.getCachingProvider(testSpecificClassLoader), JCacheTwoCachesBasicOpsTest.class, CACHE_NAME, properties);
 
       properties = new Properties();
       properties.put("infinispan.client.hotrod.server_list", hotRodServer2.getHost() + ":" + hotRodServer2.getPort());
-      cache2 = createCacheWithProperties(Caching.getCachingProvider(testSpecificClassLoader), JCacheTwoCachesBasicOpsTest.class, "default", properties);
+      cm2 = createCacheManager(Caching.getCachingProvider(testSpecificClassLoader), JCacheTwoCachesBasicOpsTest.class, CACHE_NAME, properties);
 
       waitForClusterToForm("default");
    }
@@ -60,11 +59,11 @@ public class JCacheTwoCachesBasicOpsTest extends AbstractTwoCachesBasicOpsTest {
 
    @Override
    public Cache getCache1(Method m) {
-      return cache1;
+      return cm1.getCache(CACHE_NAME);
    }
 
    @Override
    public Cache getCache2(Method m) {
-      return cache2;
+      return cm2.getCache(CACHE_NAME);
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6574

* Provide a proper implementation for JCache remote getCache() method so
  that it verifies whether any remote caches exist and then wrap those
  inside a JCache instance and register it into the caches collection.