### PR TITLE
fix document, current wakeupInterval's default value is 60000.

### DIFF
--- a/documentation/src/main/asciidoc/user_guide/eviction.adoc
+++ b/documentation/src/main/asciidoc/user_guide/eviction.adoc
@@ -96,7 +96,7 @@ Eviction is disabled by default.  If enabled (using an empty `<eviction />` elem
 
 
 * strategy: EvictionStrategy.NONE is assumed, if a strategy is not specified..
-* wakeupInterval: 5000 is used if not specified.
+* wakeupInterval: 60000 is used if not specified.
 * If you wish to disable the eviction thread, set wakeupInterval to -1.
 * maxEntries: -1 is used if not specified, which means unlimited entries.
 * 0 means no entries, and the eviction thread will strive to keep the cache empty.


### PR DESCRIPTION
The default value of wakeupInterval seems to have been 5000 in Infinispan 4.x,
https://github.com/infinispan/infinispan/blob/4.2.x/core/src/main/java/org/infinispan/config/Configuration.java#L1730

I think present is 60000, but how about?
https://github.com/infinispan/infinispan/blob/9.0.0.Alpha2/core/src/main/java/org/infinispan/configuration/cache/ExpirationConfiguration.java#L16
https://github.com/infinispan/infinispan/blob/9.0.0.Alpha2/core/src/main/resources/schema/infinispan-config-9.0.xsd#L924