### PR TITLE
Remove @Deprecated getProperties() method from RemoteCacheContainer interface.

### DIFF
--- a/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/remote/DefaultCacheManagerOverrideTest.java
+++ b/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/remote/DefaultCacheManagerOverrideTest.java
@@ -36,7 +36,7 @@ public class DefaultCacheManagerOverrideTest extends Arquillian {
    private RemoteCacheManager remoteCacheManager;
 
    public void testDefaultRemoteCacheManagerOverride() {
-      final Properties properties = remoteCacheManager.getProperties();
+      final Properties properties = remoteCacheManager.getConfiguration().properties();
 
       assertEquals(properties.getProperty(SERVER_LIST_KEY), SERVER_LIST_VALUE);
    }

--- a/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/remote/DefaultCacheManagerTest.java
+++ b/cdi/remote/src/test/java/org/infinispan/cdi/embedded/test/cachemanager/remote/DefaultCacheManagerTest.java
@@ -34,7 +34,7 @@ public class DefaultCacheManagerTest extends Arquillian {
    private RemoteCacheManager remoteCacheManager;
 
    public void testDefaultRemoteCacheManagerInjection() {
-      final Properties properties = remoteCacheManager.getProperties();
+      final Properties properties = remoteCacheManager.getConfiguration().properties();
 
       assertEquals(properties.getProperty(SERVER_LIST_KEY), DEFAULT_SERVER_LIST_VALUE);
    }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheContainer.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheContainer.java
@@ -25,16 +25,6 @@ public interface RemoteCacheContainer extends BasicCacheContainer {
     */
    Configuration getConfiguration();
 
-   /**
-    * Retrieves a clone of the properties currently in use.  Note that making
-    * any changes to the properties instance retrieved will not affect an
-    * already-running RemoteCacheManager.
-    *
-    * @return a clone of the properties used to configure this RemoteCacheManager
-    */
-   @Deprecated
-   Properties getProperties();
-
    <K, V> RemoteCache<K, V> getCache(String cacheName, boolean forceReturnValue);
 
    <K, V> RemoteCache<K, V> getCache(boolean forceReturnValue);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -104,19 +104,6 @@ public class RemoteCacheManager implements RemoteCacheContainer {
    }
 
    /**
-    * Retrieves a clone of the properties currently in use.  Note that making
-    * any changes to the properties instance retrieved will not affect an
-    * already-running RemoteCacheManager.
-    *
-    * @return a clone of the properties used to configure this RemoteCacheManager
-    * @since 4.2
-    */
-   @Deprecated
-   public Properties getProperties() {
-      return configuration.properties();
-   }
-
-   /**
     * Same as {@link RemoteCacheManager(java.util.Properties)}, but it will try to lookup the config properties in the
     * classpath, in a file named <tt>hotrod-client.properties</tt>. If no properties can be found in the classpath, the
     * server tries to connect to "127.0.0.1:11222" in start.

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -103,11 +103,14 @@ public class RemoteCacheManager implements RemoteCacheContainer {
       return configuration;
    }
 
-
    /**
+    * Retrieves a clone of the properties currently in use.  Note that making
+    * any changes to the properties instance retrieved will not affect an
+    * already-running RemoteCacheManager.
+    *
+    * @return a clone of the properties used to configure this RemoteCacheManager
     * @since 4.2
     */
-   @Override
    @Deprecated
    public Properties getProperties() {
       return configuration.properties();

--- a/spring/spring4/spring4-remote/src/main/java/org/infinispan/spring/AbstractRemoteCacheManagerFactory.java
+++ b/spring/spring4/spring4-remote/src/main/java/org/infinispan/spring/AbstractRemoteCacheManagerFactory.java
@@ -64,7 +64,7 @@ public abstract class AbstractRemoteCacheManagerFactory {
       } else {
          this.logger
                .debug("No configuration properties. RemoteCacheManager will use default configuration.");
-         answer = new RemoteCacheManager().getProperties();
+         answer = new RemoteCacheManager().getConfiguration().properties();
       }
       return answer;
    }

--- a/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/provider/SpringRemoteCacheManagerFactoryBeanTest.java
+++ b/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/provider/SpringRemoteCacheManagerFactoryBeanTest.java
@@ -117,8 +117,8 @@ public class SpringRemoteCacheManagerFactoryBeanTest {
               "The configuration properties used by the SpringRemoteCacheManager returned von getObject() should be equal "
                       + "to SpringRemoteCacheManager's default settings since neither property 'configurationProperties' "
                       + "nor property 'configurationPropertiesFileLocation' has been set. However, those two are not equal.",
-              new RemoteCacheManager().getProperties(), remoteCacheManager.getNativeCacheManager()
-                      .getProperties());
+              new RemoteCacheManager().getConfiguration().properties(), remoteCacheManager.getNativeCacheManager()
+                      .getConfiguration().properties());
       objectUnderTest.destroy();
    }
 
@@ -176,7 +176,7 @@ public class SpringRemoteCacheManagerFactoryBeanTest {
               "The configuration properties used by the SpringRemoteCacheManager returned von getObject() should be equal "
                       + "to those passed into SpringRemoteCacheManagerFactoryBean via setConfigurationProperties(props). "
                       + "However, those two are not equal.", configurationProperties,
-              remoteCacheManager.getNativeCacheManager().getProperties());
+              remoteCacheManager.getNativeCacheManager().getConfiguration().properties());
       objectUnderTest.destroy();
    }
 
