### PR TITLE
ISPN-6610 Stop using forkInvocationSync

### DIFF
--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/event/CacheEventTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/event/CacheEventTest.java
@@ -38,8 +38,7 @@ import static org.mockito.Mockito.mock;
 @Test(groups = "functional", testName = "cdi.test.event.CacheEventTest")
 public class CacheEventTest extends Arquillian {
 
-   private final NonTxInvocationContext invocationContext = new NonTxInvocationContext(null, AnyEquivalence.getInstance(),
-                                                                                       null);
+   private final NonTxInvocationContext invocationContext = new NonTxInvocationContext(null, AnyEquivalence.getInstance());
 
    @Inject
    @Cache1

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV2IntegrationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ConsistentHashV2IntegrationTest.java
@@ -9,7 +9,7 @@ import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.ch.ConsistentHash;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.server.hotrod.HotRodServer;
@@ -189,7 +189,7 @@ public class ConsistentHashV2IntegrationTest extends MultipleCacheManagersTest {
    }
 
    private HitsAwareCacheManagersTest.HitCountInterceptor hitCountInterceptor(int i) {
-      SequentialInterceptorChain ic = advancedCache(i).getSequentialInterceptorChain();
+      AsyncInterceptorChain ic = advancedCache(i).getAsyncInterceptorChain();
       return ic.findInterceptorWithClass(HitsAwareCacheManagersTest.HitCountInterceptor.class);
    }
 }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/LockingTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/LockingTest.java
