### PR TITLE
ISPN-6720 Don't force default testing dependencies on modules.

### DIFF
--- a/all/cli/pom.xml
+++ b/all/cli/pom.xml
@@ -27,6 +27,12 @@
       <finalName>${project.artifactId}-${project.version}</finalName>
       <plugins>
          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <skipTests>true</skipTests>
+            </configuration>
+         </plugin>
+         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
             <executions>

--- a/all/embedded-query/pom.xml
+++ b/all/embedded-query/pom.xml
@@ -39,6 +39,12 @@
       </pluginManagement>
       <plugins>
          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <skipTests>true</skipTests>
+            </configuration>
+         </plugin>
+         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
             <executions>

--- a/all/embedded/pom.xml
+++ b/all/embedded/pom.xml
@@ -148,6 +148,12 @@
       </resources>
       <plugins>
          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <skipTests>true</skipTests>
+            </configuration>
+         </plugin>
+         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
             <executions>

--- a/all/remote/pom.xml
+++ b/all/remote/pom.xml
@@ -94,6 +94,12 @@
       </resources>
       <plugins>
          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <skipTests>true</skipTests>
+            </configuration>
+         </plugin>
+         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
             <executions>

--- a/atomic-factory/pom.xml
+++ b/atomic-factory/pom.xml
@@ -37,6 +37,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
             <version>${version.javassist}</version>

--- a/cdi/common/pom.xml
+++ b/cdi/common/pom.xml
@@ -24,5 +24,16 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    
+    <build>
+       <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <skipTests>true</skipTests>
+            </configuration>
+         </plugin>
+       </plugins>
+    </build>
 
 </project>

--- a/cdi/embedded/pom.xml
+++ b/cdi/embedded/pom.xml
@@ -68,10 +68,15 @@
             <scope>test</scope>
         </dependency>
 
-
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cli/cli-client/pom.xml
+++ b/cli/cli-client/pom.xml
@@ -57,6 +57,11 @@
          <artifactId>metainf-services</artifactId>
          <optional>true</optional>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/cli/cli-interpreter/pom.xml
+++ b/cli/cli-interpreter/pom.xml
@@ -13,7 +13,7 @@
    <name>Infinispan CLI Interpreter</name>
    <description>Infinispan CLI Interpreter module</description>
 
-   
+
    <properties>
       <module.skipComponentMetaDataProcessing>false</module.skipComponentMetaDataProcessing>
    </properties>
@@ -101,6 +101,11 @@
          <groupId>org.kohsuke.metainf-services</groupId>
          <artifactId>metainf-services</artifactId>
          <optional>true</optional>
+      </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
       </dependency>
    </dependencies>
 

--- a/client/hotrod-client/pom.xml
+++ b/client/hotrod-client/pom.xml
@@ -54,13 +54,13 @@
          <artifactId>infinispan-remote-query-server</artifactId>
          <scope>test</scope>
       </dependency>
-      
+
       <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-scripting</artifactId>
          <scope>test</scope>
       </dependency>
-      
+
       <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>infinispan-scripting</artifactId>
@@ -115,6 +115,18 @@
       <dependency>
          <groupId>org.jboss.sasl</groupId>
          <artifactId>jboss-sasl</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-all</artifactId>
          <scope>test</scope>
       </dependency>
    </dependencies>

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/BulkGetKeysDistTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/BulkGetKeysDistTest.java
@@ -8,8 +8,8 @@ import org.testng.annotations.Test;
 import java.util.Set;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Tests functionality related to getting multiple entries from a HotRod server

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/MultipleCacheTopologyChangeTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/MultipleCacheTopologyChangeTest.java
@@ -19,10 +19,8 @@ import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.startHot
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 import static org.infinispan.test.TestingUtil.killCacheManagers;
 import static org.infinispan.test.fwk.TestCacheManagerFactory.createClusteredCacheManager;
-import static org.junit.Assert.assertTrue;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
 
 /**
  * @since 9.0

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteAsyncAPITest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/RemoteAsyncAPITest.java
@@ -13,7 +13,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.AssertJUnit.*;
 
 /**
  * @author Mircea.Markus@jboss.com

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerShutdownTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ServerShutdownTest.java
@@ -8,7 +8,7 @@ import org.infinispan.test.CacheManagerCallable;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.withRemoteCacheManager;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientEventsOOMTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientEventsOOMTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author anistor@redhat.com

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerWithFilterAndProtobufTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerWithFilterAndProtobufTest.java
@@ -27,9 +27,9 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNull;
 
 
 /**

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerWithFilterAndRawProtobufTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerWithFilterAndRawProtobufTest.java
@@ -27,9 +27,9 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNull;
 
 
 /**

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerWithIndexingAndProtobufTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/ClientListenerWithIndexingAndProtobufTest.java
@@ -21,10 +21,10 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
 
 
 /**

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatClientListenerWithDslFilterTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatClientListenerWithDslFilterTest.java
@@ -45,10 +45,10 @@ import java.util.concurrent.TimeUnit;
 import static org.infinispan.query.dsl.Expression.max;
 import static org.infinispan.query.dsl.Expression.param;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
 
 
 /**

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatContinuousQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatContinuousQueryTest.java
@@ -4,11 +4,7 @@ package org.infinispan.client.hotrod.event;
 import static org.infinispan.query.dsl.Expression.max;
 import static org.infinispan.query.dsl.Expression.param;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,7 +44,6 @@ import org.infinispan.util.ControlledTimeService;
 import org.infinispan.util.KeyValuePair;
 import org.infinispan.util.TimeService;
 import org.testng.annotations.Test;
-
 
 /**
  * Test remote continuous query in compat mode.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteContinuousQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteContinuousQueryTest.java
@@ -4,11 +4,7 @@ package org.infinispan.client.hotrod.event;
 import static org.infinispan.query.dsl.Expression.max;
 import static org.infinispan.query.dsl.Expression.param;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,7 +39,6 @@ import org.infinispan.util.ControlledTimeService;
 import org.infinispan.util.KeyValuePair;
 import org.infinispan.util.TimeService;
 import org.testng.annotations.Test;
-
 
 /**
  * Test remote continuous query in compat mode.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteListenerWithDslFilterTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteListenerWithDslFilterTest.java
@@ -42,10 +42,10 @@ import java.util.concurrent.TimeUnit;
 import static org.infinispan.query.dsl.Expression.max;
 import static org.infinispan.query.dsl.Expression.param;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
 
 
 /**

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/RemoteCacheImplTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/RemoteCacheImplTest.java
@@ -1,7 +1,7 @@
 package org.infinispan.client.hotrod.impl;
 
 import org.infinispan.client.hotrod.impl.protocol.CodecUtils;
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.concurrent.TimeUnit;
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
@@ -50,10 +50,10 @@ import java.util.stream.IntStream;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Tests compatibility between remote query and embedded mode.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/PrimitiveEmbeddedCompatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/PrimitiveEmbeddedCompatTest.java
@@ -16,8 +16,8 @@ import org.testng.annotations.Test;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Tests compatibility mode with primitive types.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/PrimitiveProtoStreamMarshallerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/PrimitiveProtoStreamMarshallerTest.java
@@ -14,9 +14,9 @@ import org.testng.annotations.Test;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Tests integration between HotRod client and ProtoStream marshalling library with primitive types.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ProtoStreamMarshallerTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ProtoStreamMarshallerTest.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 /**
  * Tests integration between HotRod client and ProtoStream marshalling library.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ProtoStreamMarshallerWithAnnotationsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/ProtoStreamMarshallerWithAnnotationsTest.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 /**
  * Tests integration between HotRod client and ProtoStream marshalling library.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryFileSystemTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryFileSystemTest.java
@@ -3,10 +3,11 @@ package org.infinispan.client.hotrod.query;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.test.TestingUtil;
-import org.junit.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
+
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Tests verifying the functionality of Remote queries for HotRod using FileSystem as a directory provider.
@@ -32,7 +33,7 @@ public class HotRodQueryFileSystemTest extends HotRodQueryTest {
    protected void setup() throws Exception {
       Util.recursiveFileRemove(indexDirectory);
       boolean created = new File(indexDirectory).mkdirs();
-      Assert.assertTrue(created);
+      assertTrue(created);
       super.setup();
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryTest.java
@@ -34,10 +34,7 @@ import java.util.List;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.*;
 
 /**
  * Test query via Hot Rod on a LOCAL cache.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultiHotRodServerQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultiHotRodServerQueryTest.java
@@ -26,10 +26,10 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Tests query over Hot Rod in a two-node cluster.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsFilesystemTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsFilesystemTest.java
@@ -8,7 +8,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Verifying the functionality of Remote Queries for filesystem directory provider.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
@@ -41,10 +41,10 @@ import static org.infinispan.query.dsl.Expression.min;
 import static org.infinispan.query.dsl.Expression.param;
 import static org.infinispan.query.dsl.Expression.sum;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Test for query conditions (filtering). Exercises the whole query DSL on the sample domain model.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTunedTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTunedTest.java
@@ -8,8 +8,8 @@ import org.infinispan.query.Search;
 import org.infinispan.query.remote.impl.indexing.ProtobufValueWrapper;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.assertNotNull;
 
 /**
  * Verifying that the tuned query configuration also works for Remote Queries.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryJmxTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryJmxTest.java
@@ -40,11 +40,11 @@ import java.util.Set;
 
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Testing the functionality of JMX operations for the Remote Queries.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryWithProtostreamAnnotationsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryWithProtostreamAnnotationsTest.java
@@ -24,9 +24,9 @@ import org.testng.annotations.BeforeClass;
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
 
 /**
  * Tests for remote queries over HotRod on a local cache using RAM directory.

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/RemoteQueryDslPerfTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/RemoteQueryDslPerfTest.java
@@ -35,8 +35,8 @@ import java.util.concurrent.TimeUnit;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killRemoteCacheManager;
 import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.killServers;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
 
 /**
  * Perf test for remote query. This test runs in compat mode so we can also run queries with lucene directly and compare

--- a/commons/src/test/java/org/infinispan/commons/configuration/attributes/AttributeTest.java
+++ b/commons/src/test/java/org/infinispan/commons/configuration/attributes/AttributeTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.infinispan.commons.util.TypedProperties;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class AttributeTest {

--- a/commons/src/test/java/org/infinispan/commons/io/SignedNumericTest.java
+++ b/commons/src/test/java/org/infinispan/commons/io/SignedNumericTest.java
@@ -1,12 +1,12 @@
 package org.infinispan.commons.io;
 
-import org.testng.annotations.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import static org.testng.Assert.assertEquals;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author gustavonalle

--- a/commons/src/test/java/org/infinispan/commons/util/MemoryUnitTest.java
+++ b/commons/src/test/java/org/infinispan/commons/util/MemoryUnitTest.java
@@ -1,11 +1,11 @@
 package org.infinispan.commons.util;
 
-import static org.testng.AssertJUnit.assertEquals;
-import org.testng.annotations.Test;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
-@Test(testName="commons.util.MemoryUnitTest", groups="functional")
 public class MemoryUnitTest {
 
+   @Test
    public void testMemoryUnitParser() {
       assertEquals(1000, MemoryUnit.parseBytes("1000"));
       assertEquals(1000, MemoryUnit.parseBytes("1K"));

--- a/commons/src/test/java/org/infinispan/commons/util/ServiceFinderTest.java
+++ b/commons/src/test/java/org/infinispan/commons/util/ServiceFinderTest.java
@@ -1,19 +1,19 @@
 package org.infinispan.commons.util;
 
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 import java.util.Collection;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.junit.Assert.assertEquals;
+
 
 /**
  * @author Tristan Tarrant
  * @since 9.0
  */
