### PR TITLE
Update WildFly Extras Creaper to 1.1.0

### DIFF
--- a/server/integration/versions/pom.xml
+++ b/server/integration/versions/pom.xml
@@ -46,7 +46,7 @@
       <version.remoting.jmx.wildfly>2.0.1.Final</version.remoting.jmx.wildfly>
       <version.org.wildfly.build-tools>1.1.6.Final</version.org.wildfly.build-tools>
       <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>1.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>
-      <version.org.wildfly.extras.creaper>0.9.5</version.org.wildfly.extras.creaper>
+      <version.org.wildfly.extras.creaper>1.1.0</version.org.wildfly.extras.creaper>
       <version.org.xerial.snappy>1.0.5</version.org.xerial.snappy>
       <version.antrun.maven.plugin>1.8</version.antrun.maven.plugin>
       <version.xml.maven.plugin>1.0</version.xml.maven.plugin>


### PR DESCRIPTION
This fixes the issue with the previous versions being broken on Maven Central