@@ -114,7 +114,7 @@ public class LockingTest extends SingleCacheManagerTest {
    private CheckPoint injectBlockingCommandInterceptor(String cacheName) {
       AdvancedCache<?, ?> advancedCache = cache(cacheName).getAdvancedCache();
       final CheckPoint checkPoint = new CheckPoint();
-      advancedCache.getSequentialInterceptorChain().addInterceptorBefore(new BaseCustomInterceptor() {
+      advancedCache.getAsyncInterceptorChain().addInterceptorBefore(new BaseCustomInterceptor() {
 
          private final AtomicBoolean first = new AtomicBoolean(false);
 
@@ -130,7 +130,7 @@ public class LockingTest extends SingleCacheManagerTest {
       return checkPoint;
    }
 
-   private static enum CacheName {
+   private enum CacheName {
       STRIPPED_LOCK {
          @Override
          void configure(ConfigurationBuilder builder) {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ServerFailureRetryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/retry/ServerFailureRetryTest.java
@@ -42,13 +42,13 @@ public class ServerFailureRetryTest extends AbstractRetryTest {
    private void retryExceptions(boolean throwJGroupsException) {
       AdvancedCache<?, ?> nextCache = cacheToHit(1);
       ErrorInducingInterceptor interceptor = new ErrorInducingInterceptor(throwJGroupsException);
-      nextCache.getSequentialInterceptorChain().addInterceptor(interceptor, 1);
+      nextCache.getAsyncInterceptorChain().addInterceptor(interceptor, 1);
       try {
          remoteCache.put(1, "v1");
          assertTrue(interceptor.suspectExceptionThrown);
          assertEquals("v1", remoteCache.get(1));
       } finally {
-         nextCache.getSequentialInterceptorChain().removeInterceptor(ErrorInducingInterceptor.class);
+         nextCache.getAsyncInterceptorChain().removeInterceptor(ErrorInducingInterceptor.class);
       }
    }
 

--- a/core/src/main/java/org/infinispan/AdvancedCache.java
+++ b/core/src/main/java/org/infinispan/AdvancedCache.java
@@ -13,7 +13,7 @@ import org.infinispan.distribution.DistributionManager;
 import org.infinispan.eviction.EvictionManager;
 import org.infinispan.expiration.ExpirationManager;
 import org.infinispan.factories.ComponentRegistry;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.partitionhandling.AvailabilityMode;
@@ -74,7 +74,7 @@ public interface AdvancedCache<K, V> extends Cache<K, V> {
     *
     * @param i        the interceptor to add
     * @param position the position to add the interceptor
-    * @deprecated Since 9.0, use {@link #getSequentialInterceptorChain()} instead.
+    * @deprecated Since 9.0, use {@link #getAsyncInterceptorChain()} instead.
     */
    void addInterceptor(CommandInterceptor i, int position);
 
@@ -85,7 +85,7 @@ public interface AdvancedCache<K, V> extends Cache<K, V> {
     * @param i                interceptor to add
     * @param afterInterceptor interceptor type after which to place custom interceptor
     * @return true if successful, false otherwise.
-    * @deprecated Since 9.0, use {@link #getSequentialInterceptorChain()} instead.
+    * @deprecated Since 9.0, use {@link #getAsyncInterceptorChain()} instead.
     */
    boolean addInterceptorAfter(CommandInterceptor i, Class<? extends CommandInterceptor> afterInterceptor);
 
@@ -96,7 +96,7 @@ public interface AdvancedCache<K, V> extends Cache<K, V> {
     * @param i                 interceptor to add
     * @param beforeInterceptor interceptor type before which to place custom interceptor
     * @return true if successful, false otherwise.
-    * @deprecated Since 9.0, use {@link #getSequentialInterceptorChain()} instead.
+    * @deprecated Since 9.0, use {@link #getAsyncInterceptorChain()} instead.
     */
    boolean addInterceptorBefore(CommandInterceptor i, Class<? extends CommandInterceptor> beforeInterceptor);
 
@@ -105,7 +105,7 @@ public interface AdvancedCache<K, V> extends Cache<K, V> {
     * last one at getInterceptorChain().size() - 1.
     *
     * @param position the position at which to remove an interceptor
-    * @deprecated Since 9.0, use {@link #getSequentialInterceptorChain()} instead.
+    * @deprecated Since 9.0, use {@link #getAsyncInterceptorChain()} instead.
     */
    void removeInterceptor(int position);
 
@@ -113,12 +113,12 @@ public interface AdvancedCache<K, V> extends Cache<K, V> {
     * Removes the interceptor of specified type.
     *
     * @param interceptorType type of interceptor to remove
-    * @deprecated Since 9.0, use {@link #getSequentialInterceptorChain()} instead.
+    * @deprecated Since 9.0, use {@link #getAsyncInterceptorChain()} instead.
     */
    void removeInterceptor(Class<? extends CommandInterceptor> interceptorType);
 
    /**
-    * @deprecated Since 9.0, use {@link #getSequentialInterceptorChain()} instead.
+    * @deprecated Since 9.0, use {@link #getAsyncInterceptorChain()} instead.
     */
    List<CommandInterceptor> getInterceptorChain();
 
@@ -130,7 +130,7 @@ public interface AdvancedCache<K, V> extends Cache<K, V> {
     * @since 9.0
     */
    @Experimental
-   SequentialInterceptorChain getSequentialInterceptorChain();
+   AsyncInterceptorChain getAsyncInterceptorChain();
 
    /**
     * @return the eviction manager - if one is configured - for this cache instance

--- a/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingAdvancedCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingAdvancedCache.java
@@ -13,7 +13,7 @@ import org.infinispan.distribution.DistributionManager;
 import org.infinispan.eviction.EvictionManager;
 import org.infinispan.expiration.ExpirationManager;
 import org.infinispan.factories.ComponentRegistry;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.partitionhandling.AvailabilityMode;
@@ -61,32 +61,32 @@ public class AbstractDelegatingAdvancedCache<K, V> extends AbstractDelegatingCac
 
    @Override
    public void addInterceptor(CommandInterceptor i, int position) {
-      cache.getSequentialInterceptorChain().addInterceptor(i, position);
+      cache.getAsyncInterceptorChain().addInterceptor(i, position);
    }
 
    @Override
-   public SequentialInterceptorChain getSequentialInterceptorChain() {
-      return cache.getSequentialInterceptorChain();
+   public AsyncInterceptorChain getAsyncInterceptorChain() {
+      return cache.getAsyncInterceptorChain();
    }
 
    @Override
    public boolean addInterceptorAfter(CommandInterceptor i, Class<? extends CommandInterceptor> afterInterceptor) {
-      return cache.getSequentialInterceptorChain().addInterceptorAfter(i, afterInterceptor);
+      return cache.getAsyncInterceptorChain().addInterceptorAfter(i, afterInterceptor);
    }
 
    @Override
    public boolean addInterceptorBefore(CommandInterceptor i, Class<? extends CommandInterceptor> beforeInterceptor) {
-      return cache.getSequentialInterceptorChain().addInterceptorBefore(i, beforeInterceptor);
+      return cache.getAsyncInterceptorChain().addInterceptorBefore(i, beforeInterceptor);
    }
 
    @Override
    public void removeInterceptor(int position) {
-      cache.getSequentialInterceptorChain().removeInterceptor(position);
+      cache.getAsyncInterceptorChain().removeInterceptor(position);
    }
 
    @Override
    public void removeInterceptor(Class<? extends CommandInterceptor> interceptorType) {
-      cache.getSequentialInterceptorChain().removeInterceptor(interceptorType);
+      cache.getAsyncInterceptorChain().removeInterceptor(interceptorType);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -50,8 +50,8 @@ import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.SurvivesRestarts;
 import org.infinispan.filter.KeyFilter;
-import org.infinispan.interceptors.SequentialInterceptor;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptor;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.jmx.annotations.DataType;
 import org.infinispan.jmx.annotations.DisplayType;
@@ -87,8 +87,6 @@ import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAResource;
-
-import java.lang.Throwable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -130,7 +128,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    protected InvocationContextContainer icc;
    protected InvocationContextFactory invocationContextFactory;
    protected CommandsFactory commandsFactory;
-   protected SequentialInterceptorChain invoker;
+   protected AsyncInterceptorChain invoker;
    protected Configuration config;
    protected CacheNotifier notifier;
    protected BatchContainer batchContainer;
@@ -169,7 +167,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
                                   InvocationContextFactory invocationContextFactory,
                                   InvocationContextContainer icc,
                                   CommandsFactory commandsFactory,
-                                  SequentialInterceptorChain interceptorChain,
+                                  AsyncInterceptorChain interceptorChain,
                                   Configuration configuration,
                                   CacheNotifier notifier,
                                   ComponentRegistry componentRegistry,
@@ -952,7 +950,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
 
    @Override
    public List<CommandInterceptor> getInterceptorChain() {
-      List<SequentialInterceptor> interceptors = invoker.getInterceptors();
+      List<AsyncInterceptor> interceptors = invoker.getInterceptors();
       ArrayList<CommandInterceptor> list = new ArrayList<>(interceptors.size());
       interceptors.forEach(interceptor -> {
          if (interceptor instanceof CommandInterceptor) {
@@ -968,7 +966,7 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    }
 
    @Override
-   public SequentialInterceptorChain getSequentialInterceptorChain() {
+   public AsyncInterceptorChain getAsyncInterceptorChain() {
       return invoker;
    }
 

--- a/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
@@ -34,8 +34,8 @@ import org.infinispan.expiration.ExpirationManager;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.filter.KeyFilter;
-import org.infinispan.interceptors.EmptySequentialInterceptorChain;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.interceptors.EmptyAsyncInterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.jmx.annotations.DataType;
 import org.infinispan.jmx.annotations.DisplayType;
@@ -949,8 +949,8 @@ public class SimpleCacheImpl<K, V> implements AdvancedCache<K, V> {
    }
 
    @Override
-   public SequentialInterceptorChain getSequentialInterceptorChain() {
-      return EmptySequentialInterceptorChain.INSTANCE;
+   public AsyncInterceptorChain getAsyncInterceptorChain() {
+      return EmptyAsyncInterceptorChain.INSTANCE;
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
@@ -64,6 +64,7 @@ import org.infinispan.stream.impl.local.EntryStreamSupplier;
 import org.infinispan.stream.impl.local.KeyStreamSupplier;
 import org.infinispan.stream.impl.local.LocalCacheStream;
 import org.infinispan.util.TimeService;
+import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -739,25 +740,25 @@ public class SimpleCacheImpl<K, V> implements AdvancedCache<K, V> {
    @Override
    public CompletableFuture<Void> putAllAsync(Map<? extends K, ? extends V> data) {
       putAll(data);
-      return CompletableFuture.completedFuture(null);
+      return CompletableFutures.completedNull();
    }
 
    @Override
    public CompletableFuture<Void> putAllAsync(Map<? extends K, ? extends V> data, long lifespan, TimeUnit unit) {
       putAll(data, lifespan, unit);
-      return CompletableFuture.completedFuture(null);
+      return CompletableFutures.completedNull();
    }
 
    @Override
    public CompletableFuture<Void> putAllAsync(Map<? extends K, ? extends V> data, long lifespan, TimeUnit lifespanUnit, long maxIdle, TimeUnit maxIdleUnit) {
       putAll(data, lifespan, lifespanUnit, maxIdle, maxIdleUnit);
-      return CompletableFuture.completedFuture(null);
+      return CompletableFutures.completedNull();
    }
 
    @Override
    public CompletableFuture<Void> clearAsync() {
       clear();
-      return CompletableFuture.completedFuture(null);
+      return CompletableFutures.completedNull();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/InterceptorConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/InterceptorConfiguration.java
@@ -6,7 +6,7 @@ import org.infinispan.commons.configuration.attributes.AttributeDefinition;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.commons.configuration.attributes.IdentityAttributeCopier;
 import org.infinispan.commons.util.Util;
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.base.CommandInterceptor;
 
 /**
@@ -35,7 +35,7 @@ public class InterceptorConfiguration extends AbstractTypedPropertiesConfigurati
    public static final AttributeDefinition<Position> POSITION = AttributeDefinition.builder("position", Position.OTHER_THAN_FIRST_OR_LAST).immutable().build();
    public static final AttributeDefinition<Class> AFTER = AttributeDefinition.builder("after", null, Class.class).immutable().build();
    public static final AttributeDefinition<Class> BEFORE = AttributeDefinition.builder("before", null, Class.class).immutable().build();
-   public static final AttributeDefinition<SequentialInterceptor> INTERCEPTOR = AttributeDefinition.builder("interceptor", null, SequentialInterceptor.class).copier(IdentityAttributeCopier.INSTANCE).immutable().build();
+   public static final AttributeDefinition<AsyncInterceptor> INTERCEPTOR = AttributeDefinition.builder("interceptor", null, AsyncInterceptor.class).copier(IdentityAttributeCopier.INSTANCE).immutable().build();
    public static final AttributeDefinition<Class> INTERCEPTOR_CLASS = AttributeDefinition.builder("interceptorClass", null, Class.class).xmlName("class").immutable().build();
    public static final AttributeDefinition<Integer> INDEX = AttributeDefinition.builder("index", -1).immutable().build();
 
@@ -46,7 +46,7 @@ public class InterceptorConfiguration extends AbstractTypedPropertiesConfigurati
    private final Attribute<Position> position;
    private final Attribute<Class> after;
    private final Attribute<Class> before;
-   private final Attribute<SequentialInterceptor> interceptor;
+   private final Attribute<AsyncInterceptor> interceptor;
    private final Attribute<Class> interceptorClass;
    private final Attribute<Integer> index;
 
@@ -61,17 +61,17 @@ public class InterceptorConfiguration extends AbstractTypedPropertiesConfigurati
    }
 
    @SuppressWarnings("unchecked")
-   public Class<? extends SequentialInterceptor> after() {
+   public Class<? extends AsyncInterceptor> after() {
       return after.get();
    }
 
    @SuppressWarnings("unchecked")
-   public Class<? extends SequentialInterceptor> before() {
+   public Class<? extends AsyncInterceptor> before() {
       return before.get();
    }
 
    /**
-    * @deprecated Since 9.0, please use {@link #sequentialInterceptor()} instead.
+    * @deprecated Since 9.0, please use {@link #asyncInterceptor()} instead.
     */
    @Deprecated
    public CommandInterceptor interceptor() {
@@ -82,9 +82,9 @@ public class InterceptorConfiguration extends AbstractTypedPropertiesConfigurati
       }
    }
 
-   public SequentialInterceptor sequentialInterceptor() {
+   public AsyncInterceptor asyncInterceptor() {
       if (interceptor.isNull()) {
-         return (SequentialInterceptor) Util.getInstance(interceptorClass.get());
+         return (AsyncInterceptor) Util.getInstance(interceptorClass.get());
       } else {
          return interceptor.get();
       }
@@ -98,7 +98,7 @@ public class InterceptorConfiguration extends AbstractTypedPropertiesConfigurati
       return interceptorClass.get();
    }
 
-   public Class<? extends SequentialInterceptor> sequentialInterceptorClass() {
+   public Class<? extends AsyncInterceptor> sequentialInterceptorClass() {
       return interceptorClass.get();
    }
 

--- a/core/src/main/java/org/infinispan/container/EntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/EntryFactoryImpl.java
@@ -1,7 +1,5 @@
 package org.infinispan.container;
 
-import org.infinispan.distribution.DistributionManager;
-import org.infinispan.metadata.Metadata;
 import org.infinispan.atomic.Delta;
 import org.infinispan.atomic.DeltaAware;
 import org.infinispan.configuration.cache.Configuration;
@@ -13,8 +11,10 @@ import org.infinispan.container.entries.ReadCommittedEntry;
 import org.infinispan.container.entries.RepeatableReadEntry;
 import org.infinispan.container.entries.StateChangingEntry;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
+import org.infinispan.metadata.Metadata;
 import org.infinispan.util.TimeService;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
@@ -31,7 +31,7 @@ import static org.infinispan.commons.util.Util.toStr;
 public class EntryFactoryImpl implements EntryFactory {
 
    private static final Log log = LogFactory.getLog(EntryFactoryImpl.class);
-   private final boolean trace = log.isTraceEnabled();
+   private final static boolean trace = log.isTraceEnabled();
    
    private boolean useRepeatableRead;
    private DataContainer container;

--- a/core/src/main/java/org/infinispan/context/AbstractInvocationContextFactory.java
+++ b/core/src/main/java/org/infinispan/context/AbstractInvocationContextFactory.java
@@ -5,7 +5,7 @@ import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.context.impl.ClearInvocationContext;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.remoting.transport.Address;
 
 
@@ -19,11 +19,11 @@ import org.infinispan.remoting.transport.Address;
 public abstract class AbstractInvocationContextFactory implements InvocationContextFactory {
 
    protected Configuration config;
-   protected SequentialInterceptorChain interceptorChain;
+   protected AsyncInterceptorChain interceptorChain;
    protected Equivalence keyEq;
 
    // Derived classes must call init() in their @Inject methods, to keep only one @Inject method per class.
-   public void init(Configuration config, SequentialInterceptorChain interceptorChain) {
+   public void init(Configuration config, AsyncInterceptorChain interceptorChain) {
       this.config = config;
       this.interceptorChain = interceptorChain;
       keyEq = config.dataContainer().keyEquivalence();

--- a/core/src/main/java/org/infinispan/context/AbstractInvocationContextFactory.java
+++ b/core/src/main/java/org/infinispan/context/AbstractInvocationContextFactory.java
@@ -14,7 +14,7 @@ import org.infinispan.remoting.transport.Address;
  *
  * @author Mircea Markus
  * @author Dan Berindei
- * @since 7.0
+ * @deprecated Since 9.0, this class is going to be moved to an internal package.
  */
 public abstract class AbstractInvocationContextFactory implements InvocationContextFactory {
 

--- a/core/src/main/java/org/infinispan/context/AsyncInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/AsyncInvocationContext.java
@@ -2,7 +2,7 @@ package org.infinispan.context;
 
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commons.util.Experimental;
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -16,7 +16,7 @@ import java.util.function.Function;
  * @author Dan Berindei
  * @since 9.0
  */
-public interface SequentialInvocationContext {
+public interface AsyncInvocationContext {
    /**
     * Execute a callback after the rest of the interceptors in the chain have finished executing.
     *
@@ -29,12 +29,12 @@ public interface SequentialInvocationContext {
     * Returning {@code null} will preserve the previous result or exception (equivalent to a
     * {@code finally} block in an old-style interceptor).
     */
-   CompletableFuture<Void> onReturn(SequentialInterceptor.ReturnHandler returnHandler);
+   CompletableFuture<Void> onReturn(AsyncInterceptor.ReturnHandler returnHandler);
 
    /**
     * Equivalent to {@code null}, when returned by
-    * {@link SequentialInterceptor#visitCommand(InvocationContext, VisitableCommand)} or
-    * {@link SequentialInterceptor.ReturnHandler#handle(InvocationContext, VisitableCommand, Object, Throwable)}.
+    * {@link AsyncInterceptor#visitCommand(InvocationContext, VisitableCommand)} or
+    * {@link AsyncInterceptor.ReturnHandler#handle(InvocationContext, VisitableCommand, Object, Throwable)}.
     *
     * <p>Unlike {@code null}, it can be used with {@link CompletableFuture#thenCompose(Function)}.
     * And unlike {@code CompletableFuture.completedFuture(null)}, it will not allocate a new object.</p>
@@ -65,14 +65,14 @@ public interface SequentialInvocationContext {
     * @param newCommand The command to fork
     * @param forkReturnHandler The return callback
     */
-   CompletableFuture<Void> forkInvocation(VisitableCommand newCommand, SequentialInterceptor.ForkReturnHandler forkReturnHandler);
+   CompletableFuture<Void> forkInvocation(VisitableCommand newCommand, AsyncInterceptor.ForkReturnHandler forkReturnHandler);
 
    /**
     * Fork the command invocation, and execute the remaining interceptors (and their return handlers)
     * synchronously.
     *
     * <p>Usually it is easier to use than
-    * {@link #forkInvocation(VisitableCommand, SequentialInterceptor.ForkReturnHandler)}.
+    * {@link #forkInvocation(VisitableCommand, AsyncInterceptor.ForkReturnHandler)}.
     * However, it is not recommended, because any asynchronous work in the remaining interceptors will block
     * the calling thread.</p>
     *
@@ -81,5 +81,5 @@ public interface SequentialInvocationContext {
     * @param newCommand The command to fork
     */
    @Experimental
-   Object forkInvocationSync(VisitableCommand newCommand) throws InterruptedException, Throwable;
+   Object forkInvocationSync(VisitableCommand newCommand) throws Throwable;
 }

--- a/core/src/main/java/org/infinispan/context/InvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/InvocationContext.java
@@ -1,11 +1,11 @@
 package org.infinispan.context;
 
-import java.util.Set;
-
 import org.infinispan.container.EntryFactory;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.remoting.transport.Address;
+
+import java.util.Set;
 
 /**
  * A context that contains information pertaining to a given invocation.  These contexts typically have the lifespan of
@@ -15,7 +15,7 @@ import org.infinispan.remoting.transport.Address;
  * @author Mircea.Markus@jboss.com
  * @since 4.0
  */
-public interface InvocationContext extends EntryLookup, SequentialInvocationContext, Cloneable {
+public interface InvocationContext extends EntryLookup, AsyncInvocationContext, Cloneable {
 
    /**
     * Returns true if the call was originated locally, false if it is the result of a remote rpc.

--- a/core/src/main/java/org/infinispan/context/InvocationContextContainer.java
+++ b/core/src/main/java/org/infinispan/context/InvocationContextContainer.java
@@ -9,7 +9,7 @@ import org.infinispan.factories.scopes.Scopes;
  *
  * @author Manik Surtani (manik AT infinispan DOT org)
  * @author Mircea.Markus@jboss.com
- * @since 4.0
+ * @deprecated Since 9.0, this interface is going to be moved to an internal package.
  */
 @Scope(Scopes.NAMED_CACHE)
 public interface InvocationContextContainer {
@@ -35,4 +35,8 @@ public interface InvocationContextContainer {
     * Must be called as each thread exists the interceptor chain.
     */
    void clearThreadLocal();
+
+   default void clearThreadLocal(InvocationContext context) {
+      clearThreadLocal();
+   }
 }

--- a/core/src/main/java/org/infinispan/context/InvocationContextContainerImpl.java
+++ b/core/src/main/java/org/infinispan/context/InvocationContextContainerImpl.java
@@ -9,7 +9,7 @@ import org.infinispan.factories.annotations.Stop;
  * InvocationContextContainer implementation.
  *
  * @author Dan Berindei
- * @since 7.0
+ * @deprecated Since 9.0, this class is going to be moved to an internal package.
  */
 public class InvocationContextContainerImpl implements InvocationContextContainer {
 
@@ -50,6 +50,14 @@ public class InvocationContextContainerImpl implements InvocationContextContaine
    @Override
    public void clearThreadLocal() {
       ctxHolder.remove();
+   }
+
+
+   @Override
+   public void clearThreadLocal(InvocationContext context) {
+      if (isThreadLocalRequired(context)) {
+         ctxHolder.remove();
+      }
    }
 
    private boolean isThreadLocalRequired(InvocationContext context) {

--- a/core/src/main/java/org/infinispan/context/InvocationContextFactory.java
+++ b/core/src/main/java/org/infinispan/context/InvocationContextFactory.java
@@ -38,9 +38,6 @@ public interface InvocationContextFactory {
 
    /**
     * Creates an invocation context
-    *
-    * @param tx
-    * @return
     */
    InvocationContext createInvocationContext(Transaction tx, boolean implicitTransaction);
 
@@ -87,7 +84,7 @@ public interface InvocationContextFactory {
     * As {@link #createRemoteInvocationContext(org.infinispan.remoting.transport.Address)},
     * but returning the flags to the context from the Command if any Flag was set.
     *
-    * @param cacheCommand
+    * @param cacheCommand the remote command
     * @param origin       the origin of the command, or null if local
     */
    InvocationContext createRemoteInvocationContextForCommand(VisitableCommand cacheCommand, Address origin);

--- a/core/src/main/java/org/infinispan/context/NonTransactionalInvocationContextFactory.java
+++ b/core/src/main/java/org/infinispan/context/NonTransactionalInvocationContextFactory.java
@@ -20,7 +20,7 @@ import javax.transaction.Transaction;
  * Invocation Context container to be used for non-transactional caches.
  *
  * @author Mircea Markus
- * @since 5.1
+ * @deprecated Since 9.0, this class is going to be moved to an internal package.
  */
 @SurvivesRestarts
 public class NonTransactionalInvocationContextFactory extends AbstractInvocationContextFactory {

--- a/core/src/main/java/org/infinispan/context/NonTransactionalInvocationContextFactory.java
+++ b/core/src/main/java/org/infinispan/context/NonTransactionalInvocationContextFactory.java
@@ -9,7 +9,7 @@ import org.infinispan.context.impl.NonTxInvocationContext;
 import org.infinispan.context.impl.RemoteTxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.SurvivesRestarts;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.transaction.impl.RemoteTransaction;
@@ -25,8 +25,9 @@ import javax.transaction.Transaction;
 @SurvivesRestarts
 public class NonTransactionalInvocationContextFactory extends AbstractInvocationContextFactory {
 
+   @Override
    @Inject
-   public void init(Configuration config, SequentialInterceptorChain interceptorChain) {
+   public void init(Configuration config, AsyncInterceptorChain interceptorChain) {
       super.init(config, interceptorChain);
    }
 

--- a/core/src/main/java/org/infinispan/context/NonTransactionalInvocationContextFactory.java
+++ b/core/src/main/java/org/infinispan/context/NonTransactionalInvocationContextFactory.java
@@ -35,7 +35,7 @@ public class NonTransactionalInvocationContextFactory extends AbstractInvocation
       if (keyCount == 1) {
          return new SingleKeyNonTxInvocationContext(null, keyEq);
       } else if (keyCount > 0) {
-         return new NonTxInvocationContext(keyCount, null, keyEq, interceptorChain);
+         return new NonTxInvocationContext(keyCount, null, keyEq);
       }
       return createInvocationContext(null, false);
    }
@@ -47,8 +47,7 @@ public class NonTransactionalInvocationContextFactory extends AbstractInvocation
 
    @Override
    public NonTxInvocationContext createNonTxInvocationContext() {
-      NonTxInvocationContext ctx = new NonTxInvocationContext(null, keyEq, interceptorChain);
-      return ctx;
+      return new NonTxInvocationContext(null, keyEq);
    }
 
    @Override
@@ -58,8 +57,7 @@ public class NonTransactionalInvocationContextFactory extends AbstractInvocation
 
    @Override
    public NonTxInvocationContext createRemoteInvocationContext(Address origin) {
-      NonTxInvocationContext ctx = new NonTxInvocationContext(origin, keyEq, interceptorChain);
-      return ctx;
+      return new NonTxInvocationContext(origin, keyEq);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/context/SequentialInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/SequentialInvocationContext.java
@@ -72,7 +72,7 @@ public interface SequentialInvocationContext {
     * synchronously.
     *
     * <p>Usually it is easier to use than
-    * {@link #forkInvocation(VisitableCommand, SequentialInterceptor.ReturnHandler)}.
+    * {@link #forkInvocation(VisitableCommand, SequentialInterceptor.ForkReturnHandler)}.
     * However, it is not recommended, because any asynchronous work in the remaining interceptors will block
     * the calling thread.</p>
     *

--- a/core/src/main/java/org/infinispan/context/SingleKeyNonTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/SingleKeyNonTxInvocationContext.java
@@ -13,8 +13,9 @@ import java.util.Set;
 /**
  * @author Mircea Markus
  * @author Sanne Grinovero
- * @since 5.1
+ * @deprecated Since 9.0, this class is going to be moved to an internal package.
  */
+@Deprecated
 public final class SingleKeyNonTxInvocationContext extends BaseSequentialInvocationContext implements InvocationContext {
 
    /**

--- a/core/src/main/java/org/infinispan/context/SingleKeyNonTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/SingleKeyNonTxInvocationContext.java
@@ -2,8 +2,7 @@ package org.infinispan.context;
 
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.interceptors.impl.BaseSequentialInvocationContext;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.impl.BaseAsyncInvocationContext;
 import org.infinispan.remoting.transport.Address;
 
 import java.util.Collections;
@@ -16,7 +15,7 @@ import java.util.Set;
  * @deprecated Since 9.0, this class is going to be moved to an internal package.
  */
 @Deprecated
-public final class SingleKeyNonTxInvocationContext extends BaseSequentialInvocationContext implements InvocationContext {
+public final class SingleKeyNonTxInvocationContext extends BaseAsyncInvocationContext implements InvocationContext {
 
    /**
     * It is possible for the key to only be wrapped but not locked, e.g. when a get takes place.
@@ -101,7 +100,7 @@ public final class SingleKeyNonTxInvocationContext extends BaseSequentialInvocat
 
    @Override
    public Map<Object, CacheEntry> getLookedUpEntries() {
-      return cacheEntry == null ? Collections.<Object, CacheEntry>emptyMap() : Collections.singletonMap(key, cacheEntry);
+      return cacheEntry == null ? Collections.emptyMap() : Collections.singletonMap(key, cacheEntry);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/context/TransactionalInvocationContextFactory.java
+++ b/core/src/main/java/org/infinispan/context/TransactionalInvocationContextFactory.java
@@ -68,18 +68,18 @@ public class TransactionalInvocationContextFactory extends AbstractInvocationCon
          throw new IllegalArgumentException("Cannot create a transactional context without a valid Transaction instance.");
       }
       LocalTransaction localTransaction = transactionTable.getOrCreateLocalTransaction(tx, implicitTransaction);
-      return new LocalTxInvocationContext(localTransaction, interceptorChain);
+      return new LocalTxInvocationContext(localTransaction);
    }
 
    @Override
    public LocalTxInvocationContext createTxInvocationContext(LocalTransaction localTransaction) {
-      return new LocalTxInvocationContext(localTransaction, interceptorChain);
+      return new LocalTxInvocationContext(localTransaction);
    }
 
    @Override
    public RemoteTxInvocationContext createRemoteTxInvocationContext(
          RemoteTransaction tx, Address origin) {
-      RemoteTxInvocationContext ctx = new RemoteTxInvocationContext(tx, interceptorChain);
+      RemoteTxInvocationContext ctx = new RemoteTxInvocationContext(tx);
       return ctx;
    }
 
@@ -104,7 +104,7 @@ public class TransactionalInvocationContextFactory extends AbstractInvocationCon
    }
 
    protected final NonTxInvocationContext newNonTxInvocationContext(Address origin) {
-      NonTxInvocationContext ctx = new NonTxInvocationContext(origin, keyEq, interceptorChain);
+      NonTxInvocationContext ctx = new NonTxInvocationContext(origin, keyEq);
       return ctx;
    }
 }

--- a/core/src/main/java/org/infinispan/context/TransactionalInvocationContextFactory.java
+++ b/core/src/main/java/org/infinispan/context/TransactionalInvocationContextFactory.java
@@ -21,7 +21,7 @@ import javax.transaction.TransactionManager;
  * Invocation context to be used for transactional caches.
  *
  * @author Mircea.Markus@jboss.com
- * @since 4.0
+ * @deprecated Since 9.0, this class is going to be moved to an internal package.
  */
 public class TransactionalInvocationContextFactory extends AbstractInvocationContextFactory {
 

--- a/core/src/main/java/org/infinispan/context/TransactionalInvocationContextFactory.java
+++ b/core/src/main/java/org/infinispan/context/TransactionalInvocationContextFactory.java
@@ -7,7 +7,7 @@ import org.infinispan.context.impl.LocalTxInvocationContext;
 import org.infinispan.context.impl.NonTxInvocationContext;
 import org.infinispan.context.impl.RemoteTxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.transaction.impl.RemoteTransaction;
@@ -32,7 +32,7 @@ public class TransactionalInvocationContextFactory extends AbstractInvocationCon
 
    @Inject
    public void init(TransactionManager tm, TransactionTable transactionTable, Configuration config,
-                    BatchContainer batchContainer, SequentialInterceptorChain interceptorChain) {
+                    BatchContainer batchContainer, AsyncInterceptorChain interceptorChain) {
       super.init(config, interceptorChain);
       this.tm = tm;
       this.transactionTable = transactionTable;

--- a/core/src/main/java/org/infinispan/context/impl/AbstractInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/AbstractInvocationContext.java
@@ -3,8 +3,7 @@ package org.infinispan.context.impl;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.interceptors.SequentialInterceptorChain;
-import org.infinispan.interceptors.impl.BaseSequentialInvocationContext;
+import org.infinispan.interceptors.impl.BaseAsyncInvocationContext;
 import org.infinispan.remoting.transport.Address;
 
 /**
@@ -14,7 +13,7 @@ import org.infinispan.remoting.transport.Address;
  * @author Mircea.Markus@jboss.com
  * @since 4.0
  */
-public abstract class AbstractInvocationContext extends BaseSequentialInvocationContext implements InvocationContext {
+public abstract class AbstractInvocationContext extends BaseAsyncInvocationContext implements InvocationContext {
    private final Address origin;
    // Class loader associated with this invocation which supports AdvancedCache.with() functionality
    private ClassLoader classLoader;

--- a/core/src/main/java/org/infinispan/context/impl/AbstractTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/AbstractTxInvocationContext.java
@@ -2,7 +2,6 @@ package org.infinispan.context.impl;
 
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.interceptors.SequentialInterceptorChain;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.transaction.impl.AbstractCacheTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
@@ -25,8 +24,7 @@ public abstract class AbstractTxInvocationContext<T extends AbstractCacheTransac
 
    private final T cacheTransaction;
 
-   protected AbstractTxInvocationContext(T cacheTransaction, Address origin,
-                                         SequentialInterceptorChain interceptorChain) {
+   protected AbstractTxInvocationContext(T cacheTransaction, Address origin) {
       super(origin);
       if (cacheTransaction == null) {
          throw new NullPointerException("CacheTransaction cannot be null");

--- a/core/src/main/java/org/infinispan/context/impl/ClearInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/ClearInvocationContext.java
@@ -2,7 +2,7 @@ package org.infinispan.context.impl;
 
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.entries.ClearCacheEntry;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.remoting.transport.Address;
 
 import java.util.Collections;
@@ -20,7 +20,7 @@ public class ClearInvocationContext extends AbstractInvocationContext implements
 
    private static final Map<Object, CacheEntry> LOOKUP_ENTRIES = Collections.singletonMap((Object) "_clear_", (CacheEntry) ClearCacheEntry.getInstance());
 
-   public ClearInvocationContext(Address origin, SequentialInterceptorChain interceptorChain) {
+   public ClearInvocationContext(Address origin, AsyncInterceptorChain interceptorChain) {
       super(origin);
    }
 

--- a/core/src/main/java/org/infinispan/context/impl/ImmutableContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/ImmutableContext.java
@@ -4,7 +4,7 @@ import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commons.CacheException;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.remoting.transport.Address;
 
 import java.util.Collections;
@@ -119,7 +119,7 @@ public final class ImmutableContext implements InvocationContext {
    }
 
    @Override
-   public CompletableFuture<Void> onReturn(SequentialInterceptor.ReturnHandler returnHandler) {
+   public CompletableFuture<Void> onReturn(AsyncInterceptor.ReturnHandler returnHandler) {
       throw new UnsupportedOperationException();
    }
 
@@ -135,7 +135,7 @@ public final class ImmutableContext implements InvocationContext {
 
    @Override
    public CompletableFuture<Void> forkInvocation(VisitableCommand newCommand,
-         SequentialInterceptor.ForkReturnHandler returnHandler) {
+         AsyncInterceptor.ForkReturnHandler returnHandler) {
       throw new UnsupportedOperationException();
    }
 

--- a/core/src/main/java/org/infinispan/context/impl/ImmutableContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/ImmutableContext.java
@@ -5,7 +5,6 @@ import org.infinispan.commons.CacheException;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.interceptors.SequentialInterceptor;
-import org.infinispan.interceptors.impl.BaseSequentialInvocationContext;
 import org.infinispan.remoting.transport.Address;
 
 import java.util.Collections;
@@ -19,7 +18,7 @@ import java.util.concurrent.CompletableFuture;
  * 
  * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.
  */
-public final class ImmutableContext extends BaseSequentialInvocationContext {
+public final class ImmutableContext implements InvocationContext {
    
    public static final ImmutableContext INSTANCE = new ImmutableContext();
 

--- a/core/src/main/java/org/infinispan/context/impl/LocalTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/LocalTxInvocationContext.java
@@ -6,7 +6,6 @@ import org.infinispan.transaction.impl.LocalTransaction;
 import javax.transaction.Status;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
-
 import java.util.Collection;
 
 /**

--- a/core/src/main/java/org/infinispan/context/impl/LocalTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/LocalTxInvocationContext.java
@@ -1,6 +1,5 @@
 package org.infinispan.context.impl;
 
-import org.infinispan.interceptors.SequentialInterceptorChain;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.transaction.impl.LocalTransaction;
 
@@ -20,9 +19,8 @@ import java.util.Collection;
  */
 public class LocalTxInvocationContext extends AbstractTxInvocationContext<LocalTransaction> {
 
-   public LocalTxInvocationContext(LocalTransaction localTransaction,
-                                   SequentialInterceptorChain interceptorChain) {
-      super(localTransaction, null, interceptorChain);
+   public LocalTxInvocationContext(LocalTransaction localTransaction) {
+      super(localTransaction, null);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/context/impl/NonTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/NonTxInvocationContext.java
@@ -4,7 +4,6 @@ import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.interceptors.SequentialInterceptorChain;
 import org.infinispan.remoting.transport.Address;
 
 import java.util.Collections;
@@ -27,15 +26,13 @@ public class NonTxInvocationContext extends AbstractInvocationContext {
    private Object lockOwner;
 
 
-   public NonTxInvocationContext(int numEntries, Address origin, Equivalence<Object> keyEq,
-                                 SequentialInterceptorChain interceptorChain) {
+   public NonTxInvocationContext(int numEntries, Address origin, Equivalence<Object> keyEq) {
       super(origin);
       lookedUpEntries = CollectionFactory.makeMap(CollectionFactory.computeCapacity(numEntries), keyEq, AnyEquivalence.getInstance());
       this.keyEq = keyEq;
    }
 
-   public NonTxInvocationContext(Address origin, Equivalence<Object> keyEq,
-                                 SequentialInterceptorChain interceptorChain) {
+   public NonTxInvocationContext(Address origin, Equivalence<Object> keyEq) {
       super(origin);
       lookedUpEntries = CollectionFactory.makeMap(INITIAL_CAPACITY, keyEq, AnyEquivalence.getInstance());
       this.keyEq = keyEq;

--- a/core/src/main/java/org/infinispan/context/impl/RemoteTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/RemoteTxInvocationContext.java
@@ -1,6 +1,5 @@
 package org.infinispan.context.impl;
 
-import org.infinispan.interceptors.SequentialInterceptorChain;
 import org.infinispan.transaction.impl.RemoteTransaction;
 
 import javax.transaction.Transaction;
@@ -15,9 +14,8 @@ import javax.transaction.Transaction;
  */
 public class RemoteTxInvocationContext extends AbstractTxInvocationContext<RemoteTransaction> {
 
-   public RemoteTxInvocationContext(RemoteTransaction cacheTransaction,
-                                    SequentialInterceptorChain interceptorChain) {
-      super(cacheTransaction, cacheTransaction.getGlobalTransaction().getAddress(), interceptorChain);
+   public RemoteTxInvocationContext(RemoteTransaction cacheTransaction) {
+      super(cacheTransaction, cacheTransaction.getGlobalTransaction().getAddress());
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/distexec/SecurityActions.java
+++ b/core/src/main/java/org/infinispan/distexec/SecurityActions.java
@@ -8,7 +8,7 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.security.AuthorizationManager;
 import org.infinispan.security.Security;
@@ -62,7 +62,7 @@ final class SecurityActions {
       return doPrivileged(action);
    }
 
-   static List<SequentialInterceptor> getInterceptorChain(final AdvancedCache<?, ?> cache) {
+   static List<AsyncInterceptor> getInterceptorChain(final AdvancedCache<?, ?> cache) {
       GetCacheInterceptorChainAction action = new GetCacheInterceptorChainAction(cache);
       return doPrivileged(action);
    }

--- a/core/src/main/java/org/infinispan/eviction/impl/EvictionManagerImpl.java
+++ b/core/src/main/java/org/infinispan/eviction/impl/EvictionManagerImpl.java
@@ -7,7 +7,7 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.ImmutableContext;
 import org.infinispan.eviction.EvictionManager;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.impl.CacheMgmtInterceptor;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 
@@ -17,11 +17,11 @@ import java.util.Map;
 public class EvictionManagerImpl<K, V> implements EvictionManager<K, V> {
    // components to be injected
    private CacheNotifier<K, V> cacheNotifier;
-   private SequentialInterceptorChain interceptorChain;
+   private AsyncInterceptorChain interceptorChain;
    private Configuration cfg;
 
    @Inject
-   public void initialize(CacheNotifier<K, V> cacheNotifier, Configuration cfg,  SequentialInterceptorChain chain) {
+   public void initialize(CacheNotifier<K, V> cacheNotifier, Configuration cfg,  AsyncInterceptorChain chain) {
       this.cacheNotifier = cacheNotifier;
       this.cfg = cfg;
       this.interceptorChain = chain;

--- a/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
+++ b/core/src/main/java/org/infinispan/factories/AbstractComponentRegistry.java
@@ -817,7 +817,11 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
                }
                Method m = meta.getMethod();
                if (m == null) {
-                  m = ReflectionUtil.findMethod(clazz, meta.getMethodName(), parameterClasses);
+                  try {
+                     m = ReflectionUtil.findMethod(clazz, meta.getMethodName(), parameterClasses);
+                  } catch (CacheException e) {
+                     throw new CacheException("Injection method not found in class " + clazz + ": " + meta.getMethodName() + Arrays.toString(parameterClasses), e);
+                  }
                   meta.setMethod(m);
                }
             }
@@ -848,9 +852,8 @@ public abstract class AbstractComponentRegistry implements Lifecycle, Cloneable 
          PrioritizedMethod that = (PrioritizedMethod) o;
 
          if (component != null ? !component.equals(that.component) : that.component != null) return false;
-         if (metadata != null ? !metadata.equals(that.metadata) : that.metadata != null) return false;
+         return metadata != null ? metadata.equals(that.metadata) : that.metadata == null;
 
-         return true;
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/interceptors/AsyncInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/AsyncInterceptor.java
@@ -2,8 +2,8 @@ package org.infinispan.interceptors;
 
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commons.util.Experimental;
+import org.infinispan.context.AsyncInvocationContext;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.context.SequentialInvocationContext;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -14,26 +14,26 @@ import java.util.concurrent.CompletableFuture;
  * @since 9.0
  */
 @Experimental
-public interface SequentialInterceptor {
+public interface AsyncInterceptor {
    /**
     * Perform some work for the command, before the command itself is executed.
     *
     * <p>Must return an instance of {@code CompletableFuture<Void>}.</p>
     *
     * <p>Can return an already-completed {@code CompletableFuture<Void>}
-    * (e.g. {@link SequentialInvocationContext#continueInvocation()}) if the interceptor is synchronous,
+    * (e.g. {@link AsyncInvocationContext#continueInvocation()}) if the interceptor is synchronous,
     * i.e. it finishes executing when {@code visitCommand} returns.</p>
     *
     * <p>The interceptor can also influence the execution of the following interceptors in the chain:</p>
     * <ul>
-    * <li>The interceptor can call {@link SequentialInvocationContext#shortCircuit(Object)} in order to skip
+    * <li>The interceptor can call {@link AsyncInvocationContext#shortCircuit(Object)} in order to skip
     * the execution of the rest of the chain (and the command itself).</li>
     * <li>The interceptor can call
-    * {@link SequentialInvocationContext#forkInvocation(VisitableCommand, ForkReturnHandler)} in order to invoke
+    * {@link AsyncInvocationContext#forkInvocation(VisitableCommand, ForkReturnHandler)} in order to invoke
     * a new command, starting with the next interceptor in the chain. The return handler then behaves as
     * another {@code visitCommand} invocation: it can allow the invocation of the original command to continue
     * with the next interceptor, short-circuit the invocation, or fork another command.</li>
-    * <li>{@link SequentialInvocationContext#forkInvocationSync(VisitableCommand)} is a synchronous
+    * <li>{@link AsyncInvocationContext#forkInvocationSync(VisitableCommand)} is a synchronous
     * alternative to {@code forkInvocation}. It is easier to use, however it is not recommended,
     * because any asynchronous work in the remaining interceptors will block the calling thread.</li>
     * </ul>
@@ -65,7 +65,7 @@ public interface SequentialInterceptor {
 
    /**
     * A return handler installed with
-    * {@link SequentialInvocationContext#forkInvocation(VisitableCommand, ForkReturnHandler)}.
+    * {@link AsyncInvocationContext#forkInvocation(VisitableCommand, ForkReturnHandler)}.
     *
     * <p>It must behave just like {@link #visitCommand(InvocationContext, VisitableCommand)}.</p>
     */

--- a/core/src/main/java/org/infinispan/interceptors/AsyncInterceptorChain.java
+++ b/core/src/main/java/org/infinispan/interceptors/AsyncInterceptorChain.java
@@ -3,13 +3,12 @@ package org.infinispan.interceptors;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commons.util.Experimental;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.context.SequentialInvocationContext;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Interceptor chain using {@link SequentialInterceptor}s.
+ * Interceptor chain using {@link AsyncInterceptor}s.
  *
  * Experimental: The ability to modify the interceptors at runtime may be removed in future versions.
  *
@@ -17,11 +16,11 @@ import java.util.concurrent.CompletableFuture;
  * @since 9.0
  */
 @Experimental
-public interface SequentialInterceptorChain {
+public interface AsyncInterceptorChain {
    /**
     * @return An immutable list of the current interceptors.
     */
-   List<SequentialInterceptor> getInterceptors();
+   List<AsyncInterceptor> getInterceptors();
 
    /**
     * Inserts the given interceptor at the specified position in the chain (0 based indexing).
@@ -29,7 +28,7 @@ public interface SequentialInterceptorChain {
     * @throws IllegalArgumentException if the position is invalid (e.g. 5 and there are only 2 interceptors
     *       in the chain)
     */
-   void addInterceptor(SequentialInterceptor interceptor, int position);
+   void addInterceptor(AsyncInterceptor interceptor, int position);
 
    /**
     * Removes the interceptor at the given position.
@@ -47,23 +46,22 @@ public interface SequentialInterceptorChain {
    /**
     * Removes all the occurrences of supplied interceptor type from the chain.
     */
-   void removeInterceptor(Class<? extends SequentialInterceptor> clazz);
+   void removeInterceptor(Class<? extends AsyncInterceptor> clazz);
 
    /**
     * Adds a new interceptor in list after an interceptor of a given type.
     *
     * @return true if the interceptor was added; i.e. the {@code afterInterceptor} exists
     */
-   boolean addInterceptorAfter(SequentialInterceptor toAdd, Class<? extends
-         SequentialInterceptor> afterInterceptor);
+   boolean addInterceptorAfter(AsyncInterceptor toAdd, Class<? extends
+         AsyncInterceptor> afterInterceptor);
 
    /**
     * Adds a new interceptor in list before an interceptor of a given type.
     *
     * @return true if the interceptor was added; i.e. the {@code beforeInterceptor} exists
     */
-   boolean addInterceptorBefore(SequentialInterceptor toAdd,
-                                                Class<? extends SequentialInterceptor> beforeInterceptor);
+   boolean addInterceptorBefore(AsyncInterceptor toAdd, Class<? extends AsyncInterceptor> beforeInterceptor);
 
    /**
     * Replaces an existing interceptor of the given type in the interceptor chain with a new interceptor
@@ -73,24 +71,21 @@ public interface SequentialInterceptorChain {
     * @param toBeReplacedInterceptorType the type of interceptor that should be swapped with the new one
     * @return true if the interceptor was replaced
     */
-   boolean replaceInterceptor(SequentialInterceptor replacingInterceptor,
-                                              Class<? extends SequentialInterceptor> toBeReplacedInterceptorType);
+   boolean replaceInterceptor(AsyncInterceptor replacingInterceptor,
+         Class<? extends AsyncInterceptor> toBeReplacedInterceptorType);
 
    /**
     * Appends at the end.
     */
-   void appendInterceptor(SequentialInterceptor ci, boolean isCustom);
+   void appendInterceptor(AsyncInterceptor ci, boolean isCustom);
 
    /**
     * Walks the command through the interceptor chain. The received ctx is being passed in.
     *
     * <p>Note: Reusing the context for multiple invocations is allowed. However, the two invocations
-    * must not overlap, so calling {@code invoke(InvocationContext, VisitableCommand)} from an interceptor
-    * is not allowed.
-    * If an interceptor wants to invoke a new command and cannot use
-    * {@link SequentialInvocationContext#forkInvocation(VisitableCommand, SequentialInterceptor.ForkReturnHandler)}
-    * or {@link SequentialInvocationContext#forkInvocationSync(VisitableCommand)},
-    * it must first copy the invocation context with {@link InvocationContext#clone()}.</p>
+    * must not overlap, so calling {@code invoke(ctx, command)} from an interceptor is not allowed.
+    * If an interceptor needs to invoke a new command through the entire chain, it must first
+    * copy the invocation context with {@link InvocationContext#clone()}.</p>
     */
    Object invoke(InvocationContext ctx, VisitableCommand command);
 
@@ -102,26 +97,26 @@ public interface SequentialInterceptorChain {
    /**
     * Returns the first interceptor extending the given class, or {@code null} if there is none.
     */
-   <T extends SequentialInterceptor> T findInterceptorExtending(Class<T> interceptorClass);
+   <T extends AsyncInterceptor> T findInterceptorExtending(Class<T> interceptorClass);
 
    /**
     * Returns the first interceptor with the given class, or {@code null} if there is none.
     */
-   <T extends SequentialInterceptor> T findInterceptorWithClass(Class<T> interceptorClass);
+   <T extends AsyncInterceptor> T findInterceptorWithClass(Class<T> interceptorClass);
 
    /**
     * Checks whether the chain contains the supplied interceptor instance.
     */
-   boolean containsInstance(SequentialInterceptor interceptor);
+   boolean containsInstance(AsyncInterceptor interceptor);
 
    /**
     * Checks whether the chain contains an interceptor with the given class.
     */
-   boolean containsInterceptorType(Class<? extends SequentialInterceptor> interceptorType);
+   boolean containsInterceptorType(Class<? extends AsyncInterceptor> interceptorType);
 
    /**
     * Checks whether the chain contains an interceptor with the given class, or a subclass.
     */
-   boolean containsInterceptorType(Class<? extends SequentialInterceptor> interceptorType,
+   boolean containsInterceptorType(Class<? extends AsyncInterceptor> interceptorType,
                                                    boolean alsoMatchSubClasses);
 }

--- a/core/src/main/java/org/infinispan/interceptors/BaseAsyncInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/BaseAsyncInterceptor.java
@@ -2,7 +2,6 @@ package org.infinispan.interceptors;
 
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.SequentialInterceptor;
 
 /**
  * Base class for an interceptor in the new sequential invocation chain.
@@ -10,7 +9,7 @@ import org.infinispan.interceptors.SequentialInterceptor;
  * @author Dan Berindei
  * @since 9.0
  */
-public abstract class BaseSequentialInterceptor implements SequentialInterceptor {
+public abstract class BaseAsyncInterceptor implements AsyncInterceptor {
    protected Configuration cacheConfiguration;
 
    @Inject

--- a/core/src/main/java/org/infinispan/interceptors/BaseCustomAsyncInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/BaseCustomAsyncInterceptor.java
@@ -7,7 +7,7 @@ import org.infinispan.factories.annotations.Stop;
 import org.infinispan.manager.EmbeddedCacheManager;
 
 /**
- * Anyone using the {@link org.infinispan.interceptors.SequentialInterceptorChain#addInterceptor(SequentialInterceptor, int)} method (or any of its
+ * Anyone using the {@link AsyncInterceptorChain#addInterceptor(AsyncInterceptor, int)} method (or any of its
  * overloaded forms) or registering custom interceptors via XML should extend this base class when creating their own 
  * custom interceptors.
  * <p />
@@ -21,7 +21,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
  * @author Dan Berindei
  * @since 9.0
  */
-public class BaseCustomSequentialInterceptor extends DDSequentialInterceptor {
+public class BaseCustomAsyncInterceptor extends DDAsyncInterceptor {
    protected Cache<?, ?> cache;
    protected EmbeddedCacheManager embeddedCacheManager;
 

--- a/core/src/main/java/org/infinispan/interceptors/DDAsyncInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/DDAsyncInterceptor.java
@@ -39,12 +39,12 @@ import org.infinispan.context.impl.TxInvocationContext;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Interface for sequential interceptors using double-dispatch.
+ * Interface for async interceptors using double-dispatch.
  *
  * @author Dan Berindei
  * @since 9.0
  */
-   public abstract class DDSequentialInterceptor extends BaseSequentialInterceptor implements Visitor {
+   public abstract class DDAsyncInterceptor extends BaseAsyncInterceptor implements Visitor {
 
    @SuppressWarnings("unchecked")
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/EmptyAsyncInterceptorChain.java
+++ b/core/src/main/java/org/infinispan/interceptors/EmptyAsyncInterceptorChain.java
@@ -13,18 +13,18 @@ import java.util.concurrent.CompletableFuture;
  * @author Dan Berindei
  * @since 9.0
  */
-public class EmptySequentialInterceptorChain implements SequentialInterceptorChain {
-   public static final EmptySequentialInterceptorChain INSTANCE = new EmptySequentialInterceptorChain();
+public class EmptyAsyncInterceptorChain implements AsyncInterceptorChain {
+   public static final EmptyAsyncInterceptorChain INSTANCE = new EmptyAsyncInterceptorChain();
 
-   private static final Log log = LogFactory.getLog(EmptySequentialInterceptorChain.class);
+   private static final Log log = LogFactory.getLog(EmptyAsyncInterceptorChain.class);
 
    @Override
-   public List<SequentialInterceptor> getInterceptors() {
+   public List<AsyncInterceptor> getInterceptors() {
       return Collections.emptyList();
    }
 
    @Override
-   public void addInterceptor(SequentialInterceptor interceptor, int position) {
+   public void addInterceptor(AsyncInterceptor interceptor, int position) {
       throw log.interceptorStackNotSupported();
    }
 
@@ -39,30 +39,30 @@ public class EmptySequentialInterceptorChain implements SequentialInterceptorCha
    }
 
    @Override
-   public void removeInterceptor(Class<? extends SequentialInterceptor> clazz) {
+   public void removeInterceptor(Class<? extends AsyncInterceptor> clazz) {
       throw log.interceptorStackNotSupported();
    }
 
    @Override
-   public boolean addInterceptorAfter(SequentialInterceptor toAdd,
-         Class<? extends SequentialInterceptor> afterInterceptor) {
+   public boolean addInterceptorAfter(AsyncInterceptor toAdd,
+         Class<? extends AsyncInterceptor> afterInterceptor) {
       throw log.interceptorStackNotSupported();
    }
 
    @Override
-   public boolean addInterceptorBefore(SequentialInterceptor toAdd,
-         Class<? extends SequentialInterceptor> beforeInterceptor) {
+   public boolean addInterceptorBefore(AsyncInterceptor toAdd,
+         Class<? extends AsyncInterceptor> beforeInterceptor) {
       throw log.interceptorStackNotSupported();
    }
 
    @Override
-   public boolean replaceInterceptor(SequentialInterceptor replacingInterceptor,
-         Class<? extends SequentialInterceptor> toBeReplacedInterceptorType) {
+   public boolean replaceInterceptor(AsyncInterceptor replacingInterceptor,
+         Class<? extends AsyncInterceptor> toBeReplacedInterceptorType) {
       throw log.interceptorStackNotSupported();
    }
 
    @Override
-   public void appendInterceptor(SequentialInterceptor ci, boolean isCustom) {
+   public void appendInterceptor(AsyncInterceptor ci, boolean isCustom) {
       throw log.interceptorStackNotSupported();
    }
 
@@ -77,27 +77,27 @@ public class EmptySequentialInterceptorChain implements SequentialInterceptorCha
    }
 
    @Override
-   public <T extends SequentialInterceptor> T findInterceptorExtending(Class<T> interceptorClass) {
+   public <T extends AsyncInterceptor> T findInterceptorExtending(Class<T> interceptorClass) {
       return null;
    }
 
    @Override
-   public <T extends SequentialInterceptor> T findInterceptorWithClass(Class<T> interceptorClass) {
+   public <T extends AsyncInterceptor> T findInterceptorWithClass(Class<T> interceptorClass) {
       return null;
    }
 
    @Override
-   public boolean containsInstance(SequentialInterceptor interceptor) {
+   public boolean containsInstance(AsyncInterceptor interceptor) {
       return false;
    }
 
    @Override
-   public boolean containsInterceptorType(Class<? extends SequentialInterceptor> interceptorType) {
+   public boolean containsInterceptorType(Class<? extends AsyncInterceptor> interceptorType) {
       return false;
    }
 
    @Override
-   public boolean containsInterceptorType(Class<? extends SequentialInterceptor> interceptorType,
+   public boolean containsInterceptorType(Class<? extends AsyncInterceptor> interceptorType,
          boolean alsoMatchSubClasses) {
       return false;
    }

--- a/core/src/main/java/org/infinispan/interceptors/InterceptorChain.java
+++ b/core/src/main/java/org/infinispan/interceptors/InterceptorChain.java
@@ -15,16 +15,16 @@ import java.util.List;
  * @author Mircea.Markus@jboss.com
  * @author Galder Zamarreño
  * @since 4.0
- * @deprecated Since 9.0, use {@link SequentialInterceptorChain} instead. Some methods will ignore the
+ * @deprecated Since 9.0, use {@link AsyncInterceptorChain} instead. Some methods will ignore the
  * interceptors that do not extend {@link CommandInterceptor}.
  */
 @Scope(Scopes.NAMED_CACHE)
 @Deprecated
 public class InterceptorChain {
-   private SequentialInterceptorChain sequentialInterceptorChain;
+   private AsyncInterceptorChain asyncInterceptorChain;
 
-   public InterceptorChain(SequentialInterceptorChain sequentialInterceptorChain) {
-      this.sequentialInterceptorChain = sequentialInterceptorChain;
+   public InterceptorChain(AsyncInterceptorChain asyncInterceptorChain) {
+      this.asyncInterceptorChain = asyncInterceptorChain;
    }
 
    /**
@@ -34,7 +34,7 @@ public class InterceptorChain {
     *                                  chain)
     */
    public void addInterceptor(CommandInterceptor interceptor, int position) {
-      sequentialInterceptorChain.addInterceptor(interceptor, position);
+      asyncInterceptorChain.addInterceptor(interceptor, position);
    }
 
    /**
@@ -44,14 +44,14 @@ public class InterceptorChain {
     *                                  chain)
     */
    public void removeInterceptor(int position) {
-      sequentialInterceptorChain.removeInterceptor(position);
+      asyncInterceptorChain.removeInterceptor(position);
    }
 
    /**
     * Returns the number of interceptors in the chain.
     */
    public int size() {
-      return sequentialInterceptorChain.size();
+      return asyncInterceptorChain.size();
    }
 
    /**
@@ -60,8 +60,8 @@ public class InterceptorChain {
     */
    public List<CommandInterceptor> asList() {
       ArrayList<CommandInterceptor> list =
-            new ArrayList<>(sequentialInterceptorChain.getInterceptors().size());
-      sequentialInterceptorChain.getInterceptors().forEach(ci -> {
+            new ArrayList<>(asyncInterceptorChain.getInterceptors().size());
+      asyncInterceptorChain.getInterceptors().forEach(ci -> {
          if (ci instanceof CommandInterceptor) {
             list.add((CommandInterceptor) ci);
          }
@@ -73,7 +73,7 @@ public class InterceptorChain {
     * Removes all the occurences of supplied interceptor type from the chain.
     */
    public void removeInterceptor(Class<? extends CommandInterceptor> clazz) {
-      sequentialInterceptorChain.removeInterceptor(clazz);
+      asyncInterceptorChain.removeInterceptor(clazz);
    }
 
    /**
@@ -83,7 +83,7 @@ public class InterceptorChain {
     */
    public boolean addInterceptorAfter(CommandInterceptor toAdd,
                                       Class<? extends CommandInterceptor> afterInterceptor) {
-      return sequentialInterceptorChain.addInterceptorAfter(toAdd, afterInterceptor);
+      return asyncInterceptorChain.addInterceptorAfter(toAdd, afterInterceptor);
    }
 
    /**
@@ -93,7 +93,7 @@ public class InterceptorChain {
    public boolean addInterceptorBefore(CommandInterceptor toAdd,
                                        Class<? extends CommandInterceptor> beforeInterceptor,
                                        boolean isCustom) {
-      return sequentialInterceptorChain.addInterceptorBefore(toAdd, beforeInterceptor);
+      return asyncInterceptorChain.addInterceptorBefore(toAdd, beforeInterceptor);
    }
 
    /**
@@ -103,7 +103,7 @@ public class InterceptorChain {
     */
    public boolean addInterceptorBefore(CommandInterceptor toAdd,
                                        Class<? extends CommandInterceptor> beforeInterceptor) {
-      return sequentialInterceptorChain.addInterceptorBefore(toAdd, beforeInterceptor);
+      return asyncInterceptorChain.addInterceptorBefore(toAdd, beforeInterceptor);
    }
 
    /**
@@ -115,35 +115,35 @@ public class InterceptorChain {
     */
    public boolean replaceInterceptor(CommandInterceptor replacingInterceptor,
                                      Class<? extends CommandInterceptor> toBeReplacedInterceptorType) {
-      return sequentialInterceptorChain.replaceInterceptor(replacingInterceptor, toBeReplacedInterceptorType);
+      return asyncInterceptorChain.replaceInterceptor(replacingInterceptor, toBeReplacedInterceptorType);
    }
 
    /**
     * Appends at the end.
     */
    public void appendInterceptor(CommandInterceptor ci, boolean isCustom) {
-      sequentialInterceptorChain.appendInterceptor(ci, isCustom);
+      asyncInterceptorChain.appendInterceptor(ci, isCustom);
    }
 
    /**
     * Walks the command through the interceptor chain. The received ctx is being passed in.
     *
     * <p>Note: Reusing the context for multiple invocations is allowed. However, the two invocations
-    * must not overlap, so calling {@link #invoke(InvocationContext, VisitableCommand)} from an interceptor
-    * is not allowed. If an interceptor wants to invoke a new command, it must first copy the invocation
-    * context with {@link InvocationContext#clone()}.</p>
+    * must not overlap, so calling {@code invoke(ctx, command)} from an interceptor is not allowed.
+    * If an interceptor needs to invoke a new command through the entire chain, it must first
+    * copy the invocation context with {@link InvocationContext#clone()}.</p>
     */
    public Object invoke(InvocationContext ctx, VisitableCommand command) {
-      return sequentialInterceptorChain.invoke(ctx, command);
+      return asyncInterceptorChain.invoke(ctx, command);
    }
 
    /**
     * @return the first {@code CommandInterceptor} in the chain.
-    * Since 9.0, there will likely be other {@link SequentialInterceptor}s before it.
+    * Since 9.0, there will likely be other {@link AsyncInterceptor}s before it.
     */
    @Deprecated
    public CommandInterceptor getFirstInChain() {
-      return (CommandInterceptor) sequentialInterceptorChain
+      return asyncInterceptorChain
             .findInterceptorExtending(CommandInterceptor.class);
    }
 
@@ -162,8 +162,8 @@ public class InterceptorChain {
    public List<CommandInterceptor> getInterceptorsWhichExtend(
          Class<? extends CommandInterceptor> interceptorClass) {
       ArrayList<CommandInterceptor> list =
-            new ArrayList<>(sequentialInterceptorChain.getInterceptors().size());
-      sequentialInterceptorChain.getInterceptors().forEach(ci -> {
+            new ArrayList<>(asyncInterceptorChain.getInterceptors().size());
+      asyncInterceptorChain.getInterceptors().forEach(ci -> {
          if (interceptorClass.isInstance(ci)) {
             list.add((CommandInterceptor) ci);
          }
@@ -177,8 +177,8 @@ public class InterceptorChain {
     */
    public List<CommandInterceptor> getInterceptorsWithClass(Class clazz) {
       ArrayList<CommandInterceptor> list =
-            new ArrayList<>(sequentialInterceptorChain.getInterceptors().size());
-      sequentialInterceptorChain.getInterceptors().forEach(ci -> {
+            new ArrayList<>(asyncInterceptorChain.getInterceptors().size());
+      asyncInterceptorChain.getInterceptors().forEach(ci -> {
          if (clazz == ci.getClass()) {
             list.add((CommandInterceptor) ci);
          }
@@ -190,15 +190,15 @@ public class InterceptorChain {
     * Checks whether the chain contains the supplied interceptor instance.
     */
    public boolean containsInstance(CommandInterceptor interceptor) {
-      return sequentialInterceptorChain.containsInstance(interceptor);
+      return asyncInterceptorChain.containsInstance(interceptor);
    }
 
    public boolean containsInterceptorType(Class<? extends CommandInterceptor> interceptorType) {
-      return sequentialInterceptorChain.containsInterceptorType(interceptorType);
+      return asyncInterceptorChain.containsInterceptorType(interceptorType);
    }
 
    public boolean containsInterceptorType(Class<? extends CommandInterceptor> interceptorType,
                                           boolean alsoMatchSubClasses) {
-      return sequentialInterceptorChain.containsInterceptorType(interceptorType, alsoMatchSubClasses);
+      return asyncInterceptorChain.containsInterceptorType(interceptorType, alsoMatchSubClasses);
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/SequentialInterceptorChain.java
+++ b/core/src/main/java/org/infinispan/interceptors/SequentialInterceptorChain.java
@@ -3,6 +3,7 @@ package org.infinispan.interceptors;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commons.util.Experimental;
 import org.infinispan.context.InvocationContext;
+import org.infinispan.context.SequentialInvocationContext;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -17,21 +18,24 @@ import java.util.concurrent.CompletableFuture;
  */
 @Experimental
 public interface SequentialInterceptorChain {
+   /**
+    * @return An immutable list of the current interceptors.
+    */
    List<SequentialInterceptor> getInterceptors();
 
    /**
-    * Inserts the given interceptor at the specified position in the chain (o based indexing).
+    * Inserts the given interceptor at the specified position in the chain (0 based indexing).
     *
-    * @throws IllegalArgumentException if the position is invalid (e.g. 5 and there are only 2 interceptors in the
-    *                                  chain)
+    * @throws IllegalArgumentException if the position is invalid (e.g. 5 and there are only 2 interceptors
+    *       in the chain)
     */
    void addInterceptor(SequentialInterceptor interceptor, int position);
 
    /**
-    * Removes the interceptor at the given postion.
+    * Removes the interceptor at the given position.
     *
-    * @throws IllegalArgumentException if the position is invalid (e.g. 5 and there are only 2 interceptors in the
-    *                                  chain)
+    * @throws IllegalArgumentException if the position is invalid (e.g. 5 and there are only 2 interceptors
+    *       in the chain)
     */
    void removeInterceptor(int position);
 
@@ -41,28 +45,29 @@ public interface SequentialInterceptorChain {
    int size();
 
    /**
-    * Removes all the occurences of supplied interceptor type from the chain.
+    * Removes all the occurrences of supplied interceptor type from the chain.
     */
    void removeInterceptor(Class<? extends SequentialInterceptor> clazz);
 
    /**
     * Adds a new interceptor in list after an interceptor of a given type.
     *
-    * @return true if the interceptor was added; i.e. the afterInterceptor exists
+    * @return true if the interceptor was added; i.e. the {@code afterInterceptor} exists
     */
    boolean addInterceptorAfter(SequentialInterceptor toAdd, Class<? extends
          SequentialInterceptor> afterInterceptor);
 
    /**
-    * Adds a new interceptor in list after an interceptor of a given type.
+    * Adds a new interceptor in list before an interceptor of a given type.
     *
-    * @return true if the interceptor was added; i.e. the afterInterceptor exists
+    * @return true if the interceptor was added; i.e. the {@code beforeInterceptor} exists
     */
    boolean addInterceptorBefore(SequentialInterceptor toAdd,
                                                 Class<? extends SequentialInterceptor> beforeInterceptor);
 
    /**
-    * Replaces an existing interceptor of the given type in the interceptor chain with a new interceptor instance passed as parameter.
+    * Replaces an existing interceptor of the given type in the interceptor chain with a new interceptor
+    * instance passed as parameter.
     *
     * @param replacingInterceptor        the interceptor to add to the interceptor chain
     * @param toBeReplacedInterceptorType the type of interceptor that should be swapped with the new one
@@ -80,11 +85,11 @@ public interface SequentialInterceptorChain {
     * Walks the command through the interceptor chain. The received ctx is being passed in.
     *
     * <p>Note: Reusing the context for multiple invocations is allowed. However, the two invocations
-    * must not overlap, so calling {@link #invoke(InvocationContext, VisitableCommand)} from an interceptor
-    * is not allowed. If an interceptor wants to invoke a new command and cannot use {@link org.infinispan
-    * .context.SequentialInvocationContext#forkInvocation(VisitableCommand, SequentialInterceptor
-    * .ForkReturnHandler)} or
-    * {@link org.infinispan.context.SequentialInvocationContext#forkInvocationSync(VisitableCommand)},
+    * must not overlap, so calling {@code invoke(InvocationContext, VisitableCommand)} from an interceptor
+    * is not allowed.
+    * If an interceptor wants to invoke a new command and cannot use
+    * {@link SequentialInvocationContext#forkInvocation(VisitableCommand, SequentialInterceptor.ForkReturnHandler)}
+    * or {@link SequentialInvocationContext#forkInvocationSync(VisitableCommand)},
     * it must first copy the invocation context with {@link InvocationContext#clone()}.</p>
     */
    Object invoke(InvocationContext ctx, VisitableCommand command);

--- a/core/src/main/java/org/infinispan/interceptors/base/BaseCustomInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/base/BaseCustomInterceptor.java
@@ -4,7 +4,7 @@ import org.infinispan.Cache;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
-import org.infinispan.interceptors.BaseCustomSequentialInterceptor;
+import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 
 /**
@@ -20,7 +20,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
  * and {@link #stop()} as defined in this class.
  *
  * @author Manik Surtani
- * @deprecated Since 9.0, use {@link BaseCustomSequentialInterceptor} instead.
+ * @deprecated Since 9.0, use {@link BaseCustomAsyncInterceptor} instead.
  */
 @Deprecated
 public class BaseCustomInterceptor extends CommandInterceptor {

--- a/core/src/main/java/org/infinispan/interceptors/base/CommandInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/base/CommandInterceptor.java
@@ -13,10 +13,10 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
-import org.infinispan.interceptors.BaseSequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
+import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.interceptors.BaseAsyncInterceptor;
 import org.infinispan.interceptors.InterceptorChain;
-import org.infinispan.interceptors.SequentialInterceptor;
-import org.infinispan.interceptors.SequentialInterceptorChain;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -46,13 +46,13 @@ import java.util.concurrent.CompletableFuture;
  * @see VisitableCommand
  * @see Visitor
  * @see InterceptorChain
- * @deprecated Since 9.0, please extend {@link BaseSequentialInterceptor} instead.
+ * @deprecated Since 9.0, please extend {@link BaseAsyncInterceptor} instead.
  */
 @Deprecated
 @Scope(Scopes.NAMED_CACHE)
-public abstract class CommandInterceptor extends AbstractVisitor implements SequentialInterceptor {
+public abstract class CommandInterceptor extends AbstractVisitor implements AsyncInterceptor {
 
-   private SequentialInterceptorChain interceptorChain;
+   private AsyncInterceptorChain interceptorChain;
 
    protected Configuration cacheConfiguration;
 
@@ -63,7 +63,7 @@ public abstract class CommandInterceptor extends AbstractVisitor implements Sequ
    }
 
    @Inject
-   public void injectConfiguration(Configuration configuration, SequentialInterceptorChain interceptorChain) {
+   public void injectConfiguration(Configuration configuration, AsyncInterceptorChain interceptorChain) {
       this.cacheConfiguration = configuration;
       this.interceptorChain = interceptorChain;
    }
@@ -75,12 +75,12 @@ public abstract class CommandInterceptor extends AbstractVisitor implements Sequ
     * @return the next interceptor in the chain.
     */
    public final CommandInterceptor getNext() {
-      List<SequentialInterceptor> interceptors = interceptorChain.getInterceptors();
+      List<AsyncInterceptor> interceptors = interceptorChain.getInterceptors();
       int myIndex = interceptors.indexOf(this);
       if (myIndex < interceptors.size() - 1) {
-         SequentialInterceptor sequentialInterceptor = interceptors.get(myIndex + 1);
-         if (sequentialInterceptor instanceof CommandInterceptor)
-            return (CommandInterceptor) sequentialInterceptor;
+         AsyncInterceptor asyncInterceptor = interceptors.get(myIndex + 1);
+         if (asyncInterceptor instanceof CommandInterceptor)
+            return (CommandInterceptor) asyncInterceptor;
       }
       return null;
    }
@@ -92,7 +92,7 @@ public abstract class CommandInterceptor extends AbstractVisitor implements Sequ
     * @return true if there is another interceptor in the chain after this; false otherwise.
     */
    public final boolean hasNext() {
-      List<SequentialInterceptor> interceptors = interceptorChain.getInterceptors();
+      List<AsyncInterceptor> interceptors = interceptorChain.getInterceptors();
       int myIndex = interceptors.indexOf(this);
       return myIndex < interceptors.size();
    }

--- a/core/src/main/java/org/infinispan/interceptors/base/PrePostProcessingCommandInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/base/PrePostProcessingCommandInterceptor.java
@@ -14,6 +14,7 @@ import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.interceptors.AsyncInterceptor;
 
 /**
  * This interceptor adds pre and post processing to each <tt>visitXXX()</tt> method.
@@ -29,7 +30,7 @@ import org.infinispan.context.impl.TxInvocationContext;
  * <p/>
  *
  * @author Mircea.Markus@jboss.com
- * @deprecated Since 9.0, please extend {@link org.infinispan.interceptors.SequentialInterceptor} instead.
+ * @deprecated Since 9.0, please extend {@link AsyncInterceptor} instead.
  */
 @Deprecated
 public abstract class PrePostProcessingCommandInterceptor extends CommandInterceptor {

--- a/core/src/main/java/org/infinispan/interceptors/compat/BaseTypeConverterInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/compat/BaseTypeConverterInterceptor.java
@@ -25,7 +25,7 @@ import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.stream.impl.interceptor.AbstractDelegatingEntryCacheSet;
 import org.infinispan.stream.impl.interceptor.AbstractDelegatingKeyCacheSet;
@@ -50,7 +50,7 @@ import java.util.stream.StreamSupport;
  *
  * @author Galder Zamarreño
  */
-public abstract class BaseTypeConverterInterceptor<K, V> extends DDSequentialInterceptor {
+public abstract class BaseTypeConverterInterceptor<K, V> extends DDAsyncInterceptor {
 
    private InternalEntryFactory entryFactory;
    private VersionGenerator versionGenerator;

--- a/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/BaseDistributionInterceptor.java
@@ -45,6 +45,7 @@ import org.infinispan.remoting.transport.jgroups.SuspectException;
 import org.infinispan.statetransfer.OutdatedTopologyException;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.transaction.xa.GlobalTransaction;
+import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -182,14 +183,14 @@ public abstract class BaseDistributionInterceptor extends ClusteringInterceptor 
             if (trace) {
                log.tracef("No valid values found for key '%s' (topologyId=%s).", key, currentTopologyId);
             }
-            return CompletableFuture.completedFuture(null);
+            return CompletableFutures.completedNull();
          }
          } else { // lastTopologyId > currentTopologyId || cacheTopology.getPendingCH() == null
             // We have not received a valid value from the pending CH owners either, and the topology id hasn't changed
          if (trace) {
             log.tracef("No valid values found for key '%s' (topologyId=%s).", key, currentTopologyId);
          }
-         return CompletableFuture.completedFuture(null);
+         return CompletableFutures.completedNull();
       }
 
       return invokeClusterGetCommandRemotely(targets, rpcOptionsBuilder, getCommand, key).thenCompose(

--- a/core/src/main/java/org/infinispan/interceptors/distribution/DistributionBulkInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/DistributionBulkInterceptor.java
@@ -21,7 +21,7 @@ import org.infinispan.context.impl.LocalTxInvocationContext;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.stream.StreamMarshalling;
 import org.infinispan.stream.impl.ClusterStreamManager;
 import org.infinispan.stream.impl.DistributedCacheStream;
@@ -47,7 +47,7 @@ import static org.infinispan.factories.KnownComponentNames.ASYNC_OPERATIONS_EXEC
  * @param <K> The key type of entries
  * @param <V> The value type of entries
  */
-public class DistributionBulkInterceptor<K, V> extends DDSequentialInterceptor {
+public class DistributionBulkInterceptor<K, V> extends DDAsyncInterceptor {
    private Cache<K, V> cache;
 
    @Inject

--- a/core/src/main/java/org/infinispan/interceptors/distribution/NonTxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/NonTxDistributionInterceptor.java
@@ -33,6 +33,7 @@ import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.responses.SuccessfulResponse;
 import org.infinispan.remoting.rpc.RpcOptions;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -265,7 +266,7 @@ public class NonTxDistributionInterceptor extends BaseDistributionInterceptor {
                   log.tracef("Doing a remote get for key %s", key);
                remoteFuture = retrieveFromRemoteSource(key, ctx, false, command, false);
             } else {
-               remoteFuture = CompletableFuture.completedFuture(null);
+               remoteFuture = CompletableFutures.completedNull();
             }
             return remoteFuture.thenCompose(remoteEntry -> {
                // TODO Do we need to do something else instead of setRemotelyFetchedValue?

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -56,6 +56,7 @@ import static org.infinispan.util.DeltaCompositeKeyUtil.getAffectedKeysFromConte
  * Handles the distribution of the transactional caches.
  *
  * @author Mircea Markus
+ * @author Dan Berindei
  */
 public class TxDistributionInterceptor extends BaseDistributionInterceptor {
 
@@ -79,41 +80,55 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
    }
 
    @Override
-   public CompletableFuture<Void> visitReplaceCommand(InvocationContext ctx, ReplaceCommand command) throws Throwable {
-      try {
-         return ctx.shortCircuit(handleTxWriteCommand(ctx, command, command.getKey()));
-      } finally {
-         if (ctx.isOriginLocal()) {
-            // If the state transfer interceptor has to retry the command, it should ignore the previous value.
-            command.setValueMatcher(command.isSuccessful() ? ValueMatcher.MATCH_ALWAYS : ValueMatcher.MATCH_NEVER);
-         }
+   public CompletableFuture<Void> visitReplaceCommand(InvocationContext ctx, ReplaceCommand command)
+         throws Throwable {
+      if (ctx.isOriginLocal()) {
+         ctx.onReturn((rCtx, rCommand, rv, throwable) -> {
+            // If the state transfer interceptor has to retry the command, it should ignore the previous
+            // value.
+            ReplaceCommand replaceCommand = (ReplaceCommand) rCommand;
+            replaceCommand.setValueMatcher(
+                  replaceCommand.isSuccessful() ? ValueMatcher.MATCH_ALWAYS : ValueMatcher.MATCH_NEVER);
+            return null;
+         });
       }
+      return handleTxWriteCommand(ctx, command, command.getKey());
    }
 
    @Override
-   public CompletableFuture<Void> visitRemoveCommand(InvocationContext ctx, RemoveCommand command) throws Throwable {
-      try {
-         return ctx.shortCircuit(handleTxWriteCommand(ctx, command, command.getKey()));
-      } finally {
-         if (ctx.isOriginLocal()) {
-            // If the state transfer interceptor has to retry the command, it should ignore the previous value.
-            command.setValueMatcher(command.isSuccessful() ? ValueMatcher.MATCH_ALWAYS : ValueMatcher.MATCH_NEVER);
-         }
+   public CompletableFuture<Void> visitRemoveCommand(InvocationContext ctx, RemoveCommand command)
+         throws Throwable {
+      if (ctx.isOriginLocal()) {
+         ctx.onReturn((rCtx, rCommand, rv, throwable) -> {
+            // If the state transfer interceptor has to retry the command, it should ignore the previous
+            // value.
+            RemoveCommand removeCommand = (RemoveCommand) rCommand;
+            removeCommand.setValueMatcher(
+                  removeCommand.isSuccessful() ? ValueMatcher.MATCH_ALWAYS : ValueMatcher.MATCH_NEVER);
+            return null;
+         });
       }
+      return handleTxWriteCommand(ctx, command, command.getKey());
    }
 
    @Override
-   public CompletableFuture<Void> visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command) throws Throwable {
+   public CompletableFuture<Void> visitPutKeyValueCommand(InvocationContext ctx, PutKeyValueCommand command)
+         throws Throwable {
       if (command.hasFlag(Flag.PUT_FOR_EXTERNAL_READ)) {
          return handleNonTxWriteCommand(ctx, command);
       }
 
-      Object returnValue = handleTxWriteCommand(ctx, command, command.getKey());
       if (ctx.isOriginLocal()) {
-         // If the state transfer interceptor has to retry the command, it should ignore the previous value.
-         command.setValueMatcher(command.isSuccessful() ? ValueMatcher.MATCH_ALWAYS : ValueMatcher.MATCH_NEVER);
+         ctx.onReturn((rCtx, rCommand, rv, throwable) -> {
+            // If the state transfer interceptor has to retry the command, it should ignore the previous
+            // value.
+            PutKeyValueCommand putKeyValueCommand = (PutKeyValueCommand) rCommand;
+            putKeyValueCommand.setValueMatcher(
+                  putKeyValueCommand.isSuccessful() ? ValueMatcher.MATCH_ALWAYS : ValueMatcher.MATCH_NEVER);
+            return null;
+         });
       }
-      return ctx.shortCircuit(returnValue);
+      return handleTxWriteCommand(ctx, command, command.getKey());
    }
 
    @Override
@@ -152,15 +167,16 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
    @Override
    public CompletableFuture<Void> visitLockControlCommand(TxInvocationContext ctx, LockControlCommand command) throws Throwable {
       if (ctx.isOriginLocal()) {
+         TxInvocationContext<LocalTransaction> localTxCtx = (TxInvocationContext<LocalTransaction>) ctx;
          //In Pessimistic mode, the delta composite keys were sent to the wrong owner and never locked.
          final Collection<Address> affectedNodes = cdl.getOwners(filterDeltaCompositeKeys(command.getKeys()));
-         ((LocalTxInvocationContext) ctx).remoteLocksAcquired(affectedNodes == null ? dm.getConsistentHash()
-               .getMembers() : affectedNodes);
+         localTxCtx.getCacheTransaction()
+               .locksAcquired(affectedNodes == null ? dm.getConsistentHash().getMembers() : affectedNodes);
          log.tracef("Registered remote locks acquired %s", affectedNodes);
          RpcOptions rpcOptions = rpcManager.getRpcOptionsBuilder(ResponseMode.SYNCHRONOUS_IGNORE_LEAVERS, DeliverOrder.NONE).build();
          Map<Address, Response> responseMap = rpcManager.invokeRemotely(affectedNodes, command, rpcOptions);
-         checkTxCommandResponses(responseMap, command, (LocalTxInvocationContext) ctx,
-                                 ((LocalTxInvocationContext) ctx).getRemoteLocksAcquired());
+         checkTxCommandResponses(responseMap, command, localTxCtx,
+               localTxCtx.getCacheTransaction().getRemoteLocksAcquired());
       }
       return ctx.continueInvocation();
    }
@@ -172,22 +188,27 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
          Collection<Address> recipients = getCommitNodes(ctx);
          Map<Address, Response> responseMap =
                rpcManager.invokeRemotely(recipients, command, createCommitRpcOptions());
-         checkTxCommandResponses(responseMap, command, (LocalTxInvocationContext) ctx, recipients);
+         checkTxCommandResponses(responseMap, command, ctx, recipients);
       }
       return ctx.continueInvocation();
    }
 
    @Override
-   public CompletableFuture<Void> visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
-      Object retVal = ctx.forkInvocationSync(command);
-
-      if (shouldInvokeRemoteTxCommand(ctx)) {
-         Collection<Address> recipients = cdl.getOwners(getAffectedKeysFromContext(ctx));
-         prepareOnAffectedNodes(ctx, command, recipients);
-         ((LocalTxInvocationContext) ctx).remoteLocksAcquired(
-               recipients == null ? dm.getWriteConsistentHash().getMembers() : recipients);
+   public CompletableFuture<Void> visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command)
+         throws Throwable {
+      if (!ctx.isOriginLocal()) {
+         return ctx.continueInvocation();
       }
-      return ctx.shortCircuit(retVal);
+      return ctx.onReturn((rCtx, rCommand, rv, throwable) -> {
+         if (throwable == null && shouldInvokeRemoteTxCommand(ctx)) {
+            TxInvocationContext<LocalTransaction> localTxCtx = (TxInvocationContext<LocalTransaction>) rCtx;
+            Collection<Address> recipients = cdl.getOwners(getAffectedKeysFromContext(localTxCtx));
+            prepareOnAffectedNodes(localTxCtx, (PrepareCommand) rCommand, recipients);
+            localTxCtx.getCacheTransaction().locksAcquired(
+                  recipients == null ? dm.getWriteConsistentHash().getMembers() : recipients);
+         }
+         return null;
+      });
    }
 
    protected void prepareOnAffectedNodes(TxInvocationContext<?> ctx, PrepareCommand command, Collection<Address> recipients) {
@@ -205,7 +226,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       if (shouldInvokeRemoteTxCommand(ctx)) {
          Collection<Address> recipients = getCommitNodes(ctx);
          Map<Address, Response> responseMap = rpcManager.invokeRemotely(recipients, command, createRollbackRpcOptions());
-         checkTxCommandResponses(responseMap, command, (LocalTxInvocationContext) ctx, recipients);
+         checkTxCommandResponses(responseMap, command, ctx, recipients);
       }
 
       return ctx.continueInvocation();
@@ -218,8 +239,9 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       return localTx.getCommitNodes(affectedNodes, rpcManager.getTopologyId(), members);
    }
 
-   protected void checkTxCommandResponses(Map<Address, Response> responseMap, TransactionBoundaryCommand command,
-                                          LocalTxInvocationContext context, Collection<Address> recipients) {
+   protected void checkTxCommandResponses(Map<Address, Response> responseMap,
+         TransactionBoundaryCommand command, TxInvocationContext<LocalTransaction> context,
+         Collection<Address> recipients) {
       OutdatedTopologyException outdatedTopologyException = null;
       for (Map.Entry<Address, Response> e : responseMap.entrySet()) {
          Address recipient = e.getKey();
@@ -251,8 +273,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
    }
 
    private boolean checkCacheNotFoundResponseInPartitionHandling(TransactionBoundaryCommand command,
-                                                                 LocalTxInvocationContext context,
-                                                                 Collection<Address> recipients) {
+         TxInvocationContext<LocalTransaction> context, Collection<Address> recipients) {
       final GlobalTransaction globalTransaction = command.getGlobalTransaction();
       final Collection<Object> lockedKeys = context.getLockedKeys();
       if (command instanceof RollbackCommand) {
@@ -276,11 +297,10 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
     * If we are within one transaction we won't do any replication as replication would only be performed at commit
     * time. If the operation didn't originate locally we won't do any replication either.
     */
-   private Object handleTxWriteCommand(InvocationContext ctx, WriteCommand command, Object key) throws Throwable {
+   private CompletableFuture<Void> handleTxWriteCommand(InvocationContext ctx, WriteCommand command,
+         Object key) throws Throwable {
       // see if we need to load values from remote sources first
-      remoteGetBeforeWrite(ctx, command, key);
-
-      return ctx.forkInvocationSync(command);
+      return remoteGetBeforeWrite(ctx, command, key);
    }
 
    @Override
@@ -314,11 +334,13 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       }
    }
 
-   protected void remoteGetBeforeWrite(InvocationContext ctx, WriteCommand command, Object key) throws Throwable {
+   @Override
+   protected CompletableFuture<Void> remoteGetBeforeWrite(InvocationContext ctx, WriteCommand command,
+         Object key) throws Throwable {
       CacheEntry entry = ctx.lookupEntry(key);
       if (!valueIsMissing(entry)) {
          // The entry already exists in the context, and it shouldn't be re-fetched
-         return;
+         return ctx.continueInvocation();
       }
       InternalCacheEntry remoteEntry = null;
       if (writeNeedsRemoteValue(ctx, command, key)) {
@@ -333,6 +355,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
             localGet(ctx, key, true);
          }
       }
+      return ctx.continueInvocation();
    }
 
    protected InternalCacheEntry remoteGet(InvocationContext ctx, Object key, boolean isWrite,
@@ -340,7 +363,7 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
       if (trace) log.tracef("Doing a remote get for key %s", key);
 
       // attempt a remote lookup
-      InternalCacheEntry ice = retrieveFromRemoteSource(key, ctx, false, command, isWrite);
+      InternalCacheEntry ice = retrieveFromRemoteSource(key, ctx, false, command, isWrite).get();
 
       if (ice != null) {
          if (useClusteredWriteSkewCheck && ctx.isInTxScope()) {

--- a/core/src/main/java/org/infinispan/interceptors/distribution/VersionedDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/VersionedDistributionInterceptor.java
@@ -15,9 +15,11 @@ import java.util.Map;
 import static org.infinispan.transaction.impl.WriteSkewHelper.readVersionsFromResponse;
 
 /**
- * A version of the {@link TxDistributionInterceptor} that adds logic to handling prepares when entries are versioned.
+ * A version of the {@link TxDistributionInterceptor} that adds logic to handling prepares when entries are
+ * versioned.
  *
  * @author Manik Surtani
+ * @author Dan Berindei
  */
 public class VersionedDistributionInterceptor extends TxDistributionInterceptor {
 

--- a/core/src/main/java/org/infinispan/interceptors/impl/AsyncSubCommandInvoker.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/AsyncSubCommandInvoker.java
@@ -1,0 +1,51 @@
+package org.infinispan.interceptors.impl;
+
+import org.infinispan.commands.VisitableCommand;
+import org.infinispan.context.InvocationContext;
+import org.infinispan.interceptors.SequentialInterceptor;
+
+import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+/**
+ * Invoke a sequence of sub-commands, allowing the caller to define a single
+ * {@link org.infinispan.interceptors.SequentialInterceptor.ForkReturnHandler}.
+ *
+ * @author Dan Berindei
+ * @since 9.0
+ */
+public class AsyncSubCommandInvoker implements SequentialInterceptor.ForkReturnHandler {
+   private Object returnValue;
+   private final Iterator<VisitableCommand> subCommands;
+   private final SequentialInterceptor.ForkReturnHandler finalReturnHandler;
+
+   private AsyncSubCommandInvoker(Object returnValue, Iterator<VisitableCommand> subCommands,
+         SequentialInterceptor.ForkReturnHandler finalReturnHandler) {
+      this.returnValue = returnValue;
+      this.subCommands = subCommands;
+      this.finalReturnHandler = finalReturnHandler;
+   }
+
+   public static <T> CompletableFuture<Void> forEach(InvocationContext ctx, VisitableCommand command,
+         Object returnValue, Stream<VisitableCommand> subCommandStream,
+         SequentialInterceptor.ForkReturnHandler finalReturnHandler) throws Throwable {
+      AsyncSubCommandInvoker forkInvoker =
+            new AsyncSubCommandInvoker(returnValue, subCommandStream.iterator(), finalReturnHandler);
+      return forkInvoker.handle(ctx, command, null, null);
+   }
+
+   @Override
+   public CompletableFuture<Void> handle(InvocationContext rCtx, VisitableCommand rCommand,
+         Object subReturnValue, Throwable throwable) throws Throwable {
+      if (throwable != null)
+         throw throwable;
+
+      if (subCommands.hasNext()) {
+         VisitableCommand newCommand = subCommands.next();
+         return rCtx.forkInvocation(newCommand, this);
+      } else {
+         return finalReturnHandler.handle(rCtx, rCommand, returnValue, null);
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/interceptors/impl/AsyncSubCommandInvoker.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/AsyncSubCommandInvoker.java
@@ -2,7 +2,7 @@ package org.infinispan.interceptors.impl;
 
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
@@ -10,29 +10,29 @@ import java.util.stream.Stream;
 
 /**
  * Invoke a sequence of sub-commands, allowing the caller to define a single
- * {@link org.infinispan.interceptors.SequentialInterceptor.ForkReturnHandler}.
+ * {@link AsyncInterceptor.ForkReturnHandler}.
  *
  * @author Dan Berindei
  * @since 9.0
  */
-public class AsyncSubCommandInvoker implements SequentialInterceptor.ForkReturnHandler {
+public class AsyncSubCommandInvoker implements AsyncInterceptor.ForkReturnHandler {
    private Object returnValue;
    private final Iterator<VisitableCommand> subCommands;
-   private final SequentialInterceptor.ForkReturnHandler finalReturnHandler;
+   private final AsyncInterceptor.ForkReturnHandler finalReturnHandler;
 
    private AsyncSubCommandInvoker(Object returnValue, Iterator<VisitableCommand> subCommands,
-         SequentialInterceptor.ForkReturnHandler finalReturnHandler) {
+         AsyncInterceptor.ForkReturnHandler finalReturnHandler) {
       this.returnValue = returnValue;
       this.subCommands = subCommands;
       this.finalReturnHandler = finalReturnHandler;
    }
 
-   public static <T> CompletableFuture<Void> forEach(InvocationContext ctx, VisitableCommand command,
+   public static CompletableFuture<Void> forEach(InvocationContext ctx, VisitableCommand command,
          Object returnValue, Stream<VisitableCommand> subCommandStream,
-         SequentialInterceptor.ForkReturnHandler finalReturnHandler) throws Throwable {
-      AsyncSubCommandInvoker forkInvoker =
+         AsyncInterceptor.ForkReturnHandler finalReturnHandler) throws Throwable {
+      AsyncSubCommandInvoker forker =
             new AsyncSubCommandInvoker(returnValue, subCommandStream.iterator(), finalReturnHandler);
-      return forkInvoker.handle(ctx, command, null, null);
+      return forker.handle(ctx, command, null, null);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/interceptors/impl/BaseRpcInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/BaseRpcInterceptor.java
@@ -7,7 +7,7 @@ import org.infinispan.context.impl.LocalTxInvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.responses.Response;
 import org.infinispan.remoting.responses.SelfDeliverFilter;
@@ -31,7 +31,7 @@ import java.util.Set;
  * @author Mircea.Markus@jboss.com
  * @since 9.0
  */
-public abstract class BaseRpcInterceptor extends DDSequentialInterceptor {
+public abstract class BaseRpcInterceptor extends DDAsyncInterceptor {
    protected boolean trace = getLog().isTraceEnabled();
 
    protected RpcManager rpcManager;

--- a/core/src/main/java/org/infinispan/interceptors/impl/BaseRpcInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/BaseRpcInterceptor.java
@@ -16,7 +16,6 @@ import org.infinispan.remoting.rpc.ResponseMode;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.remoting.rpc.RpcOptionsBuilder;
 import org.infinispan.remoting.transport.Address;
-import org.infinispan.statetransfer.StateConsumer;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.util.logging.Log;
 
@@ -42,7 +41,7 @@ public abstract class BaseRpcInterceptor extends DDSequentialInterceptor {
    protected abstract Log getLog();
 
    @Inject
-   public void inject(RpcManager rpcManager, StateConsumer stateConsumer) {
+   public void inject(RpcManager rpcManager) {
       this.rpcManager = rpcManager;
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/impl/BaseStateTransferInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/BaseStateTransferInterceptor.java
@@ -7,7 +7,7 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.distribution.group.GroupManager;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.remoting.RemoteException;
 import org.infinispan.remoting.transport.jgroups.SuspectException;
 import org.infinispan.statetransfer.OutdatedTopologyException;
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
  * @author Pedro Ruivo
  * @since 9.0
  */
-public abstract class BaseStateTransferInterceptor extends DDSequentialInterceptor {
+public abstract class BaseStateTransferInterceptor extends DDAsyncInterceptor {
    private final boolean trace = getLog().isTraceEnabled();
 
    protected StateTransferManager stateTransferManager;

--- a/core/src/main/java/org/infinispan/interceptors/impl/CallInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/CallInterceptor.java
@@ -4,7 +4,7 @@ package org.infinispan.interceptors.impl;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.tx.AbstractTransactionBoundaryCommand;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.interceptors.BaseSequentialInterceptor;
+import org.infinispan.interceptors.BaseAsyncInterceptor;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -21,8 +21,7 @@ import java.util.concurrent.CompletableFuture;
  * @author Dan Berindei
  * @since 9.0
  */
-public class CallInterceptor extends BaseSequentialInterceptor {
-   // TODO Invoke the command directly in BaseSequentialInvocationChain#invokeNext and remove this interceptor?
+public class CallInterceptor extends BaseAsyncInterceptor {
    private static final Log log = LogFactory.getLog(CallInterceptor.class);
    private static final boolean trace = log.isTraceEnabled();
 

--- a/core/src/main/java/org/infinispan/interceptors/impl/CallInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/CallInterceptor.java
@@ -1,26 +1,13 @@
 package org.infinispan.interceptors.impl;
 
 
-import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.VisitableCommand;
-import org.infinispan.commands.control.LockControlCommand;
-import org.infinispan.commands.read.GetAllCommand;
-import org.infinispan.commands.read.GetCacheEntryCommand;
-import org.infinispan.commands.read.GetKeyValueCommand;
-import org.infinispan.commands.tx.CommitCommand;
-import org.infinispan.commands.tx.PrepareCommand;
-import org.infinispan.commands.tx.RollbackCommand;
-import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.context.Flag;
+import org.infinispan.commands.tx.AbstractTransactionBoundaryCommand;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.context.impl.TxInvocationContext;
-import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.DDSequentialInterceptor;
-import org.infinispan.notifications.cachelistener.CacheNotifier;
+import org.infinispan.interceptors.BaseSequentialInterceptor;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -34,91 +21,22 @@ import java.util.concurrent.CompletableFuture;
  * @author Dan Berindei
  * @since 9.0
  */
-public class CallInterceptor extends DDSequentialInterceptor {
+public class CallInterceptor extends BaseSequentialInterceptor {
    // TODO Invoke the command directly in BaseSequentialInvocationChain#invokeNext and remove this interceptor?
    private static final Log log = LogFactory.getLog(CallInterceptor.class);
    private static final boolean trace = log.isTraceEnabled();
-   private CacheNotifier notifier;
-
-   @Inject
-   public void inject(CacheNotifier notifier) {
-      this.notifier = notifier;
-   }
 
    @Override
-   public CompletableFuture<Void> visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
-      if (trace) log.trace("Suppressing invocation of method handlePrepareCommand.");
-      return ctx.shortCircuit(null);
-   }
-
-   @Override
-   public CompletableFuture<Void> visitCommitCommand(TxInvocationContext ctx, CommitCommand command) throws Throwable {
-      if (trace) log.trace("Suppressing invocation of method handleCommitCommand.");
-      return ctx.shortCircuit(null);
-   }
-
-   @Override
-   public CompletableFuture<Void> visitRollbackCommand(TxInvocationContext ctx, RollbackCommand command) throws Throwable {
-      if (trace) log.trace("Suppressing invocation of method handleRollbackCommand.");
-      return ctx.shortCircuit(null);
-   }
-
-   @Override
-   public CompletableFuture<Void> visitLockControlCommand(TxInvocationContext ctx, LockControlCommand c) throws Throwable {
-      if (trace) log.trace("Suppressing invocation of method handleLockControlCommand.");
-      return ctx.shortCircuit(null);
-   }
-
-   @Override
-   public CompletableFuture<Void> visitGetKeyValueCommand(InvocationContext ctx, GetKeyValueCommand command) throws Throwable {
-      if (trace) log.trace("Executing command: " + command + ".");
-      Object ret = command.perform(ctx);
-      if (ret != null) {
-         notifyCacheEntryVisit(ctx, command, command.getKey(), ret);
+   public CompletableFuture<Void> visitCommand(InvocationContext ctx, VisitableCommand command)
+         throws Throwable {
+      if (command instanceof AbstractTransactionBoundaryCommand) {
+         if (trace)
+            log.tracef("Suppressing invocation for %s", command.getClass().getSimpleName());
+         return ctx.shortCircuit(null);
       }
-      return ctx.shortCircuit(ret);
-   }
 
-   @Override
-   public CompletableFuture<Void> visitGetCacheEntryCommand(InvocationContext ctx, GetCacheEntryCommand command) throws Throwable {
-      if (trace) log.trace("Executing command: " + command + ".");
-      Object ret = command.perform(ctx);
-      if (ret != null) {
-         notifyCacheEntryVisit(ctx, command, command.getKey(), ((CacheEntry) ret).getValue());
-      }
-      return ctx.shortCircuit(ret);
-   }
-
-   @Override
-   public CompletableFuture<Void> visitGetAllCommand(InvocationContext ctx, GetAllCommand command) throws Throwable {
-      if (trace) log.trace("Executing command: " + command + ".");
-      Object ret = command.perform(ctx);
-      if (ret != null) {
-         Map<Object, Object> map = (Map<Object, Object>) ret;
-         // TODO: it would be nice to know if a listener was registered for this and
-         // not do the full iteration if there was no visitor listener registered
-         if (command.getFlags() == null || !command.getFlags().contains(Flag.SKIP_LISTENER_NOTIFICATION)) {
-            for (Map.Entry<Object, Object> entry : map.entrySet()) {
-               Object value = entry.getValue();
-               if (value != null) {
-                  value = command.isReturnEntries() ? ((CacheEntry) value).getValue() : entry.getValue();
-                  notifyCacheEntryVisit(ctx, command, entry.getKey(), value);
-               }
-            }
-         }
-      }
-      return ctx.shortCircuit(ret);
-   }
-
-   private void notifyCacheEntryVisit(InvocationContext ctx, FlagAffectedCommand command,
-         Object key, Object value) {
-      notifier.notifyCacheEntryVisited(key, value, true, ctx, command);
-      notifier.notifyCacheEntryVisited(key, value, false, ctx, command);
-   }
-
-   @Override
-   final public CompletableFuture<Void> handleDefault(InvocationContext ctx, VisitableCommand command) throws Throwable {
-      if (trace) log.trace("Executing command: " + command + ".");
+      if (trace)
+         log.tracef("Invoking: %s", command.getClass().getSimpleName());
       return ctx.shortCircuit(command.perform(ctx));
    }
 }

--- a/core/src/main/java/org/infinispan/interceptors/impl/ClusteringInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/ClusteringInterceptor.java
@@ -22,9 +22,8 @@ public abstract class ClusteringInterceptor extends BaseRpcInterceptor {
    protected StateTransferManager stateTransferManager;
 
    @Inject
-   public void injectDependencies(CommandsFactory cf, EntryFactory entryFactory,
-                                  LockManager lockManager, DataContainer dataContainer,
-                                  StateTransferManager stateTransferManager) {
+   public void injectDependencies(CommandsFactory cf, EntryFactory entryFactory, LockManager lockManager,
+         DataContainer dataContainer, StateTransferManager stateTransferManager) {
       this.cf = cf;
       this.entryFactory = entryFactory;
       this.lockManager = lockManager;

--- a/core/src/main/java/org/infinispan/interceptors/impl/DeadlockDetectingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/DeadlockDetectingInterceptor.java
@@ -9,7 +9,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Start;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.transaction.xa.DldGlobalTransaction;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -27,7 +27,7 @@ import java.util.concurrent.CompletableFuture;
  * @author Mircea.Markus@jboss.com
  * @since 9.0
  */
-public class DeadlockDetectingInterceptor extends DDSequentialInterceptor {
+public class DeadlockDetectingInterceptor extends DDAsyncInterceptor {
 
    private static final Log log = LogFactory.getLog(DeadlockDetectingInterceptor.class);
    private static final boolean trace = log.isTraceEnabled();

--- a/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
@@ -49,7 +49,7 @@ import org.infinispan.factories.annotations.Start;
 import org.infinispan.filter.CollectionKeyFilter;
 import org.infinispan.filter.CompositeKeyFilter;
 import org.infinispan.filter.KeyFilter;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
@@ -76,7 +76,7 @@ import static org.infinispan.commons.util.Util.toStr;
  * @author Pedro Ruivo
  * @since 9.0
  */
-public class EntryWrappingInterceptor extends DDSequentialInterceptor {
+public class EntryWrappingInterceptor extends DDAsyncInterceptor {
    private EntryFactory entryFactory;
    protected DataContainer<Object, Object> dataContainer;
    protected ClusteringDependentLogic cdl;

--- a/core/src/main/java/org/infinispan/interceptors/impl/GroupingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/GroupingInterceptor.java
@@ -48,33 +48,34 @@ public class GroupingInterceptor extends DDSequentialInterceptor {
       final String groupName = command.getGroupName();
       command.setGroupOwner(isGroupOwner(groupName));
       if (!command.isGroupOwner() || !isPassivationEnabled) {
-         Object result = ctx.forkInvocationSync(command);
-         if (result instanceof List) {
-            //noinspection unchecked
-            filter((List<CacheEntry>) result);
-         }
-         return ctx.shortCircuit(result);
+         return ctx.onReturn((rCtx, rCommand, rv, throwable) -> {
+            if (rv instanceof List) {
+               //noinspection unchecked
+               filter((List<CacheEntry>) rv);
+            }
+            return null;
+         });
       }
+
       KeyListener listener = new KeyListener(groupName, groupManager, factory);
       //this is just to try to make the snapshot the most recent possible by picking some modification on the fly.
       cacheNotifier.addListener(listener);
-      try {
-         Object result = ctx.forkInvocationSync(command);
-         if (result instanceof List) {
+      return ctx.onReturn((rCtx, rCommand, rv, throwable) -> {
+         cacheNotifier.removeListener(listener);
+
+         if (rv instanceof List) {
             //noinspection unchecked
-            ((List) result).addAll(listener.activatedKeys);
+            ((List) rv).addAll(listener.activatedKeys);
             //noinspection unchecked
-            filter((List<CacheEntry>) result);
-         } else if (result instanceof Map) {
+            filter((List<CacheEntry>) rv);
+         } else if (rv instanceof Map) {
             for (CacheEntry entry : listener.activatedKeys) {
                //noinspection unchecked
-               ((Map) result).put(entry.getKey(), entry.getValue());
+               ((Map) rv).put(entry.getKey(), entry.getValue());
             }
          }
-         return ctx.shortCircuit(result);
-      } finally {
-         cacheNotifier.removeListener(listener);
-      }
+         return null;
+      });
    }
 
    private void filter(List<CacheEntry> list) {

--- a/core/src/main/java/org/infinispan/interceptors/impl/GroupingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/GroupingInterceptor.java
@@ -9,7 +9,7 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.distribution.group.GroupFilter;
 import org.infinispan.distribution.group.GroupManager;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated;
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * @author Pedro Ruivo
  * @since 9.0
  */
-public class GroupingInterceptor extends DDSequentialInterceptor {
+public class GroupingInterceptor extends DDAsyncInterceptor {
 
    private CacheNotifier<?, ?> cacheNotifier;
    private GroupManager groupManager;

--- a/core/src/main/java/org/infinispan/interceptors/impl/InterceptorListNode.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/InterceptorListNode.java
@@ -1,6 +1,6 @@
 package org.infinispan.interceptors.impl;
 
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 
 /**
  * Node in a single-linked list of interceptors.
@@ -9,10 +9,10 @@ import org.infinispan.interceptors.SequentialInterceptor;
  * @since 9.0
  */
 class InterceptorListNode {
-   public final SequentialInterceptor interceptor;
+   public final AsyncInterceptor interceptor;
    public final InterceptorListNode nextNode;
 
-   public InterceptorListNode(SequentialInterceptor interceptor, InterceptorListNode next) {
+   public InterceptorListNode(AsyncInterceptor interceptor, InterceptorListNode next) {
       this.interceptor = interceptor;
       this.nextNode = next;
    }

--- a/core/src/main/java/org/infinispan/interceptors/impl/InterceptorListNode.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/InterceptorListNode.java
@@ -8,7 +8,7 @@ import org.infinispan.interceptors.SequentialInterceptor;
  * @author Dan Berindei
  * @since 9.0
  */
-public class InterceptorListNode {
+class InterceptorListNode {
    public final SequentialInterceptor interceptor;
    public final InterceptorListNode nextNode;
 

--- a/core/src/main/java/org/infinispan/interceptors/impl/InvocationContextInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/InvocationContextInterceptor.java
@@ -16,7 +16,7 @@ import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
-import org.infinispan.interceptors.BaseSequentialInterceptor;
+import org.infinispan.interceptors.BaseAsyncInterceptor;
 import org.infinispan.interceptors.totalorder.RetryPrepareException;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.CacheContainer;
@@ -42,7 +42,7 @@ import static org.infinispan.commons.util.Util.toStr;
  * @author Galder Zamarreño
  * @since 9.0
  */
-public class InvocationContextInterceptor extends BaseSequentialInterceptor {
+public class InvocationContextInterceptor extends BaseAsyncInterceptor {
 
    private TransactionManager tm;
    private ComponentRegistry componentRegistry;

--- a/core/src/main/java/org/infinispan/interceptors/impl/InvocationContextInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/InvocationContextInterceptor.java
@@ -57,7 +57,7 @@ public class InvocationContextInterceptor extends BaseSequentialInterceptor {
       @Override
       public CompletableFuture<Object> handle(InvocationContext rCtx, VisitableCommand rCommand, Object rv,
             Throwable throwable) throws Throwable {
-         invocationContextContainer.clearThreadLocal();
+         invocationContextContainer.clearThreadLocal(rCtx);
          if (throwable == null)
             return null;
 

--- a/core/src/main/java/org/infinispan/interceptors/impl/IsMarshallableInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/IsMarshallableInterceptor.java
@@ -18,7 +18,7 @@ import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -39,7 +39,7 @@ import static org.infinispan.factories.KnownComponentNames.CACHE_MARSHALLER;
  * @author Galder Zamarreño
  * @since 9.0
  */
-public class IsMarshallableInterceptor extends DDSequentialInterceptor {
+public class IsMarshallableInterceptor extends DDAsyncInterceptor {
 
    private StreamingMarshaller marshaller;
    private DistributionManager distManager;

--- a/core/src/main/java/org/infinispan/interceptors/impl/JmxStatsCommandInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/JmxStatsCommandInterceptor.java
@@ -1,7 +1,7 @@
 package org.infinispan.interceptors.impl;
 
 import org.infinispan.factories.annotations.Start;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.jmx.JmxStatisticsExposer;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
@@ -12,7 +12,7 @@ import org.infinispan.jmx.annotations.ManagedOperation;
  * @author Mircea.Markus@jboss.com
  * @since 9.0
  */
-public abstract class JmxStatsCommandInterceptor extends DDSequentialInterceptor implements JmxStatisticsExposer {
+public abstract class JmxStatsCommandInterceptor extends DDAsyncInterceptor implements JmxStatisticsExposer {
    @ManagedAttribute(description = "Enables or disables the gathering of statistics by this component", writable = true)
    private boolean statisticsEnabled = false;
 

--- a/core/src/main/java/org/infinispan/interceptors/impl/MarshalledValueInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/MarshalledValueInterceptor.java
@@ -26,7 +26,7 @@ import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.marshall.core.MarshalledValue;
 import org.infinispan.stream.impl.interceptor.AbstractDelegatingEntryCacheSet;
 import org.infinispan.stream.impl.interceptor.AbstractDelegatingKeyCacheSet;
@@ -61,7 +61,7 @@ import static org.infinispan.marshall.core.MarshalledValue.isTypeExcluded;
  * @see MarshalledValue
  * @since 9.0
  */
-public class MarshalledValueInterceptor<K, V> extends DDSequentialInterceptor {
+public class MarshalledValueInterceptor<K, V> extends DDAsyncInterceptor {
    private StreamingMarshaller marshaller;
    private boolean wrapKeys = true;
    private boolean wrapValues = true;

--- a/core/src/main/java/org/infinispan/interceptors/impl/NotificationInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/NotificationInterceptor.java
@@ -7,7 +7,7 @@ import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 
 import java.util.concurrent.CompletableFuture;
@@ -18,7 +18,7 @@ import java.util.concurrent.CompletableFuture;
  * @author <a href="mailto:manik@jboss.org">Manik Surtani</a>
  * @since 9.0
  */
-public class NotificationInterceptor extends DDSequentialInterceptor {
+public class NotificationInterceptor extends DDAsyncInterceptor {
    private CacheNotifier notifier;
    private final ReturnHandler transactionCompleteReturnHandler = new ReturnHandler() {
       @Override

--- a/core/src/main/java/org/infinispan/interceptors/impl/TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/TxInterceptor.java
@@ -34,7 +34,7 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.RemoteTxInvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.jmx.JmxStatisticsExposer;
 import org.infinispan.jmx.annotations.DataType;
 import org.infinispan.jmx.annotations.DisplayType;
@@ -80,7 +80,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @since 9.0
  */
 @MBean(objectName = "Transactions", description = "Component that manages the cache's participation in JTA transactions.")
-public class TxInterceptor<K, V> extends DDSequentialInterceptor implements JmxStatisticsExposer {
+public class TxInterceptor<K, V> extends DDAsyncInterceptor implements JmxStatisticsExposer {
 
    private static final Log log = LogFactory.getLog(TxInterceptor.class);
    private static final boolean trace = log.isTraceEnabled();

--- a/core/src/main/java/org/infinispan/interceptors/locking/AbstractLockingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/locking/AbstractLockingInterceptor.java
@@ -20,7 +20,7 @@ import org.infinispan.container.DataContainer;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.util.concurrent.TimeoutException;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.concurrent.locks.LockUtil;
@@ -41,7 +41,7 @@ import static org.infinispan.commons.util.Util.toStr;
  *
  * @author Mircea Markus
  */
-public abstract class AbstractLockingInterceptor extends DDSequentialInterceptor {
+public abstract class AbstractLockingInterceptor extends DDAsyncInterceptor {
    private final boolean trace = getLog().isTraceEnabled();
 
    protected LockManager lockManager;

--- a/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/totalorder/TotalOrderInterceptor.java
@@ -11,7 +11,7 @@ import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.KnownComponentNames;
 import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.impl.TotalOrderRemoteTransactionState;
@@ -34,7 +34,7 @@ import static org.infinispan.commons.util.Util.toStr;
  * @author Pedro Ruivo
  * @author Mircea.Markus@jboss.com
  */
-public class TotalOrderInterceptor extends DDSequentialInterceptor {
+public class TotalOrderInterceptor extends DDAsyncInterceptor {
 
    private static final Log log = LogFactory.getLog(TotalOrderInterceptor.class);
    private static final boolean trace = log.isTraceEnabled();

--- a/core/src/main/java/org/infinispan/interceptors/xsite/BaseBackupInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/xsite/BaseBackupInterceptor.java
@@ -9,7 +9,7 @@ import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.remoting.transport.BackupResponse;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.transaction.impl.TransactionTable;
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture;
  * @author Mircea Markus
  * @since 5.2
  */
-public class BaseBackupInterceptor extends DDSequentialInterceptor {
+public class BaseBackupInterceptor extends DDAsyncInterceptor {
 
    protected BackupSender backupSender;
    protected TransactionTable txTable;

--- a/core/src/main/java/org/infinispan/interceptors/xsite/OptimisticBackupInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/xsite/OptimisticBackupInterceptor.java
@@ -18,23 +18,6 @@ import java.util.concurrent.CompletableFuture;
 public class OptimisticBackupInterceptor extends BaseBackupInterceptor {
 
    @Override
-   public CompletableFuture<Void> visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
-      //if this is an "empty" tx no point replicating it to other clusters
-      if (!shouldInvokeRemoteTxCommand(ctx))
-         return ctx.continueInvocation();
-
-      boolean isTxFromRemoteSite = isTxFromRemoteSite(command.getGlobalTransaction());
-      if (isTxFromRemoteSite) {
-         return ctx.continueInvocation();
-      }
-
-      BackupResponse backupResponse = backupSender.backupPrepare(command);
-      Object result = ctx.forkInvocationSync(command);
-      backupSender.processResponses(backupResponse, command, ctx.getTransaction());
-      return ctx.shortCircuit(result);
-   }
-
-   @Override
    public CompletableFuture<Void> visitCommitCommand(TxInvocationContext ctx, CommitCommand command) throws Throwable {
       if (!shouldInvokeRemoteTxCommand(ctx))
          return ctx.continueInvocation();
@@ -44,9 +27,7 @@ public class OptimisticBackupInterceptor extends BaseBackupInterceptor {
       }
 
       BackupResponse backupResponse = backupSender.backupCommit(command);
-      Object result = ctx.forkInvocationSync(command);
-      backupSender.processResponses(backupResponse, command, ctx.getTransaction());
-      return ctx.shortCircuit(result);
+      return processBackupResponse(ctx, command, backupResponse);
    }
 
    @Override
@@ -59,9 +40,7 @@ public class OptimisticBackupInterceptor extends BaseBackupInterceptor {
       }
 
       BackupResponse backupResponse = backupSender.backupRollback(command);
-      Object result = ctx.forkInvocationSync(command);
-      backupSender.processResponses(backupResponse, command, ctx.getTransaction());
-      return ctx.shortCircuit(result);
+      return processBackupResponse(ctx, command, backupResponse);
    }
 
    private boolean shouldRollbackRemoteTxCommand(TxInvocationContext ctx) {

--- a/core/src/main/java/org/infinispan/interceptors/xsite/PessimisticBackupInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/xsite/PessimisticBackupInterceptor.java
@@ -1,9 +1,7 @@
 package org.infinispan.interceptors.xsite;
 
 import org.infinispan.commands.tx.CommitCommand;
-import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.context.impl.TxInvocationContext;
-import org.infinispan.remoting.transport.BackupResponse;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -14,23 +12,6 @@ import java.util.concurrent.CompletableFuture;
  * @since 5.2
  */
 public class PessimisticBackupInterceptor extends BaseBackupInterceptor {
-
-   @Override
-   public CompletableFuture<Void> visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
-      //if this is an "empty" tx no point replicating it to other clusters
-      if (!shouldInvokeRemoteTxCommand(ctx))
-         return ctx.continueInvocation();
-
-      boolean isTxFromRemoteSite = isTxFromRemoteSite( command.getGlobalTransaction() );
-      if (isTxFromRemoteSite) {
-         return ctx.continueInvocation();
-      }
-
-      BackupResponse backupResponse = backupSender.backupPrepare(command);
-      Object result = ctx.forkInvocationSync(command);
-      backupSender.processResponses(backupResponse, command, ctx.getTransaction());
-      return ctx.shortCircuit(result);
-   }
 
    @Override
    public CompletableFuture<Void> visitCommitCommand(TxInvocationContext ctx, CommitCommand command) throws Throwable {

--- a/core/src/main/java/org/infinispan/manager/impl/ClusterExecutorImpl.java
+++ b/core/src/main/java/org/infinispan/manager/impl/ClusterExecutorImpl.java
@@ -282,7 +282,7 @@ public class ClusterExecutorImpl implements ClusterExecutor {
       } else if (localFuture != null) {
          return localFuture.handle((r, t) -> null);
       } else {
-         return CompletableFuture.completedFuture(null);
+         return CompletableFutures.completedNull();
       }
    }
 

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
@@ -25,7 +25,7 @@ import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.filter.CacheFilters;
 import org.infinispan.filter.KeyFilter;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.metadata.Metadata;
@@ -192,7 +192,7 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
    @Override
    public void start() {
       super.start();
-      SequentialInterceptorChain interceptorChain = SecurityActions.getSequentialInterceptorChain(cache);
+      AsyncInterceptorChain interceptorChain = SecurityActions.getAsyncInterceptorChain(cache);
       if (interceptorChain != null && !interceptorChain.getInterceptors().isEmpty()) {
          this.distExecutorService = SecurityActions.getDefaultExecutorService(cache);
       }
@@ -729,6 +729,8 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
     * @param <C>
     * @return
     */
+
+   @Override
    public <C> void addListener(Object listener, CacheEventFilter<? super K, ? super V> filter,
                                            CacheEventConverter<? super K, ? super V, C> converter, ClassLoader classLoader) {
       final Listener l = testListenerClassValidity(listener.getClass());

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/SecurityActions.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/SecurityActions.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 import org.infinispan.Cache;
 import org.infinispan.distexec.DefaultExecutorService;
-import org.infinispan.interceptors.SequentialInterceptor;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptor;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.security.Security;
 import org.infinispan.security.actions.GetCacheInterceptorChainAction;
 import org.infinispan.security.actions.GetDefaultExecutorServiceAction;
@@ -35,12 +35,12 @@ final class SecurityActions {
       return doPrivileged(action);
    }
 
-   static List<SequentialInterceptor> getInterceptorChain(final Cache<?, ?> cache) {
+   static List<AsyncInterceptor> getInterceptorChain(final Cache<?, ?> cache) {
       GetCacheInterceptorChainAction action = new GetCacheInterceptorChainAction(cache.getAdvancedCache());
       return doPrivileged(action);
    }
 
-   static SequentialInterceptorChain getSequentialInterceptorChain(final Cache<?, ?> cache) {
-      return doPrivileged(() -> cache.getAdvancedCache().getSequentialInterceptorChain());
+   static AsyncInterceptorChain getAsyncInterceptorChain(final Cache<?, ?> cache) {
+      return doPrivileged(() -> cache.getAdvancedCache().getAsyncInterceptorChain());
    }
 }

--- a/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingInterceptor.java
+++ b/core/src/main/java/org/infinispan/partitionhandling/impl/PartitionHandlingInterceptor.java
@@ -22,7 +22,7 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.partitionhandling.AvailabilityMode;
 import org.infinispan.remoting.RpcException;
 import org.infinispan.remoting.transport.Transport;
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-public class PartitionHandlingInterceptor extends DDSequentialInterceptor {
+public class PartitionHandlingInterceptor extends DDAsyncInterceptor {
    private static final Log log = LogFactory.getLog(PartitionHandlingInterceptor.class);
    
    PartitionHandlingManager partitionHandlingManager;

--- a/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
+++ b/core/src/main/java/org/infinispan/persistence/manager/PersistenceManagerImpl.java
@@ -18,8 +18,8 @@ import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.filter.KeyFilter;
-import org.infinispan.interceptors.SequentialInterceptor;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptor;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.impl.CacheLoaderInterceptor;
 import org.infinispan.interceptors.impl.CacheWriterInterceptor;
 import org.infinispan.marshall.core.MarshalledEntry;
@@ -269,15 +269,15 @@ public class PersistenceManagerImpl implements PersistenceManager {
          }
 
          if (loaders.isEmpty() && writers.isEmpty()) {
-            SequentialInterceptorChain chain = cache.getAdvancedCache().getSequentialInterceptorChain();
-            SequentialInterceptor loaderInterceptor = chain.findInterceptorExtending(CacheLoaderInterceptor.class);
+            AsyncInterceptorChain chain = cache.getAdvancedCache().getAsyncInterceptorChain();
+            AsyncInterceptor loaderInterceptor = chain.findInterceptorExtending(CacheLoaderInterceptor.class);
             if (loaderInterceptor == null) {
                log.persistenceWithoutCacheLoaderInterceptor();
             } else {
                ((CacheLoaderInterceptor) loaderInterceptor).disableInterceptor();
                chain.removeInterceptor(loaderInterceptor.getClass());
             }
-            SequentialInterceptor writerInterceptor = chain.findInterceptorExtending(CacheWriterInterceptor.class);
+            AsyncInterceptor writerInterceptor = chain.findInterceptorExtending(CacheWriterInterceptor.class);
             if (writerInterceptor == null) {
                log.persistenceWithoutCacheWriteInterceptor();
             } else {

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -582,7 +582,7 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
 
       List<org.jgroups.Address> jgAddressList = toJGroupsAddressListExcludingSelf(recipients, totalOrder);
       if (jgAddressList != null && jgAddressList.isEmpty()) {
-         return CompletableFutures.returnEmptyMap();
+         return CompletableFutures.completedEmptyMap();
       }
 
       List<Address> localMembers = this.members;
@@ -620,7 +620,7 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
             }
          }
          if (skipRpc) {
-            return CompletableFutures.returnEmptyMap();
+            return CompletableFutures.completedEmptyMap();
          }
 
          if (singleRecipient) {
@@ -635,7 +635,7 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
       }
 
       if (mode.isAsynchronous()) {
-         return CompletableFutures.returnEmptyMap();
+         return CompletableFutures.completedEmptyMap();
       }
 
       if (singleResponseFuture != null) {

--- a/core/src/main/java/org/infinispan/security/actions/GetCacheInterceptorChainAction.java
+++ b/core/src/main/java/org/infinispan/security/actions/GetCacheInterceptorChainAction.java
@@ -1,9 +1,9 @@
 package org.infinispan.security.actions;
 
-import java.util.List;
-
 import org.infinispan.AdvancedCache;
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
+
+import java.util.List;
 
 /**
  * GetCacheInterceptorChainAction.
@@ -11,15 +11,15 @@ import org.infinispan.interceptors.SequentialInterceptor;
  * @author Tristan Tarrant
  * @since 7.0
  */
-public class GetCacheInterceptorChainAction extends AbstractAdvancedCacheAction<List<SequentialInterceptor>> {
+public class GetCacheInterceptorChainAction extends AbstractAdvancedCacheAction<List<AsyncInterceptor>> {
 
    public GetCacheInterceptorChainAction(AdvancedCache<?, ?> cache) {
       super(cache);
    }
 
    @Override
-   public List<SequentialInterceptor> run() {
-      return cache.getSequentialInterceptorChain().getInterceptors();
+   public List<AsyncInterceptor> run() {
+      return cache.getAsyncInterceptorChain().getInterceptors();
    }
 
 }

--- a/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
+++ b/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
@@ -15,7 +15,7 @@ import org.infinispan.eviction.EvictionManager;
 import org.infinispan.expiration.ExpirationManager;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.filter.KeyFilter;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -193,9 +193,9 @@ public final class SecureCacheImpl<K, V> implements SecureCache<K, V> {
    }
 
    @Override
-   public SequentialInterceptorChain getSequentialInterceptorChain() {
+   public AsyncInterceptorChain getAsyncInterceptorChain() {
       authzManager.checkPermission(AuthorizationPermission.ADMIN);
-      return delegate.getSequentialInterceptorChain();
+      return delegate.getAsyncInterceptorChain();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/statetransfer/TransactionSynchronizerInterceptor.java
+++ b/core/src/main/java/org/infinispan/statetransfer/TransactionSynchronizerInterceptor.java
@@ -4,7 +4,7 @@ import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.tx.TransactionBoundaryCommand;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
-import org.infinispan.interceptors.BaseSequentialInterceptor;
+import org.infinispan.interceptors.BaseAsyncInterceptor;
 import org.infinispan.transaction.impl.RemoteTransaction;
 
 import java.util.concurrent.CompletableFuture;
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture;
  * @author Mircea Markus
  * @since 5.2
  */
-public class TransactionSynchronizerInterceptor extends BaseSequentialInterceptor {
+public class TransactionSynchronizerInterceptor extends BaseAsyncInterceptor {
 
    @Override
    public CompletableFuture<Void> visitCommand(InvocationContext ctx, VisitableCommand command)

--- a/core/src/main/java/org/infinispan/stats/impl/ClusterCacheStatsImpl.java
+++ b/core/src/main/java/org/infinispan/stats/impl/ClusterCacheStatsImpl.java
@@ -21,7 +21,7 @@ import org.infinispan.eviction.PassivationManager;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.impl.ActivationInterceptor;
 import org.infinispan.interceptors.impl.CacheWriterInterceptor;
 import org.infinispan.interceptors.impl.InvalidationInterceptor;
@@ -144,6 +144,7 @@ public class ClusterCacheStatsImpl implements ClusterCacheStats, JmxStatisticsEx
 
    // -------------------------------------------- JMX information -----------------------------------------------
 
+   @Override
    @ManagedOperation(description = "Resets statistics gathered by this component", displayName = "Reset statistics")
    public void resetStatistics() {
       if (isStatisticsEnabled()) {
@@ -174,6 +175,7 @@ public class ClusterCacheStatsImpl implements ClusterCacheStats, JmxStatisticsEx
       return getStatisticsEnabled();
    }
 
+   @Override
    @ManagedAttribute(description = "Cluster wide total average number of milliseconds for a read operation on the cache",
          displayName = "Cluster wide total average read time",
          units = Units.MILLISECONDS,
@@ -187,6 +189,7 @@ public class ClusterCacheStatsImpl implements ClusterCacheStats, JmxStatisticsEx
       }
    }
 
+   @Override
    @ManagedAttribute(description = "Cluster wide total average number of milliseconds for a remove operation in the cache",
          displayName = "Cluster wide total average remove time",
          units = Units.MILLISECONDS,
@@ -200,6 +203,7 @@ public class ClusterCacheStatsImpl implements ClusterCacheStats, JmxStatisticsEx
       }
    }
 
+   @Override
    @ManagedAttribute(description = "Cluster wide average number of milliseconds for a write operation in the cache",
          displayName = "Cluster wide average write time",
          units = Units.MILLISECONDS,
@@ -255,6 +259,7 @@ public class ClusterCacheStatsImpl implements ClusterCacheStats, JmxStatisticsEx
       }
    }
 
+   @Override
    @ManagedAttribute(description = "Cluster wide total number of cache attribute misses",
          displayName = "Cluster wide total number of cache misses",
          measurementType = MeasurementType.TRENDSUP,
@@ -350,6 +355,7 @@ public class ClusterCacheStatsImpl implements ClusterCacheStats, JmxStatisticsEx
       }
    }
 
+   @Override
    @ManagedAttribute(
          description = "Number of seconds since the cluster-wide cache statistics were last reset",
          displayName = "Seconds since cluster-wide cache statistics were reset",
@@ -435,6 +441,7 @@ public class ClusterCacheStatsImpl implements ClusterCacheStats, JmxStatisticsEx
       }
    }
 
+   @Override
    @ManagedAttribute(description = "The total number of invalidations in the cluster",
          displayName = "Cluster wide total number of invalidations",
          measurementType = MeasurementType.TRENDSUP,
@@ -639,8 +646,10 @@ public class ClusterCacheStatsImpl implements ClusterCacheStats, JmxStatisticsEx
       return hitRatio;
    }
 
-   private static <T extends SequentialInterceptor> T getFirstInterceptorWhichExtends(AdvancedCache<?,?> cache, Class<T> interceptorClass) {
-      return interceptorClass.cast(cache.getSequentialInterceptorChain().findInterceptorExtending(interceptorClass));
+   private static <T extends AsyncInterceptor> T getFirstInterceptorWhichExtends(AdvancedCache<?, ?> cache,
+         Class<T> interceptorClass) {
+      return interceptorClass
+            .cast(cache.getAsyncInterceptorChain().findInterceptorExtending(interceptorClass));
    }
 
    private static CacheMode getCacheMode(Cache cache) {

--- a/core/src/main/java/org/infinispan/stats/impl/StatsImpl.java
+++ b/core/src/main/java/org/infinispan/stats/impl/StatsImpl.java
@@ -1,8 +1,7 @@
 package org.infinispan.stats.impl;
 
 import net.jcip.annotations.Immutable;
-
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.impl.CacheMgmtInterceptor;
 import org.infinispan.stats.Stats;
 
@@ -31,8 +30,8 @@ public class StatsImpl implements Stats {
    final CacheMgmtInterceptor mgmtInterceptor;
    final Stats source;
 
-   public StatsImpl(SequentialInterceptorChain chain) {
-      mgmtInterceptor = (CacheMgmtInterceptor) chain.findInterceptorExtending(CacheMgmtInterceptor.class);
+   public StatsImpl(AsyncInterceptorChain chain) {
+      mgmtInterceptor = chain.findInterceptorExtending(CacheMgmtInterceptor.class);
       source = null;
 
       if (mgmtInterceptor.getStatisticsEnabled()) {

--- a/core/src/main/java/org/infinispan/transaction/impl/RemoteTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/RemoteTransaction.java
@@ -8,6 +8,7 @@ import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.InvalidTransactionException;
+import org.infinispan.util.concurrent.CompletableFutures;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -31,7 +32,7 @@ public class RemoteTransaction extends AbstractCacheTransaction implements Clone
 
    private static final Log log = LogFactory.getLog(RemoteTransaction.class);
    private static final boolean trace = log.isTraceEnabled();
-   private static final CompletableFuture<Void> INITIAL_FUTURE = CompletableFuture.completedFuture(null);
+   private static final CompletableFuture<Void> INITIAL_FUTURE = CompletableFutures.completedNull();
 
    /**
     * This int should be set to the highest topology id for transactions received via state transfer. During state

--- a/core/src/main/java/org/infinispan/transaction/impl/RemoteTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/RemoteTransaction.java
@@ -16,6 +16,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.infinispan.commons.util.Util.toStr;
 
@@ -29,6 +31,7 @@ public class RemoteTransaction extends AbstractCacheTransaction implements Clone
 
    private static final Log log = LogFactory.getLog(RemoteTransaction.class);
    private static final boolean trace = log.isTraceEnabled();
+   private static final CompletableFuture<Void> INITIAL_FUTURE = CompletableFuture.completedFuture(null);
 
    /**
     * This int should be set to the highest topology id for transactions received via state transfer. During state
@@ -42,6 +45,9 @@ public class RemoteTransaction extends AbstractCacheTransaction implements Clone
 
    private volatile TotalOrderRemoteTransactionState transactionState;
    private final Object transactionStateLock = new Object();
+
+   private final AtomicReference<CompletableFuture<Void>> synchronization =
+         new AtomicReference<>(INITIAL_FUTURE);
 
    public RemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId,
                             Equivalence<Object> keyEquivalence, long txCreationTime) {
@@ -152,5 +158,13 @@ public class RemoteTransaction extends AbstractCacheTransaction implements Clone
          }
          return transactionState;
       }
+   }
+
+   public final CompletableFuture<Void> enterSynchronizationAsync(CompletableFuture<Void> releaseFuture) {
+      CompletableFuture<Void> currentFuture;
+      do {
+         currentFuture = synchronization.get();
+      } while (!synchronization.compareAndSet(currentFuture, releaseFuture));
+      return currentFuture;
    }
 }

--- a/core/src/main/java/org/infinispan/util/concurrent/CompletableFutures.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/CompletableFutures.java
@@ -1,16 +1,15 @@
 package org.infinispan.util.concurrent;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import java.util.Map;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Utility methods connecting {@link CompletableFuture} futures.
@@ -21,10 +20,17 @@ import java.util.Map;
 public class CompletableFutures {
 
    private static final CompletableFuture completedEmptyMapFuture = CompletableFuture.completedFuture(Collections.emptyMap());
-   public static final long BIG_DELAY_NANOS = TimeUnit.DAYS.toNanos(1);
+   private static final CompletableFuture completedNullFuture = CompletableFuture.completedFuture(null);
+   private static final long BIG_DELAY_NANOS = TimeUnit.DAYS.toNanos(1);
 
-   public static <K,V> CompletableFuture<Map<K, V>> returnEmptyMap() {
+   @SuppressWarnings("unchecked")
+   public static <K,V> CompletableFuture<Map<K, V>> completedEmptyMap() {
       return completedEmptyMapFuture;
+   }
+
+   @SuppressWarnings("unchecked")
+   public static <T> CompletableFuture<T> completedNull() {
+      return completedNullFuture;
    }
 
    public static <T> CompletableFuture<List<T>> sequence(List<CompletableFuture<T>> futures) {

--- a/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadTest.java
+++ b/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadTest.java
@@ -25,7 +25,7 @@ import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.distribution.MagicKey;
-import org.infinispan.interceptors.BaseSequentialInterceptor;
+import org.infinispan.interceptors.BaseAsyncInterceptor;
 import org.infinispan.interceptors.impl.CallInterceptor;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.ReplListener;
@@ -55,7 +55,7 @@ public abstract class PutForExternalReadTest extends MultipleCacheManagersTest {
       final Cache<MagicKey, String> cache2 = cache(1, CACHE_NAME);
 
       final CyclicBarrier barrier = new CyclicBarrier(2);
-      cache1.getAdvancedCache().getSequentialInterceptorChain().addInterceptor(new BaseSequentialInterceptor() {
+      cache1.getAdvancedCache().getAsyncInterceptorChain().addInterceptor(new BaseAsyncInterceptor() {
          @Override
          public CompletableFuture<Void> visitCommand(InvocationContext ctx, VisitableCommand command)
                throws Throwable {
@@ -167,7 +167,7 @@ public abstract class PutForExternalReadTest extends MultipleCacheManagersTest {
       Cache<String, String> cache1 = cache(0, CACHE_NAME);
       Cache<String, String> cache2 = cache(1, CACHE_NAME);
 
-      assertTrue(cache1.getAdvancedCache().getSequentialInterceptorChain().addInterceptorBefore(new BaseSequentialInterceptor() {
+      assertTrue(cache1.getAdvancedCache().getAsyncInterceptorChain().addInterceptorBefore(new BaseAsyncInterceptor() {
          @Override
          public CompletableFuture<Void> visitCommand(InvocationContext ctx, VisitableCommand command)
                throws Throwable {

--- a/core/src/test/java/org/infinispan/configuration/XmlFileParsingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/XmlFileParsingTest.java
@@ -513,7 +513,7 @@ public class XmlFileParsingTest extends AbstractInfinispanTest {
       assertTrue(!c.customInterceptors().interceptors().isEmpty());
       assertEquals(6, c.customInterceptors().interceptors().size());
       for(InterceptorConfiguration i : c.customInterceptors().interceptors()) {
-         if (i.sequentialInterceptor() instanceof FooInterceptor) {
+         if (i.asyncInterceptor() instanceof FooInterceptor) {
             assertEquals(i.properties().getProperty("foo"), "bar");
          }
       }

--- a/core/src/test/java/org/infinispan/configuration/override/XMLConfigurationOverridingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/override/XMLConfigurationOverridingTest.java
@@ -4,7 +4,7 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.commons.util.Util;
 import org.infinispan.context.Flag;
 import org.infinispan.distribution.MagicKey;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.junit.Assert;
 import org.infinispan.Cache;
 import org.infinispan.commands.write.PutKeyValueCommand;
@@ -493,7 +493,7 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
       }
    }
 
-   private static class SimpleInterceptor extends DDSequentialInterceptor {
+   private static class SimpleInterceptor extends DDAsyncInterceptor {
       private boolean putOkay;
 
       @Override

--- a/core/src/test/java/org/infinispan/context/MarshalledValueContextTest.java
+++ b/core/src/test/java/org/infinispan/context/MarshalledValueContextTest.java
@@ -42,7 +42,7 @@ public class MarshalledValueContextTest extends SingleCacheManagerTest {
    public void testContentsOfContext() throws Exception {
       Cache<Key, String> c = cacheManager.getCache();
       ContextExtractingInterceptor cex = new ContextExtractingInterceptor();
-      assertTrue(c.getAdvancedCache().getSequentialInterceptorChain().addInterceptorAfter(cex, InvocationContextInterceptor.class));
+      assertTrue(c.getAdvancedCache().getAsyncInterceptorChain().addInterceptorAfter(cex, InvocationContextInterceptor.class));
 
       c.put(new Key("k"), "v");
 

--- a/core/src/test/java/org/infinispan/context/SingleKeyNonTxInvocationContextTest.java
+++ b/core/src/test/java/org/infinispan/context/SingleKeyNonTxInvocationContextTest.java
@@ -6,7 +6,7 @@ import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.interceptors.BaseCustomSequentialInterceptor;
+import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.testng.annotations.Test;
 
@@ -31,9 +31,9 @@ public class SingleKeyNonTxInvocationContextTest extends MultipleCacheManagersTe
       createCluster(c, 2);
       waitForClusterToForm();
       ci0 = new CheckInterceptor();
-      advancedCache(0).getSequentialInterceptorChain().addInterceptor(ci0, 1);
+      advancedCache(0).getAsyncInterceptorChain().addInterceptor(ci0, 1);
       ci1 = new CheckInterceptor();
-      advancedCache(1).getSequentialInterceptorChain().addInterceptor(ci1, 1);
+      advancedCache(1).getAsyncInterceptorChain().addInterceptor(ci1, 1);
    }
 
 
@@ -78,7 +78,7 @@ public class SingleKeyNonTxInvocationContextTest extends MultipleCacheManagersTe
    }
 
 
-   static class CheckInterceptor extends BaseCustomSequentialInterceptor {
+   static class CheckInterceptor extends BaseCustomAsyncInterceptor {
 
       private boolean putOkay;
       private boolean removeOkay;

--- a/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
@@ -11,7 +11,7 @@ import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.container.entries.L1InternalCacheEntry;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.distribution.group.Grouper;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
@@ -276,7 +276,7 @@ public abstract class BaseDistFunctionalTest<K, V> extends MultipleCacheManagers
    }
 
    protected static void removeAllBlockingInterceptorsFromCache(Cache<?, ?> cache) {
-      SequentialInterceptorChain chain = cache.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain chain = cache.getAdvancedCache().getAsyncInterceptorChain();
       BlockingInterceptor blockingInterceptor = chain.findInterceptorExtending(BlockingInterceptor.class);
       while (blockingInterceptor != null) {
          blockingInterceptor.suspend(true);

--- a/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistFunctionalTest.java
@@ -48,6 +48,7 @@ public abstract class BaseDistFunctionalTest<K, V> extends MultipleCacheManagers
    protected LockingMode lockingMode;
    protected boolean onePhaseCommitOptimization = false;
 
+   @Override
    protected void createCacheManagers() throws Throwable {
       cacheName = "dist";
       configuration = buildConfiguration();
@@ -147,7 +148,7 @@ public abstract class BaseDistFunctionalTest<K, V> extends MultipleCacheManagers
          }
       }
       // Allow some time for all ClusteredGetCommands to finish executing
-      TestingUtil.sleepThread(1000);
+      TestingUtil.sleepThread(100);
    }
 
    protected void assertOwnershipAndNonOwnership(Object key, boolean allowL1) {

--- a/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
@@ -7,8 +7,8 @@ import org.infinispan.commands.read.GetKeyValueCommand;
 import org.infinispan.commands.write.InvalidateL1Command;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.entries.CacheEntry;
-import org.infinispan.interceptors.SequentialInterceptor;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptor;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.distribution.L1WriteSynchronizer;
 import org.infinispan.statetransfer.StateTransferLock;
 import org.infinispan.test.Exceptions;
@@ -77,17 +77,17 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
 
    protected BlockingInterceptor addBlockingInterceptor(Cache<?, ?> cache, final CyclicBarrier barrier,
                                          Class<? extends VisitableCommand> commandClass,
-         Class<? extends SequentialInterceptor> interceptorPosition,
+         Class<? extends AsyncInterceptor> interceptorPosition,
                                          boolean blockAfterCommand) {
       BlockingInterceptor bi = new BlockingInterceptor(barrier, commandClass, blockAfterCommand, false);
-      SequentialInterceptorChain interceptorChain = cache.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain interceptorChain = cache.getAdvancedCache().getAsyncInterceptorChain();
       assertTrue(interceptorChain.addInterceptorBefore(bi, interceptorPosition));
       return bi;
    }
 
-   protected abstract Class<? extends SequentialInterceptor> getDistributionInterceptorClass();
+   protected abstract Class<? extends AsyncInterceptor> getDistributionInterceptorClass();
 
-   protected abstract Class<? extends SequentialInterceptor> getL1InterceptorClass();
+   protected abstract Class<? extends AsyncInterceptor> getL1InterceptorClass();
 
    protected <K> void assertL1StateOnLocalWrite(Cache<? super K,?> cache, Cache<?, ?> updatingCache, K key, Object valueWrite) {
       // Default just assumes it invalidated the cache

--- a/core/src/test/java/org/infinispan/distribution/BlockingInterceptor.java
+++ b/core/src/test/java/org/infinispan/distribution/BlockingInterceptor.java
@@ -2,7 +2,7 @@ package org.infinispan.distribution;
 
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author William Burns
  * @since 6.0
  */
-public class BlockingInterceptor extends DDSequentialInterceptor {
+public class BlockingInterceptor extends DDAsyncInterceptor {
    private static final Log log = LogFactory.getLog(BlockingInterceptor.class);
 
    private final CyclicBarrier barrier;

--- a/core/src/test/java/org/infinispan/distribution/BlockingInterceptor.java
+++ b/core/src/test/java/org/infinispan/distribution/BlockingInterceptor.java
@@ -59,15 +59,14 @@ public class BlockingInterceptor extends DDSequentialInterceptor {
 
    @Override
    protected CompletableFuture<Void> handleDefault(InvocationContext ctx, VisitableCommand command) throws Throwable {
-      try {
-         if (!blockAfter) {
-            blockIfNeeded(ctx, command);
-         }
-         return ctx.shortCircuit(ctx.forkInvocationSync(command));
-      } finally {
-         if (blockAfter) {
-            blockIfNeeded(ctx, command);
-         }
+      if (!blockAfter) {
+         blockIfNeeded(ctx, command);
       }
+      return ctx.onReturn((rCtx, rCommand, rv, throwable) -> {
+         if (blockAfter) {
+            blockIfNeeded(rCtx, rCommand);
+         }
+         return null;
+      });
    }
 }

--- a/core/src/test/java/org/infinispan/distribution/DistSyncL1FuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncL1FuncTest.java
@@ -4,7 +4,7 @@ import org.infinispan.Cache;
 import org.infinispan.commands.read.GetCacheEntryCommand;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.ReplaceCommand;
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.distribution.L1NonTxInterceptor;
 import org.infinispan.interceptors.distribution.NonTxDistributionInterceptor;
 import org.infinispan.remoting.rpc.RpcManager;
@@ -33,12 +33,12 @@ public class DistSyncL1FuncTest extends BaseDistSyncL1Test {
    }
 
    @Override
-   protected Class<? extends SequentialInterceptor> getDistributionInterceptorClass() {
+   protected Class<? extends AsyncInterceptor> getDistributionInterceptorClass() {
       return NonTxDistributionInterceptor.class;
    }
 
    @Override
-   protected Class<? extends SequentialInterceptor> getL1InterceptorClass() {
+   protected Class<? extends AsyncInterceptor> getL1InterceptorClass() {
       return L1NonTxInterceptor.class;
    }
 

--- a/core/src/test/java/org/infinispan/distribution/DistSyncL1PessimisticFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncL1PessimisticFuncTest.java
@@ -75,7 +75,7 @@ public class DistSyncL1PessimisticFuncTest extends BaseDistFunctionalTest {
 
          assertIsInL1(nonOwner, key);
       } finally {
-         nonOwner.getAdvancedCache().getSequentialInterceptorChain().removeInterceptor(BlockingInterceptor.class);
+         nonOwner.getAdvancedCache().getAsyncInterceptorChain().removeInterceptor(BlockingInterceptor.class);
       }
    }
 
@@ -137,7 +137,7 @@ public class DistSyncL1PessimisticFuncTest extends BaseDistFunctionalTest {
 
          assertIsNotInL1(nonOwner, key);
       } finally {
-         nonOwner.getAdvancedCache().getSequentialInterceptorChain().removeInterceptor(BlockingInterceptor.class);
+         nonOwner.getAdvancedCache().getAsyncInterceptorChain().removeInterceptor(BlockingInterceptor.class);
       }
    }
 }

--- a/core/src/test/java/org/infinispan/distribution/DistSyncTxL1FuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncTxL1FuncTest.java
@@ -9,7 +9,7 @@ import org.infinispan.commands.write.InvalidateL1Command;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.container.entries.InternalCacheEntry;
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.distribution.L1TxInterceptor;
 import org.infinispan.interceptors.distribution.TxDistributionInterceptor;
 import org.infinispan.remoting.RemoteException;
@@ -55,12 +55,12 @@ public class DistSyncTxL1FuncTest extends BaseDistSyncL1Test {
    }
 
    @Override
-   protected Class<? extends SequentialInterceptor> getDistributionInterceptorClass() {
+   protected Class<? extends AsyncInterceptor> getDistributionInterceptorClass() {
       return TxDistributionInterceptor.class;
    }
 
    @Override
-   protected Class<? extends SequentialInterceptor> getL1InterceptorClass() {
+   protected Class<? extends AsyncInterceptor> getL1InterceptorClass() {
       return L1TxInterceptor.class;
    }
 

--- a/core/src/test/java/org/infinispan/distribution/SingleOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/SingleOwnerTest.java
@@ -2,12 +2,13 @@ package org.infinispan.distribution;
 
 
 import org.infinispan.Cache;
-import org.infinispan.commons.CacheException;
 import org.infinispan.commons.marshall.NotSerializableException;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.RemoteException;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.test.Exceptions;
+import org.infinispan.test.TestException;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.testng.annotations.Test;
 
@@ -17,7 +18,9 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
-import static org.testng.AssertJUnit.*;
+
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.fail;
 
 /**
  * Test single owner distributed cache configurations.
@@ -93,26 +96,21 @@ public class SingleOwnerTest extends BaseDistFunctionalTest<Object, String> {
       assert nonOwners.length == 1;
       Cache ownerCache = owners[0];
       Cache nonOwnerCache = nonOwners[0];
-      ownerCache.put("diffkey", new Externalizable() {
-         private static final long serialVersionUID = -483939825697574242L;
+      ownerCache.put("diffkey", new ExceptionExternalizable());
+      Exceptions
+            .expectException(RemoteException.class, TestException.class, () -> nonOwnerCache.get("diffkey"));
+   }
 
-         @Override
-         public void writeExternal(ObjectOutput out) throws IOException {
-            throw new UnknownError();
-         }
-         @Override
-         public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-         }
-      });
-      try {
-         nonOwnerCache.get("diffkey");
-         assert false : "Should have failed with a CacheException that contains an UnknownError";
-      } catch (CacheException e) {
-         if (e.getCause() != null) {
-            assertTrue(e.getCause() instanceof UnknownError);
-         } else {
-            throw e;
-         }
+   private static class ExceptionExternalizable implements Externalizable {
+      private static final long serialVersionUID = -483939825697574242L;
+
+      @Override
+      public void writeExternal(ObjectOutput out) throws IOException {
+         throw new TestException();
+      }
+
+      @Override
+      public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
       }
    }
 }

--- a/core/src/test/java/org/infinispan/distribution/groups/BaseGetGroupKeysTest.java
+++ b/core/src/test/java/org/infinispan/distribution/groups/BaseGetGroupKeysTest.java
@@ -9,7 +9,7 @@ import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.filter.KeyFilter;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.interceptors.impl.EntryWrappingInterceptor;
 import org.infinispan.interceptors.impl.VersionedEntryWrappingInterceptor;
@@ -54,7 +54,7 @@ public abstract class BaseGetGroupKeysTest extends BaseUtilGroupTest {
    }
 
    public void testGetKeysInGroup() {
-      final TestCache testCache = createTestCacheAndReset(GROUP, this.<GroupKey, String>caches());
+      final TestCache testCache = createTestCacheAndReset(GROUP, this.caches());
       initCache(testCache.primaryOwner);
       Map<GroupKey, String> groupKeySet = testCache.testCache.getGroup(GROUP);
       Map<GroupKey, String> expectedGroupSet = createMap(0, 10);
@@ -62,7 +62,7 @@ public abstract class BaseGetGroupKeysTest extends BaseUtilGroupTest {
    }
 
    public void testGetKeysInGroupWithPersistence() {
-      final TestCache testCache = createTestCacheAndReset(GROUP, this.<GroupKey, String>caches(PERSISTENCE_CACHE));
+      final TestCache testCache = createTestCacheAndReset(GROUP, this.caches(PERSISTENCE_CACHE));
       initCache(testCache.primaryOwner);
       Map<GroupKey, String> groupKeySet = testCache.testCache.getGroup(GROUP);
       Map<GroupKey, String> expectedGroupSet = createMap(0, 10);
@@ -70,7 +70,7 @@ public abstract class BaseGetGroupKeysTest extends BaseUtilGroupTest {
    }
 
    public void testGetKeysInGroupWithPersistenceAndPassivation() {
-      final TestCache testCache = createTestCacheAndReset(GROUP, this.<GroupKey, String>caches(PERSISTENCE_PASSIVATION_CACHE));
+      final TestCache testCache = createTestCacheAndReset(GROUP, this.caches(PERSISTENCE_PASSIVATION_CACHE));
       initCache(testCache.primaryOwner);
       Map<GroupKey, String> groupKeySet = testCache.testCache.getGroup(GROUP);
       Map<GroupKey, String> expectedGroupSet = createMap(0, 10);
@@ -78,7 +78,7 @@ public abstract class BaseGetGroupKeysTest extends BaseUtilGroupTest {
    }
 
    public void testGetKeysInGroupWithPersistenceAndSkipCacheLoader() {
-      final TestCache testCache = createTestCacheAndReset(GROUP, this.<GroupKey, String>caches(PERSISTENCE_CACHE));
+      final TestCache testCache = createTestCacheAndReset(GROUP, this.caches(PERSISTENCE_CACHE));
       initCache(testCache.primaryOwner);
       Map<GroupKey, String> groupKeySet = testCache.testCache.withFlags(Flag.SKIP_CACHE_LOAD).getGroup(GROUP);
       //noinspection unchecked
@@ -94,7 +94,7 @@ public abstract class BaseGetGroupKeysTest extends BaseUtilGroupTest {
    }
 
    public void testGetKeyInGroupWithConcurrentActivation() throws TimeoutException, InterruptedException, ExecutionException {
-      final TestCache testCache = createTestCacheAndReset(GROUP, this.<GroupKey, String>caches(PERSISTENCE_PASSIVATION_CACHE));
+      final TestCache testCache = createTestCacheAndReset(GROUP, this.caches(PERSISTENCE_PASSIVATION_CACHE));
       initCache(testCache.primaryOwner);
       final BlockCommandInterceptor interceptor = injectIfAbsent(extractTargetCache(testCache));
 
@@ -128,7 +128,7 @@ public abstract class BaseGetGroupKeysTest extends BaseUtilGroupTest {
    }
 
    public void testRemoveGroupKeys() {
-      final TestCache testCache = createTestCacheAndReset(GROUP, this.<GroupKey, String>caches());
+      final TestCache testCache = createTestCacheAndReset(GROUP, this.caches());
       initCache(testCache.primaryOwner);
       Map<GroupKey, String> groupKeySet = testCache.testCache.getGroup(GROUP);
       Map<GroupKey, String> expectedGroupSet = createMap(0, 10);
@@ -139,7 +139,7 @@ public abstract class BaseGetGroupKeysTest extends BaseUtilGroupTest {
    }
 
    public void testRemoveGroupKeysWithPersistence() {
-      final TestCache testCache = createTestCacheAndReset(GROUP, this.<GroupKey, String>caches(PERSISTENCE_CACHE));
+      final TestCache testCache = createTestCacheAndReset(GROUP, this.caches(PERSISTENCE_CACHE));
       initCache(testCache.primaryOwner);
       Map<GroupKey, String> groupKeySet = testCache.testCache.getGroup(GROUP);
       Map<GroupKey, String> expectedGroupSet = createMap(0, 10);
@@ -150,7 +150,7 @@ public abstract class BaseGetGroupKeysTest extends BaseUtilGroupTest {
    }
 
    public void testRemoveGroupKeysWithPersistenceAndPassivation() {
-      final TestCache testCache = createTestCacheAndReset(GROUP, this.<GroupKey, String>caches(PERSISTENCE_PASSIVATION_CACHE));
+      final TestCache testCache = createTestCacheAndReset(GROUP, this.caches(PERSISTENCE_PASSIVATION_CACHE));
       initCache(testCache.primaryOwner);
       Map<GroupKey, String> groupKeySet = testCache.testCache.getGroup(GROUP);
       Map<GroupKey, String> expectedGroupSet = createMap(0, 10);
@@ -161,7 +161,7 @@ public abstract class BaseGetGroupKeysTest extends BaseUtilGroupTest {
    }
 
    public void testRemoveGroupKeysWithPersistenceAndSkipCacheWriter() {
-      final TestCache testCache = createTestCacheAndReset(GROUP, this.<GroupKey, String>caches(PERSISTENCE_CACHE));
+      final TestCache testCache = createTestCacheAndReset(GROUP, this.caches(PERSISTENCE_CACHE));
       initCache(testCache.primaryOwner);
       Map<GroupKey, String> groupKeySet = testCache.testCache.getGroup(GROUP);
       Map<GroupKey, String> expectedGroupSet = createMap(0, 10);
@@ -206,7 +206,7 @@ public abstract class BaseGetGroupKeysTest extends BaseUtilGroupTest {
    @Override
    protected final void resetCaches(List<Cache<BaseUtilGroupTest.GroupKey, String>> cacheList) {
       for (Cache cache : cacheList) {
-         SequentialInterceptorChain chain = cache.getAdvancedCache().getSequentialInterceptorChain();
+         AsyncInterceptorChain chain = cache.getAdvancedCache().getAsyncInterceptorChain();
          BlockCommandInterceptor interceptor = chain.findInterceptorExtending(BlockCommandInterceptor.class);
          if (interceptor != null) {
             interceptor.reset();
@@ -235,7 +235,7 @@ public abstract class BaseGetGroupKeysTest extends BaseUtilGroupTest {
 
    private BlockCommandInterceptor injectIfAbsent(Cache<?, ?> cache) {
       log.debugf("Injecting BlockCommandInterceptor in %s", cache);
-      SequentialInterceptorChain chain = cache.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain chain = cache.getAdvancedCache().getAsyncInterceptorChain();
       BlockCommandInterceptor interceptor = chain.findInterceptorExtending(BlockCommandInterceptor.class);
       if (interceptor == null) {
          interceptor = new BlockCommandInterceptor(log);

--- a/core/src/test/java/org/infinispan/distribution/groups/BaseStateTransferGetGroupKeysTest.java
+++ b/core/src/test/java/org/infinispan/distribution/groups/BaseStateTransferGetGroupKeysTest.java
@@ -5,7 +5,7 @@ import org.infinispan.commands.remote.GetKeysInGroupCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.interceptors.impl.EntryWrappingInterceptor;
 import org.infinispan.remoting.transport.Address;
@@ -50,7 +50,7 @@ public abstract class BaseStateTransferGetGroupKeysTest extends BaseUtilGroupTes
        * 2) when the topology changes but the ownership doesn't (when we execute the query on the backup owner)
        * 3) when the ownership changes and the query is executed in a non-owner
        */
-      final TestCache testCache = createTestCacheAndReset(GROUP, this.<GroupKey, String>caches());
+      final TestCache testCache = createTestCacheAndReset(GROUP, this.caches());
       initCache(testCache.primaryOwner);
       final BlockCommandInterceptor interceptor = injectBlockCommandInterceptorIfAbsent(extractTargetCache(testCache));
 
@@ -93,7 +93,7 @@ public abstract class BaseStateTransferGetGroupKeysTest extends BaseUtilGroupTes
    @Override
    protected final void resetCaches(List<Cache<GroupKey, String>> cacheList) {
       for (Cache cache : cacheList) {
-         SequentialInterceptorChain chain = cache.getAdvancedCache().getSequentialInterceptorChain();
+         AsyncInterceptorChain chain = cache.getAdvancedCache().getAsyncInterceptorChain();
          BlockCommandInterceptor interceptor = chain.findInterceptorWithClass(BlockCommandInterceptor.class);
          if (interceptor != null) {
             interceptor.reset();
@@ -107,7 +107,7 @@ public abstract class BaseStateTransferGetGroupKeysTest extends BaseUtilGroupTes
    }
 
    private static BlockCommandInterceptor injectBlockCommandInterceptorIfAbsent(Cache<GroupKey, String> cache) {
-      SequentialInterceptorChain chain = cache.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain chain = cache.getAdvancedCache().getAsyncInterceptorChain();
       BlockCommandInterceptor interceptor = chain.findInterceptorWithClass(BlockCommandInterceptor.class);
       if (interceptor == null) {
          interceptor = new BlockCommandInterceptor();

--- a/core/src/test/java/org/infinispan/distribution/rehash/BaseTxStateTransferOverwriteTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/BaseTxStateTransferOverwriteTest.java
@@ -237,7 +237,7 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
                   primaryOwnerCache.put(mk, value);
                   log.tracef("Adding additional value on nonOwner value inserted: %s = %s", mk, value);
                }
-               primaryOwnerCache.getAdvancedCache().getSequentialInterceptorChain().addInterceptorBefore(
+               primaryOwnerCache.getAdvancedCache().getAsyncInterceptorChain().addInterceptorBefore(
                      new BlockingInterceptor(cyclicBarrier, getVisitableCommand(op), true, false),
                      StateTransferInterceptor.class);
                return op.perform(primaryOwnerCache, key);
@@ -356,7 +356,7 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
       CyclicBarrier beforeCommitCache1Barrier = new CyclicBarrier(2);
       BlockingInterceptor blockingInterceptor1 = new BlockingInterceptor(beforeCommitCache1Barrier,
                                                                          op.getCommandClass(), true, false);
-      nonOwnerCache.getSequentialInterceptorChain().addInterceptorAfter(blockingInterceptor1, EntryWrappingInterceptor.class);
+      nonOwnerCache.getAsyncInterceptorChain().addInterceptorAfter(blockingInterceptor1, EntryWrappingInterceptor.class);
 
       // Put/Replace/Remove from cache0 with cache0 as primary owner, cache1 will become a backup owner for the retry
       // The put command will be blocked on cache1 just before committing the entry.
@@ -438,7 +438,7 @@ public abstract class BaseTxStateTransferOverwriteTest extends BaseDistFunctiona
       CyclicBarrier beforeCommitCache1Barrier = new CyclicBarrier(2);
       BlockingInterceptor blockingInterceptor1 = new BlockingInterceptor(beforeCommitCache1Barrier,
                                                                          getVisitableCommand(op), false, false);
-      primaryOwnerCache.getSequentialInterceptorChain().addInterceptorAfter(blockingInterceptor1, StateTransferInterceptor.class);
+      primaryOwnerCache.getAsyncInterceptorChain().addInterceptorAfter(blockingInterceptor1, StateTransferInterceptor.class);
 
       // Put/Replace/Remove from primary owner.  This will block before it is committing on remote nodes
       Future<Object> future = fork(new Callable<Object>() {

--- a/core/src/test/java/org/infinispan/distribution/rehash/L1StateTransferRemovesValueTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/L1StateTransferRemovesValueTest.java
@@ -139,7 +139,7 @@ public class L1StateTransferRemovesValueTest extends BaseDistFunctionalTest<Stri
       assertIsInL1(c3, key);
 
       CyclicBarrier barrier = new CyclicBarrier(2);
-      c3.getAdvancedCache().getSequentialInterceptorChain()
+      c3.getAdvancedCache().getAsyncInterceptorChain()
             .addInterceptorAfter(new BlockingInterceptor(barrier, InvalidateL1Command.class, true, false),
                   EntryWrappingInterceptor.class);
 

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxBackupOwnerBecomingPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxBackupOwnerBecomingPrimaryOwnerTest.java
@@ -35,7 +35,9 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.testng.AssertJUnit.*;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
 
 /**
  * Tests data loss during state transfer a backup owner of a key becomes the primary owner
@@ -145,13 +147,13 @@ public class NonTxBackupOwnerBecomingPrimaryOwnerTest extends MultipleCacheManag
       CyclicBarrier beforeCache1Barrier = new CyclicBarrier(2);
       BlockingInterceptor blockingInterceptor1 = new BlockingInterceptor(beforeCache1Barrier,
             op.getCommandClass(), false, false);
-      cache1.getSequentialInterceptorChain().addInterceptorBefore(blockingInterceptor1, NonTxDistributionInterceptor.class);
+      cache1.getAsyncInterceptorChain().addInterceptorBefore(blockingInterceptor1, NonTxDistributionInterceptor.class);
 
       // Every operation command will be blocked after returning to the distribution interceptor on cache2
       CyclicBarrier afterCache2Barrier = new CyclicBarrier(2);
       BlockingInterceptor blockingInterceptor2 = new BlockingInterceptor(afterCache2Barrier,
             op.getCommandClass(), true, false);
-      cache2.getSequentialInterceptorChain().addInterceptorBefore(blockingInterceptor2, StateTransferInterceptor.class);
+      cache2.getAsyncInterceptorChain().addInterceptorBefore(blockingInterceptor2, StateTransferInterceptor.class);
 
       // Put from cache0 with cache0 as primary owner, cache2 will become the primary owner for the retry
       Future<Object> future = fork(new Callable<Object>() {

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxOriginatorBecomingPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxOriginatorBecomingPrimaryOwnerTest.java
@@ -61,7 +61,7 @@ public class NonTxOriginatorBecomingPrimaryOwnerTest extends MultipleCacheManage
       // Every PutKeyValueCommand will be blocked before reaching the distribution interceptor
       CyclicBarrier distInterceptorBarrier = new CyclicBarrier(2);
       BlockingInterceptor blockingInterceptor = new BlockingInterceptor(distInterceptorBarrier, PutKeyValueCommand.class, false, false);
-      cache0.getSequentialInterceptorChain().addInterceptorBefore(blockingInterceptor, NonTxDistributionInterceptor.class);
+      cache0.getAsyncInterceptorChain().addInterceptorBefore(blockingInterceptor, NonTxDistributionInterceptor.class);
 
       for (int i = 0; i < NUM_KEYS; i++) {
          // Try to put a key/value from cache0 with cache1 the primary owner

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxPrimaryOwnerBecomingNonOwnerTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxPrimaryOwnerBecomingNonOwnerTest.java
@@ -34,7 +34,9 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.testng.AssertJUnit.*;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
 
 /**
  * Tests that a conditional write is retried properly if the write is unsuccessful on the primary owner
@@ -141,7 +143,7 @@ public class NonTxPrimaryOwnerBecomingNonOwnerTest extends MultipleCacheManagers
       CyclicBarrier beforeCache0Barrier = new CyclicBarrier(2);
       BlockingInterceptor blockingInterceptor0 = new BlockingInterceptor(beforeCache0Barrier,
             op.getCommandClass(), false, true);
-      cache0.getSequentialInterceptorChain().addInterceptorBefore(blockingInterceptor0, EntryWrappingInterceptor.class);
+      cache0.getAsyncInterceptorChain().addInterceptorBefore(blockingInterceptor0, EntryWrappingInterceptor.class);
 
       // Write from cache0 with cache0 as primary owner, cache2 will become the primary owner for the retry
       Future<Object> future = fork(new Callable<Object>() {

--- a/core/src/test/java/org/infinispan/distribution/rehash/NonTxStateTransferOverwritingValueTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/NonTxStateTransferOverwritingValueTest.java
@@ -26,7 +26,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.testng.AssertJUnit.assertEquals;
@@ -136,7 +138,7 @@ public class NonTxStateTransferOverwritingValueTest extends MultipleCacheManager
       CyclicBarrier beforeCommitCache1Barrier = new CyclicBarrier(2);
       BlockingInterceptor blockingInterceptor1 = new BlockingInterceptor(beforeCommitCache1Barrier,
             op.getCommandClass(), true, false);
-      cache1.getSequentialInterceptorChain().addInterceptorAfter(blockingInterceptor1, EntryWrappingInterceptor.class);
+      cache1.getAsyncInterceptorChain().addInterceptorAfter(blockingInterceptor1, EntryWrappingInterceptor.class);
 
       // Wait for cache0 to collect the state to send to cache1 (including our previous value).
       blockingRpcManager0.waitForCommandToBlock();

--- a/core/src/test/java/org/infinispan/distribution/rehash/OngoingTransactionsAndJoinTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/OngoingTransactionsAndJoinTest.java
@@ -8,7 +8,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.ComponentRegistry;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.interceptors.impl.TxInterceptor;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
@@ -74,7 +74,7 @@ public class OngoingTransactionsAndJoinTest extends MultipleCacheManagersTest {
       PrepareDuringRehashTask pt = new PrepareDuringRehashTask(firstNode, txsStarted, txsReady, joinEnded, rehashStarted);
       CommitDuringRehashTask ct = new CommitDuringRehashTask(firstNode, txsStarted, txsReady, joinEnded, rehashStarted);
 
-      SequentialInterceptorChain ic = firstNode.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain ic = firstNode.getAdvancedCache().getAsyncInterceptorChain();
       ic.addInterceptorAfter(pt, TxInterceptor.class);
       ic.addInterceptorAfter(ct, TxInterceptor.class);
 

--- a/core/src/test/java/org/infinispan/eviction/impl/EvictionWithConcurrentOperationsTest.java
+++ b/core/src/test/java/org/infinispan/eviction/impl/EvictionWithConcurrentOperationsTest.java
@@ -12,8 +12,8 @@ import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.eviction.PassivationManager;
-import org.infinispan.interceptors.SequentialInterceptor;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptor;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.base.BaseCustomInterceptor;
 import org.infinispan.interceptors.impl.EntryWrappingInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -37,7 +37,11 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.testng.AssertJUnit.*;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.fail;
 
 /**
  * Tests size-based eviction with concurrent read and/or write operation. In this test, we have no passivation.
@@ -600,7 +604,7 @@ public class EvictionWithConcurrentOperationsTest extends SingleCacheManagerTest
    protected class AfterEntryWrappingInterceptor extends ControlledCommandInterceptor {
 
       public AfterEntryWrappingInterceptor injectThis(Cache<Object, Object> injectInCache) {
-         injectInCache.getAdvancedCache().getSequentialInterceptorChain().addInterceptorAfter(this, EntryWrappingInterceptor.class);
+         injectInCache.getAdvancedCache().getAsyncInterceptorChain().addInterceptorAfter(this, EntryWrappingInterceptor.class);
          return this;
       }
 
@@ -609,11 +613,11 @@ public class EvictionWithConcurrentOperationsTest extends SingleCacheManagerTest
    private class AfterActivationOrCacheLoader extends ControlledCommandInterceptor {
 
       public AfterActivationOrCacheLoader injectThis(Cache<Object, Object> injectInCache) {
-         SequentialInterceptorChain chain =
-               TestingUtil.extractComponent(injectInCache, SequentialInterceptorChain.class);
-         SequentialInterceptor loaderInterceptor =
+         AsyncInterceptorChain chain =
+               TestingUtil.extractComponent(injectInCache, AsyncInterceptorChain.class);
+         AsyncInterceptor loaderInterceptor =
                chain.findInterceptorExtending(org.infinispan.interceptors.impl.CacheLoaderInterceptor.class);
-         injectInCache.getAdvancedCache().getSequentialInterceptorChain().addInterceptorAfter(this, loaderInterceptor.getClass());
+         injectInCache.getAdvancedCache().getAsyncInterceptorChain().addInterceptorAfter(this, loaderInterceptor.getClass());
          return this;
       }
 

--- a/core/src/test/java/org/infinispan/eviction/impl/ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/eviction/impl/ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTest.java
@@ -11,8 +11,8 @@ import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.filter.KeyFilter;
 import org.infinispan.filter.KeyValueFilter;
-import org.infinispan.interceptors.SequentialInterceptor;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptor;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.impl.CacheLoaderInterceptor;
 import org.infinispan.interceptors.impl.CacheWriterInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -333,6 +333,7 @@ public class ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTes
       assertInMemory(key1, "v3");
    }
 
+   @Override
    protected void configurePersistence(ConfigurationBuilder builder) {
       builder.persistence().passivation(false).addStore(DummyInMemoryStoreConfigurationBuilder.class)
             .storeName(storeName + storeNamePrefix.getAndIncrement());
@@ -532,8 +533,8 @@ public class ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTes
       volatile Runnable afterEvict;
 
       public AfterPassivationOrCacheWriter injectThis(Cache<Object, Object> injectInCache) {
-         SequentialInterceptorChain chain = extractComponent(injectInCache, SequentialInterceptorChain.class);
-         SequentialInterceptor interceptor = chain.findInterceptorExtending(CacheWriterInterceptor.class);
+         AsyncInterceptorChain chain = extractComponent(injectInCache, AsyncInterceptorChain.class);
+         AsyncInterceptor interceptor = chain.findInterceptorExtending(CacheWriterInterceptor.class);
          if (interceptor == null) {
             interceptor = chain.findInterceptorExtending(CacheLoaderInterceptor.class);
          }

--- a/core/src/test/java/org/infinispan/functional/decorators/FunctionalAdvancedCache.java
+++ b/core/src/test/java/org/infinispan/functional/decorators/FunctionalAdvancedCache.java
@@ -28,7 +28,7 @@ import org.infinispan.filter.KeyFilter;
 import org.infinispan.functional.impl.FunctionalMapImpl;
 import org.infinispan.functional.impl.ReadWriteMapImpl;
 import org.infinispan.functional.impl.WriteOnlyMapImpl;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -54,7 +54,12 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static org.infinispan.commons.marshall.MarshallableFunctions.*;
+import static org.infinispan.commons.marshall.MarshallableFunctions.removeConsumer;
+import static org.infinispan.commons.marshall.MarshallableFunctions.setValueIfEqualsReturnBoolean;
+import static org.infinispan.commons.marshall.MarshallableFunctions.setValueMetasConsumer;
+import static org.infinispan.commons.marshall.MarshallableFunctions.setValueMetasIfAbsentReturnPrevOrNull;
+import static org.infinispan.commons.marshall.MarshallableFunctions.setValueMetasIfPresentReturnPrevOrNull;
+import static org.infinispan.commons.marshall.MarshallableFunctions.setValueMetasReturnPrevOrNull;
 
 public final class FunctionalAdvancedCache<K, V> implements AdvancedCache<K, V> {
 
@@ -280,8 +285,8 @@ public final class FunctionalAdvancedCache<K, V> implements AdvancedCache<K, V> 
    }
 
    @Override
-   public SequentialInterceptorChain getSequentialInterceptorChain() {
-      return cache.getSequentialInterceptorChain();
+   public AsyncInterceptorChain getAsyncInterceptorChain() {
+      return cache.getAsyncInterceptorChain();
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/interceptors/CustomInterceptorTest.java
+++ b/core/src/test/java/org/infinispan/interceptors/CustomInterceptorTest.java
@@ -4,7 +4,6 @@ import org.infinispan.Cache;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.InterceptorConfiguration.Position;
-import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.CacheManagerCallable;
@@ -14,7 +13,9 @@ import org.testng.annotations.Test;
 import java.util.List;
 
 import static org.infinispan.test.TestingUtil.withCacheManager;
-import static org.testng.AssertJUnit.*;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 @Test(groups = "functional", testName = "interceptors.CustomInterceptorTest")
 public class CustomInterceptorTest extends AbstractInfinispanTest {
@@ -27,8 +28,8 @@ public class CustomInterceptorTest extends AbstractInfinispanTest {
          @Override
          public void call() {
             final Cache<Object,Object> cache = cm.getCache();
-            SequentialInterceptor i =
-                  cache.getAdvancedCache().getSequentialInterceptorChain().getInterceptors().get(0);
+            AsyncInterceptor i =
+                  cache.getAdvancedCache().getAsyncInterceptorChain().getInterceptors().get(0);
             assertTrue("Expecting FooInterceptor in the interceptor chain", i instanceof FooInterceptor);
             assertEquals("bar", ((FooInterceptor)i).getFoo());
          }
@@ -50,8 +51,8 @@ public class CustomInterceptorTest extends AbstractInfinispanTest {
       withCacheManager(new CacheManagerCallable(cacheManager) {
          @Override
          public void call() {
-            List<SequentialInterceptor> interceptors =
-                  cacheManager.getCache("interceptors").getAdvancedCache().getSequentialInterceptorChain()
+            List<AsyncInterceptor> interceptors =
+                  cacheManager.getCache("interceptors").getAdvancedCache().getAsyncInterceptorChain()
                               .getInterceptors();
             assertEquals(FooInterceptor.class, interceptors.get(interceptors.size() - 2).getClass());
          }
@@ -66,8 +67,8 @@ public class CustomInterceptorTest extends AbstractInfinispanTest {
       withCacheManager(new CacheManagerCallable(cacheManager) {
          @Override
          public void call() {
-            SequentialInterceptorChain
-                  interceptorChain = cacheManager.getCache("interceptors").getAdvancedCache().getSequentialInterceptorChain();
+            AsyncInterceptorChain
+                  interceptorChain = cacheManager.getCache("interceptors").getAdvancedCache().getAsyncInterceptorChain();
             assertEquals(interceptorChain.getInterceptors().get(1).getClass(), FooInterceptor.class);
          }
       });
@@ -81,8 +82,8 @@ public class CustomInterceptorTest extends AbstractInfinispanTest {
       withCacheManager(new CacheManagerCallable(cacheManager) {
          @Override
          public void call() {
-            List<SequentialInterceptor> interceptors =
-                  cacheManager.getCache().getAdvancedCache().getSequentialInterceptorChain()
+            List<AsyncInterceptor> interceptors =
+                  cacheManager.getCache().getAdvancedCache().getAsyncInterceptorChain()
                               .getInterceptors();
             Object o = interceptors.get(interceptors.size() - 2);
             assertEquals(FooInterceptor.class, o.getClass());

--- a/core/src/test/java/org/infinispan/interceptors/InterceptorChainTest.java
+++ b/core/src/test/java/org/infinispan/interceptors/InterceptorChainTest.java
@@ -3,9 +3,8 @@ package org.infinispan.interceptors;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.factories.components.ComponentMetadataRepo;
-import org.infinispan.factories.components.ModuleMetadataFileFinder;
 import org.infinispan.interceptors.base.CommandInterceptor;
-import org.infinispan.interceptors.impl.SequentialInterceptorChainImpl;
+import org.infinispan.interceptors.impl.AsyncInterceptorChainImpl;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -32,11 +31,11 @@ public class InterceptorChainTest extends AbstractInfinispanTest {
 
    public void testConcurrentAddRemove() throws Exception {
       ComponentMetadataRepo componentMetadataRepo = new ComponentMetadataRepo();
-      componentMetadataRepo.initialize(Collections.<ModuleMetadataFileFinder>emptyList(), InterceptorChainTest.class.getClassLoader());
-      SequentialInterceptorChainImpl sequentialInterceptorChain =
-            new SequentialInterceptorChainImpl(componentMetadataRepo);
+      componentMetadataRepo.initialize(Collections.emptyList(), InterceptorChainTest.class.getClassLoader());
+      AsyncInterceptorChainImpl asyncInterceptorChain =
+            new AsyncInterceptorChainImpl(componentMetadataRepo);
       GlobalConfiguration globalConfiguration = new GlobalConfigurationBuilder().build();
-      InterceptorChain ic = new InterceptorChain(sequentialInterceptorChain);
+      InterceptorChain ic = new InterceptorChain(asyncInterceptorChain);
       ic.setFirstInChain(new DummyCallInterceptor());
       ic.addInterceptor(new DummyActivationInterceptor(), 1);
       CyclicBarrier barrier = new CyclicBarrier(4);

--- a/core/src/test/java/org/infinispan/lock/StaleEagerLocksOnPrepareFailureTest.java
+++ b/core/src/test/java/org/infinispan/lock/StaleEagerLocksOnPrepareFailureTest.java
@@ -5,7 +5,7 @@ import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.MagicKey;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.distribution.TxDistributionInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.MultipleCacheManagersTest;
@@ -53,7 +53,7 @@ public class StaleEagerLocksOnPrepareFailureTest extends MultipleCacheManagersTe
       // force the prepare command to fail on c2
       FailInterceptor interceptor = new FailInterceptor();
       interceptor.failFor(PrepareCommand.class);
-      SequentialInterceptorChain ic = c2.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain ic = c2.getAdvancedCache().getAsyncInterceptorChain();
       ic.addInterceptorBefore(interceptor, TxDistributionInterceptor.class);
 
       MagicKey k1 = new MagicKey("k1", c1);

--- a/core/src/test/java/org/infinispan/lock/StaleLocksOnPrepareFailureTest.java
+++ b/core/src/test/java/org/infinispan/lock/StaleLocksOnPrepareFailureTest.java
@@ -5,7 +5,7 @@ import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.distribution.MagicKey;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.distribution.TxDistributionInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.MultipleCacheManagersTest;
@@ -41,7 +41,7 @@ public class StaleLocksOnPrepareFailureTest extends MultipleCacheManagersTest {
       // force the prepare command to fail on c2
       FailInterceptor interceptor = new FailInterceptor();
       interceptor.failFor(PrepareCommand.class);
-      SequentialInterceptorChain ic = c2.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain ic = c2.getAdvancedCache().getAsyncInterceptorChain();
       ic.addInterceptorBefore(interceptor, TxDistributionInterceptor.class);
 
       MagicKey k1 = new MagicKey("k1", c1);

--- a/core/src/test/java/org/infinispan/manager/CacheManagerComponentRegistryTest.java
+++ b/core/src/test/java/org/infinispan/manager/CacheManagerComponentRegistryTest.java
@@ -5,7 +5,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.eviction.EvictionManager;
 import org.infinispan.eviction.EvictionStrategy;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.impl.BatchingInterceptor;
 import org.infinispan.remoting.transport.Transport;
 import org.infinispan.test.AbstractCacheTest;
@@ -100,9 +100,9 @@ public class CacheManagerComponentRegistryTest extends AbstractCacheTest {
       Cache overridden = cm.getCache("overridden");
 
       // assert components.
-      SequentialInterceptorChain initialChain = c.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain initialChain = c.getAdvancedCache().getAsyncInterceptorChain();
       assert !initialChain.containsInterceptorType(BatchingInterceptor.class);
-      SequentialInterceptorChain overriddenChain = overridden.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain overriddenChain = overridden.getAdvancedCache().getAsyncInterceptorChain();
       assert overriddenChain.containsInterceptorType(BatchingInterceptor.class);
    }
 }

--- a/core/src/test/java/org/infinispan/marshall/InvalidatedMarshalledValueTest.java
+++ b/core/src/test/java/org/infinispan/marshall/InvalidatedMarshalledValueTest.java
@@ -3,7 +3,7 @@ package org.infinispan.marshall;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.impl.MarshalledValueInterceptor;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.util.logging.Log;
@@ -40,7 +40,7 @@ public class InvalidatedMarshalledValueTest extends MultipleCacheManagersTest {
    }
 
    private void assertMarshalledValueInterceptorPresent(Cache<?, ?> c) {
-      SequentialInterceptorChain ic1 = c.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain ic1 = c.getAdvancedCache().getAsyncInterceptorChain();
       assert ic1.containsInterceptorType(MarshalledValueInterceptor.class);
    }
 

--- a/core/src/test/java/org/infinispan/marshall/core/MarshalledValueTest.java
+++ b/core/src/test/java/org/infinispan/marshall/core/MarshalledValueTest.java
@@ -10,8 +10,8 @@ import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.ImmortalCacheEntry;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.InvocationContext;
-import org.infinispan.interceptors.DDSequentialInterceptor;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.interceptors.impl.MarshalledValueInterceptor;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
@@ -82,7 +82,7 @@ public class MarshalledValueTest extends MultipleCacheManagersTest {
    }
 
    private void assertMarshalledValueInterceptorPresent(Cache c) {
-      SequentialInterceptorChain ic1 = c.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain ic1 = c.getAdvancedCache().getAsyncInterceptorChain();
       assertTrue(ic1.containsInterceptorType(MarshalledValueInterceptor.class));
    }
 
@@ -91,7 +91,7 @@ public class MarshalledValueTest extends MultipleCacheManagersTest {
       Cache cache1;
       cache1 = cache(0, "replSync");
       cache(1, "replSync");
-      SequentialInterceptorChain chain = cache1.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain chain = cache1.getAdvancedCache().getAsyncInterceptorChain();
       chain.removeInterceptor(MarshalledValueListenerInterceptor.class);
       mvli = new MarshalledValueListenerInterceptor();
       chain.addInterceptorAfter(mvli, MarshalledValueInterceptor.class);
@@ -663,7 +663,7 @@ public class MarshalledValueTest extends MultipleCacheManagersTest {
       }
    }
 
-   class MarshalledValueListenerInterceptor extends DDSequentialInterceptor {
+   class MarshalledValueListenerInterceptor extends DDAsyncInterceptor {
       int invocationCount = 0;
 
       @Override

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/BaseCacheNotifierImplInitialTransferTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/BaseCacheNotifierImplInitialTransferTest.java
@@ -12,7 +12,6 @@ import org.infinispan.container.entries.TransientMortalCacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.NonTxInvocationContext;
 import org.infinispan.distribution.DistributionManager;
-import org.infinispan.interceptors.EmptySequentialInterceptorChain;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.metadata.Metadata;
@@ -116,7 +115,7 @@ public abstract class BaseCacheNotifierImplInitialTransferTest extends AbstractI
                            mock(DistributionManager.class), new InternalEntryFactoryImpl(),
                            mock(ClusterEventManager.class));
       n.start();
-      ctx = new NonTxInvocationContext(null, AnyEquivalence.getInstance(), EmptySequentialInterceptorChain.INSTANCE);
+      ctx = new NonTxInvocationContext(null, AnyEquivalence.getInstance());
    }
 
 //   TODO: commented out until local listners support includeCurrentState

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/BaseCacheNotifierImplInitialTransferTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/BaseCacheNotifierImplInitialTransferTest.java
@@ -43,7 +43,9 @@ import java.util.concurrent.TimeoutException;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 
 @Test(groups = "unit", testName = "notifications.cachelistener.BaseCacheNotifierImplInitialTransferTest")
@@ -87,7 +89,7 @@ public abstract class BaseCacheNotifierImplInitialTransferTest extends AbstractI
 
       private final Event.Type type;
 
-      private Operation(Event.Type type) {
+      Operation(Event.Type type) {
          this.type = type;
       }
 

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierFilterTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierFilterTest.java
@@ -4,8 +4,6 @@ import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.filter.CollectionKeyFilter;
-import org.infinispan.filter.KeyFilter;
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated;
@@ -22,13 +20,9 @@ import org.infinispan.notifications.cachelistener.event.Event;
 import org.infinispan.notifications.cachelistener.event.TopologyChangedEvent;
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilter;
 import org.infinispan.notifications.cachelistener.filter.EventType;
-import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.MultipleCacheManagersTest;
-import org.infinispan.test.SingleCacheManagerTest;
-import org.infinispan.test.TestingUtil;
-import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.infinispan.transaction.TransactionMode;
-import org.testng.annotations.BeforeMethod;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -63,14 +57,17 @@ public class CacheNotifierFilterTest extends MultipleCacheManagersTest {
       }
    }
 
+   @SuppressWarnings("unused")
    @Listener
    private static class TestListener {
+      private static final Log log = LogFactory.getLog(TestListener.class);
       private final List<CacheEntryVisitedEvent> visitedEvents = Collections.synchronizedList(
-            new ArrayList<CacheEntryVisitedEvent>());
-      private final List<TopologyChangedEvent> topologyEvents = Collections.synchronizedList(
-            new ArrayList<TopologyChangedEvent>());
+            new ArrayList<>());
+      private final List<TopologyChangedEvent> topologyEvents = Collections.synchronizedList(new ArrayList<>());
+
       @CacheEntryVisited
       public void entryVisited(CacheEntryVisitedEvent event) {
+         log.tracef("Visited %s", event.getKey());
          visitedEvents.add(event);
       }
 
@@ -80,10 +77,10 @@ public class CacheNotifierFilterTest extends MultipleCacheManagersTest {
       }
    }
 
+   @SuppressWarnings("unused")
    @Listener
    private static class AllCacheEntryListener {
-      private final List<CacheEntryEvent> events = Collections.synchronizedList(
-            new ArrayList<CacheEntryEvent>());
+      private final List<CacheEntryEvent> events = Collections.synchronizedList(new ArrayList<>());
 
       @CacheEntryVisited
       @CacheEntryActivated
@@ -118,8 +115,9 @@ public class CacheNotifierFilterTest extends MultipleCacheManagersTest {
       String notKey = "not" + key;
       cache0.put(notKey, value);
       cache0.get("not" + key);
+      cache0.getAdvancedCache().getAll(Collections.singleton("not" + key));
 
-      assertEquals(2, listener.visitedEvents.size());
+      assertEquals(4, listener.visitedEvents.size());
    }
 
    @Test

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplInitialTransferDistTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplInitialTransferDistTest.java
@@ -9,7 +9,7 @@ import org.infinispan.commands.read.EntrySetCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.distribution.ch.ConsistentHash;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
@@ -44,8 +44,16 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 
 @Test(groups = "unit", testName = "notifications.cachelistener.CacheNotifierImplInitialTransferDistTest")
@@ -210,7 +218,7 @@ public class CacheNotifierImplInitialTransferDistTest extends MultipleCacheManag
 
       final CheckPoint checkPoint = new CheckPoint();
 
-      SequentialInterceptorChain chain = mockStream(cache, (mock, real, additional) ->
+      AsyncInterceptorChain chain = mockStream(cache, (mock, real, additional) ->
               doAnswer(i -> {
                  // Wait for main thread to sync up
                  checkPoint.trigger("pre_retrieve_entry_invoked");
@@ -243,7 +251,7 @@ public class CacheNotifierImplInitialTransferDistTest extends MultipleCacheManag
 
          verifyEvents(isClustered(listener), listener, expectedValues);
       } finally {
-         TestingUtil.replaceComponent(cache, SequentialInterceptorChain.class, chain, true);
+         TestingUtil.replaceComponent(cache, AsyncInterceptorChain.class, chain, true);
          cache.removeListener(listener);
       }
    }
@@ -281,7 +289,7 @@ public class CacheNotifierImplInitialTransferDistTest extends MultipleCacheManag
 
       CheckPoint checkPoint = new CheckPoint();
 
-      SequentialInterceptorChain chain = mockStream(cache, (mock, real, additional) -> {
+      AsyncInterceptorChain chain = mockStream(cache, (mock, real, additional) -> {
          doAnswer(i -> {
             // Wait for main thread to sync up
             checkPoint.trigger("pre_close_iter_invoked");
@@ -367,7 +375,7 @@ public class CacheNotifierImplInitialTransferDistTest extends MultipleCacheManag
             assertEquals(event.getValue(), value);
          }
       } finally {
-         TestingUtil.replaceComponent(cache, SequentialInterceptorChain.class, chain, true);
+         TestingUtil.replaceComponent(cache, AsyncInterceptorChain.class, chain, true);
          cache.removeListener(listener);
       }
    }
@@ -730,9 +738,9 @@ public class CacheNotifierImplInitialTransferDistTest extends MultipleCacheManag
       void additionalInformation(Stream mockStream, Stream realStream, StreamMocking ourselves);
    }
 
-   protected SequentialInterceptorChain mockStream(final Cache<?, ?> cache, StreamMocking mocking) {
-      SequentialInterceptorChain chain = TestingUtil.extractComponent(cache, SequentialInterceptorChain.class);
-      SequentialInterceptorChain mockChain = spy(chain);
+   protected AsyncInterceptorChain mockStream(final Cache<?, ?> cache, StreamMocking mocking) {
+      AsyncInterceptorChain chain = TestingUtil.extractComponent(cache, AsyncInterceptorChain.class);
+      AsyncInterceptorChain mockChain = spy(chain);
       doAnswer(i -> {
          CacheSet cacheSet = (CacheSet) i.callRealMethod();
 
@@ -747,7 +755,7 @@ public class CacheNotifierImplInitialTransferDistTest extends MultipleCacheManag
          return mockSet;
       }).when(mockChain).invoke(Mockito.any(InvocationContext.class),
               (VisitableCommand) argThat(new IsInstanceOf(EntrySetCommand.class)));
-      TestingUtil.replaceComponent(cache, SequentialInterceptorChain.class, mockChain, true);
+      TestingUtil.replaceComponent(cache, AsyncInterceptorChain.class, mockChain, true);
       return chain;
    }
 }

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
@@ -9,7 +9,6 @@ import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.NonTxInvocationContext;
 import org.infinispan.distribution.DistributionManager;
-import org.infinispan.interceptors.EmptySequentialInterceptorChain;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.notifications.cachelistener.cluster.ClusterEventManager;
@@ -59,7 +58,7 @@ public class CacheNotifierImplTest extends AbstractInfinispanTest {
       cl = new CacheListener();
       n.start();
       n.addListener(cl);
-      ctx = new NonTxInvocationContext(null, AnyEquivalence.getInstance(), EmptySequentialInterceptorChain.INSTANCE);
+      ctx = new NonTxInvocationContext(null, AnyEquivalence.getInstance());
    }
 
    public void testNotifyCacheEntryCreated() {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
@@ -12,7 +12,20 @@ import org.infinispan.distribution.DistributionManager;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.notifications.cachelistener.cluster.ClusterEventManager;
-import org.infinispan.notifications.cachelistener.event.*;
+import org.infinispan.notifications.cachelistener.event.CacheEntriesEvictedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryActivatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryExpiredEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryInvalidatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryLoadedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryPassivatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent;
+import org.infinispan.notifications.cachelistener.event.Event;
+import org.infinispan.notifications.cachelistener.event.TransactionCompletedEvent;
+import org.infinispan.notifications.cachelistener.event.TransactionRegisteredEvent;
 import org.infinispan.test.AbstractInfinispanTest;
 import org.infinispan.test.fwk.TestInternalCacheEntryFactory;
 import org.infinispan.transaction.xa.GlobalTransaction;
@@ -27,8 +40,11 @@ import java.util.Map;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
-import static org.testng.AssertJUnit.*;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 
 @Test(groups = "unit", testName = "notifications.cachelistener.CacheNotifierImplTest")

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/KeyFilterTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/KeyFilterTest.java
@@ -20,7 +20,11 @@ import org.mockito.stubbing.Answer;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @Test(testName = "notifications.cachelistener.KeyFilterTest", groups = "unit")
 public class KeyFilterTest extends AbstractInfinispanTest {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/KeyFilterTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/KeyFilterTest.java
@@ -8,7 +8,6 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.NonTxInvocationContext;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.filter.KeyFilter;
-import org.infinispan.interceptors.EmptySequentialInterceptorChain;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.notifications.cachelistener.cluster.ClusterEventManager;
@@ -57,7 +56,7 @@ public class KeyFilterTest extends AbstractInfinispanTest {
       cl = new CacheListener();
       n.start();
       n.addListener(cl, kf);
-      ctx = new NonTxInvocationContext(null, AnyEquivalence.getInstance(), EmptySequentialInterceptorChain.INSTANCE);
+      ctx = new NonTxInvocationContext(null, AnyEquivalence.getInstance());
    }
 
    public void testFilters() {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
@@ -14,7 +14,6 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.NonTxInvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.distribution.DistributionManager;
-import org.infinispan.interceptors.EmptySequentialInterceptorChain;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.metadata.Metadata;
@@ -62,7 +61,7 @@ public class OnlyPrimaryOwnerTest {
       cl = new PrimaryOwnerCacheListener();
       n.start();
       n.addListener(cl);
-      ctx = new NonTxInvocationContext(null, AnyEquivalence.getInstance(), EmptySequentialInterceptorChain.INSTANCE);
+      ctx = new NonTxInvocationContext(null, AnyEquivalence.getInstance());
    }
 
    private static class MockCDL implements ClusteringDependentLogic {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
@@ -32,7 +32,9 @@ import java.util.List;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @Test(testName = "notifications.cachelistener.OnlyPrimaryOwnerTest", groups = "unit")
 public class OnlyPrimaryOwnerTest {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerDistTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerDistTest.java
@@ -47,7 +47,7 @@ public class ClusterListenerDistTest extends AbstractClusterListenerNonTxTest {
 
       CyclicBarrier barrier = new CyclicBarrier(2);
       BlockingInterceptor blockingInterceptor = new BlockingInterceptor(barrier, PutKeyValueCommand.class, true, false);
-      cache1.getAdvancedCache().getSequentialInterceptorChain().addInterceptorBefore(blockingInterceptor, NonTxDistributionInterceptor.class);
+      cache1.getAdvancedCache().getAsyncInterceptorChain().addInterceptorBefore(blockingInterceptor, NonTxDistributionInterceptor.class);
 
       final MagicKey key = new MagicKey(cache1, cache2);
       Future<String> future = fork(new Callable<String>() {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplTest.java
@@ -23,7 +23,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.testng.AssertJUnit.*;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Cluster listener test having a configuration of non tx and replication
@@ -93,10 +96,10 @@ public class ClusterListenerReplTest extends AbstractClusterListenerNonTxTest {
       CyclicBarrier barrier = new CyclicBarrier(3);
       BlockingInterceptor blockingInterceptor0 = new BlockingInterceptor(barrier, PutKeyValueCommand.class,
             true, false);
-      cache0.getAdvancedCache().getSequentialInterceptorChain().addInterceptorBefore(blockingInterceptor0, EntryWrappingInterceptor.class);
+      cache0.getAdvancedCache().getAsyncInterceptorChain().addInterceptorBefore(blockingInterceptor0, EntryWrappingInterceptor.class);
       BlockingInterceptor blockingInterceptor2 = new BlockingInterceptor(barrier, PutKeyValueCommand.class,
             true, false);
-      cache2.getAdvancedCache().getSequentialInterceptorChain().addInterceptorBefore(blockingInterceptor2, EntryWrappingInterceptor.class);
+      cache2.getAdvancedCache().getAsyncInterceptorChain().addInterceptorBefore(blockingInterceptor2, EntryWrappingInterceptor.class);
 
       final MagicKey key = new MagicKey(cache1, cache2);
       Future<String> future = fork(new Callable<String>() {
@@ -110,8 +113,8 @@ public class ClusterListenerReplTest extends AbstractClusterListenerNonTxTest {
       barrier.await(10, TimeUnit.SECONDS);
 
       // Remove the interceptor so the next command can proceed properly
-      cache0.getAdvancedCache().getSequentialInterceptorChain().removeInterceptor(BlockingInterceptor.class);
-      cache2.getAdvancedCache().getSequentialInterceptorChain().removeInterceptor(BlockingInterceptor.class);
+      cache0.getAdvancedCache().getAsyncInterceptorChain().removeInterceptor(BlockingInterceptor.class);
+      cache2.getAdvancedCache().getAsyncInterceptorChain().removeInterceptor(BlockingInterceptor.class);
       blockingInterceptor0.suspend(true);
       blockingInterceptor2.suspend(true);
 

--- a/core/src/test/java/org/infinispan/persistence/ClassLoaderManagerDisablingTest.java
+++ b/core/src/test/java/org/infinispan/persistence/ClassLoaderManagerDisablingTest.java
@@ -4,7 +4,7 @@ import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.eviction.EvictionStrategy;
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.impl.CacheLoaderInterceptor;
 import org.infinispan.interceptors.impl.CacheWriterInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -86,10 +86,10 @@ public class ClassLoaderManagerDisablingTest extends AbstractInfinispanTest {
       PersistenceManager clm = TestingUtil.extractComponent(cache, PersistenceManager.class);
       assertEquals(count, clm.getStores(DummyInMemoryStore.class).size());
       clm.disableStore(DummyInMemoryStore.class.getName());
-      SequentialInterceptor interceptor = cache.getAdvancedCache().getSequentialInterceptorChain()
+      AsyncInterceptor interceptor = cache.getAdvancedCache().getAsyncInterceptorChain()
             .findInterceptorExtending(CacheLoaderInterceptor.class);
       assertNull(interceptor);
-      interceptor = cache.getAdvancedCache().getSequentialInterceptorChain()
+      interceptor = cache.getAdvancedCache().getAsyncInterceptorChain()
             .findInterceptorExtending(CacheWriterInterceptor.class);
       assertNull(interceptor);
    }

--- a/core/src/test/java/org/infinispan/persistence/ClusteredConditionalCommandTest.java
+++ b/core/src/test/java/org/infinispan/persistence/ClusteredConditionalCommandTest.java
@@ -5,7 +5,7 @@ import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.Flag;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.impl.CacheLoaderInterceptor;
 import org.infinispan.interceptors.locking.ClusteringDependentLogic;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -20,8 +20,12 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.infinispan.test.TestingUtil.*;
-import static org.testng.AssertJUnit.*;
+import static org.infinispan.test.TestingUtil.extractComponent;
+import static org.infinispan.test.TestingUtil.getFirstWriter;
+import static org.infinispan.test.TestingUtil.waitForRehashToComplete;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Tests if the conditional commands correctly fetch the value from cache loader even with the skip cache load/store
@@ -174,300 +178,300 @@ public class ClusteredConditionalCommandTest extends MultipleCacheManagersTest {
    }
 
    public void testPutIfAbsentOnPrimaryOwnerWithSkipCacheLoaderShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testPutIfAbsentOnPrimaryOwnerWithSkipCacheLoader() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testPutIfAbsentOnPrimaryOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, true);
    }
 
    public void testPutIfAbsentOnPrimaryOwnerWithIgnoreReturnValues() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, false);
    }
 
    public void testPutIfAbsentOnPrimaryOwnerShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY_OWNER, null, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY_OWNER, null, true);
    }
 
    public void testPutIfAbsentOnPrimaryOwner() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY_OWNER, null, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.PRIMARY_OWNER, null, false);
    }
 
    public void testPutIfAbsentOnBackupOwnerWithSkipCacheLoaderShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testPutIfAbsentOnBackupOwnerWithSkipCacheLoader() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testPutIfAbsentOnBackupOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, true);
    }
 
    public void testPutIfAbsentOnBackupOwnerWithIgnoreReturnValues() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, false);
    }
 
    public void testPutIfAbsentOnBackupOwnerShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP_OWNER, null, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP_OWNER, null, true);
    }
 
    public void testPutIfAbsentOnBackupOwner() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP_OWNER, null, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.BACKUP_OWNER, null, false);
    }
 
    public void testPutIfAbsentOnNonOwnerWithSkipCacheLoaderShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testPutIfAbsentOnNonOwnerWithSkipCacheLoader() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testPutIfAbsentOnNonOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, true);
    }
 
    public void testPutIfAbsentOnNonOwnerWithIgnoreReturnValues() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, false);
    }
 
    public void testPutIfAbsentOnNonOwnerShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, null, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, null, true);
    }
 
    public void testPutIfAbsentOnNonOwner() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, null, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Ownership.NON_OWNER, null, false);
    }
 
    public void testReplaceOnPrimaryOwnerWithSkipCacheLoaderShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testReplaceOnPrimaryOwnerWithSkipCacheLoader() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testReplaceOnPrimaryOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, true);
    }
 
    public void testReplaceOnPrimaryOwnerWithIgnoreReturnValues() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, false);
    }
 
    public void testReplaceOnPrimaryOwnerShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY_OWNER, null, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY_OWNER, null, true);
    }
 
    public void testReplaceOnPrimaryOwner() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY_OWNER, null, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.PRIMARY_OWNER, null, false);
    }
 
    public void testReplaceOnBackupOwnerWithSkipCacheLoaderShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testReplaceOnBackupOwnerWithSkipCacheLoader() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testReplaceOnBackupOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, true);
    }
 
    public void testReplaceOnBackupOwnerWithIgnoreReturnValues() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, false);
    }
 
    public void testReplaceOnBackupOwnerShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP_OWNER, null, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP_OWNER, null, true);
    }
 
    public void testReplaceOnBackupOwner() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP_OWNER, null, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.BACKUP_OWNER, null, false);
    }
 
    public void testReplaceOnNonOwnerWithSkipCacheLoaderShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testReplaceOnNonOwnerWithSkipCacheLoader() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testReplaceOnNonOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, true);
    }
 
    public void testReplaceOnNonOwnerWithIgnoreReturnValues() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, false);
    }
 
    public void testReplaceOnNonOwnerShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, null, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, null, true);
    }
 
    public void testReplaceOnNonOwner() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, null, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Ownership.NON_OWNER, null, false);
    }
 
    public void testReplaceIfOnPrimaryOwnerWithSkipCacheLoaderShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testReplaceIfOnPrimaryOwnerWithSkipCacheLoader() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testReplaceIfOnPrimaryOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, true);
    }
 
    public void testReplaceIfOnPrimaryOwnerWithIgnoreReturnValues() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, false);
    }
 
    public void testReplaceIfOnPrimaryOwnerShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY_OWNER, null, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY_OWNER, null, true);
    }
 
    public void testReplaceIfOnPrimaryOwner() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY_OWNER, null, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.PRIMARY_OWNER, null, false);
    }
 
    public void testReplaceIfOnBackupOwnerWithSkipCacheLoaderShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testReplaceIfOnBackupOwnerWithSkipCacheLoader() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testReplaceIfOnBackupOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, true);
    }
 
    public void testReplaceIfOnBackupOwnerWithIgnoreReturnValues() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, false);
    }
 
    public void testReplaceIfOnBackupOwnerShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP_OWNER, null, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP_OWNER, null, true);
    }
 
    public void testReplaceIfOnBackupOwner() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP_OWNER, null, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.BACKUP_OWNER, null, false);
    }
 
    public void testReplaceIfOnNonOwnerWithSkipCacheLoaderShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testReplaceIfOnNonOwnerWithSkipCacheLoader() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testReplaceIfOnNonOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, true);
    }
 
    public void testReplaceIfOnNonOwnerWithIgnoreReturnValues() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, false);
    }
 
    public void testReplaceIfOnNonOwnerShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, null, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, null, true);
    }
 
    public void testReplaceIfOnNonOwner() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, null, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Ownership.NON_OWNER, null, false);
    }
 
    public void testRemoveIfOnPrimaryOwnerWithSkipCacheLoaderShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testRemoveIfOnPrimaryOwnerWithSkipCacheLoader() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY_OWNER, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testRemoveIfOnPrimaryOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, true);
    }
 
    public void testRemoveIfOnPrimaryOwnerWithIgnoreReturnValues() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY_OWNER, Flag.IGNORE_RETURN_VALUES, false);
    }
 
    public void testRemoveIfOnPrimaryOwnerShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY_OWNER, null, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY_OWNER, null, true);
    }
 
    public void testRemoveIfOnPrimaryOwner() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY_OWNER, null, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.PRIMARY_OWNER, null, false);
    }
 
    public void testRemoveIfOnBackupOwnerWithSkipCacheLoaderShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testRemoveIfOnBackupOwnerWithSkipCacheLoader() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP_OWNER, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testRemoveIfOnBackupOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, true);
    }
 
    public void testRemoveIfOnBackupOwnerWithIgnoreReturnValues() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP_OWNER, Flag.IGNORE_RETURN_VALUES, false);
    }
 
    public void testRemoveIfOnBackupOwnerShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP_OWNER, null, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP_OWNER, null, true);
    }
 
    public void testRemoveIfOnBackupOwner() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP_OWNER, null, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.BACKUP_OWNER, null, false);
    }
 
    public void testRemoveIfOnNonOwnerWithSkipCacheLoaderShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, true);
    }
 
    public void testRemoveIfOnNonOwnerWithSkipCacheLoader() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.SKIP_CACHE_LOAD, false);
    }
 
    public void testRemoveIfOnNonOwnerWithIgnoreReturnValuesShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, true);
    }
 
    public void testRemoveIfOnNonOwnerWithIgnoreReturnValues() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, Flag.IGNORE_RETURN_VALUES, false);
    }
 
    public void testRemoveIfOnNonOwnerShared() {
-      doTest(this.<String, String>caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, null, true);
+      doTest(this.caches(SHARED_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, null, true);
    }
 
    public void testRemoveIfOnNonOwner() {
-      doTest(this.<String, String>caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, null, false);
+      doTest(this.caches(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Ownership.NON_OWNER, null, false);
    }
 
-   protected static enum Ownership {
+   protected enum Ownership {
       PRIMARY_OWNER,
       BACKUP_OWNER,
       NON_OWNER
    }
 
-   protected static enum ConditionalOperation {
+   protected enum ConditionalOperation {
       PUT_IF_ABSENT {
          @Override
          public <K, V> void execute(Cache<K, V> cache, K key, V value1, V value2) {
@@ -546,14 +550,14 @@ public class ClusteredConditionalCommandTest extends MultipleCacheManagersTest {
       }
 
       protected long loads(Ownership ownership) {
-         SequentialInterceptorChain chain = extractComponent(cache(ownership), SequentialInterceptorChain.class);
-         CacheLoaderInterceptor interceptor = (CacheLoaderInterceptor) chain.findInterceptorExtending(CacheLoaderInterceptor.class);
+         AsyncInterceptorChain chain = extractComponent(cache(ownership), AsyncInterceptorChain.class);
+         CacheLoaderInterceptor interceptor = chain.findInterceptorExtending(CacheLoaderInterceptor.class);
          return interceptor.getCacheLoaderLoads();
       }
 
       private void resetStats(Ownership ownership) {
-         SequentialInterceptorChain chain = extractComponent(cache(ownership), SequentialInterceptorChain.class);
-         CacheLoaderInterceptor interceptor = (CacheLoaderInterceptor) chain.findInterceptorExtending(
+         AsyncInterceptorChain chain = extractComponent(cache(ownership), AsyncInterceptorChain.class);
+         CacheLoaderInterceptor interceptor = chain.findInterceptorExtending(
                CacheLoaderInterceptor.class);
          interceptor.resetStatistics();
       }

--- a/core/src/test/java/org/infinispan/persistence/LocalConditionalCommandTest.java
+++ b/core/src/test/java/org/infinispan/persistence/LocalConditionalCommandTest.java
@@ -5,7 +5,7 @@ import org.infinispan.commons.marshall.StreamingMarshaller;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.Flag;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.impl.CacheLoaderInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.core.MarshalledEntry;
@@ -70,10 +70,10 @@ public class LocalConditionalCommandTest extends SingleCacheManagerTest {
    }
 
    private static CacheLoaderInterceptor cacheLoaderInterceptor(Cache<?, ?> cache) {
-      SequentialInterceptorChain chain =
-            TestingUtil.extractComponent(cache, SequentialInterceptorChain.class);
-      return (CacheLoaderInterceptor) chain.findInterceptorExtending(
-            org.infinispan.interceptors.impl.CacheLoaderInterceptor.class);
+      AsyncInterceptorChain chain =
+            TestingUtil.extractComponent(cache, AsyncInterceptorChain.class);
+      return chain.findInterceptorExtending(
+            CacheLoaderInterceptor.class);
    }
 
    private void doTest(Cache<String, String> cache, ConditionalOperation operation, Flag flag) {
@@ -113,51 +113,51 @@ public class LocalConditionalCommandTest extends SingleCacheManagerTest {
    }
 
    public void testPutIfAbsentWithSkipCacheLoader() {
-      doTest(this.<String, String>cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Flag.SKIP_CACHE_LOAD);
+      doTest(this.cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Flag.SKIP_CACHE_LOAD);
    }
 
    public void testPutIfAbsentWithIgnoreReturnValues() {
-      doTest(this.<String, String>cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Flag.IGNORE_RETURN_VALUES);
+      doTest(this.cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, Flag.IGNORE_RETURN_VALUES);
    }
 
    public void testPutIfAbsent() {
-      doTest(this.<String, String>cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, null);
+      doTest(this.cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.PUT_IF_ABSENT, null);
    }
 
    public void testReplaceWithSkipCacheLoader() {
-      doTest(this.<String, String>cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Flag.SKIP_CACHE_LOAD);
+      doTest(this.cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Flag.SKIP_CACHE_LOAD);
    }
 
    public void testReplaceWithIgnoreReturnValues() {
-      doTest(this.<String, String>cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Flag.IGNORE_RETURN_VALUES);
+      doTest(this.cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, Flag.IGNORE_RETURN_VALUES);
    }
 
    public void testReplace() {
-      doTest(this.<String, String>cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, null);
+      doTest(this.cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE, null);
    }
 
    public void testReplaceIfWithSkipCacheLoader() {
-      doTest(this.<String, String>cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Flag.SKIP_CACHE_LOAD);
+      doTest(this.cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Flag.SKIP_CACHE_LOAD);
    }
 
    public void testReplaceIfWithIgnoreReturnValues() {
-      doTest(this.<String, String>cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Flag.IGNORE_RETURN_VALUES);
+      doTest(this.cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, Flag.IGNORE_RETURN_VALUES);
    }
 
    public void testReplaceIf() {
-      doTest(this.<String, String>cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, null);
+      doTest(this.cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REPLACE_IF, null);
    }
 
    public void testRemoveIfWithSkipCacheLoader() {
-      doTest(this.<String, String>cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Flag.SKIP_CACHE_LOAD);
+      doTest(this.cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Flag.SKIP_CACHE_LOAD);
    }
 
    public void testRemoveIfWithIgnoreReturnValues() {
-      doTest(this.<String, String>cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Flag.IGNORE_RETURN_VALUES);
+      doTest(this.cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, Flag.IGNORE_RETURN_VALUES);
    }
 
    public void testRemoveIf() {
-      doTest(this.<String, String>cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, null);
+      doTest(this.cache(PRIVATE_STORE_CACHE_NAME), ConditionalOperation.REMOVE_IF, null);
    }
 
    @Override
@@ -168,7 +168,7 @@ public class LocalConditionalCommandTest extends SingleCacheManagerTest {
       return embeddedCacheManager;
    }
 
-   private static enum ConditionalOperation {
+   private enum ConditionalOperation {
       PUT_IF_ABSENT {
          @Override
          public <K, V> void execute(Cache<K, V> cache, K key, V value1, V value2) {

--- a/core/src/test/java/org/infinispan/persistence/PreloadWithAsyncStoreTest.java
+++ b/core/src/test/java/org/infinispan/persistence/PreloadWithAsyncStoreTest.java
@@ -132,11 +132,11 @@ public class PreloadWithAsyncStoreTest extends SingleCacheManagerTest {
    }
 
    private ExceptionTrackerInterceptor getInterceptor(Cache cache) {
-      return cache.getAdvancedCache().getSequentialInterceptorChain()
+      return cache.getAdvancedCache().getAsyncInterceptorChain()
             .findInterceptorWithClass(ExceptionTrackerInterceptor.class);
    }
 
-   private static enum CacheType {
+   private enum CacheType {
       NO_TRANSACTIONAL("NO_TX"),
       TRANSACTIONAL_SYNCHRONIZATION(TRANSACTIONAL, "TX_SYNC", true, false),
       TRANSACTIONAL_XA(TRANSACTIONAL, "TX_XA", false, false),
@@ -146,14 +146,15 @@ public class PreloadWithAsyncStoreTest extends SingleCacheManagerTest {
       final boolean useSynchronization;
       final boolean useRecovery;
 
-      private CacheType(TransactionMode transactionMode, String cacheName, boolean useSynchronization, boolean useRecovery) {
+      CacheType(TransactionMode transactionMode, String cacheName, boolean useSynchronization,
+            boolean useRecovery) {
          this.transactionMode = transactionMode;
          this.cacheName = cacheName;
          this.useSynchronization = useSynchronization;
          this.useRecovery = useRecovery;
       }
 
-      private CacheType(String cacheName) {
+      CacheType(String cacheName) {
          //no tx cache. the boolean parameters are ignored.
          this(NON_TRANSACTIONAL, cacheName, false, false);
       }

--- a/core/src/test/java/org/infinispan/replication/SyncReplLockingTest.java
+++ b/core/src/test/java/org/infinispan/replication/SyncReplLockingTest.java
@@ -5,10 +5,6 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
-
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertNull;
-
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
 import org.infinispan.transaction.tm.DummyTransactionManager;
@@ -17,6 +13,9 @@ import org.testng.annotations.Test;
 import javax.transaction.TransactionManager;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
 
 /**
  * Tests for lock API
@@ -38,6 +37,7 @@ public class SyncReplLockingTest extends MultipleCacheManagersTest {
       return CacheMode.REPL_SYNC;
    }
 
+   @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder cfg = getDefaultClusteredCacheConfig(getCacheMode(), true);
       cfg.transaction().transactionManagerLookup(new DummyTransactionManagerLookup())
@@ -130,7 +130,7 @@ public class SyncReplLockingTest extends MultipleCacheManagersTest {
       assertNull("Should be null", cache2.get(k));
       final CountDownLatch latch = new CountDownLatch(1);
 
-      Thread t = new Thread() {
+      Thread t = getTestThreadFactory("Worker").newThread(new Runnable() {
          @Override
          public void run() {
             log.info("Concurrent " + (useTx ? "tx" : "non-tx") + " write started "
@@ -162,7 +162,7 @@ public class SyncReplLockingTest extends MultipleCacheManagersTest {
                latch.countDown();
             }
          }
-      };
+      });
 
       String name = "Infinispan";
       TransactionManager mgr = TestingUtil.getTransactionManager(cache1);

--- a/core/src/test/java/org/infinispan/security/SecureCacheTestDriver.java
+++ b/core/src/test/java/org/infinispan/security/SecureCacheTestDriver.java
@@ -103,8 +103,8 @@ public class SecureCacheTestDriver {
 
    @TestCachePermission(AuthorizationPermission.ADMIN)
    public void testAddInterceptor_CommandInterceptor_int(SecureCache<String, String> cache) {
-      cache.getSequentialInterceptorChain().addInterceptor(interceptor, 0);
-      cache.getSequentialInterceptorChain().removeInterceptor(0);
+      cache.getAsyncInterceptorChain().addInterceptor(interceptor, 0);
+      cache.getAsyncInterceptorChain().removeInterceptor(0);
    }
 
    @TestCachePermission(AuthorizationPermission.LISTEN)
@@ -237,8 +237,8 @@ public class SecureCacheTestDriver {
 
    @TestCachePermission(AuthorizationPermission.ADMIN)
    public void testAddInterceptorAfter_CommandInterceptor_Class(SecureCache<String, String> cache) {
-      cache.getSequentialInterceptorChain().addInterceptorAfter(interceptor, InvocationContextInterceptor.class);
-      cache.getSequentialInterceptorChain().removeInterceptor(interceptor.getClass());
+      cache.getAsyncInterceptorChain().addInterceptorAfter(interceptor, InvocationContextInterceptor.class);
+      cache.getAsyncInterceptorChain().removeInterceptor(interceptor.getClass());
    }
 
    @TestCachePermission(AuthorizationPermission.WRITE)
@@ -410,7 +410,7 @@ public class SecureCacheTestDriver {
 
    @TestCachePermission(AuthorizationPermission.ADMIN)
    public void testRemoveInterceptor_Class(SecureCache<String, String> cache) {
-      cache.getSequentialInterceptorChain().removeInterceptor(interceptor.getClass());
+      cache.getAsyncInterceptorChain().removeInterceptor(interceptor.getClass());
    }
 
    @TestCachePermission(AuthorizationPermission.WRITE)
@@ -492,8 +492,8 @@ public class SecureCacheTestDriver {
 
    @TestCachePermission(AuthorizationPermission.ADMIN)
    public void testRemoveInterceptor_int(SecureCache<String, String> cache) {
-      cache.getSequentialInterceptorChain().addInterceptor(interceptor, 0);
-      cache.getSequentialInterceptorChain().removeInterceptor(0);
+      cache.getAsyncInterceptorChain().addInterceptor(interceptor, 0);
+      cache.getAsyncInterceptorChain().removeInterceptor(0);
    }
 
    @TestCachePermission(AuthorizationPermission.ADMIN)
@@ -593,8 +593,8 @@ public class SecureCacheTestDriver {
    }
 
    @TestCachePermission(AuthorizationPermission.ADMIN)
-   public void testGetSequentialInterceptorChain(SecureCache<String, String> cache) {
-      cache.getSequentialInterceptorChain();
+   public void testGetAsyncInterceptorChain(SecureCache<String, String> cache) {
+      cache.getAsyncInterceptorChain();
    }
 
    @TestCachePermission(AuthorizationPermission.WRITE)
@@ -614,8 +614,8 @@ public class SecureCacheTestDriver {
 
    @TestCachePermission(AuthorizationPermission.ADMIN)
    public void testAddInterceptorBefore_CommandInterceptor_Class(SecureCache<String, String> cache) {
-      cache.getSequentialInterceptorChain().addInterceptorBefore(interceptor, InvocationContextInterceptor.class);
-      cache.getSequentialInterceptorChain().removeInterceptor(interceptor.getClass());
+      cache.getAsyncInterceptorChain().addInterceptorBefore(interceptor, InvocationContextInterceptor.class);
+      cache.getAsyncInterceptorChain().removeInterceptor(interceptor.getClass());
    }
 
    @TestCachePermission(AuthorizationPermission.READ)

--- a/core/src/test/java/org/infinispan/statetransfer/StaleLocksWithCommitDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StaleLocksWithCommitDuringStateTransferTest.java
@@ -10,7 +10,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.distribution.MagicKey;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.MultipleCacheManagersTest;
@@ -158,7 +158,7 @@ public class StaleLocksWithCommitDuringStateTransferTest extends MultipleCacheMa
       txCoordinator.prepare(localTx);
 
       // Delay the commit on the remote node. Can't used blockNewTransactions because we don't want a StateTransferInProgressException
-      SequentialInterceptorChain c2ic = c2.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain c2ic = c2.getAdvancedCache().getAsyncInterceptorChain();
       c2ic.addInterceptorBefore(new CommandInterceptor() {
          @Override
          protected Object handleDefault(InvocationContext ctx, VisitableCommand command) throws Throwable {

--- a/core/src/test/java/org/infinispan/statetransfer/TxReplay2Test.java
+++ b/core/src/test/java/org/infinispan/statetransfer/TxReplay2Test.java
@@ -12,7 +12,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.impl.TxInvocationContext;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.interceptors.impl.CallInterceptor;
 import org.infinispan.test.MultipleCacheManagersTest;
@@ -204,7 +204,7 @@ public class TxReplay2Test extends MultipleCacheManagersTest {
       }
 
       public static CountingInterceptor inject(Cache cache) {
-         SequentialInterceptorChain chain = cache.getAdvancedCache().getSequentialInterceptorChain();
+         AsyncInterceptorChain chain = cache.getAdvancedCache().getAsyncInterceptorChain();
          if (chain.containsInterceptorType(CountingInterceptor.class)) {
             return chain.findInterceptorWithClass(CountingInterceptor.class);
          }

--- a/core/src/test/java/org/infinispan/statetransfer/TxReplayTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/TxReplayTest.java
@@ -10,7 +10,7 @@ import org.infinispan.container.DataContainer;
 import org.infinispan.container.entries.InternalCacheEntry;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.distribution.MagicKey;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.interceptors.impl.CallInterceptor;
 import org.infinispan.test.MultipleCacheManagersTest;
@@ -22,10 +22,11 @@ import org.infinispan.transaction.tm.DummyTransactionManager;
 import org.testng.annotations.Test;
 
 import javax.transaction.Status;
-
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.testng.AssertJUnit.*;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
 
 /**
  * Tests the prepare replay.
@@ -127,7 +128,7 @@ public class TxReplayTest extends MultipleCacheManagersTest {
       }
 
       public static TxCommandInterceptor inject(Cache cache) {
-         SequentialInterceptorChain chain = cache.getAdvancedCache().getSequentialInterceptorChain();
+         AsyncInterceptorChain chain = cache.getAdvancedCache().getAsyncInterceptorChain();
          if (chain.containsInterceptorType(TxCommandInterceptor.class)) {
             return chain.findInterceptorWithClass(TxCommandInterceptor.class);
          }

--- a/core/src/test/java/org/infinispan/test/Exceptions.java
+++ b/core/src/test/java/org/infinispan/test/Exceptions.java
@@ -18,7 +18,7 @@ public class Exceptions {
 
    public static void assertException(Class<? extends Throwable> exceptionClass, Throwable t) {
       if (t == null) {
-         throw new AssertionError("Should have thrown an " + exceptionClass, t);
+         throw new AssertionError("Should have thrown an " + exceptionClass, null);
       }
       if (t.getClass() != exceptionClass) {
          throw new AssertionError(
@@ -60,7 +60,17 @@ public class Exceptions {
          String messageRegex, ExceptionRunnable runnable) {
       Throwable t = extractException(runnable);
       assertException(wrapperExceptionClass, t);
+      assertException(exceptionClass, t.getCause());
       assertException(exceptionClass, messageRegex, t.getCause());
+   }
+
+   public static void expectException(Class<? extends Throwable> wrapperExceptionClass2,
+         Class<? extends Throwable> wrapperExceptionClass1, Class<? extends Throwable> exceptionClass,
+         ExceptionRunnable runnable) {
+      Throwable t = extractException(runnable);
+      assertException(wrapperExceptionClass2, t);
+      assertException(wrapperExceptionClass1, t.getCause());
+      assertException(exceptionClass, t.getCause().getCause());
    }
 
    public static void expectException(Class<? extends Throwable> exceptionClass, ExceptionRunnable runnable) {

--- a/core/src/test/java/org/infinispan/test/concurrent/InterceptorSequencerAction.java
+++ b/core/src/test/java/org/infinispan/test/concurrent/InterceptorSequencerAction.java
@@ -100,11 +100,10 @@ public class InterceptorSequencerAction {
       protected CompletableFuture<Void> handleDefault(InvocationContext ctx, VisitableCommand command) throws Throwable {
          boolean commandAccepted = matcher.accept(command);
          StateSequencerUtil.advanceMultiple(stateSequencer, commandAccepted, statesBefore);
-         try {
-            return ctx.shortCircuit(ctx.forkInvocationSync(command));
-         } finally {
+         return ctx.onReturn((rCtx, rCommand, rv, throwable) -> {
             StateSequencerUtil.advanceMultiple(stateSequencer, commandAccepted, statesAfter);
-         }
+            return null;
+         });
       }
 
       public void beforeStates(List<String> states) {

--- a/core/src/test/java/org/infinispan/test/concurrent/StateSequencerUtil.java
+++ b/core/src/test/java/org/infinispan/test/concurrent/StateSequencerUtil.java
@@ -2,7 +2,7 @@ package org.infinispan.test.concurrent;
 
 import org.infinispan.Cache;
 import org.infinispan.commands.ReplicableCommand;
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 
 import java.util.ArrayList;
@@ -24,7 +24,7 @@ public class StateSequencerUtil {
     * Start decorating interceptor {@code interceptorClass} on {@code cache} to interact with a {@code StateSequencer}.
     */
    public static InterceptorSequencerAction advanceOnInterceptor(StateSequencer stateSequencer, Cache<?, ?> cache,
-         Class<? extends SequentialInterceptor> interceptorClass, CommandMatcher matcher) {
+         Class<? extends AsyncInterceptor> interceptorClass, CommandMatcher matcher) {
       return new InterceptorSequencerAction(stateSequencer, cache, interceptorClass, matcher);
    }
 

--- a/core/src/test/java/org/infinispan/tx/ExceptionDuringGetTest.java
+++ b/core/src/test/java/org/infinispan/tx/ExceptionDuringGetTest.java
@@ -29,7 +29,7 @@ public class ExceptionDuringGetTest extends MultipleCacheManagersTest {
 
    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Induced!")
    public void testExceptionDuringGet() {
-      advancedCache(0).getSequentialInterceptorChain().addInterceptorAfter(new CommandInterceptor() {
+      advancedCache(0).getAsyncInterceptorChain().addInterceptorAfter(new CommandInterceptor() {
          @Override
          protected Object handleDefault(InvocationContext ctx, VisitableCommand command) throws Throwable {
             throw new RuntimeException("Induced!");

--- a/core/src/test/java/org/infinispan/tx/NonTxCacheInterceptorTest.java
+++ b/core/src/test/java/org/infinispan/tx/NonTxCacheInterceptorTest.java
@@ -1,6 +1,6 @@
 package org.infinispan.tx;
 
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.impl.TxInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -22,7 +22,7 @@ public class NonTxCacheInterceptorTest extends SingleCacheManagerTest {
    }
 
    public void testNoTxInterceptor() {
-      final SequentialInterceptorChain interceptorChain = cache.getAdvancedCache().getSequentialInterceptorChain();
+      final AsyncInterceptorChain interceptorChain = cache.getAdvancedCache().getAsyncInterceptorChain();
       log.trace(interceptorChain);
       assertFalse(interceptorChain.containsInterceptorType(TxInterceptor.class));
    }

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/CommitFailsTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/CommitFailsTest.java
@@ -40,8 +40,8 @@ public class CommitFailsTest extends AbstractRecoveryTest {
 
       failureInterceptor0 = new InDoubtWithCommitFailsTest.ForceFailureInterceptor();
       failureInterceptor1 = new InDoubtWithCommitFailsTest.ForceFailureInterceptor();
-      advancedCache(0).getSequentialInterceptorChain().addInterceptorAfter(failureInterceptor0, InvocationContextInterceptor.class);
-      advancedCache(1).getSequentialInterceptorChain().addInterceptorAfter(failureInterceptor1, InvocationContextInterceptor.class);
+      advancedCache(0).getAsyncInterceptorChain().addInterceptorAfter(failureInterceptor0, InvocationContextInterceptor.class);
+      advancedCache(1).getAsyncInterceptorChain().addInterceptorAfter(failureInterceptor1, InvocationContextInterceptor.class);
    }
 
    @BeforeMethod
@@ -110,6 +110,7 @@ public class CommitFailsTest extends AbstractRecoveryTest {
       assertCleanup(0, 1, 2);
    }
 
+   @Override
    protected int getTxParticipant(boolean txParticipant) {
       int expectedNumber = txParticipant ? 1 : 0;
 

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/InDoubtWithCommitFailsTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/InDoubtWithCommitFailsTest.java
@@ -14,7 +14,10 @@ import org.infinispan.transaction.tm.DummyTransaction;
 import org.infinispan.tx.recovery.RecoveryDummyTransactionManagerLookup;
 import org.testng.annotations.Test;
 
-import static org.infinispan.tx.recovery.RecoveryTestUtil.*;
+import static org.infinispan.tx.recovery.RecoveryTestUtil.beginAndSuspendTx;
+import static org.infinispan.tx.recovery.RecoveryTestUtil.commitTransaction;
+import static org.infinispan.tx.recovery.RecoveryTestUtil.prepareTransaction;
+import static org.infinispan.tx.recovery.RecoveryTestUtil.rollbackTransaction;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -38,7 +41,7 @@ public class InDoubtWithCommitFailsTest extends AbstractRecoveryTest {
             .clustering().l1().disable().stateTransfer().fetchInMemoryState(false);
       createCluster(configuration, 2);
       waitForClusterToForm();
-      advancedCache(1).getSequentialInterceptorChain().addInterceptorBefore(new ForceFailureInterceptor(), InvocationContextInterceptor.class);
+      advancedCache(1).getAsyncInterceptorChain().addInterceptorBefore(new ForceFailureInterceptor(), InvocationContextInterceptor.class);
    }
 
    public void testRecoveryInfoListCommit() throws Exception {

--- a/core/src/test/java/org/infinispan/tx/totalorder/CleanupAfterFailTest.java
+++ b/core/src/test/java/org/infinispan/tx/totalorder/CleanupAfterFailTest.java
@@ -7,8 +7,8 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.VersioningScheme;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.distribution.MagicKey;
-import org.infinispan.interceptors.BaseCustomSequentialInterceptor;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.transaction.TransactionProtocol;
@@ -35,14 +35,14 @@ public class CleanupAfterFailTest extends MultipleCacheManagersTest {
 
    public void testTimeoutCleanup() throws Exception {
       final CountDownLatch block = new CountDownLatch(1);
-      final BaseCustomSequentialInterceptor interceptor = new BaseCustomSequentialInterceptor() {
+      final BaseCustomAsyncInterceptor interceptor = new BaseCustomAsyncInterceptor() {
          @Override
          public CompletableFuture<Void> visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command) throws Throwable {
             block.await();
             return ctx.continueInvocation();
          }
       };
-      final SequentialInterceptorChain chain = TestingUtil.extractComponent(cache(1), SequentialInterceptorChain.class);
+      final AsyncInterceptorChain chain = TestingUtil.extractComponent(cache(1), AsyncInterceptorChain.class);
       final Object key = new MagicKey(cache(1));
       try {
          chain.addInterceptor(interceptor, 0);
@@ -63,7 +63,7 @@ public class CleanupAfterFailTest extends MultipleCacheManagersTest {
 
    public void testTimeoutCleanupInLocalNode() throws Exception {
       final CountDownLatch block = new CountDownLatch(1);
-      final BaseCustomSequentialInterceptor interceptor = new BaseCustomSequentialInterceptor() {
+      final BaseCustomAsyncInterceptor interceptor = new BaseCustomAsyncInterceptor() {
          @Override
          public CompletableFuture<Void> visitPrepareCommand(TxInvocationContext ctx, PrepareCommand command)
                throws Throwable {
@@ -73,7 +73,7 @@ public class CleanupAfterFailTest extends MultipleCacheManagersTest {
             return ctx.continueInvocation();
          }
       };
-      final SequentialInterceptorChain chain = TestingUtil.extractComponent(cache(0), SequentialInterceptorChain.class);
+      final AsyncInterceptorChain chain = TestingUtil.extractComponent(cache(0), AsyncInterceptorChain.class);
       final Object key1 = new MagicKey(cache(0));
       final Object key2 = new MagicKey(cache(1));
       try {

--- a/core/src/test/java/org/infinispan/tx/totalorder/simple/BaseSimpleTotalOrderTest.java
+++ b/core/src/test/java/org/infinispan/tx/totalorder/simple/BaseSimpleTotalOrderTest.java
@@ -5,7 +5,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Configurations;
 import org.infinispan.configuration.cache.VersioningScheme;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.locking.OptimisticLockingInterceptor;
 import org.infinispan.interceptors.locking.PessimisticLockingInterceptor;
 import org.infinispan.interceptors.totalorder.TotalOrderDistributionInterceptor;
@@ -24,7 +24,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author Pedro Ruivo
@@ -64,7 +67,7 @@ public abstract class BaseSimpleTotalOrderTest extends MultipleCacheManagersTest
    }
 
    public final void testInterceptorChain() {
-      SequentialInterceptorChain ic = advancedCache(0).getSequentialInterceptorChain();
+      AsyncInterceptorChain ic = advancedCache(0).getAsyncInterceptorChain();
       assertTrue(ic.containsInterceptorType(TotalOrderInterceptor.class));
       if (writeSkew) {
          assertFalse(ic.containsInterceptorType(TotalOrderDistributionInterceptor.class));

--- a/core/src/test/java/org/infinispan/util/TransactionTrackInterceptor.java
+++ b/core/src/test/java/org/infinispan/util/TransactionTrackInterceptor.java
@@ -8,8 +8,8 @@ import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
-import org.infinispan.interceptors.BaseCustomSequentialInterceptor;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.logging.Log;
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
  * @author Pedro Ruivo
  * @since 5.3
  */
-public class TransactionTrackInterceptor extends BaseCustomSequentialInterceptor {
+public class TransactionTrackInterceptor extends BaseCustomAsyncInterceptor {
 
    private static final Log log = LogFactory.getLog(TransactionTrackInterceptor.class);
    private static final GlobalTransaction CLEAR_TRANSACTION = new ClearGlobalTransaction();
@@ -44,7 +44,7 @@ public class TransactionTrackInterceptor extends BaseCustomSequentialInterceptor
    }
 
    public static TransactionTrackInterceptor injectInCache(Cache<?, ?> cache) {
-      SequentialInterceptorChain chain = cache.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain chain = cache.getAdvancedCache().getAsyncInterceptorChain();
       if (chain.containsInterceptorType(TransactionTrackInterceptor.class)) {
          return chain.findInterceptorWithClass(TransactionTrackInterceptor.class);
       }

--- a/extended-statistics/src/main/java/org/infinispan/stats/topK/CacheUsageInterceptor.java
+++ b/extended-statistics/src/main/java/org/infinispan/stats/topK/CacheUsageInterceptor.java
@@ -9,7 +9,7 @@ import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
-import org.infinispan.interceptors.BaseCustomSequentialInterceptor;
+import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture;
  * @since 6.0
  */
 @MBean(objectName = "CacheUsageStatistics", description = "Keeps tracks of the accessed keys")
-public class CacheUsageInterceptor extends BaseCustomSequentialInterceptor {
+public class CacheUsageInterceptor extends BaseCustomAsyncInterceptor {
 
    public static final int DEFAULT_TOP_KEY = 10;
    private static final Log log = LogFactory.getLog(CacheUsageInterceptor.class, Log.class);

--- a/extended-statistics/src/main/java/org/infinispan/stats/wrappers/ExtendedStatisticInterceptor.java
+++ b/extended-statistics/src/main/java/org/infinispan/stats/wrappers/ExtendedStatisticInterceptor.java
@@ -15,7 +15,7 @@ import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.annotations.Start;
-import org.infinispan.interceptors.BaseCustomSequentialInterceptor;
+import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
 import org.infinispan.jmx.annotations.MBean;
 import org.infinispan.jmx.annotations.ManagedAttribute;
 import org.infinispan.jmx.annotations.ManagedOperation;
@@ -60,7 +60,7 @@ import static org.infinispan.stats.percentiles.PercentileStatistic.WR_REMOTE_EXE
  */
 @MBean(objectName = "ExtendedStatistics", description = "Component that manages and exposes extended statistics " +
       "relevant to transactions.")
-public class ExtendedStatisticInterceptor extends BaseCustomSequentialInterceptor {
+public class ExtendedStatisticInterceptor extends BaseCustomAsyncInterceptor {
 
    private static final Log log = LogFactory.getLog(ExtendedStatisticInterceptor.class, Log.class);
    private static final boolean trace = log.isTraceEnabled();

--- a/extended-statistics/src/test/java/org/infinispan/stats/AbstractTopKeyTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/stats/AbstractTopKeyTest.java
@@ -4,8 +4,8 @@ import org.infinispan.Cache;
 import org.infinispan.commands.tx.PrepareCommand;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.distribution.DistributionManager;
-import org.infinispan.interceptors.DDSequentialInterceptor;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.interceptors.impl.TxInterceptor;
 import org.infinispan.stats.topK.CacheUsageInterceptor;
 import org.infinispan.test.MultipleCacheManagersTest;
@@ -27,8 +27,8 @@ public abstract class AbstractTopKeyTest extends MultipleCacheManagersTest {
    }
 
    protected CacheUsageInterceptor getTopKey(Cache<?, ?> cache) {
-      SequentialInterceptorChain interceptorChain =
-            cache.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain interceptorChain =
+            cache.getAdvancedCache().getAsyncInterceptorChain();
       return interceptorChain.findInterceptorExtending(CacheUsageInterceptor.class);
    }
 
@@ -81,7 +81,7 @@ public abstract class AbstractTopKeyTest extends MultipleCacheManagersTest {
    }
 
    protected PrepareCommandBlocker addPrepareBlockerIfAbsent(Cache<?, ?> cache) {
-      SequentialInterceptorChain chain = cache.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain chain = cache.getAdvancedCache().getAsyncInterceptorChain();
 
       PrepareCommandBlocker blocker = chain.findInterceptorWithClass(PrepareCommandBlocker.class);
       if (blocker != null)
@@ -92,7 +92,7 @@ public abstract class AbstractTopKeyTest extends MultipleCacheManagersTest {
       return blocker;
    }
 
-   protected class PrepareCommandBlocker extends DDSequentialInterceptor {
+   protected class PrepareCommandBlocker extends DDAsyncInterceptor {
 
       private boolean unblock = false;
       private boolean prepareBlocked = false;

--- a/extended-statistics/src/test/java/org/infinispan/stats/BaseClusteredExtendedStatisticTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/stats/BaseClusteredExtendedStatisticTest.java
@@ -19,7 +19,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.InterceptorConfiguration;
 import org.infinispan.configuration.cache.VersioningScheme;
 import org.infinispan.factories.ComponentRegistry;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
 import org.infinispan.remoting.inboundhandler.PerCacheInboundInvocationHandler;
 import org.infinispan.remoting.inboundhandler.Reply;
@@ -397,7 +397,7 @@ public abstract class BaseClusteredExtendedStatisticTest extends MultipleCacheMa
    }
 
    private ExtendedStatisticInterceptor getExtendedStatistic(Cache<?, ?> cache) {
-      SequentialInterceptorChain interceptorChain = cache.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain interceptorChain = cache.getAdvancedCache().getAsyncInterceptorChain();
       ExtendedStatisticInterceptor extendedStatisticInterceptor =
             interceptorChain.findInterceptorExtending(ExtendedStatisticInterceptor.class);
       if (extendedStatisticInterceptor != null) {

--- a/extended-statistics/src/test/java/org/infinispan/stats/simple/LocalExtendedStatisticTest.java
+++ b/extended-statistics/src/test/java/org/infinispan/stats/simple/LocalExtendedStatisticTest.java
@@ -4,7 +4,7 @@ import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.InterceptorConfiguration;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.stats.wrappers.ExtendedStatisticInterceptor;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -254,7 +254,7 @@ public class LocalExtendedStatisticTest extends SingleCacheManagerTest {
    }
 
    private ExtendedStatisticInterceptor getExtendedStatistic(Cache<?, ?> cache) {
-      SequentialInterceptorChain interceptorChain = cache.getAdvancedCache().getSequentialInterceptorChain();
+      AsyncInterceptorChain interceptorChain = cache.getAdvancedCache().getAsyncInterceptorChain();
       ExtendedStatisticInterceptor extendedStatisticInterceptor =
             interceptorChain.findInterceptorExtending(ExtendedStatisticInterceptor.class);
       if (extendedStatisticInterceptor != null) {

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/TestCacheListener.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/TestCacheListener.java
@@ -9,6 +9,8 @@ import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
 import org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent;
 import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
 import org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,6 +23,8 @@ import java.util.Map;
  */
 @Listener
 public class TestCacheListener {
+   private static final Log log = LogFactory.getLog(TestCacheListener.class);
+
    //Map is used instead of List so we could test if key is correct too
    Map<Object, Object> created = new HashMap<Object, Object>();
    Map<Object, Object> removed = new HashMap<Object, Object>();
@@ -36,6 +40,7 @@ public class TestCacheListener {
    @CacheEntryCreated
    public void handleCreated(CacheEntryCreatedEvent e) {
       if (!e.isPre()) {
+         log.tracef("Created %s", e.getKey());
          created.put(e.getKey(), e.getValue());
          createdCounter++;
       }
@@ -45,6 +50,7 @@ public class TestCacheListener {
    @CacheEntryRemoved
    public void handleRemoved(CacheEntryRemovedEvent e) {
       if (!e.isPre()) {
+         log.tracef("Removed %s", e.getKey());
          removed.put(e.getKey(), e.getOldValue());
          removedCounter++;
       }
@@ -54,6 +60,7 @@ public class TestCacheListener {
    @CacheEntryModified
    public void handleModified(CacheEntryModifiedEvent e) {
       if (!e.isPre()) {
+         log.tracef("Modified %s", e.getKey());
          modified.put(e.getKey(), e.getValue());
          modifiedCounter++;
       }
@@ -63,6 +70,7 @@ public class TestCacheListener {
    @CacheEntryVisited
    public void handleVisited(CacheEntryVisitedEvent e) {
       if (!e.isPre()) {
+         log.tracef("Visited %s", e.getKey());
          visited.put(e.getKey(), e.getValue());
          visitedCounter++;
       }

--- a/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
+++ b/query/src/main/java/org/infinispan/query/backend/QueryInterceptor.java
@@ -27,7 +27,7 @@ import org.infinispan.factories.annotations.ComponentName;
 import org.infinispan.factories.annotations.Inject;
 import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
-import org.infinispan.interceptors.DDSequentialInterceptor;
+import org.infinispan.interceptors.DDAsyncInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.marshall.core.MarshalledValue;
 import org.infinispan.query.Transformer;
@@ -62,7 +62,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author anistor@redhat.com
  * @since 4.0
  */
-public final class QueryInterceptor extends DDSequentialInterceptor {
+public final class QueryInterceptor extends DDAsyncInterceptor {
 
    private final IndexModificationStrategy indexingMode;
    private final SearchIntegrator searchFactory;

--- a/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
+++ b/query/src/main/java/org/infinispan/query/impl/LifecycleManager.java
@@ -20,7 +20,7 @@ import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.components.ManageableComponentMetadata;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.locking.NonTransactionalLockingInterceptor;
 import org.infinispan.interceptors.locking.OptimisticLockingInterceptor;
 import org.infinispan.interceptors.locking.PessimisticLockingInterceptor;
@@ -166,7 +166,7 @@ public class LifecycleManager extends AbstractModuleLifecycle {
 
          // Interceptor registration not needed, core configuration handling
          // already does it for all custom interceptors - UNLESS the InterceptorChain already exists in the component registry!
-         SequentialInterceptorChain ic = cr.getComponent(SequentialInterceptorChain.class);
+         AsyncInterceptorChain ic = cr.getComponent(AsyncInterceptorChain.class);
 
          ConfigurationBuilder builder = new ConfigurationBuilder().read(cfg);
          InterceptorConfigurationBuilder interceptorBuilder = builder.customInterceptors().addInterceptor();
@@ -286,7 +286,7 @@ public class LifecycleManager extends AbstractModuleLifecycle {
    }
 
    private boolean verifyChainContainsQueryInterceptor(ComponentRegistry cr) {
-      SequentialInterceptorChain interceptorChain = cr.getComponent(SequentialInterceptorChain.class);
+      AsyncInterceptorChain interceptorChain = cr.getComponent(AsyncInterceptorChain.class);
       return interceptorChain != null && interceptorChain.containsInterceptorType(QueryInterceptor.class, true);
    }
 
@@ -375,7 +375,7 @@ public class LifecycleManager extends AbstractModuleLifecycle {
       CustomInterceptorsConfigurationBuilder customInterceptorsBuilder = builder.customInterceptors();
 
       for (InterceptorConfiguration interceptorConfig : cfg.customInterceptors().interceptors()) {
-         if (!(interceptorConfig.sequentialInterceptor() instanceof QueryInterceptor)) {
+         if (!(interceptorConfig.asyncInterceptor() instanceof QueryInterceptor)) {
             customInterceptorsBuilder.addInterceptor().read(interceptorConfig);
          }
       }

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
@@ -139,7 +139,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
    private void assertQueryInterceptorPresent(Cache<?, ?> c) {
       QueryInterceptor i = TestingUtil.findInterceptor(c, QueryInterceptor.class);
       assert i != null : "Expected to find a QueryInterceptor, only found " +
-            c.getAdvancedCache().getSequentialInterceptorChain().getInterceptors();
+            c.getAdvancedCache().getAsyncInterceptorChain().getInterceptors();
    }
 
    public void testModified() throws Exception {

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/LifecycleManager.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/LifecycleManager.java
@@ -16,7 +16,7 @@ import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.components.ComponentMetadataRepo;
 import org.infinispan.factories.components.ManageableComponentMetadata;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
 import org.infinispan.interceptors.impl.BatchingInterceptor;
 import org.infinispan.interceptors.impl.InvocationContextInterceptor;
 import org.infinispan.jmx.JmxUtil;
@@ -133,7 +133,7 @@ public final class LifecycleManager extends AbstractModuleLifecycle {
 
          // Interceptor registration not needed, core configuration handling
          // already does it for all custom interceptors - UNLESS the InterceptorChain already exists in the component registry!
-         SequentialInterceptorChain ic = cr.getComponent(SequentialInterceptorChain.class);
+         AsyncInterceptorChain ic = cr.getComponent(AsyncInterceptorChain.class);
 
          ConfigurationBuilder builder = new ConfigurationBuilder().read(cfg);
          InterceptorConfigurationBuilder interceptorBuilder = builder.customInterceptors().addInterceptor();
@@ -190,7 +190,7 @@ public final class LifecycleManager extends AbstractModuleLifecycle {
    }
 
    private boolean verifyChainContainsRemoteValueWrapperInterceptor(ComponentRegistry cr) {
-      SequentialInterceptorChain interceptorChain = cr.getComponent(SequentialInterceptorChain.class);
+      AsyncInterceptorChain interceptorChain = cr.getComponent(AsyncInterceptorChain.class);
       return interceptorChain != null && interceptorChain.containsInterceptorType(RemoteValueWrapperInterceptor.class, true);
    }
 
@@ -205,7 +205,7 @@ public final class LifecycleManager extends AbstractModuleLifecycle {
       CustomInterceptorsConfigurationBuilder customInterceptorsBuilder = builder.customInterceptors();
 
       for (InterceptorConfiguration interceptorConfig : cfg.customInterceptors().interceptors()) {
-         if (!(interceptorConfig.sequentialInterceptor() instanceof RemoteValueWrapperInterceptor)) {
+         if (!(interceptorConfig.asyncInterceptor() instanceof RemoteValueWrapperInterceptor)) {
             customInterceptorsBuilder.addInterceptor().read(interceptorConfig);
          }
       }

--- a/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptor.java
+++ b/remote-query/remote-query-server/src/main/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptor.java
@@ -16,8 +16,8 @@ import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.BaseCustomSequentialInterceptor;
-import org.infinispan.interceptors.SequentialInterceptorChain;
+import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
 import org.infinispan.protostream.DescriptorParserException;
 import org.infinispan.protostream.FileDescriptorSource;
 import org.infinispan.protostream.SerializationContext;
@@ -38,11 +38,11 @@ import java.util.concurrent.CompletableFuture;
  * @author anistor@redhat.com
  * @since 7.0
  */
-final class ProtobufMetadataManagerInterceptor extends BaseCustomSequentialInterceptor implements ProtobufMetadataManagerConstants {
+final class ProtobufMetadataManagerInterceptor extends BaseCustomAsyncInterceptor implements ProtobufMetadataManagerConstants {
 
    private CommandsFactory commandsFactory;
 
-   private SequentialInterceptorChain invoker;
+   private AsyncInterceptorChain invoker;
 
    private SerializationContext serializationContext;
 
@@ -165,7 +165,7 @@ final class ProtobufMetadataManagerInterceptor extends BaseCustomSequentialInter
    };
 
    @Inject
-   public void init(CommandsFactory commandsFactory, SequentialInterceptorChain invoker, ProtobufMetadataManager protobufMetadataManager) {
+   public void init(CommandsFactory commandsFactory, AsyncInterceptorChain invoker, ProtobufMetadataManager protobufMetadataManager) {
       this.commandsFactory = commandsFactory;
       this.invoker = invoker;
       this.serializationContext = ((ProtobufMetadataManagerImpl) protobufMetadataManager).getSerializationContext();

--- a/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingInterceptor.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingInterceptor.java
@@ -6,7 +6,7 @@ import org.infinispan.commands.write.RemoveCommand;
 import org.infinispan.commands.write.ReplaceCommand;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.factories.annotations.Inject;
-import org.infinispan.interceptors.BaseCustomSequentialInterceptor;
+import org.infinispan.interceptors.BaseCustomAsyncInterceptor;
 import org.infinispan.scripting.ScriptingManager;
 
 import java.util.concurrent.CompletableFuture;
@@ -18,7 +18,7 @@ import java.util.concurrent.CompletableFuture;
  * @author Tristan Tarrant
  * @since 7.2
  */
-public final class ScriptingInterceptor extends BaseCustomSequentialInterceptor {
+public final class ScriptingInterceptor extends BaseCustomAsyncInterceptor {
 
    private ScriptingManagerImpl scriptingManager;
 

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/SecurityActions.java
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/SecurityActions.java
@@ -2,16 +2,13 @@ package org.infinispan.server.hotrod;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.List;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.interceptors.SequentialInterceptor;
 import org.infinispan.manager.EmbeddedCacheManager;
-import org.infinispan.interceptors.SequentialInterceptorChain;
 import org.infinispan.notifications.Listenable;
 import org.infinispan.remoting.rpc.RpcManager;
 import org.infinispan.security.Security;
@@ -20,7 +17,6 @@ import org.infinispan.security.actions.GetCacheComponentRegistryAction;
 import org.infinispan.security.actions.GetCacheConfigurationAction;
 import org.infinispan.security.actions.GetCacheDistributionManagerAction;
 import org.infinispan.security.actions.GetCacheGlobalComponentRegistryAction;
-import org.infinispan.security.actions.GetCacheInterceptorChainAction;
 import org.infinispan.security.actions.GetCacheRpcManagerAction;
 import org.infinispan.security.actions.RemoveListenerAction;
 

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/SkipIndexingHotRodTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/SkipIndexingHotRodTest.scala
@@ -1,11 +1,12 @@
 package org.infinispan.server.hotrod
 
-import org.infinispan.interceptors.base.BaseCustomInterceptor
-import org.infinispan.context.{Flag, InvocationContext}
+import java.lang.reflect.Method
+
 import org.infinispan.commands.{LocalFlagAffectedCommand, VisitableCommand}
 import org.infinispan.commons.CacheException
-import java.lang.reflect.Method
-import test.HotRodTestingUtil._
+import org.infinispan.context.{Flag, InvocationContext}
+import org.infinispan.interceptors.base.BaseCustomInterceptor
+import org.infinispan.server.hotrod.test.HotRodTestingUtil._
 import org.testng.annotations.Test
 
 /**
@@ -148,7 +149,7 @@ class SkipIndexingHotRodTest extends HotRodSingleNodeTest {
       }
 
       val ci = new SkipIndexingFlagCheckCommandInterceptor
-      cacheManager.getCache(cacheName).getAdvancedCache.getSequentialInterceptorChain().addInterceptor(ci, 1)
+      cacheManager.getCache(cacheName).getAdvancedCache.getAsyncInterceptorChain().addInterceptor(ci, 1)
       ci
    }
 

--- a/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/SecurityActions.java
+++ b/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/SecurityActions.java
@@ -13,7 +13,7 @@ import org.infinispan.cli.interpreter.Interpreter;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.factories.GlobalComponentRegistry;
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.jmx.JmxStatisticsExposer;
 import org.infinispan.lifecycle.ComponentStatus;
@@ -163,7 +163,7 @@ public final class SecurityActions {
         return doPrivileged(action);
     }
 
-    public static List<SequentialInterceptor> getInterceptorChain(final AdvancedCache<?, ?> cache) {
+    public static List<AsyncInterceptor> getInterceptorChain(final AdvancedCache<?, ?> cache) {
         GetCacheInterceptorChainAction action = new GetCacheInterceptorChainAction(cache);
         return doPrivileged(action);
     }

--- a/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/actions/ResetInterceptorJmxStatisticsAction.java
+++ b/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/actions/ResetInterceptorJmxStatisticsAction.java
@@ -1,7 +1,7 @@
 package org.infinispan.server.infinispan.actions;
 
 import org.infinispan.AdvancedCache;
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.jmx.JmxStatisticsExposer;
 
 import static org.jboss.as.clustering.infinispan.subsystem.CacheMetricsHandler.getFirstInterceptorWhichExtends;
@@ -14,7 +14,7 @@ import static org.jboss.as.clustering.infinispan.subsystem.CacheMetricsHandler.g
  * @author wburns
  * @since 7.0
  */
-public class ResetInterceptorJmxStatisticsAction<T extends SequentialInterceptor & JmxStatisticsExposer> extends AbstractAdvancedCacheAction<Void> {
+public class ResetInterceptorJmxStatisticsAction<T extends AsyncInterceptor & JmxStatisticsExposer> extends AbstractAdvancedCacheAction<Void> {
    private final Class<T> interceptorClass;
 
    public ResetInterceptorJmxStatisticsAction(AdvancedCache<?, ?> cache, Class<T> interceptorClass) {
@@ -24,7 +24,7 @@ public class ResetInterceptorJmxStatisticsAction<T extends SequentialInterceptor
 
    @Override
    public Void run() {
-      T interceptor = getFirstInterceptorWhichExtends(cache.getSequentialInterceptorChain().getInterceptors(), interceptorClass);
+      T interceptor = getFirstInterceptorWhichExtends(cache.getAsyncInterceptorChain().getInterceptors(), interceptorClass);
       if (interceptor != null) {
          interceptor.resetStatistics();
       }

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheMetricsHandler.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheMetricsHandler.java
@@ -27,7 +27,7 @@ import org.infinispan.Cache;
 import org.infinispan.eviction.ActivationManager;
 import org.infinispan.eviction.PassivationManager;
 import org.infinispan.factories.ComponentRegistry;
-import org.infinispan.interceptors.SequentialInterceptor;
+import org.infinispan.interceptors.AsyncInterceptor;
 import org.infinispan.interceptors.impl.ActivationInterceptor;
 import org.infinispan.interceptors.impl.CacheMgmtInterceptor;
 import org.infinispan.interceptors.impl.CacheWriterInterceptor;
@@ -130,20 +130,20 @@ public class CacheMetricsHandler extends AbstractRuntimeOnlyHandler {
         final AttributeDefinition definition;
         final boolean clustered;
 
-        private CacheMetrics(final AttributeDefinition definition, final boolean clustered) {
+        CacheMetrics(final AttributeDefinition definition, final boolean clustered) {
             this.definition = definition;
             this.clustered = clustered;
         }
 
-        private CacheMetrics(String attributeName, ModelType type, boolean allowNull) {
+        CacheMetrics(String attributeName, ModelType type, boolean allowNull) {
             this(new SimpleAttributeDefinitionBuilder(attributeName, type, allowNull).setStorageRuntime().build(), false);
         }
 
-        private CacheMetrics(String attributeName, ModelType type, boolean allowNull, final boolean clustered) {
+        CacheMetrics(String attributeName, ModelType type, boolean allowNull, final boolean clustered) {
             this(new SimpleAttributeDefinitionBuilder(attributeName, type, allowNull).setStorageRuntime().build(), clustered);
         }
 
-        private CacheMetrics(String attributeName, ModelType outerType, ModelType innerType, boolean allowNull) {
+        CacheMetrics(String attributeName, ModelType outerType, ModelType innerType, boolean allowNull) {
             if (outerType != ModelType.LIST) {
                 throw new IllegalArgumentException();
             }
@@ -192,7 +192,7 @@ public class CacheMetricsHandler extends AbstractRuntimeOnlyHandler {
             AdvancedCache<?, ?> aCache = cache.getAdvancedCache();
             DefaultLockManager lockManager = (DefaultLockManager) SecurityActions.getLockManager(aCache);
             RpcManagerImpl rpcManager = (RpcManagerImpl) SecurityActions.getRpcManager(aCache);
-            List<SequentialInterceptor> interceptors = SecurityActions.getInterceptorChain(aCache);
+            List<AsyncInterceptor> interceptors = SecurityActions.getInterceptorChain(aCache);
             ComponentRegistry registry = SecurityActions.getComponentRegistry(aCache);
             ComponentStatus status = SecurityActions.getCacheStatus(aCache);
             switch (metric) {
@@ -383,9 +383,9 @@ public class CacheMetricsHandler extends AbstractRuntimeOnlyHandler {
         }
     }
 
-    public static <T extends SequentialInterceptor> T getFirstInterceptorWhichExtends(List<SequentialInterceptor> interceptors,
+    public static <T extends AsyncInterceptor> T getFirstInterceptorWhichExtends(List<AsyncInterceptor> interceptors,
                                                                                     Class<T> interceptorClass) {
-        for (SequentialInterceptor interceptor : interceptors) {
+        for (AsyncInterceptor interceptor : interceptors) {
             boolean isSubclass = interceptorClass.isAssignableFrom(interceptor.getClass());
             if (isSubclass) {
                 return (T) interceptor;


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6610

Interceptors must use onReturn() for things they need
to do after command.perform(). While forkInvocationSync()
still works, it doesn't allow asynchronous execution.

* Fix forkInvocation-related problems in BaseSequentialInvocationContext.
* Make BaseSequentialInvocationContext.invokeInterceptors invoke
  visitCommand in sequence for all interceptors, to allow inlining.
* Move visit notification from CallInterceptor to EntryWrappingInterceptor

With the invokeInterceptors unrolled loop and all the interceptors inlined, the performance in local caches is similar to the performance with forkInvocationSync. Performance in clustered scenarios should be better once we enable asynchronous execution.