### PR TITLE
ISPN-6581 Typed remote exec in binary cache

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SecureExecTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SecureExecTest.java
@@ -39,7 +39,7 @@ import static org.testng.AssertJUnit.assertEquals;
 @CleanupAfterMethod
 public class SecureExecTest extends AuthenticationTest {
     static final Subject ADMIN = TestingUtil.makeSubject("user", ScriptingManager.SCRIPT_MANAGER_ROLE);
-
+    static final String CACHE_NAME = "secured-exec";
     private RemoteCacheManager remoteCacheManager;
 
     @Override
@@ -57,6 +57,13 @@ public class SecureExecTest extends AuthenticationTest {
                 .marshaller(new GenericJBossMarshaller())
                 .security().authorization().enable().role("user");
         cacheManager = TestCacheManagerFactory.createCacheManager(global, config);
+        ConfigurationBuilder config2 = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+        config2
+              .dataContainer()
+                  .keyEquivalence(new AnyServerEquivalence())
+                  .valueEquivalence(new AnyServerEquivalence())
+              .security().authorization().enable().role("user");
+        cacheManager.defineConfiguration(CACHE_NAME, config2.build());
         cacheManager.getCache();
 
         return cacheManager;
@@ -127,9 +134,9 @@ public class SecureExecTest extends AuthenticationTest {
             scriptingManager.addScript(scriptName, script);
         }
 
-        String result = remoteCacheManager.getCache().execute(scriptName, params);
+        String result = remoteCacheManager.getCache(CACHE_NAME).execute(scriptName, params);
         assertEquals("guinness", result);
-        assertEquals("guinness", remoteCacheManager.getCache().get("a"));
+        assertEquals("guinness", remoteCacheManager.getCache(CACHE_NAME).get("a"));
     }
 
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterFailoverEventsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientClusterFailoverEventsTest.java
@@ -58,29 +58,29 @@ public class ClientClusterFailoverEventsTest extends MultiHotRodServersTest {
          clientBuilder.balancingStrategy(StickyServerLoadBalancingStrategy.class);
          RemoteCacheManager newClient = new RemoteCacheManager(clientBuilder.build());
          try {
-            WithStateEventLogListener<Integer> statefulListener = new WithStateEventLogListener<>();
-            EventLogListener<Integer> statelessListener = new EventLogListener<>();
-            FailoverEventLogListener<Integer> failoverListener = new FailoverEventLogListener<>();
             RemoteCache<Integer, String> c = newClient.getCache();
+            WithStateEventLogListener<Integer> statefulListener = new WithStateEventLogListener<>(c);
+            EventLogListener<Integer> statelessListener = new EventLogListener<>(c);
+            FailoverEventLogListener<Integer> failoverListener = new FailoverEventLogListener<>(c);
             c.addClientListener(statelessListener);
             c.addClientListener(statefulListener);
             c.addClientListener(failoverListener);
             c.put(key00, "zero");
-            statefulListener.expectOnlyCreatedEvent(key00, cache(0));
-            statelessListener.expectOnlyCreatedEvent(key00, cache(0));
-            failoverListener.expectOnlyCreatedEvent(key00, cache(0));
+            statefulListener.expectOnlyCreatedEvent(key00);
+            statelessListener.expectOnlyCreatedEvent(key00);
+            failoverListener.expectOnlyCreatedEvent(key00);
             c.put(key10, "one", 1000, TimeUnit.MILLISECONDS);
-            statefulListener.expectOnlyCreatedEvent(key10, cache(0));
-            statelessListener.expectOnlyCreatedEvent(key10, cache(0));
-            failoverListener.expectOnlyCreatedEvent(key10, cache(0));
+            statefulListener.expectOnlyCreatedEvent(key10);
+            statelessListener.expectOnlyCreatedEvent(key10);
+            failoverListener.expectOnlyCreatedEvent(key10);
             c.put(key11, "two");
-            statefulListener.expectOnlyCreatedEvent(key11, cache(0));
-            statelessListener.expectOnlyCreatedEvent(key11, cache(0));
-            failoverListener.expectOnlyCreatedEvent(key11, cache(0));
+            statefulListener.expectOnlyCreatedEvent(key11);
+            statelessListener.expectOnlyCreatedEvent(key11);
+            failoverListener.expectOnlyCreatedEvent(key11);
             c.put(key41, "three", 1000, TimeUnit.MILLISECONDS);
-            statefulListener.expectOnlyCreatedEvent(key41, cache(0));
-            statelessListener.expectOnlyCreatedEvent(key41, cache(0));
-            failoverListener.expectOnlyCreatedEvent(key41, cache(0));
+            statefulListener.expectOnlyCreatedEvent(key41);
+            statelessListener.expectOnlyCreatedEvent(key41);
+            failoverListener.expectOnlyCreatedEvent(key41);
             ts0.advance(1001);
             ts1.advance(1001);
             findServerAndKill(newClient, servers, cacheManagers);
@@ -111,6 +111,10 @@ public class ClientClusterFailoverEventsTest extends MultiHotRodServersTest {
    }
 
    @ClientListener(includeCurrentState = true)
-   public static class WithStateEventLogListener<K> extends FailoverEventLogListener<K> {}
+   public static class WithStateEventLogListener<K> extends FailoverEventLogListener<K> {
+      public WithStateEventLogListener(RemoteCache<K, ?> remote) {
+         super(remote);
+      }
+   }
 
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerLeakTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerLeakTest.java
@@ -31,11 +31,11 @@ public class ClientListenerLeakTest extends SingleHotRodServerTest {
          @Override
          public void call() {
             RemoteCache<Integer, String> remote = rcm.getCache(cacheName);
-            EventLogListener<Integer> eventListener = new EventLogListener<>();
+            EventLogListener<Integer> eventListener = new EventLogListener<>(remote);
             remote.addClientListener(eventListener);
             eventListener.expectNoEvents();
             remote.put(1, "one");
-            eventListener.expectOnlyCreatedEvent(1, cache(cacheName));
+            eventListener.expectOnlyCreatedEvent(1);
          }
       });
       detectThreadLeaks(".*Client-Listener-ClientListenerLeakTest-.*");

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerRemoveOnStopTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerRemoveOnStopTest.java
@@ -13,13 +13,13 @@ import static org.testng.AssertJUnit.assertTrue;
 public class ClientListenerRemoveOnStopTest extends SingleHotRodServerTest {
 
    public void testAllListenersRemovedOnStop() {
-      final EventLogListener eventListener1 = new EventLogListener();
       final RemoteCache<Integer, String> rcache = remoteCacheManager.getCache();
+      final EventLogListener<Integer> eventListener1 = new EventLogListener<>(rcache);
       rcache.addClientListener(eventListener1);
       Set<Object> listeners = rcache.getListeners();
       assertEquals(1, listeners.size());
       assertEquals(eventListener1, listeners.iterator().next());
-      final EventLogListener eventListener2 = new EventLogListener();
+      final EventLogListener<Integer> eventListener2 = new EventLogListener<>(rcache);
       rcache.addClientListener(eventListener2);
       listeners = rcache.getListeners();
       assertEquals(2, listeners.size());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/FailoverEventLogListener.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/FailoverEventLogListener.java
@@ -1,5 +1,6 @@
 package org.infinispan.client.hotrod.event;
 
+import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.annotation.ClientCacheFailover;
 
 import java.util.concurrent.ArrayBlockingQueue;
@@ -8,6 +9,10 @@ import java.util.concurrent.BlockingQueue;
 public class FailoverEventLogListener<K> extends EventLogListener<K> {
    public BlockingQueue<ClientCacheFailoverEvent> failoverEvents =
          new ArrayBlockingQueue<ClientCacheFailoverEvent>(128);
+
+   public FailoverEventLogListener(RemoteCache<K, ?> remote) {
+      super(remote);
+   }
 
    @Override @SuppressWarnings("unchecked")
    public <E extends ClientEvent> BlockingQueue<E> queue(ClientEvent.Type type) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ListenerCacheManagerStopTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ListenerCacheManagerStopTest.java
@@ -64,7 +64,7 @@ public class ListenerCacheManagerStopTest extends AbstractInfinispanTest {
 
    @Test
    public void testThreadsAreStopped() throws Exception {
-      final EventLogListener listener = new EventLogListener();
+      final EventLogListener listener = new EventLogListener<>(remoteCacheManager.getCache());
       cache.addClientListener(listener);
 
       final String listenerId = findListenerId(listener);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteCacheSupplier.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteCacheSupplier.java
@@ -1,0 +1,7 @@
+package org.infinispan.client.hotrod.event;
+
+import org.infinispan.client.hotrod.RemoteCache;
+
+public interface RemoteCacheSupplier<K> {
+   <V> RemoteCache<K, V> get();
+}

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/HotRodClientTestingUtil.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/test/HotRodClientTestingUtil.java
@@ -5,6 +5,7 @@ import org.infinispan.Cache;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.event.RemoteCacheSupplier;
 import org.infinispan.client.hotrod.impl.protocol.HotRodConstants;
 import org.infinispan.client.hotrod.impl.transport.tcp.FailoverRequestBalancingStrategy;
 import org.infinispan.client.hotrod.impl.transport.tcp.TcpTransportFactory;
@@ -156,24 +157,23 @@ public class HotRodClientTestingUtil {
       }
    }
 
-   public static <K, V> void withClientListener(Object listener, RemoteCacheManagerCallable c) {
-      RemoteCache<K, V> cache = c.rcm.getCache();
-      cache.addClientListener(listener);
+   public static <K, V> void withClientListener(
+         RemoteCacheSupplier<K> l, Consumer<RemoteCache<K, V>> cons) {
+      l.get().addClientListener(l);
       try {
-         c.call();
+         cons.accept(l.get());
       } finally {
-         cache.removeClientListener(listener);
+         l.get().removeClientListener(l);
       }
    }
 
-   public static <K, V> void withClientListener(Object listener,
-         Object[] filterFactoryParams, Object[] converterFactoryParams, RemoteCacheManagerCallable c) {
-      RemoteCache<K, V> cache = c.rcm.getCache();
-      cache.addClientListener(listener, filterFactoryParams, converterFactoryParams);
+   public static <K, V> void withClientListener(RemoteCacheSupplier<K> listener,
+         Object[] fparams, Object[] cparams, Consumer<RemoteCache<K, V>> cons) {
+      listener.get().addClientListener(listener, fparams, cparams);
       try {
-         c.call();
+         cons.accept(listener.get());
       } finally {
-         cache.removeClientListener(listener);
+         listener.get().removeClientListener(listener);
       }
    }
 

--- a/client/hotrod-client/src/test/resources/testRole_hotrod.js
+++ b/client/hotrod-client/src/test/resources/testRole_hotrod.js
@@ -1,4 +1,4 @@
 // mode=local,language=javascript,parameters=[a],role=user
-var cache = cacheManager.getCache();
+var cache = cacheManager.getCache("secured-exec");
 cache.put("a", a);
 cache.get("a");

--- a/client/hotrod-client/src/test/resources/typed-cachemanager-put-get.js
+++ b/client/hotrod-client/src/test/resources/typed-cachemanager-put-get.js
@@ -1,3 +1,3 @@
 // mode=local,language=javascript,datatype='text/plain; charset=utf-8'
-cacheManager.getCache().put("a", "a");
-cacheManager.getCache().get("a");
+cacheManager.getCache("exec-typed-cache").put("a", "a");
+cacheManager.getCache("exec-typed-cache").get("a");

--- a/client/hotrod-client/src/test/resources/typed-put-get-dist.js
+++ b/client/hotrod-client/src/test/resources/typed-put-get-dist.js
@@ -1,4 +1,3 @@
 // mode=distributed,language=javascript,parameters=[k, v],datatype='text/plain; charset=utf-8'
-var cache = cacheManager.getCache();
 cache.put(k, v);
 cache.get(k);

--- a/client/hotrod-client/src/test/resources/typed-put-get.js
+++ b/client/hotrod-client/src/test/resources/typed-put-get.js
@@ -1,4 +1,3 @@
 // mode=local,language=javascript,parameters=[k, v],datatype='text/plain; charset=utf-8'
-var cache = cacheManager.getCache();
 cache.put(k, v);
 cache.get(k);

--- a/core/src/main/java/org/infinispan/util/CollectionAsCacheCollection.java
+++ b/core/src/main/java/org/infinispan/util/CollectionAsCacheCollection.java
@@ -1,0 +1,97 @@
+package org.infinispan.util;
+
+import org.infinispan.CacheCollection;
+import org.infinispan.CacheStream;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.CloseableSpliterator;
+import org.infinispan.commons.util.Closeables;
+
+import java.util.Collection;
+
+public class CollectionAsCacheCollection<E> implements CacheCollection<E> {
+   private final Collection<E> col;
+
+   public CollectionAsCacheCollection(Collection<E> col) {
+      this.col = col;
+   }
+
+   @Override
+   public int size() {
+      return col.size();
+   }
+
+   @Override
+   public boolean isEmpty() {
+      return col.isEmpty();
+   }
+
+   @Override
+   public boolean contains(Object o) {
+      return col.contains(o);
+   }
+
+   @Override
+   public CloseableIterator<E> iterator() {
+      return Closeables.iterator(col.iterator());
+   }
+
+   @Override
+   public CloseableSpliterator<E> spliterator() {
+      return null;  // TODO: Customise this generated block
+   }
+
+   @Override
+   public Object[] toArray() {
+      return col.toArray();
+   }
+
+   @Override
+   public <T> T[] toArray(T[] a) {
+      return col.toArray(a);
+   }
+
+   @Override
+   public boolean add(E e) {
+      return col.add(e);
+   }
+
+   @Override
+   public boolean remove(Object o) {
+      return col.remove(o);
+   }
+
+   @Override
+   public boolean containsAll(Collection<?> c) {
+      return col.containsAll(c);
+   }
+
+   @Override
+   public boolean addAll(Collection<? extends E> c) {
+      return col.addAll(c);
+   }
+
+   @Override
+   public boolean removeAll(Collection<?> c) {
+      return col.removeAll(c);
+   }
+
+   @Override
+   public boolean retainAll(Collection<?> c) {
+      return col.retainAll(c);
+   }
+
+   @Override
+   public void clear() {
+      col.clear();
+   }
+
+   @Override
+   public CacheStream<E> stream() {
+      return null;
+   }
+
+   @Override
+   public CacheStream<E> parallelStream() {
+      return null;
+   }
+}

--- a/core/src/main/java/org/infinispan/util/SetAsCacheSet.java
+++ b/core/src/main/java/org/infinispan/util/SetAsCacheSet.java
@@ -1,0 +1,112 @@
+package org.infinispan.util;
+
+import org.infinispan.CacheSet;
+import org.infinispan.CacheStream;
+import org.infinispan.commons.util.CloseableIterator;
+import org.infinispan.commons.util.CloseableSpliterator;
+import org.infinispan.commons.util.Closeables;
+
+import java.util.Collection;
+import java.util.Set;
+
+public class SetAsCacheSet<E> implements CacheSet<E> {
+   final Set<E> set;
+   final CacheStream<E> stream;
+
+   public SetAsCacheSet(Set<E> set) {
+      this.set = set;
+      this.stream = null;
+   }
+
+   public SetAsCacheSet(Set<E> set, CacheStream<E> stream) {
+      this.set = set;
+      this.stream = stream;
+   }
+
+   @Override
+   public CacheStream<E> stream() {
+      return stream;
+   }
+
+   @Override
+   public CacheStream<E> parallelStream() {
+      return stream.parallel();
+   }
+
+   @Override
+   public int size() {
+      return set.size();
+   }
+
+   @Override
+   public boolean isEmpty() {
+      return set.isEmpty();
+   }
+
+   @Override
+   public boolean contains(Object o) {
+      return set.contains(o);
+   }
+
+   @Override
+   public CloseableIterator<E> iterator() {
+      return Closeables.iterator(set.iterator());
+   }
+
+   @Override
+   public Object[] toArray() {
+      return set.toArray();
+   }
+
+   @Override
+   public <T> T[] toArray(T[] a) {
+      return set.toArray(a);
+   }
+
+   @Override
+   public boolean add(E e) {
+      return set.add(e);
+   }
+
+   @Override
+   public boolean remove(Object o) {
+      return set.remove(o);
+   }
+
+   @Override
+   public boolean containsAll(Collection<?> c) {
+      return set.containsAll(c);
+   }
+
+   @Override
+   public boolean addAll(Collection<? extends E> c) {
+      return set.addAll(c);
+   }
+
+   @Override
+   public boolean removeAll(Collection<?> c) {
+      return set.removeAll(c);
+   }
+
+   @Override
+   public boolean retainAll(Collection<?> c) {
+      return set.retainAll(c);
+   }
+
+   @Override
+   public void clear() {
+      set.clear();
+   }
+
+   @Override
+   public CloseableSpliterator<E> spliterator() {
+      return null;
+   }
+
+   @Override
+   public String toString() {
+      return "SetAsCacheSet{" +
+            "set=" + set +
+            '}';
+   }
+}

--- a/core/src/test/java/org/infinispan/functional/decorators/FunctionalAdvancedCache.java
+++ b/core/src/test/java/org/infinispan/functional/decorators/FunctionalAdvancedCache.java
@@ -3,7 +3,6 @@ package org.infinispan.functional.decorators;
 import org.infinispan.AdvancedCache;
 import org.infinispan.CacheCollection;
 import org.infinispan.CacheSet;
-import org.infinispan.CacheStream;
 import org.infinispan.atomic.Delta;
 import org.infinispan.batch.BatchContainer;
 import org.infinispan.commons.api.functional.FunctionalMap.ReadWriteMap;
@@ -12,9 +11,6 @@ import org.infinispan.commons.api.functional.MetaParam.MetaLifespan;
 import org.infinispan.commons.api.functional.MetaParam.MetaMaxIdle;
 import org.infinispan.commons.api.functional.Param.FutureMode;
 import org.infinispan.commons.api.functional.Param.PersistenceMode;
-import org.infinispan.commons.util.CloseableIterator;
-import org.infinispan.commons.util.CloseableSpliterator;
-import org.infinispan.commons.util.Closeables;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.CacheEntry;
@@ -39,6 +35,8 @@ import org.infinispan.partitionhandling.AvailabilityMode;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.security.AuthorizationManager;
 import org.infinispan.stats.Stats;
+import org.infinispan.util.CollectionAsCacheCollection;
+import org.infinispan.util.SetAsCacheSet;
 import org.infinispan.util.concurrent.locks.LockManager;
 
 import javax.transaction.TransactionManager;
@@ -645,186 +643,4 @@ public final class FunctionalAdvancedCache<K, V> implements AdvancedCache<K, V> 
       }
    }
 
-   private static final class SetAsCacheSet<E> implements CacheSet<E> {
-      final Set<E> set;
-
-      private SetAsCacheSet(Set<E> set) {
-         this.set = set;
-      }
-
-      @Override
-      public CacheStream<E> stream() {
-         return null;
-      }
-
-      @Override
-      public CacheStream<E> parallelStream() {
-         return null;
-      }
-
-      @Override
-      public int size() {
-         return set.size();
-      }
-
-      @Override
-      public boolean isEmpty() {
-         return set.isEmpty();
-      }
-
-      @Override
-      public boolean contains(Object o) {
-         return set.contains(o);
-      }
-
-      @Override
-      public CloseableIterator<E> iterator() {
-         return Closeables.iterator(set.iterator());
-      }
-
-      @Override
-      public Object[] toArray() {
-         return set.toArray();
-      }
-
-      @Override
-      public <T> T[] toArray(T[] a) {
-         return set.toArray(a);
-      }
-
-      @Override
-      public boolean add(E e) {
-         return set.add(e);
-      }
-
-      @Override
-      public boolean remove(Object o) {
-         return set.remove(o);
-      }
-
-      @Override
-      public boolean containsAll(Collection<?> c) {
-         return set.containsAll(c);
-      }
-
-      @Override
-      public boolean addAll(Collection<? extends E> c) {
-         return set.addAll(c);
-      }
-
-      @Override
-      public boolean removeAll(Collection<?> c) {
-         return set.removeAll(c);
-      }
-
-      @Override
-      public boolean retainAll(Collection<?> c) {
-         return set.retainAll(c);
-      }
-
-      @Override
-      public void clear() {
-         set.clear();
-      }
-
-      @Override
-      public CloseableSpliterator<E> spliterator() {
-         return null;
-      }
-
-      @Override
-      public String toString() {
-         return "SetAsCacheSet{" +
-            "set=" + set +
-            '}';
-      }
-   }
-
-   private static class CollectionAsCacheCollection<E> implements CacheCollection<E> {
-      private final Collection<E> col;
-
-      public CollectionAsCacheCollection(Collection<E> col) {
-         this.col = col;
-      }
-
-      @Override
-      public int size() {
-         return col.size();
-      }
-
-      @Override
-      public boolean isEmpty() {
-         return col.isEmpty();
-      }
-
-      @Override
-      public boolean contains(Object o) {
-         return col.contains(o);
-      }
-
-      @Override
-      public CloseableIterator<E> iterator() {
-         return Closeables.iterator(col.iterator());
-      }
-
-      @Override
-      public CloseableSpliterator<E> spliterator() {
-         return null;  // TODO: Customise this generated block
-      }
-
-      @Override
-      public Object[] toArray() {
-         return col.toArray();
-      }
-
-      @Override
-      public <T> T[] toArray(T[] a) {
-         return col.toArray(a);
-      }
-
-      @Override
-      public boolean add(E e) {
-         return col.add(e);
-      }
-
-      @Override
-      public boolean remove(Object o) {
-         return col.remove(o);
-      }
-
-      @Override
-      public boolean containsAll(Collection<?> c) {
-         return col.containsAll(c);
-      }
-
-      @Override
-      public boolean addAll(Collection<? extends E> c) {
-         return col.addAll(c);
-      }
-
-      @Override
-      public boolean removeAll(Collection<?> c) {
-         return col.removeAll(c);
-      }
-
-      @Override
-      public boolean retainAll(Collection<?> c) {
-         return col.retainAll(c);
-      }
-
-      @Override
-      public void clear() {
-         col.clear();
-      }
-
-      @Override
-      public CacheStream<E> stream() {
-         return null;
-      }
-
-      @Override
-      public CacheStream<E> parallelStream() {
-         return null;
-      }
-   }
 }

--- a/scripting/src/main/java/org/infinispan/scripting/impl/DataTypedCache.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/DataTypedCache.java
@@ -1,0 +1,308 @@
+package org.infinispan.scripting.impl;
+
+import org.infinispan.Cache;
+import org.infinispan.CacheCollection;
+import org.infinispan.CacheSet;
+import org.infinispan.CacheStream;
+import org.infinispan.cache.impl.AbstractDelegatingAdvancedCache;
+import org.infinispan.commons.util.Immutables;
+import org.infinispan.util.CollectionAsCacheCollection;
+import org.infinispan.util.SetAsCacheSet;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class DataTypedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> {
+
+   final DataTypedCacheManager dataTypedCacheManager;
+
+   public DataTypedCache(DataTypedCacheManager dataTypedCacheManager, Cache<K, V> cache) {
+      super(cache.getAdvancedCache());
+      this.dataTypedCacheManager = dataTypedCacheManager;
+   }
+
+   private <T> T fromDataType(Object obj) {
+      return (T) dataTypedCacheManager.dataType.transformer.fromDataType(obj, dataTypedCacheManager.marshaller);
+   }
+
+   private <T> T toDataType(Object obj) {
+      return (T) dataTypedCacheManager.dataType.transformer.toDataType(obj, dataTypedCacheManager.marshaller);
+   }
+
+   @Override
+   public void putForExternalRead(K key, V value) {
+      getDelegate().putForExternalRead(fromDataType(key), fromDataType(value));
+   }
+
+   @Override
+   public void putForExternalRead(K key, V value, long lifespan, TimeUnit unit) {
+      getDelegate().putForExternalRead(fromDataType(key), fromDataType(value), lifespan, unit);
+   }
+
+   @Override
+   public void putForExternalRead(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
+      getDelegate().putForExternalRead(fromDataType(key), fromDataType(value), lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+   }
+
+   @Override
+   public void evict(K key) {
+      getDelegate().evict(fromDataType(key));
+   }
+
+   @Override
+   public boolean containsKey(Object key) {
+      return getDelegate().containsKey(fromDataType(key));
+   }
+
+   @Override
+   public boolean containsValue(Object value) {
+      return getDelegate().containsValue(fromDataType(value));
+   }
+
+   @Override
+   public V get(Object key) {
+      return toDataType(getDelegate().get(fromDataType(key)));
+   }
+
+   @Override
+   public CacheSet<K> keySet() {
+      CacheStream<K> stream = getDelegate().keySet().stream().map(this::toDataType);
+      return new SetAsCacheSet<>(stream.collect(Collectors.toSet()));
+   }
+
+   @Override
+   public CacheCollection<V> values() {
+      CacheStream<V> stream = getDelegate().values().stream().map(this::toDataType);
+      return new CollectionAsCacheCollection<>(stream.collect(Collectors.toList()));
+   }
+
+   @Override
+   public CacheSet<Entry<K, V>> entrySet() {
+      CacheStream<Entry<K, V>> stream = getDelegate().entrySet().stream()
+            .map(e -> Immutables.immutableEntry(
+                  toDataType(e.getKey()), toDataType(e.getValue())));
+      return new SetAsCacheSet<>(stream.collect(Collectors.toSet()), stream);
+   }
+
+   @Override
+   public V put(K key, V value) {
+      return toDataType(getDelegate().put(fromDataType(key), fromDataType(value)));
+   }
+
+   @Override
+   public V put(K key, V value, long lifespan, TimeUnit unit) {
+      return toDataType(getDelegate().put(
+            fromDataType(key), fromDataType(value), lifespan, unit));
+   }
+
+   @Override
+   public V putIfAbsent(K key, V value, long lifespan, TimeUnit unit) {
+      return toDataType(getDelegate().putIfAbsent(
+            fromDataType(key), fromDataType(value), lifespan, unit));
+   }
+
+   @Override
+   public void putAll(Map<? extends K, ? extends V> map, long lifespan, TimeUnit unit) {
+      Map<K, V> map2 = fromDataTypeMap(map);
+      getDelegate().putAll(map2, lifespan, unit);
+   }
+
+   public Map<K, V> fromDataTypeMap(Map<? extends K, ? extends V> map) {
+      Stream<Entry<K, V>> stream = map.entrySet().stream().map(
+            e -> Immutables.immutableEntry(
+                  fromDataType(e.getKey()), fromDataType(e.getValue())));
+      return (Map<K, V>) stream.collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+   }
+
+   @Override
+   public V replace(K key, V value, long lifespan, TimeUnit unit) {
+      return toDataType(getDelegate().replace(
+            fromDataType(key), fromDataType(value), lifespan, unit));
+   }
+
+   @Override
+   public boolean replace(K key, V oldValue, V value, long lifespan, TimeUnit unit) {
+      return getDelegate().replace(fromDataType(key), fromDataType(oldValue),
+            fromDataType(value), lifespan, unit);
+   }
+
+   @Override
+   public V put(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+      return toDataType(getDelegate().put(
+            fromDataType(key), fromDataType(value), lifespan, lifespanUnit,
+            maxIdleTime, maxIdleTimeUnit));
+   }
+
+   @Override
+   public V putIfAbsent(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+      return toDataType(getDelegate().putIfAbsent(
+            fromDataType(key), fromDataType(value), lifespan, lifespanUnit,
+            maxIdleTime, maxIdleTimeUnit));
+   }
+
+   @Override
+   public void putAll(Map<? extends K, ? extends V> map, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+      Map<K, V> map2 = fromDataTypeMap(map);
+      getDelegate().putAll(map2, lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+   }
+
+   @Override
+   public V replace(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+      return toDataType(getDelegate().replace(fromDataType(key), fromDataType(value),
+            lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit));
+   }
+
+   @Override
+   public boolean replace(K key, V oldValue, V value, long lifespan, TimeUnit lifespanUnit, long maxIdleTime, TimeUnit maxIdleTimeUnit) {
+      return getDelegate().replace(fromDataType(key), fromDataType(oldValue),
+            fromDataType(value), lifespan, lifespanUnit, maxIdleTime, maxIdleTimeUnit);
+   }
+
+   @Override
+   public V remove(Object key) {
+      return toDataType(getDelegate().remove(fromDataType(key)));
+   }
+
+   @Override
+   public void putAll(Map<? extends K, ? extends V> m) {
+      Map<K, V> map2 = fromDataTypeMap(m);
+      getDelegate().putAll(map2);
+   }
+
+   @Override
+   public CompletableFuture<V> putAsync(K key, V value) {
+      return getDelegate().putAsync(fromDataType(key), fromDataType(value))
+            .thenApply(this::toDataType);
+   }
+
+   @Override
+   public CompletableFuture<V> putAsync(K key, V value, long lifespan, TimeUnit unit) {
+      return getDelegate().putAsync(fromDataType(key), fromDataType(value), lifespan, unit)
+            .thenApply(this::toDataType);
+   }
+
+   @Override
+   public CompletableFuture<V> putAsync(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
+      return getDelegate().putAsync(fromDataType(key), fromDataType(value),
+            lifespan, lifespanUnit, maxIdle, maxIdleUnit)
+            .thenApply(this::toDataType);
+   }
+
+   @Override
+   public CompletableFuture<Void> putAllAsync(Map<? extends K, ? extends V> data) {
+      Map<K, V> map2 = fromDataTypeMap(data);
+      return getDelegate().putAllAsync(map2);
+   }
+
+   @Override
+   public CompletableFuture<Void> putAllAsync(Map<? extends K, ? extends V> data, long lifespan, TimeUnit unit) {
+      Map<K, V> map2 = fromDataTypeMap(data);
+      return getDelegate().putAllAsync(map2, lifespan, unit);
+   }
+
+   @Override
+   public CompletableFuture<Void> putAllAsync(Map<? extends K, ? extends V> data, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
+      Map<K, V> map2 = fromDataTypeMap(data);
+      return getDelegate().putAllAsync(map2, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+   }
+
+   @Override
+   public CompletableFuture<V> putIfAbsentAsync(K key, V value) {
+      return getDelegate().putIfAbsentAsync(fromDataType(key), fromDataType(value))
+            .thenApply(this::toDataType);
+   }
+
+   @Override
+   public CompletableFuture<V> putIfAbsentAsync(K key, V value, long lifespan, TimeUnit unit) {
+      return getDelegate().putIfAbsentAsync(fromDataType(key), fromDataType(value), lifespan, unit)
+            .thenApply(this::toDataType);
+   }
+
+   @Override
+   public CompletableFuture<V> putIfAbsentAsync(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
+      return getDelegate().putIfAbsentAsync(fromDataType(key), fromDataType(value),
+            lifespan, lifespanUnit, maxIdle, maxIdleUnit)
+            .thenApply(this::toDataType);
+   }
+
+   @Override
+   public CompletableFuture<V> removeAsync(Object key) {
+      return getDelegate().removeAsync(fromDataType(key))
+            .thenApply(this::toDataType);
+   }
+
+   @Override
+   public CompletableFuture<Boolean> removeAsync(Object key, Object value) {
+      return getDelegate().removeAsync(fromDataType(key), fromDataType(value))
+            .thenApply(this::toDataType);
+   }
+
+   @Override
+   public CompletableFuture<V> replaceAsync(K key, V value) {
+      return getDelegate().replaceAsync(fromDataType(key), fromDataType(value))
+            .thenApply(this::toDataType);
+   }
+
+   @Override
+   public CompletableFuture<V> replaceAsync(K key, V value, long lifespan, TimeUnit unit) {
+      return getDelegate().replaceAsync(fromDataType(key), fromDataType(value), lifespan, unit)
+            .thenApply(this::toDataType);
+   }
+
+   @Override
+   public CompletableFuture<V> replaceAsync(K key, V value, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
+      return getDelegate().replaceAsync(fromDataType(key), fromDataType(value),
+            lifespan, lifespanUnit, maxIdle, maxIdleUnit)
+            .thenApply(this::toDataType);
+   }
+
+   @Override
+   public CompletableFuture<Boolean> replaceAsync(K key, V oldValue, V newValue) {
+      return getDelegate().replaceAsync(fromDataType(key),
+            fromDataType(oldValue), fromDataType(newValue));
+   }
+
+   @Override
+   public CompletableFuture<Boolean> replaceAsync(K key, V oldValue, V newValue, long lifespan, TimeUnit unit) {
+      return getDelegate().replaceAsync(fromDataType(key),
+            fromDataType(oldValue), fromDataType(newValue), lifespan, unit);
+   }
+
+   @Override
+   public CompletableFuture<Boolean> replaceAsync(K key, V oldValue, V newValue, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
+      return getDelegate().replaceAsync(fromDataType(key),
+            fromDataType(oldValue), fromDataType(newValue),
+            lifespan, lifespanUnit, maxIdle, maxIdleUnit);
+   }
+
+   @Override
+   public CompletableFuture<V> getAsync(K key) {
+      return getDelegate().getAsync(fromDataType(key))
+            .thenApply(this::toDataType);
+   }
+
+   @Override
+   public V putIfAbsent(K key, V value) {
+      return toDataType(getDelegate().putIfAbsent(fromDataType(key), fromDataType(value)));
+   }
+
+   @Override
+   public boolean remove(Object key, Object value) {
+      return getDelegate().remove(fromDataType(key), fromDataType(value));
+   }
+
+   @Override
+   public boolean replace(K key, V oldValue, V newValue) {
+      return getDelegate().replace(fromDataType(key), fromDataType(oldValue), fromDataType(newValue));
+   }
+
+   @Override
+   public V replace(K key, V value) {
+      return getDelegate().replace(fromDataType(key), fromDataType(value));
+   }
+
+}
+

--- a/scripting/src/main/java/org/infinispan/scripting/impl/DataTypedCacheManager.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/DataTypedCacheManager.java
@@ -1,0 +1,39 @@
+package org.infinispan.scripting.impl;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.manager.impl.AbstractDelegatingEmbeddedCacheManager;
+import org.infinispan.scripting.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import java.util.Optional;
+
+public final class DataTypedCacheManager extends AbstractDelegatingEmbeddedCacheManager {
+
+   private static final Log log = LogFactory.getLog(DataTypedCacheManager.class, Log.class);
+
+   final DataType dataType;
+   final Optional<Marshaller> marshaller;
+
+   public DataTypedCacheManager(DataType dataType, Optional<Marshaller> marshaller, EmbeddedCacheManager cm) {
+      super(cm);
+      this.dataType = dataType;
+      this.marshaller = marshaller;
+   }
+
+   @Override
+   public <K, V> Cache<K, V> getCache() {
+      throw log.scriptsCanOnlyAccessNamedCaches();
+   }
+
+   @Override
+   public <K, V> Cache<K, V> getCache(String cacheName) {
+      Configuration cfg = super.getCacheConfiguration(cacheName);
+      return cfg != null && cfg.compatibility().enabled()
+            ? super.getCache(cacheName)
+            : new DataTypedCache<>(this, super.getCache(cacheName));
+   }
+
+}

--- a/scripting/src/main/java/org/infinispan/scripting/impl/DistributedScript.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/DistributedScript.java
@@ -2,6 +2,7 @@ package org.infinispan.scripting.impl;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.script.Bindings;
@@ -38,8 +39,11 @@ class DistributedScript<T> implements DistributedCallable<Object, Object, T>, Se
       scriptManager = (ScriptingManagerImpl) SecurityActions.getGlobalComponentRegistry(cache.getCacheManager()).getComponent(ScriptingManager.class);
       bindings = new SimpleBindings();
       bindings.put("inputKeys", inputKeys);
-      bindings.put("cache", cache);
-      bindings.put("cacheManager", cache.getCacheManager());
+      DataTypedCacheManager dataTypedCacheManager = new DataTypedCacheManager(metadata.dataType(), Optional.empty(), cache.getCacheManager());
+      bindings.put("cacheManager", dataTypedCacheManager);
+      Cache<?, ?> c = cache.getCacheConfiguration().compatibility().enabled()
+            ? cache : new DataTypedCache<>(dataTypedCacheManager, cache);
+      bindings.put("cache", c);
       ctxParams.entrySet().stream().forEach(e -> bindings.put(e.getKey(), e.getValue()));
    }
 }

--- a/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingManagerImpl.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingManagerImpl.java
@@ -165,10 +165,13 @@ public class ScriptingManagerImpl implements ScriptingManager {
          .orElseGet(() -> new SimpleBindings());
 
       SimpleBindings systemBindings = new SimpleBindings();
-      systemBindings.put(SystemBindings.CACHE_MANAGER.toString(), cacheManager);
+      DataTypedCacheManager cm = new DataTypedCacheManager(metadata.dataType(), context.getMarshaller(), cacheManager);
+      systemBindings.put(SystemBindings.CACHE_MANAGER.toString(), cm);
       systemBindings.put(SystemBindings.SCRIPTING_MANAGER.toString(), this);
       context.getCache().ifPresent(cache -> {
-         systemBindings.put(SystemBindings.CACHE.toString(), cache);
+         Cache<?, ?> c = cm.getCacheConfiguration(cache.getName()).compatibility().enabled()
+               ? cache : new DataTypedCache<>(cm, cache);
+         systemBindings.put(SystemBindings.CACHE.toString(), c);
       });
 
       context.getMarshaller().ifPresent(marshaller -> {

--- a/scripting/src/main/java/org/infinispan/scripting/logging/Log.java
+++ b/scripting/src/main/java/org/infinispan/scripting/logging/Log.java
@@ -51,4 +51,8 @@ public interface Log extends org.infinispan.util.logging.Log {
 
    @Message(value = "Script parameters must be declared using the array notation, e.g. [a,b,c]", id = 26011)
    IllegalArgumentException parametersNotArray();
+
+   @Message(value = "Scripts can only access named caches", id = 26012)
+   IllegalArgumentException scriptsCanOnlyAccessNamedCaches();
+
 }

--- a/scripting/src/test/java/org/infinispan/scripting/ClusteredScriptingTest.java
+++ b/scripting/src/test/java/org/infinispan/scripting/ClusteredScriptingTest.java
@@ -35,7 +35,7 @@ public class ClusteredScriptingTest extends AbstractInfinispanTest {
          @Override
          public void call() throws IOException, ExecutionException, InterruptedException {
             ScriptingManager scriptingManager = getScriptingManager(cms[0]);
-            Cache cache = cms[0].getCache();
+            Cache cache = cms[0].getCache(ScriptingTest.CACHE_NAME);
             loadScript(scriptingManager, "/test.js");
             executeScriptOnManager("test.js", cms[0]);
             executeScriptOnManager("test.js", cms[1]);
@@ -224,7 +224,7 @@ public class ClusteredScriptingTest extends AbstractInfinispanTest {
    private void executeScriptOnManager(String scriptName, EmbeddedCacheManager cacheManager) throws InterruptedException, ExecutionException {
       ScriptingManager scriptingManager = getScriptingManager(cacheManager);
       String value = (String) scriptingManager.runScript(scriptName, new TaskContext().addParameter("a", "value")).get();
-      assertEquals(value, cacheManager.getCache().get("a"));
+      assertEquals(value, cacheManager.getCache(ScriptingTest.CACHE_NAME).get("a"));
    }
 
    @DataProvider(name = "cacheModeProvider")

--- a/scripting/src/test/java/org/infinispan/scripting/ReplicatedSecuredScriptingTest.java
+++ b/scripting/src/test/java/org/infinispan/scripting/ReplicatedSecuredScriptingTest.java
@@ -4,6 +4,7 @@ import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.jgroups.JGroupsAddress;
 import org.infinispan.security.AuthorizationPermission;
 import org.infinispan.security.Security;
@@ -59,7 +60,9 @@ public class ReplicatedSecuredScriptingTest extends MultipleCacheManagersTest {
             @Override
             public Void run() throws Exception {
                 createCluster(global, builder, 2);
-
+                defineConfigurationOnAllManagers(SecureScriptingTest.CACHE_NAME, builder);
+                for (EmbeddedCacheManager cm : cacheManagers)
+                    cm.getCache(SecureScriptingTest.CACHE_NAME);
                 waitForClusterToForm();
                 return null;
             }
@@ -108,7 +111,7 @@ public class ReplicatedSecuredScriptingTest extends MultipleCacheManagersTest {
         Security.doAs(PHEIDIPPIDES, new PrivilegedExceptionAction<Void>() {
             @Override
             public Void run() throws Exception {
-                Cache cache = manager(0).getCache();
+                Cache cache = manager(0).getCache(SecureScriptingTest.CACHE_NAME);
                 String value = (String) scriptingManager.runScript("testRole.js",
                         new TaskContext().cache(cache).addParameter("a", "value")).get();
 

--- a/scripting/src/test/java/org/infinispan/scripting/ScriptingTest.java
+++ b/scripting/src/test/java/org/infinispan/scripting/ScriptingTest.java
@@ -22,6 +22,8 @@ import static org.testng.AssertJUnit.assertNotNull;
 @CleanupAfterMethod
 public class ScriptingTest extends AbstractScriptingTest {
 
+   static final String CACHE_NAME = "script-exec";
+
    protected String[] getScripts() {
       return new String[] { "test.js", "testMissingMetaProps.js", "testExecWithoutProp.js", "testInnerScriptCall.js" };
    }
@@ -127,7 +129,7 @@ public class ScriptingTest extends AbstractScriptingTest {
               new TaskContext().cache(cacheManager.getCache("test_cache")).addParameter("a", "ahoj")).get();
 
       assertEquals("script1:additionFromJavascript", result);
-      assertEquals("ahoj", cacheManager.getCache().get("a"));
+      assertEquals("ahoj", cacheManager.getCache(CACHE_NAME).get("a"));
    }
 
    public void testSimpleScriptWithMissingLanguageInMetaPropeties() throws Exception {

--- a/scripting/src/test/java/org/infinispan/scripting/SecureScriptingTaskManagerTest.java
+++ b/scripting/src/test/java/org/infinispan/scripting/SecureScriptingTaskManagerTest.java
@@ -79,6 +79,7 @@ public class SecureScriptingTaskManagerTest extends SingleCacheManagerTest {
                     String script = TestingUtil.loadFileAsString(is);
                     scriptCache.put(SCRIPT_NAME, script);
                 }
+                cacheManager.getCache(SecureScriptingTest.CACHE_NAME);
                 return null;
             }
         });

--- a/scripting/src/test/java/org/infinispan/scripting/SecureScriptingTest.java
+++ b/scripting/src/test/java/org/infinispan/scripting/SecureScriptingTest.java
@@ -29,6 +29,7 @@ public class SecureScriptingTest extends AbstractScriptingTest {
    static final Subject ADMIN = TestingUtil.makeSubject("admin", ScriptingManager.SCRIPT_MANAGER_ROLE);
    static final Subject RUNNER = TestingUtil.makeSubject("runner", "runner");
    static final Subject PHEIDIPPIDES = TestingUtil.makeSubject("pheidippides", "pheidippides");
+   static final String CACHE_NAME = "secured-script-exec";
 
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
@@ -49,7 +50,17 @@ public class SecureScriptingTest extends AbstractScriptingTest {
          .role("admin")
             .permission(AuthorizationPermission.ALL);
       authConfig.role("runner").role("pheidippides").role("admin");
-      return TestCacheManagerFactory.createCacheManager(global, config);
+      EmbeddedCacheManager cm = TestCacheManagerFactory.createCacheManager(global, config);
+      Security.doAs(ADMIN, new PrivilegedExceptionAction<Void>() {
+         @Override
+         public Void run() throws Exception {
+            cm.getCache(ScriptingTest.CACHE_NAME);
+            cm.getCache(SecureScriptingTest.CACHE_NAME);
+            return null;
+         }
+      });
+
+      return cm;
    }
 
    @Override

--- a/scripting/src/test/resources/test-null-return.js
+++ b/scripting/src/test/resources/test-null-return.js
@@ -1,2 +1,2 @@
-// mode=local,language=javascript,datatype='text/plain; charset=utf-8'
+// mode=local,language=javascript
 cache.get('key-not-present');

--- a/scripting/src/test/resources/test-put-get-dist.js
+++ b/scripting/src/test/resources/test-put-get-dist.js
@@ -1,4 +1,4 @@
-// mode=distributed,language=javascript,parameters=[k, v]
-var cache = cacheManager.getCache();
+// mode=distributed,language=javascript,parameters=[cacheName, k, v]
+var cache = cacheManager.getCache(cacheName);
 cache.put(k, v);
 cache.get(k);

--- a/scripting/src/test/resources/test-put-get.js
+++ b/scripting/src/test/resources/test-put-get.js
@@ -1,4 +1,3 @@
 // mode=local,language=javascript,parameters=[k, v]
-var cache = cacheManager.getCache();
 cache.put(k, v);
 cache.get(k);

--- a/scripting/src/test/resources/test.js
+++ b/scripting/src/test/resources/test.js
@@ -1,4 +1,4 @@
 // mode=local,language=javascript,parameters=[a]
-var cache = cacheManager.getCache();
+var cache = cacheManager.getCache("script-exec");
 cache.put("a", a);
 cache.get("a");

--- a/scripting/src/test/resources/test1.js
+++ b/scripting/src/test/resources/test1.js
@@ -1,5 +1,5 @@
 // mode=local,language=javascript
-var cache = cacheManager.getCache();
+var cache = cacheManager.getCache("script-exec");
 var a = cache.get("a");
 
 cache.put("a", a + ":modified");

--- a/scripting/src/test/resources/testMissingMetaProps.js
+++ b/scripting/src/test/resources/testMissingMetaProps.js
@@ -1,3 +1,3 @@
-var cache = cacheManager.getCache();
+var cache = cacheManager.getCache("script-exec");
 cache.put("a", a);
 cache.get("a");

--- a/scripting/src/test/resources/testRole.js
+++ b/scripting/src/test/resources/testRole.js
@@ -1,4 +1,4 @@
 // mode=local,language=javascript,parameters=[a],role=pheidippides
-var cache = cacheManager.getCache();
+var cache = cacheManager.getCache("secured-script-exec");
 cache.put("a", a);
 cache.get("a");

--- a/scripting/src/test/resources/testWrongPropertyRef.js
+++ b/scripting/src/test/resources/testWrongPropertyRef.js
@@ -1,5 +1,5 @@
 // mode=local,language=javascript
-var cache = cacheManager.getCache();
+var cache = cacheManager.getCache("script-exec");
 
 var d = new Date();
 d.setDate(d.getDate() - 5);

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/CacheDecodeContext.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/CacheDecodeContext.scala
@@ -142,9 +142,10 @@ class CacheDecodeContext(server: HotRodServer) extends ServerConstants with Log 
          val v = ce.getValue
          val lifespan = if (ce.getLifespan < 0) -1 else (ce.getLifespan / 1000).toInt
          val maxIdle = if (ce.getMaxIdle < 0) -1 else (ce.getMaxIdle / 1000).toInt
+         val version = Option(entryVersion).map(e => e.getVersion).getOrElse(0L)
          new GetWithMetadataResponse(header.version, header.messageId, header.cacheName,
             header.clientIntel, OperationResponse.GetWithMetadataResponse, Success, header.topologyId,
-            Some(v), entryVersion.getVersion, ce.getCreated, lifespan, ce.getLastUsed, maxIdle)
+            Some(v), version, ce.getCreated, lifespan, ce.getLastUsed, maxIdle)
       } else {
          new GetWithMetadataResponse(header.version, header.messageId, header.cacheName,
             header.clientIntel, OperationResponse.GetWithMetadataResponse, KeyDoesNotExist, header.topologyId,

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ClientListenerRegistry.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ClientListenerRegistry.scala
@@ -237,10 +237,15 @@ class ClientListenerRegistry(configuration: HotRodServerConfiguration) extends L
       @CacheEntryExpired
       def onCacheEvent(event: CacheEntryEvent[Bytes, Bytes]) {
          if (isSendEvent(event)) {
-            sendEvent(event.getKey, event.getValue, Option(event.getMetadata)
-              .map(_.version().asInstanceOf[NumericVersion].getVersion)
-              .getOrElse(null.asInstanceOf[Long]), event)
+            val dataVersion =
+               for {
+                  meta <- Option(event.getMetadata)
+                  ver <- Option(meta.version())
+               } yield {
+                  ver.asInstanceOf[NumericVersion].getVersion
+               }
 
+            sendEvent(event.getKey, event.getValue, dataVersion.getOrElse(null.asInstanceOf[Long]), event)
          }
       }
 

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
@@ -204,7 +204,9 @@ object Decoder2x extends AbstractVersionedDecoder with ServerConstants with Log 
             GetResponse, Success, h.topologyId,
             Some(entry.getValue))
       else if (entry != null && op == HotRodOperation.GetWithVersionRequest) {
-         val version = entry.getMetadata.version().asInstanceOf[NumericVersion].getVersion
+         val version = Option(entry.getMetadata.version())
+             .map(v => v.asInstanceOf[NumericVersion].getVersion)
+             .getOrElse(0L)
          new GetWithVersionResponse(h.version, h.messageId, h.cacheName,
             h.clientIntel, GetWithVersionResponse, Success, h.topologyId,
             Some(entry.getValue), version)

--- a/server/integration/testsuite/src/test/resources/stream.js
+++ b/server/integration/testsuite/src/test/resources/stream.js
@@ -4,7 +4,7 @@ var Collectors = Java.type("java.util.stream.Collectors")
 var Arrays = Java.type("org.infinispan.scripting.utils.JSArrays")
 cache
     .entrySet().stream()
-    .map(function(e) marshaller.objectFromByteBuffer(e.getValue()))
+    .map(function(e) e.getValue())
     .map(function(v) v.toLowerCase())
     .map(function(v) v.split(/[\W]+/))
     .flatMap(function(f) Arrays.stream(f))


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6581

* Remote execution for typed scripts should be done in binary cache so
  that remote events can be correctly propagated. So, data conversion
  for non-compatibility mode caches is provided by a new class called
  DataTypedCache and it comes with a corresponding
  DataTypedCacheManager.
* When compatibility mode is enabled, the inner layer already provides
  data conversion layer. The problem with compatiblity mode is that it
  currently needs server-side configuration as opposed to a simple
  script header definition. Once encoding is better handled, we should
  be able to find a better solution for both.
* When data is inserted directly by the script, no version information
  is currently provided since that's managed by Hot Rod, so code had to
  be adjusted to deal with this situation. This might change in the
  future.
* Simplified EventLogListener code to check version information using
  purely the remote interface, just like other language target clients
  will use. This uncovered issues with dealing with version-less
  entries.
* Ported EventLogListener code to using Java 8 to make the code a lot
  clearer and cleaner to read.