### PR TITLE
ISPN-6961 AbstractClusterListenerUtilTest tests fail from IDE

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/CommandAwareRpcDispatcher.java
@@ -253,9 +253,12 @@ public class CommandAwareRpcDispatcher extends RpcDispatcher {
          try {
             rsp_buf = rsp_marshaller.objectToBuffer(retVal);
          } catch (Throwable t) {
-            try {  // this call should succeed (all exceptions are serializable)
+            try {
+               // this call should succeed (all exceptions are serializable)
                rsp_buf = rsp_marshaller.objectToBuffer(t);
                is_exception = true;
+            } catch (IllegalLifecycleStateException tt) {
+               return;
             } catch (Throwable tt) {
                log.errorMarshallingObject(tt, retVal);
                return;


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6961

Remove the resetTimeServices method, it's not needed and it fails
with an IllegalArgumentException if the test didn't advance() all the
ControlledTimeService instances.

Don't log marshalling errors during shutdown.