-
-@Test(testName = "util.ServiceFinderTest", groups = "functional")
 public class ServiceFinderTest {
 
+   @Test
    public void testDuplicateServiceFinder() {
       ClassLoader mainClassLoader = this.getClass().getClassLoader();
       ClassLoader otherClassLoader = new ClonedClassLoader(mainClassLoader);

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,6 +53,18 @@
       </dependency>
 
       <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-all</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-math</artifactId>
          <scope>test</scope>

--- a/core/src/test/java/org/infinispan/affinity/impl/BaseFilterKeyAffinityServiceTest.java
+++ b/core/src/test/java/org/infinispan/affinity/impl/BaseFilterKeyAffinityServiceTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.affinity.impl;
 
-import org.junit.Assert;
 import org.infinispan.Cache;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.remoting.transport.Address;
@@ -56,7 +55,7 @@ public abstract class BaseFilterKeyAffinityServiceTest extends BaseKeyAffinitySe
       caches.get(2).getCacheManager().stop();
       caches.remove(2);
       waitForClusterToResize();
-      Assert.assertEquals(2, caches.size());
+      assertEquals(2, caches.size());
       assertUnaffected();
    }
 
@@ -64,9 +63,9 @@ public abstract class BaseFilterKeyAffinityServiceTest extends BaseKeyAffinitySe
       log.info("**** here it starts");
       caches.get(0).getCacheManager().stop();
       caches.remove(0);
-      Assert.assertEquals(1, caches.size());
+      assertEquals(1, caches.size());
       TestingUtil.blockUntilViewsReceived(10000, false, caches.toArray(new Cache[0]));
-      Assert.assertEquals(1, topology().size());
+      assertEquals(1, topology().size());
 
       eventually(new Condition() {
          @Override

--- a/core/src/test/java/org/infinispan/affinity/impl/BaseKeyAffinityServiceTest.java
+++ b/core/src/test/java/org/infinispan/affinity/impl/BaseKeyAffinityServiceTest.java
@@ -16,9 +16,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.fail;
 
 /**
  * @author Mircea.Markus@jboss.com

--- a/core/src/test/java/org/infinispan/affinity/impl/KeyAffinityServiceShutdownTest.java
+++ b/core/src/test/java/org/infinispan/affinity/impl/KeyAffinityServiceShutdownTest.java
@@ -5,7 +5,7 @@ import org.infinispan.affinity.ListenerRegistration;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author Mircea.Markus@jboss.com
@@ -74,5 +74,5 @@ public class KeyAffinityServiceShutdownTest extends BaseKeyAffinityServiceTest {
          }
       }
       assertEquals(registered, isRegistered);
-   }   
+   }
 }

--- a/core/src/test/java/org/infinispan/affinity/impl/KeyAffinityServiceTest.java
+++ b/core/src/test/java/org/infinispan/affinity/impl/KeyAffinityServiceTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author Mircea.Markus@jboss.com

--- a/core/src/test/java/org/infinispan/api/AsyncAPITest.java
+++ b/core/src/test/java/org/infinispan/api/AsyncAPITest.java
@@ -14,7 +14,7 @@ import java.util.Collections;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 import static org.testng.AssertJUnit.assertTrue;
 
 @Test(groups = "functional", testName = "api.AsyncAPITest")

--- a/core/src/test/java/org/infinispan/api/ClearTest.java
+++ b/core/src/test/java/org/infinispan/api/ClearTest.java
@@ -13,8 +13,8 @@ import org.infinispan.util.logging.LogFactory;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Tests if clear operation actually succeeds in removing all keys from all nodes of a distributed cluster.

--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentTest.java
@@ -13,7 +13,6 @@ import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.concurrent.locks.LockManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.junit.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -27,6 +26,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Verifies the atomic semantic of Infinispan's implementations of java.util.concurrent.ConcurrentMap'
@@ -120,14 +122,14 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
       exec.shutdown();
       try {
          boolean finished = exec.awaitTermination(5, TimeUnit.MINUTES);
-         Assert.assertTrue("Test took too long", finished);
+         assertTrue("Test took too long", finished);
       } catch (InterruptedException e) {
-         Assert.fail("Thread interrupted!");
+         fail("Thread interrupted!");
       } finally {
          // Stop the worker threads so that they don't affect the following tests
          exec.shutdownNow();
       }
-      Assert.assertFalse(failureMessage, failed.get());
+      assertFalse(failureMessage, failed.get());
    }
 
    private String[] generateValidMoves() {

--- a/core/src/test/java/org/infinispan/api/SimpleCacheTest.java
+++ b/core/src/test/java/org/infinispan/api/SimpleCacheTest.java
@@ -14,7 +14,7 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.TransactionMode;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 /**

--- a/core/src/test/java/org/infinispan/atomic/BaseAtomicHashMapAPITest.java
+++ b/core/src/test/java/org/infinispan/atomic/BaseAtomicHashMapAPITest.java
@@ -12,7 +12,6 @@ import org.infinispan.transaction.TransactionMode;
 import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.concurrent.TimeoutException;
-import org.junit.Assert;
 import org.testng.annotations.Test;
 
 import javax.transaction.Transaction;
@@ -574,7 +573,7 @@ public abstract class BaseAtomicHashMapAPITest extends MultipleCacheManagersTest
       final Cache<MagicKey, Object> cache2 = cache(1, "atomic");
       testInsertDeleteCycle(new MagicKey(cache2));
    }
-   
+
    public void testInsertDeleteInsertCyclePrimaryOwner() throws Exception {
       final Cache<MagicKey, Object> cache1 = cache(0, "atomic");
       testInsertDeleteCycle(new MagicKey(cache1));
@@ -610,7 +609,7 @@ public abstract class BaseAtomicHashMapAPITest extends MultipleCacheManagersTest
          fails = am.containsKey("k1");
          TestingUtil.getTransactionManager(cache1).commit();
       }
-      Assert.assertFalse(fails);
+      assertFalse(fails);
    }
 
    public void testDuplicateValue() {

--- a/core/src/test/java/org/infinispan/atomic/LocalDeltaAwareEvictionTest.java
+++ b/core/src/test/java/org/infinispan/atomic/LocalDeltaAwareEvictionTest.java
@@ -18,7 +18,9 @@ import org.testng.annotations.Test;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author anistor@redhat.com

--- a/core/src/test/java/org/infinispan/atomic/LocalDeltaAwarePassivationTest.java
+++ b/core/src/test/java/org/infinispan/atomic/LocalDeltaAwarePassivationTest.java
@@ -11,7 +11,7 @@ import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author anistor@redhat.com

--- a/core/src/test/java/org/infinispan/atomic/ReplDeltaAwarePassivationTest.java
+++ b/core/src/test/java/org/infinispan/atomic/ReplDeltaAwarePassivationTest.java
@@ -12,8 +12,9 @@ import org.infinispan.test.fwk.CleanupAfterMethod;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
 import org.infinispan.transaction.lookup.JBossStandaloneJTAManagerLookup;
-import org.junit.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author anistor@redhat.com
@@ -47,9 +48,9 @@ public class ReplDeltaAwarePassivationTest extends ReplDeltaAwareEvictionTest {
    @Override
    protected void assertNumberOfEntries(int cacheIndex) throws Exception {
       AdvancedCacheLoader cacheStore = (AdvancedCacheLoader) TestingUtil.getCacheLoader(cache(cacheIndex));
-      Assert.assertEquals(1, PersistenceUtil.count(cacheStore, null)); // one entry in store
+      assertEquals(1, PersistenceUtil.count(cacheStore, null)); // one entry in store
 
       DataContainer dataContainer = cache(cacheIndex).getAdvancedCache().getDataContainer();
-      Assert.assertEquals(1, dataContainer.size());        // only one entry in memory (the other one was evicted)
+      assertEquals(1, dataContainer.size());        // only one entry in memory (the other one was evicted)
    }
 }

--- a/core/src/test/java/org/infinispan/commands/PutMapCommandNonTxTest.java
+++ b/core/src/test/java/org/infinispan/commands/PutMapCommandNonTxTest.java
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
 import java.util.Collections;
 import java.util.concurrent.Future;
 
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 @Test(groups = "functional", testName = "commands.PutMapCommandNonTxTest")
 @CleanupAfterMethod

--- a/core/src/test/java/org/infinispan/commands/PutMapCommandTest.java
+++ b/core/src/test/java/org/infinispan/commands/PutMapCommandTest.java
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 @Test(groups = "functional", testName = "commands.PutMapCommandTest")
 public class PutMapCommandTest extends MultipleCacheManagersTest {

--- a/core/src/test/java/org/infinispan/configuration/TxManagerLookupConfigTest.java
+++ b/core/src/test/java/org/infinispan/configuration/TxManagerLookupConfigTest.java
@@ -12,8 +12,8 @@ import org.testng.annotations.Test;
 
 import javax.transaction.TransactionManager;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 import static org.infinispan.test.TestingUtil.withCacheManager;
 
 /**

--- a/core/src/test/java/org/infinispan/configuration/module/ModuleConfigurationTest.java
+++ b/core/src/test/java/org/infinispan/configuration/module/ModuleConfigurationTest.java
@@ -2,8 +2,9 @@ package org.infinispan.configuration.module;
 
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.junit.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
 
 @Test(groups = "unit", testName = "configuration.module.ModuleConfigurationTest")
 public class ModuleConfigurationTest {
@@ -13,11 +14,11 @@ public class ModuleConfigurationTest {
       builder.addModule(MyModuleConfigurationBuilder.class).attribute("testValue");
 
       Configuration configuration = builder.build();
-      Assert.assertEquals(configuration.module(MyModuleConfiguration.class).attribute(), "testValue");
+      assertEquals(configuration.module(MyModuleConfiguration.class).attribute(), "testValue");
 
       ConfigurationBuilder secondBuilder = new ConfigurationBuilder();
       secondBuilder.read(configuration);
       Configuration secondConfiguration = secondBuilder.build();
-      Assert.assertEquals(secondConfiguration.module(MyModuleConfiguration.class).attribute(), "testValue");
+      assertEquals(secondConfiguration.module(MyModuleConfiguration.class).attribute(), "testValue");
    }
 }

--- a/core/src/test/java/org/infinispan/configuration/override/XMLConfigurationOverridingTest.java
+++ b/core/src/test/java/org/infinispan/configuration/override/XMLConfigurationOverridingTest.java
@@ -5,7 +5,6 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.context.Flag;
 import org.infinispan.distribution.MagicKey;
 import org.infinispan.interceptors.DDAsyncInterceptor;
-import org.junit.Assert;
 import org.infinispan.Cache;
 import org.infinispan.commands.write.PutKeyValueCommand;
 import org.infinispan.configuration.cache.CacheMode;
@@ -32,8 +31,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.infinispan.test.TestingUtil.waitForRehashToComplete;
 import static org.infinispan.test.TestingUtil.withCacheManager;
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.*;
 
 /**
  * Tests verifying that the overriding of the configuration which is read from the configuration XML file is done
@@ -56,21 +54,21 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
       withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.fromXml("configs/named-cache-override-test.xml")) {
          @Override
          public void call() {
-            Assert.assertEquals(EvictionStrategy.NONE, cm.getCacheConfiguration(simpleCacheName).eviction().strategy());
+            assertEquals(EvictionStrategy.NONE, cm.getCacheConfiguration(simpleCacheName).eviction().strategy());
 
             Configuration newConfig = new ConfigurationBuilder().eviction().strategy(EvictionStrategy.LRU)
                   .size(5).build();
 
             cm.defineConfiguration(simpleCacheName, newConfig);
 
-            Assert.assertEquals(EvictionStrategy.LRU, cm.getCacheConfiguration(simpleCacheName).eviction().strategy());
-            Assert.assertEquals(5, cm.getCacheConfiguration(simpleCacheName).eviction().maxEntries());
+            assertEquals(EvictionStrategy.LRU, cm.getCacheConfiguration(simpleCacheName).eviction().strategy());
+            assertEquals(5, cm.getCacheConfiguration(simpleCacheName).eviction().maxEntries());
 
             for(int i = 0; i < 10; i++) {
                cm.getCache(simpleCacheName).put("test" + i, "value" + i);
             }
 
-            Assert.assertTrue(cm.getCache(simpleCacheName).size() <= 5);
+            assertTrue(cm.getCache(simpleCacheName).size() <= 5);
          }
       });
    }
@@ -79,22 +77,22 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
       withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.fromXml("configs/named-cache-override-test.xml")) {
          @Override
          public void call() {
-            Assert.assertEquals(EvictionStrategy.LRU, cm.getCacheConfiguration(localCacheWithEviction).eviction().strategy());
-            Assert.assertEquals(10, cm.getCacheConfiguration(localCacheWithEviction).eviction().maxEntries());
+            assertEquals(EvictionStrategy.LRU, cm.getCacheConfiguration(localCacheWithEviction).eviction().strategy());
+            assertEquals(10, cm.getCacheConfiguration(localCacheWithEviction).eviction().maxEntries());
 
             Configuration newConfig = new ConfigurationBuilder().eviction().strategy(EvictionStrategy.LIRS)
                   .maxEntries(20).build();
 
             cm.defineConfiguration(localCacheWithEviction, newConfig);
 
-            Assert.assertEquals(EvictionStrategy.LIRS, cm.getCacheConfiguration(localCacheWithEviction).eviction().strategy());
-            Assert.assertEquals(20, cm.getCacheConfiguration(localCacheWithEviction).eviction().maxEntries());
+            assertEquals(EvictionStrategy.LIRS, cm.getCacheConfiguration(localCacheWithEviction).eviction().strategy());
+            assertEquals(20, cm.getCacheConfiguration(localCacheWithEviction).eviction().maxEntries());
 
             for(int i = 0; i < 30; i++) {
                cm.getCache(localCacheWithEviction).put("test" + i, "value" + i);
             }
 
-            Assert.assertTrue(cm.getCache(localCacheWithEviction).size() <= 20 && cm.getCache(localCacheWithEviction).size() > 10);
+            assertTrue(cm.getCache(localCacheWithEviction).size() <= 20 && cm.getCache(localCacheWithEviction).size() > 10);
          }
       });
    }
@@ -103,17 +101,17 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
       withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.fromXml("configs/named-cache-override-test.xml")) {
          @Override
          public void call() {
-            Assert.assertEquals(10000, cm.getCacheConfiguration(localCacheWithEviction).expiration().lifespan());
-            Assert.assertEquals(60000, cm.getCacheConfiguration(localCacheWithEviction).expiration().wakeUpInterval());
-            Assert.assertEquals(-1, cm.getCacheConfiguration(localCacheWithEviction).expiration().maxIdle());
+            assertEquals(10000, cm.getCacheConfiguration(localCacheWithEviction).expiration().lifespan());
+            assertEquals(60000, cm.getCacheConfiguration(localCacheWithEviction).expiration().wakeUpInterval());
+            assertEquals(-1, cm.getCacheConfiguration(localCacheWithEviction).expiration().maxIdle());
 
             Configuration newConfig = new ConfigurationBuilder().expiration().lifespan(5000).wakeUpInterval(1000).maxIdle(2000).build();
 
             cm.defineConfiguration(localCacheWithEviction, newConfig);
 
-            Assert.assertEquals(5000, cm.getCacheConfiguration(localCacheWithEviction).expiration().lifespan());
-            Assert.assertEquals(2000, cm.getCacheConfiguration(localCacheWithEviction).expiration().maxIdle());
-            Assert.assertEquals(1000, cm.getCacheConfiguration(localCacheWithEviction).expiration().wakeUpInterval());
+            assertEquals(5000, cm.getCacheConfiguration(localCacheWithEviction).expiration().lifespan());
+            assertEquals(2000, cm.getCacheConfiguration(localCacheWithEviction).expiration().maxIdle());
+            assertEquals(1000, cm.getCacheConfiguration(localCacheWithEviction).expiration().wakeUpInterval());
          }
       });
    }
@@ -122,12 +120,12 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
       withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.fromXml("configs/named-cache-override-test.xml")) {
          @Override
          public void call() throws Exception {
-            Assert.assertEquals(CacheMode.LOCAL, cm.getCacheConfiguration(simpleCacheName).clustering().cacheMode());
+            assertEquals(CacheMode.LOCAL, cm.getCacheConfiguration(simpleCacheName).clustering().cacheMode());
 
             Configuration newConfig = new ConfigurationBuilder().clustering().cacheMode(CacheMode.REPL_SYNC).build();
             cm.defineConfiguration(simpleCacheName, newConfig);
 
-            Assert.assertEquals(CacheMode.REPL_SYNC, cm.getCacheConfiguration(simpleCacheName).clustering().cacheMode());
+            assertEquals(CacheMode.REPL_SYNC, cm.getCacheConfiguration(simpleCacheName).clustering().cacheMode());
 
             for(int i = 0; i < 10; i++) {
                cm.getCache(simpleCacheName).put("test" + i, "value" + i);
@@ -155,12 +153,12 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
       withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.fromXml("configs/named-cache-override-test.xml")) {
          @Override
          public void call() {
-            Assert.assertEquals(CacheMode.REPL_SYNC, cm.getCacheConfiguration(replSync).clustering().cacheMode());
+            assertEquals(CacheMode.REPL_SYNC, cm.getCacheConfiguration(replSync).clustering().cacheMode());
 
             Configuration newConfig = new ConfigurationBuilder().clustering().cacheMode(CacheMode.LOCAL).build();
             cm.defineConfiguration(replSync, newConfig);
 
-            Assert.assertEquals(CacheMode.LOCAL, cm.getCacheConfiguration(replSync).clustering().cacheMode());
+            assertEquals(CacheMode.LOCAL, cm.getCacheConfiguration(replSync).clustering().cacheMode());
 
             for(int i = 0; i < 10; i++) {
                cm.getCache(replSync).put("test" + i, "value" + i);
@@ -171,7 +169,7 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
                cm1 = TestCacheManagerFactory.createClusteredCacheManager();
 
                cm1.defineConfiguration(replSync, newConfig);
-               Assert.assertTrue(cm1.getCache(replSync).isEmpty());
+               assertTrue(cm1.getCache(replSync).isEmpty());
             } finally {
                TestingUtil.killCacheManagers(cm1);
             }
@@ -183,14 +181,14 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
       withCacheManager(new CacheManagerCallable(TestCacheManagerFactory.fromXml("configs/named-cache-override-test.xml")) {
          @Override
          public void call() {
-            Assert.assertFalse(cm.getCacheConfiguration(replSync).jmxStatistics().enabled());
+            assertFalse(cm.getCacheConfiguration(replSync).jmxStatistics().enabled());
 
             Configuration conf = new ConfigurationBuilder().jmxStatistics().enable().build();
 
             cm.defineConfiguration(replSync, conf);
 
-            Assert.assertEquals(CacheMode.REPL_SYNC, cm.getCacheConfiguration(replSync).clustering().cacheMode());
-            Assert.assertTrue(cm.getCacheConfiguration(replSync).jmxStatistics().enabled());
+            assertEquals(CacheMode.REPL_SYNC, cm.getCacheConfiguration(replSync).clustering().cacheMode());
+            assertTrue(cm.getCacheConfiguration(replSync).jmxStatistics().enabled());
          }
       });
    }
@@ -202,7 +200,7 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
          @Override
          public void call() {
             Configuration configuration = cm.getCacheConfiguration(simpleCacheName);
-            Assert.assertFalse(configuration.jmxStatistics().enabled());
+            assertFalse(configuration.jmxStatistics().enabled());
 
             Configuration conf = new ConfigurationBuilder().eviction().maxEntries(5).strategy(EvictionStrategy.LRU)
                   .persistence().passivation(true).addSingleFileStore().location(tmpDir + "/testOverrideLoaders").build();
@@ -210,17 +208,17 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
             cm.defineConfiguration(simpleCacheName, conf);
 
             configuration = cm.getCacheConfiguration(simpleCacheName);
-            Assert.assertEquals(CacheMode.LOCAL, configuration.clustering().cacheMode());
-            Assert.assertTrue(configuration.persistence().passivation());
+            assertEquals(CacheMode.LOCAL, configuration.clustering().cacheMode());
+            assertTrue(configuration.persistence().passivation());
 
             Cache cache = cm.getCache(simpleCacheName);
             for (int i = 0; i < 10; i++) {
                cache.put("key" + i, "value" + i);
             }
 
-            Assert.assertTrue(cache.getAdvancedCache().getDataContainer().size() <= 5);
+            assertTrue(cache.getAdvancedCache().getDataContainer().size() <= 5);
             for (int i = 0; i < 10; i++) {
-               Assert.assertEquals(cache.get("key" + i), "value" + i);
+               assertEquals(cache.get("key" + i), "value" + i);
             }
          }
       });
@@ -234,8 +232,8 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
          @Override
          public void call() throws Exception {
             Configuration cnf = cm.getCacheConfiguration(simpleNonTransactionalCache);
-            Assert.assertEquals(TransactionMode.NON_TRANSACTIONAL, cnf.transaction().transactionMode());
-            Assert.assertEquals(100, cnf.locking().concurrencyLevel());
+            assertEquals(TransactionMode.NON_TRANSACTIONAL, cnf.transaction().transactionMode());
+            assertEquals(100, cnf.locking().concurrencyLevel());
 
             Configuration conf = new ConfigurationBuilder().transaction().transactionMode(TransactionMode.TRANSACTIONAL)
                   .jmxStatistics().enable().locking().concurrencyLevel(1).build();
@@ -243,9 +241,9 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
             cm.defineConfiguration(simpleNonTransactionalCache, conf);
 
             cnf = cm.getCacheConfiguration(simpleNonTransactionalCache);
-            Assert.assertEquals(TransactionMode.TRANSACTIONAL, cnf.transaction().transactionMode());
-            Assert.assertTrue(cnf.jmxStatistics().enabled());
-            Assert.assertEquals(1, cnf.locking().concurrencyLevel());
+            assertEquals(TransactionMode.TRANSACTIONAL, cnf.transaction().transactionMode());
+            assertTrue(cnf.jmxStatistics().enabled());
+            assertEquals(1, cnf.locking().concurrencyLevel());
 
             TransactionManager tm = cm.getCache(simpleNonTransactionalCache).getAdvancedCache().getTransactionManager();
 
@@ -257,7 +255,7 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
             tm.commit();
 
             for (int i = 0; i < 10; i++) {
-               Assert.assertNotNull(cm.getCache(simpleNonTransactionalCache).get("key" + i));
+               assertNotNull(cm.getCache(simpleNonTransactionalCache).get("key" + i));
             }
          }
       });
@@ -268,7 +266,7 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
          @Override
          public void call() {
             Configuration cnf = cm.getCacheConfiguration(simpleTransactionalCache);
-            Assert.assertEquals(TransactionMode.TRANSACTIONAL, cnf.transaction().transactionMode());
+            assertEquals(TransactionMode.TRANSACTIONAL, cnf.transaction().transactionMode());
 
             Configuration conf = new ConfigurationBuilder().transaction().transactionMode(TransactionMode.NON_TRANSACTIONAL)
                   .build();
@@ -276,16 +274,16 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
             cm.defineConfiguration(simpleTransactionalCache, conf);
 
             cnf = cm.getCacheConfiguration(simpleTransactionalCache);
-            Assert.assertEquals(TransactionMode.NON_TRANSACTIONAL, cnf.transaction().transactionMode());
+            assertEquals(TransactionMode.NON_TRANSACTIONAL, cnf.transaction().transactionMode());
 
             TransactionManager tm = cm.getCache(simpleTransactionalCache).getAdvancedCache().getTransactionManager();
-            Assert.assertNull(tm);
+            assertNull(tm);
             for (int i = 0; i < 10; i++) {
                cm.getCache(simpleTransactionalCache).put("key" + i, "value" + i);
             }
 
             for (int i = 0; i < 10; i++) {
-               Assert.assertNotNull(cm.getCache(simpleTransactionalCache).get("key" + i));
+               assertNotNull(cm.getCache(simpleTransactionalCache).get("key" + i));
             }
          }
       });
@@ -296,15 +294,15 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
          @Override
          public void call() {
             Configuration cnf = cm.getCacheConfiguration(simpleCacheName);
-            Assert.assertFalse(cnf.storeAsBinary().enabled());
+            assertFalse(cnf.storeAsBinary().enabled());
 
             Configuration conf = new ConfigurationBuilder().storeAsBinary().enable().defensive(true).build();
 
             cm.defineConfiguration(simpleCacheName, conf);
 
             cnf = cm.getCacheConfiguration(simpleCacheName);
-            Assert.assertTrue(cnf.storeAsBinary().enabled());
-            Assert.assertTrue(cnf.storeAsBinary().storeValuesAsBinary());
+            assertTrue(cnf.storeAsBinary().enabled());
+            assertTrue(cnf.storeAsBinary().storeValuesAsBinary());
 
             List<NonIndexedClass> instances = new ArrayList<NonIndexedClass>();
             for (int i = 0; i < 10; i++) {
@@ -320,7 +318,7 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
 
             //Verifying that the entry in the cache is not changed.
             for (int i = 0; i < 10; i++) {
-               Assert.assertEquals(new NonIndexedClass("value" + i), cm.getCache(simpleCacheName).get("key" + i));
+               assertEquals(new NonIndexedClass("value" + i), cm.getCache(simpleCacheName).get("key" + i));
             }
          }
       });
@@ -331,16 +329,16 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
          @Override
          public void call() throws Exception {
             Configuration cnf = cm.getCacheConfiguration(distCacheToChange);
-            Assert.assertEquals(CacheMode.DIST_SYNC, cnf.clustering().cacheMode());
-            Assert.assertEquals(2, cnf.clustering().hash().numOwners());
+            assertEquals(CacheMode.DIST_SYNC, cnf.clustering().cacheMode());
+            assertEquals(2, cnf.clustering().hash().numOwners());
 
             Configuration conf = new ConfigurationBuilder().clustering().cacheMode(CacheMode.DIST_SYNC).hash().numOwners(1).build();
 
             cm.defineConfiguration(distCacheToChange, conf);
 
             cnf = cm.getCacheConfiguration(distCacheToChange);
-            Assert.assertEquals(CacheMode.DIST_SYNC, cnf.clustering().cacheMode());
-            Assert.assertEquals(1, cnf.clustering().hash().numOwners());
+            assertEquals(CacheMode.DIST_SYNC, cnf.clustering().cacheMode());
+            assertEquals(1, cnf.clustering().hash().numOwners());
 
             AdvancedCache cache1 = cm.getCache(distCacheToChange).getAdvancedCache();
             for (int i = 0; i < 10; i++) {
@@ -371,15 +369,15 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
          @Override
          public void call() throws Exception {
             Configuration cnf = cm.getCacheConfiguration(distCacheToChange);
-            Assert.assertEquals(CacheMode.DIST_SYNC, cnf.clustering().cacheMode());
-            Assert.assertEquals(2, cnf.clustering().hash().numOwners());
+            assertEquals(CacheMode.DIST_SYNC, cnf.clustering().cacheMode());
+            assertEquals(2, cnf.clustering().hash().numOwners());
 
             Configuration conf = new ConfigurationBuilder().clustering().cacheMode(CacheMode.DIST_ASYNC).build();
 
             cm.defineConfiguration(distCacheToChange, conf);
 
             cnf = cm.getCacheConfiguration(distCacheToChange);
-            Assert.assertEquals(CacheMode.DIST_ASYNC, cnf.clustering().cacheMode());
+            assertEquals(CacheMode.DIST_ASYNC, cnf.clustering().cacheMode());
 
             EmbeddedCacheManager cm1 = null;
             try {
@@ -413,14 +411,14 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
          @Override
          public void call() throws Exception {
             Configuration cnf = cm.getCacheConfiguration(replAsync);
-            Assert.assertEquals(CacheMode.REPL_ASYNC, cnf.clustering().cacheMode());
+            assertEquals(CacheMode.REPL_ASYNC, cnf.clustering().cacheMode());
 
             Configuration conf = new ConfigurationBuilder().clustering().cacheMode(CacheMode.REPL_SYNC).build();
 
             cm.defineConfiguration(replAsync, conf);
 
             cnf = cm.getCacheConfiguration(replAsync);
-            Assert.assertEquals(CacheMode.REPL_SYNC, cnf.clustering().cacheMode());
+            assertEquals(CacheMode.REPL_SYNC, cnf.clustering().cacheMode());
 
             EmbeddedCacheManager cm1 = null;
             try {
@@ -448,7 +446,7 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
          @Override
          public void call() {
             Configuration cnf = cm.getCacheConfiguration(simpleCacheName);
-            Assert.assertTrue(cnf.customInterceptors().interceptors().isEmpty());
+            assertTrue(cnf.customInterceptors().interceptors().isEmpty());
 
             SimpleInterceptor interceptor = new SimpleInterceptor();
             Configuration conf = new ConfigurationBuilder().customInterceptors().addInterceptor().interceptor(interceptor)
@@ -457,13 +455,13 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest imple
             cm.defineConfiguration(simpleCacheName, conf);
 
             cnf = cm.getCacheConfiguration(simpleCacheName);
-            Assert.assertFalse(cnf.customInterceptors().interceptors().isEmpty());
+            assertFalse(cnf.customInterceptors().interceptors().isEmpty());
 
-            Assert.assertFalse(interceptor.putOkay);
+            assertFalse(interceptor.putOkay);
             cm.getCache(simpleCacheName).put("key1", "value1");
 
-            Assert.assertTrue(interceptor.putOkay);
-            Assert.assertEquals("value1", cm.getCache(simpleCacheName).get("key1"));
+            assertTrue(interceptor.putOkay);
+            assertEquals("value1", cm.getCache(simpleCacheName).get("key1"));
          }
       });
    }

--- a/core/src/test/java/org/infinispan/container/versioning/TransactionalLocalWriteSkewTest.java
+++ b/core/src/test/java/org/infinispan/container/versioning/TransactionalLocalWriteSkewTest.java
@@ -17,8 +17,8 @@ import javax.transaction.TransactionManager;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Future;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 @Test(groups = "functional", testName = "container.versioning.TransactionalLocalWriteSkewTest")
 public class TransactionalLocalWriteSkewTest extends SingleCacheManagerTest {

--- a/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
+++ b/core/src/test/java/org/infinispan/distribution/BaseDistSyncL1Test.java
@@ -16,7 +16,6 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.CheckPoint;
 import org.infinispan.transaction.TransactionMode;
 import org.infinispan.util.concurrent.IsolationLevel;
-import org.junit.Assert;
 import org.mockito.AdditionalAnswers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -34,9 +33,7 @@ import java.util.concurrent.TimeoutException;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertNotNull;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.*;
 
 /**
  * Base class for various L1 tests for use with distributed cache.  Note these only currently work for synchronous based
@@ -332,14 +329,14 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
          // Wait until get goes remote and retrieves value before going back into L1 interceptor
          getBarrier.await(10, TimeUnit.SECONDS);
 
-         Assert.assertEquals(firstValue, ownerCache.put(key, secondValue));
+         assertEquals(firstValue, ownerCache.put(key, secondValue));
 
          // Let the get complete finally
          getBarrier.await(10, TimeUnit.SECONDS);
 
          final String expectedValue;
          expectedValue = firstValue;
-         Assert.assertEquals(expectedValue, future.get(10, TimeUnit.SECONDS));
+         assertEquals(expectedValue, future.get(10, TimeUnit.SECONDS));
 
          assertIsNotInL1(nonOwnerCache, key);
       } finally {
@@ -374,9 +371,9 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
       // Let the get complete finally
       checkPoint.triggerForever("pre_acquire_shared_topology_lock_released");
 
-      Assert.assertEquals(firstValue, getFuture.get(10, TimeUnit.SECONDS));
+      assertEquals(firstValue, getFuture.get(10, TimeUnit.SECONDS));
 
-      Assert.assertEquals(firstValue, putFuture.get(10, TimeUnit.SECONDS));
+      assertEquals(firstValue, putFuture.get(10, TimeUnit.SECONDS));
 
       assertIsNotInL1(nonOwnerCache, key);
    }
@@ -408,9 +405,9 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
          // Let the get complete finally
          checkPoint.triggerForever("pre_acquire_shared_topology_lock_released");
 
-         Assert.assertEquals(firstValue, getFuture.get(10, TimeUnit.SECONDS));
+         assertEquals(firstValue, getFuture.get(10, TimeUnit.SECONDS));
 
-         Assert.assertEquals(firstValue, getFuture2.get(10, TimeUnit.SECONDS));
+         assertEquals(firstValue, getFuture2.get(10, TimeUnit.SECONDS));
 
          assertIsInL1(nonOwnerCache, key);
       } finally {
@@ -443,9 +440,9 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
          // Let the get complete finally
          checkPoint.triggerForever("pre_acquire_shared_topology_lock_released");
 
-         Assert.assertNull(getFuture.get(10, TimeUnit.SECONDS));
+         assertNull(getFuture.get(10, TimeUnit.SECONDS));
 
-         Assert.assertNull(getFuture2.get(10, TimeUnit.SECONDS));
+         assertNull(getFuture2.get(10, TimeUnit.SECONDS));
       } finally {
          TestingUtil.replaceComponent(nonOwnerCache, L1Manager.class, l1Manager, true);
       }
@@ -477,9 +474,9 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
       // Let the get complete finally
       checkPoint.triggerForever("pre_acquire_shared_topology_lock_released");
 
-      Assert.assertEquals(firstValue, getFuture.get(10, TimeUnit.SECONDS));
+      assertEquals(firstValue, getFuture.get(10, TimeUnit.SECONDS));
 
-      Assert.assertEquals(firstValue, putFuture.get(10, TimeUnit.SECONDS));
+      assertEquals(firstValue, putFuture.get(10, TimeUnit.SECONDS));
 
       if (nonOwnerCache.getCacheConfiguration().transaction().transactionMode() == TransactionMode.TRANSACTIONAL) {
          assertIsInL1(nonOwnerCache, key);
@@ -496,13 +493,13 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
 
       ownerCache.put(key, firstValue);
 
-      Assert.assertEquals(firstValue, nonOwnerCache.get(key));
+      assertEquals(firstValue, nonOwnerCache.get(key));
 
       assertIsInL1(nonOwnerCache, key);
 
       CacheEntry<Object, String> entry = nonOwnerCache.getAdvancedCache().getCacheEntry(key);
-      Assert.assertEquals(key, entry.getKey());
-      Assert.assertEquals(firstValue, entry.getValue());
+      assertEquals(key, entry.getKey());
+      assertEquals(firstValue, entry.getValue());
    }
 
    @Test
@@ -532,11 +529,11 @@ public abstract class BaseDistSyncL1Test extends BaseDistFunctionalTest<Object, 
          // Let the get complete finally
          checkPoint.triggerForever("pre_acquire_shared_topology_lock_released");
 
-         Assert.assertEquals(firstValue, getFuture.get(10, TimeUnit.SECONDS));
+         assertEquals(firstValue, getFuture.get(10, TimeUnit.SECONDS));
 
          CacheEntry<Object, String> entry = getFuture2.get(10, TimeUnit.SECONDS);
-         Assert.assertEquals(key, entry.getKey());
-         Assert.assertEquals(firstValue, entry.getValue());
+         assertEquals(key, entry.getKey());
+         assertEquals(firstValue, entry.getValue());
 
          assertIsInL1(nonOwnerCache, key);
       } finally {

--- a/core/src/test/java/org/infinispan/distribution/DistSyncL1FuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncL1FuncTest.java
@@ -20,8 +20,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
 
 @Test(groups = {"functional", "smoke"}, testName = "distribution.DistSyncL1FuncTest")
 public class DistSyncL1FuncTest extends BaseDistSyncL1Test {

--- a/core/src/test/java/org/infinispan/distribution/DistSyncL1PassivationFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncL1PassivationFuncTest.java
@@ -13,8 +13,8 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 @Test(groups = "functional", testName = "distribution.DistSyncL1PassivationFuncTest")
 public class DistSyncL1PassivationFuncTest extends BaseDistFunctionalTest {

--- a/core/src/test/java/org/infinispan/distribution/DistSyncTxL1FuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/DistSyncTxL1FuncTest.java
@@ -36,8 +36,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyCollection;
 import static org.mockito.Mockito.doAnswer;

--- a/core/src/test/java/org/infinispan/distribution/UnicastInvalidationFuncTest.java
+++ b/core/src/test/java/org/infinispan/distribution/UnicastInvalidationFuncTest.java
@@ -9,12 +9,12 @@ import org.infinispan.test.ReplListener;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
 
 @Test(groups = "functional", testName = "distribution.UnicastInvalidationFuncTest")
 public class UnicastInvalidationFuncTest extends BaseDistFunctionalTest<Object, String> {
-   
+
    public static final String KEY1 = "k1";
 
    public UnicastInvalidationFuncTest() {
@@ -30,17 +30,17 @@ public class UnicastInvalidationFuncTest extends BaseDistFunctionalTest<Object, 
       Cache<Object, String> owner = getOwners(KEY1)[0];
       Cache<Object, String> secondNonOwner = getSecondNonOwner(KEY1);
       Collection<ReplListener> listeners = new ArrayList<ReplListener>();
-      
+
       // Put an object in from a non-owner, this will cause an L1 record to be created there
-      
+
       nonOwner.put(KEY1, "foo");
       assertNull(nonOwner.getAdvancedCache().getDataContainer().get(KEY1));
       assertEquals(owner.getAdvancedCache().getDataContainer().get(KEY1).getValue(), "foo");
-      
+
       // Request from another non-owner so that we can get an invalidation command there
       assertEquals(secondNonOwner.get(KEY1), "foo");
       assertEquals(secondNonOwner.getAdvancedCache().getDataContainer().get(KEY1).getValue(), "foo");
-      
+
       // Check that the non owners are notified
       ReplListener rl = new ReplListener(nonOwner);
       rl.expect(InvalidateL1Command.class);
@@ -48,18 +48,18 @@ public class UnicastInvalidationFuncTest extends BaseDistFunctionalTest<Object, 
       rl = new ReplListener(secondNonOwner);
       rl.expect(InvalidateL1Command.class);
       listeners.add(rl);
-      
+
       // Put an object into an owner, this will cause the L1 records for this key to be invalidated
       owner.put(KEY1, "bar");
-      
+
       for (ReplListener r : listeners) {
          r.waitForRpc();
       }
-      
+
       Assert.assertNull(secondNonOwner.getAdvancedCache().getDataContainer().get(KEY1));
       Assert.assertNull(nonOwner.getAdvancedCache().getDataContainer().get(KEY1));
-      
-      
+
+
    }
-   
+
 }

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashAfterJoinWithPreloadTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashAfterJoinWithPreloadTest.java
@@ -18,7 +18,7 @@ import org.testng.annotations.Test;
 
 import java.util.Set;
 
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Test with a distributed cache (numOwners=1), a shared cache store and 'preload' enabled

--- a/core/src/test/java/org/infinispan/distribution/rehash/SharedStoreInvalidationDuringRehashTest.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/SharedStoreInvalidationDuringRehashTest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 

--- a/core/src/test/java/org/infinispan/eviction/impl/EvictionDuringBatchTest.java
+++ b/core/src/test/java/org/infinispan/eviction/impl/EvictionDuringBatchTest.java
@@ -11,8 +11,8 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author Mircea Markus

--- a/core/src/test/java/org/infinispan/functional/FunctionalListenersTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalListenersTest.java
@@ -20,8 +20,8 @@ import java.util.function.Supplier;
 
 import static org.infinispan.functional.FunctionalTestUtils.*;
 import static org.infinispan.commons.marshall.MarshallableFunctions.*;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 
 /**

--- a/core/src/test/java/org/infinispan/interceptors/distribution/L1WriteSynchronizerTest.java
+++ b/core/src/test/java/org/infinispan/interceptors/distribution/L1WriteSynchronizerTest.java
@@ -18,7 +18,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/core/src/test/java/org/infinispan/lock/InvalidationModePessimisticLockReleaseTest.java
+++ b/core/src/test/java/org/infinispan/lock/InvalidationModePessimisticLockReleaseTest.java
@@ -9,8 +9,8 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.Callable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
 
 /**
  * Test for stale remote locks on invalidation mode caches with pessimistic transactions.

--- a/core/src/test/java/org/infinispan/lock/L1LockTest.java
+++ b/core/src/test/java/org/infinispan/lock/L1LockTest.java
@@ -6,7 +6,7 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author Mircea Markus <mircea.markus@jboss.com> (C) 2011 Red Hat Inc.

--- a/core/src/test/java/org/infinispan/lock/singlelock/MainOwnerChangesPessimisticLockTest.java
+++ b/core/src/test/java/org/infinispan/lock/singlelock/MainOwnerChangesPessimisticLockTest.java
@@ -15,7 +15,7 @@ import javax.transaction.Transaction;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Main owner changes due to state transfer in a distributed cluster using pessimistic locking.

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CustomClassLoaderListenerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CustomClassLoaderListenerTest.java
@@ -23,7 +23,7 @@ import org.infinispan.notifications.cachelistener.event.CacheEntryVisitedEvent;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * CustomClassLoaderListenerTest.

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerFilterWithDependenciesTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerFilterWithDependenciesTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 
 /**

--- a/core/src/test/java/org/infinispan/persistence/BaseStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/BaseStoreFunctionalTest.java
@@ -1,6 +1,6 @@
 package org.infinispan.persistence;
 
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;

--- a/core/src/test/java/org/infinispan/persistence/MultiStoresFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/MultiStoresFunctionalTest.java
@@ -2,7 +2,7 @@ package org.infinispan.persistence;
 
 import static org.infinispan.test.TestingUtil.withCacheManager;
 import static org.infinispan.test.TestingUtil.withCacheManagers;
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 
 /**
  * This is a base functional test class for tests with multiple cache stores
- * 
+ *
  * @author Michal Linhard (mlinhard@redhat.com)
  */
 @Test(groups = "unit", testName = "persistence.MultiStoresFunctionalTest")
@@ -34,7 +34,7 @@ public abstract class MultiStoresFunctionalTest<TStoreConfigurationBuilder exten
    protected abstract TStoreConfigurationBuilder buildCacheStoreConfig(PersistenceConfigurationBuilder builder, String discriminator) throws Exception;
 
    /**
-    * 
+    *
     * Create n configs using cache store. sets passivation = false, purge = false, fetch persistent
     * state = true
     */

--- a/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/persistence/file/SingleFileStoreFunctionalTest.java
@@ -16,7 +16,7 @@ import java.io.File;
 import java.io.InputStream;
 
 import static org.infinispan.test.TestingUtil.*;
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Single file cache store functional test.

--- a/core/src/test/java/org/infinispan/remoting/NonExistentCacheTest.java
+++ b/core/src/test/java/org/infinispan/remoting/NonExistentCacheTest.java
@@ -12,7 +12,7 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.TransactionMode;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 @Test (testName = "remoting.NonExistentCacheTest", groups = "functional")
 public class NonExistentCacheTest extends AbstractInfinispanTest {

--- a/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerCustomReplicableCommandTest.java
+++ b/core/src/test/java/org/infinispan/remoting/rpc/RpcManagerCustomReplicableCommandTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 /**
  * @author William Burns

--- a/core/src/test/java/org/infinispan/statetransfer/DistStateTransferOnJoinConsistencyTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/DistStateTransferOnJoinConsistencyTest.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 /**
  * Test for ISPN-2362 and ISPN-2502 in distributed mode. Uses a cluster which initially has 2 nodes

--- a/core/src/test/java/org/infinispan/statetransfer/DistStateTransferOnLeaveConsistencyTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/DistStateTransferOnLeaveConsistencyTest.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 /**
  * Test for ISPN-2362 and ISPN-2502 in distributed mode. Uses a cluster which initially has 3 nodes and

--- a/core/src/test/java/org/infinispan/statetransfer/InitialStateTransferCompletionTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/InitialStateTransferCompletionTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 /**
  * Tests that config option StateTransferConfiguration.awaitInitialTransfer() is honored correctly.

--- a/core/src/test/java/org/infinispan/statetransfer/MergeDuringReplaceTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/MergeDuringReplaceTest.java
@@ -23,8 +23,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.fail;
 import static org.testng.Assert.assertEquals;
 
 @Test(groups = "functional", testName = "statetransfer.MergeDuringReplaceTest")

--- a/core/src/test/java/org/infinispan/statetransfer/OperationsDuringStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/OperationsDuringStateTransferTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.*;
 
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 /**
  * @author anistor@redhat.com

--- a/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
@@ -67,8 +67,8 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;

--- a/core/src/test/java/org/infinispan/statetransfer/StateProviderTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateProviderTest.java
@@ -50,10 +50,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferFunctionalTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 @Test(groups = "functional", testName = "statetransfer.StateTransferFunctionalTest")
 public class StateTransferFunctionalTest extends MultipleCacheManagersTest {

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferPessimisticTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferPessimisticTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Test if state transfer happens properly on a cache with pessimistic transactions.

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferRestartTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferRestartTest.java
@@ -25,7 +25,7 @@ import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
 import org.jgroups.protocols.DISCARD;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * tests scenario for ISPN-2574

--- a/core/src/test/java/org/infinispan/stress/AsyncStoreStressTest.java
+++ b/core/src/test/java/org/infinispan/stress/AsyncStoreStressTest.java
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.lang.Math.sqrt;
 import static org.infinispan.test.TestingUtil.marshalledEntry;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Async store stress test.
@@ -317,7 +317,7 @@ public class AsyncStoreStressTest {
          }
       };
    }
-   
+
    private boolean withStore(String key, Callable<Boolean> call) {
       boolean result = false;
       try {

--- a/core/src/test/java/org/infinispan/tx/DefaultEnlistmentModeTest.java
+++ b/core/src/test/java/org/infinispan/tx/DefaultEnlistmentModeTest.java
@@ -13,8 +13,8 @@ import org.infinispan.transaction.TransactionMode;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
 
 @Test (groups = "functional", testName = "tx.DefaultEnlistmentModeTest")
 public class DefaultEnlistmentModeTest extends AbstractCacheTest {

--- a/core/src/test/java/org/infinispan/tx/GetEntryTxTest.java
+++ b/core/src/test/java/org/infinispan/tx/GetEntryTxTest.java
@@ -7,7 +7,7 @@ import org.infinispan.distribution.MagicKey;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertNotNull;
 
 /**
  * Tests for getCacheEntry under Tx

--- a/core/src/test/java/org/infinispan/tx/InfinispanNodeFailureTest.java
+++ b/core/src/test/java/org/infinispan/tx/InfinispanNodeFailureTest.java
@@ -21,8 +21,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.infinispan.test.TestingUtil.waitForRehashToComplete;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * This test reproduces following scenario in Infinispan:
@@ -133,7 +133,7 @@ public class InfinispanNodeFailureTest extends MultipleCacheManagersTest {
 
       // check that second node state is inconsistent, second result should be FALSE in read committed pessimistic cache
       // uncomment when this bug is fixed
-      assertEquals(Boolean.FALSE, secondResult);
+      assertEquals(false, secondResult);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/tx/LockCleanupStateTransferTest.java
+++ b/core/src/test/java/org/infinispan/tx/LockCleanupStateTransferTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 /**
  * test:

--- a/core/src/test/java/org/infinispan/tx/TxCleanupServiceTest.java
+++ b/core/src/test/java/org/infinispan/tx/TxCleanupServiceTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Test for https://issues.jboss.org/browse/ISPN-2383

--- a/core/src/test/java/org/infinispan/tx/recovery/PostCommitRecoveryStateTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/PostCommitRecoveryStateTest.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 import static org.infinispan.tx.recovery.RecoveryTestUtil.beginAndSuspendTx;
 import static org.infinispan.tx.recovery.RecoveryTestUtil.commitTransaction;
 import static org.infinispan.tx.recovery.RecoveryTestUtil.prepareTransaction;

--- a/core/src/test/java/org/infinispan/tx/recovery/admin/ForgetTest.java
+++ b/core/src/test/java/org/infinispan/tx/recovery/admin/ForgetTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.Xid;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 import static org.infinispan.tx.recovery.RecoveryTestUtil.*;
 
 /**

--- a/core/src/test/java/org/infinispan/xsite/NonTxAsyncBackupTest.java
+++ b/core/src/test/java/org/infinispan/xsite/NonTxAsyncBackupTest.java
@@ -21,8 +21,8 @@ import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
 
 /**
  * @author Mircea Markus

--- a/core/src/test/java/org/infinispan/xsite/backupfailure/CustomFailurePolicyTest.java
+++ b/core/src/test/java/org/infinispan/xsite/backupfailure/CustomFailurePolicyTest.java
@@ -6,8 +6,8 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.xsite.CountingCustomFailurePolicy;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author Mircea Markus

--- a/core/src/test/java/org/infinispan/xsite/backupfailure/tx/CustomFailurePolicyTxTest.java
+++ b/core/src/test/java/org/infinispan/xsite/backupfailure/tx/CustomFailurePolicyTxTest.java
@@ -6,8 +6,8 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.xsite.CountingCustomFailurePolicy;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author Mircea Markus

--- a/core/src/test/java/org/infinispan/xsite/offline/NonTxOfflineTest.java
+++ b/core/src/test/java/org/infinispan/xsite/offline/NonTxOfflineTest.java
@@ -11,8 +11,8 @@ import org.infinispan.xsite.BaseSiteUnreachableTest;
 import org.infinispan.xsite.OfflineStatus;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.fail;
 
 /**
  * @author Mircea Markus

--- a/core/src/test/java/org/infinispan/xsite/offline/ResetOfflineStatusTest.java
+++ b/core/src/test/java/org/infinispan/xsite/offline/ResetOfflineStatusTest.java
@@ -13,8 +13,8 @@ import org.infinispan.xsite.BaseSiteUnreachableTest;
 import org.infinispan.xsite.OfflineStatus;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.fail;
 
 /**
  * @author Mircea Markus

--- a/demos/distexec/pom.xml
+++ b/demos/distexec/pom.xml
@@ -28,6 +28,12 @@
    <build>
       <plugins>
          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <skipTests>true</skipTests>
+            </configuration>
+         </plugin>
+         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
             <configuration>

--- a/demos/gridfs-webdav/pom.xml
+++ b/demos/gridfs-webdav/pom.xml
@@ -21,7 +21,7 @@
          <groupId>net.sf.webdav-servlet</groupId>
          <artifactId>webdav-servlet</artifactId>
       </dependency>
-      
+
       <dependency>
          <groupId>javax.servlet</groupId>
          <artifactId>servlet-api</artifactId>
@@ -32,4 +32,15 @@
          <artifactId>log4j-core</artifactId>
       </dependency>
    </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <skipTests>true</skipTests>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
 </project>

--- a/demos/gui/pom.xml
+++ b/demos/gui/pom.xml
@@ -46,6 +46,12 @@
                <failOnError>true</failOnError>
             </configuration>
          </plugin>
+         <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <skipTests>true</skipTests>
+            </configuration>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/demos/lucene-directory-demo/pom.xml
+++ b/demos/lucene-directory-demo/pom.xml
@@ -33,12 +33,17 @@
          <type>test-jar</type>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>
       <plugins>
-      
-         
+
+
          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>appassembler-maven-plugin</artifactId>
@@ -53,8 +58,8 @@
                <assembleDirectory>${project.build.directory}/assembly</assembleDirectory>
             </configuration>
          </plugin>
-         
-         
+
+
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
@@ -64,7 +69,7 @@
                <trimStackTrace>false</trimStackTrace>
             </configuration>
          </plugin>
-         
+
       </plugins>
    </build>
 

--- a/extended-statistics/pom.xml
+++ b/extended-statistics/pom.xml
@@ -13,7 +13,7 @@
     <name>Infinispan Extended Statistics</name>
     <description>Infinispan Extended Statistics module</description>
 
-    
+
     <properties>
         <module.skipComponentMetaDataProcessing>false</module.skipComponentMetaDataProcessing>
     </properties>
@@ -29,6 +29,7 @@
             <artifactId>infinispan-commons-test</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>infinispan-core</artifactId>
@@ -46,6 +47,12 @@
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/integrationtests/all-remote-it/pom.xml
+++ b/integrationtests/all-remote-it/pom.xml
@@ -34,7 +34,7 @@
          <artifactId>infinispan-remote</artifactId>
          <scope>test</scope>
       </dependency>
-      
+
       <dependency>
          <groupId>org.infinispan.server</groupId>
          <artifactId>infinispan-server-build</artifactId>
@@ -50,6 +50,11 @@
       <dependency>
          <groupId>org.wildfly.arquillian</groupId>
          <artifactId>wildfly-arquillian-container-managed</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
          <scope>test</scope>
       </dependency>
    </dependencies>
@@ -116,6 +121,18 @@
                <systemPropertyVariables>
                   <infinispan.jcache.mgmt.lookup.skip>true</infinispan.jcache.mgmt.lookup.skip>
                </systemPropertyVariables>
+               <groups combine.self="override"/>
+               <excludedGroups combine.self="override"/>
+               <properties>
+                  <property>
+                     <name>usedefaultlisteners</name>
+                     <value>false</value>
+                  </property>
+                  <property>
+                     <name>listener</name>
+                     <value>${junitListener}</value>
+                  </property>
+               </properties>
             </configuration>
          </plugin>
       </plugins>

--- a/integrationtests/all-remote-it/src/test/java/org/infinispan/all/remote/jcache/TrackingCacheEntryListener.java
+++ b/integrationtests/all-remote-it/src/test/java/org/infinispan/all/remote/jcache/TrackingCacheEntryListener.java
@@ -1,7 +1,5 @@
 package org.infinispan.all.remote.jcache;
 
-import org.testng.Assert;
-
 import javax.cache.event.CacheEntryCreatedListener;
 import javax.cache.event.CacheEntryEvent;
 import javax.cache.event.CacheEntryExpiredListener;
@@ -11,6 +9,8 @@ import javax.cache.event.CacheEntryUpdatedListener;
 import javax.cache.event.EventType;
 import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Borrowed from TCK tests
@@ -40,7 +40,7 @@ public class TrackingCacheEntryListener<K, V> implements CacheEntryCreatedListen
    public void onCreated(Iterable<CacheEntryEvent<? extends K, ? extends V>> events) throws CacheEntryListenerException {
 
       for (CacheEntryEvent<? extends K, ? extends V> event : events) {
-         Assert.assertEquals(EventType.CREATED, event.getEventType());
+         assertEquals(EventType.CREATED, event.getEventType());
          this.created.incrementAndGet();
       }
 
@@ -52,7 +52,7 @@ public class TrackingCacheEntryListener<K, V> implements CacheEntryCreatedListen
    public void onRemoved(Iterable<CacheEntryEvent<? extends K, ? extends V>> events) throws CacheEntryListenerException {
 
       for (CacheEntryEvent<? extends K, ? extends V> event : events) {
-         Assert.assertEquals(EventType.REMOVED, event.getEventType());
+         assertEquals(EventType.REMOVED, event.getEventType());
          this.removed.incrementAndGet();
          if (event.isOldValueAvailable()) {
             event.getOldValue();
@@ -64,7 +64,7 @@ public class TrackingCacheEntryListener<K, V> implements CacheEntryCreatedListen
    public void onUpdated(Iterable<CacheEntryEvent<? extends K, ? extends V>> events) throws CacheEntryListenerException {
 
       for (CacheEntryEvent<? extends K, ? extends V> event : events) {
-         Assert.assertEquals(EventType.UPDATED, event.getEventType());
+         assertEquals(EventType.UPDATED, event.getEventType());
          this.updated.incrementAndGet();
          if (event.isOldValueAvailable()) {
             event.getOldValue();

--- a/integrationtests/as-integration-client/pom.xml
+++ b/integrationtests/as-integration-client/pom.xml
@@ -83,6 +83,11 @@
             <groupId>org.infinispan.protostream</groupId>
             <artifactId>protostream</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -103,6 +108,13 @@
             </plugin>
 
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
@@ -114,7 +126,7 @@
                     <properties>
                         <property>
                             <name>listener</name>
-                            <value>org.infinispan.commons.test.JUnitTestListener</value>
+                            <value>${junitListener}</value>
                         </property>
                     </properties>
                 </configuration>

--- a/integrationtests/as-integration-embedded/pom.xml
+++ b/integrationtests/as-integration-embedded/pom.xml
@@ -100,6 +100,11 @@
          <artifactId>hibernate-jpa-2.1-api</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>
@@ -131,6 +136,13 @@
          </plugin>
 
          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <skipTests>true</skipTests>
+            </configuration>
+         </plugin>
+
+         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
@@ -138,7 +150,7 @@
                <properties>
                   <property>
                      <name>listener</name>
-                     <value>org.infinispan.commons.test.JUnitTestListener</value>
+                     <value>${junitListener}</value>
                   </property>
                </properties>
             </configuration>
@@ -208,7 +220,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
             <executions>
-               
+
                <execution>
                   <id>configure-as-node1</id>
                   <phase>pre-integration-test</phase>

--- a/integrationtests/as-lucene-directory/pom.xml
+++ b/integrationtests/as-lucene-directory/pom.xml
@@ -110,8 +110,13 @@
          <groupId>com.h2database</groupId>
          <artifactId>h2</artifactId>
          <scope>test</scope>
-         
+
          <version>${version.h2.driver-within-wildfly}</version>
+      </dependency>
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <scope>test</scope>
       </dependency>
    </dependencies>
 
@@ -211,7 +216,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
             <executions>
-                  
+
                <execution>
                   <id>configure-as-node-node1</id>
                   <phase>pre-integration-test</phase>

--- a/integrationtests/cdi-jcache-it/pom.xml
+++ b/integrationtests/cdi-jcache-it/pom.xml
@@ -66,11 +66,16 @@
          <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
-   
+
    <build>
       <plugins>
-         
+
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>

--- a/integrationtests/compatibility-mode-it/pom.xml
+++ b/integrationtests/compatibility-mode-it/pom.xml
@@ -83,6 +83,11 @@
          <artifactId>spymemcached</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
 </project>

--- a/integrationtests/osgi/pom.xml
+++ b/integrationtests/osgi/pom.xml
@@ -98,6 +98,7 @@
       <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>${project.groupId}</groupId>
@@ -181,6 +182,11 @@
          <artifactId>org.apache.karaf.features.core</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <properties>
@@ -203,7 +209,7 @@
          </testResource>
       </testResources>
       <plugins>
-         
+
          <plugin>
             <groupId>org.apache.servicemix.tooling</groupId>
             <artifactId>depends-maven-plugin</artifactId>

--- a/integrationtests/security-manager-it/pom.xml
+++ b/integrationtests/security-manager-it/pom.xml
@@ -36,6 +36,11 @@
          <type>test-jar</type>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/integrationtests/security-manager-it/src/test/java/org/infinispan/security/QueryAuthorizationTest.java
+++ b/integrationtests/security-manager-it/src/test/java/org/infinispan/security/QueryAuthorizationTest.java
@@ -1,7 +1,5 @@
 package org.infinispan.security;
 
-import static org.junit.Assert.assertEquals;
-
 import java.security.Policy;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
@@ -22,6 +20,8 @@ import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * QueryAuthorizationTest.

--- a/jcache/commons/pom.xml
+++ b/jcache/commons/pom.xml
@@ -60,6 +60,12 @@
          <artifactId>metainf-services</artifactId>
          <optional>true</optional>
       </dependency>
+
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/jcache/embedded/pom.xml
+++ b/jcache/embedded/pom.xml
@@ -13,7 +13,7 @@
    <name>Infinispan JCACHE (JSR-107) Embedded Implementation</name>
    <description>JCACHE (JSR-107) implementation using Infinispan embedded mode</description>
 
-   
+
    <properties>
       <module.skipComponentMetaDataProcessing>false</module.skipComponentMetaDataProcessing>
    </properties>
@@ -78,6 +78,12 @@
          <groupId>org.kohsuke.metainf-services</groupId>
          <artifactId>metainf-services</artifactId>
          <optional>true</optional>
+      </dependency>
+
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
       </dependency>
    </dependencies>
 

--- a/jcache/remote/pom.xml
+++ b/jcache/remote/pom.xml
@@ -88,6 +88,12 @@
          <artifactId>wildfly-controller</artifactId>
          <optional>true</optional>
       </dependency>
+
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/lucene/lucene-directory/pom.xml
+++ b/lucene/lucene-directory/pom.xml
@@ -20,30 +20,40 @@
             <artifactId>lucene-core</artifactId>
         </dependency>
         <dependency>
-         <groupId>org.apache.lucene</groupId>
-         <artifactId>lucene-analyzers-common</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.infinispan</groupId>
-         <artifactId>infinispan-cachestore-jdbc</artifactId>
-         <optional>true</optional>
-      </dependency>
-      <dependency>
-         <groupId>org.infinispan</groupId>
-         <artifactId>infinispan-cachestore-jdbc</artifactId>
-         <type>test-jar</type>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>com.mchange</groupId>
-         <artifactId>c3p0</artifactId>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>com.h2database</groupId>
-         <artifactId>h2</artifactId>
-         <scope>test</scope>
-      </dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-analyzers-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-cachestore-jdbc</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-cachestore-jdbc</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mchange</groupId>
+            <artifactId>c3p0</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/object-filter/src/test/java/org/infinispan/objectfilter/impl/util/IntervalTest.java
+++ b/object-filter/src/test/java/org/infinispan/objectfilter/impl/util/IntervalTest.java
@@ -1,7 +1,6 @@
 package org.infinispan.objectfilter.impl.util;
 
-import org.testng.annotations.Test;
-
+import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/object-filter/src/test/java/org/infinispan/objectfilter/impl/util/IntervalTreeTest.java
+++ b/object-filter/src/test/java/org/infinispan/objectfilter/impl/util/IntervalTreeTest.java
@@ -1,8 +1,8 @@
 package org.infinispan.objectfilter.impl.util;
 
-import org.testng.annotations.Test;
-
 import java.util.List;
+
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -56,6 +56,12 @@
 
       <plugins>
          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <skipTests>true</skipTests>
+            </configuration>
+         </plugin>
+         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-checkstyle-plugin</artifactId>
          </plugin>
@@ -71,9 +77,9 @@
                   </Export-Package>
                   <Import-Package>
                   *
-                  
+
                   </Import-Package>
-                  
+
                   <DynamicImport-Package>*</DynamicImport-Package>
                </instructions>
             </configuration>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -85,6 +85,7 @@
       <defaultExcludedTestGroup>unstable,stress,unstable_xsite</defaultExcludedTestGroup>
       <forkJvmArgs>-Xmx2G</forkJvmArgs>
       <testNGListener>org.infinispan.commons.test.TestNGTestListener</testNGListener>
+      <junitListener>org.infinispan.commons.test.JUnitTestListener</junitListener>
       <infinispan.test.parallel.threads>15</infinispan.test.parallel.threads>
       <infinispan.test.jgroups.protocol>tcp</infinispan.test.jgroups.protocol>
       <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
@@ -985,12 +986,6 @@
       </dependencies>
    </dependencyManagement>
    <dependencies>
-
-      <dependency>
-         <groupId>com.thoughtworks.xstream</groupId>
-         <artifactId>xstream</artifactId>
-         <scope>test</scope>
-      </dependency>
       <dependency>
          <groupId>org.apache.logging.log4j</groupId>
          <artifactId>log4j-core</artifactId>
@@ -1003,17 +998,10 @@
          <optional>true</optional>
       </dependency>
       <dependency>
-         <groupId>org.mockito</groupId>
-         <artifactId>mockito-all</artifactId>
-         <version>${version.mockito}</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
          <groupId>org.jboss</groupId>
          <artifactId>jboss-transaction-spi</artifactId>
          <scope>test</scope>
       </dependency>
-
       <dependency>
          <groupId>org.jboss.narayana.jta</groupId>
          <artifactId>narayana-jta</artifactId>
@@ -1024,16 +1012,6 @@
          <artifactId>jboss-logging-processor</artifactId>
          <version>${version.jboss.logging.processor}</version>
          <scope>provided</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.testng</groupId>
-         <artifactId>testng</artifactId>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>junit</groupId>
-         <artifactId>junit</artifactId>
-         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.jacoco</groupId>
@@ -1414,7 +1392,6 @@
                <trimStackTrace>false</trimStackTrace>
                <properties>
                   <property>
-
                      <name>usedefaultlisteners</name>
                      <value>false</value>
                   </property>

--- a/persistence/cli/pom.xml
+++ b/persistence/cli/pom.xml
@@ -33,6 +33,16 @@
          <artifactId>metainf-services</artifactId>
          <optional>true</optional>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-all</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/persistence/jdbc/pom.xml
+++ b/persistence/jdbc/pom.xml
@@ -15,6 +15,18 @@
 
    <dependencies>
       <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-all</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
          <groupId>com.mchange</groupId>
          <artifactId>c3p0</artifactId>
          <optional>true</optional>
@@ -122,7 +134,7 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            
+
             <configuration>
                <threadCount>1</threadCount>
             </configuration>

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/mixed/JdbcMixedStoreConfigurationTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/mixed/JdbcMixedStoreConfigurationTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.persistence.jdbc.mixed;
 
-import org.junit.Assert;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
@@ -12,6 +11,10 @@ import org.infinispan.persistence.keymappers.DefaultTwoWayKey2StringMapper;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Tester class for {@link org.infinispan.persistence.jdbc.configuration.JdbcMixedStoreConfiguration}.
@@ -51,12 +54,12 @@ public class JdbcMixedStoreConfigurationTest {
       config = storeBuilder.create();
 
       //some checks
-      Assert.assertFalse(config.binaryTable().createOnStart());
-      Assert.assertTrue(config.stringTable().createOnStart());
-      Assert.assertEquals(config.binaryTable().dataColumnName(), "binary_dc");
-      Assert.assertEquals(config.binaryTable().dataColumnType(), "binary_dct");
-      Assert.assertEquals(config.stringTable().dataColumnName(), "strings_dc");
-      Assert.assertEquals(config.stringTable().dataColumnType(), "strings_dct");
+      assertFalse(config.binaryTable().createOnStart());
+      assertTrue(config.stringTable().createOnStart());
+      assertEquals(config.binaryTable().dataColumnName(), "binary_dc");
+      assertEquals(config.binaryTable().dataColumnType(), "binary_dct");
+      assertEquals(config.stringTable().dataColumnName(), "strings_dc");
+      assertEquals(config.stringTable().dataColumnType(), "strings_dct");
    }
 
    @Test(expectedExceptions = CacheConfigurationException.class)
@@ -70,12 +73,12 @@ public class JdbcMixedStoreConfigurationTest {
    public void testKey2StringMapper() {
       storeBuilder.key2StringMapper(DefaultTwoWayKey2StringMapper.class.getName());
       config = storeBuilder.create();
-      Assert.assertEquals(config.key2StringMapper(), DefaultTwoWayKey2StringMapper.class.getName());
+      assertEquals(config.key2StringMapper(), DefaultTwoWayKey2StringMapper.class.getName());
    }
 
    public void testConcurrencyLevel() {
       config = storeBuilder.create();
-      Assert.assertEquals(2048, config.lockConcurrencyLevel());
+      assertEquals(2048, config.lockConcurrencyLevel());
       JdbcMixedStoreConfigurationBuilder storeBuilder2 = TestCacheManagerFactory.getDefaultCacheConfiguration
             (false)
             .persistence()
@@ -83,12 +86,12 @@ public class JdbcMixedStoreConfigurationTest {
                .read(config)
                .lockConcurrencyLevel(12);
       config = storeBuilder2.create();
-      Assert.assertEquals(12, config.lockConcurrencyLevel());
+      assertEquals(12, config.lockConcurrencyLevel());
    }
 
    public void voidTestLockAcquisitionTimeout() {
       config = storeBuilder.create();
-      Assert.assertEquals(60000, config.lockAcquisitionTimeout());
+      assertEquals(60000, config.lockAcquisitionTimeout());
       JdbcMixedStoreConfigurationBuilder storeBuilder2 = TestCacheManagerFactory.getDefaultCacheConfiguration
             (false)
             .persistence()
@@ -96,7 +99,7 @@ public class JdbcMixedStoreConfigurationTest {
                .read(config)
                .lockConcurrencyLevel(13);
       config = storeBuilder2.create();
-      Assert.assertEquals(13, config.lockConcurrencyLevel());
+      assertEquals(13, config.lockConcurrencyLevel());
    }
 
    public void testDatabaseConfiguration() {
@@ -123,6 +126,6 @@ public class JdbcMixedStoreConfigurationTest {
             .jndiUrl("java:jboss/datasources/ExampleDS");
       Configuration build = bld.build();
       JdbcMixedStoreConfiguration sc = (JdbcMixedStoreConfiguration) build.persistence().stores().get(0);
-      Assert.assertEquals(DatabaseType.MYSQL, sc.dialect());
+      assertEquals(DatabaseType.MYSQL, sc.dialect());
    }
 }

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/NonStringKeyPreloadTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/NonStringKeyPreloadTest.java
@@ -1,8 +1,8 @@
 package org.infinispan.persistence.jdbc.stringbased;
 
-import static org.junit.Assert.assertEquals;
 import static org.infinispan.test.TestingUtil.clearCacheLoader;
 import static org.infinispan.test.TestingUtil.withCacheManager;
+import static org.testng.AssertJUnit.assertEquals;
 
 import java.sql.Connection;
 

--- a/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/NonStringKeyStateTransferTest.java
+++ b/persistence/jdbc/src/test/java/org/infinispan/persistence/jdbc/stringbased/NonStringKeyStateTransferTest.java
@@ -9,7 +9,7 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author Mircea.Markus@jboss.com

--- a/persistence/jpa/pom.xml
+++ b/persistence/jpa/pom.xml
@@ -101,7 +101,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-               
+
                <threadCount>1</threadCount>
             </configuration>
          </plugin>
@@ -117,6 +117,11 @@
          <groupId>org.hibernate.javax.persistence</groupId>
          <artifactId>hibernate-jpa-2.1-api</artifactId>
          <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-all</artifactId>
+         <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.apache.logging.log4j</groupId>
@@ -142,6 +147,11 @@
          <groupId>org.kohsuke.metainf-services</groupId>
          <artifactId>metainf-services</artifactId>
          <optional>true</optional>
+      </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
       </dependency>
    </dependencies>
 

--- a/persistence/leveldb/pom.xml
+++ b/persistence/leveldb/pom.xml
@@ -26,6 +26,16 @@
          <artifactId>metainf-services</artifactId>
          <optional>true</optional>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-all</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/persistence/remote/pom.xml
+++ b/persistence/remote/pom.xml
@@ -43,6 +43,16 @@
          <artifactId>metainf-services</artifactId>
          <optional>true</optional>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-all</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreConfigTest.java
+++ b/persistence/remote/src/test/java/org/infinispan/persistence/remote/RemoteStoreConfigTest.java
@@ -14,9 +14,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
 import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
 import static org.infinispan.test.TestingUtil.withCacheManager;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Simple test to sample how remote cache store is configured.

--- a/persistence/rest/pom.xml
+++ b/persistence/rest/pom.xml
@@ -11,7 +11,7 @@
    <packaging>bundle</packaging>
    <name>Infinispan REST CacheStore</name>
    <description>Infinispan REST CacheStore</description>
-   
+
    <dependencies>
       <dependency>
          <groupId>${project.groupId}</groupId>
@@ -47,6 +47,16 @@
          <groupId>org.kohsuke.metainf-services</groupId>
          <artifactId>metainf-services</artifactId>
          <optional>true</optional>
+      </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-all</artifactId>
+         <scope>test</scope>
       </dependency>
    </dependencies>
 

--- a/persistence/rest/src/test/java/org/infinispan/persistence/rest/configuration/RestCacheStoreConfigTest.java
+++ b/persistence/rest/src/test/java/org/infinispan/persistence/rest/configuration/RestCacheStoreConfigTest.java
@@ -14,8 +14,8 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
 import static org.infinispan.test.TestingUtil.withCacheManager;
+import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertSame;
 
 /**

--- a/persistence/soft-index/pom.xml
+++ b/persistence/soft-index/pom.xml
@@ -23,6 +23,16 @@
          <artifactId>metainf-services</artifactId>
          <optional>true</optional>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-all</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -87,33 +87,44 @@
       </dependency>
 
       <dependency>
-           <groupId>${project.groupId}</groupId>
-           <artifactId>infinispan-cachestore-jdbc</artifactId>
-           <scope>test</scope>
-       </dependency>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>infinispan-cachestore-jdbc</artifactId>
+         <scope>test</scope>
+      </dependency>
 
-       <dependency>
-           <groupId>com.h2database</groupId>
-           <artifactId>h2</artifactId>
-           <scope>test</scope>
-       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+      </dependency>
 
-       <dependency>
-           <groupId>org.kohsuke.metainf-services</groupId>
-           <artifactId>metainf-services</artifactId>
-           <optional>true</optional>
-       </dependency>
+      <dependency>
+         <groupId>com.h2database</groupId>
+         <artifactId>h2</artifactId>
+         <scope>test</scope>
+      </dependency>
 
-       <dependency>
-           <groupId>org.jboss.byteman</groupId>
-           <artifactId>byteman</artifactId>
-           <scope>test</scope>
-       </dependency>
-       <dependency>
-           <groupId>org.jboss.byteman</groupId>
-           <artifactId>byteman-bmunit</artifactId>
-           <scope>test</scope>
-       </dependency>
+      <dependency>
+         <groupId>org.kohsuke.metainf-services</groupId>
+         <artifactId>metainf-services</artifactId>
+         <optional>true</optional>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.byteman</groupId>
+         <artifactId>byteman</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.jboss.byteman</groupId>
+         <artifactId>byteman-bmunit</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.mockito</groupId>
+         <artifactId>mockito-all</artifactId>
+         <scope>test</scope>
+      </dependency>
 
    </dependencies>
 

--- a/query/src/test/java/org/infinispan/query/analysis/AnalyzerTest.java
+++ b/query/src/test/java/org/infinispan/query/analysis/AnalyzerTest.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Copied and adapted from Hibernate Search

--- a/query/src/test/java/org/infinispan/query/api/ManualIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/api/ManualIndexingTest.java
@@ -10,11 +10,12 @@ import org.infinispan.query.SearchManager;
 import org.infinispan.query.queries.faceting.Car;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.junit.Assert;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.testng.AssertJUnit.assertEquals;
 
 @Test(groups = "functional", testName = "query.api.ManualIndexingTest")
 public class ManualIndexingTest extends MultipleCacheManagersTest {
@@ -60,8 +61,8 @@ public class ManualIndexingTest extends MultipleCacheManagersTest {
          SearchManager sm = Search.getSearchManager(cache);
          Query query = sm.buildQueryBuilderForClass(Car.class).get().keyword().onField("make").matching(carMake).createQuery();
          CacheQuery cacheQuery = sm.getQuery(query, Car.class);
-         Assert.assertEquals("Expected count not met on cache " + cache, expectedCount, cacheQuery.getResultSize());
-         Assert.assertEquals("Expected count not met on cache " + cache, expectedCount, cacheQuery.list().size());
+         assertEquals("Expected count not met on cache " + cache, expectedCount, cacheQuery.getResultSize());
+         assertEquals("Expected count not met on cache " + cache, expectedCount, cacheQuery.list().size());
       }
    }
 }

--- a/query/src/test/java/org/infinispan/query/api/NonIndexedValuesTest.java
+++ b/query/src/test/java/org/infinispan/query/api/NonIndexedValuesTest.java
@@ -1,6 +1,6 @@
 package org.infinispan.query.api;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 import org.apache.lucene.search.Query;
 import org.infinispan.configuration.cache.ConfigurationBuilder;

--- a/query/src/test/java/org/infinispan/query/api/PutAllTest.java
+++ b/query/src/test/java/org/infinispan/query/api/PutAllTest.java
@@ -17,8 +17,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 @Test(groups = "functional", testName = "query.api.PutAllTest")
 @CleanupAfterMethod

--- a/query/src/test/java/org/infinispan/query/api/ReplaceTest.java
+++ b/query/src/test/java/org/infinispan/query/api/ReplaceTest.java
@@ -10,7 +10,7 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 @Test(groups = "functional", testName = "query.api.ReplaceTest")
 public class ReplaceTest extends SingleCacheManagerTest {

--- a/query/src/test/java/org/infinispan/query/backend/KeyTransformationHandlerTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/KeyTransformationHandlerTest.java
@@ -12,9 +12,10 @@ import org.infinispan.query.test.CustomKey3Transformer;
 import org.infinispan.query.test.NonSerializableKey;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
-import org.junit.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
 /**
  * This is the test class for {@link org.infinispan.query.backend.KeyTransformationHandler}
@@ -120,7 +121,7 @@ public class KeyTransformationHandlerTest {
 
       byte[] arr = new byte[]{1, 2, 3, 4, 5, 6};
       key = keyTransformationHandler.stringToKey("A:" + Base64.encodeBytes((arr)), contextClassLoader);
-      Assert.assertArrayEquals(arr, (byte[]) key);
+      assertArrayEquals(arr, (byte[]) key);
    }
 
    @Test(expectedExceptions = CacheException.class)

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithLongIndexNameTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithLongIndexNameTest.java
@@ -19,7 +19,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * The test verifies the issue ISPN-3092.

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
@@ -26,7 +26,7 @@ import org.infinispan.query.test.Person;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * ClusteredQueryTest.

--- a/query/src/test/java/org/infinispan/query/blackbox/IndexedEntityAutodetectTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/IndexedEntityAutodetectTest.java
@@ -17,9 +17,9 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Tests that undeclared indexed entities are autodetected.

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCacheAsyncCacheStoreTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCacheAsyncCacheStoreTest.java
@@ -7,7 +7,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Testing the ISPN Directory configuration with Async. FileCacheStore. The tests are performed on Local cache.

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCachePerformantConfTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCachePerformantConfTest.java
@@ -7,7 +7,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Tests the functionality of the queries in case when the NRT index manager is used in combination with FileStore.

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCacheTest.java
@@ -39,8 +39,8 @@ import java.util.NoSuchElementException;
 import static java.util.Arrays.asList;
 import static org.infinispan.query.helper.TestQueryHelperFactory.createCacheQuery;
 import static org.infinispan.query.helper.TestQueryHelperFactory.createQueryParser;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/query/src/test/java/org/infinispan/query/blackbox/QueryCacheRestartTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/QueryCacheRestartTest.java
@@ -20,8 +20,8 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
 import static org.infinispan.test.TestingUtil.withCacheManager;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.fail;
 
 /**
  * Tests whether query caches can restart without problems.

--- a/query/src/test/java/org/infinispan/query/config/DeclarativeConfigTest.java
+++ b/query/src/test/java/org/infinispan/query/config/DeclarativeConfigTest.java
@@ -19,9 +19,9 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.assertNotNull;
 
 @Test(testName = "query.config.DeclarativeConfigTest", groups = "functional")
 public class DeclarativeConfigTest extends SingleCacheManagerTest {

--- a/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
@@ -1,6 +1,6 @@
 package org.infinispan.query.config;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;

--- a/query/src/test/java/org/infinispan/query/config/XMLConfigurationOverridingTest.java
+++ b/query/src/test/java/org/infinispan/query/config/XMLConfigurationOverridingTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.query.config;
 
-import org.junit.Assert;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -12,6 +11,8 @@ import org.testng.annotations.Test;
 import java.io.Serializable;
 
 import static org.infinispan.test.TestingUtil.withCacheManager;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
 
 /**
  * Tests verifying that the overriding of the configuration which is read from the configuration XML file is done
@@ -29,7 +30,7 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest {
          @Override
          public void call() {
             Configuration cnf = cm.getCacheConfiguration(simpleCacheName);
-            Assert.assertFalse(cnf.indexing().index().isEnabled());
+            assertFalse(cnf.indexing().index().isEnabled());
 
             Configuration conf = new ConfigurationBuilder().indexing().index(Index.NONE)
                   .addProperty("default.directory_provider", "infinispan").build();
@@ -37,14 +38,14 @@ public class XMLConfigurationOverridingTest extends AbstractInfinispanTest {
             cm.defineConfiguration(simpleCacheName, conf);
 
             cnf = cm.getCacheConfiguration(simpleCacheName);
-            Assert.assertFalse(cnf.indexing().index().isEnabled());
-            Assert.assertFalse(cnf.indexing().index().isLocalOnly());
-            Assert.assertEquals("infinispan", cnf.indexing().properties().getProperty("default.directory_provider"));
-            Assert.assertFalse(cm.getCacheNames().contains("LuceneIndexesMetadata"));
+            assertFalse(cnf.indexing().index().isEnabled());
+            assertFalse(cnf.indexing().index().isLocalOnly());
+            assertEquals("infinispan", cnf.indexing().properties().getProperty("default.directory_provider"));
+            assertFalse(cm.getCacheNames().contains("LuceneIndexesMetadata"));
 
             cm.getCache(simpleCacheName).put("key0", new NonIndexedClass("value0"));
 
-            Assert.assertFalse(cm.getCacheNames().contains("LuceneIndexesMetadata"));
+            assertFalse(cm.getCacheNames().contains("LuceneIndexesMetadata"));
          }
       });
    }

--- a/query/src/test/java/org/infinispan/query/continuous/AbstractCQMultipleCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/continuous/AbstractCQMultipleCachesTest.java
@@ -1,6 +1,6 @@
 package org.infinispan.query.continuous;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.Map;
 

--- a/query/src/test/java/org/infinispan/query/continuous/ContinuousQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/continuous/ContinuousQueryTest.java
@@ -1,9 +1,5 @@
 package org.infinispan.query.continuous;
 
-import static org.infinispan.query.dsl.Expression.max;
-import static org.infinispan.query.dsl.Expression.param;
-import static org.junit.Assert.assertEquals;
-
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -21,6 +17,10 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.util.ControlledTimeService;
 import org.infinispan.util.TimeService;
 import org.testng.annotations.Test;
+
+import static org.infinispan.query.dsl.Expression.max;
+import static org.infinispan.query.dsl.Expression.param;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author anistor@redhat.com

--- a/query/src/test/java/org/infinispan/query/distributed/DegeneratedClusterMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/DegeneratedClusterMassIndexingTest.java
@@ -12,7 +12,7 @@ import org.infinispan.query.queries.faceting.Car;
 import org.infinispan.test.MultipleCacheManagersTest;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author anistor@redhat.com

--- a/query/src/test/java/org/infinispan/query/distributed/DistProgrammaticMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/DistProgrammaticMassIndexTest.java
@@ -1,6 +1,6 @@
 package org.infinispan.query.distributed;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.Query;

--- a/query/src/test/java/org/infinispan/query/distributed/IndexManagerLocalTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/IndexManagerLocalTest.java
@@ -1,6 +1,6 @@
 package org.infinispan.query.distributed;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 import java.io.IOException;
 

--- a/query/src/test/java/org/infinispan/query/distributed/MultiNodeDistributedTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/MultiNodeDistributedTest.java
@@ -1,6 +1,6 @@
 package org.infinispan.query.distributed;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 import javax.transaction.TransactionManager;
 

--- a/query/src/test/java/org/infinispan/query/distributed/PerfTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/PerfTest.java
@@ -18,7 +18,7 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Stress test running on an indexed Cache which is storing the index in a distributed Lucene Directory

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/ClusteredListenerWithDslFilterTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/ClusteredListenerWithDslFilterTest.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.infinispan.query.dsl.Expression.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 
 /**

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/ClusteredQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/ClusteredQueryDslConditionsTest.java
@@ -8,10 +8,10 @@ import org.infinispan.configuration.cache.Index;
 import org.infinispan.query.Search;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Verifies the functionality of Query DSL in clustered environment for ISPN directory provider.

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/FilesystemQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/FilesystemQueryDslConditionsTest.java
@@ -10,7 +10,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Verifies the Query DSL functionality for Filesystem directory_provider.

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/JPAFilterAndConverterDistTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/JPAFilterAndConverterDistTest.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 /**
  * @author anistor@redhat.com

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/ListenerWithDslFilterTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/ListenerWithDslFilterTest.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.infinispan.query.dsl.Expression.*;
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 
 /**

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NamedParamsPerfTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NamedParamsPerfTest.java
@@ -18,8 +18,8 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
 
 /**
  * @author Matej Cimbora

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedQueryDslConditionsTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import static org.infinispan.test.TestingUtil.withTx;
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Test for query conditions (filtering) on cache without indexing. Exercises the whole query DSL on the sample domain

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
@@ -38,12 +38,12 @@ import static org.infinispan.query.dsl.Expression.min;
 import static org.infinispan.query.dsl.Expression.param;
 import static org.infinispan.query.dsl.Expression.property;
 import static org.infinispan.query.dsl.Expression.sum;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Test for query conditions (filtering). Exercises the whole query DSL on the sample domain model. Uses indexing,

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/impl/QueryEngineTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/impl/QueryEngineTest.java
@@ -33,7 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.TimeZone;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author anistor@redhat.com

--- a/query/src/test/java/org/infinispan/query/externalizers/TermExternalizerTest.java
+++ b/query/src/test/java/org/infinispan/query/externalizers/TermExternalizerTest.java
@@ -11,7 +11,7 @@ import org.infinispan.test.MultipleCacheManagersTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 @Test(groups = "functional", testName = "query.externalizers.TermExternalizerTest")
 public class TermExternalizerTest extends MultipleCacheManagersTest {

--- a/query/src/test/java/org/infinispan/query/helper/StaticTestingErrorHandler.java
+++ b/query/src/test/java/org/infinispan/query/helper/StaticTestingErrorHandler.java
@@ -10,7 +10,10 @@ import org.hibernate.search.spi.SearchIntegrator;
 import org.infinispan.Cache;
 import org.infinispan.query.Search;
 import org.infinispan.query.SearchManager;
-import org.junit.Assert;
+
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.fail;
 
 public class StaticTestingErrorHandler implements ErrorHandler {
 
@@ -34,12 +37,12 @@ public class StaticTestingErrorHandler implements ErrorHandler {
       SearchManager searchManager = Search.getSearchManager(cache);
       SearchIntegrator searchFactory = searchManager.unwrap(SearchIntegrator.class);
       ErrorHandler errorHandler = searchFactory.getErrorHandler();
-      Assert.assertNotNull(errorHandler);
-      Assert.assertTrue(errorHandler instanceof StaticTestingErrorHandler);
+      assertNotNull(errorHandler);
+      assertTrue(errorHandler instanceof StaticTestingErrorHandler);
       StaticTestingErrorHandler instance = (StaticTestingErrorHandler) errorHandler;
       Object fault = instance.getAndReset();
       if (fault!=null) {
-         Assert.fail(fault.toString());
+         fail(fault.toString());
       }
    }
 

--- a/query/src/test/java/org/infinispan/query/helper/TestQueryHelperFactory.java
+++ b/query/src/test/java/org/infinispan/query/helper/TestQueryHelperFactory.java
@@ -1,6 +1,6 @@
 package org.infinispan.query.helper;
 
-import static org.junit.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertNotNull;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;

--- a/query/src/test/java/org/infinispan/query/helper/TestableCluster.java
+++ b/query/src/test/java/org/infinispan/query/helper/TestableCluster.java
@@ -9,7 +9,8 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.junit.Assert;
+
+import static org.testng.AssertJUnit.assertTrue;
 
 public class TestableCluster<K, V> {
 
@@ -52,8 +53,8 @@ public class TestableCluster<K, V> {
    public synchronized void killNode(Cache<K, V> cache) {
       EmbeddedCacheManager cacheManager = cache.getCacheManager();
       TestingUtil.killCacheManagers(cacheManager);
-      Assert.assertTrue(caches.remove(cache));
-      Assert.assertTrue(cacheManagers.remove(cacheManager));
+      assertTrue(caches.remove(cache));
+      assertTrue(cacheManagers.remove(cacheManager));
       waitForRehashToComplete(cache, caches);
    }
 

--- a/query/src/test/java/org/infinispan/query/impl/QueryCacheEmbeddedTest.java
+++ b/query/src/test/java/org/infinispan/query/impl/QueryCacheEmbeddedTest.java
@@ -26,9 +26,9 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.calls;

--- a/query/src/test/java/org/infinispan/query/indexedembedded/CollectionsIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/indexedembedded/CollectionsIndexingTest.java
@@ -18,8 +18,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.

--- a/query/src/test/java/org/infinispan/query/jmx/QueryMBeanTest.java
+++ b/query/src/test/java/org/infinispan/query/jmx/QueryMBeanTest.java
@@ -27,9 +27,9 @@ import java.util.List;
 import java.util.Set;
 
 import static org.infinispan.query.helper.TestQueryHelperFactory.createQueryParser;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * // TODO: Document this

--- a/query/src/test/java/org/infinispan/query/nulls/NullCollectionElementsTest.java
+++ b/query/src/test/java/org/infinispan/query/nulls/NullCollectionElementsTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Callable;
 
 import static org.infinispan.query.FetchOptions.FetchMode.*;
 import static org.infinispan.test.TestingUtil.withTx;
-import static org.junit.Assert.*;
+import static org.testng.AssertJUnit.*;
 
 /**
  * @author <a href="mailto:mluksa@redhat.com">Marko Luksa</a>

--- a/query/src/test/java/org/infinispan/query/persistence/EntryActivatingTest.java
+++ b/query/src/test/java/org/infinispan/query/persistence/EntryActivatingTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author Sanne Grinovero <sanne@infinispan.org> (C) 2011 Red Hat Inc.

--- a/query/src/test/java/org/infinispan/query/projection/ProjectionTest.java
+++ b/query/src/test/java/org/infinispan/query/projection/ProjectionTest.java
@@ -17,11 +17,12 @@ import org.infinispan.query.Search;
 import org.infinispan.query.SearchManager;
 import org.infinispan.test.SingleCacheManagerTest;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
-import org.junit.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.List;
+
+import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
 @Test(groups = "functional", testName = "query.projection.ProjectionTest")
 public class ProjectionTest extends SingleCacheManagerTest {
@@ -114,7 +115,7 @@ public class ProjectionTest extends SingleCacheManagerTest {
    private void assertQueryListContains(List list, Object[] expected) {
       assert list.size() == 1;
       Object[] array = (Object[]) list.get(0);
-      Assert.assertArrayEquals(expected, array);
+      assertArrayEquals(expected, array);
    }
 
    private void assertQueryIteratorContains(ResultIterator iterator, Object[] expected) {

--- a/query/src/test/java/org/infinispan/query/queries/faceting/SimpleFacetingTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/faceting/SimpleFacetingTest.java
@@ -18,7 +18,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.

--- a/query/src/test/java/org/infinispan/query/queries/phrases/QueryPhrasesTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/phrases/QueryPhrasesTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.query.queries.phrases;
 
-import org.junit.Assert;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.Query;
 import org.hibernate.search.exception.SearchException;
@@ -20,6 +19,7 @@ import org.testng.annotations.Test;
 import java.util.List;
 
 import static org.infinispan.query.helper.TestQueryHelperFactory.createQueryParser;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Tests and verifies that the querying using keywords, phrases, etc works properly.
@@ -66,7 +66,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      Assert.assertEquals(1, found.size());
+      assertEquals(1, found.size());
       assert found.contains(person1);
 
       query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().bool()
@@ -75,7 +75,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(2, found.size());
+      assertEquals(2, found.size());
       assert found.contains(person2);
       assert found.contains(person3);
    }
@@ -95,7 +95,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      Assert.assertEquals(2, found.size());
+      assertEquals(2, found.size());
       assert found.contains(person1);
       assert found.contains(anotherGrassEater);
    }
@@ -111,7 +111,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      Assert.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(person1);
       assert found.contains(person2);
       assert found.contains(person3);
@@ -125,7 +125,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(2, found.size());
+      assertEquals(2, found.size());
       assert found.contains(person2);
       assert found.contains(person3);
    }
@@ -146,7 +146,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      Assert.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.get(0).equals(person1);
       assert found.get(1).equals(person2);
       assert found.get(2).equals(person3);
@@ -161,7 +161,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.get(0).equals(person2);
       assert found.get(1).equals(person3);
       assert found.get(2).equals(person1);
@@ -176,7 +176,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      Assert.assertEquals(2, found.size());
+      assertEquals(2, found.size());
       assert found.contains(person2);
       assert found.contains(person3);
 
@@ -191,7 +191,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(person2);
       assert found.contains(person3);
       assert found.contains(person4);
@@ -200,7 +200,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
             onFields("name", "blurb").matching("goat").createQuery();
       List<Object> foundOnFields = Search.getSearchManager(cache).getQuery(query).list();
 
-      AssertJUnit.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(person2);
       assert found.contains(person3);
       assert found.contains(person4);
@@ -217,14 +217,14 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().keyword()
             .fuzzy().withEditDistanceUpTo(1).withPrefixLength(2).onField("name").matching("yyJohny").createQuery();
       List<Object> found = Search.getSearchManager(cache).getQuery(query).list();
-      AssertJUnit.assertEquals(1, found.size());
+      assertEquals(1, found.size());
       AssertJUnit.assertTrue(found.contains(person1));
 
       //return all as edit distance excluding the prefix fit all documents
       Query queryReturnAll = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().keyword()
             .fuzzy().withEditDistanceUpTo(2).withPrefixLength(2).onField("name").matching("yyJohn").createQuery();
       List<Object> foundWithLowerThreshold = Search.getSearchManager(cache).getQuery(queryReturnAll).list();
-      AssertJUnit.assertEquals(2, foundWithLowerThreshold.size());
+      assertEquals(2, foundWithLowerThreshold.size());
       AssertJUnit.assertTrue(foundWithLowerThreshold.contains(person1));
       AssertJUnit.assertTrue(foundWithLowerThreshold.contains(person2));
    }
@@ -245,7 +245,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      AssertJUnit.assertEquals(3, found.size());  //<------ All entries should be here, because andField is executed as SHOULD;
+      assertEquals(3, found.size());  //<------ All entries should be here, because andField is executed as SHOULD;
       assert found.contains(type1);
       assert found.contains(type2);
       assert found.contains(type3);
@@ -256,7 +256,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(4, found.size());
+      assertEquals(4, found.size());
       assert found.contains(type3);
       assert found.contains(type2);
       assert found.contains(type1);
@@ -275,7 +275,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      Assert.assertEquals(2, found.size());
+      assertEquals(2, found.size());
    }
 
    public void testWildcard() {
@@ -287,7 +287,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      Assert.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(type1);
       assert found.contains(type2);
       assert found.contains(type3);
@@ -298,7 +298,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(0, found.size());
+      assertEquals(0, found.size());
 
       NumericType type4 = new NumericType(35, 40);
       type4.setName("nothing special.");
@@ -307,7 +307,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(1, found.size());
+      assertEquals(1, found.size());
       assert found.contains(type4);
 
       query = Search.getSearchManager(cache).buildQueryBuilderForClass(NumericType.class).get().keyword().wildcard()
@@ -316,7 +316,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(2, found.size());
+      assertEquals(2, found.size());
       assert found.contains(type2);
       assert found.contains(type4);
    }
@@ -330,7 +330,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      Assert.assertEquals(2, found.size());
+      assertEquals(2, found.size());
 
       person4 = new Person();
       person4.setName("Some name with Eats");
@@ -341,7 +341,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(person2);
       assert found.contains(person3);
       assert found.contains(person4);
@@ -356,7 +356,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      Assert.assertEquals(1, found.size());
+      assertEquals(1, found.size());
       assert found.contains(person2);
 
       person4 = new Person();
@@ -365,7 +365,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       cache.put("anotherKey", person4);
 
       found = cacheQuery.list();
-      Assert.assertEquals(2, found.size());
+      assertEquals(2, found.size());
       assert found.contains(person2);
       assert found.contains(person4);
    }
@@ -379,14 +379,14 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      Assert.assertEquals(0, found.size());
+      assertEquals(0, found.size());
 
       NumericType type4 = new NumericType(45,50);
       type4.setName("Some string");
       cache.put("otherKey", type4);
 
       found = cacheQuery.list();
-      Assert.assertEquals(1, found.size());
+      assertEquals(1, found.size());
       assert found.contains(type4);
    }
 
@@ -399,7 +399,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      Assert.assertEquals(1, found.size());
+      assertEquals(1, found.size());
       assert found.contains(person2);
 
       person4 = new Person();
@@ -409,7 +409,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
 
       found = cacheQuery.list();
 
-      Assert.assertEquals(2, found.size());
+      assertEquals(2, found.size());
       assert found.contains(person2);
       assert found.contains(person4);
 
@@ -417,7 +417,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       cache.put("otherKey", person4);
       found = cacheQuery.list();
 
-      Assert.assertEquals(2, found.size());
+      assertEquals(2, found.size());
       assert found.contains(person2);
       assert found.contains(person4);
 
@@ -426,7 +426,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
 
       found = cacheQuery.list();
 
-      Assert.assertEquals(2, found.size());
+      assertEquals(2, found.size());
       assert found.contains(person2);
       assert found.contains(person4);
 
@@ -435,7 +435,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
 
       found = cacheQuery.list();
 
-      Assert.assertEquals(1, found.size());
+      assertEquals(1, found.size());
       assert found.contains(person2);
    }
 
@@ -448,14 +448,14 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      Assert.assertEquals(0, found.size());
+      assertEquals(0, found.size());
 
       NumericType type = new NumericType(10, 60);
       type.setName("Some string");
       cache.put("otherKey", type);
 
       found = cacheQuery.list();
-      Assert.assertEquals(1, found.size());
+      assertEquals(1, found.size());
       assert found.contains(type);
 
       NumericType type1 = new NumericType(20, 60);
@@ -463,7 +463,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       cache.put("otherKey1", type1);
 
       found = cacheQuery.list();
-      Assert.assertEquals(1, found.size());
+      assertEquals(1, found.size());
       assert found.contains(type);
    }
 
@@ -478,7 +478,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      Assert.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(person2);
       assert found.contains(person1);
       assert found.contains(person3);
@@ -488,14 +488,14 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(0, found.size());
+      assertEquals(0, found.size());
 
       query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().all().except(subQuery).createQuery();
 
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(1, found.size());
+      assertEquals(1, found.size());
       assert found.contains(person1);
    }
 
@@ -510,7 +510,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      Assert.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(type1);
       assert found.contains(type2);
       assert found.contains(type3);
@@ -520,7 +520,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(0, found.size());
+      assertEquals(0, found.size());
    }
 
    protected void loadTestingData() {

--- a/query/src/test/java/org/infinispan/query/queries/ranges/QueryRangesTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/ranges/QueryRangesTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.query.queries.ranges;
 
-import org.junit.Assert;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.Query;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -20,6 +19,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
+
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Tests verifying that query ranges work properly.
@@ -66,7 +67,7 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      AssertJUnit.assertEquals(2, found.size());
+      assertEquals(2, found.size());
       assert found.contains(person1);
       assert found.contains(person3);
       assert !found.contains(person4) : "This should not contain object person4";
@@ -96,7 +97,7 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      AssertJUnit.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(person1);
       assert found.contains(person2);
       assert found.contains(person3);
@@ -128,14 +129,14 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      AssertJUnit.assertEquals(0, found.size());
+      assertEquals(0, found.size());
 
       query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class)
             .get().range().onField("age").above(20).excludeLimit().createQuery();
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      AssertJUnit.assertEquals(2, found.size());
+      assertEquals(2, found.size());
       assert found.contains(person2);
       assert found.contains(person3);
       assert !found.contains(person4) : "This should not contain object person4";
@@ -165,14 +166,14 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      AssertJUnit.assertEquals(0, found.size());
+      assertEquals(0, found.size());
 
       query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class)
             .get().range().onField("age").above(20).createQuery();
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      AssertJUnit.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(person1);
       assert found.contains(person2);
       assert found.contains(person3);
@@ -204,7 +205,7 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      AssertJUnit.assertEquals(1, found.size());
+      assertEquals(1, found.size());
       assert found.contains(person3);
       assert !found.contains(person4) : "This should not contain object person4";
 
@@ -232,7 +233,7 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      AssertJUnit.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(person1);
       assert found.contains(person2);
       assert found.contains(person3);
@@ -280,7 +281,7 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      AssertJUnit.assertEquals(2, found.size());
+      assertEquals(2, found.size());
       assert found.contains(person2);
       assert found.contains(person3);
       assert !found.contains(person4) : "This should not contain object person4";
@@ -295,7 +296,7 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(person2);
       assert found.contains(person3);
       assert found.contains(person4) : "This should now contain object person4";
@@ -310,7 +311,7 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(person2);
       assert found.contains(person3);
       assert found.contains(person4) : "This should now contain object person4";
@@ -321,7 +322,7 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(person1);
       assert found.contains(person3);
       assert found.contains(person4);
@@ -337,7 +338,7 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
       List<Object> found = cacheQuery.list();
 
-      AssertJUnit.assertEquals(2, found.size());
+      assertEquals(2, found.size());
       assert found.contains(person1);
       assert found.contains(person2);
 
@@ -347,7 +348,7 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(person1);
       assert found.contains(person2);
       assert found.contains(person4) : "This should now contain object person4";
@@ -358,7 +359,7 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(person1);
       assert found.contains(person2);
       assert found.contains(person4);
@@ -370,7 +371,7 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       cacheQuery = Search.getSearchManager(cache).getQuery(query);
       found = cacheQuery.list();
 
-      Assert.assertEquals(3, found.size());
+      assertEquals(3, found.size());
       assert found.contains(person2);
       assert found.contains(person3);
       assert found.contains(person4);

--- a/query/src/test/java/org/infinispan/query/queries/spatial/QuerySpatialTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/spatial/QuerySpatialTest.java
@@ -1,6 +1,6 @@
 package org.infinispan.query.queries.spatial;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 import org.apache.lucene.search.Query;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;

--- a/remote-query/remote-query-client/pom.xml
+++ b/remote-query/remote-query-client/pom.xml
@@ -28,6 +28,12 @@
    <build>
       <plugins>
          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <skipTests>true</skipTests>
+            </configuration>
+         </plugin>
+         <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>
             <configuration>

--- a/remote-query/remote-query-server/pom.xml
+++ b/remote-query/remote-query-server/pom.xml
@@ -12,7 +12,7 @@
    <name>Infinispan Remote Query Server</name>
    <description>Infinispan Remote Query Server module</description>
 
-   
+
    <properties>
       <module.skipComponentMetaDataProcessing>false</module.skipComponentMetaDataProcessing>
    </properties>
@@ -65,6 +65,12 @@
          <groupId>org.kohsuke.metainf-services</groupId>
          <artifactId>metainf-services</artifactId>
          <optional>true</optional>
+      </dependency>
+
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
       </dependency>
    </dependencies>
 

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufIndexedFieldProviderTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufIndexedFieldProviderTest.java
@@ -10,8 +10,8 @@ import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.infinispan.transaction.TransactionMode;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 /**
  * Test that ProtobufIndexedFieldProvider correctly identifies indexed fields based on the protostream annotations

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataCachePreserveStateAcrossRestartsTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataCachePreserveStateAcrossRestartsTest.java
@@ -12,8 +12,7 @@ import org.infinispan.test.TestingUtil;
 import org.infinispan.test.fwk.TestCacheManagerFactory;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertTrue;
-
+import static org.testng.AssertJUnit.assertTrue;
 
 @Test(groups = "functional", testName = "query.remote.impl.ProtobufMetadataCachePreserveStateAcrossRestartsTest")
 public class ProtobufMetadataCachePreserveStateAcrossRestartsTest extends AbstractInfinispanTest {

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptorTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/ProtobufMetadataManagerInterceptorTest.java
@@ -19,10 +19,7 @@ import org.testng.annotations.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.AssertJUnit.*;
 
 @Test(groups = "functional", testName = "query.remote.impl.ProtobufMetadataManagerInterceptorTest")
 public class ProtobufMetadataManagerInterceptorTest extends MultipleCacheManagersTest {

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/QueryFacadeImplTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/QueryFacadeImplTest.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * @author anistor@redhat.com

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/indexing/ProtobufWrapperIndexingTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/indexing/ProtobufWrapperIndexingTest.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
 
 /**
  * @author anistor@redhat.com

--- a/scripting/pom.xml
+++ b/scripting/pom.xml
@@ -41,6 +41,11 @@
          <artifactId>metainf-services</artifactId>
          <optional>true</optional>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/scripting/src/test/java/org/infinispan/scripting/ReplicatedSecuredScriptingTest.java
+++ b/scripting/src/test/java/org/infinispan/scripting/ReplicatedSecuredScriptingTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import static org.infinispan.scripting.utils.ScriptingUtils.getScriptingManager;
 import static org.infinispan.scripting.utils.ScriptingUtils.loadScript;
-import static org.junit.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Tests verifying the script execution in secured clustered ispn environment.

--- a/scripting/src/test/java/org/infinispan/scripting/ScriptingTest.java
+++ b/scripting/src/test/java/org/infinispan/scripting/ScriptingTest.java
@@ -14,9 +14,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.infinispan.scripting.utils.ScriptingUtils.loadData;
-import static org.junit.Assert.assertNull;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
 
 @Test(groups = "functional", testName = "scripting.ScriptingTest")
 @CleanupAfterMethod

--- a/server/core/pom.xml
+++ b/server/core/pom.xml
@@ -13,7 +13,7 @@
    <name>Infinispan Server - Core Components</name>
    <description>Infinispan Server - Core Components</description>
 
-   
+
    <properties>
       <module.skipComponentMetaDataProcessing>false</module.skipComponentMetaDataProcessing>
    </properties>
@@ -32,6 +32,11 @@
          <groupId>org.apache.logging.log4j</groupId>
          <artifactId>log4j-slf4j-impl</artifactId>
          <scope>runtime</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
       </dependency>
    </dependencies>
 

--- a/server/hotrod/pom.xml
+++ b/server/hotrod/pom.xml
@@ -47,6 +47,11 @@
          <artifactId>jboss-sasl</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodAuthenticationTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodAuthenticationTest.scala
@@ -4,30 +4,13 @@ import org.testng.annotations.Test
 import java.lang.reflect.Method
 import test.HotRodTestingUtil._
 import org.testng.Assert._
-import java.util.Arrays
-import org.infinispan.server.hotrod.OperationStatus._
 import org.infinispan.server.hotrod.test._
-import org.infinispan.test.TestingUtil.generateRandomString
-import java.util.concurrent.TimeUnit
-import org.infinispan.server.core.test.Stoppable
-import org.infinispan.server.hotrod.configuration.HotRodServerConfiguration
-import org.infinispan.test.fwk.TestCacheManagerFactory
-import org.infinispan.server.core.QueryFacade
-import org.infinispan.AdvancedCache
 import org.infinispan.manager.EmbeddedCacheManager
 import org.infinispan.server.hotrod.configuration.HotRodServerConfigurationBuilder
 import javax.security.sasl.Sasl
-import javax.security.sasl.SaslClient
 import java.util.HashMap
 import org.infinispan.server.core.security.simple.SimpleServerAuthenticationProvider
-import org.testng.annotations.BeforeClass
-import java.security.Provider
 import org.jboss.sasl.JBossSaslProvider
-import org.testng.annotations.AfterClass
-import java.security.AccessController
-import java.security.PrivilegedAction
-import java.security.Security
-import org.junit.rules.ExpectedException
 
 /**
  * Hot Rod server authentication test.
@@ -61,7 +44,7 @@ class HotRodAuthenticationTest extends HotRodSingleNodeTest {
       assertTrue(res.complete)
       assertEquals(1, server.getDecoder.getTransport.acceptedChannels.size())
    }
-   
+
    def testUnauthorizedOpCloseConnection(m: Method) {
       // Ensure the transport is clean
       server.getDecoder.getTransport.stop()

--- a/server/memcached/pom.xml
+++ b/server/memcached/pom.xml
@@ -30,6 +30,11 @@
          <artifactId>spymemcached</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/server/rest/pom.xml
+++ b/server/rest/pom.xml
@@ -71,7 +71,7 @@
          <artifactId>xstream</artifactId>
       </dependency>
 
-      
+
       <dependency>
          <groupId>javax.servlet</groupId>
          <artifactId>servlet-api</artifactId>
@@ -88,7 +88,12 @@
          <artifactId>scala-xml_${version.scala.major}</artifactId>
       </dependency>
 
-      
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
+
       <dependency>
          <groupId>org.mortbay.jetty</groupId>
          <artifactId>jetty-embedded</artifactId>

--- a/server/rest/src/test/scala/org/infinispan/rest/TwoServerTest.java
+++ b/server/rest/src/test/scala/org/infinispan/rest/TwoServerTest.java
@@ -1,6 +1,5 @@
 package org.infinispan.rest;
 
-import static org.junit.Assert.assertEquals;
 import static org.testng.Assert.*;
 
 import javax.servlet.http.HttpServletResponse;

--- a/server/websocket/pom.xml
+++ b/server/websocket/pom.xml
@@ -21,10 +21,16 @@
          <artifactId>infinispan-server-core</artifactId>
       </dependency>
 
-       <dependency>
-           <groupId>org.codehaus.jackson</groupId>
-           <artifactId>jackson-mapper-asl</artifactId>
-       </dependency>
+      <dependency>
+         <groupId>org.codehaus.jackson</groupId>
+         <artifactId>jackson-mapper-asl</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
 
       <dependency>
          <groupId>org.eclipse.jetty</groupId>
@@ -35,7 +41,7 @@
 
    </dependencies>
 
-   <build>     
+   <build>
       <plugins>
          <plugin>
             <groupId>org.apache.felix</groupId>

--- a/spring/spring4/spring4-common/pom.xml
+++ b/spring/spring4/spring4-common/pom.xml
@@ -27,6 +27,12 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>

--- a/spring/spring4/spring4-embedded/pom.xml
+++ b/spring/spring4/spring4-embedded/pom.xml
@@ -96,6 +96,11 @@
             <artifactId>aspectjweaver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/spring/spring4/spring4-remote/pom.xml
+++ b/spring/spring4/spring4-remote/pom.xml
@@ -96,6 +96,11 @@
             <artifactId>aspectjweaver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tasks-api/pom.xml
+++ b/tasks-api/pom.xml
@@ -22,6 +22,12 @@
    <build>
       <plugins>
          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <skipTests>true</skipTests>
+            </configuration>
+         </plugin>
+         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
             <configuration>

--- a/tasks/pom.xml
+++ b/tasks/pom.xml
@@ -45,6 +45,11 @@
          <artifactId>metainf-services</artifactId>
          <optional>true</optional>
       </dependency>
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <build>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -86,6 +86,12 @@
       </dependency>
 
       <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
          <groupId>commons-logging</groupId>
          <artifactId>commons-logging</artifactId>
          <scope>test</scope>

--- a/tree/pom.xml
+++ b/tree/pom.xml
@@ -36,6 +36,12 @@
          <optional>true</optional>
       </dependency>
 
+      <dependency>
+         <groupId>org.testng</groupId>
+         <artifactId>testng</artifactId>
+         <scope>test</scope>
+      </dependency>
+
    </dependencies>
 
    <build>


### PR DESCRIPTION
This drops the default dependencies on testing libraries and forces each module to import the one of choice.
All of the test class changes are to choose testing utility classes only from one testing package.

https://issues.jboss.org/browse/ISPN-6720