### PR TITLE
ISPN-6744 ClusterEvent doesn't implement CacheEntryExpired

### DIFF
--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
@@ -299,7 +299,7 @@ public abstract class AbstractClusterListenerUtilTest extends MultipleCacheManag
    }
 
    protected void verifySimpleExpirationEvents(ClusterListener listener, int expectedNumEvents, Object key, Object expectedValue) {
-      eventuallyEquals(expectedNumEvents, () -> listener.events.size());
+      eventually(() -> listener.events.size() >= expectedNumEvents);
 
       CacheEntryEvent event = listener.events.get(expectedNumEvents - 1); //the index starts from 0
 


### PR DESCRIPTION
* Changed test back to make it more reliable

https://issues.jboss.org/browse/ISPN-6744

This can go into 8.2.x as well.