### PR TITLE
ISPN-6679 Healthcheck API

### DIFF
--- a/core/src/main/java/org/infinispan/health/CacheHealth.java
+++ b/core/src/main/java/org/infinispan/health/CacheHealth.java
@@ -1,0 +1,20 @@
+package org.infinispan.health;
+
+/**
+ * Cache health information.
+ *
+ * @author Sebastian Łaskawiec
+ * @since 9.0
+ */
+public interface CacheHealth {
+
+    /**
+     * Returns Cache name.
+     */
+    String getCacheName();
+
+    /**
+     * Returns Cache health status.
+     */
+    HealthStatus getStatus();
+}

--- a/core/src/main/java/org/infinispan/health/ClusterHealth.java
+++ b/core/src/main/java/org/infinispan/health/ClusterHealth.java
@@ -1,0 +1,29 @@
+package org.infinispan.health;
+
+import java.util.List;
+
+/**
+ * Cluster health information.
+ */
+public interface ClusterHealth {
+
+    /**
+     * Returns total cluster health.
+     */
+    HealthStatus getHealthStatus();
+
+    /**
+     * Returns the name of the cluster.
+     */
+    String getClusterName();
+
+    /**
+     * Returns the number of nodes in the cluster.
+     */
+    int getNumberOfNodes();
+
+    /**
+     * Returns node names.
+     */
+    List<String> getNodeNames();
+}

--- a/core/src/main/java/org/infinispan/health/Health.java
+++ b/core/src/main/java/org/infinispan/health/Health.java
@@ -1,0 +1,31 @@
+package org.infinispan.health;
+
+import java.util.List;
+
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+
+/**
+ * An entry point for checking health status.
+ *
+ * @author Sebastian Łaskawiec
+ * @since 9.0
+ */
+@Scope(Scopes.GLOBAL)
+public interface Health {
+
+    /**
+     * Returns Cluster health.
+     */
+    ClusterHealth getClusterHealth();
+
+    /**
+     * Returns per cache health.
+     */
+    List<CacheHealth> getCacheHealth();
+
+    /**
+     * Gets basic information about the host.
+     */
+    HostInfo getHostInfo();
+}

--- a/core/src/main/java/org/infinispan/health/HealthStatus.java
+++ b/core/src/main/java/org/infinispan/health/HealthStatus.java
@@ -1,0 +1,29 @@
+package org.infinispan.health;
+
+/**
+ * General Health status.
+ *
+ * @author Sebastian Łaskawiec
+ * @since 9.0
+ */
+public enum HealthStatus {
+    /**
+     * Given entity is unhealthy.
+     *
+     * <p>
+     *    An unhealthy status means that a cache is in {@link org.infinispan.partitionhandling.AvailabilityMode#DEGRADED_MODE}.
+     *    Please keep in mind that in the future additional rules might be added to reflect Unhealthy status of the cache.
+     * </p>.
+     */
+    UNHEALTHY,
+
+    /**
+     * Given entity is healthy.
+     */
+    HEALTHY,
+
+    /**
+     * Given entity is healthy but a rebalance is in progress.
+     */
+    REBALANCING
+}

--- a/core/src/main/java/org/infinispan/health/HostInfo.java
+++ b/core/src/main/java/org/infinispan/health/HostInfo.java
@@ -1,0 +1,25 @@
+package org.infinispan.health;
+
+/**
+ * Information about the host.
+ *
+ * @author Sebastian Łaskawiec
+ * @since 9.0
+ */
+public interface HostInfo {
+
+    /**
+     * Returns the number of CPUs installed in the host.
+     */
+    int getNumberOfCpus();
+
+    /**
+     * Gets total memory in KB.
+     */
+    long getTotalMemoryKb();
+
+    /**
+     * Gets free memory in KB.
+     */
+    long getFreeMemoryInKb();
+}

