### PR TITLE
Necessary null checks added because WeakReference.get() may return null.

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/OsgiClassLoader.java
+++ b/commons/src/main/java/org/infinispan/commons/util/OsgiClassLoader.java
@@ -104,7 +104,7 @@ public class OsgiClassLoader extends ClassLoader {
 
       for (WeakReference<Bundle> ref : bundles) {
          final Bundle bundle = ref.get();
-         if (bundle.getState() == Bundle.ACTIVE) {
+         if (bundle != null && bundle.getState() == Bundle.ACTIVE) {
             try {
                final URL resource = bundle.getResource(name);
                if (resource != null) {
@@ -132,7 +132,7 @@ public class OsgiClassLoader extends ClassLoader {
 
       for (WeakReference<Bundle> ref : bundles) {
          final Bundle bundle = ref.get();
-         if (bundle.getState() == Bundle.ACTIVE) {
+         if (bundle != null && bundle.getState() == Bundle.ACTIVE) {
             try {
                final Enumeration<URL> resources = bundle.getResources(name);
                if (resources != null) {


### PR DESCRIPTION
Some weak references were used without checking for null.