### PR TITLE
Fixed lengthy test names in TC (testFoo on org.infinispan.FooTest@12345678)

### DIFF
--- a/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadLockCleanupTest.java
+++ b/core/src/test/java/org/infinispan/api/mvcc/PutForExternalReadLockCleanupTest.java
@@ -51,7 +51,7 @@ public class PutForExternalReadLockCleanupTest extends MultipleCacheManagersTest
 
    @Override
    protected String parameters() {
-      return "{" + name + "}";
+      return "[" + name + "]";
    }
 
    public void testLockCleanupOnBackup() {

--- a/core/src/test/java/org/infinispan/commands/GetAllCommandTest.java
+++ b/core/src/test/java/org/infinispan/commands/GetAllCommandTest.java
@@ -59,10 +59,10 @@ public class GetAllCommandTest extends MultipleCacheManagersTest {
 
    @Override
    protected String parameters() {
-      return new StringBuilder().append('{')
+      return new StringBuilder().append('[')
          .append(cacheMode)
          .append(", tx=").append(transactional)
-         .append(", compatibility=").append(compatibility).append("}").toString();
+         .append(", compatibility=").append(compatibility).append("]").toString();
    }
 
    public void testGetAllKeyNotPresent() {

--- a/core/src/test/java/org/infinispan/distribution/groups/BaseUtilGroupTest.java
+++ b/core/src/test/java/org/infinispan/distribution/groups/BaseUtilGroupTest.java
@@ -30,8 +30,8 @@ public abstract class BaseUtilGroupTest extends MultipleCacheManagersTest {
    @Override
    protected String parameters() {
       String parameters = super.parameters();
-      if (parameters == null) return "{" + factory + "}";
-      else return "{" + factory + ", " + parameters.substring(1);
+      if (parameters == null) return "[" + factory + "]";
+      else return "[" + factory + ", " + parameters.substring(1);
    }
 
    protected static GroupKey key(int index) {

--- a/core/src/test/java/org/infinispan/replication/ReplicatedAPITest.java
+++ b/core/src/test/java/org/infinispan/replication/ReplicatedAPITest.java
@@ -37,7 +37,7 @@ public class ReplicatedAPITest extends MultipleCacheManagersTest {
 
    @Override
    protected String parameters() {
-      return "{sync=" + isSync + "}";
+      return "[sync=" + isSync + "]";
    }
 
    protected void createCacheManagers() throws Throwable {

--- a/core/src/test/java/org/infinispan/statetransfer/ReadAfterLosingOwnershipTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/ReadAfterLosingOwnershipTest.java
@@ -49,7 +49,7 @@ public class ReadAfterLosingOwnershipTest extends MultipleCacheManagersTest {
 
    @Override
    protected String parameters() {
-      return "{tx=" + transactional + ", l1=" + l1 + "}";
+      return "[tx=" + transactional + ", l1=" + l1 + "]";
    }
 
    public void testOwnershipLostWithPut() throws Exception {

--- a/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
+++ b/core/src/test/java/org/infinispan/test/MultipleCacheManagersTest.java
@@ -582,7 +582,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
       if (none) {
          return null;
       }
-      StringBuilder sb = new StringBuilder().append('{');
+      StringBuilder sb = new StringBuilder().append('[');
       for (int i = 0; i < params.length; ++i) {
          if (params[i] != null) {
             if (names[i] != null) {
@@ -592,7 +592,7 @@ public abstract class MultipleCacheManagersTest extends AbstractCacheTest {
             if (!last[i]) sb.append(", ");
          }
       }
-      return sb.append('}').toString();
+      return sb.append(']').toString();
    }
 
    protected String[] parameterNames() {

--- a/core/src/test/java/org/infinispan/test/fwk/NamedTestMethod.java
+++ b/core/src/test/java/org/infinispan/test/fwk/NamedTestMethod.java
@@ -1,0 +1,346 @@
+package org.infinispan.test.fwk;
+
+import org.testng.IClass;
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestClass;
+import org.testng.ITestNGMethod;
+import org.testng.internal.ConstructorOrMethod;
+import org.testng.xml.XmlTest;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+public class NamedTestMethod implements ITestNGMethod {
+   private final ITestNGMethod method;
+   private final String name;
+
+   public NamedTestMethod(ITestNGMethod method, String name) {
+      this.method = method;
+      this.name = name;
+   }
+
+   @Override
+   public Class getRealClass() {
+      return method.getRealClass();
+   }
+
+   @Override
+   public ITestClass getTestClass() {
+      return method.getTestClass();
+   }
+
+   @Override
+   public void setTestClass(ITestClass cls) {
+      method.setTestClass(cls);
+   }
+
+   @Override
+   @Deprecated
+   public Method getMethod() {
+      return method.getMethod();
+   }
+
+   @Override
+   public String getMethodName() {
+      return name;
+   }
+
+   @Override
+   @Deprecated
+   public Object[] getInstances() {
+      return method.getInstances();
+   }
+
+   @Override
+   public Object getInstance() {
+      return method.getInstance();
+   }
+
+   @Override
+   public long[] getInstanceHashCodes() {
+      return method.getInstanceHashCodes();
+   }
+
+   @Override
+   public String[] getGroups() {
+      return method.getGroups();
+   }
+
+   @Override
+   public String[] getGroupsDependedUpon() {
+      return method.getGroupsDependedUpon();
+   }
+
+   @Override
+   public String getMissingGroup() {
+      return method.getMissingGroup();
+   }
+
+   @Override
+   public void setMissingGroup(String group) {
+      method.setMissingGroup(group);
+   }
+
+   @Override
+   public String[] getBeforeGroups() {
+      return method.getBeforeGroups();
+   }
+
+   @Override
+   public String[] getAfterGroups() {
+      return method.getAfterGroups();
+   }
+
+   @Override
+   public String[] getMethodsDependedUpon() {
+      return method.getMethodsDependedUpon();
+   }
+
+   @Override
+   public void addMethodDependedUpon(String methodName) {
+      method.addMethodDependedUpon(methodName);
+   }
+
+   @Override
+   public boolean isTest() {
+      return method.isTest();
+   }
+
+   @Override
+   public boolean isBeforeMethodConfiguration() {
+      return method.isBeforeMethodConfiguration();
+   }
+
+   @Override
+   public boolean isAfterMethodConfiguration() {
+      return method.isAfterMethodConfiguration();
+   }
+
+   @Override
+   public boolean isBeforeClassConfiguration() {
+      return method.isBeforeClassConfiguration();
+   }
+
+   @Override
+   public boolean isAfterClassConfiguration() {
+      return method.isAfterClassConfiguration();
+   }
+
+   @Override
+   public boolean isBeforeSuiteConfiguration() {
+      return method.isBeforeSuiteConfiguration();
+   }
+
+   @Override
+   public boolean isAfterSuiteConfiguration() {
+      return method.isAfterSuiteConfiguration();
+   }
+
+   @Override
+   public boolean isBeforeTestConfiguration() {
+      return method.isBeforeTestConfiguration();
+   }
+
+   @Override
+   public boolean isAfterTestConfiguration() {
+      return method.isAfterTestConfiguration();
+   }
+
+   @Override
+   public boolean isBeforeGroupsConfiguration() {
+      return method.isBeforeGroupsConfiguration();
+   }
+
+   @Override
+   public boolean isAfterGroupsConfiguration() {
+      return method.isAfterGroupsConfiguration();
+   }
+
+   @Override
+   public long getTimeOut() {
+      return method.getTimeOut();
+   }
+
+   @Override
+   public void setTimeOut(long timeOut) {
+      method.setTimeOut(timeOut);
+   }
+
+   @Override
+   public int getInvocationCount() {
+      return method.getInvocationCount();
+   }
+
+   @Override
+   public void setInvocationCount(int count) {
+      method.setInvocationCount(count);
+   }
+
+   @Override
+   public int getSuccessPercentage() {
+      return method.getSuccessPercentage();
+   }
+
+   @Override
+   public String getId() {
+      return method.getId();
+   }
+
+   @Override
+   public void setId(String id) {
+      method.setId(id);
+   }
+
+   @Override
+   public long getDate() {
+      return method.getDate();
+   }
+
+   @Override
+   public void setDate(long date) {
+      method.setDate(date);
+   }
+
+   @Override
+   public boolean canRunFromClass(IClass testClass) {
+      return method.canRunFromClass(testClass);
+   }
+
+   @Override
+   public boolean isAlwaysRun() {
+      return method.isAlwaysRun();
+   }
+
+   @Override
+   public int getThreadPoolSize() {
+      return method.getThreadPoolSize();
+   }
+
+   @Override
+   public void setThreadPoolSize(int threadPoolSize) {
+      method.setThreadPoolSize(threadPoolSize);
+   }
+
+   @Override
+   public boolean getEnabled() {
+      return method.getEnabled();
+   }
+
+   @Override
+   public String getDescription() {
+      return method.getDescription();
+   }
+
+   @Override
+   public void incrementCurrentInvocationCount() {
+      method.incrementCurrentInvocationCount();
+   }
+
+   @Override
+   public int getCurrentInvocationCount() {
+      return method.getCurrentInvocationCount();
+   }
+
+   @Override
+   public void setParameterInvocationCount(int n) {
+      method.setParameterInvocationCount(n);
+   }
+
+   @Override
+   public int getParameterInvocationCount() {
+      return method.getParameterInvocationCount();
+   }
+
+   @Override
+   public ITestNGMethod clone() {
+      return method.clone();
+   }
+
+   @Override
+   public IRetryAnalyzer getRetryAnalyzer() {
+      return method.getRetryAnalyzer();
+   }
+
+   @Override
+   public void setRetryAnalyzer(IRetryAnalyzer retryAnalyzer) {
+      method.setRetryAnalyzer(retryAnalyzer);
+   }
+
+   @Override
+   public boolean skipFailedInvocations() {
+      return method.skipFailedInvocations();
+   }
+
+   @Override
+   public void setSkipFailedInvocations(boolean skip) {
+      method.setSkipFailedInvocations(skip);
+   }
+
+   @Override
+   public long getInvocationTimeOut() {
+      return method.getInvocationTimeOut();
+   }
+
+   @Override
+   public boolean ignoreMissingDependencies() {
+      return method.ignoreMissingDependencies();
+   }
+
+   @Override
+   public void setIgnoreMissingDependencies(boolean ignore) {
+      method.setIgnoreMissingDependencies(ignore);
+   }
+
+   @Override
+   public List<Integer> getInvocationNumbers() {
+      return method.getInvocationNumbers();
+   }
+
+   @Override
+   public void setInvocationNumbers(List<Integer> numbers) {
+      method.setInvocationNumbers(numbers);
+   }
+
+   @Override
+   public void addFailedInvocationNumber(int number) {
+      method.addFailedInvocationNumber(number);
+   }
+
+   @Override
+   public List<Integer> getFailedInvocationNumbers() {
+      return method.getFailedInvocationNumbers();
+   }
+
+   @Override
+   public int getPriority() {
+      return method.getPriority();
+   }
+
+   @Override
+   public void setPriority(int priority) {
+      method.setPriority(priority);
+   }
+
+   @Override
+   public XmlTest getXmlTest() {
+      return method.getXmlTest();
+   }
+
+   @Override
+   public ConstructorOrMethod getConstructorOrMethod() {
+      return method.getConstructorOrMethod();
+   }
+
+   @Override
+   public Map<String, String> findMethodParameters(XmlTest test) {
+      return method.findMethodParameters(test);
+   }
+
+   @Override
+   public int compareTo(Object o) {
+      return method.compareTo(o);
+   }
+}
+
+

--- a/core/src/test/java/org/infinispan/tx/totalorder/statetransfer/TotalOrderStateTransferFunctionalTest.java
+++ b/core/src/test/java/org/infinispan/tx/totalorder/statetransfer/TotalOrderStateTransferFunctionalTest.java
@@ -43,7 +43,7 @@ public class TotalOrderStateTransferFunctionalTest extends StateTransferFunction
 
    @Override
    protected String parameters() {
-      return "{" + cacheName + "}";
+      return "[" + cacheName + "]";
    }
 
    protected void createCacheManagers() throws Throwable {


### PR DESCRIPTION
@danberindei recently complained that recent changes in testsuite use too lengthy test names in TC. This fixes that issue by renaming the method name (adding parameters()) but while this makes even more easily distinguishable tests in IDE, it breaks the ability to navigate to the test method/re-run the test method.

A workaround (before https://youtrack.jetbrains.com/issue/IDEA-157827#comment=27-1485365 is fixed) is using a system property in CI(TC) that uses the fix, and just don't distinguish the methods on normal runs (the threads are named using test name, so it should be still distinguishable).

WDYT?