### PR TITLE
ISPN-6626 - IntegrationTest.testGet* fails on Windows

### DIFF
--- a/server/rest/src/main/scala/org/infinispan/rest/Server.scala
+++ b/server/rest/src/main/scala/org/infinispan/rest/Server.scala
@@ -52,7 +52,7 @@ class Server(configuration: RestServerConfiguration, manager: RestCacheManager) 
                pw.print("</body></html>")
             })).build
             case MediaType.APPLICATION_XML => Response.ok.`type`(MediaType.APPLICATION_XML).entity(printIt( pw => {
-               pw.print("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n<keys>")
+               pw.print("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + System.lineSeparator() + System.lineSeparator() + "<keys>")
                keys.foreach(key => pw.printf("<key>%s</key>", Escaper.escapeXml(key)))
                pw.print("</keys>")
             })).build

--- a/server/rest/src/test/scala/org/infinispan/rest/IntegrationTest.scala
+++ b/server/rest/src/test/scala/org/infinispan/rest/IntegrationTest.scala
@@ -171,8 +171,8 @@ class IntegrationTest extends RestServerTestBase {
       assertTrue(xml.contains("<key>b</key>"))
 
       val plain = getCollection("text/plain;charset=UTF-8")
-      assertTrue(plain.contains("a\n"))
-      assertTrue(plain.contains("b\n"))
+      assertTrue(plain.contains("a" + System.lineSeparator()))
+      assertTrue(plain.contains("b" + System.lineSeparator()))
 
       val json = getCollection("application/json")
       assertTrue(json.contains("\"a\""))
@@ -196,8 +196,8 @@ class IntegrationTest extends RestServerTestBase {
       assertTrue(xml.contains("<key>b&gt;</key>"))
 
       val plain = getCollection("text/plain;charset=UTF-8")
-      assertTrue(plain.contains("\"a\"\n"))
-      assertTrue(plain.contains("b>\n"))
+      assertTrue(plain.contains("\"a\"" + System.lineSeparator()))
+      assertTrue(plain.contains("b>" + System.lineSeparator()))
 
       val json = getCollection("application/json")
       assertTrue(json.contains("\\\"a\\\""))


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6626

Adding check for "\r" which will work in case the test is run on Windows machine. 