### PR TITLE
ISPN-6816 Removed log4j and jboss modules from Uber Jars

### DIFF
--- a/all/embedded-query/pom.xml
+++ b/all/embedded-query/pom.xml
@@ -51,7 +51,6 @@
                      <artifactSet>
                         <excludes>
                            <exclude>org.infinispan:infinispan-embedded-query</exclude>
-                           <exclude>log4j:log4j:jar:</exclude>
                            <exclude>org.infinispan:infinispan-commons</exclude>
                            <exclude>org.infinispan:infinispan-core</exclude>
                            <exclude>org.jgroups:jgroups</exclude>
@@ -110,11 +109,6 @@
                            <pattern>org.codehaus</pattern>
                            <shadedPattern>infinispan.org.codehaus</shadedPattern>
                         </relocation>
-                        
-                        
-                           
-                           
-                        
                         <relocation>
                            <pattern>org.slf4j</pattern>
                            <shadedPattern>infinispan.org.slf4j</shadedPattern>

--- a/all/embedded/pom.xml
+++ b/all/embedded/pom.xml
@@ -128,12 +128,6 @@
       </dependency>
 
       <dependency>
-         <groupId>org.jboss.modules</groupId>
-         <artifactId>jboss-modules</artifactId>
-         <optional>${uberjar.deps.optional}</optional>
-      </dependency>
-
-      <dependency>
          <groupId>com.mchange</groupId>
          <artifactId>c3p0</artifactId>
          <optional>${uberjar.deps.optional}</optional>
@@ -171,8 +165,8 @@
                            <exclude>org.fusesource.hawtjni:hawtjni-runtime:jar:</exclude>
                            <exclude>org.fusesource.leveldbjni:leveldbjni:jar:</exclude>
                            <exclude>org.iq80.leveldb:leveldb-api:jar:</exclude>
-                           <exclude>org.apache.logging.log4j:log4j-core:jar:*</exclude>
-                           <exclude>log4j:log4j:jar:*</exclude>
+                           <exclude>org.apache.logging.log4j:log4j-core:jar:</exclude>
+                           <exclude>org.apache.logging.log4j:log4j-api:jar:</exclude>
                            <exclude>net.jcip:jcip-annotations:jar:</exclude>
                            <exclude>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.1_spec:jar:</exclude>
                            <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec:jar:</exclude>
@@ -263,8 +257,6 @@
                            <pattern>org.iq80</pattern>
                            <shadedPattern>infinispan.org.iq80</shadedPattern>
                         </relocation>
-                        
-                        
                      </relocations>
                      <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
@@ -318,7 +310,6 @@
                            !javax.interceptor.*,
                            !javax.persistence.*,
                            !net.jcip.annotations,
-                           !org.apache.logging.*,
                            !org.hibernate.*,
                            !org.infinispan.*,
                            !org.infinispan.client.*,

--- a/all/remote/pom.xml
+++ b/all/remote/pom.xml
@@ -57,24 +57,18 @@
          <optional>${uberjar.deps.optional}</optional>
       </dependency>
 
-
       <dependency>
          <groupId>org.jboss.marshalling</groupId>
          <artifactId>jboss-marshalling-osgi</artifactId>
          <optional>${uberjar.deps.optional}</optional>
       </dependency>
 
-      
       <dependency>
          <groupId>org.wildfly.core</groupId>
          <artifactId>wildfly-controller-client</artifactId>
          <optional>${uberjar.deps.optional}</optional>
       </dependency>
-      <dependency>
-         <groupId>org.jboss.modules</groupId>
-         <artifactId>jboss-modules</artifactId>
-         <optional>${uberjar.deps.optional}</optional>
-      </dependency>
+
       <dependency>
          <groupId>org.wildfly.core</groupId>
          <artifactId>wildfly-controller</artifactId>
@@ -113,8 +107,8 @@
                      <finalName>${intermediary_jar_name}</finalName>
                      <artifactSet>
                         <excludes>
-                           <exclude>org.apache.logging.log4j:log4j-core:jar:*</exclude>
-                           <exclude>log4j:log4j:jar:*</exclude>
+                           <exclude>org.apache.logging.log4j:log4j-core:jar:</exclude>
+                           <exclude>org.apache.logging.log4j:log4j-api:jar:</exclude>
                            <exclude>net.jcip:jcip-annotations:jar:*</exclude>
                            <exclude>org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec:*</exclude>
                            <exclude>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.1_spec:*</exclude>
@@ -144,12 +138,6 @@
                            <artifact>org.jboss.marshalling:jboss-marshalling</artifact>
                            <excludes>
                               <exclude>org/jboss/marshalling/ModularClassTable*.class</exclude>
-                           </excludes>
-                        </filter>
-                        <filter>
-                           <artifact>org.apache.logging.log4j:log4j-api</artifact>
-                           <excludes>
-                              <exclude>org/apache/logging/log4j/util/Activator*.class</exclude>
                            </excludes>
                         </filter>
                         <filter>
@@ -199,14 +187,6 @@
                            <pattern>com.google</pattern>
                            <shadedPattern>infinispan.com.google</shadedPattern>
                         </relocation>
-                        
-                        
-                        
-                        
-                        
-                           
-                           
-                        
                         <relocation>
                            <pattern>org.jboss.threads</pattern>
                            <shadedPattern>infinispan.org.jboss.threads</shadedPattern>
@@ -220,10 +200,6 @@
                            <shadedPattern>infinispan.org.jboss.logging</shadedPattern>
                         </relocation>
                         <relocation>
-                           <pattern>org.jboss.modules</pattern>
-                           <shadedPattern>infinispan.org.jboss.modules</shadedPattern>
-                        </relocation>
-                        <relocation>
                            <pattern>org.jboss.dmr</pattern>
                            <shadedPattern>infinispan.org.jboss.dmr</shadedPattern>
                         </relocation>
@@ -235,12 +211,6 @@
                            <pattern>com.squareup</pattern>
                            <shadedPattern>infinispan.com.squareup</shadedPattern>
                         </relocation>
-                        
-                        
-                        
-                           
-                           
-                        
                      </relocations>
                      <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -387,6 +387,11 @@
          </dependency>
          <dependency>
             <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${version.log4j}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jcl</artifactId>
             <version>${version.log4j}</version>
          </dependency>

--- a/server/integration/testsuite/pom.xml
+++ b/server/integration/testsuite/pom.xml
@@ -104,6 +104,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.infinispan.protostream</groupId>
             <artifactId>sample-domain-implementation</artifactId>
         </dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6816

Highlights:
* Log4J removed
* JBoss modules removed
* Hot Rod client needs to stay (remote cache store scenario)
* Protostream need to stay (remote cache store a can use custom marshaller)