### PR TITLE
ISPN-5721 ISPN-6813 SNI and encryption for REST

### DIFF
--- a/documentation/src/main/asciidoc/server_guide/server_guide.asciidoc
+++ b/documentation/src/main/asciidoc/server_guide/server_guide.asciidoc
@@ -945,9 +945,9 @@ RemoteCache<String, String> cache = remoteCacheManager.getCache("secured");
 
 For brevity we used the same callback handler both for obtaining the client subject and for handling authentication in the SASL GSSAPI mech, however different callbacks will actually be invoked: NameCallback and PasswordCallback are needed to construct the client subject, while the AuthorizeCallback will be called during the SASL authentication.
 
-=== Hot Rod encryption (SSL)
+=== Hot Rod and REST encryption (TLS/SSL)
 
-The Hot Rod protocol also supports encryption using SSL/TLS with optional TLS/SNI support (link:$$https://en.wikipedia.org/wiki/Server_Name_Indication$$[Server Name Indication]). To set this up you need to create a keystore using the +keytool+ application which is part of the JDK to store your server certificate. Then add a +<server-identities>+ element to your security realm:
+Both Hot Rod and REST protocols support encryption using SSL/TLS with optional TLS/SNI support (link:$$https://en.wikipedia.org/wiki/Server_Name_Indication$$[Server Name Indication]). To set this up you need to create a keystore using the +keytool+ application which is part of the JDK to store your server certificate. Then add a +<server-identities>+ element to your security realm:
 
 .Security Realm configuration for SSL
 [source,xml]
@@ -966,7 +966,7 @@ The Hot Rod protocol also supports encryption using SSL/TLS with optional TLS/SN
 When using SNI support there might be multiple Security Realms configured.
 ====
 
-Next modify the +<hotrod-connector>+ element in the endpoint subsystem to require encryption. Optionally add SNI configuration:
+Next modify the +<hotrod-connector>+ and/or +<rest-connector>+ elements in the endpoint subsystem to require encryption. Optionally add SNI configuration:
 
 .Hot Rod connector SSL configuration
 
@@ -979,9 +979,15 @@ Next modify the +<hotrod-connector>+ element in the endpoint subsystem to requir
         <sni host-name="domain2" security-realm="Domain2ApplicationRealm" />
     </encryption>
 </hotrod-connector>
+<rest-connector socket-binding="rest" cache-container="local">
+    <encryption security-realm="ApplicationRealm" require-ssl-client-auth="false">
+        <sni host-name="domain1" security-realm="Domain1ApplicationRealm" />
+        <sni host-name="domain2" security-realm="Domain2ApplicationRealm" />
+    </encryption>
+</rest-connector>
 ----
 
-In order to connect to the server, the client will need a trust store containing the public key of the server(s) you are going to connect to:
+In order to connect to the server using Hot Rod protocol, the client needs a trust store containing the public key of the server(s) you are going to connect to:
 
 [source,java]
 ----

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -159,7 +159,7 @@
       <version.org.jboss.naming>5.0.6.CR1</version.org.jboss.naming>
       <version.org.picketbox>4.0.20.Final</version.org.picketbox>
       <version.postgresql.driver>9.3-1101-jdbc41</version.postgresql.driver>
-      <version.resteasy>3.0.11.Final</version.resteasy>
+      <version.resteasy>3.1.0.Beta1</version.resteasy>
       <version.shrinkwrapResolver>2.1.0</version.shrinkwrapResolver>
       <version.slf4j>1.7.21</version.slf4j>
       <version.slf4j-jboss-logging>1.1.0.Final</version.slf4j-jboss-logging>

--- a/server/core/src/main/java/org/infinispan/server/core/configuration/ProtocolServerConfigurationBuilder.java
+++ b/server/core/src/main/java/org/infinispan/server/core/configuration/ProtocolServerConfigurationBuilder.java
@@ -18,7 +18,7 @@ public abstract class ProtocolServerConfigurationBuilder<T extends ProtocolServe
    protected int idleTimeout = -1;
    protected int recvBufSize = 0;
    protected int sendBufSize = 0;
-   protected final SslConfigurationBuilder ssl;
+   protected final SslConfigurationBuilder<T, S> ssl;
    protected boolean tcpNoDelay = true;
    protected int workerThreads = 2 * Runtime.getRuntime().availableProcessors();
    protected Set<String> ignoredCaches = Collections.EMPTY_SET;

--- a/server/core/src/main/java/org/infinispan/server/core/utils/SslUtils.java
+++ b/server/core/src/main/java/org/infinispan/server/core/utils/SslUtils.java
@@ -1,0 +1,47 @@
+package org.infinispan.server.core.utils;
+
+import java.util.Arrays;
+
+import javax.net.ssl.SSLContext;
+
+import org.infinispan.commons.util.SslContextFactory;
+import org.infinispan.server.core.configuration.SslConfiguration;
+import org.infinispan.server.core.configuration.SslEngineConfiguration;
+
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.IdentityCipherSuiteFilter;
+import io.netty.handler.ssl.JdkSslContext;
+
+/**
+ * SSL utils mainly for Netty.
+ *
+ * @author Sebastian Łaskawiec
+ * @since 9.0
+ */
+public class SslUtils {
+
+   public static JdkSslContext createNettySslContext(SslConfiguration sslConfiguration, SslEngineConfiguration sslEngineConfiguration) {
+      return createSslContext(createJdkSslContext(sslConfiguration, sslEngineConfiguration), requireClientAuth(sslConfiguration));
+   }
+
+   public static SSLContext createJdkSslContext(SslConfiguration sslConfiguration, SslEngineConfiguration sslEngineConfiguration) {
+      if (sslEngineConfiguration.sslContext() != null) {
+         return sslEngineConfiguration.sslContext();
+      }
+      return SslContextFactory.getContext(sslEngineConfiguration.keyStoreFileName(),
+            sslEngineConfiguration.keyStorePassword(), sslEngineConfiguration.keyStoreCertificatePassword(),
+            sslEngineConfiguration.trustStoreFileName(), sslEngineConfiguration.trustStorePassword());
+   }
+
+   public static JdkSslContext createSslContext(SSLContext sslContext, ClientAuth clientAuth) {
+      //Unfortunately we need to grap a list of available ciphers from the engine.
+      //If we won't, JdkSslContext will use common ciphers from DEFAULT and SUPPORTED, which gives us 5 out of ~50 available ciphers
+      //Of course, we don't need to any specific engine configuration here... just a list of ciphers
+      String[] ciphers = SslContextFactory.getEngine(sslContext, false, false).getSupportedCipherSuites();
+      return new JdkSslContext(sslContext, false, Arrays.asList(ciphers), IdentityCipherSuiteFilter.INSTANCE, null, clientAuth);
+   }
+
+   public static ClientAuth requireClientAuth(SslConfiguration sslConfig) {
+      return sslConfig.requireClientAuth() ? ClientAuth.REQUIRE : ClientAuth.NONE;
+   }
+}

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/EncryptableService.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/EncryptableService.java
@@ -1,0 +1,20 @@
+package org.infinispan.server.endpoint.subsystem;
+
+import java.util.Map;
+
+import org.jboss.as.domain.management.SecurityRealm;
+import org.jboss.msc.value.InjectedValue;
+
+public interface EncryptableService {
+   InjectedValue<SecurityRealm> getEncryptionSecurityRealm();
+
+   InjectedValue<SecurityRealm> getSniSecurityRealm(String sniHostName);
+
+   Map<String, InjectedValue<SecurityRealm>> getSniConfiguration();
+
+   String getServerName();
+
+   boolean getClientAuth();
+
+   void setClientAuth(boolean enabled);
+}

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/EncryptableServiceHelper.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/EncryptableServiceHelper.java
@@ -1,0 +1,58 @@
+package org.infinispan.server.endpoint.subsystem;
+
+import static java.util.Optional.ofNullable;
+import static org.infinispan.server.endpoint.EndpointLogger.ROOT_LOGGER;
+
+import java.util.Map;
+import java.util.Optional;
+
+import javax.net.ssl.SSLContext;
+
+import org.infinispan.server.core.configuration.SslConfigurationBuilder;
+import org.jboss.as.domain.management.AuthMechanism;
+import org.jboss.as.domain.management.SecurityRealm;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.value.InjectedValue;
+
+public class EncryptableServiceHelper {
+
+   private EncryptableServiceHelper() {
+   }
+
+   public static void fillSecurityConfiguration(EncryptableService service, SslConfigurationBuilder configurationBuilder) throws StartException {
+      if(isSecurityEnabled(service)) {
+         SecurityRealm encryptionRealm = service.getEncryptionSecurityRealm().getValue();
+         if (encryptionRealm != null) {
+            SSLContext sslContext = encryptionRealm.getSSLContext();
+            if (sslContext == null) {
+               throw ROOT_LOGGER.noSSLContext(service.getServerName(), encryptionRealm.getName());
+            }
+            if (configurationBuilder.ssl().create().requireClientAuth() && !encryptionRealm.getSupportedAuthenticationMechanisms().contains(AuthMechanism.CLIENT_CERT)) {
+               throw ROOT_LOGGER.noSSLTrustStore(service.getServerName(), encryptionRealm.getName());
+            }
+            configurationBuilder.ssl().enable();
+            configurationBuilder.ssl().sslContext(sslContext);
+            configurationBuilder.ssl().requireClientAuth(service.getClientAuth());
+            for (Map.Entry<String, InjectedValue<SecurityRealm>> sniConfiguration : service.getSniConfiguration().entrySet()) {
+               String sniDomain = sniConfiguration.getKey();
+               SSLContext sniSslContext = Optional.ofNullable(sniConfiguration.getValue().getOptionalValue())
+                     .flatMap(s -> ofNullable(s.getSSLContext()))
+                     .orElseGet(() -> {
+                        ROOT_LOGGER.noSSLContextForSni(service.getServerName());
+                        return sslContext;
+                     });
+               configurationBuilder.ssl().sniHostName(sniDomain).sslContext(sniSslContext);
+            }
+         }
+      }
+   }
+
+   public static boolean isSecurityEnabled(EncryptableService service) {
+      return service.getEncryptionSecurityRealm().getOptionalValue() != null;
+   }
+
+   public static boolean isSniEnabled(EncryptableService service) {
+      return isSecurityEnabled(service) && !service.getSniConfiguration().isEmpty();
+   }
+
+}

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/EncryptableSubsystemHelper.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/EncryptableSubsystemHelper.java
@@ -1,0 +1,31 @@
+package org.infinispan.server.endpoint.subsystem;
+
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceBuilder;
+
+public class EncryptableSubsystemHelper {
+
+   private EncryptableSubsystemHelper() {
+   }
+
+   static void processEncryption(ModelNode config, EncryptableService service, ServiceBuilder<?> builder) {
+      if (config.hasDefined(ModelKeys.ENCRYPTION) && config.get(ModelKeys.ENCRYPTION, ModelKeys.ENCRYPTION_NAME).isDefined()) {
+         EndpointUtils.addSecurityRealmDependency(builder, config.get(ModelKeys.ENCRYPTION, ModelKeys.ENCRYPTION_NAME, ModelKeys.SECURITY_REALM).asString(), service.getEncryptionSecurityRealm());
+         config = config.get(ModelKeys.ENCRYPTION, ModelKeys.ENCRYPTION_NAME);
+         if(config.get(ModelKeys.SNI).isDefined()) {
+            for(ModelNode sniConfiguration : config.get(ModelKeys.SNI).asList()) {
+               // if the security realm is missing, a default one will be used
+               if(sniConfiguration.get(0).hasDefined(ModelKeys.SECURITY_REALM)) {
+                  String sniHostName = sniConfiguration.get(0).get(ModelKeys.HOST_NAME).asString();
+                  String securityRealm = sniConfiguration.get(0).get(ModelKeys.SECURITY_REALM).asString();
+                  EndpointUtils.addSecurityRealmDependency(builder, securityRealm, service.getSniSecurityRealm(sniHostName));
+               }
+            }
+         }
+         if (config.hasDefined(ModelKeys.REQUIRE_SSL_CLIENT_AUTH)) {
+            service.setClientAuth(config.get(ModelKeys.REQUIRE_SSL_CLIENT_AUTH).asBoolean());
+         }
+      }
+   }
+
+}

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/EndpointSubsystemReader.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/EndpointSubsystemReader.java
@@ -283,9 +283,20 @@ class EndpointSubsystemReader implements XMLStreamConstants, XMLElementReader<Li
       PathAddress containerAddress = subsystemAddress.append(PathElement.pathElement(ModelKeys.REST_CONNECTOR, name));
       connector.get(OP_ADDR).set(containerAddress.toModelNode());
 
-      ParseUtils.requireNoContent(reader);
-
       operations.add(connector);
+
+      while (reader.hasNext() && (reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {
+         Element element = Element.forName(reader.getLocalName());
+         switch (element) {
+            case ENCRYPTION: {
+               parseEncryption(reader, connector, operations);
+               break;
+            }
+            default: {
+               throw ParseUtils.unexpectedElement(reader);
+            }
+         }
+      }
    }
 
    private void parseWebSocketConnector(XMLExtendedStreamReader reader, PathAddress subsystemAddress,

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/EndpointSubsystemWriter.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/EndpointSubsystemWriter.java
@@ -109,6 +109,7 @@ class EndpointSubsystemWriter implements XMLStreamConstants, XMLElementWriter<Su
       for (SimpleAttributeDefinition attribute : RestConnectorResource.REST_ATTRIBUTES) {
          attribute.marshallAsAttribute(connector, true, writer);
       }
+      writeEncryption(writer, connector);
       writer.writeEndElement();
    }
 

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/HotRodSubsystemAdd.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/HotRodSubsystemAdd.java
@@ -67,7 +67,6 @@ class HotRodSubsystemAdd extends ProtocolServiceSubsystemAdd {
       HotRodServerConfigurationBuilder configurationBuilder = new HotRodServerConfigurationBuilder();
       configureProtocolServer(configurationBuilder, config);
       configureProtocolServerAuthentication(configurationBuilder, config);
-      configureProtocolServerEncryption(configurationBuilder, config);
       configureProtocolServerTopology(configurationBuilder, config);
       // Create the service
       final ProtocolServerService service = new ProtocolServerService(getServiceName(operation), HotRodServer.class, configurationBuilder);
@@ -82,7 +81,7 @@ class HotRodSubsystemAdd extends ProtocolServiceSubsystemAdd {
       EndpointUtils.addCacheDependency(builder, cacheContainerName, null);
       EndpointUtils.addSocketBindingDependency(builder, getSocketBindingName(operation), service.getSocketBinding());
 
-      processEncryption(config, service, builder);
+      EncryptableSubsystemHelper.processEncryption(config, service, builder);
       processAuthentication(config, configurationBuilder, service, builder);
 
       // Extension manager dependency
@@ -123,23 +122,6 @@ class HotRodSubsystemAdd extends ProtocolServiceSubsystemAdd {
             if (sasl.hasDefined(ModelKeys.PROPERTY)) {
                for(Property property : sasl.get(ModelKeys.PROPERTY).asPropertyList()) {
                   authenticationBuilder.addMechProperty(property.getName(), property.getValue().asProperty().getValue().asString());
-               }
-            }
-         }
-      }
-   }
-
-   private void processEncryption(ModelNode config, ProtocolServerService service, ServiceBuilder<?> builder) {
-      if (config.hasDefined(ModelKeys.ENCRYPTION) && config.get(ModelKeys.ENCRYPTION, ModelKeys.ENCRYPTION_NAME).isDefined()) {
-         EndpointUtils.addSecurityRealmDependency(builder, config.get(ModelKeys.ENCRYPTION, ModelKeys.ENCRYPTION_NAME, ModelKeys.SECURITY_REALM).asString(), service.getEncryptionSecurityRealm());
-         config = config.get(ModelKeys.ENCRYPTION, ModelKeys.ENCRYPTION_NAME);
-         if(config.get(ModelKeys.SNI).isDefined()) {
-            for(ModelNode sniConfiguration : config.get(ModelKeys.SNI).asList()) {
-               // if the security realm is missing, a default one will be used
-               if(sniConfiguration.get(0).hasDefined(ModelKeys.SECURITY_REALM)) {
-                  String sniHostName = sniConfiguration.get(0).get(ModelKeys.HOST_NAME).asString();
-                  String securityRealm = sniConfiguration.get(0).get(ModelKeys.SECURITY_REALM).asString();
-                  EndpointUtils.addSecurityRealmDependency(builder, securityRealm, service.getSniSecurityRealm(sniHostName));
                }
             }
          }
@@ -189,16 +171,6 @@ class HotRodSubsystemAdd extends ProtocolServiceSubsystemAdd {
       if (config.hasDefined(ModelKeys.AUTHENTICATION) && config.get(ModelKeys.AUTHENTICATION, ModelKeys.AUTHENTICATION_NAME).isDefined()) {
          config = config.get(ModelKeys.AUTHENTICATION, ModelKeys.AUTHENTICATION_NAME);
          builder.authentication().enable();
-      }
-   }
-
-   private void configureProtocolServerEncryption(HotRodServerConfigurationBuilder builder, ModelNode config) {
-      if (config.hasDefined(ModelKeys.ENCRYPTION) && config.get(ModelKeys.ENCRYPTION, ModelKeys.ENCRYPTION_NAME).isDefined()) {
-         config = config.get(ModelKeys.ENCRYPTION, ModelKeys.ENCRYPTION_NAME);
-         builder.ssl().enable();
-         if (config.hasDefined(ModelKeys.REQUIRE_SSL_CLIENT_AUTH)) {
-            builder.ssl().requireClientAuth(config.get(ModelKeys.REQUIRE_SSL_CLIENT_AUTH).asBoolean());
-         }
       }
    }
 

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/RestConnectorResource.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/RestConnectorResource.java
@@ -102,6 +102,11 @@ public class RestConnectorResource extends CommonConnectorResource {
    }
 
    @Override
+   public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+      resourceRegistration.registerSubModel(new EncryptionResource());
+   }
+
+   @Override
    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
       super.registerAttributes(resourceRegistration);
 

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/RestService.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/RestService.java
@@ -21,6 +21,8 @@ package org.infinispan.server.endpoint.subsystem;
 import static org.infinispan.server.endpoint.EndpointLogger.ROOT_LOGGER;
 
 import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -30,6 +32,7 @@ import org.infinispan.rest.NettyRestServer;
 import org.infinispan.rest.configuration.ExtendedHeaders;
 import org.infinispan.rest.configuration.RestServerConfigurationBuilder;
 import org.jboss.as.controller.services.path.PathManager;
+import org.jboss.as.domain.management.SecurityRealm;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.security.plugins.SecurityDomainContext;
 import org.jboss.dmr.ModelNode;
@@ -45,43 +48,26 @@ import org.jboss.msc.value.InjectedValue;
  * @author Tristan Tarrant <ttarrant@redhat.com>
  * @since 6.0
  */
-public class RestService implements Service<Lifecycle> {
+public class RestService implements Service<Lifecycle>, EncryptableService {
    private static final String DEFAULT_CONTEXT_PATH = "";
    private final InjectedValue<PathManager> pathManagerInjector = new InjectedValue<PathManager>();
    private final InjectedValue<EmbeddedCacheManager> cacheManagerInjector = new InjectedValue<EmbeddedCacheManager>();
    private final InjectedValue<SecurityDomainContext> securityDomainContextInjector = new InjectedValue<SecurityDomainContext>();
    private final InjectedValue<SocketBinding> socketBinding = new InjectedValue<SocketBinding>();
+   private final InjectedValue<SecurityRealm> encryptionSecurityRealm = new InjectedValue<SecurityRealm>();
+   private final Map<String, InjectedValue<SecurityRealm>> sniDomains = new HashMap<>();
 
    private final ModelNode config;
-   private final String path;
-   private final String securityDomain;
-   private final String authMethod;
-   private final SecurityMode securityMode;
-   private PathManager.Callback.Handle callbackHandle;
-   private final RestServerConfigurationBuilder configurationBuilder;
+   private final String serverName;
    private Lifecycle restServer;
+   private boolean clientAuth;
 
-   public RestService(ModelNode config) {
+   public RestService(String serverName, ModelNode config) {
+      this.serverName = serverName;
       this.config = config.clone();
-
-      path = this.config.hasDefined(ModelKeys.CONTEXT_PATH) ? cleanContextPath(this.config.get(ModelKeys.CONTEXT_PATH).asString()) : DEFAULT_CONTEXT_PATH;
-      securityDomain = config.hasDefined(ModelKeys.SECURITY_DOMAIN) ? config.get(ModelKeys.SECURITY_DOMAIN).asString() : null;
-      authMethod = config.hasDefined(ModelKeys.AUTH_METHOD) ? config.get(ModelKeys.AUTH_METHOD).asString() : "BASIC";
-      securityMode = config.hasDefined(ModelKeys.SECURITY_MODE) ? SecurityMode.valueOf(config.get(ModelKeys.SECURITY_MODE).asString()) : SecurityMode.READ_WRITE;
-
-      RestServerConfigurationBuilder builder = new RestServerConfigurationBuilder();
-      if (config.hasDefined(ModelKeys.IGNORED_CACHES)) {
-         Set<String> ignoredCaches = config.get(ModelKeys.IGNORED_CACHES).asList()
-                 .stream().map(ModelNode::asString).collect(Collectors.toSet());
-         builder.ignoredCaches(ignoredCaches);
-      }
-      builder.extendedHeaders(config.hasDefined(ModelKeys.EXTENDED_HEADERS)
-            ? ExtendedHeaders.valueOf(config.get(ModelKeys.EXTENDED_HEADERS).asString())
-            : ExtendedHeaders.ON_DEMAND);
-      configurationBuilder = builder;
    }
 
-   private static String cleanContextPath(String s) {
+   private String cleanContextPath(String s) {
       if (s.endsWith("/")) {
          return s.substring(0, s.length() - 1);
       } else {
@@ -92,40 +78,51 @@ public class RestService implements Service<Lifecycle> {
    /** {@inheritDoc} */
    @Override
    public synchronized void start(StartContext startContext) throws StartException {
-      ROOT_LOGGER.endpointStarting("REST");
+      String path = this.config.hasDefined(ModelKeys.CONTEXT_PATH) ? cleanContextPath(this.config.get(ModelKeys.CONTEXT_PATH).asString()) : DEFAULT_CONTEXT_PATH;
+
+      RestServerConfigurationBuilder builder = new RestServerConfigurationBuilder();
+      builder.name(serverName);
+      if (config.hasDefined(ModelKeys.IGNORED_CACHES)) {
+         Set<String> ignoredCaches = config.get(ModelKeys.IGNORED_CACHES).asList()
+               .stream().map(ModelNode::asString).collect(Collectors.toSet());
+         builder.ignoredCaches(ignoredCaches);
+      }
+      builder.extendedHeaders(config.hasDefined(ModelKeys.EXTENDED_HEADERS)
+            ? ExtendedHeaders.valueOf(config.get(ModelKeys.EXTENDED_HEADERS).asString())
+            : ExtendedHeaders.ON_DEMAND);
+
+      EncryptableServiceHelper.fillSecurityConfiguration(this, builder.ssl());
+
+      String protocolName = getProtocolName();
+
+      ROOT_LOGGER.endpointStarting(protocolName);
       try {
          SocketBinding socketBinding = getSocketBinding().getValue();
          InetSocketAddress socketAddress = socketBinding.getSocketAddress();
-         configurationBuilder.host(socketAddress.getAddress().getHostAddress());
-         configurationBuilder.port(socketAddress.getPort());
-         restServer = NettyRestServer.createServer(configurationBuilder.build(), cacheManagerInjector.getValue());
+         builder.host(socketAddress.getAddress().getHostAddress());
+         builder.port(socketAddress.getPort());
+         restServer = NettyRestServer.createServer(builder.build(), cacheManagerInjector.getValue());
       } catch (Exception e) {
          throw ROOT_LOGGER.restContextCreationFailed(e);
       }
 
       try {
          restServer.start();
-         ROOT_LOGGER.httpEndpointStarted("REST", path, "rest");
+         ROOT_LOGGER.httpEndpointStarted(protocolName, path, "rest");
       } catch (Exception e) {
          throw ROOT_LOGGER.restContextStartFailed(e);
       }
    }
 
-   public String getSecurityDomain() {
-      return securityDomain;
+   private String getProtocolName() {
+      return EncryptableServiceHelper.isSecurityEnabled(this) ?
+            (EncryptableServiceHelper.isSniEnabled(this) ? serverName + "+SNI" : serverName + "+SSL") : serverName;
    }
 
    /** {@inheritDoc} */
    @Override
    public synchronized void stop(StopContext stopContext) {
       restServer.stop();
-   }
-
-   String getCacheContainerName() {
-      if (!config.hasDefined(ModelKeys.CACHE_CONTAINER)) {
-         return null;
-      }
-      return config.get(ModelKeys.CACHE_CONTAINER).asString();
    }
 
    /** {@inheritDoc} */
@@ -149,8 +146,38 @@ public class RestService implements Service<Lifecycle> {
       return securityDomainContextInjector;
    }
 
-   InjectedValue<SocketBinding> getSocketBinding() {
+   public InjectedValue<SocketBinding> getSocketBinding() {
       return socketBinding;
+   }
+
+   @Override
+   public InjectedValue<SecurityRealm> getEncryptionSecurityRealm() {
+      return encryptionSecurityRealm;
+   }
+
+   @Override
+   public InjectedValue<SecurityRealm> getSniSecurityRealm(String sniHostName) {
+      return sniDomains.computeIfAbsent(sniHostName, v -> new InjectedValue<SecurityRealm>());
+   }
+
+   @Override
+   public Map<String, InjectedValue<SecurityRealm>> getSniConfiguration() {
+      return sniDomains;
+   }
+
+   @Override
+   public String getServerName() {
+      return serverName;
+   }
+
+   @Override
+   public void setClientAuth(boolean enabled) {
+      clientAuth = enabled;
+   }
+
+   @Override
+   public boolean getClientAuth() {
+      return clientAuth;
    }
 
 }

--- a/server/integration/endpoint/src/main/resources/schema/jboss-infinispan-endpoint_9_0.xsd
+++ b/server/integration/endpoint/src/main/resources/schema/jboss-infinispan-endpoint_9_0.xsd
@@ -85,6 +85,14 @@
     </xs:complexType>
 
     <xs:complexType name="rest-connector">
+        <xs:all>
+            <xs:element name="encryption" type="tns:encryption" minOccurs="0" maxOccurs="1" />
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>The logical name to give to this connector. This attribute is required when there are more connectors of the same type defined.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="cache-container" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation>The name of the cache container which will be exposed by this connector</xs:documentation>

--- a/server/integration/endpoint/src/test/java/org/infinispan/server/endpoint/EndpointSubsystemTestCase.java
+++ b/server/integration/endpoint/src/test/java/org/infinispan/server/endpoint/EndpointSubsystemTestCase.java
@@ -69,7 +69,7 @@ public class EndpointSubsystemTestCase extends ClusteringSubsystemTest {
       Object[][] data = new Object[][] {
             { "endpoint-7.2.xml", 16, "schema/jboss-infinispan-endpoint_7_2.xsd" },
             { "endpoint-8.0.xml", 16, "schema/jboss-infinispan-endpoint_8_0.xsd" },
-            { "endpoint-9.0.xml", 21, "schema/jboss-infinispan-endpoint_9_0.xsd" },
+            { "endpoint-9.0.xml", 25, "schema/jboss-infinispan-endpoint_9_0.xsd" },
       };
       return Arrays.asList(data);
    }

--- a/server/integration/endpoint/src/test/resources/org/infinispan/server/endpoint/endpoint-9.0.xml
+++ b/server/integration/endpoint/src/test/resources/org/infinispan/server/endpoint/endpoint-9.0.xml
@@ -1,23 +1,23 @@
 <subsystem xmlns="urn:infinispan:server:endpoint:9.0">
-   <hotrod-connector name="hotrod1" socket-binding="hotrod" ignored-caches="cache1" cache-container="default" idle-timeout="100" tcp-nodelay="true" worker-threads="5" receive-buffer-size="10000" send-buffer-size="10000">
-      <topology-state-transfer external-host="localhost" external-port="1234" lazy-retrieval="false" lock-timeout="1000" replication-timeout="5000" />
-   </hotrod-connector>
-   <hotrod-connector name="hotrod2" socket-binding="hotrod" cache-container="default" idle-timeout="100" tcp-nodelay="true" worker-threads="5" receive-buffer-size="10000" send-buffer-size="10000">
-      <topology-state-transfer external-host="localhost" external-port="1234" lazy-retrieval="false" await-initial-retrieval="false" lock-timeout="1000" replication-timeout="5000" />
-      <encryption security-realm="other" />
-   </hotrod-connector>
-   <hotrod-connector name="hotrod3" socket-binding="hotrod" cache-container="default" idle-timeout="100" tcp-nodelay="true" worker-threads="5" receive-buffer-size="10000" send-buffer-size="10000">
-      <topology-state-transfer external-host="localhost" external-port="1234" lazy-retrieval="false" await-initial-retrieval="false" lock-timeout="1000" replication-timeout="5000" />
-      <authentication security-realm="other">
-        <sasl server-context-name="host" server-name="localhost" mechanisms="GSSAPI DIGEST-MD5 PLAIN" qop="auth" strength="high medium low">
-            <policy>
-                <no-anonymous value="true" />
-            </policy>
-            <property name="com.sun.security.sasl.digest.realm">ServerRealm</property>
-            <property name="com.sun.security.sasl.digest.utf8">true</property>
-        </sasl>
-      </authentication>
-   </hotrod-connector>
+    <hotrod-connector name="hotrod1" socket-binding="hotrod" ignored-caches="cache1" cache-container="default" idle-timeout="100" tcp-nodelay="true" worker-threads="5" receive-buffer-size="10000" send-buffer-size="10000">
+        <topology-state-transfer external-host="localhost" external-port="1234" lazy-retrieval="false" lock-timeout="1000" replication-timeout="5000" />
+    </hotrod-connector>
+    <hotrod-connector name="hotrod2" socket-binding="hotrod" cache-container="default" idle-timeout="100" tcp-nodelay="true" worker-threads="5" receive-buffer-size="10000" send-buffer-size="10000">
+        <topology-state-transfer external-host="localhost" external-port="1234" lazy-retrieval="false" await-initial-retrieval="false" lock-timeout="1000" replication-timeout="5000" />
+        <encryption security-realm="other" />
+    </hotrod-connector>
+    <hotrod-connector name="hotrod3" socket-binding="hotrod" cache-container="default" idle-timeout="100" tcp-nodelay="true" worker-threads="5" receive-buffer-size="10000" send-buffer-size="10000">
+        <topology-state-transfer external-host="localhost" external-port="1234" lazy-retrieval="false" await-initial-retrieval="false" lock-timeout="1000" replication-timeout="5000" />
+        <authentication security-realm="other">
+            <sasl server-context-name="host" server-name="localhost" mechanisms="GSSAPI DIGEST-MD5 PLAIN" qop="auth" strength="high medium low">
+                <policy>
+                    <no-anonymous value="true" />
+                </policy>
+                <property name="com.sun.security.sasl.digest.realm">ServerRealm</property>
+                <property name="com.sun.security.sasl.digest.utf8">true</property>
+            </sasl>
+        </authentication>
+    </hotrod-connector>
     <hotrod-connector name="hotrod5" socket-binding="hotrod" cache-container="default">
         <encryption security-realm="other">
             <sni host-name="sni" security-realm="other" />
@@ -25,7 +25,13 @@
             <sni host-name="sni3" />
         </encryption>
     </hotrod-connector>
-   <memcached-connector cache="memcachedCache" socket-binding="memcached" cache-container="default" idle-timeout="100" tcp-nodelay="true" worker-threads="5" receive-buffer-size="10000" send-buffer-size="10000" />
-   <rest-connector socket-binding="rest" cache-container="default" ignored-caches="cache1 cache2 cache3" context-path="/" security-domain="other" auth-method="BASIC" security-mode="READ_WRITE" extended-headers="ON_DEMAND"/>
-   <websocket-connector socket-binding="websocket" cache-container="default" idle-timeout="100" tcp-nodelay="true" worker-threads="5" receive-buffer-size="10000" send-buffer-size="10000" />
+    <memcached-connector cache="memcachedCache" socket-binding="memcached" cache-container="default" idle-timeout="100" tcp-nodelay="true" worker-threads="5" receive-buffer-size="10000" send-buffer-size="10000" />
+    <rest-connector name="rest1" socket-binding="rest" cache-container="default" ignored-caches="cache1 cache2 cache3" context-path="/" security-domain="other" auth-method="BASIC" security-mode="READ_WRITE" extended-headers="ON_DEMAND">
+        <encryption security-realm="other">
+            <sni host-name="sni" security-realm="other" />
+            <sni host-name="sni2" security-realm="other2" />
+            <sni host-name="sni3" />
+        </encryption>
+    </rest-connector>
+    <websocket-connector socket-binding="websocket" cache-container="default" idle-timeout="100" tcp-nodelay="true" worker-threads="5" receive-buffer-size="10000" send-buffer-size="10000" />
 </subsystem>

--- a/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-netty4/main/module.xml
+++ b/server/integration/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-netty4/main/module.xml
@@ -7,8 +7,10 @@
    </resources>
 
    <dependencies>
+      <module name="javax.api" />
       <module name="io.netty" />
       <module name="javax.ws.rs.api"/>
       <module name="org.jboss.resteasy.resteasy-jaxrs" />
+      <module name="org.jboss.logging"/>
    </dependencies>
 </module>

--- a/server/integration/testsuite/build-testsuite.xml
+++ b/server/integration/testsuite/build-testsuite.xml
@@ -358,6 +358,12 @@
                    addVault="${other.parts}/vault.xml" />
         <transform in="clustered.xml" out="testsuite/hotrod-ssl-with-sni.xml"
                    hotrodEncrypt="${infinispan.parts}/hotrod-ssl-with-sni.xml"
+                   restEncrypt="${infinispan.parts}/hotrod-ssl-with-sni.xml"
+                   addSecRealm="${other.parts}/hotrod-ssl-realm-with-sni1.xml"
+                   addSecRealm2="${other.parts}/hotrod-ssl-realm-with-sni2.xml"
+                   addVault="${other.parts}/vault.xml" />
+        <transform in="standalone.xml" out="testsuite/rest-ssl-with-sni.xml"
+                   restEncrypt="${infinispan.parts}/hotrod-ssl-with-sni.xml"
                    addSecRealm="${other.parts}/hotrod-ssl-realm-with-sni1.xml"
                    addSecRealm2="${other.parts}/hotrod-ssl-realm-with-sni2.xml"
                    addVault="${other.parts}/vault.xml" />
@@ -387,6 +393,7 @@
         <attribute name="addJGroupsSasl" default="false"/>
         <attribute name="hotrodAuth" default="false"/>
         <attribute name="hotrodEncrypt" default="false"/>
+        <attribute name="restEncrypt" default="false"/>
         <attribute name="addKrbOpts" default="false"/>
         <attribute name="addKrbSecDomain" default="false"/>
         <attribute name="addVault" default="false"/>
@@ -407,6 +414,7 @@
                 <param name="addJGroupsSasl" expression="@{addJGroupsSasl}"/>
                 <param name="hotrodAuth" expression="@{hotrodAuth}"/>
                 <param name="hotrodEncrypt" expression="@{hotrodEncrypt}"/>
+                <param name="restEncrypt" expression="@{restEncrypt}"/>
                 <param name="addKrbOpts" expression="@{addKrbOpts}"/>
                 <param name="addKrbSecDomain" expression="@{addKrbSecDomain}"/>
                 <param name="addSecRealm" expression="@{addSecRealm}"/>

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/RESTClientWithSniEncryptionIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/RESTClientWithSniEncryptionIT.java
@@ -1,0 +1,90 @@
+package org.infinispan.server.test.client.rest;
+
+import static org.infinispan.server.test.client.rest.RESTHelper.*;
+import static org.jboss.aesh.terminal.Key.e;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.util.Optional;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+
+import org.apache.http.HttpResponse;
+import org.infinispan.arquillian.core.InfinispanResource;
+import org.infinispan.arquillian.core.RemoteInfinispanServer;
+import org.infinispan.arquillian.core.RunningServer;
+import org.infinispan.arquillian.core.WithRunningServer;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.exceptions.TransportException;
+import org.infinispan.commons.util.SslContextFactory;
+import org.infinispan.server.test.category.Security;
+import org.infinispan.server.test.util.ITestUtils;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import sun.security.validator.ValidatorException;
+
+@RunWith(Arquillian.class)
+@Category({Security.class})
+@WithRunningServer({@RunningServer(name = "restSslWithSni", config = "testsuite/rest-ssl-with-sni.xml")})
+public class RESTClientWithSniEncryptionIT {
+
+   protected static final String DEFAULT_TRUSTSTORE_PATH = ITestUtils.SERVER_CONFIG_DIR + File.separator
+           + "truststore_client.jks";
+   protected static final String DEFAULT_TRUSTSTORE_PASSWORD = "secret";
+
+
+   @InfinispanResource("hotrodSslWithSni")
+   RemoteInfinispanServer ispnServer;
+
+   @Before
+   public void setup() {
+      addServer(ispnServer.getRESTEndpoint().getInetAddress().getHostName(), ispnServer.getRESTEndpoint().getContextPath());
+   }
+
+   @After
+   public void release() {
+      clearServers();
+   }
+
+   @Test
+   public void testUnauthorizedAccessToDefaultSSLContext() throws Exception {
+      //given
+      SSLContext sslContext = SslContextFactory.getContext(null, null, DEFAULT_TRUSTSTORE_PATH, DEFAULT_TRUSTSTORE_PASSWORD.toCharArray());
+
+      //when
+      setSni(sslContext, Optional.empty());
+      try {
+         //when
+         put(toSsl(fullPathKey("test")), "test", "text/plain");
+
+         fail();
+      } catch (javax.net.ssl.SSLHandshakeException ignoreMe) {
+         //then
+      }
+   }
+
+   @Test
+   public void testAuthorizedAccessThroughSni() throws Exception {
+      //given
+      SSLContext sslContext = SslContextFactory.getContext(null, null, DEFAULT_TRUSTSTORE_PATH, DEFAULT_TRUSTSTORE_PASSWORD.toCharArray());
+
+      //when
+      setSni(sslContext, Optional.of("sni"));
+      HttpResponse response = put(toSsl(fullPathKey("test")), "test", "text/plain");
+
+      //then
+      Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+   }
+}

--- a/server/integration/testsuite/src/test/resources/arquillian.xml
+++ b/server/integration/testsuite/src/test/resources/arquillian.xml
@@ -1055,6 +1055,26 @@
                 <property name="jmxDomain">${server.jmx.domain}</property>
             </configuration>
         </container>
+        <container qualifier="restSslWithSni" mode="manual">
+            <configuration>
+                <property name="javaHome">${server.jvm}</property>
+                <property name="jbossHome">${server1.dist}</property>
+                <property name="managementAddress">${node0.ip}</property>
+                <property name="serverConfig">testsuite/rest-ssl-with-sni.xml</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0
+                     -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}
+                     -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000
+                </property>
+                <!--<property name="javaVmArguments">${server.jvm.args} -Djboss.node.name=node0-->
+                     <!-- -Djboss.bind.address.management=${node0.ip} -Djboss.bind.address=${node0.ip}-->
+                     <!-- -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Djgroups.join_timeout=2000-->
+                     <!-- -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=1044-->
+                <!--</property>-->
+                <property name="managementPort">9990</property>
+                <property name="waitForPorts">11211 11222 8080</property>
+                <property name="jmxDomain">${server.jmx.domain}</property>
+            </configuration>
+        </container>
     </group>
 
     <group qualifier="queries">

--- a/server/integration/testsuite/src/test/resources/config/xslt/config-modifier.xsl
+++ b/server/integration/testsuite/src/test/resources/config/xslt/config-modifier.xsl
@@ -33,6 +33,7 @@
     <xsl:param name="addJGroupsSasl">false</xsl:param>
     <xsl:param name="hotrodAuth">false</xsl:param>
     <xsl:param name="hotrodEncrypt">false</xsl:param>
+    <xsl:param name="restEncrypt">false</xsl:param>
     <xsl:param name="addKrbOpts">false</xsl:param>
     <xsl:param name="addKrbSecDomain">false</xsl:param>
     <xsl:param name="addSecRealm">false</xsl:param>
@@ -273,13 +274,25 @@
     </xsl:template>
 
     <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $nsEndpoint)]/*[local-name()='rest-connector']">
-        <xsl:if test="$removeRestSecurity != 'true'">
+        <xsl:if test="$removeRestSecurity = 'false' and $restEncrypt = 'false'">
             <xsl:call-template name="copynode"/>
         </xsl:if>
-        <xsl:if test="$removeRestSecurity = 'true'">
+        <xsl:if test="$removeRestSecurity != 'false' and $restEncrypt = 'false'">
             <xsl:copy>
                 <xsl:copy-of select="@*[not(name() = 'security-domain' or name() = 'auth-method')]"/>
                 <xsl:apply-templates/>
+            </xsl:copy>
+        </xsl:if>
+        <xsl:if test="$removeRestSecurity = 'false' and $restEncrypt != 'false'">
+            <xsl:copy>
+                <xsl:copy-of select="@*" />
+                <xsl:copy-of select="document($restEncrypt)"/>
+            </xsl:copy>
+        </xsl:if>
+        <xsl:if test="$removeRestSecurity != 'false' and $restEncrypt != 'false'">
+            <xsl:copy>
+                <xsl:copy-of select="@*[not(name() = 'security-domain' or name() = 'auth-method')]"/>
+                <xsl:copy-of select="document($restEncrypt)"/>
             </xsl:copy>
         </xsl:if>
     </xsl:template>

--- a/server/rest/src/main/java/org/infinispan/rest/ServerBootstrap.java
+++ b/server/rest/src/main/java/org/infinispan/rest/ServerBootstrap.java
@@ -113,8 +113,4 @@ public class ServerBootstrap implements ServletContextListener {
       }
    }
 
-   private Class<?> loadClass(String name) throws Exception {
-      return Thread.currentThread().getContextClassLoader().loadClass(name);
-   }
-
 }

--- a/server/rest/src/main/java/org/infinispan/rest/configuration/RestServerConfiguration.java
+++ b/server/rest/src/main/java/org/infinispan/rest/configuration/RestServerConfiguration.java
@@ -3,34 +3,27 @@ package org.infinispan.rest.configuration;
 import java.util.Set;
 
 import org.infinispan.commons.configuration.BuiltBy;
+import org.infinispan.server.core.configuration.ProtocolServerConfiguration;
+import org.infinispan.server.core.configuration.SslConfiguration;
 
 @BuiltBy(RestServerConfigurationBuilder.class)
-public class RestServerConfiguration {
+public class RestServerConfiguration extends ProtocolServerConfiguration {
    private final ExtendedHeaders extendedHeaders;
-   private final String host;
-   private final int port;
-   private Set<String> ignoredCaches;
 
-   RestServerConfiguration(ExtendedHeaders extendedHeaders, String host, int port, Set<String> ignoredCaches) {
+   RestServerConfiguration(ExtendedHeaders extendedHeaders, String host, int port, Set<String> ignoredCaches, SslConfiguration ssl) {
+      super(null, null, host, port, -1, -1, -1, ssl, false, -1, ignoredCaches);
       this.extendedHeaders = extendedHeaders;
-      this.host = host;
-      this.port = port;
-      this.ignoredCaches = ignoredCaches;
    }
 
    public ExtendedHeaders extendedHeaders() {
       return extendedHeaders;
    }
 
-   public int port() {
-      return port;
-   }
-
-   public String host() {
-      return host;
-   }
-
+   /**
+    * @deprecated Use {@link #ignoredCaches()} instead.
+    */
+   @Deprecated
    public Set<String> getIgnoredCaches() {
-      return ignoredCaches;
+      return ignoredCaches();
    }
 }

--- a/server/rest/src/main/java/org/infinispan/rest/configuration/RestServerConfigurationBuilder.java
+++ b/server/rest/src/main/java/org/infinispan/rest/configuration/RestServerConfigurationBuilder.java
@@ -1,9 +1,9 @@
 package org.infinispan.rest.configuration;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.infinispan.commons.configuration.Builder;
+import org.infinispan.rest.logging.Log;
+import org.infinispan.server.core.configuration.ProtocolServerConfigurationBuilder;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * RestServerConfigurationBuilder.
@@ -11,30 +11,21 @@ import org.infinispan.commons.configuration.Builder;
  * @author Tristan Tarrant
  * @since 5.3
  */
-public class RestServerConfigurationBuilder implements Builder<RestServerConfiguration> {
+public class RestServerConfigurationBuilder extends ProtocolServerConfigurationBuilder<RestServerConfiguration, RestServerConfigurationBuilder> implements
+      Builder<RestServerConfiguration> {
+
+   private final static Log logger = LogFactory.getLog(RestServerConfigurationBuilder.class, Log.class);
+
+   private static final int DEFAULT_PORT = 8080;
 
    private ExtendedHeaders extendedHeaders = ExtendedHeaders.ON_DEMAND;
-   private int port = 8080;
-   private String host = "localhost";
-   private Set<String> ignoredCaches = new HashSet<String>();
+
+   public RestServerConfigurationBuilder() {
+      super(DEFAULT_PORT);
+   }
 
    public RestServerConfigurationBuilder extendedHeaders(ExtendedHeaders extendedHeaders) {
       this.extendedHeaders = extendedHeaders;
-      return this;
-   }
-
-   public RestServerConfigurationBuilder port(int port) {
-      this.port = port;
-      return this;
-   }
-
-   public RestServerConfigurationBuilder host(String host) {
-      this.host = host;
-      return this;
-   }
-
-   public RestServerConfigurationBuilder ignoredCaches(Set<String> ignoredCaches) {
-      this.ignoredCaches = ignoredCaches;
       return this;
    }
 
@@ -45,7 +36,7 @@ public class RestServerConfigurationBuilder implements Builder<RestServerConfigu
 
    @Override
    public RestServerConfiguration create() {
-      return new RestServerConfiguration(extendedHeaders, host, port, ignoredCaches);
+      return new RestServerConfiguration(extendedHeaders, host, port, ignoredCaches, ssl.create());
    }
 
    @Override
@@ -66,4 +57,38 @@ public class RestServerConfigurationBuilder implements Builder<RestServerConfigu
       return create();
    }
 
+   @Override
+   public RestServerConfigurationBuilder self() {
+      return this;
+   }
+
+   @Override
+   public RestServerConfigurationBuilder defaultCacheName(String defaultCacheName) {
+      throw logger.unsupportedConfigurationOption();
+   }
+
+   @Override
+   public RestServerConfigurationBuilder idleTimeout(int idleTimeout) {
+      throw logger.unsupportedConfigurationOption();
+   }
+
+   @Override
+   public RestServerConfigurationBuilder tcpNoDelay(boolean tcpNoDelay) {
+      throw logger.unsupportedConfigurationOption();
+   }
+
+   @Override
+   public RestServerConfigurationBuilder recvBufSize(int recvBufSize) {
+      throw logger.unsupportedConfigurationOption();
+   }
+
+   @Override
+   public RestServerConfigurationBuilder sendBufSize(int sendBufSize) {
+      throw logger.unsupportedConfigurationOption();
+   }
+
+   @Override
+   public RestServerConfigurationBuilder workerThreads(int workerThreads) {
+      throw logger.unsupportedConfigurationOption();
+   }
 }

--- a/server/rest/src/main/java/org/infinispan/rest/logging/Log.java
+++ b/server/rest/src/main/java/org/infinispan/rest/logging/Log.java
@@ -30,4 +30,7 @@ public interface Log extends org.infinispan.util.logging.Log {
    @Message(value = "REST server starting, listening on %s:%s", id = 12003)
    void startRestServer(String host, int port);
 
+   @Message(value = "Unsupported configuration option", id = 12004)
+   UnsupportedOperationException unsupportedConfigurationOption();
+
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6813

Highlights:
* Added encryption for REST (some parts were there but it wasn't working).
* Upgraded to the latest Netty and RESTEasy versions.
* Added `ProtocolServerConfiguration` as parent of `RestServerConfiguration`. Some parts of the configuration throw `UnsupportedOperationException` since we don't control this configuration parts.
* Extracted common parts for encryption subsystem and encryption service.