### PR TITLE
ISPN-6576: Functional API does not load values from cache loader on non-primary owners

### DIFF
--- a/core/src/main/java/org/infinispan/commands/functional/AbstractWriteKeyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/AbstractWriteKeyCommand.java
@@ -6,7 +6,7 @@ import org.infinispan.commands.write.ValueMatcher;
 import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.functional.impl.Params;
 
-abstract class AbstractWriteKeyCommand<K> extends AbstractDataWriteCommand implements ParamsCommand {
+public abstract class AbstractWriteKeyCommand<K> extends AbstractDataWriteCommand implements ParamsCommand {
 
    Params params;
    ValueMatcher valueMatcher;

--- a/core/src/main/java/org/infinispan/commands/functional/AbstractWriteManyCommand.java
+++ b/core/src/main/java/org/infinispan/commands/functional/AbstractWriteManyCommand.java
@@ -10,7 +10,7 @@ import org.infinispan.metadata.Metadata;
 
 import java.util.Set;
 
-abstract class AbstractWriteManyCommand<K, V> implements WriteCommand, ParamsCommand {
+public abstract class AbstractWriteManyCommand<K, V> implements WriteCommand, ParamsCommand {
 
    boolean isForwarded = false;
    int topologyId = -1;

--- a/core/src/main/java/org/infinispan/interceptors/impl/CacheLoaderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/CacheLoaderInterceptor.java
@@ -5,8 +5,11 @@ import org.infinispan.CacheSet;
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.LocalFlagAffectedCommand;
 import org.infinispan.commands.functional.ReadOnlyKeyCommand;
+import org.infinispan.commands.functional.ReadOnlyManyCommand;
 import org.infinispan.commands.functional.ReadWriteKeyCommand;
 import org.infinispan.commands.functional.ReadWriteKeyValueCommand;
+import org.infinispan.commands.functional.ReadWriteManyCommand;
+import org.infinispan.commands.functional.ReadWriteManyEntriesCommand;
 import org.infinispan.commands.read.AbstractDataCommand;
 import org.infinispan.commands.read.EntrySetCommand;
 import org.infinispan.commands.read.GetAllCommand;
@@ -183,6 +186,16 @@ public class CacheLoaderInterceptor<K, V> extends JmxStatsCommandInterceptor {
       return visitDataCommand(ctx, command);
    }
 
+   private <T extends FlagAffectedCommand> CompletableFuture<Void> visitManyDataCommand(InvocationContext ctx, T command, Set<?> keys)
+         throws Throwable {
+      if (enabled) {
+         for (Object key : keys) {
+            loadIfNeeded(ctx, key, command);
+         }
+      }
+      return ctx.continueInvocation();
+   }
+
    private CompletableFuture<Void> visitDataCommand(InvocationContext ctx, AbstractDataCommand command)
          throws Throwable {
       if (enabled) {
@@ -337,6 +350,12 @@ public class CacheLoaderInterceptor<K, V> extends JmxStatsCommandInterceptor {
    }
 
    @Override
+   public CompletableFuture<Void> visitReadOnlyManyCommand(InvocationContext ctx, ReadOnlyManyCommand command)
+         throws Throwable {
+      return visitManyDataCommand(ctx, command, command.getKeys());
+   }
+
+   @Override
    public CompletableFuture<Void> visitReadWriteKeyCommand(InvocationContext ctx, ReadWriteKeyCommand command)
          throws Throwable {
       return visitDataCommand(ctx, command);
@@ -346,6 +365,16 @@ public class CacheLoaderInterceptor<K, V> extends JmxStatsCommandInterceptor {
    public CompletableFuture<Void> visitReadWriteKeyValueCommand(InvocationContext ctx, ReadWriteKeyValueCommand command)
          throws Throwable {
       return visitDataCommand(ctx, command);
+   }
+
+   @Override
+   public CompletableFuture<Void> visitReadWriteManyCommand(InvocationContext ctx, ReadWriteManyCommand command) throws Throwable {
+      return visitManyDataCommand(ctx, command, command.getKeys());
+   }
+
+   @Override
+   public CompletableFuture<Void> visitReadWriteManyEntriesCommand(InvocationContext ctx, ReadWriteManyEntriesCommand command) throws Throwable {
+      return visitManyDataCommand(ctx, command, command.getKeys());
    }
 
    protected final boolean isConditional(WriteCommand cmd) {

--- a/core/src/main/java/org/infinispan/interceptors/impl/CacheLoaderInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/CacheLoaderInterceptor.java
@@ -4,6 +4,8 @@ import org.infinispan.Cache;
 import org.infinispan.CacheSet;
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.LocalFlagAffectedCommand;
+import org.infinispan.commands.functional.AbstractWriteKeyCommand;
+import org.infinispan.commands.functional.AbstractWriteManyCommand;
 import org.infinispan.commands.functional.ReadOnlyKeyCommand;
 import org.infinispan.commands.functional.ReadOnlyManyCommand;
 import org.infinispan.commands.functional.ReadWriteKeyCommand;
@@ -456,7 +458,12 @@ public class CacheLoaderInterceptor<K, V> extends JmxStatsCommandInterceptor {
       }
 
       boolean skip;
-      if (cmd instanceof WriteCommand) {
+      if (cmd instanceof AbstractWriteKeyCommand || cmd instanceof AbstractWriteManyCommand) {
+         skip = skipLoadForFunctionalWriteCommand((WriteCommand) cmd, key, ctx);
+         if (trace) {
+            log.tracef("Skip load for functional write command %s? %s", cmd, skip);
+         }
+      } else if (cmd instanceof WriteCommand) {
          skip = skipLoadForWriteCommand((WriteCommand) cmd, key, ctx);
          if (trace) {
             log.tracef("Skip load for write command %s? %s", cmd, skip);
@@ -469,6 +476,10 @@ public class CacheLoaderInterceptor<K, V> extends JmxStatsCommandInterceptor {
          }
       }
       return skip;
+   }
+
+   protected boolean skipLoadForFunctionalWriteCommand(WriteCommand cmd, Object key, InvocationContext ctx) {
+      return skipLoadForWriteCommand(cmd, key, ctx);
    }
 
    protected boolean skipLoadForWriteCommand(WriteCommand cmd, Object key, InvocationContext ctx) {

--- a/core/src/test/java/org/infinispan/functional/AbstractFunctionalOpTest.java
+++ b/core/src/test/java/org/infinispan/functional/AbstractFunctionalOpTest.java
@@ -1,0 +1,97 @@
+package org.infinispan.functional;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.infinispan.commons.api.functional.EntryView.ReadEntryView;
+import org.infinispan.commons.api.functional.EntryView.ReadWriteEntryView;
+import org.infinispan.commons.api.functional.EntryView.WriteEntryView;
+import org.infinispan.commons.api.functional.FunctionalMap.ReadWriteMap;
+import org.infinispan.commons.api.functional.FunctionalMap.WriteOnlyMap;
+import org.infinispan.Cache;
+import org.infinispan.commons.api.functional.Param;
+import org.infinispan.functional.impl.ReadWriteMapImpl;
+import org.infinispan.functional.impl.WriteOnlyMapImpl;
+import org.infinispan.remoting.transport.Address;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt; && Krzysztof Sobolewski &lt;Krzysztof.Sobolewski@atende.pl&gt;
+ */
+@Test(groups = "functional", testName = "functional.AbstractFunctionalOpTest")
+public abstract class AbstractFunctionalOpTest extends AbstractFunctionalTest {
+   @DataProvider(name = "owningModeAndMethod")
+   public static Object[][] booleans() {
+      return Stream.of(Boolean.TRUE, Boolean.FALSE)
+            .flatMap(isSourceOwner -> Stream.of(Method.values())
+                  .map(method -> new Object[] { isSourceOwner, method }))
+            .toArray(Object[][]::new);
+   }
+
+   static Address getAddress(Cache<Object, Object> cache) {
+      return cache.getAdvancedCache().getRpcManager().getAddress();
+   }
+
+   WriteOnlyMap<Object, String> wo;
+   ReadWriteMap<Object, String> rw;
+
+   public AbstractFunctionalOpTest() {
+      numNodes = 4;
+      numDistOwners = 2;
+      cleanup = CleanupPhase.AFTER_METHOD;
+   }
+
+   @Override
+   @BeforeMethod
+   public void createBeforeMethod() throws Throwable {
+      super.createBeforeMethod();
+      this.wo = WriteOnlyMapImpl.create(fmapD1).withParams(Param.FutureMode.COMPLETED);
+      this.rw = ReadWriteMapImpl.create(fmapD1).withParams(Param.FutureMode.COMPLETED);
+   }
+
+   static enum Method {
+      WO_EVAL((key, wo, rw, read, write) ->
+            wo.eval(key, write).join()),
+      WO_EVAL_VALUE((key, wo, rw, read, write) ->
+            wo.eval(key, null, (BiConsumer<String, WriteEntryView<String>> & Serializable)
+                  (v, view) -> write.accept(view)).join()),
+      WO_EVAL_MANY((key, wo, rw, read, write) ->
+            wo.evalMany(Collections.singleton(key), write).join()),
+      WO_EVAL_MANY_ENTRIES((key, wo, rw, read, write) -> 
+            wo.evalMany(Collections.singletonMap(key, null), (BiConsumer<String, WriteEntryView<String>> & Serializable)
+                  (v, view) -> write.accept(view)).join()),
+      RW_EVAL((key, wo, rw, read, write) ->
+            rw.eval(key, (Function<ReadWriteEntryView<Object, String>, Object> & Serializable)
+                  view -> { read.accept(view); write.accept(view); return null; }).join()),
+      RW_EVAL_VALUE((key, wo, rw, read, write) ->
+            rw.eval(key, null, (BiFunction<String, ReadWriteEntryView<Object, String>, Object> & Serializable)
+                  (v, view) -> { read.accept(view); write.accept(view); return null; }).join()),
+      RW_EVAL_MANY((key, wo, rw, read, write) ->
+            rw.evalMany(Collections.singleton(key), (Function<ReadWriteEntryView<Object, String>, Object> & Serializable)
+                  view -> { read.accept(view); write.accept(view); return null; }).forEach(v -> {})),
+      RW_EVAL_MANY_ENTRIES((key, wo, rw, read, write) ->
+            rw.evalMany(Collections.singletonMap(key, null), (BiFunction<String, ReadWriteEntryView<Object, String>, Object> & Serializable)
+                  (v, view) -> { read.accept(view); write.accept(view); return null; }).forEach(v -> {})),
+      ;
+
+      final Performer action;
+
+      private Method(Performer action) {
+         this.action = action;
+      }
+
+      @FunctionalInterface
+      static interface Performer {
+         void eval(Object key,
+               WriteOnlyMap<Object, String> wo, ReadWriteMap<Object, String> rw,
+               Consumer<ReadEntryView<Object, String>> read, Consumer<WriteEntryView<String>> write);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/functional/AbstractFunctionalReadOnlyOpTest.java
+++ b/core/src/test/java/org/infinispan/functional/AbstractFunctionalReadOnlyOpTest.java
@@ -1,0 +1,69 @@
+package org.infinispan.functional;
+
+import java.util.Collections;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.infinispan.commons.api.functional.EntryView.ReadEntryView;
+import org.infinispan.commons.api.functional.FunctionalMap.ReadOnlyMap;
+import org.infinispan.Cache;
+import org.infinispan.commons.api.functional.Param;
+import org.infinispan.functional.impl.ReadOnlyMapImpl;
+import org.infinispan.remoting.transport.Address;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt; && Krzysztof Sobolewski &lt;Krzysztof.Sobolewski@atende.pl&gt;
+ */
+@Test(groups = "functional", testName = "functional.AbstractFunctionalOpTest")
+public abstract class AbstractFunctionalReadOnlyOpTest extends AbstractFunctionalTest {
+   @DataProvider(name = "owningModeAndMethod")
+   public static Object[][] booleans() {
+      return Stream.of(Boolean.TRUE, Boolean.FALSE)
+            .flatMap(isSourceOwner -> Stream.of(Method.values())
+                  .map(method -> new Object[] { isSourceOwner, method }))
+            .toArray(Object[][]::new);
+   }
+
+   static Address getAddress(Cache<Object, Object> cache) {
+      return cache.getAdvancedCache().getRpcManager().getAddress();
+   }
+
+   ReadOnlyMap<Object, String> ro;
+
+   public AbstractFunctionalReadOnlyOpTest() {
+      numNodes = 4;
+      numDistOwners = 2;
+      cleanup = CleanupPhase.AFTER_METHOD;
+   }
+
+   @Override
+   @BeforeMethod
+   public void createBeforeMethod() throws Throwable {
+      super.createBeforeMethod();
+      this.ro = ReadOnlyMapImpl.create(fmapD1).withParams(Param.FutureMode.COMPLETED);
+   }
+
+   static enum Method {
+      RO_EVAL((key, ro, read) ->
+            ro.eval(key, view -> { read.accept(view); return null; }).join()),
+      RO_EVAL_MANY((key, ro, read) ->
+            ro.evalMany(Collections.singleton(key), view -> { read.accept(view); return null; }).forEach(v -> {})),
+      ;
+
+      final Performer action;
+
+      private Method(Performer action) {
+         this.action = action;
+      }
+
+      @FunctionalInterface
+      static interface Performer {
+         void eval(Object key,
+               ReadOnlyMap<Object, String> ro,
+               Consumer<ReadEntryView<Object, String>> read);
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/functional/AbstractFunctionalTest.java
@@ -17,6 +17,7 @@ abstract class AbstractFunctionalTest extends MultipleCacheManagersTest {
    // Create local caches as default in a cluster of 2
    int numNodes = 2;
    int numDistOwners = 1;
+   boolean isSync = true;
    boolean isPersistenceEnabled = true;
 
    FunctionalMapImpl<Integer, String> fmapL1;
@@ -37,14 +38,14 @@ abstract class AbstractFunctionalTest extends MultipleCacheManagersTest {
       createClusteredCaches(numNodes, localBuilder);
       // Create distributed caches
       ConfigurationBuilder distBuilder = new ConfigurationBuilder();
-      distBuilder.clustering().cacheMode(CacheMode.DIST_SYNC).hash().numOwners(numDistOwners);
+      distBuilder.clustering().cacheMode(isSync ? CacheMode.DIST_SYNC : CacheMode.DIST_ASYNC).hash().numOwners(numDistOwners);
       if (isPersistenceEnabled) {
          distBuilder.persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class);
       }
       cacheManagers.stream().forEach(cm -> cm.defineConfiguration(DIST, distBuilder.build()));
       // Create replicated caches
       ConfigurationBuilder replBuilder = new ConfigurationBuilder();
-      replBuilder.clustering().cacheMode(CacheMode.REPL_SYNC);
+      replBuilder.clustering().cacheMode(isSync ? CacheMode.REPL_SYNC : CacheMode.REPL_ASYNC);
       if (isPersistenceEnabled) {
          replBuilder.persistence().addStore(DummyInMemoryStoreConfigurationBuilder.class);
       }

--- a/core/src/test/java/org/infinispan/functional/FunctionalCachestoreReadOnlyTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalCachestoreReadOnlyTest.java
@@ -1,0 +1,68 @@
+package org.infinispan.functional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.api.functional.EntryView.ReadEntryView;
+import org.infinispan.persistence.dummy.DummyInMemoryStore;
+import org.infinispan.persistence.manager.PersistenceManager;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt; && Krzysztof Sobolewski &lt;Krzysztof.Sobolewski@atende.pl&gt;
+ */
+@Test(groups = "functional", testName = "functional.FunctionalCachestoreTest")
+public class FunctionalCachestoreReadOnlyTest extends AbstractFunctionalReadOnlyOpTest {
+   public FunctionalCachestoreReadOnlyTest() {
+      isPersistenceEnabled = true;
+   }
+
+   @Test(dataProvider = "owningModeAndMethod")
+   public void testLoad(boolean isSourceOwner, Method method) {
+      Object key;
+      if (isSourceOwner) {
+         // this is simple: find a key that is local to the originating node
+         key = getKeyForCache(0, DIST);
+      } else {
+         // this is more complicated: we need a key that is *not* local to the originating node
+         key = IntStream.iterate(0, i -> i + 1)
+               .mapToObj(i -> "key" + i)
+               .filter(k -> !cache(0, DIST).getAdvancedCache().getDistributionManager().getLocality(k).isLocal())
+               .findAny()
+               .get();
+      }
+      List<Cache<Object, Object>> owners = caches(DIST).stream()
+            .filter(cache -> cache.getAdvancedCache().getDistributionManager().getLocality(key).isLocal())
+            .collect(Collectors.toList());
+
+      method.action.eval(key, ro,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> assertFalse(view.find().isPresent()));
+
+      // we can't add from read-only cache, so we put manually:
+      cache(0, DIST).put(key, "value");
+
+      caches(DIST).forEach(cache -> assertEquals(cache.get(key), "value", getAddress(cache).toString()));
+      caches(DIST).forEach(cache -> cache.evict(key));
+      caches(DIST).forEach(cache -> assertFalse(cache.getAdvancedCache().getDataContainer().containsKey(key), getAddress(cache).toString()));
+      owners.forEach(cache -> {
+         Set<DummyInMemoryStore> stores = cache.getAdvancedCache().getComponentRegistry().getComponent(PersistenceManager.class).getStores(DummyInMemoryStore.class);
+         DummyInMemoryStore store = stores.iterator().next();
+         assertTrue(store.contains(key), getAddress(cache).toString());
+      });
+
+      method.action.eval(key, ro,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> {
+               assertTrue(view.find().isPresent());
+               assertEquals(view.get(), "value");
+            });
+   }
+}

--- a/core/src/test/java/org/infinispan/functional/FunctionalCachestoreTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalCachestoreTest.java
@@ -1,0 +1,68 @@
+package org.infinispan.functional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.api.functional.EntryView.ReadEntryView;
+import org.infinispan.commons.api.functional.EntryView.WriteEntryView;
+import org.infinispan.persistence.dummy.DummyInMemoryStore;
+import org.infinispan.persistence.manager.PersistenceManager;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt; && Krzysztof Sobolewski &lt;Krzysztof.Sobolewski@atende.pl&gt;
+ */
+@Test(groups = "functional", testName = "functional.FunctionalCachestoreTest")
+public class FunctionalCachestoreTest extends AbstractFunctionalOpTest {
+   public FunctionalCachestoreTest() {
+      isPersistenceEnabled = true;
+   }
+
+   @Test(dataProvider = "owningModeAndMethod")
+   public void testLoad(boolean isSourceOwner, Method method) {
+      Object key;
+      if (isSourceOwner) {
+         // this is simple: find a key that is local to the originating node
+         key = getKeyForCache(0, DIST);
+      } else {
+         // this is more complicated: we need a key that is *not* local to the originating node
+         key = IntStream.iterate(0, i -> i + 1)
+               .mapToObj(i -> "key" + i)
+               .filter(k -> !cache(0, DIST).getAdvancedCache().getDistributionManager().getLocality(k).isLocal())
+               .findAny()
+               .get();
+      }
+      List<Cache<Object, Object>> owners = caches(DIST).stream()
+            .filter(cache -> cache.getAdvancedCache().getDistributionManager().getLocality(key).isLocal())
+            .collect(Collectors.toList());
+
+      method.action.eval(key, wo, rw,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> assertFalse(view.find().isPresent()),
+            (Consumer<WriteEntryView<String>> & Serializable) view -> view.set("value"));
+
+      caches(DIST).forEach(cache -> assertEquals(cache.get(key), "value", getAddress(cache).toString()));
+      caches(DIST).forEach(cache -> cache.evict(key));
+      caches(DIST).forEach(cache -> assertFalse(cache.getAdvancedCache().getDataContainer().containsKey(key), getAddress(cache).toString()));
+      owners.forEach(cache -> {
+         Set<DummyInMemoryStore> stores = cache.getAdvancedCache().getComponentRegistry().getComponent(PersistenceManager.class).getStores(DummyInMemoryStore.class);
+         DummyInMemoryStore store = stores.iterator().next();
+         assertTrue(store.contains(key), getAddress(cache).toString());
+      });
+
+      method.action.eval(key, wo, rw,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> {
+               assertTrue(view.find().isPresent());
+               assertEquals(view.get(), "value");
+            },
+            (Consumer<WriteEntryView<String>> & Serializable) view -> {});
+   }
+}

--- a/core/src/test/java/org/infinispan/functional/FunctionalDistributionTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalDistributionTest.java
@@ -1,0 +1,105 @@
+package org.infinispan.functional;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.commons.api.functional.EntryView.ReadWriteEntryView;
+import org.infinispan.commons.api.functional.FunctionalMap.ReadWriteMap;
+import org.infinispan.functional.impl.FunctionalMapImpl;
+import org.infinispan.functional.impl.ReadWriteMapImpl;
+import org.infinispan.test.TestingUtil;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * @author Krzysztof Sobolewski &lt;Krzysztof.Sobolewski@atende.pl&gt;
+ */
+@Test(groups = "functional", testName = "functional.FunctionalDistributionTest")
+public class FunctionalDistributionTest extends AbstractFunctionalTest {
+   public FunctionalDistributionTest() {
+      numNodes = 4;
+      // we want some non-owners and some secondary owners:
+      numDistOwners = 2;
+      /*
+       * The potential problem arises in async mode: the non-primary owner
+       * executes, then forwards to the primary owner, which executes and
+       * forwards to all non-primary owners, including the originator, which
+       * executes again. In sync mode this does not cause problems because the
+       * second invocation on the originator happens before the first is
+       * committed so it receives the same input data. Not so in async mode.
+       */
+      isSync = false;
+   }
+
+   @BeforeClass
+   @Override
+   public void createBeforeClass() throws Throwable {
+      super.createBeforeClass();
+   }
+
+   public void testDistributionFromPrimaryOwner() throws InterruptedException {
+      Object key = "testDistributionFromPrimaryOwner";
+      doTestDistribution(key, cacheManagers.stream()
+            .map(cm -> cm.<Object, Integer> getCache(DIST).getAdvancedCache())
+            .filter(cache -> cache.getDistributionManager().getPrimaryLocation(key)
+                  .equals(cache.getRpcManager().getAddress()))
+            .findAny()
+            .get());
+   }
+
+   public void testDistributionFromSecondaryOwner() throws InterruptedException {
+      Object key = "testDistributionFromSecondaryOwner";
+      doTestDistribution(key, cacheManagers.stream()
+            .map(cm -> cm.<Object, Integer> getCache(DIST).getAdvancedCache())
+            // owner...
+            .filter(cache -> cache.getDistributionManager().getLocality(key).isLocal()
+                  // ...but not primary owner
+                  && !cache.getDistributionManager().getPrimaryLocation(key)
+                        .equals(cache.getRpcManager().getAddress()))
+            .findAny()
+            .get());
+   }
+
+   public void testDistributionFromNonOwner() throws InterruptedException {
+      Object key = "testDistributionFromNonOwner";
+      doTestDistribution(key, cacheManagers.stream()
+            .map(cm -> cm.<Object, Integer> getCache(DIST).getAdvancedCache())
+            .filter(cache -> !cache.getDistributionManager().getLocality(key).isLocal())
+            .findAny()
+            .get());
+   }
+
+   private void doTestDistribution(Object key, AdvancedCache<Object, Integer> originator) throws InterruptedException {
+      ReadWriteMap<Object, Integer> rw = ReadWriteMapImpl.create(FunctionalMapImpl.create(originator));
+
+      // with empty cache:
+      iterate(key, rw, 1);
+      // again:
+      iterate(key, rw, 2);
+   }
+
+   private void iterate(Object key, ReadWriteMap<Object, Integer> rw, int expectedValue) throws InterruptedException {
+      rw.eval(key, (Function<ReadWriteEntryView<Object, Integer>, Void> & Serializable)
+            entry -> {
+               // we need a small delay so that the value gets committed before the replication finishes:
+               TestingUtil.sleepThread(10);
+               return entry.set(entry.find().orElse(0) + 1);
+            }).join();
+
+      // since we're in async mode, we need to wait before the replication finishes
+      Thread.sleep(100); // TODO: find a better way?
+
+      // we want to ensure that each of the owners executes the function only once:
+      Assert.assertEquals(
+            (Object) cacheManagers.stream()
+                  .map(cm -> cm.<Object, Integer> getCache(DIST).getAdvancedCache())
+                  .filter(cache -> cache.getDistributionManager().getLocality(key).isLocal())
+                  .map(cache -> cache.getDataContainer().get(key).getValue())
+                  .collect(Collectors.toList()),
+            Collections.nCopies(numDistOwners, expectedValue));
+   }
+}

--- a/core/src/test/java/org/infinispan/functional/FunctionalInMemoryReadOnlyTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalInMemoryReadOnlyTest.java
@@ -1,0 +1,59 @@
+package org.infinispan.functional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+
+import org.infinispan.commons.api.functional.EntryView.ReadEntryView;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt; && Krzysztof Sobolewski &lt;Krzysztof.Sobolewski@atende.pl&gt;
+ */
+@Test(groups = "functional", testName = "functional.FunctionalInMemoryTest")
+public class FunctionalInMemoryReadOnlyTest extends AbstractFunctionalReadOnlyOpTest {
+   public FunctionalInMemoryReadOnlyTest() {
+      isPersistenceEnabled = false;
+   }
+
+   @Test(dataProvider = "owningModeAndMethod")
+   public void testLoad(boolean isSourceOwner, Method method) {
+      Object key;
+      if (isSourceOwner) {
+         // this is simple: find a key that is local to the originating node
+         key = getKeyForCache(0, DIST);
+      } else {
+         // this is more complicated: we need a key that is *not* local to the originating node
+         key = IntStream.iterate(0, i -> i + 1)
+               .mapToObj(i -> "key" + i)
+               .filter(k -> !cache(0, DIST).getAdvancedCache().getDistributionManager().getLocality(k).isLocal())
+               .findAny()
+               .get();
+      }
+
+      method.action.eval(key, ro,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> assertFalse(view.find().isPresent()));
+
+      // we can't add from read-only cache, so we put manually:
+      cache(0, DIST).put(key, "value");
+
+      caches(DIST).forEach(cache -> assertEquals(cache.get(key), "value", getAddress(cache).toString()));
+      caches(DIST).forEach(cache -> {
+         if (cache.getAdvancedCache().getDistributionManager().getLocality(key).isLocal()) {
+            assertTrue(cache.getAdvancedCache().getDataContainer().containsKey(key), getAddress(cache).toString());
+         } else {
+            assertFalse(cache.getAdvancedCache().getDataContainer().containsKey(key), getAddress(cache).toString());
+         }
+      });
+
+      method.action.eval(key, ro,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> {
+               assertTrue(view.find().isPresent());
+               assertEquals(view.get(), "value");
+            });
+   }
+}

--- a/core/src/test/java/org/infinispan/functional/FunctionalInMemoryTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalInMemoryTest.java
@@ -1,0 +1,59 @@
+package org.infinispan.functional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+
+import org.infinispan.commons.api.functional.EntryView.ReadEntryView;
+import org.infinispan.commons.api.functional.EntryView.WriteEntryView;
+import org.testng.annotations.Test;
+
+/**
+ * @author Radim Vansa &lt;rvansa@redhat.com&gt; && Krzysztof Sobolewski &lt;Krzysztof.Sobolewski@atende.pl&gt;
+ */
+@Test(groups = "functional", testName = "functional.FunctionalInMemoryTest")
+public class FunctionalInMemoryTest extends AbstractFunctionalOpTest {
+   public FunctionalInMemoryTest() {
+      isPersistenceEnabled = false;
+   }
+
+   @Test(dataProvider = "owningModeAndMethod")
+   public void testLoad(boolean isSourceOwner, Method method) {
+      Object key;
+      if (isSourceOwner) {
+         // this is simple: find a key that is local to the originating node
+         key = getKeyForCache(0, DIST);
+      } else {
+         // this is more complicated: we need a key that is *not* local to the originating node
+         key = IntStream.iterate(0, i -> i + 1)
+               .mapToObj(i -> "key" + i)
+               .filter(k -> !cache(0, DIST).getAdvancedCache().getDistributionManager().getLocality(k).isLocal())
+               .findAny()
+               .get();
+      }
+
+      method.action.eval(key, wo, rw,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> assertFalse(view.find().isPresent()),
+            (Consumer<WriteEntryView<String>> & Serializable) view -> view.set("value"));
+
+      caches(DIST).forEach(cache -> assertEquals(cache.get(key), "value", getAddress(cache).toString()));
+      caches(DIST).forEach(cache -> {
+         if (cache.getAdvancedCache().getDistributionManager().getLocality(key).isLocal()) {
+            assertTrue(cache.getAdvancedCache().getDataContainer().containsKey(key), getAddress(cache).toString());
+         } else {
+            assertFalse(cache.getAdvancedCache().getDataContainer().containsKey(key), getAddress(cache).toString());
+         }
+      });
+
+      method.action.eval(key, wo, rw,
+            (Consumer<ReadEntryView<Object, String>> & Serializable) view -> {
+               assertTrue(view.find().isPresent());
+               assertEquals(view.get(), "value");
+            },
+            (Consumer<WriteEntryView<String>> & Serializable) view -> {});
+   }
+}


### PR DESCRIPTION
This PR includes four commits:

* Fix for the CacheLoaderInterceptor to handle the multi-key Functional commands
* The actual fix for ISPN-6576
* Test cases for ISPN-6576
* Additional test case for my misunderstanding of how lock delegation works :)