### PR TITLE
ISPN-6912 clustered-indexing.xml example configuration file in server…

### DIFF
--- a/server/integration/endpoint/src/main/resources/subsystem-templates/infinispan-endpoint.xml
+++ b/server/integration/endpoint/src/main/resources/subsystem-templates/infinispan-endpoint.xml
@@ -91,6 +91,14 @@
          </hotrod-connector>
       </replacement>
    </supplement>
+   <supplement name="indexing">
+      <replacement placeholder="@@default-cache-container@@" attributeValue="clustered" />
+      <replacement placeholder="CONNECTORS">
+         <hotrod-connector socket-binding="hotrod" cache-container="clustered">
+            <topology-state-transfer lazy-retrieval="false" lock-timeout="1000" replication-timeout="5000" />
+         </hotrod-connector>
+      </replacement>
+   </supplement>
    <socket-binding name="hotrod" port="11222" />
    <socket-binding name="hotrod-internal" port="11223" />
    <socket-binding name="memcached" port="11211" />

--- a/server/integration/feature-pack/src/main/resources/configuration/examples/subsystems-indexing.xml
+++ b/server/integration/feature-pack/src/main/resources/configuration/examples/subsystems-indexing.xml
@@ -7,6 +7,7 @@
       <subsystem>jdr.xml</subsystem>
       <subsystem>infinispan-jgroups.xml</subsystem>
       <subsystem supplement="indexing">infinispan-core.xml</subsystem>
+      <subsystem supplement="indexing">infinispan-endpoint.xml</subsystem>
       <subsystem>jmx.xml</subsystem>
       <subsystem>naming.xml</subsystem>
       <subsystem>remoting.xml</subsystem>


### PR DESCRIPTION
… is missing an endpoint

Indexing is useful for remote querying so the HotRod endpoint should be there.

https://issues.jboss.org/browse/ISPN-6912