### PR TITLE
ISPN-6588 Query DSL 'like' queries should only accept % and _ as the …

### DIFF
--- a/object-filter/src/main/java/org/infinispan/objectfilter/impl/predicateindex/RegexCondition.java
+++ b/object-filter/src/main/java/org/infinispan/objectfilter/impl/predicateindex/RegexCondition.java
@@ -93,6 +93,8 @@ public final class RegexCondition implements Condition<String> {
                break;
 
             // regexp special characters need to be escaped
+            case '+':
+            case '*':
             case '(':
             case ')':
             case '[':

--- a/object-filter/src/test/java/org/infinispan/objectfilter/impl/predicateindex/RegexConditionTest.java
+++ b/object-filter/src/test/java/org/infinispan/objectfilter/impl/predicateindex/RegexConditionTest.java
@@ -1,0 +1,75 @@
+package org.infinispan.objectfilter.impl.predicateindex;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author anistor@redhat.com
+ * @since 9.0
+ */
+public class RegexConditionTest {
+
+   @Test
+   public void testSingleWildcard() throws Exception {
+      RegexCondition regexCondition = new RegexCondition("a_b");
+      assertTrue(regexCondition.match("aXb"));
+      assertTrue(regexCondition.match("a_b"));
+      assertTrue(regexCondition.match("a%b"));
+
+      assertFalse(regexCondition.match("ab"));
+      assertFalse(regexCondition.match("aXXb"));
+   }
+
+   @Test
+   public void testMultipleWildcard() throws Exception {
+      RegexCondition regexCondition = new RegexCondition("a%b");
+      assertTrue(regexCondition.match("ab"));
+      assertTrue(regexCondition.match("aXb"));
+      assertTrue(regexCondition.match("aXYb"));
+      assertTrue(regexCondition.match("a_b"));
+      assertTrue(regexCondition.match("a%b"));
+
+      assertFalse(regexCondition.match("a"));
+      assertFalse(regexCondition.match("aX"));
+      assertFalse(regexCondition.match("a%"));
+   }
+
+   @Test
+   public void testPlusEscaping() throws Exception {
+      RegexCondition regexCondition = new RegexCondition("a%aZ+");
+      assertTrue(regexCondition.match("aaaZ+"));
+
+      assertFalse(regexCondition.match("aaa"));
+      assertFalse(regexCondition.match("aaaZ"));
+      assertFalse(regexCondition.match("aaaZZ"));
+      assertFalse(regexCondition.match("aaaZZZ"));
+   }
+
+   @Test
+   public void testAsteriskEscaping() throws Exception {
+      RegexCondition regexCondition = new RegexCondition("a%aZ*");
+      assertTrue(regexCondition.match("aaaZ*"));
+
+      assertFalse(regexCondition.match("aaa"));
+      assertFalse(regexCondition.match("aaaZ"));
+      assertFalse(regexCondition.match("aaaZZ"));
+      assertFalse(regexCondition.match("aaaZZZ"));
+   }
+
+   @Test
+   public void testGeneralMetacharEscaping() {
+      assertTrue(new RegexCondition("a%(b").match("aaa(b"));
+      assertTrue(new RegexCondition("a%)b").match("aaa)b"));
+      assertTrue(new RegexCondition("a%[b").match("aaa[b"));
+      assertTrue(new RegexCondition("a%]b").match("aaa]b"));
+      assertTrue(new RegexCondition("a%{b").match("aaa{b"));
+      assertTrue(new RegexCondition("a%}b").match("aaa}b"));
+      assertTrue(new RegexCondition("a%$b").match("aaa$b"));
+      assertTrue(new RegexCondition("a%^b").match("aaa^b"));
+      assertTrue(new RegexCondition("a%.b").match("aaa.b"));
+      assertTrue(new RegexCondition("a%|b").match("aaa|b"));
+      assertTrue(new RegexCondition("a%\\b").match("aaa\\b"));
+   }
+}


### PR DESCRIPTION
…wildcards

* partial fix,  only for the non-indexed case

Please do not mark the issue as fixed for 8.2.x !