### PR TITLE
ISPN-6997PessimisticTxPartitionAndMergeDuringRuntimeTest

### DIFF
--- a/core/src/main/java/org/infinispan/commands/tx/CommitCommand.java
+++ b/core/src/main/java/org/infinispan/commands/tx/CommitCommand.java
@@ -3,6 +3,7 @@ package org.infinispan.commands.tx;
 import org.infinispan.commands.Visitor;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.impl.TxInvocationContext;
+import org.infinispan.remoting.responses.UnsuccessfulResponse;
 import org.infinispan.transaction.impl.TransactionTable;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.util.ByteString;
@@ -50,7 +51,7 @@ public class CommitCommand extends AbstractTransactionBoundaryCommand {
          case EXPIRED:
             throw log.remoteTransactionStatusMissing(globalTx);
          default:  // NOT_COMPLETED
-            throw new IllegalStateException("Remote transaction not found: " + globalTx);
+            return UnsuccessfulResponse.INSTANCE;
       }
    }
 

--- a/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/distribution/TxDistributionInterceptor.java
@@ -230,13 +230,12 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
 
          TxInvocationContext<LocalTransaction> localTxCtx = (TxInvocationContext<LocalTransaction>) rCtx;
          Collection<Address> recipients = cdl.getOwners(getAffectedKeysFromContext(localTxCtx));
+         // Mark the locks as acquired even if the remote invocation fails, e.g. with a SuspectException
+         localTxCtx.getCacheTransaction().locksAcquired(
+               recipients == null ? dm.getWriteConsistentHash().getMembers() : recipients);
          CompletableFuture<Object> remotePrepare =
                prepareOnAffectedNodes(localTxCtx, (PrepareCommand) rCommand, recipients);
-         return returnWithAsync(remotePrepare.thenApply(o -> {
-            localTxCtx.getCacheTransaction().locksAcquired(
-                  recipients == null ? dm.getWriteConsistentHash().getMembers() : recipients);
-            return o;
-         }));
+         return returnWithAsync(remotePrepare);
       });
    }
 
