### PR TITLE
ISPN-6647 fix DecoratedCache.putForExternalRead with Metadata

### DIFF
--- a/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/DecoratedCache.java
@@ -148,7 +148,7 @@ public class DecoratedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> 
 
    @Override
    public void putForExternalRead(K key, V value, Metadata metadata) {
-      cacheImplementation.putForExternalRead(key, value, flags, classLoader.get());
+      cacheImplementation.putForExternalRead(key, value, metadata, flags, classLoader.get());
    }
 
    @Override


### PR DESCRIPTION
The implementation of the `putForExternalRead` method ignores the `Metadata` parameter, instead of passing it on to the `putForExternalRead` method in the cache implementation. This is no doubt because the cache implementation previously didn't support `Metadata` for `putForExternalRead`.