### PR TITLE
ISPN-6576: backport to 8.2.x

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/api/functional/Param.java
+++ b/commons/src/main/java/org/infinispan/commons/api/functional/Param.java
@@ -111,6 +111,7 @@ public interface Param<P> {
       PERSIST, SKIP;
 
       public static final int ID = ParamIds.PERSISTENCE_MODE_ID;
+      private static final PersistenceMode[] CACHED_VALUES = values();
 
       @Override
       public int id() {
@@ -127,6 +128,10 @@ public interface Param<P> {
        */
       public static PersistenceMode defaultValue() {
          return PERSIST;
+      }
+
+      public static PersistenceMode valueOf(int ordinal) {
+         return CACHED_VALUES[ordinal];
       }
    }
 

--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -531,10 +531,10 @@ public interface CommandsFactory {
    <K, V> WriteOnlyKeyValueCommand<K, V> buildWriteOnlyKeyValueCommand(
       K key, V value, BiConsumer<V, WriteEntryView<V>> f, Params params);
 
-   <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Set<? extends K> keys, Consumer<WriteEntryView<V>> f);
+   <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Set<? extends K> keys, Consumer<WriteEntryView<V>> f, Params params);
 
-   <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Set<? extends K> keys, Function<ReadWriteEntryView<K,V>, R> f);
+   <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Set<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f, Params params);
 
-   <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K,V>, R> f);
+   <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f, Params params);
 
 }

--- a/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactoryImpl.java
@@ -729,13 +729,13 @@ public class CommandsFactoryImpl implements CommandsFactory {
    }
 
    @Override
-   public <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Set<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f) {
-      return new ReadWriteManyCommand<>(keys, f);
+   public <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Set<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f, Params params) {
+      return new ReadWriteManyCommand<>(keys, f, params);
    }
 
    @Override
-   public <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f) {
-      return new ReadWriteManyEntriesCommand<>(entries, f);
+   public <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f, Params params) {
+      return new ReadWriteManyEntriesCommand<>(entries, f, params);
    }
 
    @Override
@@ -751,16 +751,14 @@ public class CommandsFactoryImpl implements CommandsFactory {
    }
 
    @Override
