### PR TITLE
ISPN-6740 Client topologies not updated with persistent state

### DIFF
--- a/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
@@ -31,6 +31,10 @@ import static org.infinispan.util.logging.LogFactory.CLUSTER;
 * @since 5.2
 */
 public class ClusterCacheStatus implements AvailabilityStrategyContext {
+   // The HotRod client starts with topology 0, so we start with 1 to force an update
+   private static final int INITIAL_TOPOLOGY_ID = 1;
+   private static final int INITIAL_REBALANCE_ID = 1;
+
    private static final Log log = LogFactory.getLog(ClusterCacheStatus.class);
    private static boolean trace = log.isTraceEnabled();
 
@@ -594,7 +598,7 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
       ConsistentHash initialCH = joinInfo.getConsistentHashFactory().create(
             joinInfo.getHashFunction(), joinInfo.getNumOwners(), joinInfo.getNumSegments(),
             initialMembers, getCapacityFactors());
-      CacheTopology initialTopology = new CacheTopology(0, 0, initialCH, null, initialMembers);
+      CacheTopology initialTopology = new CacheTopology(INITIAL_TOPOLOGY_ID, INITIAL_REBALANCE_ID, initialCH, null, initialMembers);
       setCurrentTopology(initialTopology);
       setStableTopology(initialTopology);
       return initialTopology;

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDistributionTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodDistributionTest.scala
@@ -51,7 +51,7 @@ class HotRodDistributionTest extends HotRodMultiNodeTest {
       assertStatus(resp, Success)
       assertTopologyReceived(resp.topologyResponse.get, servers, currentServerTopologyId)
 
-      resp = client1.put(k(m) , 0, 0, v(m, "v3-"), INTELLIGENCE_TOPOLOGY_AWARE, 2)
+      resp = client1.put(k(m) , 0, 0, v(m, "v3-"), INTELLIGENCE_TOPOLOGY_AWARE, 10)
       assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
       assertSuccess(client2.get(k(m), 0), v(m, "v3-"))

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodReplicationTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodReplicationTest.scala
@@ -74,7 +74,7 @@ class HotRodReplicationTest extends HotRodMultiNodeTest {
       assertStatus(resp, Success)
       assertTopologyReceived(resp.topologyResponse.get, servers, currentServerTopologyId)
 
-      resp = clients.tail.head.ping(2, 2)
+      resp = clients.tail.head.ping(2, 10)
       assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
    }
@@ -93,7 +93,7 @@ class HotRodReplicationTest extends HotRodMultiNodeTest {
       assertStatus(resp, Success)
       assertTopologyReceived(resp.topologyResponse.get, servers, currentServerTopologyId)
 
-      resp = clients.head.put(k(m) , 0, 0, v(m, "v3-"), 2, 2)
+      resp = clients.head.put(k(m) , 0, 0, v(m, "v3-"), 2, 10)
       assertStatus(resp, Success)
       assertEquals(resp.topologyResponse, None)
       assertSuccess(clients.tail.head.get(k(m), 0), v(m, "v3-"))


### PR DESCRIPTION
Backport of https://github.com/infinispan/infinispan/pull/4391 for 8.2.x
https://issues.jboss.org/browse/ISPN-6740

The HotRod client starts with topology id 0, so we initialize the
cache with topology id 1 to force a topology update on the first ping.
