### PR TITLE
ISPN-6593 Adjust JNI LevelDB for Windows

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodNonIndexedSingleFileStoreQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodNonIndexedSingleFileStoreQueryTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.client.hotrod.query;
 
 import org.infinispan.commons.equivalence.ByteArrayEquivalence;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder;
 import org.infinispan.test.TestingUtil;
@@ -17,7 +18,7 @@ public class HotRodNonIndexedSingleFileStoreQueryTest extends HotRodNonIndexedQu
 
    @Override
    protected void setup() throws Exception {
-      TestingUtil.recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
       super.setup();
    }
 
@@ -26,7 +27,7 @@ public class HotRodNonIndexedSingleFileStoreQueryTest extends HotRodNonIndexedQu
       try {
          super.teardown();
       } finally {
-         TestingUtil.recursiveFileRemove(tmpDirectory);
+         Util.recursiveFileRemove(tmpDirectory);
       }
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryFileSystemTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryFileSystemTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.client.hotrod.query;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.TestingUtil;
 import org.junit.Assert;
@@ -29,7 +30,7 @@ public class HotRodQueryFileSystemTest extends HotRodQueryTest {
 
    @Override
    protected void setup() throws Exception {
-      TestingUtil.recursiveFileRemove(indexDirectory);
+      Util.recursiveFileRemove(indexDirectory);
       boolean created = new File(indexDirectory).mkdirs();
       Assert.assertTrue(created);
       super.setup();
@@ -42,7 +43,7 @@ public class HotRodQueryFileSystemTest extends HotRodQueryTest {
          super.teardown();
       } finally {
          //delete the index otherwise it will mess up the index for next tests
-         TestingUtil.recursiveFileRemove(indexDirectory);
+         Util.recursiveFileRemove(indexDirectory);
       }
    }
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsFilesystemTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsFilesystemTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.client.hotrod.query;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.TestingUtil;
 import org.testng.annotations.AfterClass;
@@ -23,7 +24,7 @@ public class RemoteQueryDslConditionsFilesystemTest extends RemoteQueryDslCondit
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      TestingUtil.recursiveFileRemove(indexDirectory);
+      Util.recursiveFileRemove(indexDirectory);
       boolean created = new File(indexDirectory).mkdirs();
       assertTrue(created);
 
@@ -47,7 +48,7 @@ public class RemoteQueryDslConditionsFilesystemTest extends RemoteQueryDslCondit
          super.destroy();
       } finally {
          //delete the index otherwise it will mess up the index for next tests
-         TestingUtil.recursiveFileRemove(indexDirectory);
+         Util.recursiveFileRemove(indexDirectory);
       }
    }
 }

--- a/commons/src/main/java/org/infinispan/commons/util/Util.java
+++ b/commons/src/main/java/org/infinispan/commons/util/Util.java
@@ -1,7 +1,17 @@
 package org.infinispan.commons.util;
 
+import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.commons.CacheException;
+import org.infinispan.commons.hash.Hash;
+import org.infinispan.commons.logging.Log;
+import org.infinispan.commons.logging.LogFactory;
+import org.infinispan.commons.marshall.Marshaller;
+
+import javax.naming.Context;
+import javax.security.auth.Subject;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -31,16 +41,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-
-import javax.naming.Context;
-import javax.security.auth.Subject;
-
-import org.infinispan.commons.CacheConfigurationException;
-import org.infinispan.commons.CacheException;
-import org.infinispan.commons.hash.Hash;
-import org.infinispan.commons.logging.Log;
-import org.infinispan.commons.logging.LogFactory;
-import org.infinispan.commons.marshall.Marshaller;
 
 /**
  * General utility methods used throughout the Infinispan code base.
@@ -943,5 +943,40 @@ public final class Util {
          }
       }
       return out.toString();
+   }
+
+   /**
+    * Deletes directory recursively.
+    *
+    * @param directoryName Directory to be deleted
+     */
+   public static void recursiveFileRemove(String directoryName) {
+      File file = new File(directoryName);
+      recursiveFileRemove(file);
+   }
+
+   /**
+    * Deletes directory recursively.
+    *
+    * @param directory Directory to be deleted
+     */
+   public static void recursiveFileRemove(File directory) {
+      if (directory.exists()) {
+         log.tracef("Deleting file %s", directory);
+         recursiveDelete(directory);
+      }
+   }
+
+   private static void recursiveDelete(File f) {
+      File absoluteFile = f.getAbsoluteFile();
+      if (absoluteFile.isDirectory()) {
+         File[] files = absoluteFile.listFiles();
+         if (files != null) {
+            for (File file : files) {
+               recursiveDelete(file);
+            }
+         }
+      }
+      absoluteFile.delete();
    }
 }

--- a/core/src/test/java/org/infinispan/configuration/override/XMLConfigurationOverridingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/override/XMLConfigurationOverridingTest.java
@@ -1,10 +1,10 @@
 package org.infinispan.configuration.override;
 
 import org.infinispan.AdvancedCache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.context.Flag;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.interceptors.DDSequentialInterceptor;
-import org.infinispan.interceptors.BaseSequentialInterceptor;
 import org.junit.Assert;
 import org.infinispan.Cache;
 import org.infinispan.commands.write.PutKeyValueCommand;
@@ -225,7 +225,7 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
          }
       });
      }finally {
-      TestingUtil.recursiveFileRemove(tmpDir);
+      Util.recursiveFileRemove(tmpDir);
    }
    }
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashAfterJoinWithPreloadTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashAfterJoinWithPreloadTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.distribution.rehash;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -144,6 +145,6 @@ public class RehashAfterJoinWithPreloadTest extends MultipleCacheManagersTest {
 
    @AfterClass
    protected void clearTempDir() {
-      TestingUtil.recursiveFileRemove(fileCacheStoreTmpDir);
+      Util.recursiveFileRemove(fileCacheStoreTmpDir);
    }
 }

--- a/core/src/test/java/org/infinispan/expiration/impl/ExpirationSingleFileStoreDistListenerFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/expiration/impl/ExpirationSingleFileStoreDistListenerFunctionalTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.expiration.impl;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder;
@@ -13,7 +14,7 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.infinispan.test.TestingUtil.recursiveFileRemove;
+import static org.infinispan.commons.util.Util.recursiveFileRemove;
 
 @Test(groups = "functional", testName = "expiration.impl.ExpirationSingleFileStoreDistListenerFunctionalTest")
 public class ExpirationSingleFileStoreDistListenerFunctionalTest extends ExpirationStoreListenerFunctionalTest {
@@ -31,8 +32,8 @@ public class ExpirationSingleFileStoreDistListenerFunctionalTest extends Expirat
 
    @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
-      recursiveFileRemove(TestingUtil.tmpDirectory(this.getClass()));
-      recursiveFileRemove(TestingUtil.tmpDirectory(this.getClass().getSimpleName() + "2"));
+      Util.recursiveFileRemove(TestingUtil.tmpDirectory(this.getClass()));
+      Util.recursiveFileRemove(TestingUtil.tmpDirectory(this.getClass().getSimpleName() + "2"));
    }
 
    protected void removeFromContainer(String key) {

--- a/core/src/test/java/org/infinispan/expiry/ExpiryTest.java
+++ b/core/src/test/java/org/infinispan/expiry/ExpiryTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.expiry;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.InternalCacheEntry;
@@ -18,7 +19,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -219,7 +219,7 @@ public class ExpiryTest extends AbstractInfinispanTest {
          doTestEntrySetAfterExpiryInPut(m, cc);
       } finally {
          cc.stop();
-         TestingUtil.recursiveFileRemove(location);
+         Util.recursiveFileRemove(location);
       }
    }
 

--- a/core/src/test/java/org/infinispan/globalstate/AbstractGlobalStateRestartTest.java
+++ b/core/src/test/java/org/infinispan/globalstate/AbstractGlobalStateRestartTest.java
@@ -1,15 +1,13 @@
 package org.infinispan.globalstate;
 
 import org.infinispan.commons.CacheException;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.distribution.ch.ConsistentHash;
-import org.infinispan.remoting.RemoteException;
 import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
-import org.infinispan.remoting.transport.jgroups.JGroupsAddressCache;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
-import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.topology.LocalTopologyManager;
 import org.infinispan.topology.PersistentUUID;
 import org.infinispan.topology.PersistentUUIDManager;
@@ -19,7 +17,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
 import static org.testng.AssertJUnit.*;
 
@@ -41,7 +38,7 @@ public abstract class AbstractGlobalStateRestartTest extends MultipleCacheManage
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      TestingUtil.recursiveFileRemove(TestingUtil.tmpDirectory(this.getClass().getSimpleName()));
+      Util.recursiveFileRemove(TestingUtil.tmpDirectory(this.getClass().getSimpleName()));
       createStatefulCacheManagers(true, -1, false);
    }
 
@@ -63,7 +60,7 @@ public abstract class AbstractGlobalStateRestartTest extends MultipleCacheManage
    private void createStatefulCacheManager(String id, boolean clear) {
       String stateDirectory = TestingUtil.tmpDirectory(this.getClass().getSimpleName() + File.separator + id);
       if (clear)
-         TestingUtil.recursiveFileRemove(stateDirectory);
+         Util.recursiveFileRemove(stateDirectory);
       GlobalConfigurationBuilder global = GlobalConfigurationBuilder.defaultClusteredBuilder();
       global.globalState().enable().persistentLocation(stateDirectory);
 

--- a/core/src/test/java/org/infinispan/persistence/LocalModePassivationTest.java
+++ b/core/src/test/java/org/infinispan/persistence/LocalModePassivationTest.java
@@ -1,13 +1,13 @@
 package org.infinispan.persistence;
 
 import org.infinispan.AdvancedCache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.eviction.EvictionStrategy;
-import org.infinispan.persistence.PersistenceUtil;
 import org.infinispan.persistence.spi.AdvancedLoadWriteStore;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -60,7 +60,7 @@ public class LocalModePassivationTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       cacheStoreDir = new File(TestingUtil.tmpDirectory(this.getClass()));
-      TestingUtil.recursiveFileRemove(cacheStoreDir);
+      Util.recursiveFileRemove(cacheStoreDir);
 
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.LOCAL, true, true);
       builder.transaction().transactionMode(TransactionMode.TRANSACTIONAL).lockingMode(LockingMode.PESSIMISTIC)