-   public <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Set<? extends K> keys, Consumer<WriteEntryView<V>> f) {
-      return new WriteOnlyManyCommand<>(keys, f);
+   public <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Set<? extends K> keys, Consumer<WriteEntryView<V>> f, Params params) {
+      return new WriteOnlyManyCommand<>(keys, f, params);
    }
 
    @Override
    public <K, V> WriteOnlyManyEntriesCommand<K, V> buildWriteOnlyManyEntriesCommand(
          Map<? extends K, ? extends V> entries, BiConsumer<V, WriteEntryView<V>> f, Params params) {
-      WriteOnlyManyEntriesCommand<K, V> cmd = new WriteOnlyManyEntriesCommand<>(entries, f);
-      cmd.setParams(params);
-      return cmd;
+      return new WriteOnlyManyEntriesCommand<>(entries, f, params);
    }
 
    private ValueMatcher getValueMatcher(Object o) {

--- a/core/src/main/java/org/infinispan/commands/functional/AbstractWriteKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/AbstractWriteKeyCommand.java
@@ -5,7 +5,7 @@ import org.infinispan.commands.write.AbstractDataWriteCommand;
 import org.infinispan.commands.write.ValueMatcher;
 import org.infinispan.functional.impl.Params;
 
-abstract class AbstractWriteKeyCommand<K, V> extends AbstractDataWriteCommand implements ParamsCommand {
+public abstract class AbstractWriteKeyCommand<K, V> extends AbstractDataWriteCommand implements ParamsCommand {
 
    Params params;
    ValueMatcher valueMatcher;

--- a/core/src/main/java/org/infinispan/commands/functional/AbstractWriteManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/AbstractWriteManyCommand.java
@@ -4,7 +4,6 @@ import org.infinispan.commands.write.ValueMatcher;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.functional.impl.FunctionalNotifier;
 import org.infinispan.functional.impl.Params;
 import org.infinispan.metadata.Metadata;
 

--- a/core/src/main/java/org/infinispan/commands/functional/AbstractWriteManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/AbstractWriteManyCommand.java
@@ -9,7 +9,7 @@ import org.infinispan.metadata.Metadata;
 
 import java.util.Set;
 
-abstract class AbstractWriteManyCommand<K, V> implements WriteCommand, ParamsCommand {
+public abstract class AbstractWriteManyCommand<K, V> implements WriteCommand, ParamsCommand {
 
    boolean isForwarded = false;
    int topologyId = -1;

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyCommand.java
@@ -45,7 +45,7 @@ public final class ReadWriteKeyCommand<K, V, R> extends AbstractWriteKeyCommand<
       output.writeObject(key);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
       output.writeObject(Flag.copyWithoutRemotableFlags(flags));
       output.writeObject(commandInvocationId);
    }
@@ -55,7 +55,7 @@ public final class ReadWriteKeyCommand<K, V, R> extends AbstractWriteKeyCommand<
       key = input.readObject();
       f = (Function<ReadWriteEntryView<K, V>, R>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
       flags = (Set<Flag>) input.readObject();
       commandInvocationId = (CommandInvocationId) input.readObject();
    }

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyCommand.java
@@ -45,6 +45,7 @@ public final class ReadWriteKeyCommand<K, V, R> extends AbstractWriteKeyCommand<
       output.writeObject(key);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
       output.writeObject(Flag.copyWithoutRemotableFlags(flags));
       output.writeObject(commandInvocationId);
    }
@@ -54,6 +55,7 @@ public final class ReadWriteKeyCommand<K, V, R> extends AbstractWriteKeyCommand<
       key = input.readObject();
       f = (Function<ReadWriteEntryView<K, V>, R>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
+      params = Params.Externalizer.INSTANCE.readObject(input);
       flags = (Set<Flag>) input.readObject();
       commandInvocationId = (CommandInvocationId) input.readObject();
    }

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyValueCommand.java
@@ -56,7 +56,7 @@ public final class ReadWriteKeyValueCommand<K, V, R> extends AbstractWriteKeyCom
       output.writeObject(value);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
       output.writeObject(Flag.copyWithoutRemotableFlags(flags));
       output.writeObject(commandInvocationId);
       output.writeObject(prevValue);
@@ -69,7 +69,7 @@ public final class ReadWriteKeyValueCommand<K, V, R> extends AbstractWriteKeyCom
       value = (V) input.readObject();
       f = (BiFunction<V, ReadWriteEntryView<K, V>, R>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
       flags = (Set<Flag>) input.readObject();
       commandInvocationId = (CommandInvocationId) input.readObject();
       prevValue = (V) input.readObject();

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyValueCommand.java
@@ -56,6 +56,7 @@ public final class ReadWriteKeyValueCommand<K, V, R> extends AbstractWriteKeyCom
       output.writeObject(value);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
       output.writeObject(Flag.copyWithoutRemotableFlags(flags));
       output.writeObject(commandInvocationId);
       output.writeObject(prevValue);
@@ -68,6 +69,7 @@ public final class ReadWriteKeyValueCommand<K, V, R> extends AbstractWriteKeyCom
       value = (V) input.readObject();
       f = (BiFunction<V, ReadWriteEntryView<K, V>, R>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
+      params = Params.Externalizer.INSTANCE.readObject(input);
       flags = (Set<Flag>) input.readObject();
       commandInvocationId = (CommandInvocationId) input.readObject();
       prevValue = (V) input.readObject();

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyCommand.java
@@ -64,7 +64,7 @@ public final class ReadWriteManyCommand<K, V, R> extends AbstractWriteManyComman
       MarshallUtil.marshallCollection(keys, output);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
    }
 
    @Override
@@ -72,7 +72,7 @@ public final class ReadWriteManyCommand<K, V, R> extends AbstractWriteManyComman
       keys = MarshallUtil.unmarshallCollection(input, size -> new HashSet<>());
       f = (Function<ReadWriteEntryView<K, V>, R>) input.readObject();
       isForwarded = input.readBoolean();
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
    }
 
    public boolean isForwarded() {

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyCommand.java
@@ -1,16 +1,13 @@
 package org.infinispan.commands.functional;
 
 import org.infinispan.commands.Visitor;
-import org.infinispan.commands.write.ValueMatcher;
-import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.api.functional.EntryView.ReadWriteEntryView;
 import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.functional.impl.EntryViews;
+import org.infinispan.functional.impl.Params;
 import org.infinispan.lifecycle.ComponentStatus;
-import org.infinispan.metadata.Metadata;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -23,7 +20,7 @@ import java.util.function.Function;
 
 import static org.infinispan.functional.impl.EntryViews.snapshot;
 
-public final class ReadWriteManyCommand<K, V, R> implements WriteCommand {
+public final class ReadWriteManyCommand<K, V, R> extends AbstractWriteManyCommand {
 
    public static final byte COMMAND_ID = 52;
 
@@ -34,14 +31,16 @@ public final class ReadWriteManyCommand<K, V, R> implements WriteCommand {
    boolean isForwarded = false;
    private List<R> remoteReturns = new ArrayList<>();
 
-   public ReadWriteManyCommand(Set<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f) {
+   public ReadWriteManyCommand(Set<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f, Params params) {
       this.keys = keys;
       this.f = f;
+      this.params = params;
    }
 
    public ReadWriteManyCommand(ReadWriteManyCommand command) {
       this.keys = command.keys;
       this.f = command.f;
+      this.params = command.params;
    }
 
    public ReadWriteManyCommand() {
@@ -65,6 +64,7 @@ public final class ReadWriteManyCommand<K, V, R> implements WriteCommand {
       MarshallUtil.marshallCollection(keys, output);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
    }
 
    @Override
@@ -72,6 +72,7 @@ public final class ReadWriteManyCommand<K, V, R> implements WriteCommand {
       keys = MarshallUtil.unmarshallCollection(input, size -> new HashSet<>());
       f = (Function<ReadWriteEntryView<K, V>, R>) input.readObject();
       isForwarded = input.readBoolean();
+      params = Params.Externalizer.INSTANCE.readObject(input);
    }
 
    public boolean isForwarded() {
@@ -104,16 +105,6 @@ public final class ReadWriteManyCommand<K, V, R> implements WriteCommand {
    @Override
    public void setTopologyId(int topologyId) {
       this.topologyId = topologyId;
-   }
-
-   @Override
-   public ValueMatcher getValueMatcher() {
-      return ValueMatcher.MATCH_ALWAYS;
-   }
-
-   @Override
-   public void setValueMatcher(ValueMatcher valueMatcher) {
-      // No-op
    }
 
    @Override
@@ -179,35 +170,4 @@ public final class ReadWriteManyCommand<K, V, R> implements WriteCommand {
    public boolean alwaysReadsExistingValues() {
       return false;
    }
-
-   @Override
-   public Set<Flag> getFlags() {
-      return null;  // TODO: Customise this generated block
-   }
-
-   @Override
-   public void setFlags(Set<Flag> flags) {
-      // TODO: Customise this generated block
-   }
-
-   @Override
-   public void setFlags(Flag... flags) {
-      // TODO: Customise this generated block
-   }
-
-   @Override
-   public boolean hasFlag(Flag flag) {
-      return false;  // TODO: Customise this generated block
-   }
-
-   @Override
-   public Metadata getMetadata() {
-      return null;  // TODO: Customise this generated block
-   }
-
-   @Override
-   public void setMetadata(Metadata metadata) {
-      // TODO: Customise this generated block
-   }
-
 }

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyEntriesCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyEntriesCommand.java
@@ -63,7 +63,7 @@ public final class ReadWriteManyEntriesCommand<K, V, R> extends AbstractWriteMan
       output.writeObject(entries);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
    }
 
    @Override
@@ -71,7 +71,7 @@ public final class ReadWriteManyEntriesCommand<K, V, R> extends AbstractWriteMan
       entries = (Map<? extends K, ? extends V>) input.readObject();
       f = (BiFunction<V, ReadWriteEntryView<K, V>, R>) input.readObject();
       isForwarded = input.readBoolean();
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
    }
 
    public boolean isForwarded() {

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyEntriesCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyEntriesCommand.java
@@ -1,15 +1,12 @@
 package org.infinispan.commands.functional;
 
 import org.infinispan.commands.Visitor;
-import org.infinispan.commands.write.ValueMatcher;
-import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.api.functional.EntryView.ReadWriteEntryView;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.functional.impl.EntryViews;
+import org.infinispan.functional.impl.Params;
 import org.infinispan.lifecycle.ComponentStatus;
-import org.infinispan.metadata.Metadata;
 
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -22,7 +19,7 @@ import java.util.function.BiFunction;
 
 import static org.infinispan.functional.impl.EntryViews.snapshot;
 
-public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand {
+public final class ReadWriteManyEntriesCommand<K, V, R> extends AbstractWriteManyCommand {
 
    public static final byte COMMAND_ID = 53;
 
@@ -33,9 +30,10 @@ public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand 
    boolean isForwarded = false;
    private List<R> remoteReturns = new ArrayList<>();
 
-   public ReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f) {
+   public ReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f, Params params) {
       this.entries = entries;
       this.f = f;
+      this.params = params;
    }
 
    public ReadWriteManyEntriesCommand() {
@@ -44,6 +42,7 @@ public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand 
    public ReadWriteManyEntriesCommand(ReadWriteManyEntriesCommand command) {
       this.entries = command.entries;
       this.f = command.f;
+      this.params = command.params;
    }
 
    public Map<? extends K, ? extends V> getEntries() {
@@ -64,6 +63,7 @@ public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand 
       output.writeObject(entries);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
    }
 
    @Override
@@ -71,6 +71,7 @@ public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand 
       entries = (Map<? extends K, ? extends V>) input.readObject();
       f = (BiFunction<V, ReadWriteEntryView<K, V>, R>) input.readObject();
       isForwarded = input.readBoolean();
+      params = Params.Externalizer.INSTANCE.readObject(input);
    }
 
    public boolean isForwarded() {
@@ -140,16 +141,6 @@ public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand 
    }
 
    @Override
-   public ValueMatcher getValueMatcher() {
-      return ValueMatcher.MATCH_ALWAYS;
-   }
-
-   @Override
-   public void setValueMatcher(ValueMatcher valueMatcher) {
-      // No-op
-   }
-
-   @Override
    public Set<Object> getAffectedKeys() {
       return null;  // TODO: Customise this generated block
    }
@@ -169,7 +160,6 @@ public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand 
       return false;  // TODO: Customise this generated block
    }
 
-   @Override
    public boolean readsExistingValues() {
       return true;
    }
@@ -179,34 +169,7 @@ public final class ReadWriteManyEntriesCommand<K, V, R> implements WriteCommand 
       return false;
    }
 
-   @Override
-   public Set<Flag> getFlags() {
-      return null;  // TODO: Customise this generated block
+   public Set<? extends K> getKeys() {
+      return entries.keySet();
    }
-
-   @Override
-   public void setFlags(Set<Flag> flags) {
-      // TODO: Customise this generated block
-   }
-
-   @Override
-   public void setFlags(Flag... flags) {
-      // TODO: Customise this generated block
-   }
-
-   @Override
-   public boolean hasFlag(Flag flag) {
-      return false;  // TODO: Customise this generated block
-   }
-
-   @Override
-   public Metadata getMetadata() {
-      return null;  // TODO: Customise this generated block
-   }
-
-   @Override
-   public void setMetadata(Metadata metadata) {
-      // TODO: Customise this generated block
-   }
-
 }

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyCommand.java
@@ -42,6 +42,7 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K, 
       output.writeObject(key);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
       output.writeObject(Flag.copyWithoutRemotableFlags(flags));
       output.writeObject(commandInvocationId);
    }
@@ -51,6 +52,7 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K, 
       key = input.readObject();
       f = (Consumer<WriteEntryView<V>>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
+      params = Params.Externalizer.INSTANCE.readObject(input);
       flags = (Set<Flag>) input.readObject();
       commandInvocationId = (CommandInvocationId) input.readObject();
    }

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyCommand.java
@@ -42,7 +42,7 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K, 
       output.writeObject(key);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
       output.writeObject(Flag.copyWithoutRemotableFlags(flags));
       output.writeObject(commandInvocationId);
    }
@@ -52,7 +52,7 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K, 
       key = input.readObject();
       f = (Consumer<WriteEntryView<V>>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
       flags = (Set<Flag>) input.readObject();
       commandInvocationId = (CommandInvocationId) input.readObject();
    }

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyValueCommand.java
@@ -46,7 +46,7 @@ public final class WriteOnlyKeyValueCommand<K, V> extends AbstractWriteKeyComman
       output.writeObject(value);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
       output.writeObject(Flag.copyWithoutRemotableFlags(flags));
       output.writeObject(commandInvocationId);
    }
@@ -57,7 +57,7 @@ public final class WriteOnlyKeyValueCommand<K, V> extends AbstractWriteKeyComman
       value = (V) input.readObject();
       f = (BiConsumer<V, WriteEntryView<V>>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
       flags = (Set<Flag>) input.readObject();
       commandInvocationId = (CommandInvocationId) input.readObject();
    }

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyValueCommand.java
@@ -46,6 +46,7 @@ public final class WriteOnlyKeyValueCommand<K, V> extends AbstractWriteKeyComman
       output.writeObject(value);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
       output.writeObject(Flag.copyWithoutRemotableFlags(flags));
       output.writeObject(commandInvocationId);
    }
@@ -56,6 +57,7 @@ public final class WriteOnlyKeyValueCommand<K, V> extends AbstractWriteKeyComman
       value = (V) input.readObject();
       f = (BiConsumer<V, WriteEntryView<V>>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
+      params = Params.Externalizer.INSTANCE.readObject(input);
       flags = (Set<Flag>) input.readObject();
       commandInvocationId = (CommandInvocationId) input.readObject();
    }

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyCommand.java
@@ -58,7 +58,7 @@ public final class WriteOnlyManyCommand<K, V> extends AbstractWriteManyCommand<K
       MarshallUtil.marshallCollection(keys, output);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
    }
 
    @Override
@@ -66,7 +66,7 @@ public final class WriteOnlyManyCommand<K, V> extends AbstractWriteManyCommand<K
       keys = MarshallUtil.unmarshallCollectionUnbounded(input, HashSet::new);
       f = (Consumer<WriteEntryView<V>>) input.readObject();
       isForwarded = input.readBoolean();
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyCommand.java
@@ -6,6 +6,7 @@ import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.functional.impl.EntryViews;
+import org.infinispan.functional.impl.Params;
 import org.infinispan.lifecycle.ComponentStatus;
 
 import java.io.IOException;
@@ -24,14 +25,16 @@ public final class WriteOnlyManyCommand<K, V> extends AbstractWriteManyCommand<K
    private Set<? extends K> keys;
    private Consumer<WriteEntryView<V>> f;
 
-   public WriteOnlyManyCommand(Set<? extends K> keys, Consumer<WriteEntryView<V>> f) {
+   public WriteOnlyManyCommand(Set<? extends K> keys, Consumer<WriteEntryView<V>> f, Params params) {
       this.keys = keys;
       this.f = f;
+      this.params = params;
    }
 
    public WriteOnlyManyCommand(WriteOnlyManyCommand<K, V> command) {
       this.keys = command.getKeys();
       this.f = command.f;
+      this.params = command.params;
    }
 
    public WriteOnlyManyCommand() {
@@ -55,6 +58,7 @@ public final class WriteOnlyManyCommand<K, V> extends AbstractWriteManyCommand<K
       MarshallUtil.marshallCollection(keys, output);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
    }
 
    @Override
@@ -62,6 +66,7 @@ public final class WriteOnlyManyCommand<K, V> extends AbstractWriteManyCommand<K
       keys = MarshallUtil.unmarshallCollectionUnbounded(input, HashSet::new);
       f = (Consumer<WriteEntryView<V>>) input.readObject();
       isForwarded = input.readBoolean();
+      params = Params.Externalizer.INSTANCE.readObject(input);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyEntriesCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyEntriesCommand.java
@@ -55,7 +55,7 @@ public final class WriteOnlyManyEntriesCommand<K, V> extends AbstractWriteManyCo
       output.writeObject(entries);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
    }
 
    @Override
@@ -63,7 +63,7 @@ public final class WriteOnlyManyEntriesCommand<K, V> extends AbstractWriteManyCo
       entries = (Map<? extends K, ? extends V>) input.readObject();
       f = (BiConsumer<V, WriteEntryView<V>>) input.readObject();
       isForwarded = input.readBoolean();
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyEntriesCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyEntriesCommand.java
@@ -5,6 +5,7 @@ import org.infinispan.commons.api.functional.EntryView.WriteEntryView;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.functional.impl.EntryViews;
+import org.infinispan.functional.impl.Params;
 import org.infinispan.lifecycle.ComponentStatus;
 
 import java.io.IOException;
@@ -21,14 +22,16 @@ public final class WriteOnlyManyEntriesCommand<K, V> extends AbstractWriteManyCo
    private Map<? extends K, ? extends V> entries;
    private BiConsumer<V, WriteEntryView<V>> f;
 
-   public WriteOnlyManyEntriesCommand(Map<? extends K, ? extends V> entries, BiConsumer<V, WriteEntryView<V>> f) {
+   public WriteOnlyManyEntriesCommand(Map<? extends K, ? extends V> entries, BiConsumer<V, WriteEntryView<V>> f, Params params) {
       this.entries = entries;
       this.f = f;
+      this.params = params;
    }
 
    public WriteOnlyManyEntriesCommand(WriteOnlyManyEntriesCommand<K, V> command) {
       this.entries = command.entries;
       this.f = command.f;
+      this.params = command.params;
    }
 
    public WriteOnlyManyEntriesCommand() {
@@ -52,6 +55,7 @@ public final class WriteOnlyManyEntriesCommand<K, V> extends AbstractWriteManyCo
       output.writeObject(entries);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
+      Params.Externalizer.INSTANCE.writeObject(output, params);
    }
 
    @Override
@@ -59,6 +63,7 @@ public final class WriteOnlyManyEntriesCommand<K, V> extends AbstractWriteManyCo
       entries = (Map<? extends K, ? extends V>) input.readObject();
       f = (BiConsumer<V, WriteEntryView<V>>) input.readObject();
       isForwarded = input.readBoolean();
+      params = Params.Externalizer.INSTANCE.readObject(input);
    }
 
    @Override
@@ -119,4 +124,7 @@ public final class WriteOnlyManyEntriesCommand<K, V> extends AbstractWriteManyCo
       return true;
    }
 
+   public Set<? extends K> getKeys() {
+      return entries.keySet();
+   }
 }

--- a/core/src/main/java/org/infinispan/functional/impl/Params.java
+++ b/core/src/main/java/org/infinispan/functional/impl/Params.java
@@ -3,10 +3,17 @@ package org.infinispan.functional.impl;
 import org.infinispan.commons.api.functional.Param;
 import org.infinispan.commons.api.functional.Param.FutureMode;
 import org.infinispan.commons.api.functional.Param.PersistenceMode;
+import org.infinispan.commons.marshall.AdvancedExternalizer;
 import org.infinispan.commons.util.Experimental;
+import org.infinispan.marshall.core.Ids;
 
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
@@ -31,6 +38,10 @@ public final class Params {
       FutureMode.defaultValue(),
       PersistenceMode.defaultValue(),
    };
+   // TODO: as Params are immutable and there's only limited number of them,
+   // there could be a table with all the possible combinations and we
+   // wouldn't have to allocate at all
+   private static final Params DEFAULT_INSTANCE = new Params(DEFAULTS);
 
    final Param<?>[] params;
 
@@ -77,7 +88,7 @@ public final class Params {
    }
 
    public static Params create() {
-      return new Params(DEFAULTS);
+      return DEFAULT_INSTANCE;
    }
 
    public static Params from(Param<?>... ps) {
@@ -108,4 +119,35 @@ public final class Params {
       }
    }
 
+   public static class Externalizer implements AdvancedExternalizer<Params> {
+      public static Externalizer INSTANCE = new Externalizer();
+
+      @Override
+      public Set<Class<? extends Params>> getTypeClasses() {
+         return Collections.singleton(Params.class);
+      }
+
+      @Override
+      public Integer getId() {
+         return Ids.PARAMS;
+      }
+
+      @Override
+      public void writeObject(ObjectOutput output, Params params) throws IOException {
+         // There's no point in sending FutureMode over wire
+         output.writeInt(((PersistenceMode) params.get(PersistenceMode.ID).get()).ordinal());
+      }
+
+      @Override
+      public Params readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+         PersistenceMode persistenceMode = PersistenceMode.values()[input.readInt()];
+         if (persistenceMode == PersistenceMode.defaultValue()) {
+            return DEFAULT_INSTANCE;
+         } else {
+            Param[] params = Arrays.copyOf(DEFAULTS, DEFAULTS.length);
+            params[PersistenceMode.ID] = persistenceMode;
+            return new Params(params);
+         }
+      }
+   }
 }

