### PR TITLE
ISPN-6704 Global security auth enabled required

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/AuthorizationConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AuthorizationConfigurationBuilder.java
@@ -3,11 +3,14 @@ package org.infinispan.configuration.cache;
 import static org.infinispan.configuration.cache.AuthorizationConfiguration.ENABLED;
 import static org.infinispan.configuration.cache.AuthorizationConfiguration.ROLES;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Set;
 
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * AuthorizationConfigurationBuilder.
@@ -16,6 +19,7 @@ import org.infinispan.configuration.global.GlobalConfiguration;
  * @since 7.0
  */
 public class AuthorizationConfigurationBuilder extends AbstractSecurityConfigurationChildBuilder implements Builder<AuthorizationConfiguration> {
+   private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass(), Log.class);
    private final AttributeSet attributes;
 
    public AuthorizationConfigurationBuilder(SecurityConfigurationBuilder securityBuilder) {
@@ -52,6 +56,8 @@ public class AuthorizationConfigurationBuilder extends AbstractSecurityConfigura
 
    @Override
    public void validate(GlobalConfiguration globalConfig) {
+      if (attributes.attribute(ENABLED).get() && !globalConfig.security().authorization().enabled())
+         throw log.globalSecurityAuthShouldBeEnabled();
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/configuration/cache/ConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/ConfigurationBuilder.java
@@ -225,7 +225,7 @@ public class ConfigurationBuilder implements ConfigurationChildBuilder {
       for (ConfigurationChildBuilder validatable:
             asList(clustering, customInterceptors, dataContainer, deadlockDetection, eviction, expiration, indexing,
                    invocationBatching, jmxStatistics, persistence, locking, storeAsBinary, transaction,
-                   versioning, unsafe, sites, compatibility)) {
+                   versioning, unsafe, sites, compatibility, security)) {
          validatable.validate(globalConfig);
       }
       // Modules cannot be checked with GlobalConfiguration

--- a/core/src/main/java/org/infinispan/configuration/cache/SecurityConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/SecurityConfigurationBuilder.java
@@ -23,6 +23,7 @@ public class SecurityConfigurationBuilder extends AbstractConfigurationChildBuil
 
    @Override
    public void validate(GlobalConfiguration globalConfig) {
+      authorizationBuilder.validate(globalConfig);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1419,4 +1419,8 @@ public interface Log extends BasicLogger {
 
    @Message(value = "Unable to instantiate serializer for StoreConfiguration %s", id = 413)
    CacheConfigurationException unableToInstantiateSerializer(Class<?> storeConfigurationClass);
+
+   @Message(value = "Global security authorization should be enabled if cache authorization enabled.", id = 414)
+   CacheConfigurationException globalSecurityAuthShouldBeEnabled();
+
 }

--- a/core/src/test/java/org/infinispan/security/SecurityConfigurationTest.java
+++ b/core/src/test/java/org/infinispan/security/SecurityConfigurationTest.java
@@ -1,0 +1,23 @@
+package org.infinispan.security;
+
+import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.CacheContainer;
+import org.infinispan.test.AbstractInfinispanTest;
+import org.testng.annotations.Test;
+
+import static org.infinispan.test.TestingUtil.withCacheManager;
+import static org.infinispan.test.fwk.TestCacheManagerFactory.createCacheManager;
+
+@Test(groups="functional", testName="security.SecurityConfigurationTest")
+public class SecurityConfigurationTest extends AbstractInfinispanTest {
+
+   @Test(expectedExceptions = CacheConfigurationException.class,
+         expectedExceptionsMessageRegExp = ".*ISPN000414.*")
+   public void testIncompleteConfiguration() {
+      ConfigurationBuilder builder = new ConfigurationBuilder();
+      builder.security().authorization().enable().role("reader");
+      withCacheManager(() -> createCacheManager(builder), CacheContainer::getCache);
+   }
+
+}


### PR DESCRIPTION
* When a cache has auth enabled, its global configuration also requires
  auth being enabled.