### PR TITLE
ISPN-6768 CommandAwareRpcDispatcher channel listener can cause classloader leaks

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
@@ -35,6 +35,7 @@ import org.jgroups.util.NotifyingFuture;
 import org.jgroups.util.Rsp;
 import org.jgroups.util.RspList;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -84,6 +85,14 @@ public class CommandAwareRpcDispatcher extends RpcDispatcher {
       }
       channel.addChannelListener(this);
       asyncDispatching(true);
+   }
+
+   @Override
+   public void close() {
+      // Ensure dispatcher is stopped
+      this.stop();
+      // We must unregister our listener, otherwise the channel will retain a reference to this dispatcher
+      this.channel.removeChannelListener(this);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/JGroupsTransport.java
@@ -293,7 +293,7 @@ public class JGroupsTransport extends AbstractTransport implements MembershipLis
 
       if (dispatcher != null) {
          log.stoppingRpcDispatcher(clusterName);
-         dispatcher.stop();
+         dispatcher.close();
          if (channel != null) {
             // Remove reference to up_handler
             UpHandler handler = channel.getUpHandler();


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6768

Please cherry-pick into 8.2.x and 8.1.x.