### PR TITLE
Ispn 6547 revert previous fix and add new

### DIFF
--- a/cdi/common/src/main/resources/META-INF/beans.xml
+++ b/cdi/common/src/main/resources/META-INF/beans.xml
@@ -2,17 +2,15 @@
 <beans xmlns="http://java.sun.com/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:weld="http://jboss.org/schema/weld/beans"
-       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_1.xsd
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd
                            http://jboss.org/schema/weld/beans http://jboss.org/schema/weld/beans_1_1.xsd">
        <weld:scan>
-              <!-- Turn on CDI only if CDI API is available -->
-              <weld:exclude name="**" />
-              <weld:include name="org.infinispan.cdi.**">
-                     <weld:if-class-available name="javax.cache.Cache"/>
-              </weld:include>
+              <weld:exclude name="org.infinispan.cdi.**">
+                     <weld:if-class-available name="!javax.cache.Cache"/>
+              </weld:exclude>
 
-              <weld:include name="org.infinispan.jcache.**">
-                     <weld:if-class-available name="javax.cache.Cache"/>
-              </weld:include>
+              <weld:exclude name="org.infinispan.jcache.**">
+                     <weld:if-class-available name="!javax.cache.Cache"/>
+              </weld:exclude>
        </weld:scan>
 </beans>

--- a/cdi/common/src/main/resources/META-INF/beans.xml
+++ b/cdi/common/src/main/resources/META-INF/beans.xml
@@ -12,5 +12,7 @@
               <weld:exclude name="org.infinispan.jcache.**">
                      <weld:if-class-available name="!javax.cache.Cache"/>
               </weld:exclude>
+              <weld:exclude name="org.apache.logging.log4j.**" />
+              <weld:exclude name="infinispan.**" />
        </weld:scan>
 </beans>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6547

The previous fix was wrong. CDI spec says:
```
If both include filters and excludes filters are specified, only class names which match at least one include filter and don't match any exclude filter are scanned.
```

So in this case we can only play with exclusions.