@@ -214,7 +214,7 @@ public class SpringRemoteCacheManagerFactoryBeanTest {
                       + "to those passed into SpringRemoteCacheManagerFactoryBean via setConfigurationPropertiesFileLocation(propsFileLocation). "
                       + "However, those two are not equal.",
               loadConfigurationProperties(HOTROD_CLIENT_PROPERTIES_LOCATION), remoteCacheManager
-                      .getNativeCacheManager().getProperties());
+                      .getNativeCacheManager().getConfiguration().properties());
       objectUnderTest.destroy();
    }
 
@@ -261,7 +261,7 @@ public class SpringRemoteCacheManagerFactoryBeanTest {
 
       assertEquals("setTransportFactory(" + expectedTransportFactory
                          + ") should have overridden property 'transportFactory'. However, it didn't.",
-                   expectedTransportFactory, remoteCacheManager.getNativeCacheManager().getProperties()
+                   expectedTransportFactory, remoteCacheManager.getNativeCacheManager().getConfiguration().properties()
                   .get(TRANSPORT_FACTORY));
       objectUnderTest.destroy();
    }
@@ -286,7 +286,7 @@ public class SpringRemoteCacheManagerFactoryBeanTest {
 
       assertEquals("setServerList(" + expectedServerList
                          + ") should have overridden property 'serverList'. However, it didn't.",
-                   expectedServerListString, remoteCacheManager.getNativeCacheManager().getProperties()
+                   expectedServerListString, remoteCacheManager.getNativeCacheManager().getConfiguration().properties()
                   .get(SERVER_LIST));
       objectUnderTest.destroy();
    }
@@ -311,7 +311,7 @@ public class SpringRemoteCacheManagerFactoryBeanTest {
       assertEquals("setMarshaller(" + expectedMarshaller
                          + ") should have overridden property 'marshaller'. However, it didn't.",
                    expectedMarshaller,
-                   remoteCacheManager.getNativeCacheManager().getProperties().get(MARSHALLER));
+                   remoteCacheManager.getNativeCacheManager().getConfiguration().properties().get(MARSHALLER));
       objectUnderTest.destroy();
    }
 
@@ -336,7 +336,7 @@ public class SpringRemoteCacheManagerFactoryBeanTest {
       assertEquals("setAsyncExecutorFactory(" + expectedAsyncExecutorFactory
                          + ") should have overridden property 'asyncExecutorFactory'. However, it didn't.",
                    expectedAsyncExecutorFactory, remoteCacheManager.getNativeCacheManager()
-                  .getProperties().get(ASYNC_EXECUTOR_FACTORY));
+                  .getConfiguration().properties().get(ASYNC_EXECUTOR_FACTORY));
       objectUnderTest.destroy();
    }
 
@@ -359,7 +359,7 @@ public class SpringRemoteCacheManagerFactoryBeanTest {
       assertEquals("setTcpNoDelay(" + expectedTcpNoDelay
                          + ") should have overridden property 'tcpNoDelay'. However, it didn't.",
                    String.valueOf(expectedTcpNoDelay), remoteCacheManager.getNativeCacheManager()
-                  .getProperties().get(TCP_NO_DELAY));
+                  .getConfiguration().properties().get(TCP_NO_DELAY));
       objectUnderTest.destroy();
    }
 
@@ -382,7 +382,7 @@ public class SpringRemoteCacheManagerFactoryBeanTest {
       assertEquals("setTcpKeepAlive(" + expectedTcpKeepAlive
                          + ") should have overridden property 'tcpKeepAlive'. However, it didn't.",
                    String.valueOf(expectedTcpKeepAlive), remoteCacheManager.getNativeCacheManager()
-                  .getProperties().get(TCP_KEEP_ALIVE));
+                  .getConfiguration().properties().get(TCP_KEEP_ALIVE));
       objectUnderTest.destroy();
    }
 