--- a/core/src/main/java/org/infinispan/health/impl/CacheHealthImpl.java
+++ b/core/src/main/java/org/infinispan/health/impl/CacheHealthImpl.java
@@ -1,0 +1,44 @@
+package org.infinispan.health.impl;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.Cache;
+import org.infinispan.distribution.DistributionManager;
+import org.infinispan.health.CacheHealth;
+import org.infinispan.health.HealthStatus;
+import org.infinispan.partitionhandling.AvailabilityMode;
+
+public class CacheHealthImpl implements CacheHealth {
+
+    private final AdvancedCache<?, ?> cache;
+
+    public CacheHealthImpl(Cache<?, ?> cache) {
+        this.cache = cache.getAdvancedCache();
+    }
+
+    @Override
+    public String getCacheName() {
+        return cache.getName();
+    }
+
+    @Override
+    public HealthStatus getStatus() {
+        if (!isComponentHealthy() || cache.getAvailability() == AvailabilityMode.DEGRADED_MODE) {
+            return HealthStatus.UNHEALTHY;
+        }
+        DistributionManager distributionManager = cache.getDistributionManager();
+        if (distributionManager != null && distributionManager.isRehashInProgress()) {
+            return HealthStatus.REBALANCING;
+        }
+        return HealthStatus.HEALTHY;
+    }
+
+    private boolean isComponentHealthy() {
+        switch (cache.getStatus()) {
+            case INSTANTIATED:
+            case RUNNING:
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/core/src/main/java/org/infinispan/health/impl/ClusterHealthImpl.java
+++ b/core/src/main/java/org/infinispan/health/impl/ClusterHealthImpl.java
@@ -1,0 +1,54 @@
+package org.infinispan.health.impl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.infinispan.health.ClusterHealth;
+import org.infinispan.health.HealthStatus;
+import org.infinispan.manager.EmbeddedCacheManager;
+
+public class ClusterHealthImpl implements ClusterHealth {
+
+    private final EmbeddedCacheManager cacheManager;
+
+    public ClusterHealthImpl(EmbeddedCacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    @Override
+    public HealthStatus getHealthStatus() {
+        Set<HealthStatus> healthStatuses = cacheManager.getCacheNames().stream()
+                .map(cacheName -> cacheManager.getCache(cacheName))
+                .map(cache -> new CacheHealthImpl(cache))
+                .map(cacheHealth -> cacheHealth.getStatus())
+                .collect(Collectors.toSet());
+
+        if (healthStatuses.contains(HealthStatus.UNHEALTHY)) {
+            return HealthStatus.UNHEALTHY;
+        } else if (healthStatuses.contains(HealthStatus.REBALANCING)) {
+            return HealthStatus.REBALANCING;
+        }
+        return HealthStatus.HEALTHY;
+    }
+
+    @Override
+    public String getClusterName() {
+        return cacheManager.getClusterName();
+    }
+
+    @Override
+    public int getNumberOfNodes() {
+        return Optional.ofNullable(cacheManager.getTransport()).map(t -> t.getMembers().size()).orElse(1);
+    }
+
+    @Override
+    public List<String> getNodeNames() {
+        return Optional.ofNullable(cacheManager.getTransport()).map(t -> t.getMembers()).orElse(Collections.emptyList())
+              .stream()
+              .map(member -> member.toString())
+              .collect(Collectors.toList());
+    }
+}

--- a/core/src/main/java/org/infinispan/health/impl/HealthImpl.java
+++ b/core/src/main/java/org/infinispan/health/impl/HealthImpl.java
@@ -1,0 +1,36 @@
+package org.infinispan.health.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.infinispan.health.CacheHealth;
+import org.infinispan.health.ClusterHealth;
+import org.infinispan.health.Health;
+import org.infinispan.health.HostInfo;
+import org.infinispan.manager.EmbeddedCacheManager;
+
+public class HealthImpl implements Health {
+
+    private final EmbeddedCacheManager embeddedCacheManager;
+
+    public HealthImpl(EmbeddedCacheManager embeddedCacheManager) {
+        this.embeddedCacheManager = embeddedCacheManager;
+    }
+
+    @Override
+    public ClusterHealth getClusterHealth() {
+        return new ClusterHealthImpl(embeddedCacheManager);
+    }
+
+    @Override
+    public List<CacheHealth> getCacheHealth() {
+        return embeddedCacheManager.getCacheNames().stream()
+                .map(cacheName -> new CacheHealthImpl(embeddedCacheManager.getCache(cacheName)))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public HostInfo getHostInfo() {
+        return new HostInfoImpl();
+    }
+}

--- a/core/src/main/java/org/infinispan/health/impl/HostInfoImpl.java
+++ b/core/src/main/java/org/infinispan/health/impl/HostInfoImpl.java
@@ -1,0 +1,21 @@
+package org.infinispan.health.impl;
+
+import org.infinispan.health.HostInfo;
+
+public class HostInfoImpl implements HostInfo {
+
+    @Override
+    public int getNumberOfCpus() {
+        return Runtime.getRuntime().availableProcessors();
+    }
+
+    @Override
+    public long getTotalMemoryKb() {
+        return Runtime.getRuntime().totalMemory() / 1024;
+    }
+
+    @Override
+    public long getFreeMemoryInKb() {
+        return Runtime.getRuntime().freeMemory() / 1024;
+    }
+}

--- a/core/src/main/java/org/infinispan/health/impl/jmx/HealthJMXExposerImpl.java
+++ b/core/src/main/java/org/infinispan/health/impl/jmx/HealthJMXExposerImpl.java
@@ -1,0 +1,73 @@
+package org.infinispan.health.impl.jmx;
+
+import java.util.List;
+
+import org.infinispan.health.CacheHealth;
+import org.infinispan.health.Health;
+import org.infinispan.health.jmx.HealthJMXExposer;
+import org.infinispan.jmx.annotations.MBean;
+import org.infinispan.jmx.annotations.ManagedAttribute;
+
+/**
+ * A JMX exposer (or adapter) for Health API.
+ *
+ * @author Sebastian Łaskawiec
+ * @since 9.0
+ */
+@MBean(objectName = HealthJMXExposer.OBJECT_NAME, description = "Health Check API")
+public class HealthJMXExposerImpl implements HealthJMXExposer {
+
+    private final Health health;
+
+    public HealthJMXExposerImpl(Health health) {
+        this.health = health;
+    }
+
+    @ManagedAttribute(displayName = "Number of CPUs in the host", description = "Number of CPUs in the host")
+    @Override
+    public int getNumberOfCpus() {
+        return health.getHostInfo().getNumberOfCpus();
+    }
+
+    @ManagedAttribute(displayName = "The amount of total memory (KB) in the host", description = "The amount of total memory (KB) in the host")
+    @Override
+    public long getTotalMemoryKb() {
+        return health.getHostInfo().getTotalMemoryKb();
+    }
+
+    @ManagedAttribute(displayName = "The amount of free memory (KB) in the host", description = "The amount of free memory (KB) in the host")
+    @Override
+    public long getFreeMemoryKb() {
+        return health.getHostInfo().getFreeMemoryInKb();
+    }
+
+    @ManagedAttribute(displayName = "Cluster health status", description = "Cluster health status")
+    @Override
+    public String getClusterHealth() {
+        return health.getClusterHealth().getHealthStatus().toString();
+    }
+
+    @ManagedAttribute(displayName = "Cluster name", description = "Cluster name")
+    @Override
+    public String getClusterName() {
+        return health.getClusterHealth().getClusterName();
+    }
+
+    @ManagedAttribute(displayName = "Total nodes in the cluster", description = "Total nodes in the cluster")
+    @Override
+    public int getNumberOfNodes() {
+        return health.getClusterHealth().getNumberOfNodes();
+    }
+
+    @ManagedAttribute(displayName = "Per Cache statuses", description = "Per Cache statuses")
+    @Override
+    public String[] getCacheHealth() {
+        List<CacheHealth> cacheHealths = health.getCacheHealth();
+        String[] returnValues = new String[cacheHealths.size() * 2];
+        for (int i = 0; i < cacheHealths.size(); ++i) {
+            returnValues[i * 2] = cacheHealths.get(i).getCacheName();
+            returnValues[i * 2 + 1] = cacheHealths.get(i).getStatus().toString();
+        }
+        return returnValues;
+    }
+}

--- a/core/src/main/java/org/infinispan/health/jmx/HealthJMXExposer.java
+++ b/core/src/main/java/org/infinispan/health/jmx/HealthJMXExposer.java
@@ -1,0 +1,54 @@
+package org.infinispan.health.jmx;
+
+import org.infinispan.factories.scopes.Scope;
+import org.infinispan.factories.scopes.Scopes;
+
+/**
+ * A Contract for exposing Health API over the JMX.
+ *
+ * @author Sebastian Łaskawiec
+ * @since 9.0
+ */
+@Scope(Scopes.GLOBAL)
+public interface HealthJMXExposer {
+
+    /**
+     * JMX Object name.
+     */
+    String OBJECT_NAME = "CacheContainerHealth";
+
+    /**
+     * Returns the total amount of CPUs for the JVM.
+     */
+    int getNumberOfCpus();
+
+    /**
+     * Returns the amount of total memory (KB) in the host.
+     */
+    long getTotalMemoryKb();
+
+    /**
+     * Returns the amount of free memory (KB) in the host.
+     */
+    long getFreeMemoryKb();
+
+    /**
+     * Returns cluster health status.
+     */
+    String getClusterHealth();
+
+    /**
+     * Returns cluster name.
+     */
+    String getClusterName();
+
+    /**
+     * Returns total nodes in the cluster.
+     */
+    int getNumberOfNodes();
+
+    /**
+     * Returns per Cache statuses.
+     */
+    String[] getCacheHealth();
+}

--- a/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/EmbeddedCacheManager.java
@@ -12,6 +12,7 @@ import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.annotations.SurvivesRestarts;
 import org.infinispan.factories.scopes.Scope;
 import org.infinispan.factories.scopes.Scopes;
+import org.infinispan.health.Health;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.notifications.Listenable;
 import org.infinispan.remoting.transport.Address;
@@ -319,5 +320,11 @@ public interface EmbeddedCacheManager extends CacheContainer, Listenable {
       throw new UnsupportedOperationException();
    }
 
-
+   /**
+    * Returns an entry point for a Health Check API.
+    *
+    * @since 9.0
+    * @return Health API for this {@link EmbeddedCacheManager}.
+     */
+   Health getHealth();
 }

--- a/core/src/main/java/org/infinispan/manager/impl/AbstractDelegatingEmbeddedCacheManager.java
+++ b/core/src/main/java/org/infinispan/manager/impl/AbstractDelegatingEmbeddedCacheManager.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.factories.GlobalComponentRegistry;
+import org.infinispan.health.Health;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.manager.ClusterExecutor;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -106,6 +107,11 @@ public class AbstractDelegatingEmbeddedCacheManager implements EmbeddedCacheMana
    @Override
    public ClusterExecutor executor() {
       return cm.executor();
+   }
+
+   @Override
+   public Health getHealth() {
+      return cm.getHealth();
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/health/CacheHealthImplTest.java
+++ b/core/src/test/java/org/infinispan/health/CacheHealthImplTest.java
@@ -1,0 +1,134 @@
+package org.infinispan.health;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
+
+import org.infinispan.cache.impl.CacheImpl;
+import org.infinispan.distribution.DistributionManager;
+import org.infinispan.health.impl.CacheHealthImpl;
+import org.infinispan.lifecycle.ComponentStatus;
+import org.infinispan.partitionhandling.AvailabilityMode;
+import org.testng.annotations.Test;
+
+@Test(testName = "health.CacheHealthImplTest", groups = "functional")
+public class CacheHealthImplTest {
+
+    @Test
+    public void testHealthyStatus() throws Exception {
+        //given
+        CacheImpl<Object, Object> cache = spy(new CacheImpl<>("test"));
+        DistributionManager distributionManagerMock = mock(DistributionManager.class);
+
+        doReturn(false).when(distributionManagerMock).isRehashInProgress();
+        doReturn(distributionManagerMock).when(cache).getDistributionManager();
+        doReturn(ComponentStatus.RUNNING).when(cache).getStatus();
+        doReturn(AvailabilityMode.AVAILABLE).when(cache).getAvailability();
+
+        CacheHealth cacheHealth = new CacheHealthImpl(cache);
+
+        //when
+        HealthStatus status = cacheHealth.getStatus();
+
+        //then
+        assertEquals(status, HealthStatus.HEALTHY);
+    }
+
+    @Test
+    public void testUnhealthyStatusWithFailedComponent() throws Exception {
+        //given
+        CacheImpl<Object, Object> cache = spy(new CacheImpl<>("test"));
+
+        doReturn(ComponentStatus.FAILED).when(cache).getStatus();
+
+        CacheHealth cacheHealth = new CacheHealthImpl(cache);
+
+        //when
+        HealthStatus status = cacheHealth.getStatus();
+
+        //then
+        assertEquals(status, HealthStatus.UNHEALTHY);
+    }
+
+    @Test
+    public void testUnhealthyStatusWithTerminatedComponent() throws Exception {
+        //given
+        CacheImpl<Object, Object> cache = spy(new CacheImpl<>("test"));
+
+        doReturn(ComponentStatus.TERMINATED).when(cache).getStatus();
+
+        CacheHealth cacheHealth = new CacheHealthImpl(cache);
+
+        //when
+        HealthStatus status = cacheHealth.getStatus();
+
+        //then
+        assertEquals(status, HealthStatus.UNHEALTHY);
+    }
+
+    @Test
+    public void testUnhealthyStatusWithStoppingComponent() throws Exception {
+        //given
+        CacheImpl<Object, Object> cache = spy(new CacheImpl<>("test"));
+
+        doReturn(ComponentStatus.STOPPING).when(cache).getStatus();
+
+        CacheHealth cacheHealth = new CacheHealthImpl(cache);
+
+        //when
+        HealthStatus status = cacheHealth.getStatus();
+
+        //then
+        assertEquals(status, HealthStatus.UNHEALTHY);
+    }
+
+    @Test
+    public void testUnhealthyStatusWithDegradedPartition() throws Exception {
+        //given
+        CacheImpl<Object, Object> cache = spy(new CacheImpl<>("test"));
+
+        doReturn(ComponentStatus.RUNNING).when(cache).getStatus();
+        doReturn(AvailabilityMode.DEGRADED_MODE).when(cache).getAvailability();
+
+        CacheHealth cacheHealth = new CacheHealthImpl(cache);
+
+        //when
+        HealthStatus status = cacheHealth.getStatus();
+
+        //then
+        assertEquals(status, HealthStatus.UNHEALTHY);
+    }
+
+    @Test
+    public void testRebalancingStatusOnRebalance() throws Exception {
+        //given
+        CacheImpl<Object, Object> cache = spy(new CacheImpl<>("test"));
+        DistributionManager distributionManagerMock = mock(DistributionManager.class);
+
+        doReturn(true).when(distributionManagerMock).isRehashInProgress();
+        doReturn(distributionManagerMock).when(cache).getDistributionManager();
+        doReturn(ComponentStatus.RUNNING).when(cache).getStatus();
+        doReturn(AvailabilityMode.AVAILABLE).when(cache).getAvailability();
+
+        CacheHealth cacheHealth = new CacheHealthImpl(cache);
+
+        //when
+        HealthStatus status = cacheHealth.getStatus();
+
+        //then
+        assertEquals(status, HealthStatus.REBALANCING);
+    }
+
+    @Test
+    public void testReturningName() throws Exception {
+        //given
+        CacheImpl<Object, Object> cache = new CacheImpl<>("test");
+
+        //when
+        String name = cache.getName();
+
+        //then
+        assertEquals(name, "test");
+    }
+}

--- a/core/src/test/java/org/infinispan/health/ClusterHealthImplTest.java
+++ b/core/src/test/java/org/infinispan/health/ClusterHealthImplTest.java
@@ -1,0 +1,105 @@
+package org.infinispan.health;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.health.impl.ClusterHealthImpl;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Test(testName = "health.ClusterHealthImplTest", groups = "functional")
+public class ClusterHealthImplTest {
+
+    private EmbeddedCacheManager cacheManager;
+    private ClusterHealth clusterHealth;
+
+    @BeforeClass
+    private void init() {
+        GlobalConfigurationBuilder globalConfigurationBuilder = new GlobalConfigurationBuilder().clusteredDefault();
+        globalConfigurationBuilder.transport().clusterName("test").nodeName("test");
+
+        cacheManager = new DefaultCacheManager(globalConfigurationBuilder.build());
+        clusterHealth = new ClusterHealthImpl(cacheManager);
+    }
+
+    @AfterClass
+    private void cleanUp() {
+        if (cacheManager != null) {
+            cacheManager.stop();
+            cacheManager = null;
+        }
+    }
+
+    @Test
+    public void testReturningClusterName() throws Exception {
+        //when
+        String clusterName = clusterHealth.getClusterName();
+
+        //then
+        assertEquals(clusterName, "test");
+    }
+
+    @Test
+    public void testReturningHealthyStatus() throws Exception {
+        //given
+        cacheManager.getCache("test", true);
+
+        //when
+        HealthStatus healthStatus = clusterHealth.getHealthStatus();
+
+        //then
+        assertEquals(healthStatus, HealthStatus.HEALTHY);
+    }
+
+    @Test
+    public void testReturningNodeName() throws Exception {
+        //when
+        String nodeName = clusterHealth.getNodeNames().get(0);
+
+        //then
+        assertTrue(nodeName.contains("test"));
+    }
+
+    @Test
+    public void testReturningNumberOfNodes() throws Exception {
+        //when
+        int numberOfNodes = clusterHealth.getNumberOfNodes();
+
+        //then
+        assertEquals(numberOfNodes, 1);
+    }
+
+    @Test
+    public void testReturningNumberOfNodesWithNullTransport() throws Exception {
+        //given
+        DefaultCacheManager cacheManagerWithNullTransport = mock(DefaultCacheManager.class);
+        clusterHealth = new ClusterHealthImpl(cacheManagerWithNullTransport);
+
+        //when
+        int numberOfNodes = clusterHealth.getNumberOfNodes();
+
+        //then
+        assertEquals(numberOfNodes, 1);
+    }
+
+    @Test
+    public void testReturningNodeNamesWithNullTransport() throws Exception {
+        //given
+        DefaultCacheManager cacheManagerWithNullTransport = mock(DefaultCacheManager.class);
+        clusterHealth = new ClusterHealthImpl(cacheManagerWithNullTransport);
+
+        //when
+        List<String> nodeNames = clusterHealth.getNodeNames();
+
+        //then
+        assertEquals(nodeNames.size(), 0);
+    }
+
+}

--- a/core/src/test/java/org/infinispan/health/HostInfoImplTest.java
+++ b/core/src/test/java/org/infinispan/health/HostInfoImplTest.java
@@ -1,0 +1,27 @@
+package org.infinispan.health;
+
+import static org.testng.Assert.assertTrue;
+
+import org.infinispan.health.impl.HostInfoImpl;
+import org.testng.annotations.Test;
+
+@Test(testName = "health.HostInfoImplTest", groups = "functional")
+public class HostInfoImplTest {
+
+    @Test
+    public void testReturningValuesFromHostInfo() throws Exception {
+        //given
+        HostInfo hostInfo = new HostInfoImpl();
+
+        //when
+        int numberOfCpus = hostInfo.getNumberOfCpus();
+        long freeMemoryInKb = hostInfo.getFreeMemoryInKb();
+        long totalMemoryKb = hostInfo.getTotalMemoryKb();
+
+        //then
+        assertTrue(numberOfCpus > 0);
+        assertTrue(freeMemoryInKb > 0);
+        assertTrue(totalMemoryKb > 0);
+    }
+
+}

--- a/core/src/test/java/org/infinispan/jmx/HealthJmxTest.java
+++ b/core/src/test/java/org/infinispan/jmx/HealthJmxTest.java
@@ -1,0 +1,72 @@
+package org.infinispan.jmx;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.health.HealthStatus;
+import org.infinispan.health.jmx.HealthJMXExposer;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.testng.annotations.Test;
+
+@Test(groups = "functional", testName = "jmx.HealthJmxTest")
+public class HealthJmxTest extends MultipleCacheManagersTest {
+
+    @Override
+    protected void createCacheManagers() throws Throwable {
+        addClusterEnabledCacheManager(getGlobalConfigurationBuilder("r1"), getConfigurationBuilder());
+    }
+
+    private ConfigurationBuilder getConfigurationBuilder() {
+        ConfigurationBuilder cb = new ConfigurationBuilder();
+        cb.clustering().cacheMode(CacheMode.DIST_SYNC)
+                .stateTransfer().awaitInitialTransfer(false)
+                .partitionHandling().enabled(true);
+        return cb;
+    }
+
+    private GlobalConfigurationBuilder getGlobalConfigurationBuilder(String rackId) {
+        GlobalConfigurationBuilder gcb = GlobalConfigurationBuilder.defaultClusteredBuilder();
+        gcb.globalJmxStatistics()
+                .enable()
+                .mBeanServerLookup(new PerThreadMBeanServerLookup())
+                .transport().rackId(rackId);
+        return gcb;
+    }
+
+    public void testHealthCheckAPI() throws Exception {
+        //given
+        //we need this to start a cache with a custom name
+        cacheManagers.get(0).getCache("test").put("1", "1");
+
+        final MBeanServer mBeanServer = PerThreadMBeanServerLookup.getThreadMBeanServer();
+
+        //when
+        String domain0 = manager(0).getCacheManagerConfiguration().globalJmxStatistics().domain();
+        ObjectName healthAPI0 = TestingUtil.getCacheManagerObjectName(domain0, "DefaultCacheManager", HealthJMXExposer.OBJECT_NAME);
+
+        Object numberOfCpus = mBeanServer.getAttribute(healthAPI0, "NumberOfCpus");
+        Object totalMemoryKb = mBeanServer.getAttribute(healthAPI0, "TotalMemoryKb");
+        Object freeMemoryKb = mBeanServer.getAttribute(healthAPI0, "FreeMemoryKb");
+        Object clusterHealth = mBeanServer.getAttribute(healthAPI0, "ClusterHealth");
+        Object clusterName = mBeanServer.getAttribute(healthAPI0, "ClusterName");
+        Object numberOfNodes = mBeanServer.getAttribute(healthAPI0, "NumberOfNodes");
+        Object cacheHealth = mBeanServer.getAttribute(healthAPI0, "CacheHealth");
+
+        //then
+        assertTrue((int) numberOfCpus > 0);
+        assertTrue((long) totalMemoryKb > 0);
+        assertTrue((long) freeMemoryKb > 0);
+        assertEquals((String) clusterHealth, HealthStatus.HEALTHY.toString());
+        assertEquals((String) clusterName, "ISPN");
+        assertEquals((int) numberOfNodes, 1);
+        assertEquals(((String[]) cacheHealth)[0], "test");
+        assertEquals(((String[]) cacheHealth)[1], HealthStatus.HEALTHY.toString());
+    }
+}

--- a/documentation/src/main/asciidoc/server_guide/server_guide.asciidoc
+++ b/documentation/src/main/asciidoc/server_guide/server_guide.asciidoc
@@ -11,3 +11,99 @@ include::management.adoc[]
 include::configuration.adoc[]
 include::security.adoc[]
 
+== Health monitoring
+
+Infinispan server has special endpoints for monitoring cluster health. The API is exposed via:
+
+* Programmatically (using `embeddedCacheManager.getHealth()`)
+* JMX
+* CLI
+* REST (using https://docs.jboss.org/author/display/WFLY10/The+HTTP+management+API[WildFly HTTP Management API])
+
+=== Accessing Health API using JMX
+
+At first you need to connect to the Infinispan Server using JMX (use JConsole or other tool for this).
+Next, navigate to object name `jboss.datagrid-infinispan:type=CacheManager,name="clustered",component=CacheContainerHealth`.
+
+=== Accessing Health API using CLI
+
+The Health API can be also accessed using CLI interface. An example invocation and result is presented below:
+
+[source,bash]
+----
+$ ispn-cli.sh -c "/subsystem=datagrid-infinispan/cache-container=clustered/health=HEALTH:read-resource(include-runtime=true)"
+
+{
+    "outcome" => "success",
+    "result" => {
+        "cache-health" => "HEALTHY",
+        "cluster-health" => ["test"],
+        "cluster-name" => "clustered",
+        "free-memory" => 99958L,
+        "log-tail" => [
+            "2016-08-10 11:54:14,706 INFO  [org.infinispan.server.endpoint] (MSC service thread 1-5) DGENDPT10001: HotRodServer listening on 127.0.0.1:11222",
+            "2016-08-10 11:54:14,706 INFO  [org.infinispan.server.endpoint] (MSC service thread 1-1) DGENDPT10001: MemcachedServer listening on 127.0.0.1:11211",
+            "2016-08-10 11:54:14,785 INFO  [org.jboss.as.clustering.infinispan] (MSC service thread 1-6) DGISPN0001: Started ___protobuf_metadata cache from clustered container",
+            "2016-08-10 11:54:14,800 INFO  [org.jboss.as.clustering.infinispan] (MSC service thread 1-6) DGISPN0001: Started ___script_cache cache from clustered container",
+            "2016-08-10 11:54:15,159 INFO  [org.jboss.as.clustering.infinispan] (MSC service thread 1-5) DGISPN0001: Started ___hotRodTopologyCache cache from clustered container",
+            "2016-08-10 11:54:15,210 INFO  [org.infinispan.rest.NettyRestServer] (MSC service thread 1-6) ISPN012003: REST server starting, listening on 127.0.0.1:8080",
+            "2016-08-10 11:54:15,210 INFO  [org.infinispan.server.endpoint] (MSC service thread 1-6) DGENDPT10002: REST mapped to /rest",
+            "2016-08-10 11:54:15,306 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0060: Http management interface listening on http://127.0.0.1:9990/management",
+            "2016-08-10 11:54:15,307 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0051: Admin console listening on http://127.0.0.1:9990",
+            "2016-08-10 11:54:15,307 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: Infinispan Server 9.0.0-SNAPSHOT (WildFly Core 2.2.0.CR9) started in 8681ms - Started 196 of 237 services (121 services are lazy, passive or on-demand)"
+        ],
+        "number-of-cpus" => 8,
+        "number-of-nodes" => 1,
+        "total-memory" => 235520L
+    }
+}
+
+----
+
+=== Accessing Health API using REST
+
+As mentioned in the https://docs.jboss.org/author/display/WFLY10/The+HTTP+management+API[WildFly HTTP Management API] article, the HTTP API requires using proper credentials (use `add-user.sh` script for that).
+
+When credentials are set, all resources accessible by CLI can also be accessed using REST interface. An example is shown below:
+
+[source,bash]
+----
+curl --digest -L -D - "http://localhost:9990/management/subsystem/datagrid-infinispan/cache-container/clustered/health/HEALTH?operation=resource&include-runtime=true&json.pretty=1" --header "Content-Type: application/json" -u ispnadmin:ispnadmin
+HTTP/1.1 401 Unauthorized
+Connection: keep-alive
+WWW-Authenticate: Digest realm="ManagementRealm",domain="/management",nonce="AuZzFxz7uC4NMTQ3MDgyNTU1NTQ3OCfIJBHXVpPHPBdzGUy7Qts=",opaque="00000000000000000000000000000000",algorithm=MD5,qop="auth"
+Content-Length: 77
+Content-Type: text/html
+Date: Wed, 10 Aug 2016 10:39:15 GMT
+
+HTTP/1.1 200 OK
+Connection: keep-alive
+Authentication-Info: nextnonce="AuZzFxz7uC4NMTQ3MDgyNTU1NTQ3OCfIJBHXVpPHPBdzGUy7Qts=",qop="auth",rspauth="b518c3170e627bd732055c382ce5d970",cnonce="NGViOWM0NDY5OGJmNjY0MjcyOWE4NDkyZDU3YzNhYjY=",nc=00000001
+Content-Type: application/json; charset=utf-8
+Content-Length: 1927
+Date: Wed, 10 Aug 2016 10:39:15 GMT
+
+{
+    "cache-health" : "HEALTHY",
+    "cluster-health" : ["test", "HEALTHY"],
+    "cluster-name" : "clustered",
+    "free-memory" : 96778,
+    "log-tail" : [
+        "2016-08-10 11:54:14,706 INFO  [org.infinispan.server.endpoint] (MSC service thread 1-5) DGENDPT10001: HotRodServer listening on 127.0.0.1:11222",
+        "2016-08-10 11:54:14,706 INFO  [org.infinispan.server.endpoint] (MSC service thread 1-1) DGENDPT10001: MemcachedServer listening on 127.0.0.1:11211",
+        "2016-08-10 11:54:14,785 INFO  [org.jboss.as.clustering.infinispan] (MSC service thread 1-6) DGISPN0001: Started ___protobuf_metadata cache from clustered container",
+        "2016-08-10 11:54:14,800 INFO  [org.jboss.as.clustering.infinispan] (MSC service thread 1-6) DGISPN0001: Started ___script_cache cache from clustered container",
+        "2016-08-10 11:54:15,159 INFO  [org.jboss.as.clustering.infinispan] (MSC service thread 1-5) DGISPN0001: Started ___hotRodTopologyCache cache from clustered container",
+        "2016-08-10 11:54:15,210 INFO  [org.infinispan.rest.NettyRestServer] (MSC service thread 1-6) ISPN012003: REST server starting, listening on 127.0.0.1:8080",
+        "2016-08-10 11:54:15,210 INFO  [org.infinispan.server.endpoint] (MSC service thread 1-6) DGENDPT10002: REST mapped to /rest",
+        "2016-08-10 11:54:15,306 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0060: Http management interface listening on http://127.0.0.1:9990/management",
+        "2016-08-10 11:54:15,307 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0051: Admin console listening on http://127.0.0.1:9990",
+        "2016-08-10 11:54:15,307 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: Infinispan Server 9.0.0-SNAPSHOT (WildFly Core 2.2.0.CR9) started in 8681ms - Started 196 of 237 services (121 services are lazy, passive or on-demand)"
+    ],
+    "number-of-cpus" : 8,
+    "number-of-nodes" : 1,
+    "total-memory" : 235520
+}%
+----
+
+Note that the result is exactly the same as the one obtained by CLI interface.

--- a/documentation/src/main/asciidoc/user_guide/management.adoc
+++ b/documentation/src/main/asciidoc/user_guide/management.adoc
@@ -57,6 +57,18 @@ Enabling Cache statistics collections differs depending on the configuration sty
  ConfigurationBuilder configurationBuilder = ...
  configurationBuilder.jmxStatistics().enable();
 
+==== Monitoring cluster health
+
+It is also possible to monitor Infinispan cluster health using JMX. On CacheManager there's an additional object called `CacheContainerHealth`. It contains the following attributes:
+
+* cacheHealth - a list of caches and corresponding statuses (HEALTHY, UNHEALTHY or REBALANCING)
+* clusterHealth - overall cluster health
+* clusterName - cluster name
+* freeMemoryKb - Free memory obtained from JVM runtime measured in KB
+* numberOfCpus - The number of CPUs obtained from JVM runtime
+* numberOfNodes - The number of nodes in the cluster
+* totalMemoryKb - Total memory obtained from JVM runtime measured in KB
+
 ==== Multiple JMX Domains
 There can be situations where several CacheManager instances are created in a single VM, or Cache names belonging to different CacheManagers under the same VM clash.
 

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerResource.java
@@ -43,6 +43,7 @@ import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.services.path.ResolvePathHandler;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -313,14 +314,16 @@ public class CacheContainerResource extends SimpleResourceDefinition {
          .build();
 
 
-   private final ResolvePathHandler resolvePathHandler;
+    private final ResolvePathHandler resolvePathHandler;
+    private final PathManager pathManager;
     private final boolean runtimeRegistration;
-    public CacheContainerResource(final ResolvePathHandler resolvePathHandler, boolean runtimeRegistration) {
+    public CacheContainerResource(final ResolvePathHandler resolvePathHandler, PathManager pathManager, boolean runtimeRegistration) {
         super(CONTAINER_PATH,
                 new InfinispanResourceDescriptionResolver(ModelKeys.CACHE_CONTAINER),
                 new CacheContainerAddHandler(),
                 new CacheContainerRemoveHandler());
         this.resolvePathHandler = resolvePathHandler;
+        this.pathManager = pathManager;
         this.runtimeRegistration = runtimeRegistration;
     }
 
@@ -372,6 +375,8 @@ public class CacheContainerResource extends SimpleResourceDefinition {
         super.registerChildren(resourceRegistration);
 
         // child resources
+        resourceRegistration.registerSubModel(new HealthResource(pathManager));
+
         resourceRegistration.registerSubModel(new TransportResource());
         resourceRegistration.registerSubModel(new CacheContainerSecurityResource());
         resourceRegistration.registerSubModel(new GlobalStateResource());

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/HealthMetricsHandler.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/HealthMetricsHandler.java
@@ -1,0 +1,217 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.infinispan.subsystem;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.infinispan.health.CacheHealth;
+import org.infinispan.health.Health;
+import org.infinispan.server.infinispan.spi.service.CacheContainerServiceName;
+import org.jboss.as.clustering.infinispan.DefaultCacheContainer;
+import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.StringListAttributeDefinition;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.services.path.PathManager;
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.ServiceController;
+
+/**
+ * Attaches HealCheck API as DMR Metrics.
+ *
+ * @author Sebastian Łaskawiec
+ * @since 9.0
+ */
+public class HealthMetricsHandler extends AbstractRuntimeOnlyHandler {
+
+    public static final HealthMetricsHandler INSTANCE = new HealthMetricsHandler();
+
+    private static final int CACHE_CONTAINER_INDEX = 1;
+    private static final int NUMBER_OF_LINES = 10;
+
+    private PathManager pathManager;
+
+    private static Collection<ModelNode> toModelNodeCollection(Collection<String> collection) {
+        if (collection == null || collection.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Collection<ModelNode> modelNodeCollection = new ArrayList<>(collection.size());
+        collection.forEach(e -> modelNodeCollection.add(new ModelNode().set(e)));
+        return modelNodeCollection;
+    }
+
+    @Override
+    protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
+        /*
+         * This is a kind of operation we are parsing:
+         *    {
+         *       "operation" => "read-attribute",
+         *       "address" => [
+         *           ("subsystem" => "datagrid-infinispan"),
+         *           ("cache-container" => "clustered"),
+         *           ("health" => "HEALTH")
+         *       ],
+         *       "name" => "number-of-nodes",
+         *       "include-defaults" => true,
+         *       "resolve-expressions" => false,
+         *       "operation-headers" => {
+         *           "caller-type" => "user",
+         *           "access-mechanism" => "NATIVE"
+         *       }
+         *   }
+         */
+        final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+        final String cacheContainerName = address.getElement(CACHE_CONTAINER_INDEX).getValue();
+        final String metricName = operation.require(ModelDescriptionConstants.NAME).asString();
+        final ServiceController<?> controller = context.getServiceRegistry(false).getService(CacheContainerServiceName.CACHE_CONTAINER.getServiceName(cacheContainerName));
+        DefaultCacheContainer cacheManager = (DefaultCacheContainer) controller.getValue();
+
+        HealthMetrics metric = HealthMetrics.getMetric(metricName);
+        ModelNode result = new ModelNode();
+
+        if (metric == null) {
+            context.getFailureDescription().set(String.format("Unknown metric %s", metricName));
+        } else if (cacheManager == null) {
+            context.getFailureDescription().set(String.format("Unavailable cache container %s", metricName));
+        } else {
+            Health health = cacheManager.getHealth();
+            switch (metric) {
+                case CACHE_HEALTH:
+                    List<CacheHealth> cacheHealths = health.getCacheHealth();
+                    List<String> perCacheHealth = new LinkedList<>();
+                    for (int i = 0; i < cacheHealths.size(); ++i) {
+                        perCacheHealth.add(cacheHealths.get(i).getCacheName());
+                        perCacheHealth.add(cacheHealths.get(i).getStatus().toString());
+                    }
+                    result.set(toModelNodeCollection(perCacheHealth));
+                    break;
+                case FREE_MEMORY_KB:
+                    result.set(health.getHostInfo().getFreeMemoryInKb());
+                    break;
+                case TOTAL_MEMORY_KB:
+                    result.set(health.getHostInfo().getTotalMemoryKb());
+                    break;
+                case NUMBER_OF_NODES:
+                    result.set(health.getClusterHealth().getNumberOfNodes());
+                    break;
+                case CLUSTER_NAME:
+                    result.set(health.getClusterHealth().getClusterName());
+                    break;
+                case NUMBER_OF_CPUS:
+                    result.set(health.getHostInfo().getNumberOfCpus());
+                    break;
+                case CLUSTER_HEALTH:
+                    result.set(health.getClusterHealth().getHealthStatus().toString());
+                    break;
+                case LOG_TAIL:
+                    File path = new File(pathManager.resolveRelativePathEntry("server.log", ServerEnvironment.SERVER_LOG_DIR));
+                    try (BufferedReader reader = new BufferedReader(new FileReader(path))) {
+                        List<String> results = new LinkedList<>();
+                        for (String line=reader.readLine(); line != null; line=reader.readLine()) {
+                            //add new lines at the end and remove the head if needed
+                            results.add(line);
+                            if(results.size() > NUMBER_OF_LINES) {
+                                results.remove(0);
+                            }
+                        }
+                        result.set(toModelNodeCollection(results));
+                    } catch (FileNotFoundException e) {
+                        result.set("File [" + path.getAbsolutePath() + "] does not exist");
+                    } catch (IOException e) {
+                        result.set("Unable to read file [" + path.getAbsolutePath() + "]");
+                    }
+                    break;
+                default:
+                    context.getFailureDescription().set(String.format("Unknown metric %s", metric));
+                    break;
+            }
+            context.getResult().set(result);
+        }
+    }
+
+    public void registerPathManager(PathManager pathManager) {
+        this.pathManager = pathManager;
+    }
+
+    public void registerMetrics(ManagementResourceRegistration container) {
+        for (HealthMetrics metric : HealthMetrics.values()) {
+            container.registerMetric(metric.definition, this);
+        }
+    }
+
+    public enum HealthMetrics {
+        NUMBER_OF_CPUS(MetricKeys.NUMBER_OF_CPUS, ModelType.INT),
+        TOTAL_MEMORY_KB(MetricKeys.TOTAL_MEMORY_KB, ModelType.LONG),
+        FREE_MEMORY_KB(MetricKeys.FREE_MEMORY_KB, ModelType.LONG),
+        CLUSTER_HEALTH(MetricKeys.CLUSTER_HEALTH, ModelType.STRING),
+        CLUSTER_NAME(MetricKeys.CLUSTER_NAME, ModelType.STRING),
+        NUMBER_OF_NODES(MetricKeys.NUMBER_OF_NODES, ModelType.INT),
+        CACHE_HEALTH(MetricKeys.CACHE_HEALTH, ModelType.LIST),
+        LOG_TAIL(MetricKeys.LOG_TAIL, ModelType.LIST);
+
+        private static final Map<String, HealthMetrics> MAP = new HashMap<String, HealthMetrics>();
+
+        static {
+            for (HealthMetrics metric : HealthMetrics.values()) {
+                MAP.put(metric.toString(), metric);
+            }
+        }
+
+        final AttributeDefinition definition;
+
+        HealthMetrics(String attributeName, ModelType type) {
+            this.definition = new StringListAttributeDefinition.Builder(attributeName)
+                    .setAllowNull(false)
+                    .setStorageRuntime()
+                    .build();
+        }
+
+        public static HealthMetrics getMetric(final String stringForm) {
+            return MAP.get(stringForm);
+        }
+
+        @Override
+        public final String toString() {
+            return definition.getName();
+        }
+    }
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/HealthResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/HealthResource.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.infinispan.subsystem;
+
+import org.infinispan.server.commons.controller.ReloadRequiredAddStepHandler;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.services.path.PathManager;
+
+/**
+ * Resource description for the addressable resource /subsystem=infinispan/cache-container=X/health=HEALTH
+ *
+ * @author Sebastian Łaskawiec
+ * @since 9.0
+ */
+public class HealthResource extends SimpleResourceDefinition {
+
+    public static final PathElement HEALTH_PATH = PathElement.pathElement(ModelKeys.HEALTH, ModelKeys.HEALTH_NAME);
+
+    private final PathManager pathManager;
+
+    public HealthResource(PathManager pathManager) {
+        super(HEALTH_PATH,
+                new InfinispanResourceDescriptionResolver(ModelKeys.CACHE_CONTAINER, ModelKeys.HEALTH),
+                new ReloadRequiredAddStepHandler(),
+                ReloadRequiredRemoveStepHandler.INSTANCE);
+        this.pathManager = pathManager;
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        HealthMetricsHandler.INSTANCE.registerPathManager(pathManager);
+        HealthMetricsHandler.INSTANCE.registerMetrics(resourceRegistration);
+    }
+
+    @Override
+    public boolean isRuntime() {
+        return true;
+    }
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
@@ -28,6 +28,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.services.path.ResolvePathHandler;
 import org.kohsuke.MetaInfServices;
 
@@ -54,16 +55,19 @@ public class InfinispanExtension implements Extension {
         SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, Namespace.CURRENT.getVersion());
         // Create the path resolver handler
         final ResolvePathHandler resolvePathHandler;
+        final PathManager pathManager;
         if (context.getProcessType().isServer()) {
             resolvePathHandler = ResolvePathHandler.Builder.of(context.getPathManager())
                     .setPathAttribute(FileStoreResource.PATH)
                     .setRelativeToAttribute(FileStoreResource.RELATIVE_TO)
                     .build();
+            pathManager = context.getPathManager();
         } else {
             resolvePathHandler = null;
+            pathManager = null;
         }
 
-        subsystem.registerSubsystemModel(new InfinispanSubsystemRootResource(resolvePathHandler, context.isRuntimeOnlyRegistrationValid()));
+        subsystem.registerSubsystemModel(new InfinispanSubsystemRootResource(resolvePathHandler, pathManager, context.isRuntimeOnlyRegistrationValid()));
         subsystem.registerXMLElementWriter(new InfinispanSubsystemXMLWriter());
     }
 

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemRootResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemRootResource.java
@@ -30,6 +30,7 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.services.path.ResolvePathHandler;
 
 /**
@@ -42,13 +43,15 @@ public class InfinispanSubsystemRootResource extends SimpleResourceDefinition {
     static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, InfinispanExtension.SUBSYSTEM_NAME);
 
     private final ResolvePathHandler resolvePathHandler;
+    private final PathManager pathManager;
     private final boolean runtimeRegistration;
-    public InfinispanSubsystemRootResource(final ResolvePathHandler resolvePathHandler, boolean runtimeRegistration) {
+    public InfinispanSubsystemRootResource(final ResolvePathHandler resolvePathHandler, PathManager pathManager, boolean runtimeRegistration) {
         super(PathElement.pathElement(SUBSYSTEM, InfinispanExtension.SUBSYSTEM_NAME),
                 new InfinispanResourceDescriptionResolver(),
                 InfinispanSubsystemAdd.INSTANCE,
                 ReloadRequiredRemoveStepHandler.INSTANCE);
         this.resolvePathHandler = resolvePathHandler;
+        this.pathManager = pathManager;
         this.runtimeRegistration = runtimeRegistration;
     }
 
@@ -66,7 +69,7 @@ public class InfinispanSubsystemRootResource extends SimpleResourceDefinition {
 
     @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerSubModel(new CacheContainerResource(resolvePathHandler, runtimeRegistration));
+        resourceRegistration.registerSubModel(new CacheContainerResource(resolvePathHandler, pathManager, runtimeRegistration));
     }
 
 

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader.java
@@ -343,6 +343,21 @@ public final class InfinispanSubsystemXMLReader implements XMLElementReader<List
                 }
             }
         }
+
+        addSyntheticHealthOperation(operations, containerAddress);
+    }
+
+    /**
+     * A {@link HealthResource} is not populated to the XML. However the easiest way to propagate a Health node
+     * (we need to attach Health node to the Cache Container node) and attach metrics to it is to
+     * simply simulate reading it.
+     *
+     * Since we are not persisting it - there is no need to check the namespaces.
+     */
+    private void addSyntheticHealthOperation(Map<PathAddress, ModelNode> operations, PathAddress containerAddress) {
+        PathAddress healthAddress = containerAddress.append(ModelKeys.HEALTH, ModelKeys.HEALTH_NAME);
+        ModelNode health = Util.createAddOperation(healthAddress);
+        operations.put(healthAddress, health);
     }
 
     private void parseGlobalState(XMLExtendedStreamReader reader, PathAddress containerAddress,

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/MetricKeys.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/MetricKeys.java
@@ -42,6 +42,7 @@ public class MetricKeys {
     public static final String CREATED_CACHE_COUNT = "created-cache-count";
     public static final String MEMBERS = "members";
     public static final String CLUSTER_SIZE = "cluster-size";
+    public static final String HEALTH = "health";
     // cache
     public static final String CACHE_STATUS = "cache-status";
     public static final String CACHE_NAME = "cache-name";
@@ -89,4 +90,12 @@ public class MetricKeys {
     public static final String SITES_ONLINE = "sites-online";
     public static final String SITES_OFFLINE = "sites-offline";
     public static final String SITES_MIXED = "sites-mixed";
+
+    public static final String NUMBER_OF_CPUS = "number-of-cpus";
+    public static final String TOTAL_MEMORY_KB = "total-memory";
+    public static final String FREE_MEMORY_KB = "free-memory";
+    public static final String CLUSTER_HEALTH = "cluster-health";
+    public static final String NUMBER_OF_NODES = "number-of-nodes";
+    public static final String CACHE_HEALTH = "cache-health";
+    public static final String LOG_TAIL = "log-tail";
 }

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
@@ -244,7 +244,9 @@ public class ModelKeys {
     static final String TRANSACTION = "transaction";
     static final String TRANSACTION_NAME = "TRANSACTION";
     static final String TRANSPORT = "transport";
+    static final String HEALTH = "health";
     static final String TRANSPORT_NAME = "TRANSPORT";
+    static final String HEALTH_NAME = "HEALTH";
     static final String TYPE = "type";
     static final String TX_INTERNAL_ID = "internal-id";
     static final String VALUE = "value";

--- a/server/integration/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/server/integration/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -623,3 +623,15 @@ datagrid-infinispan.cache-container.configurations.local-cache-configuration=
 datagrid-infinispan.cache-container.configurations.invalidation-cache-configuration=
 datagrid-infinispan.cache-container.configurations.replicated-cache-configuration=
 datagrid-infinispan.cache-container.configurations.distributed-cache-configuration=
+
+datagrid-infinispan.cache-container.health=Health check API
+datagrid-infinispan.cache-container.health.cache-health=Cache health
+datagrid-infinispan.cache-container.health.free-memory=Free memory in KB
+datagrid-infinispan.cache-container.health.total-memory=Total memory in KB
+datagrid-infinispan.cache-container.health.cluster-name=Cluster name
+datagrid-infinispan.cache-container.health.number-of-cpus=Number of CPUs
+datagrid-infinispan.cache-container.health.cluster-health=Cluster health (UNHEALTHY, REBALANCING or HEALTHY)
+datagrid-infinispan.cache-container.health.number-of-nodes=Number of nodes in the cluster
+datagrid-infinispan.cache-container.health.add=Add Health Check API
+datagrid-infinispan.cache-container.health.remove=Removed Health Check API
+datagrid-infinispan.cache-container.health.log-tail=Last 10 lines of the log file


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/ISPN-6679
Design: https://github.com/infinispan/infinispan/wiki/Health-check-API

Highlights:
- The API can be accessed using CLI/JMX/REST and also programatically.
- I decided to implement reading logs by my own (instead of using logging subsystem). The implementation is much simpler, shorter and does exactly what I need.
- The WF integration bits are based on Metrics (runtime resources which are read only). I couldn't find any advantage of using Operations for this.
