### PR TITLE
ISPN-6542 Subclasses of AbstractWriteKeyCommand don't marshal the Params params field

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/api/functional/Param.java
+++ b/commons/src/main/java/org/infinispan/commons/api/functional/Param.java
@@ -111,6 +111,7 @@ public interface Param<P> {
       PERSIST, SKIP;
 
       public static final int ID = ParamIds.PERSISTENCE_MODE_ID;
+      private static final PersistenceMode[] CACHED_VALUES = values();
 
       @Override
       public int id() {
@@ -127,6 +128,10 @@ public interface Param<P> {
        */
       public static PersistenceMode defaultValue() {
          return PERSIST;
+      }
+
+      public static PersistenceMode valueOf(int ordinal) {
+         return CACHED_VALUES[ordinal];
       }
    }
 

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyCommand.java
@@ -44,7 +44,7 @@ public final class ReadWriteKeyCommand<K, V, R> extends AbstractWriteKeyCommand<
       output.writeObject(key);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
       output.writeLong(Flag.copyWithoutRemotableFlags(getFlagsBitSet()));
       output.writeObject(commandInvocationId);
    }
@@ -54,7 +54,7 @@ public final class ReadWriteKeyCommand<K, V, R> extends AbstractWriteKeyCommand<
       key = input.readObject();
       f = (Function<ReadWriteEntryView<K, V>, R>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
       setFlagsBitSet(input.readLong());
       commandInvocationId = (CommandInvocationId) input.readObject();
    }

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteKeyValueCommand.java
@@ -55,7 +55,7 @@ public final class ReadWriteKeyValueCommand<K, V, R> extends AbstractWriteKeyCom
       output.writeObject(value);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
       output.writeLong(Flag.copyWithoutRemotableFlags(getFlagsBitSet()));
       output.writeObject(commandInvocationId);
       output.writeObject(prevValue);
@@ -68,7 +68,7 @@ public final class ReadWriteKeyValueCommand<K, V, R> extends AbstractWriteKeyCom
       value = (V) input.readObject();
       f = (BiFunction<V, ReadWriteEntryView<K, V>, R>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
       setFlagsBitSet(input.readLong());
       commandInvocationId = (CommandInvocationId) input.readObject();
       prevValue = (V) input.readObject();

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyCommand.java
@@ -64,7 +64,7 @@ public final class ReadWriteManyCommand<K, V, R> extends AbstractWriteManyComman
       MarshallUtil.marshallCollection(keys, output);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
    }
 
    @Override
@@ -72,7 +72,7 @@ public final class ReadWriteManyCommand<K, V, R> extends AbstractWriteManyComman
       keys = MarshallUtil.unmarshallCollection(input, size -> new HashSet<>());
       f = (Function<ReadWriteEntryView<K, V>, R>) input.readObject();
       isForwarded = input.readBoolean();
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
    }
 
    public boolean isForwarded() {

--- a/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyEntriesCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/ReadWriteManyEntriesCommand.java
@@ -63,7 +63,7 @@ public final class ReadWriteManyEntriesCommand<K, V, R> extends AbstractWriteMan
       output.writeObject(entries);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
    }
 
    @Override
@@ -71,7 +71,7 @@ public final class ReadWriteManyEntriesCommand<K, V, R> extends AbstractWriteMan
       entries = (Map<? extends K, ? extends V>) input.readObject();
       f = (BiFunction<V, ReadWriteEntryView<K, V>, R>) input.readObject();
       isForwarded = input.readBoolean();
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
    }
 
    public boolean isForwarded() {

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyCommand.java
@@ -41,7 +41,7 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K> 
       output.writeObject(key);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
       output.writeLong(Flag.copyWithoutRemotableFlags(getFlagsBitSet()));
       output.writeObject(commandInvocationId);
    }
@@ -51,7 +51,7 @@ public final class WriteOnlyKeyCommand<K, V> extends AbstractWriteKeyCommand<K> 
       key = input.readObject();
       f = (Consumer<WriteEntryView<V>>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
       setFlagsBitSet(input.readLong());
       commandInvocationId = (CommandInvocationId) input.readObject();
    }

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyValueCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyKeyValueCommand.java
@@ -45,7 +45,7 @@ public final class WriteOnlyKeyValueCommand<K, V> extends AbstractWriteKeyComman
       output.writeObject(value);
       output.writeObject(f);
       MarshallUtil.marshallEnum(valueMatcher, output);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
       output.writeLong(Flag.copyWithoutRemotableFlags(getFlagsBitSet()));
       output.writeObject(commandInvocationId);
    }
@@ -56,7 +56,7 @@ public final class WriteOnlyKeyValueCommand<K, V> extends AbstractWriteKeyComman
       value = (V) input.readObject();
       f = (BiConsumer<V, WriteEntryView<V>>) input.readObject();
       valueMatcher = MarshallUtil.unmarshallEnum(input, ValueMatcher::valueOf);
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
       setFlagsBitSet(input.readLong());
       commandInvocationId = (CommandInvocationId) input.readObject();
    }

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyCommand.java
@@ -58,7 +58,7 @@ public final class WriteOnlyManyCommand<K, V> extends AbstractWriteManyCommand<K
       MarshallUtil.marshallCollection(keys, output);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
    }
 
    @Override
@@ -66,7 +66,7 @@ public final class WriteOnlyManyCommand<K, V> extends AbstractWriteManyCommand<K
       keys = MarshallUtil.unmarshallCollectionUnbounded(input, HashSet::new);
       f = (Consumer<WriteEntryView<V>>) input.readObject();
       isForwarded = input.readBoolean();
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyEntriesCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/WriteOnlyManyEntriesCommand.java
@@ -55,7 +55,7 @@ public final class WriteOnlyManyEntriesCommand<K, V> extends AbstractWriteManyCo
       output.writeObject(entries);
       output.writeObject(f);
       output.writeBoolean(isForwarded);
-      Params.Externalizer.INSTANCE.writeObject(output, params);
+      Params.writeObject(output, params);
    }
 
    @Override
@@ -63,7 +63,7 @@ public final class WriteOnlyManyEntriesCommand<K, V> extends AbstractWriteManyCo
       entries = (Map<? extends K, ? extends V>) input.readObject();
       f = (BiConsumer<V, WriteEntryView<V>>) input.readObject();
       isForwarded = input.readBoolean();
-      params = Params.Externalizer.INSTANCE.readObject(input);
+      params = Params.readObject(input);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
+++ b/core/src/main/java/org/infinispan/marshall/core/ExternalizerTable.java
@@ -385,8 +385,6 @@ public class ExternalizerTable implements ObjectTable {
       addInternalExternalizer(new MarshallableFunctionExternalizers.LambdaWithMetasExternalizer());
       addInternalExternalizer(new MarshallableFunctionExternalizers.SetValueIfEqualsReturnBooleanExternalizer());
       addInternalExternalizer(new PersistentUUID.Externalizer());
-
-      addInternalExternalizer(Params.Externalizer.INSTANCE);
    }
 
    void addInternalExternalizer(AdvancedExternalizer<?> ext) {

--- a/core/src/main/java/org/infinispan/marshall/core/Ids.java
+++ b/core/src/main/java/org/infinispan/marshall/core/Ids.java
@@ -174,6 +174,4 @@ public interface Ids extends org.infinispan.commons.marshall.Ids {
    int AFFINITY_FUNCTION_PARTITIONER = 165;
 
    int PERSISTENT_UUID = 166;
-
-   int PARAMS = 167;
 }


### PR DESCRIPTION
* cache enum values
* replaced externalizer with static methods