--- a/core/src/main/java/org/infinispan/functional/impl/ReadWriteMapImpl.java
+++ b/core/src/main/java/org/infinispan/functional/impl/ReadWriteMapImpl.java
@@ -71,8 +71,7 @@ public final class ReadWriteMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    @Override
    public <R> Traversable<R> evalMany(Map<? extends K, ? extends V> entries, BiFunction<V, ReadWriteEntryView<K, V>, R> f) {
       log.tracef("Invoked evalMany(entries=%s, %s)", entries, params);
-      Param<FutureMode> futureMode = params.get(FutureMode.ID);
-      ReadWriteManyEntriesCommand cmd = fmap.cmdFactory().buildReadWriteManyEntriesCommand(entries, f);
+      ReadWriteManyEntriesCommand cmd = fmap.cmdFactory().buildReadWriteManyEntriesCommand(entries, f, params);
       InvocationContext ctx = fmap.invCtxFactory().createInvocationContext(true, entries.size());
       return Traversables.of(((List<R>) fmap.chain().invoke(ctx, cmd)).stream());
    }
@@ -80,8 +79,7 @@ public final class ReadWriteMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    @Override
    public <R> Traversable<R> evalMany(Set<? extends K> keys, Function<ReadWriteEntryView<K, V>, R> f) {
       log.tracef("Invoked evalMany(keys=%s, %s)", keys, params);
-      Param<FutureMode> futureMode = params.get(FutureMode.ID);
-      ReadWriteManyCommand cmd = fmap.cmdFactory().buildReadWriteManyCommand(keys, f);
+      ReadWriteManyCommand cmd = fmap.cmdFactory().buildReadWriteManyCommand(keys, f, params);
       InvocationContext ctx = fmap.invCtxFactory().createInvocationContext(true, keys.size());
       return Traversables.of(((List<R>) fmap.chain().invoke(ctx, cmd)).stream());
    }