@@ -285,16 +284,20 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
          TransactionBoundaryCommand command, TxInvocationContext<LocalTransaction> context,
          Collection<Address> recipients) {
       OutdatedTopologyException outdatedTopologyException = null;
+      CacheTopology cacheTopology = stateTransferManager.getCacheTopology();
       for (Map.Entry<Address, Response> e : responseMap.entrySet()) {
          Address recipient = e.getKey();
          Response response = e.getValue();
          if (response == CacheNotFoundResponse.INSTANCE) {
             // No need to retry if the missing node wasn't a member when the command started.
-            if (command.getTopologyId() == stateTransferManager.getCacheTopology().getTopologyId()
+            if (command.getTopologyId() == cacheTopology.getTopologyId()
                   && !rpcManager.getMembers().contains(recipient)) {
                if (trace) log.tracef("Ignoring response from node not targeted %s", recipient);
             } else {
-               if (checkCacheNotFoundResponseInPartitionHandling(command, context, recipients)) {
+               // If the recipient is still in the actualMembers list, but we got a CacheNotFoundResponse,
+               // it means we should receive a new topology soon, and we have to retry with that topology.
+               if (!cacheTopology.getActualMembers().contains(recipient) &&
+                     checkCacheNotFoundResponseInPartitionHandling(command, context, recipients)) {
                   if (trace) log.tracef("Cache not running on node %s, or the node is missing. It will be handled by the PartitionHandlingManager", recipient);
                   return;
                } else {
@@ -324,6 +327,11 @@ public class TxDistributionInterceptor extends BaseDistributionInterceptor {
          if (((PrepareCommand) command).isOnePhaseCommit()) {
             return partitionHandlingManager.addPartialCommit1PCTransaction(globalTransaction, recipients, lockedKeys,
                                                                            Arrays.asList(((PrepareCommand) command).getModifications()));
+         } else {
+            // The RollbackCommand will be invoked on the same nodes, and the transaction will then be registered
+            // as partially rolled back again (assuming the cluster is still split).
+            // For now, we just want to make sure that we don't throw an OutdatedTopologyException.
+            return partitionHandlingManager.addPartialRollbackTransaction(globalTransaction, recipients, lockedKeys);
          }
       } else if (command instanceof CommitCommand) {
          EntryVersionsMap newVersion = null;

--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/SingleResponseFuture.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/SingleResponseFuture.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Future;
 import java.util.function.BiConsumer;
 
 import org.infinispan.remoting.responses.Response;
+import org.infinispan.util.concurrent.TimeoutException;
 import org.jgroups.SuspectedException;
 import org.jgroups.util.Rsp;
 
@@ -48,7 +49,7 @@ public class SingleResponseFuture extends CompletableFuture<Rsp<Response>>
    @Override
    public Void call() throws Exception {
       // The request timed out
-      complete(new Rsp<>());
+      completeExceptionally(new TimeoutException("Timed out waiting for response"));
       request.cancel(false);
       return null;
    }

--- a/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateConsumerImpl.java
@@ -418,14 +418,16 @@ public class StateConsumerImpl implements StateConsumer {
             waitingForState.set(true);
          }
 
-         notifyEndOfRebalanceIfNeeded(cacheTopology.getTopologyId(), cacheTopology.getRebalanceId());
-
          // Remove the transactions whose originators have left the cache.
-         // Need to do it now, after we have applied any transactions from other nodes,
+         // Need to do it after we have applied any transactions from other nodes,
          // and after notifyTransactionDataReceived - otherwise the RollbackCommands would block.
+         // We also need to do it before sending the rebalance confirmations back to the coordinator,
+         // so that we clean up old transactions before starting the rebalance after a merge.
          if (transactionTable != null) {
             transactionTable.cleanupLeaverTransactions(rpcManager.getTransport().getMembers());
          }
+
+         notifyEndOfRebalanceIfNeeded(cacheTopology.getTopologyId(), cacheTopology.getRebalanceId());
 
          commandAckCollector.onMembersChange(newWriteCh.getMembers());
 

--- a/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
+++ b/core/src/main/java/org/infinispan/topology/ClusterCacheStatus.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -144,7 +145,7 @@ public class ClusterCacheStatus implements AvailabilityStrategyContext {
       synchronized (this) {
          boolean modeChanged = setAvailabilityMode(newAvailabilityMode);
 
-         if (modeChanged || !actualMembers.equals(currentTopology.getActualMembers())) {
+         if (modeChanged || !Objects.equals(actualMembers, currentTopology.getActualMembers())) {
             log.debugf("Updating availability for cache %s to %s", cacheName, newAvailabilityMode);
             ConsistentHash newPendingCH = currentTopology.getPendingCH();
             if (cancelRebalance) {

--- a/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
@@ -111,7 +111,7 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
 
    private ConcurrentMap<Transaction, LocalTransaction> localTransactions;
    private ConcurrentMap<GlobalTransaction, LocalTransaction> globalToLocalTransactions;
-   private ConcurrentMap<GlobalTransaction, RemoteTransaction> remoteTransactions;
+   protected ConcurrentMap<GlobalTransaction, RemoteTransaction> remoteTransactions;
    private Lock minTopologyRecalculationLock;
    protected boolean clustered = false;
    protected volatile boolean running = false;
@@ -273,33 +273,37 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
       if (remoteTransactions == null)
          return;
 
-      if (trace) log.tracef("Checking for transactions originated on leavers. Current cache members are %s, remote transactions: %d",
-            members, remoteTransactions.size());
-      HashSet<Address> membersSet = new HashSet<>(members);
-      List<GlobalTransaction> toKill = new ArrayList<>();
-      for (Map.Entry<GlobalTransaction, RemoteTransaction> e : remoteTransactions.entrySet()) {
-         GlobalTransaction gt = e.getKey();
-         if (trace) log.tracef("Checking transaction %s", gt);
-         if (!membersSet.contains(gt.getAddress())) {
-            toKill.add(gt);
-         }
-      }
-
-      if (toKill.isEmpty()) {
-         if (trace) log.tracef("No remote transactions pertain to originator(s) who have left the cluster.");
-      } else {
-         log.debugf("The originating node left the cluster for %d remote transactions", toKill.size());
-         for (GlobalTransaction gtx : toKill) {
-            if (partitionHandlingManager.canRollbackTransactionAfterOriginatorLeave(gtx)) {
-               log.debugf("Rolling back transaction %s because originator %s left the cluster", gtx, gtx.getAddress());
-               killTransaction(gtx);
-            } else {
-               log.debugf("Keeping transaction %s after the originator %s left the cluster.", gtx, gtx.getAddress());
+      try {
+         if (trace) log.tracef("Checking for transactions originated on leavers. Current cache members are %s, remote transactions: %d",
+               members, remoteTransactions.size());
+         HashSet<Address> membersSet = new HashSet<>(members);
+         List<GlobalTransaction> toKill = new ArrayList<>();
+         for (Map.Entry<GlobalTransaction, RemoteTransaction> e : remoteTransactions.entrySet()) {
+            GlobalTransaction gt = e.getKey();
+            if (trace) log.tracef("Checking transaction %s", gt);
+            if (!membersSet.contains(gt.getAddress())) {
+               toKill.add(gt);
             }
          }
 
-         if (trace) log.tracef("Completed cleaning transactions originating on leavers. Remote transactions remaining: %d",
-                               remoteTransactions.size());
+         if (toKill.isEmpty()) {
+            if (trace) log.tracef("No remote transactions pertain to originator(s) who have left the cluster.");
+         } else {
+            log.debugf("The originating node left the cluster for %d remote transactions", toKill.size());
+            for (GlobalTransaction gtx : toKill) {
+               if (partitionHandlingManager.canRollbackTransactionAfterOriginatorLeave(gtx)) {
+                  log.debugf("Rolling back transaction %s because originator %s left the cluster", gtx, gtx.getAddress());
+                  killTransaction(gtx);
+               } else {
+                  log.debugf("Keeping transaction %s after the originator %s left the cluster.", gtx, gtx.getAddress());
+               }
+            }
+
+            if (trace) log.tracef("Completed cleaning transactions originating on leavers. Remote transactions remaining: %d",
+                                  remoteTransactions.size());
+         }
+      } catch (Throwable t) {
+         log.unableToRollbackGlobalTx(null, t);
       }
    }
 

--- a/core/src/test/java/org/infinispan/partitionhandling/BaseOptimisticTxPartitionAndMergeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BaseOptimisticTxPartitionAndMergeTest.java
@@ -13,6 +13,9 @@ import org.infinispan.Cache;
 import org.infinispan.commands.tx.TransactionBoundaryCommand;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.topology.ClusterTopologyManager;
+import org.infinispan.topology.LocalTopologyManager;
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.transaction.TransactionMode;
 import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
@@ -62,6 +65,8 @@ public abstract class BaseOptimisticTxPartitionAndMergeTest extends BaseTxPartit
       });
 
       filterCollection.await(30, TimeUnit.SECONDS);
+      ClusterTopologyManager ltm0 = TestingUtil.extractGlobalComponent(manager(0), ClusterTopologyManager.class);
+      ltm0.setRebalancingEnabled(false);
       splitMode.split(this);
       filterCollection.unblock();
 
@@ -73,6 +78,7 @@ public abstract class BaseOptimisticTxPartitionAndMergeTest extends BaseTxPartit
 
       checkLocksDuringPartition(splitMode, keyInfo, discard);
 
+      ltm0.setRebalancingEnabled(true);
       mergeCluster(OPTIMISTIC_TX_CACHE_NAME);
       finalAsserts(OPTIMISTIC_TX_CACHE_NAME, keyInfo, txFail ? INITIAL_VALUE : FINAL_VALUE);
    }

--- a/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BasePartitionHandlingTest.java
@@ -42,7 +42,7 @@ import org.testng.annotations.Test;
 
 @Test(groups = "functional", testName = "partitionhandling.BasePartitionHandlingTest")
 public class BasePartitionHandlingTest extends MultipleCacheManagersTest {
-   private static Log log = LogFactory.getLog(BasePartitionHandlingTest.class);
+   static Log log = LogFactory.getLog(BasePartitionHandlingTest.class);
 
    private final AtomicInteger viewId = new AtomicInteger(5);
    protected int numMembersInCluster = 4;

--- a/core/src/test/java/org/infinispan/partitionhandling/BaseTxPartitionAndMergeTest.java
+++ b/core/src/test/java/org/infinispan/partitionhandling/BaseTxPartitionAndMergeTest.java
@@ -215,11 +215,13 @@ public abstract class BaseTxPartitionAndMergeTest extends BasePartitionHandlingT
       public boolean before(CacheRpcCommand command, Reply reply, DeliverOrder order) {
          if (aClass.isAssignableFrom(command.getClass())) {
             notifier.open();
+            log.tracef("Blocking command %s", command);
             try {
                blocker.await(30, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                Thread.currentThread().interrupt();
             }
+            log.tracef("Unblocked command %s", command);
          }
          return true;
       }


### PR DESCRIPTION
.testOriginatorIsolatedPartition random failures

https://issues.jboss.org/browse/ISPN-6997

On one node, transactionTable.cleanupLeaverTransactions was being
called only before the split and after the merge, never with the list
of members during the split.
