### PR TITLE
ISPN-6303 Fix ScriptEngine lookup classloader

### DIFF
--- a/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingManagerImpl.java
+++ b/scripting/src/main/java/org/infinispan/scripting/impl/ScriptingManagerImpl.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
 import javax.script.Bindings;
 import javax.script.Compilable;
 import javax.script.CompiledScript;
@@ -220,10 +221,10 @@ public class ScriptingManagerImpl implements ScriptingManager {
       ScriptEngine engine;
       if (metadata.language().isPresent()) {
          engine = scriptEnginesByLanguage.computeIfAbsent(metadata.language().get(),
-               scriptEngineManager::getEngineByName);
+               this::getEngineByName);
       } else {
          engine = scriptEnginesByExtension.computeIfAbsent(metadata.extension(),
-               scriptEngineManager::getEngineByExtension);
+               this::getEngineByExtension);
       }
       if (engine == null) {
          throw log.noEngineForScript(metadata.name());
@@ -231,4 +232,29 @@ public class ScriptingManagerImpl implements ScriptingManager {
          return engine;
       }
    }
+
+   private ScriptEngine getEngineByName(String shortName) {
+      return withClassLoader(ScriptingManagerImpl.class.getClassLoader(),
+            scriptEngineManager, shortName,
+            ScriptEngineManager::getEngineByName);
+   }
+
+   private ScriptEngine getEngineByExtension(String extension) {
+      return withClassLoader(ScriptingManagerImpl.class.getClassLoader(),
+            scriptEngineManager, extension,
+            ScriptEngineManager::getEngineByExtension);
+   }
+
+   private static ScriptEngine withClassLoader(ClassLoader cl,
+         ScriptEngineManager manager, String name,
+         BiFunction<ScriptEngineManager, String, ScriptEngine> f) {
+      ClassLoader curr = Thread.currentThread().getContextClassLoader();
+      try {
+         Thread.currentThread().setContextClassLoader(cl);
+         return f.apply(manager, name);
+      } finally {
+         Thread.currentThread().setContextClassLoader(curr);
+      }
+   }
+
 }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/task/AbstractDistributedServerTaskIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/task/AbstractDistributedServerTaskIT.java
@@ -143,7 +143,7 @@ public abstract class AbstractDistributedServerTaskIT {
     }
 
     @Test
-    @Ignore(value="Is disabled until the issue ISPN-6303 and ISPN-6173 are fixed.")
+    @Ignore(value="Is disabled until ISPN-6173 is fixed.")
     public void shouldExecuteMapReduceViaJavaScriptInTask() throws Exception {
         RemoteCache remoteCache = managers.get(1).getCache(DistributedJSExecutingServerTask.CACHE_NAME);
         remoteCache.put(1, "word1 word2 word3");


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6303

* Getting ScriptEngine instances from ScriptEngineManager results in
  class loading calls for referenced classes in script. By default it
  uses the thread context classloader. This change fixes this
  classloader to the ScriptManagerImpl one.