@@ -89,9 +87,8 @@ public final class ReadWriteMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    @Override
    public <R> Traversable<R> evalAll(Function<ReadWriteEntryView<K, V>, R> f) {
       log.tracef("Invoked evalAll(%s)", params);
-      Param<FutureMode> futureMode = params.get(FutureMode.ID);
       CloseableIteratorSet<K> keys = fmap.cache.keySet();
-      ReadWriteManyCommand cmd = fmap.cmdFactory().buildReadWriteManyCommand(keys, f);
+      ReadWriteManyCommand cmd = fmap.cmdFactory().buildReadWriteManyCommand(keys, f, params);
       InvocationContext ctx = fmap.invCtxFactory().createInvocationContext(true, keys.size());
       return Traversables.of(((List<R>) fmap.chain().invoke(ctx, cmd)).stream());
    }

--- a/core/src/main/java/org/infinispan/functional/impl/WriteOnlyMapImpl.java
+++ b/core/src/main/java/org/infinispan/functional/impl/WriteOnlyMapImpl.java
@@ -80,7 +80,7 @@ public final class WriteOnlyMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
    public CompletableFuture<Void> evalMany(Set<? extends K> keys, Consumer<WriteEntryView<V>> f) {
       log.tracef("Invoked evalMany(keys=%s, %s)", keys, params);
       Param<FutureMode> futureMode = params.get(FutureMode.ID);
-      WriteOnlyManyCommand cmd = fmap.cmdFactory().buildWriteOnlyManyCommand(keys, f);
+      WriteOnlyManyCommand cmd = fmap.cmdFactory().buildWriteOnlyManyCommand(keys, f, params);
       InvocationContext ctx = fmap.invCtxFactory().createInvocationContext(true, keys.size());
       return futureVoid(futureMode, ctx, cmd);
    }
@@ -90,7 +90,7 @@ public final class WriteOnlyMapImpl<K, V> extends AbstractFunctionalMap<K, V> im
       log.tracef("Invoked evalAll(%s)", params);
       Param<FutureMode> futureMode = params.get(FutureMode.ID);
       CloseableIteratorSet<K> keys = fmap.cache.keySet();
-      WriteOnlyManyCommand cmd = fmap.cmdFactory().buildWriteOnlyManyCommand(keys, f);
+      WriteOnlyManyCommand cmd = fmap.cmdFactory().buildWriteOnlyManyCommand(keys, f, params);
       InvocationContext ctx = fmap.invCtxFactory().createInvocationContext(true, keys.size());
       return futureVoid(futureMode, ctx, cmd);
    }

--- a/core/src/main/java/org/infinispan/interceptors/CacheWriterInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/CacheWriterInterceptor.java
@@ -3,11 +3,7 @@ package org.infinispan.interceptors;
 import org.infinispan.atomic.impl.AtomicHashMap;
 import org.infinispan.commands.AbstractVisitor;
 import org.infinispan.commands.FlagAffectedCommand;
-import org.infinispan.commands.functional.ParamsCommand;
-import org.infinispan.commands.functional.ReadWriteKeyCommand;
-import org.infinispan.commands.functional.ReadWriteKeyValueCommand;
-import org.infinispan.commands.functional.WriteOnlyKeyCommand;
-import org.infinispan.commands.functional.WriteOnlyManyEntriesCommand;
+import org.infinispan.commands.functional.*;
 import org.infinispan.commands.tx.CommitCommand;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.commands.write.*;
@@ -48,6 +44,7 @@ import javax.transaction.TransactionManager;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.infinispan.factories.KnownComponentNames.CACHE_MARSHALLER;
@@ -225,6 +222,11 @@ public class CacheWriterInterceptor extends JmxStatsCommandInterceptor {
       return visitWriteCommand(ctx, command);
    }
 
+   @Override
+   public Object visitWriteOnlyKeyValueCommand(InvocationContext ctx, WriteOnlyKeyValueCommand command) throws Throwable {
+      return visitWriteCommand(ctx, command);
+   }
+
    private <T extends DataWriteCommand & ParamsCommand> Object visitWriteCommand(InvocationContext ctx, T command) throws Throwable {
       Object retval = invokeNextInterceptor(ctx, command);
       if (!isStoreEnabled(command) || ctx.isInTxScope() || !command.isSuccessful()) return retval;
@@ -243,6 +245,7 @@ public class CacheWriterInterceptor extends JmxStatsCommandInterceptor {
                   storeEntry(ctx, key, command);
                }
             }
+            log.trace("Skipping cache store since entry was not found in context");
             break;
          case SKIP:
             log.trace("Skipping cache store since persistence mode parameter is SKIP");
@@ -251,16 +254,35 @@ public class CacheWriterInterceptor extends JmxStatsCommandInterceptor {
    }
 
    @Override
