### PR TITLE
ISPN-6789 EnwtryWrappingInterceptor computes location twice on backups

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/EntryWrappingInterceptor.java
@@ -313,7 +313,7 @@ public class EntryWrappingInterceptor extends DDAsyncInterceptor {
          result = true;
       } else {
          if (isUsingLockDelegation || isTransactional) {
-            result = cdl.localNodeIsPrimaryOwner(key) || (cdl.localNodeIsOwner(key) && !ctx.isOriginLocal());
+            result = ctx.isOriginLocal() ? cdl.localNodeIsPrimaryOwner(key) : cdl.localNodeIsOwner(key);
          } else {
             result = cdl.localNodeIsOwner(key);
          }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6789