### PR TITLE
[8.2] ISPN-3702 Too many threads for cleaning up infinispan transactions

### DIFF
--- a/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
@@ -46,7 +46,7 @@ public class TransactionXaAdapterTmIntegrationTest {
       Cache mockCache = mock(Cache.class);
       Configuration configuration = new ConfigurationBuilder().build();
       XaTransactionTable txTable = new XaTransactionTable();
-      txTable.initialize(null, configuration, null, null, null, null,
+      txTable.initialize(null, configuration, null, null, null,
                          null, null, null, null, mockCache, null, null, null, null);
       txTable.start();
       txTable.startXidMapping();


### PR DESCRIPTION
* use timeout executor to cleanup

https://issues.jboss.org/browse/ISPN-3702