+   public Object visitWriteOnlyManyCommand(InvocationContext ctx, WriteOnlyManyCommand command) throws Throwable {
+      return visitWriteManyCommand(ctx, command, command.getKeys());
+   }
+
+   @Override
    public Object visitWriteOnlyManyEntriesCommand(InvocationContext ctx, WriteOnlyManyEntriesCommand command) throws Throwable {
+      return visitWriteManyCommand(ctx, command, command.getKeys());
+   }
+
+   @Override
+   public Object visitReadWriteManyCommand(InvocationContext ctx, ReadWriteManyCommand command) throws Throwable {
+      return visitWriteManyCommand(ctx, command, command.getKeys());
+   }
+
+   @Override
+   public Object visitReadWriteManyEntriesCommand(InvocationContext ctx, ReadWriteManyEntriesCommand command) throws Throwable {
+      return visitWriteManyCommand(ctx, command, command.getKeys());
+   }
+
+
+   public <T extends WriteCommand & ParamsCommand, K> Object visitWriteManyCommand(InvocationContext ctx, T command, Set<Object> keys) throws Throwable {
       Object returnValue = invokeNextInterceptor(ctx, command);
       if (!isStoreEnabled(command) || ctx.isInTxScope()) return returnValue;
 
       Param<PersistenceMode> persistMode = command.getParams().get(PersistenceMode.ID);
       switch (persistMode.get()) {
          case PERSIST:
-            Map<Object, Object> map = command.getEntries();
             int storedCount = 0;
-            for (Object key : map.keySet()) {
+            for (Object key : keys) {
                CacheEntry entry = ctx.lookupEntry(key);
                if (entry != null) {
                   if (entry.isRemoved()) {

--- a/core/src/main/java/org/infinispan/interceptors/ClusteredCacheLoaderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/ClusteredCacheLoaderInterceptor.java
@@ -43,6 +43,36 @@ public class ClusteredCacheLoaderInterceptor extends CacheLoaderInterceptor {
    }
 
    @Override
+   protected boolean skipLoadForFunctionalWriteCommand(WriteCommand cmd, Object key, InvocationContext ctx) {
+      // the custom loading behaviour for functional commands happens only in DIST mode:
+      if (distributed
+            // TODO: functional API is not yet implemented for TX mode
+            && !transactional) {
+         /*
+          * Functional API in DIST: if we're the originator, we load only when
+          * we're the primary owner because the primary owner is responsible for
+          * replicating the command to other owners - and if we're not the
+          * primary owner, we forward it to one. And if we're not the
+          * originator, then this is either forwarded from non-primary owner, or
+          * replicated by primary owner to secondary owners, and the semantics
+          * of Functional API require that we must load.
+          */
+         if ((ctx.isOriginLocal() ? !cdl.localNodeIsPrimaryOwner(key) : !cdl.localNodeIsOwner(key))
+               // TODO Do we replicate CACHE_MODE_LOCAL commands?
+               && !cmd.hasFlag(Flag.CACHE_MODE_LOCAL)) {
+            if (trace) {
+               log.tracef("Skip load for functional command %s. This node is not an owner of %s", cmd, key);
+            }
+            return true;
+         } else {
+            // we can short-circuit here for we must load and no other condition will change it
+            return false;
+         }
+      }
+      return super.skipLoadForFunctionalWriteCommand(cmd, key, ctx);
+   }
+
+   @Override
    protected boolean skipLoadForWriteCommand(WriteCommand cmd, Object key, InvocationContext ctx) {
       if (!cmd.alwaysReadsExistingValues()) {
          if (transactional) {

--- a/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
+++ b/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
@@ -390,8 +390,6 @@ public class ExternalizerTable implements ObjectTable {
       addInternalExternalizer(new MarshallableFunctionExternalizers.ConstantLambdaExternalizer());
       addInternalExternalizer(new MarshallableFunctionExternalizers.LambdaWithMetasExternalizer());
       addInternalExternalizer(new MarshallableFunctionExternalizers.SetValueIfEqualsReturnBooleanExternalizer());
-
-      addInternalExternalizer(Params.Externalizer.INSTANCE);
    }
 
    void addInternalExternalizer(AdvancedExternalizer<?> ext) {

--- a/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
+++ b/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
@@ -69,6 +69,7 @@ import org.infinispan.filter.KeyValueFilterAsKeyFilter;
 import org.infinispan.filter.NullValueConverter;
 import org.infinispan.functional.impl.EntryViews;
 import org.infinispan.functional.impl.MetaParams;
+import org.infinispan.functional.impl.Params;
 import org.infinispan.marshall.exts.*;
 import org.infinispan.metadata.EmbeddedMetadata;
 import org.infinispan.metadata.impl.InternalMetadataImpl;
@@ -389,6 +390,8 @@ public class ExternalizerTable implements ObjectTable {
       addInternalExternalizer(new MarshallableFunctionExternalizers.ConstantLambdaExternalizer());
       addInternalExternalizer(new MarshallableFunctionExternalizers.LambdaWithMetasExternalizer());
       addInternalExternalizer(new MarshallableFunctionExternalizers.SetValueIfEqualsReturnBooleanExternalizer());
+
+      addInternalExternalizer(Params.Externalizer.INSTANCE);
    }
 
    void addInternalExternalizer(AdvancedExternalizer<?> ext) {

--- a/core/src/main/java/org/infinispan/marshall/core/Ids.java
+++ b/core/src/main/java/org/infinispan/marshall/core/Ids.java
@@ -172,4 +172,6 @@ public interface Ids extends org.infinispan.commons.marshall.Ids {
    int SYNC_REPLICATED_CONSISTENT_HASH_FACTORY = 164;
 
    int AFFINITY_FUNCTION_PARTITIONER = 165;
+
+   int PARAMS = 167;
 }

--- a/core/src/main/java/org/infinispan/marshall/core/Ids.java
+++ b/core/src/main/java/org/infinispan/marshall/core/Ids.java
@@ -173,5 +173,4 @@ public interface Ids extends org.infinispan.commons.marshall.Ids {
 
    int AFFINITY_FUNCTION_PARTITIONER = 165;
 
-   int PARAMS = 167;
 }

--- a/core/src/test/java/org/infinispan/functional/AbstractFunctionalOpTest.java
+++ b/core/src/test/java/org/infinispan/functional/AbstractFunctionalOpTest.java
@@ -1,0 +1,97 @@
+package org.infinispan.functional;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.infinispan.commons.api.functional.EntryView.ReadEntryView;
+import org.infinispan.commons.api.functional.EntryView.ReadWriteEntryView;
+import org.infinispan.commons.api.functional.EntryView.WriteEntryView;
+import org.infinispan.commons.api.functional.FunctionalMap.ReadWriteMap;
+import org.infinispan.commons.api.functional.FunctionalMap.WriteOnlyMap;
+import org.infinispan.Cache;
+import org.infinispan.commons.api.functional.Param;
+import org.infinispan.functional.impl.ReadWriteMapImpl;
+import org.infinispan.functional.impl.WriteOnlyMapImpl;
+import org.infinispan.remoting.transport.Address;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt; && Krzysztof Sobolewski &lt;Krzysztof.Sobolewski@atende.pl&gt;
+ */
+@Test(groups = "functional", testName = "functional.AbstractFunctionalOpTest")
+public abstract class AbstractFunctionalOpTest extends AbstractFunctionalTest {
+   @DataProvider(name = "owningModeAndMethod")
+   public static Object[][] booleans() {
+      return Stream.of(Boolean.TRUE, Boolean.FALSE)
+            .flatMap(isSourceOwner -> Stream.of(Method.values())
+                  .map(method -> new Object[] { isSourceOwner, method }))
+            .toArray(Object[][]::new);
+   }
+
+   static Address getAddress(Cache<Object, Object> cache) {
+      return cache.getAdvancedCache().getRpcManager().getAddress();
+   }
+
+   WriteOnlyMap<Object, String> wo;
+   ReadWriteMap<Object, String> rw;
+
+   public AbstractFunctionalOpTest() {
+      numNodes = 4;
+      numDistOwners = 2;
+      cleanup = CleanupPhase.AFTER_METHOD;
+   }
+
+   @Override
+   @BeforeMethod
+   public void createBeforeMethod() throws Throwable {
+      super.createBeforeMethod();
+      this.wo = WriteOnlyMapImpl.create(fmapD1).withParams(Param.FutureMode.COMPLETED);
+      this.rw = ReadWriteMapImpl.create(fmapD1).withParams(Param.FutureMode.COMPLETED);
+   }
+
+   static enum Method {
+      WO_EVAL((key, wo, rw, read, write) ->
+            wo.eval(key, write).join()),
+      WO_EVAL_VALUE((key, wo, rw, read, write) ->
+            wo.eval(key, null, (BiConsumer<String, WriteEntryView<String>> & Serializable)
+                  (v, view) -> write.accept(view)).join()),
+      WO_EVAL_MANY((key, wo, rw, read, write) ->
+            wo.evalMany(Collections.singleton(key), write).join()),
+      WO_EVAL_MANY_ENTRIES((key, wo, rw, read, write) -> 
+            wo.evalMany(Collections.singletonMap(key, null), (BiConsumer<String, WriteEntryView<String>> & Serializable)
+                  (v, view) -> write.accept(view)).join()),
+      RW_EVAL((key, wo, rw, read, write) ->
+            rw.eval(key, (Function<ReadWriteEntryView<Object, String>, Object> & Serializable)
+                  view -> { read.accept(view); write.accept(view); return null; }).join()),
+      RW_EVAL_VALUE((key, wo, rw, read, write) ->
+            rw.eval(key, null, (BiFunction<String, ReadWriteEntryView<Object, String>, Object> & Serializable)
+                  (v, view) -> { read.accept(view); write.accept(view); return null; }).join()),
+      RW_EVAL_MANY((key, wo, rw, read, write) ->
+            rw.evalMany(Collections.singleton(key), (Function<ReadWriteEntryView<Object, String>, Object> & Serializable)
+                  view -> { read.accept(view); write.accept(view); return null; }).forEach(v -> {})),
+      RW_EVAL_MANY_ENTRIES((key, wo, rw, read, write) ->
+            rw.evalMany(Collections.singletonMap(key, null), (BiFunction<String, ReadWriteEntryView<Object, String>, Object> & Serializable)
+                  (v, view) -> { read.accept(view); write.accept(view); return null; }).forEach(v -> {})),
+      ;
+
+      final Performer action;
+
+      private Method(Performer action) {
+         this.action = action;
+      }
+
+      @FunctionalInterface
+      static interface Performer {
+         void eval(Object key,
+               WriteOnlyMap<Object, String> wo, ReadWriteMap<Object, String> rw,
+               Consumer<ReadEntryView<Object, String>> read, Consumer<WriteEntryView<String>> write);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/functional/AbstractFunctionalReadOnlyOpTest.java
+++ b/core/src/test/java/org/infinispan/functional/AbstractFunctionalReadOnlyOpTest.java
@@ -1,0 +1,69 @@
+package org.infinispan.functional;
+
+import java.util.Collections;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.infinispan.commons.api.functional.EntryView.ReadEntryView;
+import org.infinispan.commons.api.functional.FunctionalMap.ReadOnlyMap;
+import org.infinispan.Cache;
+import org.infinispan.commons.api.functional.Param;
+import org.infinispan.functional.impl.ReadOnlyMapImpl;
+import org.infinispan.remoting.transport.Address;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt; && Krzysztof Sobolewski &lt;Krzysztof.Sobolewski@atende.pl&gt;
+ */
+@Test(groups = "functional", testName = "functional.AbstractFunctionalOpTest")
+public abstract class AbstractFunctionalReadOnlyOpTest extends AbstractFunctionalTest {
+   @DataProvider(name = "owningModeAndMethod")
+   public static Object[][] booleans() {
+      return Stream.of(Boolean.TRUE, Boolean.FALSE)
+            .flatMap(isSourceOwner -> Stream.of(Method.values())
+                  .map(method -> new Object[] { isSourceOwner, method }))
+            .toArray(Object[][]::new);
+   }
+
+   static Address getAddress(Cache<Object, Object> cache) {
+      return cache.getAdvancedCache().getRpcManager().getAddress();
+   }
+
+   ReadOnlyMap<Object, String> ro;
+
+   public AbstractFunctionalReadOnlyOpTest() {
+      numNodes = 4;
+      numDistOwners = 2;
+      cleanup = CleanupPhase.AFTER_METHOD;
+   }
+
+   @Override
+   @BeforeMethod
+   public void createBeforeMethod() throws Throwable {
+      super.createBeforeMethod();
+      this.ro = ReadOnlyMapImpl.create(fmapD1).withParams(Param.FutureMode.COMPLETED);
+   }
+
+   static enum Method {
+      RO_EVAL((key, ro, read) ->
+            ro.eval(key, view -> { read.accept(view); return null; }).join()),
+      RO_EVAL_MANY((key, ro, read) ->
+            ro.evalMany(Collections.singleton(key), view -> { read.accept(view); return null; }).forEach(v -> {})),
+      ;
+
+      final Performer action;
+
+      private Method(Performer action) {
+         this.action = action;
+      }
+
+      @FunctionalInterface
+      static interface Performer {
+         void eval(Object key,
+               ReadOnlyMap<Object, String> ro,
+               Consumer<ReadEntryView<Object, String>> read);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
@@ -3,6 +3,7 @@ package org.infinispan.functional;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.functional.impl.FunctionalMapImpl;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.testng.annotations.BeforeClass;
 
@@ -25,14 +26,18 @@ abstract class AbstractFunctionalTest extends MultipleCacheManagersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       // Create local caches as default in a cluster of 2
-      createClusteredCaches(2, new ConfigurationBuilder());
+      ConfigurationBuilder localBuilder = new ConfigurationBuilder();
+      localBuilder.persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class);
+      createClusteredCaches(2, localBuilder);
       // Create distributed caches
       ConfigurationBuilder distBuilder = new ConfigurationBuilder();
       distBuilder.clustering().cacheMode(CacheMode.DIST_SYNC).hash().numOwners(1);
+      distBuilder.persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class);
       cacheManagers.stream().forEach(cm -> cm.defineConfiguration(DIST, distBuilder.build()));
       // Create replicated caches
       ConfigurationBuilder replBuilder = new ConfigurationBuilder();
       replBuilder.clustering().cacheMode(CacheMode.REPL_SYNC);
+      replBuilder.persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class);
       cacheManagers.stream().forEach(cm -> cm.defineConfiguration(REPL, replBuilder.build()));
       // Wait for cluster to form
       waitForClusterToForm(DIST, REPL);

--- a/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
@@ -17,6 +17,7 @@ abstract class AbstractFunctionalTest extends MultipleCacheManagersTest {
    // Create local caches as default in a cluster of 2
    int numNodes = 2;
    int numDistOwners = 1;
+   boolean isSync = true;
    boolean isPersistenceEnabled = true;
 
    FunctionalMapImpl<Integer, String> fmapL1;
@@ -37,14 +38,14 @@ abstract class AbstractFunctionalTest extends MultipleCacheManagersTest {
       createClusteredCaches(numNodes, localBuilder);
       // Create distributed caches
       ConfigurationBuilder distBuilder = new ConfigurationBuilder();
-      distBuilder.clustering().cacheMode(CacheMode.DIST_SYNC).hash().numOwners(numDistOwners);
+      distBuilder.clustering().cacheMode(isSync ? CacheMode.DIST_SYNC : CacheMode.DIST_ASYNC).hash().numOwners(numDistOwners);
       if (isPersistenceEnabled) {
          distBuilder.persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class);
       }
       cacheManagers.stream().forEach(cm -> cm.defineConfiguration(DIST, distBuilder.build()));
       // Create replicated caches
       ConfigurationBuilder replBuilder = new ConfigurationBuilder();
-      replBuilder.clustering().cacheMode(CacheMode.REPL_SYNC);
+      replBuilder.clustering().cacheMode(isSync ? CacheMode.REPL_SYNC : CacheMode.REPL_ASYNC);
       if (isPersistenceEnabled) {
          replBuilder.persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class);
       }

--- a/core/src/test/java/org/infinispan/functional/FunctionalCachestoreReadOnlyTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalCachestoreReadOnlyTest.java
@@ -1,0 +1,68 @@
+package org.infinispan.functional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.api.functional.EntryView.ReadEntryView;
+import org.infinispan.persistence.dummy.DummyInMemoryStore;
+import org.infinispan.persistence.manager.PersistenceManager;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt; && Krzysztof Sobolewski &lt;Krzysztof.Sobolewski@atende.pl&gt;
+ */
+@Test(groups = "functional", testName = "functional.FunctionalCachestoreTest")
+public class FunctionalCachestoreReadOnlyTest extends AbstractFunctionalReadOnlyOpTest {
+   public FunctionalCachestoreReadOnlyTest() {
+      isPersistenceEnabled = true;
+   }
+
+   @Test(dataProvider = "owningModeAndMethod")
+   public void testLoad(boolean isSourceOwner, Method method) {
+      Object key;
+      if (isSourceOwner) {
+         // this is simple: find a key that is local to the originating node
+         key = getKeyForCache(0, DIST);
+      } else {
+         // this is more complicated: we need a key that is *not* local to the originating node
+         key = IntStream.iterate(0, i -> i + 1)
+               .mapToObj(i -> "key" + i)
+               .filter(k -> !cache(0, DIST).getAdvancedCache().getDistributionManager().getLocality(k).isLocal())
+               .findAny()
+               .get();
+      }
+      List<Cache<Object, Object>> owners = caches(DIST).stream()
+            .filter(cache -> cache.getAdvancedCache().getDistributionManager().getLocality(key).isLocal())
+            .collect(Collectors.toList());
+
+      method.action.eval(key, ro,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> assertFalse(view.find().isPresent()));
+
+      // we can't add from read-only cache, so we put manually:
+      cache(0, DIST).put(key, "value");
+
+      caches(DIST).forEach(cache -> assertEquals(cache.get(key), "value", getAddress(cache).toString()));
+      caches(DIST).forEach(cache -> cache.evict(key));
+      caches(DIST).forEach(cache -> assertFalse(cache.getAdvancedCache().getDataContainer().containsKey(key), getAddress(cache).toString()));
+      owners.forEach(cache -> {
+         Set<DummyInMemoryStore> stores = cache.getAdvancedCache().getComponentRegistry().getComponent(PersistenceManager.class).getStores(DummyInMemoryStore.class);
+         DummyInMemoryStore store = stores.iterator().next();
+         assertTrue(store.contains(key), getAddress(cache).toString());
+      });
+
+      method.action.eval(key, ro,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> {
+               assertTrue(view.find().isPresent());
+               assertEquals(view.get(), "value");
+            });
+   }
+}

--- a/core/src/test/java/org/infinispan/functional/FunctionalCachestoreTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalCachestoreTest.java
@@ -1,0 +1,68 @@
+package org.infinispan.functional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.api.functional.EntryView.ReadEntryView;
+import org.infinispan.commons.api.functional.EntryView.WriteEntryView;
+import org.infinispan.persistence.dummy.DummyInMemoryStore;
+import org.infinispan.persistence.manager.PersistenceManager;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt; && Krzysztof Sobolewski &lt;Krzysztof.Sobolewski@atende.pl&gt;
+ */
+@Test(groups = "functional", testName = "functional.FunctionalCachestoreTest")
+public class FunctionalCachestoreTest extends AbstractFunctionalOpTest {
+   public FunctionalCachestoreTest() {
+      isPersistenceEnabled = true;
+   }
+
+   @Test(dataProvider = "owningModeAndMethod")
+   public void testLoad(boolean isSourceOwner, Method method) {
+      Object key;
+      if (isSourceOwner) {
+         // this is simple: find a key that is local to the originating node
+         key = getKeyForCache(0, DIST);
+      } else {
+         // this is more complicated: we need a key that is *not* local to the originating node
+         key = IntStream.iterate(0, i -> i + 1)
+               .mapToObj(i -> "key" + i)
+               .filter(k -> !cache(0, DIST).getAdvancedCache().getDistributionManager().getLocality(k).isLocal())
+               .findAny()
+               .get();
+      }
+      List<Cache<Object, Object>> owners = caches(DIST).stream()
+            .filter(cache -> cache.getAdvancedCache().getDistributionManager().getLocality(key).isLocal())
+            .collect(Collectors.toList());
+
+      method.action.eval(key, wo, rw,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> assertFalse(view.find().isPresent()),
+            (Consumer<WriteEntryView<String>> & Serializable) view -> view.set("value"));
+
+      caches(DIST).forEach(cache -> assertEquals(cache.get(key), "value", getAddress(cache).toString()));
+      caches(DIST).forEach(cache -> cache.evict(key));
+      caches(DIST).forEach(cache -> assertFalse(cache.getAdvancedCache().getDataContainer().containsKey(key), getAddress(cache).toString()));
+      owners.forEach(cache -> {
+         Set<DummyInMemoryStore> stores = cache.getAdvancedCache().getComponentRegistry().getComponent(PersistenceManager.class).getStores(DummyInMemoryStore.class);
+         DummyInMemoryStore store = stores.iterator().next();
+         assertTrue(store.contains(key), getAddress(cache).toString());
+      });
+
+      method.action.eval(key, wo, rw,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> {
+               assertTrue(view.find().isPresent());
+               assertEquals(view.get(), "value");
+            },
+            (Consumer<WriteEntryView<String>> & Serializable) view -> {});
+   }
+}

--- a/core/src/test/java/org/infinispan/functional/FunctionalDistributionTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalDistributionTest.java
@@ -1,0 +1,105 @@
+package org.infinispan.functional;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.commons.api.functional.EntryView.ReadWriteEntryView;
+import org.infinispan.commons.api.functional.FunctionalMap.ReadWriteMap;
+import org.infinispan.functional.impl.FunctionalMapImpl;
+import org.infinispan.functional.impl.ReadWriteMapImpl;
+import org.infinispan.test.TestingUtil;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * @author Krzysztof Sobolewski &lt;Krzysztof.Sobolewski@atende.pl&gt;
+ */
+@Test(groups = "functional", testName = "functional.FunctionalDistributionTest")
+public class FunctionalDistributionTest extends AbstractFunctionalTest {
+   public FunctionalDistributionTest() {
+      numNodes = 4;
+      // we want some non-owners and some secondary owners:
+      numDistOwners = 2;
+      /*
+       * The potential problem arises in async mode: the non-primary owner
+       * executes, then forwards to the primary owner, which executes and
+       * forwards to all non-primary owners, including the originator, which
+       * executes again. In sync mode this does not cause problems because the
+       * second invocation on the originator happens before the first is
+       * committed so it receives the same input data. Not so in async mode.
+       */
+      isSync = false;
+   }
+
+   @BeforeClass
+   @Override
+   public void createBeforeClass() throws Throwable {
+      super.createBeforeClass();
+   }
+
+   public void testDistributionFromPrimaryOwner() throws InterruptedException {
+      Object key = "testDistributionFromPrimaryOwner";
+      doTestDistribution(key, cacheManagers.stream()
+            .map(cm -> cm.<Object, Integer> getCache(DIST).getAdvancedCache())
+            .filter(cache -> cache.getDistributionManager().getPrimaryLocation(key)
+                  .equals(cache.getRpcManager().getAddress()))
+            .findAny()
+            .get());
+   }
+
+   public void testDistributionFromSecondaryOwner() throws InterruptedException {
+      Object key = "testDistributionFromSecondaryOwner";
+      doTestDistribution(key, cacheManagers.stream()
+            .map(cm -> cm.<Object, Integer> getCache(DIST).getAdvancedCache())
+            // owner...
+            .filter(cache -> cache.getDistributionManager().getLocality(key).isLocal()
+                  // ...but not primary owner
+                  && !cache.getDistributionManager().getPrimaryLocation(key)
+                        .equals(cache.getRpcManager().getAddress()))
+            .findAny()
+            .get());
+   }
+
+   public void testDistributionFromNonOwner() throws InterruptedException {
+      Object key = "testDistributionFromNonOwner";
+      doTestDistribution(key, cacheManagers.stream()
+            .map(cm -> cm.<Object, Integer> getCache(DIST).getAdvancedCache())
+            .filter(cache -> !cache.getDistributionManager().getLocality(key).isLocal())
+            .findAny()
+            .get());
+   }
+
+   private void doTestDistribution(Object key, AdvancedCache<Object, Integer> originator) throws InterruptedException {
+      ReadWriteMap<Object, Integer> rw = ReadWriteMapImpl.create(FunctionalMapImpl.create(originator));
+
+      // with empty cache:
+      iterate(key, rw, 1);
+      // again:
+      iterate(key, rw, 2);
+   }
+
+   private void iterate(Object key, ReadWriteMap<Object, Integer> rw, int expectedValue) throws InterruptedException {
+      rw.eval(key, (Function<ReadWriteEntryView<Object, Integer>, Void> & Serializable)
+            entry -> {
+               // we need a small delay so that the value gets committed before the replication finishes:
+               TestingUtil.sleepThread(10);
+               return entry.set(entry.find().orElse(0) + 1);
+            }).join();
+
+      // since we're in async mode, we need to wait before the replication finishes
+      Thread.sleep(100); // TODO: find a better way?
+
+      // we want to ensure that each of the owners executes the function only once:
+      Assert.assertEquals(
+            (Object) cacheManagers.stream()
+                  .map(cm -> cm.<Object, Integer> getCache(DIST).getAdvancedCache())
+                  .filter(cache -> cache.getDistributionManager().getLocality(key).isLocal())
+                  .map(cache -> cache.getDataContainer().get(key).getValue())
+                  .collect(Collectors.toList()),
+            Collections.nCopies(numDistOwners, expectedValue));
+   }
+}

--- a/core/src/test/java/org/infinispan/functional/FunctionalInMemoryReadOnlyTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalInMemoryReadOnlyTest.java
@@ -1,0 +1,59 @@
+package org.infinispan.functional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+
+import org.infinispan.commons.api.functional.EntryView.ReadEntryView;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt; && Krzysztof Sobolewski &lt;Krzysztof.Sobolewski@atende.pl&gt;
+ */
+@Test(groups = "functional", testName = "functional.FunctionalInMemoryTest")
+public class FunctionalInMemoryReadOnlyTest extends AbstractFunctionalReadOnlyOpTest {
+   public FunctionalInMemoryReadOnlyTest() {
+      isPersistenceEnabled = false;
+   }
+
+   @Test(dataProvider = "owningModeAndMethod")
+   public void testLoad(boolean isSourceOwner, Method method) {
+      Object key;
+      if (isSourceOwner) {
+         // this is simple: find a key that is local to the originating node
+         key = getKeyForCache(0, DIST);
+      } else {
+         // this is more complicated: we need a key that is *not* local to the originating node
+         key = IntStream.iterate(0, i -> i + 1)
+               .mapToObj(i -> "key" + i)
+               .filter(k -> !cache(0, DIST).getAdvancedCache().getDistributionManager().getLocality(k).isLocal())
+               .findAny()
+               .get();
+      }
+
+      method.action.eval(key, ro,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> assertFalse(view.find().isPresent()));
+
+      // we can't add from read-only cache, so we put manually:
+      cache(0, DIST).put(key, "value");
+
+      caches(DIST).forEach(cache -> assertEquals(cache.get(key), "value", getAddress(cache).toString()));
+      caches(DIST).forEach(cache -> {
+         if (cache.getAdvancedCache().getDistributionManager().getLocality(key).isLocal()) {
+            assertTrue(cache.getAdvancedCache().getDataContainer().containsKey(key), getAddress(cache).toString());
+         } else {
+            assertFalse(cache.getAdvancedCache().getDataContainer().containsKey(key), getAddress(cache).toString());
+         }
+      });
+
+      method.action.eval(key, ro,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> {
+               assertTrue(view.find().isPresent());
+               assertEquals(view.get(), "value");
+            });
+   }
+}

--- a/core/src/test/java/org/infinispan/functional/FunctionalInMemoryTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalInMemoryTest.java
@@ -1,0 +1,59 @@
+package org.infinispan.functional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+
+import org.infinispan.commons.api.functional.EntryView.ReadEntryView;
+import org.infinispan.commons.api.functional.EntryView.WriteEntryView;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt; && Krzysztof Sobolewski &lt;Krzysztof.Sobolewski@atende.pl&gt;
+ */
+@Test(groups = "functional", testName = "functional.FunctionalInMemoryTest")
+public class FunctionalInMemoryTest extends AbstractFunctionalOpTest {
+   public FunctionalInMemoryTest() {
+      isPersistenceEnabled = false;
+   }
+
+   @Test(dataProvider = "owningModeAndMethod")
+   public void testLoad(boolean isSourceOwner, Method method) {
+      Object key;
+      if (isSourceOwner) {
+         // this is simple: find a key that is local to the originating node
+         key = getKeyForCache(0, DIST);
+      } else {
+         // this is more complicated: we need a key that is *not* local to the originating node
+         key = IntStream.iterate(0, i -> i + 1)
+               .mapToObj(i -> "key" + i)
+               .filter(k -> !cache(0, DIST).getAdvancedCache().getDistributionManager().getLocality(k).isLocal())
+               .findAny()
+               .get();
+      }
+
+      method.action.eval(key, wo, rw,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> assertFalse(view.find().isPresent()),
+            (Consumer<WriteEntryView<String>> & Serializable) view -> view.set("value"));
+
+      caches(DIST).forEach(cache -> assertEquals(cache.get(key), "value", getAddress(cache).toString()));
+      caches(DIST).forEach(cache -> {
+         if (cache.getAdvancedCache().getDistributionManager().getLocality(key).isLocal()) {
+            assertTrue(cache.getAdvancedCache().getDataContainer().containsKey(key), getAddress(cache).toString());
+         } else {
+            assertFalse(cache.getAdvancedCache().getDataContainer().containsKey(key), getAddress(cache).toString());
+         }
+      });
+
+      method.action.eval(key, wo, rw,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> {
+               assertTrue(view.find().isPresent());
+               assertEquals(view.get(), "value");
+            },
+            (Consumer<WriteEntryView<String>> & Serializable) view -> {});
+   }
+}

--- a/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
+++ b/core/src/test/java/org/infinispan/util/mocks/ControlledCommandFactory.java
@@ -448,18 +448,18 @@ public class ControlledCommandFactory implements CommandsFactory {
    }
 
    @Override
-   public <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Set<? extends K> keys, Consumer<EntryView.WriteEntryView<V>> f) {
-      return actual.buildWriteOnlyManyCommand(keys, f);
+   public <K, V> WriteOnlyManyCommand<K, V> buildWriteOnlyManyCommand(Set<? extends K> keys, Consumer<EntryView.WriteEntryView<V>> f, Params params) {
+      return actual.buildWriteOnlyManyCommand(keys, f, params);
    }
 
    @Override
-   public <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Set<? extends K> keys, Function<EntryView.ReadWriteEntryView<K, V>, R> f) {
-      return actual.buildReadWriteManyCommand(keys, f);
+   public <K, V, R> ReadWriteManyCommand<K, V, R> buildReadWriteManyCommand(Set<? extends K> keys, Function<EntryView.ReadWriteEntryView<K, V>, R> f, Params params) {
+      return actual.buildReadWriteManyCommand(keys, f, params);
    }
 
    @Override
-   public <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, EntryView.ReadWriteEntryView<K, V>, R> f) {
-      return actual.buildReadWriteManyEntriesCommand(entries, f);
+   public <K, V, R> ReadWriteManyEntriesCommand<K, V, R> buildReadWriteManyEntriesCommand(Map<? extends K, ? extends V> entries, BiFunction<V, EntryView.ReadWriteEntryView<K, V>, R> f, Params params) {
+      return actual.buildReadWriteManyEntriesCommand(entries, f, params);
    }
 
 }


### PR DESCRIPTION
The tests are a little different than the ones attached to the issue - there are fewer classes and the tests in transactional mode are disabled (because of ISPN-6573). The fix is almost too simple to make me confident it's the right one :)