### PR TITLE
ISPN-6773 (backport to 8.2.x): treat non-MetadataAware InternalCacheEntries as not needin…

### DIFF
--- a/core/src/main/java/org/infinispan/container/InternalEntryFactoryImpl.java
+++ b/core/src/main/java/org/infinispan/container/InternalEntryFactoryImpl.java
@@ -328,9 +328,17 @@ public class InternalEntryFactoryImpl implements InternalEntryFactory {
     */
    private boolean isStoreMetadata(Metadata metadata, InternalCacheEntry ice) {
       return metadata != null
-            && (ice == null || ice instanceof MetadataAware)
+            && (ice == null || isEntryMetadataAware(ice))
             && (metadata.version() != null
                       || !(metadata instanceof EmbeddedMetadata));
+   }
+
+
+   private boolean isEntryMetadataAware(InternalCacheEntry ice) {
+      return ice instanceof MetadataImmortalCacheEntry
+            || ice instanceof MetadataMortalCacheEntry
+            || ice instanceof MetadataTransientCacheEntry
+            || ice instanceof MetadataTransientMortalCacheEntry;
    }
 
 }

--- a/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
@@ -2,7 +2,6 @@ package org.infinispan.container.entries;
 
 import org.infinispan.metadata.Metadata;
 import org.infinispan.container.DataContainer;
-import org.infinispan.container.entries.metadata.MetadataAware;
 
 import java.util.Map;
 
@@ -13,7 +12,7 @@ import java.util.Map;
  * @author Galder Zamarreño
  * @since 4.0
  */
-public interface CacheEntry<K, V> extends Cloneable, Map.Entry<K, V>, MetadataAware {
+public interface CacheEntry<K, V> extends Cloneable, Map.Entry<K, V> {
 
    /**
     * Tests whether the entry represents a null value, typically used for repeatable read.
@@ -137,4 +136,17 @@ public interface CacheEntry<K, V> extends Cloneable, Map.Entry<K, V>, MetadataAw
 
    public CacheEntry<K, V> clone();
 
+   /**
+    * Get metadata of this cache entry.
+    *
+    * @return a Metadata instance
+    */
+   Metadata getMetadata();
+
+   /**
+    * Set the metadata in the cache entry.
+    *
+    * @param metadata to apply to the cache entry
+    */
+   void setMetadata(Metadata metadata);
 }

--- a/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
+++ b/core/src/main/java/org/infinispan/container/entries/CacheEntry.java
@@ -2,6 +2,7 @@ package org.infinispan.container.entries;
 
 import org.infinispan.metadata.Metadata;
 import org.infinispan.container.DataContainer;
+import org.infinispan.container.entries.metadata.MetadataAware;
 
 import java.util.Map;
 
@@ -12,7 +13,7 @@ import java.util.Map;
  * @author Galder Zamarreño
  * @since 4.0
  */
-public interface CacheEntry<K, V> extends Cloneable, Map.Entry<K, V> {
+public interface CacheEntry<K, V> extends Cloneable, Map.Entry<K, V>, MetadataAware {
 
    /**
     * Tests whether the entry represents a null value, typically used for repeatable read.
@@ -136,17 +137,4 @@ public interface CacheEntry<K, V> extends Cloneable, Map.Entry<K, V> {
 
    public CacheEntry<K, V> clone();
 
-   /**
-    * Get metadata of this cache entry.
-    *
-    * @return a Metadata instance
-    */
-   Metadata getMetadata();
-
-   /**
-    * Set the metadata in the cache entry.
-    *
-    * @param metadata to apply to the cache entry
-    */
-   void setMetadata(Metadata metadata);
 }

--- a/core/src/main/java/org/infinispan/container/entries/metadata/MetadataAware.java
+++ b/core/src/main/java/org/infinispan/container/entries/metadata/MetadataAware.java
@@ -3,7 +3,7 @@ package org.infinispan.container.entries.metadata;
 import org.infinispan.metadata.Metadata;
 
 /**
- * Metdata aware cache entry.
+ * Marker interface for metadata aware cache entry.
  *
  * @author Galder Zamarreño
  * @since 5.3

--- a/core/src/test/java/org/infinispan/api/MetadataAPITest.java
+++ b/core/src/test/java/org/infinispan/api/MetadataAPITest.java
@@ -153,6 +153,25 @@ public class MetadataAPITest extends SingleCacheManagerTest {
       assertEquals(newLifespan, entry.getMetadata().lifespan());
    }
 
+   /**
+    * See ISPN-6773.
+    */
+   public void testReplaceEmbeddedFunctionalWithLifespan() throws Exception {
+      final Integer key = 4;
+      long lifespan = 1_000_000;
+      advCache.put(key, "v1", withLifespan(lifespan));
+      long newLifespan = 2_000_000;
+      CompletableFuture<Void> f = WriteOnlyMapImpl.create(FunctionalMapImpl.create(advCache))
+            .eval(key, view -> view.set("v2", new MetaParam.MetaLifespan(newLifespan)));
+      assertNotNull(f);
+      assertFalse(f.isCancelled());
+      assertNull(f.get());
+      assertTrue(f.isDone());
+      CacheEntry entry = advCache.getCacheEntry(key);
+      assertEquals("v2", entry.getValue());
+      assertEquals(newLifespan, entry.getMetadata().lifespan());
+   }
+
    public void testGetCustomMetadataForMortalEntries() throws Exception {
       final Integer key = 5;
       Metadata meta = new CustomMetadata(3000, -1);


### PR DESCRIPTION
…g the entire Metadata object to be stored.

* Make CacheEntry *not* implement MetadataAware
  - Now only the Metadata*CacheEntry classes (like MetadataMortalCacheEntry)
    implement this interface, while non-Metadata* classes (like the plain
    MortalCacheEntry) do not.
  - The getMetadata() and setMetadata() method need to be specified in
    CacheEntry interface, as they used to be inherited from MetadataAware.
* Make InternalEntryFactoryImpl.isStoreMetadata() check the type of the
  InternalCacheEntry in addition to the Metadata object and return false if it
  does not implement MetadataAware.
* If the entry is new, pass null as the InternalCacheEntry and test only the
  Metadata object.

This way the correct code path (fot Metadata* or non-Metadata*) in
EntryWrappingInterceptor is used even if the Functional API replaces the
Metadata object inside the InternalCacheEntry.