### PR TITLE
Adding class-resolver to serialization in infinispan-config schema

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Attribute.java
@@ -30,6 +30,7 @@ public enum Attribute {
     CAPACITY_FACTOR("capacity"),
     CHUNK_SIZE("chunk-size"),
     CLASS("class"),
+    CLASS_RESOLVER_CLASS("class-resolver"),
     CLUSTER("cluster"),
     COMPLETED_TX_TIMEOUT("complete-timeout"),
     CONCURRENCY_LEVEL("concurrency-level"),

--- a/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
+++ b/core/src/main/java/org/infinispan/configuration/parsing/Parser.java
@@ -59,6 +59,7 @@ import org.infinispan.transaction.lookup.TransactionManagerLookup;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
+import org.jboss.marshalling.ClassResolver;
 import org.kohsuke.MetaInfServices;
 
 import javax.xml.stream.XMLStreamConstants;
@@ -143,6 +144,10 @@ public class Parser implements ConfigurationParser {
             }
             case VERSION: {
                builder.serialization().version(value);
+               break;
+            }
+            case CLASS_RESOLVER_CLASS: {
+               builder.serialization().classResolver(Util.<ClassResolver>getInstance(value, holder.getClassLoader()));
                break;
             }
             default: {

--- a/core/src/main/java/org/infinispan/configuration/serializing/Serializer.java
+++ b/core/src/main/java/org/infinispan/configuration/serializing/Serializer.java
@@ -281,6 +281,7 @@ public class Serializer extends AbstractStoreSerializer implements Configuration
          if (attributes.attribute(SerializationConfiguration.VERSION).isModified()) {
             writer.writeAttribute(Attribute.VERSION, Version.decodeVersion(serialization.version()));
          }
+         attributes.write(writer, SerializationConfiguration.CLASS_RESOLVER, Attribute.CLASS_RESOLVER_CLASS);
          writeAdvancedSerializers(writer, globalConfiguration);
          writer.writeEndElement();
       }

--- a/core/src/main/resources/schema/infinispan-config-9.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-9.0.xsd
@@ -506,6 +506,13 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="class-resolver" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Fully qualified name of the class resolver to use. It must implement org.jboss.marshalling.ClassResolver. Sometimes, a custom class resolver (e.g., org.jboss.marshalling.ContextClassResolver) might do the job instead of full blown marshaller.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="jmx">


### PR DESCRIPTION
```
Caused by: java.io.NotSerializableException: org.infinispan.topology.CacheTopologyControlCommand
	...
Caused by: an exception which occurred:
	in object org.infinispan.topology.CacheTopologyControlCommand@1d782abe
```

Often above exception occurs while using a custom marshaller for serialization. 
It mostly occurs as probably the ExternalizerTable is not available (even when tried with @Inject) to the custom marshaller.
https://issues.jboss.org/browse/ISPN-4512 can be helpful.

However, instead of a full blown custom marshaller a simple custom class resolver (e.g., org.jboss.marshalling.ContextClassResolver) might do the job, specifically, when integrating Infinispan with web applications.

This is needed as the org.infinispan.marshall.core.JBossMarshaller$EmbeddedContextClassResolver uses InvocationContextContainer and that doesn't lead to desire class loader all the time.