### PR TITLE
ISPN-6588 Query DSL 'like' queries should only accept % and _ as the …

### DIFF
--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
@@ -3093,4 +3093,36 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       assertEquals(1L, list.get(2)[0]);
       assertNull(list.get(2)[1]);
    }
+
+   /**
+    * Test that 'like' accepts only % and _ as wildcards.
+    */
+   @Test
+   public void testLuceneWildcardsAreEscaped() {
+      QueryFactory qf = getQueryFactory();
+
+      // use a true wildcard
+      Query q1 = qf.from(getModelFactory().getUserImplClass())
+            .having("name").like("J%n").toBuilder()
+            .build();
+      assertEquals(1, q1.list().size());
+
+      // use an improper wildcard
+      Query q2 = qf.from(getModelFactory().getUserImplClass())
+            .having("name").like("J*n").toBuilder()
+            .build();
+      assertEquals(0, q2.list().size());
+
+      // use a true wildcard
+      Query q3 = qf.from(getModelFactory().getUserImplClass())
+            .having("name").like("Jo_n").toBuilder()
+            .build();
+      assertEquals(1, q3.list().size());
+
+      // use an improper wildcard
+      Query q4 = qf.from(getModelFactory().getUserImplClass())
+            .having("name").like("Jo?n").toBuilder()
+            .build();
+      assertEquals(0, q4.list().size());
+   }
 }

--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/predicateindex/RegexCondition.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/predicateindex/RegexCondition.java
@@ -93,6 +93,8 @@ public final class RegexCondition implements Condition<String> {
                break;
 
             // regexp special characters need to be escaped
+            case '+':
+            case '*':
             case '(':
             case ')':
             case '[':

--- a/object-filter/src/test/java/org/infinispan/objectfilter/impl/predicateindex/RegexConditionTest.java
+++ b/object-filter/src/test/java/org/infinispan/objectfilter/impl/predicateindex/RegexConditionTest.java
@@ -1,0 +1,75 @@
+package org.infinispan.objectfilter.impl.predicateindex;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author anistor@redhat.com
+ * @since 9.0
+ */
+public class RegexConditionTest {
+
+   @Test
+   public void testSingleWildcard() throws Exception {
+      RegexCondition regexCondition = new RegexCondition("a_b");
+      assertTrue(regexCondition.match("aXb"));
+      assertTrue(regexCondition.match("a_b"));
+      assertTrue(regexCondition.match("a%b"));
+
+      assertFalse(regexCondition.match("ab"));
+      assertFalse(regexCondition.match("aXXb"));
+   }
+
+   @Test
+   public void testMultipleWildcard() throws Exception {
+      RegexCondition regexCondition = new RegexCondition("a%b");
+      assertTrue(regexCondition.match("ab"));
+      assertTrue(regexCondition.match("aXb"));
+      assertTrue(regexCondition.match("aXYb"));
+      assertTrue(regexCondition.match("a_b"));
+      assertTrue(regexCondition.match("a%b"));
+
+      assertFalse(regexCondition.match("a"));
+      assertFalse(regexCondition.match("aX"));
+      assertFalse(regexCondition.match("a%"));
+   }
+
+   @Test
+   public void testPlusEscaping() throws Exception {
+      RegexCondition regexCondition = new RegexCondition("a%aZ+");
+      assertTrue(regexCondition.match("aaaZ+"));
+
+      assertFalse(regexCondition.match("aaa"));
+      assertFalse(regexCondition.match("aaaZ"));
+      assertFalse(regexCondition.match("aaaZZ"));
+      assertFalse(regexCondition.match("aaaZZZ"));
+   }
+
+   @Test
+   public void testAsteriskEscaping() throws Exception {
+      RegexCondition regexCondition = new RegexCondition("a%aZ*");
+      assertTrue(regexCondition.match("aaaZ*"));
+
+      assertFalse(regexCondition.match("aaa"));
+      assertFalse(regexCondition.match("aaaZ"));
+      assertFalse(regexCondition.match("aaaZZ"));
+      assertFalse(regexCondition.match("aaaZZZ"));
+   }
+
+   @Test
+   public void testGeneralMetacharEscaping() {
+      assertTrue(new RegexCondition("a%(b").match("aaa(b"));
+      assertTrue(new RegexCondition("a%)b").match("aaa)b"));
+      assertTrue(new RegexCondition("a%[b").match("aaa[b"));
+      assertTrue(new RegexCondition("a%]b").match("aaa]b"));
+      assertTrue(new RegexCondition("a%{b").match("aaa{b"));
+      assertTrue(new RegexCondition("a%}b").match("aaa}b"));
+      assertTrue(new RegexCondition("a%$b").match("aaa$b"));
+      assertTrue(new RegexCondition("a%^b").match("aaa^b"));
+      assertTrue(new RegexCondition("a%.b").match("aaa.b"));
+      assertTrue(new RegexCondition("a%|b").match("aaa|b"));
+      assertTrue(new RegexCondition("a%\\b").match("aaa\\b"));
+   }
+}

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
@@ -2901,4 +2901,35 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       assertEquals(1L, list.get(2)[0]);
       assertNull(list.get(2)[1]);
    }
+
+   /**
+    * Test that 'like' accepts only % and _ as wildcards.
+    */
+   public void testLuceneWildcardsAreEscaped() {
+      QueryFactory qf = getQueryFactory();
+
+      // use a true wildcard
+      Query q1 = qf.from(getModelFactory().getUserImplClass())
+            .having("name").like("J%n").toBuilder()
+            .build();
+      assertEquals(1, q1.list().size());
+
+      // use an improper wildcard
+      Query q2 = qf.from(getModelFactory().getUserImplClass())
+            .having("name").like("J*n").toBuilder()
+            .build();
+      assertEquals(0, q2.list().size());
+
+      // use a true wildcard
+      Query q3 = qf.from(getModelFactory().getUserImplClass())
+            .having("name").like("Jo_n").toBuilder()
+            .build();
+      assertEquals(1, q3.list().size());
+
+      // use an improper wildcard
+      Query q4 = qf.from(getModelFactory().getUserImplClass())
+            .having("name").like("Jo?n").toBuilder()
+            .build();
+      assertEquals(0, q4.list().size());
+   }
 }


### PR DESCRIPTION
…wildcards

https://issues.jboss.org/browse/ISPN-6588