### PR TITLE
ISPN-6651 Reduce WARN verbosiness due to missing netty native transport

### DIFF
--- a/server/core/src/main/scala/org/infinispan/server/core/logging/JavaLog.java
+++ b/server/core/src/main/scala/org/infinispan/server/core/logging/JavaLog.java
@@ -121,6 +121,6 @@ public interface JavaLog extends org.infinispan.util.logging.Log {
    CacheConfigurationException noSniDomainConfigured();
 
    @LogMessage(level = WARN)
-   @Message(value = "EPoll based Eventloop not available, using NIO instead", id = 5028)
-   void epollNotAvailable(@Cause Throwable error);
+   @Message(value = "Native Epoll transport not available, using NIO instead: %s", id = 5028)
+   void epollNotAvailable(String message);
 }

--- a/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
+++ b/server/core/src/main/scala/org/infinispan/server/core/logging/Log.scala
@@ -95,6 +95,6 @@ trait Log {
 
    def logCreatedNettyEventLoop(eventLoopClassName: String, configuration: String) = log.createdNettyEventLoop(eventLoopClassName, configuration)
 
-   def logEpollNotAvailable(t: Throwable) = log.epollNotAvailable(t)
+   def logEpollNotAvailable(t: Throwable) = log.epollNotAvailable(t.getMessage)
 
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6651

Output is reduced to a single line:

```
15:37:03,377 WARN  [org.infinispan.server.core.transport.NettyTransport] (MSC service thread 1-7) ISPN005028: Native EPoll transport not available, using NIO instead: /tmp/libnetty-transport-native-epoll209796259230488777.so: Error relocating /tmp/libnetty-transport-native-epoll209796259230488777.so: __strndup: symbol not found
```