### PR TITLE
ISPN-6806 State transfer exception serializing L1InternalCacheEntry

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/OutboundTransferTask.java
+++ b/core/src/main/java/org/infinispan/statetransfer/OutboundTransferTask.java
@@ -148,7 +148,7 @@ public class OutboundTransferTask implements Runnable {
          for (InternalCacheEntry ice : dataContainer) {
             Object key = ice.getKey();  //todo [anistor] should we check for expired entries?
             int segmentId = readCh.getSegment(key);
-            if (segments.contains(segmentId)) {
+            if (segments.contains(segmentId) && !ice.isL1Entry()) {
                sendEntry(ice, segmentId);
             }
          }

--- a/core/src/test/java/org/infinispan/distribution/rehash/RehashWithL1Test.java
+++ b/core/src/test/java/org/infinispan/distribution/rehash/RehashWithL1Test.java
@@ -2,16 +2,18 @@ package org.infinispan.distribution.rehash;
 
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNull;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.remoting.transport.Address;
 import org.infinispan.test.MultipleCacheManagersTest;
-import org.infinispan.test.fwk.TestResourceTracker;
-import org.infinispan.test.fwk.TransportFlags;
+import org.infinispan.util.BaseControlledConsistentHashFactory;
 import org.testng.annotations.Test;
 
 /**
@@ -27,44 +29,61 @@ public class RehashWithL1Test extends MultipleCacheManagersTest {
 
    @Override
    protected void createCacheManagers() throws Throwable {
+      MyBaseControlledConsistentHashFactory chf = new MyBaseControlledConsistentHashFactory();
       builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
-      // Enable rehashing explicitly
-      builder.clustering().stateTransfer().fetchInMemoryState(true)
-            .hash().l1().enable();
-      createClusteredCaches(2, builder);
+      builder.clustering().hash().numSegments(1).numOwners(1).consistentHashFactory(chf);
+      builder.clustering().l1().enable().lifespan(10, TimeUnit.MINUTES);
+      createClusteredCaches(3, builder);
    }
 
    public void testPutWithRehashAndCacheClear() throws Exception {
-      Future<Void> node3Join = null;
-      int opCount = 100;
+      int opCount = 10;
       for (int i = 0; i < opCount; i++) {
-         cache(0).put("k" + i, "some data");
-         if (i == (opCount / 2)) {
-            node3Join = fork(new Callable<Void>() {
-               @Override
-               public Void call() throws Exception {
-                  TestResourceTracker.testThreadStarted(RehashWithL1Test.this);
-                  EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder,
-                        new TransportFlags().withMerge(true));
-                  cm.getCache();
-                  return null;
-               }
-            });
-         }
-         Thread.sleep(10);
+         cache(1).put("k" + i, "some data");
       }
 
-      if (node3Join == null) throw new Exception("Node 3 not joined");
-      node3Join.get();
+      for (int j = 0; j < caches().size(); j++) {
+         log.debugf("Populating L1 on %s", address(j));
+         for (int i = 0; i < opCount; i++) {
+            assertEquals("Wrong value for k" + i, "some data", cache(j).get("k" + i));
+         }
+      }
+
+      int killIndex = caches().size() - 1;
+      log.debugf("Killing node %s", address(killIndex));
+      killMember(killIndex);
+
+      // All entries were owned by the killed node, but they survive in the L1 of cache(1)
+      for (int j = 0; j < caches().size(); j++) {
+         log.debugf("Checking values on %s", address(j));
+         for (int i = 0; i < opCount; i++) {
+            String key = "k" + i;
+            assertEquals("Wrong value for key " + key, "some data", cache(j).get(key));
+         }
+      }
+
+      log.debugf("Starting a new joiner");
+      EmbeddedCacheManager cm = addClusterEnabledCacheManager(builder);
+      cm.getCache();
+
+      // State transfer won't copy L1 entries to cache(2), and they're deleted on cache(1) afterwards
+      // Note: we would need eventually() if we checked the data container directly
+      for (int j = 0; j < caches().size() - 1; j++) {
+         log.debugf("Checking values on %s", address(j));
+         for (int i = 0; i < opCount; i++) {
+            assertNull("wrong value for k" + i, cache(j).get("k" + i));
+         }
+      }
 
       for (int i = 0; i < opCount; i++) {
          cache(0).remove("k" + i);
-         Thread.sleep(10);
       }
 
       for (int i = 0; i < opCount; i++) {
          String key = "k" + i;
          assertFalse(cache(0).containsKey(key));
+         assertFalse("Key: " + key + " is present in cache at " + cache(0),
+                     cache(0).containsKey(key));
          assertFalse("Key: " + key + " is present in cache at " + cache(1),
                cache(1).containsKey(key));
          assertFalse("Key: " + key + " is present in cache at " + cache(2),
@@ -76,4 +95,14 @@ public class RehashWithL1Test extends MultipleCacheManagersTest {
       assertEquals(0, cache(2).size());
    }
 
+   private static class MyBaseControlledConsistentHashFactory extends BaseControlledConsistentHashFactory {
+      public MyBaseControlledConsistentHashFactory() {
+         super(1);
+      }
+
+      @Override
+      protected List<Address> createOwnersCollection(List<Address> members, int numberOfOwners, int segmentIndex) {
+         return Collections.singletonList(members.get(members.size() - 1));
+      }
+   }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-6806

Avoid sending L1 entries via state transfer.

L1 entries will still survive on the new primary owner when the last
owner leaves/crashes, but they won't be transferred to another node,
and they still expire, so they will eventually be lost.