### PR TITLE
It's Friday, so I'll pop some bubble wrap

### DIFF
--- a/atomic-factory/src/main/java/org/infinispan/atomic/AtomicObjectFactory.java
+++ b/atomic-factory/src/main/java/org/infinispan/atomic/AtomicObjectFactory.java
@@ -32,29 +32,29 @@ public class AtomicObjectFactory {
    // CLASS FIELDS
    //
    private static Log log = LogFactory.getLog(AtomicObjectFactory.class);
-   private static Map<Cache<?, ?>,AtomicObjectFactory> factories = new HashMap<>();
-   public synchronized static AtomicObjectFactory forCache(Cache<?, ?> cache){
+   private static Map<Cache<?, ?>, AtomicObjectFactory> factories = new HashMap<>();
+   public synchronized static AtomicObjectFactory forCache(Cache<?, ?> cache) {
       if(!factories.containsKey(cache))
          factories.put(cache, new AtomicObjectFactory(cache));
       return factories.get(cache);
    }
-   protected static final int MAX_CONTAINERS=1000;// 0 means no limit
-   public static final Map<Class<?>,List<String>> updateMethods;
+   protected static final int MAX_CONTAINERS = 1000;// 0 means no limit
+   public static final Map<Class<?>, List<String>> updateMethods;
    static{
       updateMethods = new HashMap<>();
 
-      updateMethods.put(List.class, new ArrayList<String>());
+      updateMethods.put(List.class, new ArrayList<>());
       updateMethods.get(List.class).add("add");
       updateMethods.get(List.class).add("addAll");
 
-      updateMethods.put(Set.class, new ArrayList<String>());
+      updateMethods.put(Set.class, new ArrayList<>());
       updateMethods.get(Set.class).add("add");
       updateMethods.get(Set.class).add("addAll");
 
-      updateMethods.put(Map.class, new ArrayList<String>());
+      updateMethods.put(Map.class, new ArrayList<>());
       updateMethods.get(Map.class).add("put");
       updateMethods.get(Map.class).add("putAll");
-   };
+   }
 
 
 
@@ -82,7 +82,7 @@ public class AtomicObjectFactory {
       registeredContainers= new LinkedHashMap<ContainerSignature,Container>() {
          @Override
          protected boolean removeEldestEntry(final java.util.Map.Entry<ContainerSignature,Container> eldest) {
-            if(maxSize!=0 && this.size() >= maxSize){
+            if (maxSize != 0 && this.size() >= maxSize) {
                evictionExecutor.submit(new Callable<Void>() {
                   @Override
                   public Void call() throws IOException {
@@ -109,7 +109,7 @@ public class AtomicObjectFactory {
     *
     * @param c a cache,  it must be synchronous.and transactional (with autoCommit set to true, its default value).
     */
-   public AtomicObjectFactory(Cache<?, ?> c) throws InvalidCacheUsageException{
+   public AtomicObjectFactory(Cache<?, ?> c) throws InvalidCacheUsageException {
       this(c,MAX_CONTAINERS);
    }
 
@@ -126,7 +126,7 @@ public class AtomicObjectFactory {
     * @throws InvalidCacheUsageException
     */
    public synchronized <T> T getInstanceOf(Class<T> clazz, Object key)
-         throws InvalidCacheUsageException{
+         throws InvalidCacheUsageException {
       return getInstanceOf(clazz, key, false);
    }
 
@@ -147,7 +147,7 @@ public class AtomicObjectFactory {
     * @throws InvalidCacheUsageException
     */
    public <T> T getInstanceOf(Class<T> clazz, Object key, boolean withReadOptimization)
-         throws InvalidCacheUsageException{
+         throws InvalidCacheUsageException {
       return getInstanceOf(clazz, key, withReadOptimization, null, true);
    }
 
@@ -172,36 +172,36 @@ public class AtomicObjectFactory {
     * @throws InvalidCacheUsageException
     */
    public <T> T getInstanceOf(Class<T> clazz, Object key, boolean withReadOptimization, Method equalsMethod, boolean forceNew, Object ... initArgs)
-         throws InvalidCacheUsageException{
+         throws InvalidCacheUsageException {
 
-      if( !(Serializable.class.isAssignableFrom(clazz))){
+      if (!(Serializable.class.isAssignableFrom(clazz))) {
          throw new InvalidCacheUsageException("The object must be serializable.");
       }
 
       ContainerSignature signature = new ContainerSignature(clazz,key);
       Container container;
 
-      try{
+      try {
 
-         synchronized (registeredContainers){
+         synchronized (registeredContainers) {
             container = registeredContainers.get(signature);
          }
 
-         if( container==null){
+         if (container == null) {
 
             List<String> methods = Collections.emptyList();
 
             if (Updatable.class.isAssignableFrom(clazz)) {
 
-               methods = new ArrayList<String>();
-               for(Method m : clazz.getDeclaredMethods()){
+               methods = new ArrayList<>();
+               for (Method m : clazz.getDeclaredMethods()) {
                   if (m.isAnnotationPresent(Update.class))
                      methods.add(m.getName());
                }
 
-            }else{
+            } else {
 
-               for(Class<?> c : updateMethods.keySet()){
+               for (Class<?> c : updateMethods.keySet()) {
                   if (c.isAssignableFrom(clazz)) {
                      methods = updateMethods.get(c);
                      break;
@@ -209,24 +209,24 @@ public class AtomicObjectFactory {
                }
 
                if (methods.isEmpty()) {
-                  methods = new ArrayList<String>();
-                  for(Method m : clazz.getDeclaredMethods()){
+                  methods = new ArrayList<>();
+                  for (Method m : clazz.getDeclaredMethods()) {
                      methods.add(m.getName());
                   }
                }
 
             }
             container = new Container(cache, clazz, key, withReadOptimization, forceNew,methods, initArgs);
-            synchronized (registeredContainers){
-               if(registeredContainers.containsKey(signature)){
+            synchronized (registeredContainers) {
+               if (registeredContainers.containsKey(signature)) {
                   container.dispose(false);
-               }else{
+               } else {
                   registeredContainers.put(signature, container);
                }
             }
          }
 
-      } catch (Exception e){
+      } catch (Exception e) {
          e.printStackTrace();
          throw new InvalidCacheUsageException(e.getCause());
       }
@@ -249,7 +249,7 @@ public class AtomicObjectFactory {
       ContainerSignature signature = new ContainerSignature(clazz,key);
       if (log.isDebugEnabled()) log.debugf("Disposing %s",signature.toString());
       Container container;
-      synchronized (registeredContainers){
+      synchronized (registeredContainers) {
          container = registeredContainers.get(signature);
          if( container == null )
             return;
@@ -258,11 +258,11 @@ public class AtomicObjectFactory {
          registeredContainers.remove(signature);
       }
 
-      try{
+      try {
          container.dispose(keepPersistent);
-      }catch (Exception e){
+      } catch (Exception e) {
          e.printStackTrace();
-         throw new InvalidCacheUsageException("Error while disposing object "+key);
+         throw new InvalidCacheUsageException("Error while disposing object " + key);
       }
 
    }

--- a/atomic-factory/src/test/java/org/infinispan/atomic/AtomicObjectFactoryTest.java
+++ b/atomic-factory/src/test/java/org/infinispan/atomic/AtomicObjectFactoryTest.java
@@ -27,7 +27,6 @@ import org.testng.annotations.Test;
 /**
  * @author Pierre Sutra
  * @since 7.2
- * *
  */
 @Test(groups = "functional", testName = "AtomicObjectFactoryTest")
 @CleanupAfterMethod
@@ -40,7 +39,7 @@ public class AtomicObjectFactoryTest extends MultipleCacheManagersTest {
 
 
     @Test(enabled = true)
-    public void basicUsageTest() throws  Exception{
+    public void basicUsageTest() throws Exception {
         Cache<?, ?> cache = cache(0);
         AtomicObjectFactory factory = new AtomicObjectFactory(cache);
 
@@ -63,7 +62,7 @@ public class AtomicObjectFactoryTest extends MultipleCacheManagersTest {
     }
 
     @Test(enabled = true)
-    public void basicPerformanceTest() throws Exception{
+    public void basicPerformanceTest() throws Exception {
         Cache<?, ?> cache = cache(0);
         AtomicObjectFactory factory = new AtomicObjectFactory(cache);
 
@@ -85,7 +84,7 @@ public class AtomicObjectFactoryTest extends MultipleCacheManagersTest {
     public void distributedCacheTest() throws Exception {
 
         List<HashSet<Integer>> sets = new ArrayList<>();
-        List<Future<Integer>> futures = new ArrayList<Future<Integer>>();
+        List<Future<Integer>> futures = new ArrayList<>();
 
         for(EmbeddedCacheManager manager: cacheManagers){
             Cache<?, ?> cache = manager.getCache();
@@ -146,13 +145,13 @@ public class AtomicObjectFactoryTest extends MultipleCacheManagersTest {
     // INNER CLASSES
     //
 
-    private class ExerciseAtomicSetTask implements Callable<Integer>{
+    private class ExerciseAtomicSetTask implements Callable<Integer> {
 
         private int ncalls;
         private Set<Integer> set;
         private Set<Integer> added;
 
-        public ExerciseAtomicSetTask(Set<Integer> s, int n){
+        public ExerciseAtomicSetTask(Set<Integer> s, int n) {
             ncalls = n;
             set = s;
             added = new HashSet<>();

--- a/cdi/embedded/src/main/java/org/infinispan/cdi/embedded/InfinispanExtensionEmbedded.java
+++ b/cdi/embedded/src/main/java/org/infinispan/cdi/embedded/InfinispanExtensionEmbedded.java
@@ -56,7 +56,7 @@ public class InfinispanExtensionEmbedded implements Extension {
 
    private final Object registerLock = new Object();
 
-   private Set<Set<Annotation>> installedEmbeddedCacheManagers = new HashSet<Set<Annotation>>();
+   private Set<Set<Annotation>> installedEmbeddedCacheManagers = new HashSet<>();
 
    public InfinispanExtensionEmbedded() {
       new ConfigurationBuilder(); // Attempt to initialize a core class
@@ -70,7 +70,7 @@ public class InfinispanExtensionEmbedded implements Extension {
         if (annotation != null) {
             configurationName = annotation.value();
         }
-        configurations.add(new ConfigurationHolder((Producer<Configuration>) event.getProducer(), configurationName,
+        configurations.add(new ConfigurationHolder(event.getProducer(), configurationName,
                 Reflections.getQualifiers(beanManager, event.getAnnotatedMember().getAnnotations())));
     }
 
@@ -81,7 +81,7 @@ public class InfinispanExtensionEmbedded implements Extension {
     }
 
    @SuppressWarnings("unchecked")
-   <T, X>void registerBeans(@Observes AfterBeanDiscovery event, final BeanManager beanManager) {
+   <T, X> void registerBeans(@Observes AfterBeanDiscovery event, final BeanManager beanManager) {
 
        if (beanManager.getBeans(Configuration.class).isEmpty()) {
            LOGGER.addDefaultEmbeddedConfiguration();
@@ -104,7 +104,7 @@ public class InfinispanExtensionEmbedded implements Extension {
               @Override
               public AdvancedCache<?, ?> create(Bean<AdvancedCache<?, ?>> bean,
                  CreationalContext<AdvancedCache<?, ?>> creationalContext) {
-                 return new ContextualReference<AdvancedCacheProducer>(beanManager, AdvancedCacheProducer.class).create(Reflections.<CreationalContext<AdvancedCacheProducer>>cast(creationalContext)).get().getAdvancedCache(holder.getName(), holder.getQualifiers());
+                 return new ContextualReference<AdvancedCacheProducer>(beanManager, AdvancedCacheProducer.class).create(Reflections.cast(creationalContext)).get().getAdvancedCache(holder.getName(), holder.getQualifiers());
               }
            }).create();
           event.addBean(advancedCacheBean);
@@ -135,7 +135,7 @@ public class InfinispanExtensionEmbedded implements Extension {
    }
 
    public Set<InstalledCacheManager> getInstalledEmbeddedCacheManagers(BeanManager beanManager) {
-       Set<InstalledCacheManager> installedCacheManagers = new HashSet<InstalledCacheManager>();
+       Set<InstalledCacheManager> installedCacheManagers = new HashSet<>();
        for (Set<Annotation> qualifiers : installedEmbeddedCacheManagers) {
            Bean<?> b = beanManager.resolve(beanManager.getBeans(EmbeddedCacheManager.class, qualifiers.toArray(Reflections.EMPTY_ANNOTATION_ARRAY)));
            EmbeddedCacheManager cm = (EmbeddedCacheManager) beanManager.getReference(b, EmbeddedCacheManager.class, beanManager.createCreationalContext(b));

--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/event/CacheEventHolder.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/event/CacheEventHolder.java
@@ -29,7 +29,7 @@ public class CacheEventHolder {
 
    private void addEventClass(Class<?> cacheAnnotationClass, Class<?> eventClass) {
       if(!eventMap.containsKey(cacheAnnotationClass)) {
-         eventMap.put(cacheAnnotationClass, new HashMap<Class<?>, List<Object>>());
+         eventMap.put(cacheAnnotationClass, new HashMap<>());
       }
       if(!eventMap.get(cacheAnnotationClass).containsKey(eventClass)) {
          eventMap.get(cacheAnnotationClass).put(eventClass, new ArrayList<>());
@@ -45,7 +45,7 @@ public class CacheEventHolder {
     * @param <T> Generic information about event type.
     */
    public <T extends org.infinispan.notifications.cachelistener.event.Event> void addEvent
-         (Class<?>cacheAnnotationClass, Class<T> eventStaticClass, T event) {
+         (Class<?> cacheAnnotationClass, Class<T> eventStaticClass, T event) {
       addEventClass(cacheAnnotationClass, eventStaticClass);
       eventMap.get(cacheAnnotationClass).get(eventStaticClass).add(event);
    }

--- a/checkstyle/src/main/resources/checkstyle.xml
+++ b/checkstyle/src/main/resources/checkstyle.xml
@@ -20,20 +20,20 @@
         <!-- Unfortunately unused import plugin is too buggy to be used https://github.com/checkstyle/checkstyle/issues/1004 -->
         <!--<module name="UnusedImports" />-->
 
-        <!--&lt;!&ndash; Checks for common coding problems &ndash;&gt;-->
+        <!-- Checks for common coding problems -->
         <!--<module name="EqualsHashCode" />-->
-        <!--<module name="IllegalInstantiation" />-->
+        <module name="IllegalInstantiation" />
 
-        <!--&lt;!&ndash; Miscellaneous other checks. &ndash;&gt;-->
+        <!-- Miscellaneous other checks. -->
         <!--<module name="ModifierOrder" />-->
-        <!--<module name="GenericWhitespace" />-->
-        <!--<module name="PackageAnnotation" />-->
+        <module name="GenericWhitespace" />
+        <module name="PackageAnnotation" />
         <!--<module name="CovariantEquals" />-->
         <!--<module name="ModifiedControlVariable" />-->
         <!--<module name="OneStatementPerLine" />-->
         <module name="EmptyStatement" />
         <!--<module name="MissingDeprecated" />-->
-        <!--<module name="DefaultComesLast" />-->
+        <module name="DefaultComesLast" />
         <!--<module name="TypecastParenPad" />-->
         <!--<module name="InnerTypeLast" />-->
         <!--<module name="HideUtilityClassConstructor" />-->
@@ -104,10 +104,10 @@
 
     </module>
 
-    <!--&lt;!&ndash; We are not using NewLineAtEndOfFile because the new line chars change-->
-        <!--on different operating systems and that rule allows only one type. This rule-->
-        <!--is not actually checking for new lines, but it will work if we check that-->
-        <!--there are not white spaces at the end of a line with another rule. &ndash;&gt;-->
+    <!-- We are not using NewLineAtEndOfFile because the new line chars change
+        on different operating systems and that rule allows only one type. This rule
+        is not actually checking for new lines, but it will work if we check that
+        there are not white spaces at the end of a line with another rule. -->
     <module name="RegexpMultiline">
         <property name="format" value="\S\z" />
         <property name="message" value="Missing new line at the end of file" />

--- a/commons/src/main/java/org/infinispan/commons/util/concurrent/ParallelIterableMap.java
+++ b/commons/src/main/java/org/infinispan/commons/util/concurrent/ParallelIterableMap.java
@@ -9,7 +9,7 @@ import java.util.function.BiConsumer;
  * @author Vladimir Blagojevic
  * @since 7.0
  */
-public interface ParallelIterableMap<K, V>{
+public interface ParallelIterableMap<K, V> {
 
    /**
     * Performs the given action for each (key, value) but traversing entries in parallel.
@@ -19,5 +19,5 @@ public interface ParallelIterableMap<K, V>{
     * @param action the action
     * @since 7.0
     */
-   void forEach(long parallelismThreshold, BiConsumer<? super K,? super V> action) throws InterruptedException;
+   void forEach(long parallelismThreshold, BiConsumer<? super K, ? super V> action) throws InterruptedException;
 }

--- a/core/src/main/java/org/infinispan/commands/CommandsFactory.java
+++ b/core/src/main/java/org/infinispan/commands/CommandsFactory.java
@@ -353,7 +353,7 @@ public interface CommandsFactory {
     * @param keys keys used in Callable
     * @return a DistributedExecuteCommand
     */
-   <T>DistributedExecuteCommand<T> buildDistributedExecuteCommand(Callable<T> callable, Address sender, Collection keys);
+   <T> DistributedExecuteCommand<T> buildDistributedExecuteCommand(Callable<T> callable, Address sender, Collection keys);
 
    /**
     * @see GetInDoubtTxInfoCommand

--- a/core/src/main/java/org/infinispan/configuration/cache/DataContainerConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/DataContainerConfiguration.java
@@ -13,15 +13,14 @@ import org.infinispan.container.DataContainer;
  * Controls the data container for the cache.
  *
  * @author pmuir
- *
  */
 public class DataContainerConfiguration extends AbstractTypedPropertiesConfiguration {
    public static final AttributeDefinition<DataContainer> DATA_CONTAINER = AttributeDefinition
          .builder("dataContainer", null, DataContainer.class).xmlName("class").copier(IdentityAttributeCopier.INSTANCE).immutable().build();
    public static final AttributeDefinition<Equivalence> KEY_EQUIVALENCE = AttributeDefinition
-         .<Equivalence> builder("keyEquivalence", AnyEquivalence.getInstance()).copier(IdentityAttributeCopier.INSTANCE).immutable().build();
+         .<Equivalence>builder("keyEquivalence", AnyEquivalence.getInstance()).copier(IdentityAttributeCopier.INSTANCE).immutable().build();
    public static final AttributeDefinition<Equivalence> VALUE_EQUIVALENCE = AttributeDefinition
-         .<Equivalence> builder("valueEquivalence", AnyEquivalence.getInstance()).copier(IdentityAttributeCopier.INSTANCE).immutable().build();
+         .<Equivalence>builder("valueEquivalence", AnyEquivalence.getInstance()).copier(IdentityAttributeCopier.INSTANCE).immutable().build();
 
    static public AttributeSet attributeDefinitionSet() {
       return new AttributeSet(DataContainerConfiguration.class, AbstractTypedPropertiesConfiguration.attributeSet(),

--- a/core/src/main/java/org/infinispan/configuration/cache/IndexingConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/IndexingConfigurationBuilder.java
@@ -20,7 +20,7 @@ import org.infinispan.util.logging.LogFactory;
 /**
  * Configures indexing of entries in the cache for searching.
  */
-public class IndexingConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<IndexingConfiguration>{
+public class IndexingConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<IndexingConfiguration> {
 
    private static final Log log = LogFactory.getLog(IndexingConfigurationBuilder.class);
 

--- a/core/src/main/java/org/infinispan/configuration/cache/TakeOfflineConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/TakeOfflineConfigurationBuilder.java
@@ -11,7 +11,7 @@ import org.infinispan.configuration.global.GlobalConfiguration;
  * @author Mircea Markus
  * @since 5.2
  */
-public class TakeOfflineConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<TakeOfflineConfiguration>{
+public class TakeOfflineConfigurationBuilder extends AbstractConfigurationChildBuilder implements Builder<TakeOfflineConfiguration> {
 
 
    private final AttributeSet attributes;

--- a/core/src/main/java/org/infinispan/distexec/DefaultExecutorService.java
+++ b/core/src/main/java/org/infinispan/distexec/DefaultExecutorService.java
@@ -571,8 +571,8 @@ public class DefaultExecutorService extends AbstractExecutorService implements D
       return list.get(0);
    }
 
-   protected <T> Address selectExecutionNode(DistributedTask <T> task) {
-     return selectExecutionNode(executionCandidates(task));
+   protected <T> Address selectExecutionNode(DistributedTask<T> task) {
+      return selectExecutionNode(executionCandidates(task));
    }
 
    protected List<Address> randomClusterMembers(final List<Address> members, int numNeeded) {
@@ -733,7 +733,7 @@ public class DefaultExecutorService extends AbstractExecutorService implements D
       boolean include(TopologyAwareAddress thisAddress, TopologyAwareAddress otherAddress);
    }
 
-   private class DefaultDistributedTaskBuilder<T> implements DistributedTaskBuilder<T>, DistributedTask<T>{
+   private class DefaultDistributedTaskBuilder<T> implements DistributedTaskBuilder<T>, DistributedTask<T> {
 
       private Callable<T> callable;
       private long timeout;

--- a/core/src/main/java/org/infinispan/distexec/DistributedExecutorService.java
+++ b/core/src/main/java/org/infinispan/distexec/DistributedExecutorService.java
@@ -130,7 +130,7 @@ public interface DistributedExecutorService extends ExecutorService {
     * @param input input keys for this task, effective if and only if task is instance of {@link DistributedCallable}
     * @return a list of Futures, one future per Infinispan cluster node where task was executed
     */
-   <T, K > List<CompletableFuture<T>> submitEverywhere(Callable<T> task, K... input);
+   <T, K> List<CompletableFuture<T>> submitEverywhere(Callable<T> task, K... input);
 
    /**
     * Submits the given DistributedTask for execution on all available Infinispan nodes using input
@@ -145,7 +145,7 @@ public interface DistributedExecutorService extends ExecutorService {
     * @param input input keys for this task, effective if and only if task is instance of {@link DistributedCallable}
     * @return a list of Futures, one future per Infinispan cluster node where task was executed
     */
-   <T, K > List<CompletableFuture<T>> submitEverywhere(DistributedTask<T> task, K... input);
+   <T, K> List<CompletableFuture<T>> submitEverywhere(DistributedTask<T> task, K... input);
 
    /**
     * Returns DistributedTaskBuilder for this DistributedExecutorService and a given Callable. As it

--- a/core/src/main/java/org/infinispan/distexec/spi/DefaultDistributedTaskLifecycle.java
+++ b/core/src/main/java/org/infinispan/distexec/spi/DefaultDistributedTaskLifecycle.java
@@ -9,7 +9,7 @@ import org.kohsuke.MetaInfServices;
 public class DefaultDistributedTaskLifecycle implements DistributedTaskLifecycle {
 
    @Override
-   public <T, K, V> void onPreExecute(Callable<T> task, Cache <K,V> inputCache) {
+   public <T, K, V> void onPreExecute(Callable<T> task, Cache<K, V> inputCache) {
       // intentionally no-op
    }
 

--- a/core/src/main/java/org/infinispan/distexec/spi/DistributedTaskLifecycle.java
+++ b/core/src/main/java/org/infinispan/distexec/spi/DistributedTaskLifecycle.java
@@ -6,7 +6,7 @@ import org.infinispan.Cache;
 
 public interface DistributedTaskLifecycle {
 
-   <T, K, V> void onPreExecute(Callable<T> task, Cache <K,V> inputDataCache);
+   <T, K, V> void onPreExecute(Callable<T> task, Cache<K, V> inputDataCache);
 
    <T> void onPostExecute(Callable<T> task);
 }

--- a/core/src/main/java/org/infinispan/distexec/spi/DistributedTaskLifecycleService.java
+++ b/core/src/main/java/org/infinispan/distexec/spi/DistributedTaskLifecycleService.java
@@ -17,7 +17,7 @@ public final class DistributedTaskLifecycleService {
    private final List<DistributedTaskLifecycle> lifecycles;
 
    private DistributedTaskLifecycleService() {
-      lifecycles = new ArrayList<DistributedTaskLifecycle>();
+      lifecycles = new ArrayList<>();
       for (DistributedTaskLifecycle cl : ServiceFinder.load(DistributedTaskLifecycle.class)) {
          lifecycles.add(cl);
       }
@@ -30,7 +30,7 @@ public final class DistributedTaskLifecycleService {
       return service;
    }
 
-   public <T,K,V> void onPreExecute(Callable<T> task, Cache <K,V> inputCache) {
+   public <T, K, V> void onPreExecute(Callable<T> task, Cache<K, V> inputCache) {
       try {
          for (DistributedTaskLifecycle l : lifecycles) {
             l.onPreExecute(task, inputCache);

--- a/core/src/main/java/org/infinispan/expiration/impl/ExpirationManagerImpl.java
+++ b/core/src/main/java/org/infinispan/expiration/impl/ExpirationManagerImpl.java
@@ -32,7 +32,7 @@ import net.jcip.annotations.ThreadSafe;
 public class ExpirationManagerImpl<K, V> implements ExpirationManager<K, V> {
    protected static final Log log = LogFactory.getLog(ExpirationManagerImpl.class);
    protected static final boolean trace = log.isTraceEnabled();
-   protected ScheduledFuture <?> expirationTask;
+   protected ScheduledFuture<?> expirationTask;
 
    // components to be injected
    protected ScheduledExecutorService executor;

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterEvent.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterEvent.java
@@ -41,7 +41,7 @@ public class ClusterEvent<K, V> implements CacheEntryCreatedEvent<K, V>, CacheEn
    private final Address origin;
    private final boolean commandRetried;
 
-   public static <K, V>ClusterEvent<K, V> fromEvent(CacheEntryEvent<K, V> event) {
+   public static <K, V> ClusterEvent<K, V> fromEvent(CacheEntryEvent<K, V> event) {
       if (event instanceof ClusterEvent) {
          return (ClusterEvent<K, V>) event;
       }

--- a/core/src/main/java/org/infinispan/security/actions/GetDefaultExecutorServiceAction.java
+++ b/core/src/main/java/org/infinispan/security/actions/GetDefaultExecutorServiceAction.java
@@ -12,7 +12,7 @@ import org.infinispan.util.concurrent.WithinThreadExecutor;
  * @author Tristan Tarrant
  * @since 7.0
  */
-public class GetDefaultExecutorServiceAction implements PrivilegedAction<DefaultExecutorService>{
+public class GetDefaultExecutorServiceAction implements PrivilegedAction<DefaultExecutorService> {
 
    private final Cache<?, ?> cache;
 

--- a/core/src/main/java/org/infinispan/util/concurrent/BoundedConcurrentHashMap.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/BoundedConcurrentHashMap.java
@@ -1221,7 +1221,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
          this.map = map;
          loadFactor = lf;
          eviction = es.make(this, map.evictCap, lf);
-         setTable(HashEntry.<K, V> newArray(cap));
+         setTable(HashEntry.newArray(cap));
          // disable rehashing if eviction is enabled (rehashing in this map
          // implementation involves recreating all entries, which breaks the
          // order maintained by the eviction algorithms)
@@ -2560,7 +2560,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
     */
    private void execute(ExecutorService executorService, final BiConsumer<? super K,? super V> action)
          throws InterruptedException {
-      List<Map.Entry<K, V>> list = new ArrayList<Map.Entry<K, V>>(entrySet());
+      List<Map.Entry<K, V>> list = new ArrayList<>(entrySet());
       int numCores = Runtime.getRuntime().availableProcessors();
       int splittingSize = Math.max(list.size() / (numCores << 2), 128);
       List<List<Map.Entry<K, V>>> partition = splitIntoLists(list, splittingSize);

--- a/core/src/main/java/org/infinispan/util/concurrent/CompletableFutures.java
+++ b/core/src/main/java/org/infinispan/util/concurrent/CompletableFutures.java
@@ -35,7 +35,7 @@ public class CompletableFutures {
 
    public static <T> CompletableFuture<List<T>> sequence(List<CompletableFuture<T>> futures) {
       CompletableFuture<Void> all = CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]));
-      return all.thenApply(v -> futures.stream().map(future -> future.join()).collect(Collectors.<T> toList()));
+      return all.thenApply(v -> futures.stream().map(future -> future.join()).collect(Collectors.toList()));
    }
 
    public static <T> CompletableFuture<T> completedExceptionFuture(Throwable ex) {

--- a/core/src/test/java/org/infinispan/distribution/ch/DefaultConsistentHashFactoryTest.java
+++ b/core/src/test/java/org/infinispan/distribution/ch/DefaultConsistentHashFactoryTest.java
@@ -47,11 +47,11 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
       // Since the number of nodes changes, the capacity factors are repeated
       float[][] capacityFactors = {null, {1}, {2}, {1, 100}, {2, 0, 1}};
 
-      ConsistentHashFactory <DefaultConsistentHash> chf = createConsistentHashFactory();
+      ConsistentHashFactory<DefaultConsistentHash> chf = createConsistentHashFactory();
       Hash hashFunction = MurmurHash3.getInstance();
 
       for (int nn : numNodes) {
-         List<Address> nodes = new ArrayList<Address>(nn);
+         List<Address> nodes = new ArrayList<>(nn);
          for (int j = 0; j < nn; j++) {
             nodes.add(new TestAddress(j, "TA"));
          }
@@ -62,7 +62,7 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
                   for (float[] lf : capacityFactors) {
                      Map<Address, Float> lfMap = null;
                      if (lf != null) {
-                        lfMap = new HashMap<Address, Float>();
+                        lfMap = new HashMap<>();
                         for (int i = 0; i < nn; i++) {
                            lfMap.put(nodes.get(i), lf[i % lf.length]);
                         }
@@ -100,9 +100,8 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
          if (nodesToRemove == baseMembers.size() && nodesToAdd == 0)
             break;
 
-         List<Address> newMembers = new ArrayList<Address>(baseMembers);
-         HashMap<Address, Float> newCapacityFactors = lfMap != null ?
-               new HashMap<Address, Float>(lfMap) : null;
+         List<Address> newMembers = new ArrayList<>(baseMembers);
+         HashMap<Address, Float> newCapacityFactors = lfMap != null ? new HashMap<>(lfMap) : null;
          for (int k = 0; k < nodesToRemove; k++) {
             int indexToRemove = Math.abs(baseCH.getHashFunction().hash(k) % newMembers.size());
             if (newCapacityFactors != null) {
@@ -241,7 +240,7 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
    protected Map<Address, Float> computeExpectedOwned(int numSegments, int numNodes, int actualNumOwners,
                                                        Collection<Address> nodes,
                                                        final Map<Address, Float> capacityFactors) {
-      Map<Address, Float> expectedOwned = new HashMap<Address, Float>();
+      Map<Address, Float> expectedOwned = new HashMap<>();
       if (capacityFactors == null) {
          float expected = Math.min(numSegments, (float) numSegments * actualNumOwners / numNodes);
          for (Address node : nodes) {
@@ -250,7 +249,7 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
          return expectedOwned;
       }
 
-      List<Address> sortedNodes = new ArrayList<Address>(nodes);
+      List<Address> sortedNodes = new ArrayList<>(nodes);
       Collections.sort(sortedNodes, new Comparator<Address>() {
          @Override
          public int compare(Address o1, Address o2) {
@@ -278,7 +277,7 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
    }
 
    protected float allowedDeviationOwned(int numSegments, int actualNumOwners, int numNodes, float totalCapacity,
-                                          float maxCapacityFactor) {
+                                         float maxCapacityFactor) {
       return numNodes * maxCapacityFactor / totalCapacity;
    }
 
@@ -315,8 +314,8 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
    private void checkMovedSegments(DefaultConsistentHash oldCH, DefaultConsistentHash newCH) {
       int numSegments = oldCH.getNumSegments();
       int numOwners = oldCH.getNumOwners();
-      Set<Address> oldMembers = new HashSet<Address>(oldCH.getMembers());
-      Set<Address> newMembers = new HashSet<Address>(newCH.getMembers());
+      Set<Address> oldMembers = new HashSet<>(oldCH.getMembers());
+      Set<Address> newMembers = new HashSet<>(newCH.getMembers());
 
       // Compute the number of segments owned by members that left
       int leaverSegments = 0;
@@ -329,7 +328,7 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
       // Compute the number of segments where an old node became an owner
       int oldMembersAddedSegments = 0;
       for (int segment = 0; segment < numSegments; segment++) {
-         ArrayList<Address> oldMembersAdded = new ArrayList<Address>(newCH.locateOwnersForSegment(segment));
+         ArrayList<Address> oldMembersAdded = new ArrayList<>(newCH.locateOwnersForSegment(segment));
          oldMembersAdded.removeAll(oldCH.locateOwnersForSegment(segment));
          oldMembersAdded.retainAll(oldMembers);
          oldMembersAddedSegments += oldMembersAdded.size();
@@ -346,10 +345,10 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
             oldCH, newCH, expectedExtraMoves, oldMembersAddedSegments);
    }
 
-   protected <T> Set<T> symmetricalDiff(Collection <T> set1, Collection<T> set2) {
-      HashSet<T> commonMembers = new HashSet<T>(set1);
+   protected <T> Set<T> symmetricalDiff(Collection<T> set1, Collection<T> set2) {
+      HashSet<T> commonMembers = new HashSet<>(set1);
       commonMembers.retainAll(set2);
-      HashSet<T> symDiffMembers = new HashSet<T>(set1);
+      HashSet<T> symDiffMembers = new HashSet<>(set1);
       symDiffMembers.addAll(set2);
       symDiffMembers.removeAll(commonMembers);
       return symDiffMembers;
@@ -362,18 +361,18 @@ public class DefaultConsistentHashFactoryTest extends AbstractInfinispanTest {
       TestAddress C = new TestAddress(2, "C");
       TestAddress D = new TestAddress(3, "D");
 
-      DefaultConsistentHash ch1 = chf.create(MurmurHash3.getInstance(), 2, 60, Arrays.<Address>asList(A), null);
+      DefaultConsistentHash ch1 = chf.create(MurmurHash3.getInstance(), 2, 60, Arrays.asList(A), null);
       //System.out.println(ch1);
 
-      DefaultConsistentHash ch2 = chf.updateMembers(ch1, Arrays.<Address>asList(A, B), null);
+      DefaultConsistentHash ch2 = chf.updateMembers(ch1, Arrays.asList(A, B), null);
       ch2 = chf.rebalance(ch2);
       //System.out.println(ch2);
 
-      DefaultConsistentHash ch3 = chf.updateMembers(ch2, Arrays.<Address>asList(A, B, C), null);
+      DefaultConsistentHash ch3 = chf.updateMembers(ch2, Arrays.asList(A, B, C), null);
       ch3 = chf.rebalance(ch3);
       //System.out.println(ch3);
 
-      DefaultConsistentHash ch4 = chf.updateMembers(ch3, Arrays.<Address>asList(A, B, C, D), null);
+      DefaultConsistentHash ch4 = chf.updateMembers(ch3, Arrays.asList(A, B, C, D), null);
       ch4 = chf.rebalance(ch4);
       //System.out.println(ch4);
    }

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashTestBase.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashTestBase.java
@@ -53,7 +53,7 @@ public abstract class RehashTestBase extends BaseDistFunctionalTest<Object, Stri
 
    protected List<MagicKey> init() {
 
-      List<MagicKey> keys = new ArrayList<MagicKey>(Arrays.asList(
+      List<MagicKey> keys = new ArrayList<>(Arrays.asList(
             new MagicKey("k1", c1), new MagicKey("k2", c2),
             new MagicKey("k3", c3), new MagicKey("k4", c4)
       ));
@@ -97,7 +97,7 @@ public abstract class RehashTestBase extends BaseDistFunctionalTest<Object, Stri
       final CountDownLatch l = new CountDownLatch(1);
       final AtomicBoolean rollback = new AtomicBoolean(false);
 
-      Future<Void>future = fork(new Runnable() {
+      Future<Void> future = fork(new Runnable() {
          @Override
          public void run() {
             try {
@@ -171,7 +171,7 @@ public abstract class RehashTestBase extends BaseDistFunctionalTest<Object, Stri
    private void stressTest(boolean tx) throws Throwable {
       final List<MagicKey> keys = init();
       final CountDownLatch latch = new CountDownLatch(1);
-      List<Updater> updaters = new ArrayList<Updater>(keys.size());
+      List<Updater> updaters = new ArrayList<>(keys.size());
       for (MagicKey k : keys) {
          Updater u = new Updater(c1, k, latch, tx);
          u.start();

--- a/core/src/test/java/org/infinispan/eviction/impl/ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/eviction/impl/ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTest.java
@@ -509,7 +509,7 @@ public class ManualEvictionWithSizeBasedAndConcurrentOperationsInPrimaryOwnerTes
       }
 
       @Override
-      public void executeTask(KeyFilter<? super K> filter, BiConsumer<? super K, InternalCacheEntry< K, V>> action)
+      public void executeTask(KeyFilter<? super K> filter, BiConsumer<? super K, InternalCacheEntry<K, V>> action)
             throws InterruptedException {
          throw new UnsupportedOperationException();
       }

--- a/core/src/test/java/org/infinispan/functional/FunctionalDistributionTest.java
+++ b/core/src/test/java/org/infinispan/functional/FunctionalDistributionTest.java
@@ -44,7 +44,7 @@ public class FunctionalDistributionTest extends AbstractFunctionalTest {
    public void testDistributionFromPrimaryOwner() throws InterruptedException {
       Object key = "testDistributionFromPrimaryOwner";
       doTestDistribution(key, cacheManagers.stream()
-            .map(cm -> cm.<Object, Integer> getCache(DIST).getAdvancedCache())
+            .map(cm -> cm.<Object, Integer>getCache(DIST).getAdvancedCache())
             .filter(cache -> cache.getDistributionManager().getPrimaryLocation(key)
                   .equals(cache.getRpcManager().getAddress()))
             .findAny()
@@ -54,7 +54,7 @@ public class FunctionalDistributionTest extends AbstractFunctionalTest {
    public void testDistributionFromSecondaryOwner() throws InterruptedException {
       Object key = "testDistributionFromSecondaryOwner";
       doTestDistribution(key, cacheManagers.stream()
-            .map(cm -> cm.<Object, Integer> getCache(DIST).getAdvancedCache())
+            .map(cm -> cm.<Object, Integer>getCache(DIST).getAdvancedCache())
             // owner...
             .filter(cache -> cache.getDistributionManager().getLocality(key).isLocal()
                   // ...but not primary owner
@@ -67,7 +67,7 @@ public class FunctionalDistributionTest extends AbstractFunctionalTest {
    public void testDistributionFromNonOwner() throws InterruptedException {
       Object key = "testDistributionFromNonOwner";
       doTestDistribution(key, cacheManagers.stream()
-            .map(cm -> cm.<Object, Integer> getCache(DIST).getAdvancedCache())
+            .map(cm -> cm.<Object, Integer>getCache(DIST).getAdvancedCache())
             .filter(cache -> !cache.getDistributionManager().getLocality(key).isLocal())
             .findAny()
             .get());
@@ -96,7 +96,7 @@ public class FunctionalDistributionTest extends AbstractFunctionalTest {
       // we want to ensure that each of the owners executes the function only once:
       Assert.assertEquals(
             (Object) cacheManagers.stream()
-                  .map(cm -> cm.<Object, Integer> getCache(DIST).getAdvancedCache())
+                  .map(cm -> cm.<Object, Integer>getCache(DIST).getAdvancedCache())
                   .filter(cache -> cache.getDistributionManager().getLocality(key).isLocal())
                   .map(cache -> cache.getDataContainer().get(key).getValue())
                   .collect(Collectors.toList()),

--- a/jcache/commons/src/main/java/org/infinispan/jcache/AbstractJCacheManager.java
+++ b/jcache/commons/src/main/java/org/infinispan/jcache/AbstractJCacheManager.java
@@ -33,7 +33,7 @@ public abstract class AbstractJCacheManager implements CacheManager {
    private final CachingProvider provider;
    protected Properties properties;
 
-   private final HashMap<String, AbstractJCache<?, ?>> caches = new HashMap<String, AbstractJCache<?, ?>>();
+   private final HashMap<String, AbstractJCache<?, ?>> caches = new HashMap<>();
 
    private final StackTraceElement[] allocationStackTrace;
 
@@ -147,7 +147,7 @@ public abstract class AbstractJCacheManager implements CacheManager {
 
    @Override
    public Iterable<String> getCacheNames() {
-      return isClosed ? Collections.<String>emptyList() : delegateCacheNames();
+      return isClosed ? Collections.emptyList() : delegateCacheNames();
    }
 
    @Override
@@ -183,7 +183,7 @@ public abstract class AbstractJCacheManager implements CacheManager {
       if (!isClosed()) {
          ArrayList<AbstractJCache<?, ?>> cacheList;
          synchronized (caches) {
-            cacheList = new ArrayList<AbstractJCache<?, ?>>(caches.values());
+            cacheList = new ArrayList<>(caches.values());
             caches.clear();
          }
          for (AbstractJCache<?, ?> cache : cacheList) {
@@ -224,7 +224,7 @@ public abstract class AbstractJCacheManager implements CacheManager {
       }
    }
 
-   public <K, V, I extends BasicCache<K, V> > Cache<K, V> getOrCreateCache(String cacheName, I ispnCache) {
+   public <K, V, I extends BasicCache<K, V>> Cache<K, V> getOrCreateCache(String cacheName, I ispnCache) {
       synchronized (caches) {
          AbstractJCache<?, ?> cache = caches.get(cacheName);
          if (cache == null) {
@@ -246,10 +246,10 @@ public abstract class AbstractJCacheManager implements CacheManager {
    protected abstract <K, V> void delegateRemoveCache(AbstractJCache<K, V> cacheName);
 
    protected abstract <K, V, C extends Configuration<K, V>> AbstractJCache<K, V> create(String cacheName, C configuration);
-   protected abstract <K, V, I extends BasicCache<K, V> > AbstractJCache<K, V> create(I ispnCache);
+   protected abstract <K, V, I extends BasicCache<K, V>> AbstractJCache<K, V> create(I ispnCache);
 
    protected Set<String> getManagedCacheNames() {
-      HashSet<String> result = new HashSet<String>();
+      HashSet<String> result = new HashSet<>();
       synchronized (caches) {
          result.addAll(caches.keySet());
       }

--- a/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/InjectedCacheResolver.java
+++ b/jcache/embedded/src/main/java/org/infinispan/jcache/annotation/InjectedCacheResolver.java
@@ -110,7 +110,7 @@ public class InjectedCacheResolver implements CacheResolver {
    private <K, V> Cache<K, V> getCacheFromDefaultCacheManager(final String cacheName) {
       final Configuration defaultInjectedConfiguration = getBeanReference(Configuration.class);
       defaultCacheManager.defineConfiguration(cacheName, defaultInjectedConfiguration);
-      return defaultJCacheManager.getOrCreateCache(cacheName, defaultCacheManager.<K, V> getCache(cacheName)
+      return defaultJCacheManager.getOrCreateCache(cacheName, defaultCacheManager.<K, V>getCache(cacheName)
             .getAdvancedCache());
    }
 

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfigurationParser.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteStoreConfigurationParser.java
@@ -5,7 +5,6 @@ import static org.infinispan.commons.util.StringPropertyReplacer.replaceProperti
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
-import org.infinispan.commons.executors.ExecutorFactory;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
@@ -96,7 +95,7 @@ public class RemoteStoreConfigurationParser implements ConfigurationParser {
          Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
          switch (attribute) {
             case FACTORY: {
-               builder.factory(Util.<ExecutorFactory> getInstance(value, classLoader));
+               builder.factory(Util.getInstance(value, classLoader));
                break;
             }
             default: {

--- a/tools/src/main/java/org/infinispan/tools/config/v6/remote/RemoteStoreConfigurationParser60.java
+++ b/tools/src/main/java/org/infinispan/tools/config/v6/remote/RemoteStoreConfigurationParser60.java
@@ -5,7 +5,6 @@ import static org.infinispan.commons.util.StringPropertyReplacer.replaceProperti
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
-import org.infinispan.commons.executors.ExecutorFactory;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
@@ -94,7 +93,7 @@ public class RemoteStoreConfigurationParser60 implements ConfigurationParser {
          Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
          switch (attribute) {
          case FACTORY: {
-            builder.factory(Util.<ExecutorFactory> getInstance(value, classLoader));
+            builder.factory(Util.getInstance(value, classLoader));
             break;
          }
          default: {


### PR DESCRIPTION
Fix whitespace around generics and update some usages of vintage generics syntax. Allso enable some checkstyle rules that are not violated.

I'm fixing this because the wonderful artifact org.infinispan:infinispan-checkstyle-9.0.0-SNAPSHOT.jar is also used by protostream and the new infinispan-ql parser projects. And having a mostly disabled checkstyle is pretty useless.

Jira: https://issues.jboss.org/browse/ISPN-5683   Please DO NOT CLOSE JIRA yet