@@ -409,7 +409,7 @@ public class SpringRemoteCacheManagerFactoryBeanTest {
                   + expectedRequestBalancingStrategy
                   + ") should have overridden property 'requestBalancingStrategy'. However, it didn't.",
             expectedRequestBalancingStrategy, remoteCacheManager.getNativeCacheManager()
-                  .getProperties().get(REQUEST_BALANCING_STRATEGY));
+                  .getConfiguration().properties().get(REQUEST_BALANCING_STRATEGY));
       objectUnderTest.destroy();
    }
 
@@ -432,7 +432,7 @@ public class SpringRemoteCacheManagerFactoryBeanTest {
       assertEquals("setKeySizeEstimate(" + expectedKeySizeEstimate
                          + ") should have overridden property 'keySizeEstimate'. However, it didn't.",
                    String.valueOf(expectedKeySizeEstimate), remoteCacheManager.getNativeCacheManager()
-                  .getProperties().get(KEY_SIZE_ESTIMATE));
+                  .getConfiguration().properties().get(KEY_SIZE_ESTIMATE));
       objectUnderTest.destroy();
    }
 
@@ -455,7 +455,7 @@ public class SpringRemoteCacheManagerFactoryBeanTest {
       assertEquals("setValueSizeEstimate(" + expectedValueSizeEstimate
                          + ") should have overridden property 'valueSizeEstimate'. However, it didn't.",
                    String.valueOf(expectedValueSizeEstimate), remoteCacheManager
-                  .getNativeCacheManager().getProperties().get(VALUE_SIZE_ESTIMATE));
+                  .getNativeCacheManager().getConfiguration().properties().get(VALUE_SIZE_ESTIMATE));
       objectUnderTest.destroy();
    }
 
@@ -478,7 +478,7 @@ public class SpringRemoteCacheManagerFactoryBeanTest {
       assertEquals("setForceReturnValue(" + expectedForceReturnValues
                          + ") should have overridden property 'forceReturnValue'. However, it didn't.",
                    String.valueOf(expectedForceReturnValues), remoteCacheManager
-                  .getNativeCacheManager().getProperties().get(FORCE_RETURN_VALUES));
+                  .getNativeCacheManager().getConfiguration().properties().get(FORCE_RETURN_VALUES));
       objectUnderTest.destroy();
    }
 }

--- a/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/support/remote/InfinispanRemoteCacheManagerFactoryBeanTest.java
+++ b/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/support/remote/InfinispanRemoteCacheManagerFactoryBeanTest.java
@@ -120,7 +120,7 @@ public class InfinispanRemoteCacheManagerFactoryBeanTest {
               "The configuration properties used by the RemoteCacheManager returned by getObject() should be equal "
                       + "to RemoteCacheManager's default settings since neither property 'configurationProperties' "
                       + "nor property 'configurationPropertiesFileLocation' has been set. However, those two are not equal.",
-              new RemoteCacheManager().getProperties(), remoteCacheManager.getProperties());
+              new RemoteCacheManager().getConfiguration().properties(), remoteCacheManager.getConfiguration().properties());
       objectUnderTest.destroy();
    }
 
@@ -180,7 +180,7 @@ public class InfinispanRemoteCacheManagerFactoryBeanTest {
               "The configuration properties used by the RemoteCacheManager returned by getObject() should be equal "
                       + "to those passed into InfinispanRemoteCacheMangerFactoryBean via setConfigurationProperties(props). "
                       + "However, those two are not equal.", configurationProperties,
-              remoteCacheManager.getProperties());
+              remoteCacheManager.getConfiguration().properties());
       objectUnderTest.destroy();
    }
 
@@ -218,7 +218,7 @@ public class InfinispanRemoteCacheManagerFactoryBeanTest {
                       + "to those passed into InfinispanRemoteCacheMangerFactoryBean via setConfigurationPropertiesFileLocation(propsFileLocation). "
                       + "However, those two are not equal.",
               loadConfigurationProperties(HOTROD_CLIENT_PROPERTIES_LOCATION),
-              remoteCacheManager.getProperties());
+              remoteCacheManager.getConfiguration().properties());
       objectUnderTest.destroy();
    }
 
@@ -265,7 +265,7 @@ public class InfinispanRemoteCacheManagerFactoryBeanTest {
 
       assertEquals("setTransportFactory(" + expectedTransportFactory
                          + ") should have overridden property 'transportFactory'. However, it didn't.",
-                   expectedTransportFactory, remoteCacheManager.getProperties().get(TRANSPORT_FACTORY));
+                   expectedTransportFactory, remoteCacheManager.getConfiguration().properties().get(TRANSPORT_FACTORY));
       objectUnderTest.destroy();
    }
 
@@ -289,7 +289,7 @@ public class InfinispanRemoteCacheManagerFactoryBeanTest {
 
       assertEquals("setServerList(" + expectedServerList
                          + ") should have overridden property 'serverList'. However, it didn't.",
-                   expectedServerListString, remoteCacheManager.getProperties().get(SERVER_LIST));
+                   expectedServerListString, remoteCacheManager.getConfiguration().properties().get(SERVER_LIST));
       objectUnderTest.destroy();
    }
 
