### PR TITLE
Potential null pointer dereference. Minor refactoring.

### DIFF
--- a/core/src/main/java/org/infinispan/factories/components/JmxOperationMetadata.java
+++ b/core/src/main/java/org/infinispan/factories/components/JmxOperationMetadata.java
@@ -42,7 +42,7 @@ public class JmxOperationMetadata implements Serializable {
          }
       }
       ManagedOperation mo = m.getAnnotation(ManagedOperation.class);
-      operationName = mo.name();
+      operationName = mo != null ? (mo.name().isEmpty() ? methodName : mo.name()) : methodName;
       description = mo != null ? mo.description() : null;
    }
 
@@ -51,7 +51,7 @@ public class JmxOperationMetadata implements Serializable {
    }
 
    public String getOperationName() {
-      return operationName.isEmpty() ? methodName : operationName;
+      return operationName;
    }
 
    public String getMethodName() {


### PR DESCRIPTION
Added a null check and moved the check from the getter for operationName inside the constructor. Now operationName takes methodName in case when mo is null.