### PR TITLE
ISPN-6494 Re-add the DONT_BUNDLE flag

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
@@ -244,6 +244,10 @@ public class CommandAwareRpcDispatcher extends RpcDispatcher {
       Message msg = new Message();
       msg.setBuffer(buf);
       encodeDeliverMode(msg, deliverOrder);
+      //some issues with the new bundler. put back the DONT_BUNDLE flag.
+      if (deliverOrder == DeliverOrder.NONE || mode != ResponseMode.GET_NONE) {
+         msg.setFlag(Message.Flag.DONT_BUNDLE.value());
+      }
       // Only the commands in total order must be received by the originator.
       if (deliverOrder != DeliverOrder.TOTAL) {
          msg.setTransientFlag(Message.TransientFlag.DONT_LOOPBACK.value());


### PR DESCRIPTION
We're still investigating transfer-queue vs sender-sends-with-timer, and it's better to have DONT_BUNDLE for testing because transfer-queue ignores it.

Please keep the issue open.