@@ -312,7 +312,7 @@ public class InfinispanRemoteCacheManagerFactoryBeanTest {
 
       assertEquals("setMarshaller(" + expectedMarshaller
                          + ") should have overridden property 'marshaller'. However, it didn't.",
-                   expectedMarshaller, remoteCacheManager.getProperties().get(MARSHALLER));
+                   expectedMarshaller, remoteCacheManager.getConfiguration().properties().get(MARSHALLER));
       objectUnderTest.destroy();
    }
 
@@ -337,7 +337,7 @@ public class InfinispanRemoteCacheManagerFactoryBeanTest {
       assertEquals("setAsyncExecutorFactory(" + expectedAsyncExecutorFactory
                          + ") should have overridden property 'asyncExecutorFactory'. However, it didn't.",
                    expectedAsyncExecutorFactory,
-                   remoteCacheManager.getProperties().get(ASYNC_EXECUTOR_FACTORY));
+                   remoteCacheManager.getConfiguration().properties().get(ASYNC_EXECUTOR_FACTORY));
       objectUnderTest.destroy();
    }
 
@@ -360,7 +360,7 @@ public class InfinispanRemoteCacheManagerFactoryBeanTest {
       assertEquals("setTcpNoDelay(" + expectedTcpNoDelay
                          + ") should have overridden property 'tcpNoDelay'. However, it didn't.",
                    String.valueOf(expectedTcpNoDelay),
-                   remoteCacheManager.getProperties().get(TCP_NO_DELAY));
+                   remoteCacheManager.getConfiguration().properties().get(TCP_NO_DELAY));
       objectUnderTest.destroy();
    }
 
@@ -382,7 +382,7 @@ public class InfinispanRemoteCacheManagerFactoryBeanTest {
       assertEquals("setTcpKeepAlive(" + expectedTcpKeepAlive
                          + ") should have overridden property 'tcpNoDelay'. However, it didn't.",
                    String.valueOf(expectedTcpKeepAlive),
-                   remoteCacheManager.getProperties().get(TCP_KEEP_ALIVE));
+                   remoteCacheManager.getConfiguration().properties().get(TCP_KEEP_ALIVE));
       objectUnderTest.destroy();
    }
 
@@ -409,7 +409,7 @@ public class InfinispanRemoteCacheManagerFactoryBeanTest {
                   + expectedRequestBalancingStrategy
                   + ") should have overridden property 'requestBalancingStrategy'. However, it didn't.",
             expectedRequestBalancingStrategy,
-            remoteCacheManager.getProperties().get(REQUEST_BALANCING_STRATEGY));
+            remoteCacheManager.getConfiguration().properties().get(REQUEST_BALANCING_STRATEGY));
       objectUnderTest.destroy();
    }
 
@@ -432,7 +432,7 @@ public class InfinispanRemoteCacheManagerFactoryBeanTest {
       assertEquals("setKeySizeEstimate(" + expectedKeySizeEstimate
                          + ") should have overridden property 'keySizeEstimate'. However, it didn't.",
                    String.valueOf(expectedKeySizeEstimate),
-                   remoteCacheManager.getProperties().get(KEY_SIZE_ESTIMATE));
+                   remoteCacheManager.getConfiguration().properties().get(KEY_SIZE_ESTIMATE));
       objectUnderTest.destroy();
    }
 
@@ -455,7 +455,7 @@ public class InfinispanRemoteCacheManagerFactoryBeanTest {
       assertEquals("setValueSizeEstimate(" + expectedValueSizeEstimate
                          + ") should have overridden property 'valueSizeEstimate'. However, it didn't.",
                    String.valueOf(expectedValueSizeEstimate),
-                   remoteCacheManager.getProperties().get(VALUE_SIZE_ESTIMATE));
+                   remoteCacheManager.getConfiguration().properties().get(VALUE_SIZE_ESTIMATE));
       objectUnderTest.destroy();
    }
 
@@ -478,7 +478,7 @@ public class InfinispanRemoteCacheManagerFactoryBeanTest {
       assertEquals("setForceReturnValue(" + expectedForceReturnValues
                          + ") should have overridden property 'forceReturnValue'. However, it didn't.",
                    String.valueOf(expectedForceReturnValues),
-                   remoteCacheManager.getProperties().get(FORCE_RETURN_VALUES));
+                   remoteCacheManager.getConfiguration().properties().get(FORCE_RETURN_VALUES));
       objectUnderTest.destroy();
    }
 }


### PR DESCRIPTION
Since this is a new interface, there's no reason to introduce deprecated methods.