### PR TITLE
ISPN-6740 Client topologies not updated with persistent state

### DIFF
--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDistributionTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDistributionTest.scala
@@ -51,7 +51,7 @@ class HotRodDistributionTest extends HotRodMultiNodeTest {
       assertStatus(resp, Success)
       assertTopologyReceived(resp.topologyResponse.get, servers, currentServerTopologyId)
 
-      resp = client1.put(k(m) , 0, 0, v(m, "v3-"), INTELLIGENCE_TOPOLOGY_AWARE, 2)
+      resp = client1.put(k(m) , 0, 0, v(m, "v3-"), INTELLIGENCE_TOPOLOGY_AWARE, 10)
       assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
       assertSuccess(client2.get(k(m), 0), v(m, "v3-"))

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodReplicationTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodReplicationTest.scala
@@ -74,7 +74,7 @@ class HotRodReplicationTest extends HotRodMultiNodeTest {
       assertStatus(resp, Success)
       assertTopologyReceived(resp.topologyResponse.get, servers, currentServerTopologyId)
 
-      resp = clients.tail.head.ping(2, 2)
+      resp = clients.tail.head.ping(2, 10)
       assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
    }
@@ -93,7 +93,7 @@ class HotRodReplicationTest extends HotRodMultiNodeTest {
       assertStatus(resp, Success)
       assertTopologyReceived(resp.topologyResponse.get, servers, currentServerTopologyId)
 
-      resp = clients.head.put(k(m) , 0, 0, v(m, "v3-"), 2, 2)
+      resp = clients.head.put(k(m) , 0, 0, v(m, "v3-"), 2, 10)
       assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
       assertSuccess(clients.tail.head.get(k(m), 0), v(m, "v3-"))


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6740

The HotRod client starts with topology id 0, so we initialize the
cache with topology id 1 to force a topology update on the first ping.

Please cherry-pick on 8.2.x as well.