### PR TITLE
ISPN-6954 Stabilize LiveRunningTest.liveRun

### DIFF
--- a/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/LiveRunningTest.java
+++ b/lucene/directory-provider/src/test/java/org/infinispan/hibernate/search/LiveRunningTest.java
@@ -51,10 +51,10 @@ public class LiveRunningTest {
             assertViews();
          }
       } finally {
-         master.close();
          for (FullTextSessionBuilder slave : slaves) {
             slave.close();
          }
+         master.close();
       }
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6954

@belaban @Sanne - Hey! I'm trying to stabilize `LiveRunningTest`. As you can see the test uses loopback and up to 5 slaves. Unfortunately I didn't manage to reproduce the failure locally but I think JGroups were operating on very low timeout values. I tried to make them a bit higher and use more defaults. Could you please have a look if proposed changes make sense? Thanks!