### PR TITLE
ISPN-6045: Fix transaction aware iterator remove

### DIFF
--- a/core/src/main/java/org/infinispan/interceptors/impl/TxInterceptor.java
+++ b/core/src/main/java/org/infinispan/interceptors/impl/TxInterceptor.java
@@ -595,7 +595,11 @@ public class TxInterceptor<K, V> extends DDAsyncInterceptor implements JmxStatis
 
       @Override
       public void remove() {
+         if (previousValue == null) {
+            throw new IllegalStateException();
+         }
          cache.remove(previousValue);
+         previousValue = null;
       }
    }
 
@@ -610,7 +614,11 @@ public class TxInterceptor<K, V> extends DDAsyncInterceptor implements JmxStatis
 
       @Override
       public void remove() {
+         if (previousValue == null) {
+            throw new IllegalStateException();
+         }
          cache.remove(previousValue.getKey(), previousValue.getValue());
+         previousValue = null;
       }
 
       @Override
@@ -664,6 +672,7 @@ public class TxInterceptor<K, V> extends DDAsyncInterceptor implements JmxStatis
          if (e == null) {
             throw new NoSuchElementException();
          }
+         previousValue = e;
          currentValue = null;
          return e;
       }

--- a/core/src/test/java/org/infinispan/api/APITxTest.java
+++ b/core/src/test/java/org/infinispan/api/APITxTest.java
@@ -2,10 +2,13 @@ package org.infinispan.api;
 
 import static org.testng.AssertJUnit.assertEquals;
 
+import java.util.Map;
+
 import javax.transaction.NotSupportedException;
 import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 
+import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
@@ -103,4 +106,39 @@ public class APITxTest extends APINonTxTest {
          tm1.rollback();
       }
    }
+   
+   public void testEntrySetIteratorRemoveInExplicitTx() throws SystemException, NotSupportedException {
+      assertEquals(0, cache.size());
+      cache.put("k1", "v1");
+	   
+      TransactionManager tm1 = TestingUtil.getTransactionManager(cache);
+      tm1.begin();
+      try {
+         try (CloseableIterator<Map.Entry<Object, Object>> entryIterator = cache.entrySet().iterator()) {
+            entryIterator.next();
+            entryIterator.remove();
+            assertEquals(0, cache.size());
+         }
+      } finally {
+         tm1.rollback();
+      }
+   }
+   
+   public void testKeySetIteratorRemoveInExplicitTx() throws SystemException, NotSupportedException {
+      assertEquals(0, cache.size());
+      cache.put("k1", "v1");
+	   
+      TransactionManager tm1 = TestingUtil.getTransactionManager(cache);
+      tm1.begin();
+      try {
+         try (CloseableIterator<Object> entryIterator = cache.keySet().iterator()) {
+            entryIterator.next();
+            entryIterator.remove();
+            assertEquals(0, cache.size());
+         }
+      } finally {
+         tm1.rollback();
+      }
+   }
+
 }


### PR DESCRIPTION
Fixed the problem where TransactionAwareKeyCloseableIterator did not set
the previousValue field, which made any calls to remove() throw NPE.
Additionally, the iterator now throws IllegalStateException if next()
has not been called, or remove() has been already called for the current
item as Iterator interface specifies.