@@ -83,7 +83,7 @@ public class LocalModePassivationTest extends SingleCacheManagerTest {
 
    @AfterClass
    protected void clearTempDir() {
-      TestingUtil.recursiveFileRemove(cacheStoreDir);
+      Util.recursiveFileRemove(cacheStoreDir);
    }
 
    public void testStoreAndLoad() throws Exception {

--- a/core/src/test/java/org/infinispan/persistence/SingleFileStoreParallelIterationTest.java
+++ b/core/src/test/java/org/infinispan/persistence/SingleFileStoreParallelIterationTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.persistence;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder;
 import org.infinispan.test.TestingUtil;
@@ -23,7 +24,7 @@ public class SingleFileStoreParallelIterationTest extends ParallelIterationTest 
    @Override
    protected void teardown() {
       super.teardown();
-      TestingUtil.recursiveFileRemove(location);
+      Util.recursiveFileRemove(location);
    }
 
 }

--- a/core/src/test/java/org/infinispan/persistence/file/BoundedSingleFileStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/file/BoundedSingleFileStoreTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.persistence.file;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder;
 import org.infinispan.persistence.spi.PersistenceException;
@@ -15,7 +16,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.infinispan.test.TestingUtil.recursiveFileRemove;
+import static org.infinispan.commons.util.Util.recursiveFileRemove;
 import static org.testng.AssertJUnit.assertEquals;
 
 /**
@@ -38,7 +39,7 @@ public class BoundedSingleFileStoreTest extends AbstractInfinispanTest {
 
    @AfterClass
    protected void clearTempDir() {
-      recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
    }
 
    @BeforeMethod

--- a/core/src/test/java/org/infinispan/persistence/file/ClusterFileStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/file/ClusterFileStoreFunctionalTest.java
@@ -7,6 +7,7 @@ import javax.transaction.TransactionManager;
 
 import org.infinispan.Cache;
 import org.infinispan.atomic.AtomicMap;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
@@ -35,7 +36,7 @@ public class ClusterFileStoreFunctionalTest extends MultipleCacheManagersTest {
 
    @AfterClass
    protected void clearTempDir() {
-      TestingUtil.recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
       new File(tmpDirectory).mkdirs();
    }
 

--- a/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreFunctionalTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.persistence.file;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 import org.infinispan.persistence.BaseStoreFunctionalTest;
 import org.infinispan.test.CacheManagerCallable;
@@ -35,7 +36,7 @@ public class SingleFileStoreFunctionalTest extends BaseStoreFunctionalTest {
 
    @AfterClass
    protected void clearTempDir() {
-      TestingUtil.recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
       new File(tmpDirectory).mkdirs();
    }
 
@@ -70,7 +71,7 @@ public class SingleFileStoreFunctionalTest extends BaseStoreFunctionalTest {
             assertEquals(-1, cacheLoader.getConfiguration().maxEntries());
          }
       });
-      TestingUtil.recursiveFileRemove("Infinispan-SingleFileStore");
+      Util.recursiveFileRemove("Infinispan-SingleFileStore");
    }
 
    public void testParsingElement() throws Exception {
@@ -96,7 +97,7 @@ public class SingleFileStoreFunctionalTest extends BaseStoreFunctionalTest {
             assertEquals(0.75f, store.getConfiguration().fragmentationFactor(), 0f);
          }
       });
-      TestingUtil.recursiveFileRemove("other-location");
+      Util.recursiveFileRemove("other-location");
    }
 
 }

--- a/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreStressTest.java
+++ b/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreStressTest.java
@@ -2,6 +2,7 @@ package org.infinispan.persistence.file;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.filter.KeyFilter;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -46,7 +47,7 @@ public class SingleFileStoreStressTest extends SingleCacheManagerTest {
 
    @AfterClass
    protected void clearTempDir() {
-      TestingUtil.recursiveFileRemove(this.location);
+      Util.recursiveFileRemove(this.location);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.persistence.file;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder;
 import org.infinispan.persistence.BaseStoreTest;
@@ -10,7 +11,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.infinispan.test.TestingUtil.recursiveFileRemove;
+import static org.infinispan.commons.util.Util.recursiveFileRemove;
 
 /**
  * Low level single-file cache store tests.
@@ -30,7 +31,7 @@ public class SingleFileStoreTest extends BaseStoreTest {
 
    @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
-      recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/persistence/support/BatchAsyncStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/support/BatchAsyncStoreTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.HashMap;
 
 import org.infinispan.AdvancedCache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -100,6 +101,6 @@ public class BatchAsyncStoreTest extends SingleCacheManagerTest {
 
    @AfterClass
    protected void clearTempDir() {
-      TestingUtil.recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
    }
 }

--- a/core/src/test/java/org/infinispan/statetransfer/ReplStateTransferCacheLoaderTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ReplStateTransferCacheLoaderTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.statetransfer;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.eviction.EvictionStrategy;
@@ -39,7 +40,7 @@ public class ReplStateTransferCacheLoaderTest extends MultipleCacheManagersTest 
    @Override
    protected void createCacheManagers() {
       tmpDir = new File(TestingUtil.tmpDirectory(this.getClass()));
-      TestingUtil.recursiveFileRemove(tmpDir);
+      Util.recursiveFileRemove(tmpDir);
 
       // reproduce the MODE-1754 config as closely as possible
       builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, true, true);
@@ -63,7 +64,7 @@ public class ReplStateTransferCacheLoaderTest extends MultipleCacheManagersTest 
 
    @AfterClass
    protected void clearTempDir() {
-      TestingUtil.recursiveFileRemove(tmpDir);
+      Util.recursiveFileRemove(tmpDir);
    }
 
    public void testStateTransfer() throws Exception {

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferFileCacheLoaderFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferFileCacheLoaderFunctionalTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.statetransfer;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder;
@@ -58,13 +59,13 @@ public class StateTransferFileCacheLoaderFunctionalTest extends MultipleCacheMan
 
    @AfterMethod
    protected void clearTempDir() {
-      TestingUtil.recursiveFileRemove(tmpDirectory1);
+      Util.recursiveFileRemove(tmpDirectory1);
       new File(tmpDirectory1).mkdirs();
-      TestingUtil.recursiveFileRemove(tmpDirectory2);
+      Util.recursiveFileRemove(tmpDirectory2);
       new File(tmpDirectory2).mkdirs();
-      TestingUtil.recursiveFileRemove(tmpDirectory3);
+      Util.recursiveFileRemove(tmpDirectory3);
       new File(tmpDirectory3).mkdirs();
-      TestingUtil.recursiveFileRemove(tmpDirectory4);
+      Util.recursiveFileRemove(tmpDirectory4);
       new File(tmpDirectory4).mkdirs();
    }
 

--- a/core/src/test/java/org/infinispan/test/TestingUtil.java
+++ b/core/src/test/java/org/infinispan/test/TestingUtil.java
@@ -7,7 +7,6 @@ import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commons.marshall.AbstractDelegatingMarshaller;
 import org.infinispan.commons.marshall.StreamingMarshaller;
-import org.infinispan.commons.util.ReflectionUtil;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
@@ -43,13 +42,10 @@ import org.infinispan.persistence.spi.CacheWriter;
 import org.infinispan.remoting.inboundhandler.PerCacheInboundInvocationHandler;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.remoting.transport.Transport;
-import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
-import org.infinispan.remoting.transport.jgroups.JGroupsAddressCache;
 import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
 import org.infinispan.security.impl.SecureCacheImpl;
 import org.infinispan.statetransfer.StateTransferManager;
 import org.infinispan.topology.CacheTopology;
-import org.infinispan.topology.PersistentUUID;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.util.DependencyGraph;
 import org.infinispan.util.concurrent.TimeoutException;
@@ -74,7 +70,6 @@ import javax.security.auth.Subject;
 import javax.transaction.Status;
 import javax.transaction.TransactionManager;
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -84,22 +79,7 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.security.Principal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
-import java.util.Random;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
@@ -613,31 +593,6 @@ public class TestingUtil {
 
    public static void sleepRandom(int maxTime) {
       sleepThread(random.nextInt(maxTime));
-   }
-
-   public static void recursiveFileRemove(String directoryName) {
-      File file = new File(directoryName);
-      recursiveFileRemove(file);
-   }
-
-   public static void recursiveFileRemove(File file) {
-      if (file.exists()) {
-         log.tracef("Deleting file %s", file);
-         recursiveDelete(file);
-      }
-   }
-
-   private static void recursiveDelete(File f) {
-      File absoluteFile = f.getAbsoluteFile();
-      if (absoluteFile.isDirectory()) {
-         File[] files = absoluteFile.listFiles();
-         if (files != null) {
-            for (File file : files) {
-               recursiveDelete(file);
-            }
-         }
-      }
-      absoluteFile.delete();
    }
 
    public static void killCacheManagers(CacheContainer... cacheContainers) {

--- a/core/src/test/java/org/infinispan/util/ThreadLocalLeakTest.java
+++ b/core/src/test/java/org/infinispan/util/ThreadLocalLeakTest.java
@@ -54,7 +54,7 @@ public class ThreadLocalLeakTest extends AbstractInfinispanTest {
 
    @AfterClass
    protected void clearTempDir() {
-      TestingUtil.recursiveFileRemove(tmpDirectory);
+      org.infinispan.commons.util.Util.recursiveFileRemove(tmpDirectory);
       new File(tmpDirectory).mkdirs();
    }
 

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/file/SingleFileStoreFunctionalTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/file/SingleFileStoreFunctionalTest.java
@@ -3,6 +3,7 @@ package org.infinispan.it.osgi.persistence.file;
 import static org.infinispan.it.osgi.util.IspnKarafOptions.perSuiteOptions;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestResourceTracker;
@@ -40,7 +41,7 @@ public class SingleFileStoreFunctionalTest extends org.infinispan.persistence.fi
 
    @AfterClass
    public static void clearTmpDir() {
-      TestingUtil.recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
    }
 
    @Before

--- a/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/leveldb/JniLevelDBStoreFunctionalTest.java
+++ b/integrationtests/osgi/src/test/java/org/infinispan/it/osgi/persistence/leveldb/JniLevelDBStoreFunctionalTest.java
@@ -1,8 +1,6 @@
 package org.infinispan.it.osgi.persistence.leveldb;
 
-import static org.infinispan.it.osgi.util.IspnKarafOptions.perSuiteOptions;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 import org.infinispan.persistence.BaseStoreFunctionalTest;
 import org.infinispan.persistence.leveldb.configuration.LevelDBStoreConfiguration;
@@ -21,6 +19,9 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerSuite;
+
+import static org.infinispan.it.osgi.util.IspnKarafOptions.perSuiteOptions;
+import static org.ops4j.pax.exam.CoreOptions.options;
 
 /**
  * @author mgencur
@@ -44,7 +45,7 @@ public class JniLevelDBStoreFunctionalTest extends BaseStoreFunctionalTest {
 
    @AfterClass
    public static void clearTempDir() {
-      TestingUtil.recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
    }
 
    @Before

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/InfinispanDirectoryIOTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/InfinispanDirectoryIOTest.java
@@ -15,6 +15,7 @@ import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.RAMDirectory;
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.lucene.directory.DirectoryBuilder;
 import org.infinispan.lucene.impl.DirectoryBuilderImpl;
 import org.infinispan.lucene.impl.DirectoryExtensions;
@@ -61,7 +62,7 @@ public class InfinispanDirectoryIOTest extends AbstractInfinispanTest {
       if (cacheManager != null) {
          cacheManager.getCache().clear();
       }
-      TestingUtil.recursiveFileRemove(indexDir);
+      Util.recursiveFileRemove(indexDir);
    }
 
    @Test

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/cacheloader/CacheLoaderAPITest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/cacheloader/CacheLoaderAPITest.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.InternalEntryFactory;
 import org.infinispan.container.entries.InternalCacheEntry;
@@ -306,7 +307,7 @@ public class CacheLoaderAPITest extends SingleCacheManagerTest {
 
    @Override
    protected void teardown() {
-      TestingUtil.recursiveFileRemove(rootDir);
+      Util.recursiveFileRemove(rootDir);
       super.teardown();
    }
 

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/cacheloader/IndexCacheLoaderTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/cacheloader/IndexCacheLoaderTest.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 
 import org.apache.lucene.store.Directory;
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.lucene.cacheloader.configuration.LuceneLoaderConfigurationBuilder;
 import org.infinispan.lucene.directory.DirectoryBuilder;
@@ -49,7 +50,7 @@ public class IndexCacheLoaderTest extends AbstractInfinispanTest {
    @AfterMethod
    public void tearDown() {
       if(rootDir != null) {
-         TestingUtil.recursiveFileRemove(rootDir);
+         Util.recursiveFileRemove(rootDir);
       }
    }
 

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/cacheloader/LuceneCacheLoaderTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/cacheloader/LuceneCacheLoaderTest.java
@@ -5,6 +5,7 @@ import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.logging.Log;
 import org.infinispan.commons.logging.LogFactory;
+import org.infinispan.commons.util.Util;
 import org.infinispan.lucene.FileCacheKey;
 import org.infinispan.lucene.directory.DirectoryBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -58,7 +59,7 @@ public class LuceneCacheLoaderTest extends IndexCacheLoaderTest {
             }
          });
       } finally {
-         if(file != null) TestingUtil.recursiveFileRemove(file);
+         if(file != null) Util.recursiveFileRemove(file);
       }
    }
 
@@ -110,7 +111,7 @@ public class LuceneCacheLoaderTest extends IndexCacheLoaderTest {
             }
          });
       } finally {
-         TestingUtil.recursiveFileRemove(rootDir);
+         Util.recursiveFileRemove(rootDir);
       }
    }
 }

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/cacheloader/WarmCacheTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/cacheloader/WarmCacheTest.java
@@ -2,6 +2,7 @@ package org.infinispan.lucene.cacheloader;
 
 import org.apache.lucene.store.Directory;
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.interceptors.impl.CacheLoaderInterceptor;
@@ -10,7 +11,6 @@ import org.infinispan.lucene.directory.DirectoryBuilder;
 import org.infinispan.lucene.testutils.LuceneUtils;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.MultipleCacheManagersTest;
-import org.infinispan.test.TestingUtil;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -75,7 +75,7 @@ public class WarmCacheTest extends MultipleCacheManagersTest {
 
    @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
-      TestingUtil.recursiveFileRemove(indexDir);
+      Util.recursiveFileRemove(indexDir);
    }
 
 }

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/profiling/IndexReadingStressTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/profiling/IndexReadingStressTest.java
@@ -21,6 +21,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.RAMDirectory;
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.lucene.CacheTestSupport;
 import org.infinispan.lucene.directory.DirectoryBuilder;
 import org.infinispan.lucene.testutils.ClusteredCacheFactory;
@@ -141,7 +142,7 @@ public class IndexReadingStressTest {
    @AfterClass
    public static void afterTest() {
       cacheFactory.stop();
-      TestingUtil.recursiveFileRemove(indexName);
+      Util.recursiveFileRemove(indexName);
    }
 
    private static class IndependentLuceneReaderThread extends LuceneUserThread {

--- a/lucene/lucene-directory/src/test/java/org/infinispan/lucene/profiling/PerformanceCompareStressTest.java
+++ b/lucene/lucene-directory/src/test/java/org/infinispan/lucene/profiling/PerformanceCompareStressTest.java
@@ -19,6 +19,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.RAMDirectory;
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.lucene.CacheTestSupport;
 import org.infinispan.lucene.directory.BuildContext;
 import org.infinispan.lucene.directory.DirectoryBuilder;
@@ -246,7 +247,7 @@ public class PerformanceCompareStressTest extends AbstractInfinispanTest {
       for (EmbeddedCacheManager node : cacheManagers.values()) {
          TestingUtil.killCacheManagers(node);
       }
-      TestingUtil.recursiveFileRemove(indexName);
+      Util.recursiveFileRemove(indexName);
    }
 
    private void verifyDirectoryState() {

--- a/persistence/leveldb/src/main/java/org/infinispan/persistence/leveldb/LevelDBStore.java
+++ b/persistence/leveldb/src/main/java/org/infinispan/persistence/leveldb/LevelDBStore.java
@@ -1,18 +1,7 @@
 package org.infinispan.persistence.leveldb;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletionService;
-import java.util.concurrent.Executor;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.Semaphore;
-
+import org.fusesource.leveldbjni.JniDBFactory;
+import org.fusesource.leveldbjni.internal.JniDB;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.util.Util;
@@ -30,569 +19,638 @@ import org.infinispan.persistence.spi.PersistenceException;
 import org.infinispan.util.logging.LogFactory;
 import org.iq80.leveldb.CompressionType;
 import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBException;
 import org.iq80.leveldb.DBFactory;
 import org.iq80.leveldb.DBIterator;
 import org.iq80.leveldb.Options;
 import org.iq80.leveldb.ReadOptions;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
+
 @ConfiguredBy(LevelDBStoreConfiguration.class)
 public class LevelDBStore implements AdvancedLoadWriteStore {
-   private static final Log log = LogFactory.getLog(LevelDBStore.class, Log.class);
+    private static final Log log = LogFactory.getLog(LevelDBStore.class, Log.class);
 
-   private static final String JNI_DB_FACTORY_CLASS_NAME = "org.fusesource.leveldbjni.JniDBFactory";
-   private static final String JAVA_DB_FACTORY_CLASS_NAME = "org.iq80.leveldb.impl.Iq80DBFactory";
-   private static final String[] DB_FACTORY_CLASS_NAMES = new String[] { JNI_DB_FACTORY_CLASS_NAME, JAVA_DB_FACTORY_CLASS_NAME };
+    private static final String JNI_DB_FACTORY_CLASS_NAME = "org.fusesource.leveldbjni.JniDBFactory";
+    private static final String JAVA_DB_FACTORY_CLASS_NAME = "org.iq80.leveldb.impl.Iq80DBFactory";
+    private static final String[] DB_FACTORY_CLASS_NAMES = new String[]{JNI_DB_FACTORY_CLASS_NAME, JAVA_DB_FACTORY_CLASS_NAME};
 
-   private LevelDBStoreConfiguration configuration;
-   private BlockingQueue<ExpiryEntry> expiryEntryQueue;
-   private DBFactory dbFactory;
-   private DB db;
-   private DB expiredDb;
-   private InitializationContext ctx;
-   private Semaphore semaphore;
-   private volatile boolean stopped = true;
+    private LevelDBStoreConfiguration configuration;
+    private BlockingQueue<ExpiryEntry> expiryEntryQueue;
+    private DBFactory dbFactory;
+    private DB db;
+    private DB expiredDb;
+    private InitializationContext ctx;
+    private Semaphore semaphore;
+    private volatile boolean stopped = true;
 
-   @Override
-   public void init(InitializationContext ctx) {
-      this.configuration = ctx.getConfiguration();
-      this.dbFactory = newDbFactory();
-      this.ctx = ctx;
-      this.semaphore = new Semaphore(Integer.MAX_VALUE, true);
+    @Override
+    public void init(InitializationContext ctx) {
+        this.configuration = ctx.getConfiguration();
+        this.dbFactory = newDbFactory();
+        this.ctx = ctx;
+        this.semaphore = new Semaphore(Integer.MAX_VALUE, true);
 
-      if (this.dbFactory == null) {
-         throw log.cannotLoadlevelDBFactories(Arrays.toString(DB_FACTORY_CLASS_NAMES));
-      }
-      String dbFactoryClassName = this.dbFactory.getClass().getName();
-      if (dbFactoryClassName.equals("org.iq80.leveldb.impl.Iq80DBFactory")) {
-         log.infoUsingJavaDbFactory(dbFactoryClassName);
-      } else {
-         log.infoUsingJNIDbFactory(dbFactoryClassName);
-      }
-   }
+        if (this.dbFactory == null) {
+            throw log.cannotLoadlevelDBFactories(Arrays.toString(DB_FACTORY_CLASS_NAMES));
+        }
+        String dbFactoryClassName = this.dbFactory.getClass().getName();
+        if (dbFactoryClassName.equals("org.iq80.leveldb.impl.Iq80DBFactory")) {
+            log.infoUsingJavaDbFactory(dbFactoryClassName);
+        } else {
+            log.infoUsingJNIDbFactory(dbFactoryClassName);
+        }
+    }
 
-   protected DBFactory newDbFactory() {
-      switch (configuration.implementationType()) {
-         case JNI: {
-            return Util.getInstance(JNI_DB_FACTORY_CLASS_NAME, LevelDBStore.class.getClassLoader());
-         }
-         case JAVA: {
-            return Util.getInstance(JAVA_DB_FACTORY_CLASS_NAME, LevelDBStore.class.getClassLoader());
-         }
-         default: {
-            for (String className : DB_FACTORY_CLASS_NAMES) {
-               try {
-                  return Util.getInstance(className, LevelDBStore.class.getClassLoader());
-               } catch (Throwable e) {
-                  if (log.isDebugEnabled())
-                     log.debugUnableToInstantiateDbFactory(className, e);
-               }
+    protected DBFactory newDbFactory() {
+        switch (configuration.implementationType()) {
+            case JNI: {
+                return Util.getInstance(JNI_DB_FACTORY_CLASS_NAME, LevelDBStore.class.getClassLoader());
             }
-         }
-      }
-      return null;
-   }
-
-   @Override
-   public void start()  {
-      expiryEntryQueue = new LinkedBlockingQueue<ExpiryEntry>(configuration.expiryQueueSize());
-
-      try {
-         db = openDatabase(getQualifiedLocation(), dataDbOptions());
-         expiredDb = openDatabase(getQualifiedExpiredLocation(), expiredDbOptions());
-         stopped = false;
-      } catch (IOException e) {
-         throw new CacheConfigurationException("Unable to open database", e);
-      }
-   }
-
-   private String sanitizedCacheName() {
-      String cacheFileName = ctx.getCache().getName().replaceAll("[^a-zA-Z0-9-_\\.]", "_");
-      return cacheFileName;
-   }
-
-   private String getQualifiedLocation() {
-      return configuration.location() + sanitizedCacheName();
-   }
-
-   private String getQualifiedExpiredLocation() {
-      return configuration.expiredLocation() + sanitizedCacheName();
-   }
-
-   private Options dataDbOptions() {
-      Options options = new Options().createIfMissing(true);
-
-      options.compressionType(CompressionType.valueOf(configuration.compressionType().name()));
-
-      if (configuration.blockSize() != null) {
-         options.blockSize(configuration.blockSize());
-      }
-
-      if (configuration.cacheSize() != null) {
-         options.cacheSize(configuration.cacheSize());
-      }
-
-      return options;
-   }
-
-   private Options expiredDbOptions() {
-      return new Options().createIfMissing(true);
-   }
-
-   /**
-    * Creates database if it doesn't exist.
-    */
-   protected DB openDatabase(String location, Options options) throws IOException {
-      File dir = new File(location);
-
-      // LevelDB JNI Option createIfMissing doesn't seem to work properly
-      dir.mkdirs();
-      return dbFactory.open(dir, options);
-   }
-
-   protected void destroyDatabase(String location) throws IOException {
-      File dir = new File(location);
-      dbFactory.destroy(dir, new Options());
-   }
-
-   protected DB reinitDatabase(String location, Options options) throws IOException {
-      destroyDatabase(location);
-      return openDatabase(location, options);
-   }
-
-   protected void reinitAllDatabases() throws IOException {
-      try {
-         semaphore.acquire(Integer.MAX_VALUE);
-      } catch (InterruptedException e) {
-         throw new PersistenceException("Cannot acquire semaphore", e);
-      }
-      try {
-         if (stopped) {
-            throw new PersistenceException("LevelDB is stopped");
-         }
-         try {
-            db.close();
-         } catch (IOException e) {
-            log.warnUnableToCloseDb(e);
-         }
-         try {
-            expiredDb.close();
-         } catch (IOException e) {
-            log.warnUnableToCloseExpiredDb(e);
-         }
-         db = reinitDatabase(getQualifiedLocation(), dataDbOptions());
-         expiredDb = reinitDatabase(getQualifiedExpiredLocation(), expiredDbOptions());
-      } finally {
-         semaphore.release(Integer.MAX_VALUE);
-      }
-   }
-
-   @Override
-   public void stop()  {
-      try {
-         semaphore.acquire(Integer.MAX_VALUE);
-      } catch (InterruptedException e) {
-         throw new PersistenceException("Cannot acquire semaphore", e);
-      }
-      try {
-         try {
-            db.close();
-         } catch (IOException e) {
-            log.warnUnableToCloseDb(e);
-         }
-
-         try {
-            expiredDb.close();
-         } catch (IOException e) {
-            log.warnUnableToCloseExpiredDb(e);
-         }
-      } finally {
-         stopped = true;
-         semaphore.release(Integer.MAX_VALUE);
-      }
-   }
-
-   @Override
-   public void clear() {
-      long count = 0;
-      boolean destroyDatabase = false;
-      try {
-         semaphore.acquire();
-      } catch (InterruptedException e) {
-         throw new PersistenceException("Cannot acquire semaphore", e);
-      }
-      try {
-         if (stopped) {
-            throw new PersistenceException("LevelDB is stopped");
-         }
-         DBIterator it = db.iterator(new ReadOptions().fillCache(false));
-         if (configuration.clearThreshold() <= 0) {
-            try {
-               for (it.seekToFirst(); it.hasNext(); ) {
-                  Map.Entry<byte[], byte[]> entry = it.next();
-                  db.delete(entry.getKey());
-                  count++;
-
-                  if (count > configuration.clearThreshold()) {
-                     destroyDatabase = true;
-                     break;
-                  }
-               }
-            } finally {
-               try {
-                  it.close();
-               } catch (IOException e) {
-                  log.warnUnableToCloseDbIterator(e);
-               }
+            case JAVA: {
+                return Util.getInstance(JAVA_DB_FACTORY_CLASS_NAME, LevelDBStore.class.getClassLoader());
             }
-         } else {
-            destroyDatabase = true;
-         }
-      } finally {
-         semaphore.release();
-      }
-
-      if (destroyDatabase) {
-         try {
-            reinitAllDatabases();
-         } catch (IOException e) {
-            throw new PersistenceException(e);
-         }
-      }
-   }
-
-   @Override
-   public int size() {
-      return PersistenceUtil.count(this, null);
-   }
-
-   @Override
-   public boolean contains(Object key) {
-      try {
-         return load(key) != null;
-      } catch (Exception e) {
-         throw new PersistenceException(e);
-      }
-   }
-
-   @SuppressWarnings("unchecked")
-   @Override
-   public void process(KeyFilter keyFilter, CacheLoaderTask cacheLoaderTask, Executor executor, boolean loadValues, boolean loadMetadata) {
-
-      int batchSize = 100;
-      ExecutorAllCompletionService eacs = new ExecutorAllCompletionService(executor);
-      final TaskContext taskContext = new TaskContextImpl();
-
-      List<Map.Entry<byte[], byte[]>> entries = new ArrayList<Map.Entry<byte[], byte[]>>(batchSize);
-      try {
-         semaphore.acquire();
-      } catch (InterruptedException e) {
-         throw new PersistenceException("Cannot acquire semaphore: CacheStore is likely stopped.", e);
-      }
-      try {
-         if (stopped) {
-            throw new PersistenceException("LevelDB is stopped");
-         }
-         DBIterator it = db.iterator(new ReadOptions().fillCache(false));
-         try {
-            for (it.seekToFirst(); it.hasNext(); ) {
-               Map.Entry<byte[], byte[]> entry = it.next();
-               entries.add(entry);
-               if (entries.size() == batchSize) {
-                  final List<Map.Entry<byte[], byte[]>> batch = entries;
-                  entries = new ArrayList<Map.Entry<byte[], byte[]>>(batchSize);
-                  submitProcessTask(cacheLoaderTask, keyFilter, eacs, taskContext, batch, loadValues, loadMetadata);
-               }
+            default: {
+                for (String className : DB_FACTORY_CLASS_NAMES) {
+                    try {
+                        return Util.getInstance(className, LevelDBStore.class.getClassLoader());
+                    } catch (Throwable e) {
+                        if (log.isDebugEnabled())
+                            log.debugUnableToInstantiateDbFactory(className, e);
+                    }
+                }
             }
-            if (!entries.isEmpty()) {
-               submitProcessTask(cacheLoaderTask, keyFilter, eacs, taskContext, entries, loadValues, loadMetadata);
-            }
+        }
+        return null;
+    }
 
-            eacs.waitUntilAllCompleted();
-            if (eacs.isExceptionThrown()) {
-               throw new PersistenceException("Execution exception!", eacs.getFirstException());
-            }
-         } catch (Exception e) {
-            throw new PersistenceException(e);
-         } finally {
-            try {
-               it.close();
-            } catch (IOException e) {
-               log.warnUnableToCloseDbIterator(e);
-            }
-         }
-      } finally {
-         semaphore.release();
-      }
-   }
+    @Override
+    public void start() {
+        expiryEntryQueue = new LinkedBlockingQueue<ExpiryEntry>(configuration.expiryQueueSize());
 
-   @SuppressWarnings("unchecked")
-   private void submitProcessTask(final CacheLoaderTask cacheLoaderTask, final KeyFilter filter, CompletionService ecs,
-                                  final TaskContext taskContext, final List<Map.Entry<byte[], byte[]>> batch,
-                                  final boolean loadValues, final boolean loadMetadata) {
-      ecs.submit(new Callable<Void>() {
-         @Override
-         public Void call() throws Exception {
-            try {
-               long now = ctx.getTimeService().wallClockTime();
-               for (Map.Entry<byte[], byte[]> pair : batch) {
-                  if (taskContext.isStopped()) {break;}
-                  Object key = unmarshall(pair.getKey());
-                  if (filter == null || filter.accept(key)) {
-                     MarshalledEntry entry = loadValues || loadMetadata ? (MarshalledEntry) unmarshall(pair.getValue()) : null;
-                     boolean isExpired = entry != null && entry.getMetadata() != null && entry.getMetadata().isExpired(now);
-                     if (!isExpired) {
-                        if (!loadValues || !loadMetadata) {
-                           entry = ctx.getMarshalledEntryFactory().newMarshalledEntry(
-                                 key, loadValues ? entry.getValue() : null, loadMetadata ? entry.getMetadata() : null);
-                        }
-                        cacheLoaderTask.processEntry(entry, taskContext);
-                     }
-                  }
-               }
-            } catch (Exception e) {
-               log.errorExecutingParallelStoreTask(e);
-               throw e;
-            }
-            return null;
-         }
-      });
-   }
+        try {
+            db = openDatabase(getQualifiedLocation(), dataDbOptions());
+            expiredDb = openDatabase(getQualifiedExpiredLocation(), expiredDbOptions());
+            stopped = false;
+        } catch (IOException e) {
+            throw new CacheConfigurationException("Unable to open database", e);
+        }
+    }
 
-   @Override
-   public boolean delete(Object key)  {
-      try {
-         byte[] keyBytes = marshall(key);
-         semaphore.acquire();
-         try {
-            if (stopped) {
-               throw new PersistenceException("LevelDB is stopped");
-            }
-            if (db.get(keyBytes) == null) {
-               return false;
-            }
-            db.delete(keyBytes);
-         } finally {
-            semaphore.release();
-         }
-         return true;
-      } catch (Exception e) {
-         throw new PersistenceException(e);
-      }
-   }
+    private String sanitizedCacheName() {
+        String cacheFileName = ctx.getCache().getName().replaceAll("[^a-zA-Z0-9-_\\.]", "_");
+        return cacheFileName;
+    }
 
-   @Override
-   public void write(MarshalledEntry me)  {
-      try {
-         byte[] marshelledKey = marshall(me.getKey());
-         byte[] marshalledEntry = marshall(me);
-         semaphore.acquire();
-         try {
-            if (stopped) {
-               throw new PersistenceException("LevelDB is stopped");
-            }
-            db.put(marshelledKey, marshalledEntry);
-         } finally {
-            semaphore.release();
-         }
-         InternalMetadata meta = me.getMetadata();
-         if (meta != null && meta.expiryTime() > -1) {
-            addNewExpiry(me);
-         }
-      } catch (Exception e) {
-         throw new PersistenceException(e);
-      }
-   }
+    private String getQualifiedLocation() {
+        return configuration.location() + sanitizedCacheName();
+    }
 
-   @Override
-   public MarshalledEntry load(Object key)  {
-      try {
-         byte[] marshalledEntry;
-         semaphore.acquire();
-         try {
-            if (stopped) {
-               throw new PersistenceException("LevelDB is stopped");
-            }
-            marshalledEntry = db.get(marshall(key));
-         } finally {
-            semaphore.release();
-         }
-         MarshalledEntry me = (MarshalledEntry) unmarshall(marshalledEntry);
-         if (me == null) return null;
+    private String getQualifiedExpiredLocation() {
+        return configuration.expiredLocation() + sanitizedCacheName();
+    }
 
-         InternalMetadata meta = me.getMetadata();
-         if (meta != null && meta.isExpired(ctx.getTimeService().wallClockTime())) {
-            return null;
-         }
-         return me;
-      } catch (Exception e) {
-         throw new PersistenceException(e);
-      }
-   }
+    private Options dataDbOptions() {
+        Options options = new Options().createIfMissing(true);
 
-   @SuppressWarnings("unchecked")
-   @Override
-   public void purge(Executor executor, PurgeListener purgeListener) {
-      try {
-         semaphore.acquire();
-      } catch (InterruptedException e) {
-         throw new PersistenceException("Cannot acquire semaphore: CacheStore is likely stopped.", e);
-      }
-      try {
-         if (stopped) {
-            throw new PersistenceException("LevelDB is stopped");
-         }
-         // Drain queue and update expiry tree
-         List<ExpiryEntry> entries = new ArrayList<ExpiryEntry>();
-         expiryEntryQueue.drainTo(entries);
-         for (ExpiryEntry entry : entries) {
-            final byte[] expiryBytes = marshall(entry.expiry);
-            final byte[] keyBytes = marshall(entry.key);
-            final byte[] existingBytes = expiredDb.get(expiryBytes);
+        options.compressionType(CompressionType.valueOf(configuration.compressionType().name()));
 
-            if (existingBytes != null) {
-               // in the case of collision make the key a List ...
-               final Object existing = unmarshall(existingBytes);
-               if (existing instanceof List) {
-                  ((List<Object>) existing).add(entry.key);
-                  expiredDb.put(expiryBytes, marshall(existing));
-               } else {
-                  List<Object> al = new ArrayList<Object>(2);
-                  al.add(existing);
-                  al.add(entry.key);
-                  expiredDb.put(expiryBytes, marshall(al));
-               }
+        if (configuration.blockSize() != null) {
+            options.blockSize(configuration.blockSize());
+        }
+
+        if (configuration.cacheSize() != null) {
+            options.cacheSize(configuration.cacheSize());
+        }
+
+        return options;
+    }
+
+    private Options expiredDbOptions() {
+        return new Options().createIfMissing(true);
+    }
+
+    /**
+     * Creates database if it doesn't exist.
+     */
+    protected DB openDatabase(String location, Options options) throws IOException {
+        File dir = new File(location);
+
+        // LevelDB JNI Option createIfMissing doesn't seem to work properly
+        dir.mkdirs();
+        return dbFactory.open(dir, options);
+    }
+
+    protected void destroyDatabase(String location) throws IOException {
+        File dir = new File(location);
+        try {
+            dbFactory.destroy(dir, new Options());
+        } catch (IOException e) {
+            if (dbFactory instanceof JniDBFactory) {
+                // Level DB JNI does not remove files correctly on Windows - so let's do a clean up manually
+                deleteFilesFromDirectory(dir);
+                log.warnAboutExceptionInLevelDB(e);
             } else {
-               expiredDb.put(expiryBytes, keyBytes);
+                throw e;
             }
-         }
+        }
 
-         List<Long> times = new ArrayList<Long>();
-         List<Object> keys = new ArrayList<Object>();
-         DBIterator it = expiredDb.iterator(new ReadOptions().fillCache(false));
-         long now = ctx.getTimeService().wallClockTime();
-         try {
-            for (it.seekToFirst(); it.hasNext();) {
-               Map.Entry<byte[], byte[]> entry = it.next();
+    }
 
-               Long time = (Long) unmarshall(entry.getKey());
-               if (time > now)
-                  break;
-               times.add(time);
-               Object key = unmarshall(entry.getValue());
-               if (key instanceof List)
-                  keys.addAll((List<?>) key);
-               else
-                  keys.add(key);
+    private void deleteFilesFromDirectory(File directory) {
+        if (directory.exists() && directory.isDirectory()) {
+            // Now here comes the fun part - Windows does not allow removing files opened with FileChannel.map
+            // http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4715154
+            // However adding a GC should deallocate direct buffers and we should be able to delete them
+            System.gc();
+            File[] files = directory.listFiles();
+            if (null != files) {
+                for (int i = 0; i < files.length; i++) {
+                    if (files[i].isDirectory()) {
+                        deleteFilesFromDirectory(files[i]);
+                    } else {
+                        files[i].delete();
+                    }
+                }
             }
+            directory.delete();
+        }
+    }
 
-            for (Long time : times) {
-               expiredDb.delete(marshall(time));
+    protected DB reinitDatabase(String location, Options options) throws IOException {
+        destroyDatabase(location);
+        return openDatabase(location, options);
+    }
+
+    protected void reinitAllDatabases() throws IOException {
+        try {
+            semaphore.acquire(Integer.MAX_VALUE);
+        } catch (InterruptedException e) {
+            throw new PersistenceException("Cannot acquire semaphore", e);
+        }
+        try {
+            if (stopped) {
+                throw new PersistenceException("LevelDB is stopped");
             }
-
-            if (!keys.isEmpty())
-               log.debugf("purge (up to) %d entries", keys.size());
-            int count = 0;
-            for (Object key : keys) {
-               byte[] keyBytes = marshall(key);
-
-               byte[] b = db.get(keyBytes);
-               if (b == null)
-                  continue;
-               MarshalledEntry me = (MarshalledEntry) ctx.getMarshaller().objectFromByteBuffer(b);
-               // TODO race condition: the entry could be updated between the get and delete!
-               if (me.getMetadata() != null && me.getMetadata().isExpired(now)) {
-                  // somewhat inefficient to FIND then REMOVE...
-                  db.delete(keyBytes);
-                  purgeListener.entryPurged(key);
-                  count++;
-               }
-
-            }
-            if (count != 0)
-               log.debugf("purged %d entries", count);
-         } catch (Exception e) {
-            throw new PersistenceException(e);
-         } finally {
             try {
-               it.close();
+                db.close();
             } catch (IOException e) {
-               log.warnUnableToCloseDbIterator(e);
+                log.warnUnableToCloseDb(e);
             }
-         }
-      } catch (PersistenceException e) {
-         throw e;
-      } catch (Exception e) {
-         throw new PersistenceException(e);
-      } finally {
-         semaphore.release();
-      }
-   }
+            try {
+                expiredDb.close();
+            } catch (IOException e) {
+                log.warnUnableToCloseExpiredDb(e);
+            }
+            db = reinitDatabase(getQualifiedLocation(), dataDbOptions());
+            expiredDb = reinitDatabase(getQualifiedExpiredLocation(), expiredDbOptions());
+        } finally {
+            semaphore.release(Integer.MAX_VALUE);
+        }
+    }
 
-   private byte[] marshall(Object entry) throws IOException, InterruptedException {
-      return ctx.getMarshaller().objectToByteBuffer(entry);
-   }
+    @Override
+    public void stop() {
+        try {
+            semaphore.acquire(Integer.MAX_VALUE);
+        } catch (InterruptedException e) {
+            throw new PersistenceException("Cannot acquire semaphore", e);
+        }
+        try {
+            try {
+                db.close();
+            } catch (IOException e) {
+                log.warnUnableToCloseDb(e);
+            }
 
-   private Object unmarshall(byte[] bytes) throws IOException, ClassNotFoundException {
-      if (bytes == null)
-         return null;
+            try {
+                expiredDb.close();
+            } catch (IOException e) {
+                log.warnUnableToCloseExpiredDb(e);
+            }
+        } finally {
+            stopped = true;
+            semaphore.release(Integer.MAX_VALUE);
+        }
+    }
 
-      return ctx.getMarshaller().objectFromByteBuffer(bytes);
-   }
+    @Override
+    public void clear() {
+        long count = 0;
+        boolean destroyDatabase = false;
+        try {
+            semaphore.acquire();
+        } catch (InterruptedException e) {
+            throw new PersistenceException("Cannot acquire semaphore", e);
+        }
+        try {
+            if (stopped) {
+                throw new PersistenceException("LevelDB is stopped");
+            }
+            Optional<DBIterator> optionalIterator = getDBIterator(this.db);
+            if (optionalIterator.isPresent() && configuration.clearThreshold() <= 0) {
+                DBIterator it = optionalIterator.get();
+                try {
+                    for (it.seekToFirst(); it.hasNext(); ) {
+                        Map.Entry<byte[], byte[]> entry = it.next();
+                        db.delete(entry.getKey());
+                        count++;
 
-   private void addNewExpiry(MarshalledEntry entry) throws IOException {
-      long expiry = entry.getMetadata().expiryTime();
-      long maxIdle = entry.getMetadata().maxIdle();
-      if (maxIdle > 0) {
-         // Coding getExpiryTime() for transient entries has the risk of
-         // being a moving target
-         // which could lead to unexpected results, hence, InternalCacheEntry
-         // calls are required
-         expiry = maxIdle + ctx.getTimeService().wallClockTime();
-      }
-      Long at = expiry;
-      Object key = entry.getKey();
+                        if (count > configuration.clearThreshold()) {
+                            destroyDatabase = true;
+                            break;
+                        }
+                    }
+                } finally {
+                    try {
+                        it.close();
+                    } catch (IOException e) {
+                        log.warnUnableToCloseDbIterator(e);
+                    }
+                }
+            } else {
+                destroyDatabase = true;
+            }
+        } finally {
+            semaphore.release();
+        }
 
-      try {
-         expiryEntryQueue.put(new ExpiryEntry(at, key));
-      } catch (InterruptedException e) {
-         Thread.currentThread().interrupt(); // Restore interruption status
-      }
-   }
+        if (destroyDatabase) {
+            try {
+                reinitAllDatabases();
+            } catch (IOException e) {
+                throw new PersistenceException(e);
+            }
+        }
+    }
 
-   private static final class ExpiryEntry {
-      private final Long expiry;
-      private final Object key;
+    private Optional<DBIterator> getDBIterator(DB db) {
+        try {
+            return Optional.of(db.iterator(new ReadOptions().fillCache(false)));
+        } catch (DBException e) {
+            // Some Cache Store tests use clear and in case of JNI Level DB implementation
+            // this clears out internal references and results in throwing exceptions
+            // when getting an iterator. Unfortunately there is no nice way to check that...
+            if (db instanceof JniDB) {
+                log.warnAboutExceptionInLevelDB(e);
+                return Optional.empty();
+            }
+            throw e;
+        }
+    }
 
-      private ExpiryEntry(long expiry, Object key) {
-         this.expiry = expiry;
-         this.key = key;
-      }
+    @Override
+    public int size() {
+        return PersistenceUtil.count(this, null);
+    }
 
-      @Override
-      public int hashCode() {
-         final int prime = 31;
-         int result = 1;
-         result = prime * result + ((key == null) ? 0 : key.hashCode());
-         return result;
-      }
+    @Override
+    public boolean contains(Object key) {
+        try {
+            return load(key) != null;
+        } catch (Exception e) {
+            throw new PersistenceException(e);
+        }
+    }
 
-      @Override
-      public boolean equals(Object obj) {
-         if (this == obj)
+    @SuppressWarnings("unchecked")
+    @Override
+    public void process(KeyFilter keyFilter, CacheLoaderTask cacheLoaderTask, Executor executor, boolean loadValues, boolean loadMetadata) {
+
+        int batchSize = 100;
+        ExecutorAllCompletionService eacs = new ExecutorAllCompletionService(executor);
+        final TaskContext taskContext = new TaskContextImpl();
+
+        List<Map.Entry<byte[], byte[]>> entries = new ArrayList<Map.Entry<byte[], byte[]>>(batchSize);
+        try {
+            semaphore.acquire();
+        } catch (InterruptedException e) {
+            throw new PersistenceException("Cannot acquire semaphore: CacheStore is likely stopped.", e);
+        }
+        try {
+            if (stopped) {
+                throw new PersistenceException("LevelDB is stopped");
+            }
+            Optional<DBIterator> optionalIterator = getDBIterator(this.db);
+            try {
+                if (optionalIterator.isPresent()) {
+                    DBIterator it = optionalIterator.get();
+                    for (it.seekToFirst(); it.hasNext(); ) {
+                        Map.Entry<byte[], byte[]> entry = it.next();
+                        entries.add(entry);
+                        if (entries.size() == batchSize) {
+                            final List<Map.Entry<byte[], byte[]>> batch = entries;
+                            entries = new ArrayList<Map.Entry<byte[], byte[]>>(batchSize);
+                            submitProcessTask(cacheLoaderTask, keyFilter, eacs, taskContext, batch, loadValues, loadMetadata);
+                        }
+                    }
+                    if (!entries.isEmpty()) {
+                        submitProcessTask(cacheLoaderTask, keyFilter, eacs, taskContext, entries, loadValues, loadMetadata);
+                    }
+
+                    eacs.waitUntilAllCompleted();
+                    if (eacs.isExceptionThrown()) {
+                        throw new PersistenceException("Execution exception!", eacs.getFirstException());
+                    }
+                }
+            } catch (Exception e) {
+                throw new PersistenceException(e);
+            } finally {
+                try {
+                    if (optionalIterator.isPresent()) {
+                        optionalIterator.get().close();
+                    }
+                } catch (IOException e) {
+                    log.warnUnableToCloseDbIterator(e);
+                }
+            }
+        } finally {
+            semaphore.release();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void submitProcessTask(final CacheLoaderTask cacheLoaderTask, final KeyFilter filter, CompletionService ecs,
+                                   final TaskContext taskContext, final List<Map.Entry<byte[], byte[]>> batch,
+                                   final boolean loadValues, final boolean loadMetadata) {
+        ecs.submit(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                try {
+                    long now = ctx.getTimeService().wallClockTime();
+                    for (Map.Entry<byte[], byte[]> pair : batch) {
+                        if (taskContext.isStopped()) {
+                            break;
+                        }
+                        Object key = unmarshall(pair.getKey());
+                        if (filter == null || filter.accept(key)) {
+                            MarshalledEntry entry = loadValues || loadMetadata ? (MarshalledEntry) unmarshall(pair.getValue()) : null;
+                            boolean isExpired = entry != null && entry.getMetadata() != null && entry.getMetadata().isExpired(now);
+                            if (!isExpired) {
+                                if (!loadValues || !loadMetadata) {
+                                    entry = ctx.getMarshalledEntryFactory().newMarshalledEntry(
+                                            key, loadValues ? entry.getValue() : null, loadMetadata ? entry.getMetadata() : null);
+                                }
+                                cacheLoaderTask.processEntry(entry, taskContext);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    log.errorExecutingParallelStoreTask(e);
+                    throw e;
+                }
+                return null;
+            }
+        });
+    }
+
+    @Override
+    public boolean delete(Object key) {
+        try {
+            byte[] keyBytes = marshall(key);
+            semaphore.acquire();
+            try {
+                if (stopped) {
+                    throw new PersistenceException("LevelDB is stopped");
+                }
+                if (db.get(keyBytes) == null) {
+                    return false;
+                }
+                db.delete(keyBytes);
+            } finally {
+                semaphore.release();
+            }
             return true;
-         if (obj == null)
-            return false;
-         if (getClass() != obj.getClass())
-            return false;
-         ExpiryEntry other = (ExpiryEntry) obj;
-         if (key == null) {
-            if (other.key != null)
-               return false;
-         } else if (!key.equals(other.key))
-            return false;
-         return true;
-      }
+        } catch (Exception e) {
+            throw new PersistenceException(e);
+        }
+    }
 
-   }
+    @Override
+    public void write(MarshalledEntry me) {
+        try {
+            byte[] marshelledKey = marshall(me.getKey());
+            byte[] marshalledEntry = marshall(me);
+            semaphore.acquire();
+            try {
+                if (stopped) {
+                    throw new PersistenceException("LevelDB is stopped");
+                }
+                db.put(marshelledKey, marshalledEntry);
+            } finally {
+                semaphore.release();
+            }
+            InternalMetadata meta = me.getMetadata();
+            if (meta != null && meta.expiryTime() > -1) {
+                addNewExpiry(me);
+            }
+        } catch (Exception e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    @Override
+    public MarshalledEntry load(Object key) {
+        try {
+            byte[] marshalledEntry;
+            semaphore.acquire();
+            try {
+                if (stopped) {
+                    throw new PersistenceException("LevelDB is stopped");
+                }
+                marshalledEntry = db.get(marshall(key));
+            } finally {
+                semaphore.release();
+            }
+            MarshalledEntry me = (MarshalledEntry) unmarshall(marshalledEntry);
+            if (me == null) return null;
+
+            InternalMetadata meta = me.getMetadata();
+            if (meta != null && meta.isExpired(ctx.getTimeService().wallClockTime())) {
+                return null;
+            }
+            return me;
+        } catch (Exception e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void purge(Executor executor, PurgeListener purgeListener) {
+        try {
+            semaphore.acquire();
+        } catch (InterruptedException e) {
+            throw new PersistenceException("Cannot acquire semaphore: CacheStore is likely stopped.", e);
+        }
+        try {
+            if (stopped) {
+                throw new PersistenceException("LevelDB is stopped");
+            }
+            // Drain queue and update expiry tree
+            List<ExpiryEntry> entries = new ArrayList<ExpiryEntry>();
+            expiryEntryQueue.drainTo(entries);
+            for (ExpiryEntry entry : entries) {
+                final byte[] expiryBytes = marshall(entry.expiry);
+                final byte[] keyBytes = marshall(entry.key);
+                final byte[] existingBytes = expiredDb.get(expiryBytes);
+
+                if (existingBytes != null) {
+                    // in the case of collision make the key a List ...
+                    final Object existing = unmarshall(existingBytes);
+                    if (existing instanceof List) {
+                        ((List<Object>) existing).add(entry.key);
+                        expiredDb.put(expiryBytes, marshall(existing));
+                    } else {
+                        List<Object> al = new ArrayList<Object>(2);
+                        al.add(existing);
+                        al.add(entry.key);
+                        expiredDb.put(expiryBytes, marshall(al));
+                    }
+                } else {
+                    expiredDb.put(expiryBytes, keyBytes);
+                }
+            }
+
+            List<Long> times = new ArrayList<Long>();
+            List<Object> keys = new ArrayList<Object>();
+            DBIterator it = expiredDb.iterator(new ReadOptions().fillCache(false));
+            long now = ctx.getTimeService().wallClockTime();
+            try {
+                for (it.seekToFirst(); it.hasNext(); ) {
+                    Map.Entry<byte[], byte[]> entry = it.next();
+
+                    Long time = (Long) unmarshall(entry.getKey());
+                    if (time > now)
+                        break;
+                    times.add(time);
+                    Object key = unmarshall(entry.getValue());
+                    if (key instanceof List)
+                        keys.addAll((List<?>) key);
+                    else
+                        keys.add(key);
+                }
+
+                for (Long time : times) {
+                    expiredDb.delete(marshall(time));
+                }
+
+                if (!keys.isEmpty())
+                    log.debugf("purge (up to) %d entries", keys.size());
+                int count = 0;
+                for (Object key : keys) {
+                    byte[] keyBytes = marshall(key);
+
+                    byte[] b = db.get(keyBytes);
+                    if (b == null)
+                        continue;
+                    MarshalledEntry me = (MarshalledEntry) ctx.getMarshaller().objectFromByteBuffer(b);
+                    // TODO race condition: the entry could be updated between the get and delete!
+                    if (me.getMetadata() != null && me.getMetadata().isExpired(now)) {
+                        // somewhat inefficient to FIND then REMOVE...
+                        db.delete(keyBytes);
+                        purgeListener.entryPurged(key);
+                        count++;
+                    }
+
+                }
+                if (count != 0)
+                    log.debugf("purged %d entries", count);
+            } catch (Exception e) {
+                throw new PersistenceException(e);
+            } finally {
+                try {
+                    it.close();
+                } catch (IOException e) {
+                    log.warnUnableToCloseDbIterator(e);
+                }
+            }
+        } catch (PersistenceException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new PersistenceException(e);
+        } finally {
+            semaphore.release();
+        }
+    }
+
+    private byte[] marshall(Object entry) throws IOException, InterruptedException {
+        return ctx.getMarshaller().objectToByteBuffer(entry);
+    }
+
+    private Object unmarshall(byte[] bytes) throws IOException, ClassNotFoundException {
+        if (bytes == null)
+            return null;
+
+        return ctx.getMarshaller().objectFromByteBuffer(bytes);
+    }
+
+    private void addNewExpiry(MarshalledEntry entry) throws IOException {
+        long expiry = entry.getMetadata().expiryTime();
+        long maxIdle = entry.getMetadata().maxIdle();
+        if (maxIdle > 0) {
+            // Coding getExpiryTime() for transient entries has the risk of
+            // being a moving target
+            // which could lead to unexpected results, hence, InternalCacheEntry
+            // calls are required
+            expiry = maxIdle + ctx.getTimeService().wallClockTime();
+        }
+        Long at = expiry;
+        Object key = entry.getKey();
+
+        try {
+            expiryEntryQueue.put(new ExpiryEntry(at, key));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt(); // Restore interruption status
+        }
+    }
+
+    private static final class ExpiryEntry {
+        private final Long expiry;
+        private final Object key;
+
+        private ExpiryEntry(long expiry, Object key) {
+            this.expiry = expiry;
+            this.key = key;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((key == null) ? 0 : key.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            ExpiryEntry other = (ExpiryEntry) obj;
+            if (key == null) {
+                if (other.key != null)
+                    return false;
+            } else if (!key.equals(other.key))
+                return false;
+            return true;
+        }
+
+    }
 
 }

--- a/persistence/leveldb/src/main/java/org/infinispan/persistence/leveldb/logging/Log.java
+++ b/persistence/leveldb/src/main/java/org/infinispan/persistence/leveldb/logging/Log.java
@@ -1,6 +1,7 @@
 package org.infinispan.persistence.leveldb.logging;
 
 import org.infinispan.persistence.spi.PersistenceException;
+import org.iq80.leveldb.DBException;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
@@ -44,4 +45,8 @@ public interface Log extends org.infinispan.util.logging.Log {
 
    @Message(value = "Could not load any LevelDB Factories: : %s", id = 23007)
    PersistenceException cannotLoadlevelDBFactories(String formattedArrayOfClassNames);
+
+   @LogMessage(level = DEBUG)
+   @Message(value = "An internal LevelDB exception occurred", id = 23008)
+   void warnAboutExceptionInLevelDB(@Cause Exception e);
 }

--- a/persistence/leveldb/src/main/resources/features.xml
+++ b/persistence/leveldb/src/main/resources/features.xml
@@ -2,6 +2,7 @@
 <features name="infinispan-cachestore-leveldb-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
    <feature name="infinispan-cachestore-leveldb-jni" version="${project.version}">
       <bundle>mvn:org.fusesource.leveldbjni/leveldbjni-all/${version.leveldbjni}</bundle>
+      <bundle>mvn:org.fusesource.leveldbjni/leveldbjni/${version.leveldbjni}</bundle>
       <bundle>mvn:org.infinispan/infinispan-cachestore-leveldb/${project.version}</bundle>
    </feature>
    <feature name="infinispan-cachestore-leveldb-java" version="${project.version}">

--- a/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBMultiCacheStoreFunctionalTest.java
+++ b/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBMultiCacheStoreFunctionalTest.java
@@ -1,11 +1,11 @@
 package org.infinispan.persistence.leveldb;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 import org.infinispan.persistence.leveldb.configuration.LevelDBStoreConfiguration;
 import org.infinispan.persistence.leveldb.configuration.LevelDBStoreConfigurationBuilder;
 import org.infinispan.persistence.MultiStoresFunctionalTest;
 import org.infinispan.test.TestingUtil;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -19,7 +19,7 @@ public class LevelDBMultiCacheStoreFunctionalTest extends MultiStoresFunctionalT
    @BeforeMethod
    protected void cleanDataFiles() {
       if (tmpDir.exists()) {
-         TestingUtil.recursiveFileRemove(tmpDir);
+         Util.recursiveFileRemove(tmpDir);
       }
    }
 

--- a/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBParallelIterationTest.java
+++ b/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBParallelIterationTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.persistence.leveldb;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.persistence.ParallelIterationTest;
 import org.infinispan.persistence.leveldb.configuration.LevelDBStoreConfigurationBuilder;
@@ -30,7 +31,7 @@ public class LevelDBParallelIterationTest extends ParallelIterationTest {
 
    @Override
    protected void teardown() {
-      TestingUtil.recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
       super.teardown();
    }
 

--- a/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBStoreFunctionalTest.java
+++ b/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBStoreFunctionalTest.java
@@ -15,10 +15,10 @@ public abstract class LevelDBStoreFunctionalTest extends BaseStoreFunctionalTest
    @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
       TestingUtil.recursiveFileRemove(tmpDirectory);
-      new File(tmpDirectory).mkdirs();
    }
 
    LevelDBStoreConfigurationBuilder createStoreBuilder(PersistenceConfigurationBuilder loaders) {
+      new File(tmpDirectory).mkdirs();
       return loaders.addStore(LevelDBStoreConfigurationBuilder.class).location(tmpDirectory + "/data").expiredLocation(tmpDirectory + "/expiry").clearThreshold(2);
    }
 }

--- a/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBStoreFunctionalTest.java
+++ b/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBStoreFunctionalTest.java
@@ -1,11 +1,11 @@
 package org.infinispan.persistence.leveldb;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 import org.infinispan.persistence.leveldb.configuration.LevelDBStoreConfigurationBuilder;
 import org.infinispan.persistence.BaseStoreFunctionalTest;
 import org.infinispan.test.TestingUtil;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 
 import java.io.File;
 
@@ -14,7 +14,7 @@ public abstract class LevelDBStoreFunctionalTest extends BaseStoreFunctionalTest
 
    @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
-      TestingUtil.recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
    }
 
    LevelDBStoreConfigurationBuilder createStoreBuilder(PersistenceConfigurationBuilder loaders) {

--- a/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBStoreTest.java
+++ b/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/LevelDBStoreTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 import org.infinispan.container.entries.InternalCacheEntry;
@@ -20,7 +21,6 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 @Test(groups = "unit", testName = "persistence.leveldb.LevelDBStoreTest")
@@ -30,7 +30,7 @@ public class LevelDBStoreTest extends BaseStoreTest {
 
    @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
-      TestingUtil.recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
    }
 
    protected LevelDBStoreConfigurationBuilder createCacheStoreConfig(PersistenceConfigurationBuilder lcb) {

--- a/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/config/ConfigurationTest.java
+++ b/persistence/leveldb/src/test/java/org/infinispan/persistence/leveldb/config/ConfigurationTest.java
@@ -1,6 +1,7 @@
 package org.infinispan.persistence.leveldb.config;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.StoreConfiguration;
@@ -13,7 +14,6 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.TestingUtil;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -34,7 +34,7 @@ public class ConfigurationTest extends AbstractInfinispanTest {
 
    @AfterClass(alwaysRun = true)
    protected void clearTempDir() {
-      TestingUtil.recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
    }
 
    public void testConfigBuilder() {
@@ -74,7 +74,7 @@ public class ConfigurationTest extends AbstractInfinispanTest {
       cache.stop();
       cacheManager.stop();
 
-      TestingUtil.recursiveFileRemove("/tmp/leveldb/60");
+      Util.recursiveFileRemove("/tmp/leveldb/60");
    }
 
 }

--- a/persistence/soft-index/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreFunctionalTest.java
+++ b/persistence/soft-index/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreFunctionalTest.java
@@ -2,6 +2,7 @@ package org.infinispan.persistence.sifs;
 
 import java.io.File;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
 import org.infinispan.persistence.BaseStoreFunctionalTest;
 import org.infinispan.persistence.sifs.configuration.SoftIndexFileStoreConfigurationBuilder;
@@ -24,7 +25,7 @@ public class SoftIndexFileStoreFunctionalTest extends BaseStoreFunctionalTest {
 
    @AfterClass
    protected void clearTempDir() {
-      TestingUtil.recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
       new File(tmpDirectory).mkdirs();
    }
 

--- a/persistence/soft-index/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreStressTest.java
+++ b/persistence/soft-index/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreStressTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.persistence.sifs;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.InternalEntryFactory;
 import org.infinispan.container.InternalEntryFactoryImpl;
@@ -34,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static org.testng.Assert.fail;
-import static org.infinispan.test.TestingUtil.recursiveFileRemove;
+import static org.infinispan.commons.util.Util.recursiveFileRemove;
 
 /**
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
@@ -56,7 +57,7 @@ public class SoftIndexFileStoreStressTest extends AbstractInfinispanTest {
    @BeforeMethod(alwaysRun = true)
    public void setUp() throws Exception {
       tmpDirectory = TestingUtil.tmpDirectory(this.getClass());
-      recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
       marshaller = new TestObjectStreamMarshaller();
       factory = new InternalEntryFactoryImpl();
       store = new SoftIndexFileStore();

--- a/persistence/soft-index/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreTest.java
+++ b/persistence/soft-index/src/test/java/org/infinispan/persistence/sifs/SoftIndexFileStoreTest.java
@@ -1,12 +1,13 @@
 package org.infinispan.persistence.sifs;
 
 import static org.infinispan.persistence.PersistenceUtil.internalMetadata;
-import static org.infinispan.test.TestingUtil.recursiveFileRemove;
+import static org.infinispan.commons.util.Util.recursiveFileRemove;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.marshall.core.MarshalledEntry;
@@ -45,7 +46,7 @@ public class SoftIndexFileStoreTest extends BaseStoreTest {
 
    @AfterClass
    protected void clearTempDir() {
-      recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
    }
 
    @Override

--- a/query/src/test/java/org/infinispan/query/backend/QueryInterceptorTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/QueryInterceptorTest.java
@@ -3,6 +3,7 @@ package org.infinispan.query.backend;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
@@ -27,7 +28,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.util.concurrent.atomic.LongAdder;
 
-import static org.infinispan.test.TestingUtil.recursiveFileRemove;
+import static org.infinispan.commons.util.Util.recursiveFileRemove;
 import static org.infinispan.test.TestingUtil.withCacheManager;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -59,8 +60,8 @@ public class QueryInterceptorTest {
 
    @AfterMethod
    protected void tearDown() {
-      recursiveFileRemove(indexDir);
-      recursiveFileRemove(storeDir);
+      Util.recursiveFileRemove(indexDir);
+      Util.recursiveFileRemove(storeDir);
    }
 
    @Test

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheFSDirectoryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheFSDirectoryTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.query.blackbox;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -58,7 +59,7 @@ public class ClusteredCacheFSDirectoryTest extends ClusteredCacheTest {
          super.clearContent();
       } finally {
          //delete the index otherwise it will mess up the index for next tests
-         TestingUtil.recursiveFileRemove(TMP_DIR);
+         Util.recursiveFileRemove(TMP_DIR);
       }
    }
 }

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCacheAsyncCacheStoreTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCacheAsyncCacheStoreTest.java
@@ -1,7 +1,7 @@
 package org.infinispan.query.blackbox;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
@@ -29,7 +29,7 @@ public class LocalCacheAsyncCacheStoreTest extends LocalCacheTest {
 
    @Override
    protected void setup() throws Exception {
-      TestingUtil.recursiveFileRemove(indexDirectory);
+      Util.recursiveFileRemove(indexDirectory);
       boolean created = new File(indexDirectory).mkdirs();
       assertTrue(created);
       super.setup();
@@ -40,7 +40,7 @@ public class LocalCacheAsyncCacheStoreTest extends LocalCacheTest {
       try {
          super.teardown();
       } finally {
-         TestingUtil.recursiveFileRemove(indexDirectory);
+         Util.recursiveFileRemove(indexDirectory);
       }
    }
 }

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCacheFSDirectoryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCacheFSDirectoryTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.query.blackbox;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -38,7 +39,7 @@ public class LocalCacheFSDirectoryTest extends LocalCacheTest {
 
    @Override
    protected void setup() throws Exception {
-      TestingUtil.recursiveFileRemove(indexDirectory);
+      Util.recursiveFileRemove(indexDirectory);
       new File(indexDirectory).mkdirs();
       super.setup();
    }
@@ -48,7 +49,7 @@ public class LocalCacheFSDirectoryTest extends LocalCacheTest {
       try {
          super.teardown();
       } finally {
-         TestingUtil.recursiveFileRemove(indexDirectory);
+         Util.recursiveFileRemove(indexDirectory);
       }
    }
 }

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCachePerfProgrammaticConfTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCachePerfProgrammaticConfTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.query.blackbox;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -46,7 +47,7 @@ public class LocalCachePerfProgrammaticConfTest extends LocalCacheTest {
 
    @Override
    protected void setup() throws Exception {
-      TestingUtil.recursiveFileRemove(indexDirectory);
+      Util.recursiveFileRemove(indexDirectory);
       new File(indexDirectory).mkdirs();
       super.setup();
    }
@@ -56,7 +57,7 @@ public class LocalCachePerfProgrammaticConfTest extends LocalCacheTest {
       try {
          super.teardown();
       } finally {
-         TestingUtil.recursiveFileRemove(indexDirectory);
+         Util.recursiveFileRemove(indexDirectory);
       }
    }
 }

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCachePerformantConfTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCachePerformantConfTest.java
@@ -1,7 +1,7 @@
 package org.infinispan.query.blackbox;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
@@ -30,7 +30,7 @@ public class LocalCachePerformantConfTest extends LocalCacheTest {
 
    @Override
    protected void setup() throws Exception {
-      TestingUtil.recursiveFileRemove(indexDirectory);
+      Util.recursiveFileRemove(indexDirectory);
       boolean created = new File(indexDirectory).mkdirs();
       assertTrue(created);
       super.setup();
@@ -41,7 +41,7 @@ public class LocalCachePerformantConfTest extends LocalCacheTest {
       try {
          super.teardown();
       } finally {
-         TestingUtil.recursiveFileRemove(indexDirectory);
+         Util.recursiveFileRemove(indexDirectory);
       }
    }
 }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/FilesystemQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/FilesystemQueryDslConditionsTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.query.dsl.embedded;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.test.TestingUtil;
@@ -25,7 +26,7 @@ public class FilesystemQueryDslConditionsTest extends QueryDslConditionsTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      TestingUtil.recursiveFileRemove(indexDirectory);
+      Util.recursiveFileRemove(indexDirectory);
       boolean created = new File(indexDirectory).mkdirs();
       assertTrue(created);
 
@@ -48,7 +49,7 @@ public class FilesystemQueryDslConditionsTest extends QueryDslConditionsTest {
          super.destroy();
       } finally {
          //delete the index otherwise it will mess up the index for next tests
-         TestingUtil.recursiveFileRemove(indexDirectory);
+         Util.recursiveFileRemove(indexDirectory);
       }
    }
 }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedSingleFileStoreQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedSingleFileStoreQueryDslConditionsTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.query.dsl.embedded;
 
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder;
 import org.infinispan.test.TestingUtil;
@@ -24,13 +25,13 @@ public class NonIndexedSingleFileStoreQueryDslConditionsTest extends NonIndexedQ
       try {
          super.destroy();
       } finally {
-         TestingUtil.recursiveFileRemove(tmpDirectory);
+         Util.recursiveFileRemove(tmpDirectory);
       }
    }
 
    @Override
    protected void createCacheManagers() throws Throwable {
-      TestingUtil.recursiveFileRemove(tmpDirectory);
+      Util.recursiveFileRemove(tmpDirectory);
       ConfigurationBuilder cfg = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
       cfg.persistence()
             .addStore(SingleFileStoreConfigurationBuilder.class)

--- a/query/src/test/java/org/infinispan/query/persistence/InconsistentIndexesAfterRestartTest.java
+++ b/query/src/test/java/org/infinispan/query/persistence/InconsistentIndexesAfterRestartTest.java
@@ -9,6 +9,7 @@ import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.Store;
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -169,7 +170,7 @@ public class InconsistentIndexesAfterRestartTest extends AbstractInfinispanTest 
 
     @AfterClass
     protected void clearTempDir() {
-       TestingUtil.recursiveFileRemove(TMP_DIR);
+       Util.recursiveFileRemove(TMP_DIR);
     }
 
 }

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataCachePreserveStateAcrossRestartsTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataCachePreserveStateAcrossRestartsTest.java
@@ -2,6 +2,7 @@ package org.infinispan.query.remote.impl;
 
 import static org.testng.AssertJUnit.assertTrue;
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -25,7 +26,7 @@ public class ProtobufMetadataCachePreserveStateAcrossRestartsTest extends Abstra
 
    public void testStatePreserved() throws Exception {
       String persistentStateLocation = TestingUtil.tmpDirectory(this.getClass());
-      TestingUtil.recursiveFileRemove(persistentStateLocation);
+      Util.recursiveFileRemove(persistentStateLocation);
 
       TestingUtil.withCacheManager(new CacheManagerCallable(createCacheManager(persistentStateLocation)) {
          @Override

--- a/scripting/src/test/java/org/infinispan/scripting/ScriptCachePreserveStateAcrossRestarts.java
+++ b/scripting/src/test/java/org/infinispan/scripting/ScriptCachePreserveStateAcrossRestarts.java
@@ -4,6 +4,7 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.io.InputStream;
 
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -28,7 +29,7 @@ public class ScriptCachePreserveStateAcrossRestarts extends AbstractInfinispanTe
 
    public void testStatePreserved() throws Exception {
       String persistentStateLocation = TestingUtil.tmpDirectory(this.getClass());
-      TestingUtil.recursiveFileRemove(persistentStateLocation);
+      Util.recursiveFileRemove(persistentStateLocation);
 
       TestingUtil.withCacheManager(new CacheManagerCallable(createCacheManager(persistentStateLocation)) {
          @Override

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/cs/leveldb/LevelDBCacheStoreIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/cs/leveldb/LevelDBCacheStoreIT.java
@@ -13,9 +13,9 @@ import org.infinispan.commons.io.ByteBufferImpl;
 import org.infinispan.commons.logging.Log;
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.commons.marshall.AbstractMarshaller;
+import org.infinispan.commons.util.Util;
 import org.infinispan.server.test.category.CacheStore;
 import org.infinispan.server.test.util.ITestUtils;
-import org.infinispan.test.TestingUtil;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.Options;
 import org.iq80.leveldb.impl.Iq80DBFactory;
@@ -59,10 +59,10 @@ public class LevelDBCacheStoreIT {
 
     private void removeDataFilesIfExists() {
         if (dataDir.exists()) {
-            TestingUtil.recursiveFileRemove(dataDir);
+            Util.recursiveFileRemove(dataDir);
         }
         if (expiredDir.exists()) {
-            TestingUtil.recursiveFileRemove(expiredDir);
+            Util.recursiveFileRemove(expiredDir);
         }
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6593

Windows adjustments for LevelDB and some reformatting. Highlights:
* Most of the fixes should go to LevelDB itself, that's why they look a bit ugly in our code
* I tried to limit the scope of changes (that's why I often check if an instance is a JNI and do something slightly differently).

To both `master` and `8.2.x` please.
TIP: Review files with "ignore whitespaces" on: https://github.com/infinispan/infinispan/pull/4309/files?w=1