### PR TITLE
Default XSD/doc values are now extracted from source.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -346,7 +346,11 @@
             <artifactId>infinispan-cli</artifactId>
             <version>${project.version}</version>
          </dependency>
-
+         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>infinispan-defaults-maven-plugin</artifactId>
+            <version>${project.version}</version>
+         </dependency>
          <dependency>
             <groupId>gnu.getopt</groupId>
             <artifactId>java-getopt</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -201,6 +201,18 @@
                </execution>
             </executions>
          </plugin>
+         <plugin>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-defaults-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>extract-defaults</id>
+                  <goals>
+                     <goal>extract-defaults</goal>
+                  </goals>
+               </execution>
+            </executions>
+         </plugin>
       </plugins>
    </build>
 

--- a/core/src/main/resources/schema/infinispan-config-9.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-9.0.xsd
@@ -493,7 +493,7 @@
         </xs:complexType>
       </xs:element>
     </xs:sequence>
-    <xs:attribute name="marshaller" type="xs:string" default="org.infinispan.marshall.core.VersionAwareMarshaller">
+    <xs:attribute name="marshaller" type="xs:string">
       <xs:annotation>
         <xs:documentation>
           Fully qualified name of the marshaller to use. It must implement org.infinispan.marshall.StreamingMarshaller
@@ -517,21 +517,21 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
-    <xs:attribute name="domain" type="xs:string" default="org.infinispan">
+    <xs:attribute name="domain" type="xs:string" default="${GlobalJmxStatistics.jmxDomain}">
       <xs:annotation>
         <xs:documentation>
           If JMX statistics are enabled then all 'published' JMX objects will appear under this name. This is optional, if not specified an object name will be created for you by default.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="mbean-server-lookup" type="xs:string" default="org.infinispan.jmx.PlatformMBeanServerLookup">
+    <xs:attribute name="mbean-server-lookup" type="xs:string" default="${GlobalJmxStatistics.mBeanServerLookup}">
       <xs:annotation>
         <xs:documentation>
           Class that will attempt to locate a JMX MBean server to bind to. Defaults to using the platform MBean server.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="duplicate-domains" type="xs:boolean" default="false">
+    <xs:attribute name="duplicate-domains" type="xs:boolean" default="${GlobalJmxStatistics.allowDuplicateDomains}">
       <xs:annotation>
         <xs:documentation>
           If true, multiple cache manager instances could be configured under the same configured JMX domain. Each cache manager will in practice use a different JMX domain that has been calculated based on the configured one by adding an incrementing index to it.
@@ -692,12 +692,12 @@
               </xs:annotation>
             </xs:element>
           </xs:sequence>
-          <xs:attribute name="index" type="tns:indexing" default="NONE">
+          <xs:attribute name="index" type="tns:indexing" default="${Indexing.index}">
             <xs:annotation>
               <xs:documentation>The indexing mode of the cache. Defaults to NONE.</xs:documentation>
             </xs:annotation>
           </xs:attribute>
-          <xs:attribute name="auto-config" type="xs:boolean" default="false" use="optional">
+          <xs:attribute name="auto-config" type="xs:boolean" default="${Indexing.autoConfig}" use="optional">
             <xs:annotation>
               <xs:documentation>Whether or not to apply automatic index configuration based on cache type</xs:documentation>
             </xs:annotation>
@@ -735,24 +735,24 @@
     <xs:attribute name="module" type="xs:string">
       <xs:annotation><xs:documentation>Unused XML attribute</xs:documentation></xs:annotation>
     </xs:attribute>
-    <xs:attribute name="statistics" type="xs:boolean" default="true">
+    <xs:attribute name="statistics" type="xs:boolean" default="${JMXStatistics.enabled}">
       <xs:annotation>
         <xs:documentation>Determines whether or not the cache should collect statistics.  Keep disabled for optimal performance.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="statistics-available" type="xs:boolean" default="true">
+    <xs:attribute name="statistics-available" type="xs:boolean" default="${JMXStatistics.available}">
       <xs:annotation>
         <xs:documentation>If set to false, statistics gathering cannot be enabled during runtime. Keep disabled for optimal performance.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="deadlock-detection-spin" type="xs:long" default="100">
+    <xs:attribute name="deadlock-detection-spin" type="xs:long" default="${DeadlockDetection.spinDuration}">
       <xs:annotation>
         <xs:documentation>
           Time period that determines how often is lock acquisition attempted within maximum time allowed to acquire a particular lock. Defaults to 100ms.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="unreliable-return-values" type="xs:boolean" default="false">
+    <xs:attribute name="unreliable-return-values" type="xs:boolean" default="${Unsafe.unreliable-return-values}">
       <xs:annotation>
         <xs:documentation>
           Specifies whether Infinispan is allowed to disregard the Map contract when providing return values for org.infinispan.Cache#put(Object, Object) and org.infinispan.Cache#remove(Object) methods.
@@ -764,7 +764,7 @@
   <xs:complexType name="local-cache">
     <xs:complexContent>
       <xs:extension base="tns:cache">
-        <xs:attribute name="simple-cache" default="false">
+        <xs:attribute name="simple-cache" default="${Configuration.simpleCache}">
           <xs:annotation>
             <xs:documentation>
               This cache will be using optimized (faster) implementation that does not support transactions/invocation batching, persistence, custom interceptors, indexing, store-as-binary or compatibility. Also, this type of cache does not support Map-Reduce jobs or Distributed Executor framework.
@@ -776,27 +776,27 @@
   </xs:complexType>
 
   <xs:complexType name="locking">
-    <xs:attribute name="isolation" type="tns:isolation" default="READ_COMMITTED">
+    <xs:attribute name="isolation" type="tns:isolation" default="${Locking.isolationLevel}">
       <xs:annotation>
         <xs:documentation>Sets the cache locking isolation level. Infinispan only supports READ_COMMITTED or REPEATABLE_READ isolation level.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="striping" type="xs:boolean" default="false">
+    <xs:attribute name="striping" type="xs:boolean" default="${Locking.striping}">
       <xs:annotation>
         <xs:documentation>If true, a pool of shared locks is maintained for all entries that need to be locked. Otherwise, a lock is created per entry in the cache. Lock striping helps control memory footprint but may reduce concurrency in the system.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="acquire-timeout" type="xs:long" default="10000">
+    <xs:attribute name="acquire-timeout" type="xs:long" default="${Locking.lockAcquisitionTimeout}">
       <xs:annotation>
         <xs:documentation>Maximum time to attempt a particular lock acquisition.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="concurrency-level" type="xs:int" default="32">
+    <xs:attribute name="concurrency-level" type="xs:int" default="${Locking.concurrencyLevel}">
       <xs:annotation>
         <xs:documentation>Concurrency level for lock containers. Adjust this value according to the number of concurrent threads interacting with Infinispan.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="write-skew" type="xs:boolean" default="false">
+    <xs:attribute name="write-skew" type="xs:boolean" default="${Locking.writeSkewCheck}">
       <xs:annotation>
         <xs:documentation>
           This setting is only applicable in the case of REPEATABLE_READ. When write skew check is set to false, if the writer at commit time discovers that the working entry and the underlying entry have different versions, the working entry will overwrite the underlying entry. If true, such version conflict - known as a write-skew - will throw an Exception. Defaults to false.
@@ -811,38 +811,38 @@
         <xs:documentation>Sets the cache transaction mode to one of NONE, BATCH, NON_XA, NON_DURABLE_XA, FULL_XA.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="stop-timeout" type="xs:long" default="30000">
+    <xs:attribute name="stop-timeout" type="xs:long" default="${Transaction.stop-timeout}">
       <xs:annotation>
         <xs:documentation>If there are any ongoing transactions when a cache is stopped, Infinispan waits for ongoing remote and local transactions to finish. The amount of time to wait for is defined by the cache stop timeout.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="locking" type="tns:locking-mode" default="OPTIMISTIC">
+    <xs:attribute name="locking" type="tns:locking-mode" default="${Transaction.locking}">
       <xs:annotation>
         <xs:documentation>The locking mode for this cache, one of OPTIMISTIC or PESSIMISTIC.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="transaction-manager-lookup" type="xs:string" default="org.infinispan.transaction.lookup.GenericTransactionManagerLookup.GenericTransactionManagerLookup">
+    <xs:attribute name="transaction-manager-lookup" type="xs:string" default="${Transaction.transaction-manager-lookup}">
       <xs:annotation>
         <xs:documentation>
           Configure Transaction manager lookup directly using an instance of TransactionManagerLookup. Calling this method marks the cache as transactional.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="complete-timeout" type="xs:long" default="60000">
+    <xs:attribute name="complete-timeout" type="xs:long" default="${Transaction.complete-timeout}">
       <xs:annotation>
         <xs:documentation>
           The duration (millis) in which to keep information about the completion of a transaction. Defaults to 60000.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="reaper-interval" type="xs:long" default="30000">
+    <xs:attribute name="reaper-interval" type="xs:long" default="${Transaction.reaper-wake-up-interval}">
       <xs:annotation>
         <xs:documentation>
           The time interval (millis) at which the thread that cleans up transaction completion information kicks in. Defaults to 30000.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="auto-commit" type="xs:boolean" default="true">
+    <xs:attribute name="auto-commit" type="xs:boolean" default="${Transaction.auto-commit}">
       <xs:annotation>
         <xs:documentation>
           If the cache is transactional and transactionAutoCommit is enabled then for single operation transactions the user doesn't need to manually start a transaction, but a transactions is injected by the system. Defaults to true.
@@ -856,14 +856,14 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="recovery-cache" type="xs:string" default="__recoveryInfoCacheName__">
+    <xs:attribute name="recovery-cache" type="xs:string" default="${Recovery.recoveryInfoCacheName}">
       <xs:annotation>
         <xs:documentation>
           Sets the name of the cache where recovery related information is held. The cache's default name is "__recoveryInfoCacheName__"
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="notifications" type="xs:boolean" default="true">
+    <xs:attribute name="notifications" type="xs:boolean" default="${Transaction.notifications}">
       <xs:annotation>
         <xs:documentation>
           Enables or disables triggering transactional notifications on cache listeners. By default is enabled.
@@ -878,7 +878,7 @@
         DEPRECATED: please use memory element instead
       </xs:documentation>
     </xs:annotation>
-    <xs:attribute name="strategy" type="tns:eviction-strategy" default="NONE">
+    <xs:attribute name="strategy" type="tns:eviction-strategy" default="${Eviction.strategy}">
       <xs:annotation>
         <xs:documentation>Sets the cache eviction strategy. Available options are 'UNORDERED', 'FIFO', 'LRU', 'LIRS' and 'NONE' (to disable eviction).</xs:documentation>
       </xs:annotation>
@@ -888,19 +888,19 @@
         <xs:documentation>Deprecated since 8.1. Use the size attribute instead.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="thread-policy" type="tns:eviction-thread-policy" default="DEFAULT">
+    <xs:attribute name="thread-policy" type="tns:eviction-thread-policy" default="${Eviction.threadPolicy}">
       <xs:annotation>
         <xs:documentation>
           Threading policy for eviction. Defaults to using the DEFAULT eviction policy.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="type" type="tns:eviction-type" default="COUNT">
+    <xs:attribute name="type" type="tns:eviction-type" default="${Eviction.type}">
       <xs:annotation>
         <xs:documentation>Specifies whether to use entry count or memory-based approximation to decide when to evict entries.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="size" type="xs:long" default="-1">
+    <xs:attribute name="size" type="xs:long" default="${Eviction.size}">
       <xs:annotation>
         <xs:documentation>Maximum size to use for eviction. When using the COUNT type, this is the maximum number of entries in a cache instance. When using the MEMORY threshold policy, this is the maximum number of allocated bytes used by a cache's datacontainer. A value of -1 means no limit. This is currently limited to 2^48 - 1 in size.</xs:documentation>
       </xs:annotation>
@@ -908,17 +908,17 @@
   </xs:complexType>
 
   <xs:complexType name="expiration">
-    <xs:attribute name="max-idle" type="xs:long" default="-1">
+    <xs:attribute name="max-idle" type="xs:long" default="${Expiration.maxIdle}">
       <xs:annotation>
         <xs:documentation>Maximum idle time a cache entry will be maintained in the cache, in milliseconds. If the idle time is exceeded, the entry will be expired cluster-wide. -1 means the entries never expire.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="lifespan" type="xs:long" default="-1">
+    <xs:attribute name="lifespan" type="xs:long" default="${Eviction.size}">
       <xs:annotation>
         <xs:documentation>Maximum lifespan of a cache entry, after which the entry is expired cluster-wide, in milliseconds. -1 means the entries never expire.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="interval" type="xs:long" default="60000">
+    <xs:attribute name="interval" type="xs:long" default="${Expiration.wakeUpInterval}">
       <xs:annotation>
         <xs:documentation>Interval (in milliseconds) between subsequent runs to purge expired entries from memory and any cache stores. If you wish to disable the periodic eviction process altogether, set interval to -1.</xs:documentation>
       </xs:annotation>
@@ -940,14 +940,14 @@
         DEPRECATED: please use memory element instead
       </xs:documentation>
     </xs:annotation>
-    <xs:attribute name="keys" type="xs:boolean" default="true">
+    <xs:attribute name="keys" type="xs:boolean" default="${StoreAsBinary.keys}">
       <xs:annotation>
         <xs:documentation>
           Specify whether keys are stored as binary or not. Enabled by default if the "enabled" attribute is set to true.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="values" type="xs:boolean" default="true">
+    <xs:attribute name="values" type="xs:boolean" default="${StoreAsBinary.values}">
       <xs:annotation>
         <xs:documentation>
           Specify whether values are stored as binary or not. Enabled by default if the "enabled" attribute is set to true.
@@ -975,7 +975,7 @@
       </xs:element>
       <xs:any namespace="##other" />
     </xs:choice>
-    <xs:attribute name="passivation" type="xs:boolean" default="false">
+    <xs:attribute name="passivation" type="xs:boolean" default="${Persistence.passivation}">
       <xs:annotation>
         <xs:documentation>
           If true, data is only written to the cache store when it is evicted from memory, a phenomenon known as 'passivation'. Next time the data is requested, it will be 'activated' which means that data will be brought back to memory and removed from the persistent store. This gives you the ability to 'overflow' to disk, similar to swapping in an operating system. If false, the cache store contains a copy of the contents in memory, so writes to cache result in cache store writes. This essentially gives you a 'write-through' configuration. Defaults to false.
@@ -1020,7 +1020,7 @@
           </xs:documentation>
         </xs:annotation>
         <xs:complexType>
-          <xs:attribute name="enabled" type="xs:boolean" default="true">
+          <xs:attribute name="enabled" type="xs:boolean" default="${Authorization.enabled}">
             <xs:annotation>
               <xs:documentation>
                 Enables authorization checks for this cache. Defaults to true if the authorization element is present.
@@ -1040,7 +1040,7 @@
   </xs:complexType>
 
   <xs:complexType name="versioning">
-    <xs:attribute name="scheme" type="tns:versioning-scheme" default="NONE">
+    <xs:attribute name="scheme" type="tns:versioning-scheme" default="${Versioning.scheme}">
       <xs:annotation>
         <xs:documentation>
           The scheme to use when versioning entries. Can be either SIMPLE or NONE. Defaults to NONE
@@ -1192,7 +1192,7 @@
             <xs:documentation>Sets the clustered cache mode, ASYNC for asynchronous operation, or SYNC for synchronous operation.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="remote-timeout" type="xs:long" default="15000">
+        <xs:attribute name="remote-timeout" type="xs:long" default="${Clustering.remoteTimeout}">
           <xs:annotation>
             <xs:documentation>In SYNC mode, the timeout (in ms) used to wait for an acknowledgment when making a remote call, after which the call is aborted and an exception is thrown.</xs:documentation>
           </xs:annotation>
@@ -1218,7 +1218,7 @@
             </xs:annotation>
           </xs:element>
         </xs:sequence>
-        <xs:attribute name="segments" type="xs:int" default="256">
+        <xs:attribute name="segments" type="xs:int" default="${Hash.numSegments}">
           <xs:annotation>
             <xs:documentation>Number of hash space segments (per cluster). The default value is 256, and should be at least 20 * cluster size.
             </xs:documentation>
@@ -1265,17 +1265,17 @@
             </xs:annotation>
           </xs:element>
         </xs:sequence>
-        <xs:attribute name="owners" type="xs:int" default="2">
+        <xs:attribute name="owners" type="xs:int" default="${Hash.numOwners}">
           <xs:annotation>
             <xs:documentation>Number of cluster-wide replicas for each cache entry.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="segments" type="xs:int" default="256">
+        <xs:attribute name="segments" type="xs:int" default="${Hash.numSegments}">
           <xs:annotation>
             <xs:documentation>Number of hash space segments (per cluster). The default value is 256, and should be at least 20 * cluster size.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="capacity-factor" type="xs:double" default="1">
+        <xs:attribute name="capacity-factor" type="xs:double" default="${Hash.capacityFactor}">
           <xs:annotation>
             <xs:documentation>Controls the proportion of entries that will reside on the local node,
               compared to the other nodes in the cluster. Value must be positive. The default is 1</xs:documentation>
@@ -1288,14 +1288,14 @@
                If the attribute is not present, L1 is disabled.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="l1-cleanup-interval" type="xs:long" default="60000">
+        <xs:attribute name="l1-cleanup-interval" type="xs:long" default="${L1.cleanupTaskFrequency}">
           <xs:annotation>
             <xs:documentation>
               Controls how often a cleanup task to prune L1 tracking data is run. Defaults to 10 minutes.
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="capacity" type="xs:float" default="1">
+        <xs:attribute name="capacity" type="xs:float" default="${Hash.capacityFactor}">
           <xs:annotation>
             <xs:documentation>
               Controls the proportion of entries that will reside on the local node, compared to the other nodes
@@ -1341,12 +1341,12 @@
     <xs:attribute name="name" type="xs:string">
       <xs:annotation><xs:documentation>Unused XML attribute.</xs:documentation></xs:annotation>
     </xs:attribute>
-    <xs:attribute name="shared" type="xs:boolean" default="false">
+    <xs:attribute name="shared" type="xs:boolean" default="${AbstractStore.shared}">
       <xs:annotation>
         <xs:documentation>This setting should be set to true when multiple cache instances share the same cache store (e.g., multiple nodes in a cluster using a JDBC-based CacheStore pointing to the same, shared database.) Setting this to true avoids multiple cache instances writing the same modification multiple times. If enabled, only the node where the modification originated will write to the cache store. If disabled, each individual cache reacts to a potential remote update by storing the data to the cache store.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="preload" type="xs:boolean" default="false">
+    <xs:attribute name="preload" type="xs:boolean" default="${AbstractStore.preload}">
       <xs:annotation>
         <xs:documentation>If true, when the cache starts, data stored in the cache store will be pre-loaded into memory. This is particularly useful when data in the cache store will be needed immediately after startup and you want to avoid cache operations being delayed as a result of loading this data lazily. Can be used to provide a 'warm-cache' on startup, however there is a performance penalty as startup time is affected by this process.</xs:documentation>
       </xs:annotation>
@@ -1356,7 +1356,7 @@
   <xs:complexType name="cluster-loader">
     <xs:complexContent>
       <xs:extension base="tns:loader">
-        <xs:attribute name="remote-timeout" type="xs:long" default="15000">
+        <xs:attribute name="remote-timeout" type="xs:long" default="${ClusterLoader.remoteCallTimeout}">
           <xs:annotation>
             <xs:documentation>The timeout when performing remote calls.</xs:documentation>
           </xs:annotation>
@@ -1378,27 +1378,27 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
-    <xs:attribute name="shared" type="xs:boolean" default="false">
+    <xs:attribute name="shared" type="xs:boolean" default="${AbstractStore.shared}">
       <xs:annotation>
         <xs:documentation>This setting should be set to true when multiple cache instances share the same cache store (e.g., multiple nodes in a cluster using a JDBC-based CacheStore pointing to the same, shared database.) Setting this to true avoids multiple cache instances writing the same modification multiple times. If enabled, only the node where the modification originated will write to the cache store. If disabled, each individual cache reacts to a potential remote update by storing the data to the cache store.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="transactional" type="xs:boolean" default="false">
+    <xs:attribute name="transactional" type="xs:boolean" default="${AbstractStore.transactional}">
       <xs:annotation>
         <xs:documentation>This setting should be set to true when the underlying cache store supports transactions and it is desirable for the underlying store and the cache to remain synchronized. With this enabled any Exceptions thrown whilst writing to the underlying store will result in both the store's and cache's transactions rollingback.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="preload" type="xs:boolean" default="false">
+    <xs:attribute name="preload" type="xs:boolean" default="${AbstractStore.preload}">
       <xs:annotation>
         <xs:documentation>If true, when the cache starts, data stored in the cache store will be pre-loaded into memory. This is particularly useful when data in the cache store will be needed immediately after startup and you want to avoid cache operations being delayed as a result of loading this data lazily. Can be used to provide a 'warm-cache' on startup, however there is a performance penalty as startup time is affected by this process.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="fetch-state" type="xs:boolean" default="true">
+    <xs:attribute name="fetch-state" type="xs:boolean" default="${AbstractStore.fetchPersistentState}">
       <xs:annotation>
         <xs:documentation>If true, fetch persistent state when joining a cluster. If multiple cache stores are chained, only one of them can have this property enabled.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="purge" type="xs:boolean" default="true">
+    <xs:attribute name="purge" type="xs:boolean" default="${AbstractStore.purgeOnStartup}">
       <xs:annotation>
         <xs:documentation>If true, purges this cache store when it starts up.</xs:documentation>
       </xs:annotation>
@@ -1408,7 +1408,7 @@
         <xs:documentation>If true, the singleton store cache store is enabled. SingletonStore is a delegating cache store used for situations when only one instance in a cluster should interact with the underlying store. Deprecated: A shared store should be used instead, as this limits store writes to the primary owner of a key</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="read-only" type="xs:boolean" default="false">
+    <xs:attribute name="read-only" type="xs:boolean" default="${AbstractStore.ignoreModifications}">
       <xs:annotation>
         <xs:documentation>If true, the cache store will only be used to load entries. Any modifications made to the caches will not be applied to the store.</xs:documentation>
       </xs:annotation>
@@ -1416,7 +1416,7 @@
   </xs:complexType>
 
   <xs:complexType name="write-behind">
-    <xs:attribute name="modification-queue-size" type="xs:int" default="1024">
+    <xs:attribute name="modification-queue-size" type="xs:int" default="${AsyncStore.modificationQueueSize}">
       <xs:annotation>
         <xs:documentation>
           Maximum number of entries in the asynchronous queue. When the queue is full, the store becomes write-through.
@@ -1424,7 +1424,7 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="thread-pool-size" type="xs:int" default="1">
+    <xs:attribute name="thread-pool-size" type="xs:int" default="${AsyncStore.threadPoolSize}">
       <xs:annotation>
         <xs:documentation>
           Size of the thread pool whose threads are responsible for applying the modifications to the cache store.
@@ -1500,17 +1500,17 @@
         <xs:documentation>If enabled, this will cause the cache to ask neighboring caches for state when it starts up, so the cache starts 'warm', although it will impact startup time.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="timeout" type="xs:long" default="240000">
+    <xs:attribute name="timeout" type="xs:long" default="${StateTransfer.timeout}">
       <xs:annotation>
         <xs:documentation>The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="chunk-size" type="xs:integer" default="512">
+    <xs:attribute name="chunk-size" type="xs:integer" default="${StateTransfer.chunkSize}">
       <xs:annotation>
         <xs:documentation>The number of cache entries to batch in each transfer.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="await-initial-transfer" type="xs:boolean" default="true">
+    <xs:attribute name="await-initial-transfer" type="xs:boolean" default="${StateTransfer.awaitInitialTransfer}">
       <xs:annotation>
         <xs:documentation>If enabled, this will cause the cache to wait for initial state transfer to complete before responding to requests.</xs:documentation>
       </xs:annotation>
@@ -1604,30 +1604,30 @@
         <xs:documentation>Name of the remote site where this cache backups data.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="strategy" type="tns:mode" default="ASYNC">
+    <xs:attribute name="strategy" type="tns:mode" default="${Backup.strategy}">
       <xs:annotation>
         <xs:documentation>The strategy used for backing up data: "SYNC" or "ASYNC". Defaults to "ASYNC"</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="failure-policy" type="tns:backup-failure-policy" default="WARN">
+    <xs:attribute name="failure-policy" type="tns:backup-failure-policy" default="${Backup.backupFailurePolicy}">
       <xs:annotation>
         <xs:documentation>Decides what the system would do in case of failure during backup. Defaults to "WARN"</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="timeout" type="xs:long" default="10000">
+    <xs:attribute name="timeout" type="xs:long" default="${Backup.replicationTimeout}">
       <xs:annotation>
         <xs:documentation>The timeout(millis) to be used when backing up data remotely. Defaults to 10 secs.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="enabled" type="xs:boolean" default="true">
+    <xs:attribute name="enabled" type="xs:boolean" default="${Backup.enabled}">
       <xs:annotation>
         <xs:documentation>If 'false' then no data is backed up to this site. Defaults to 'true'.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="two-phase-commit" use="optional" type="xs:boolean" default="false">
+    <xs:attribute name="two-phase-commit" use="optional" type="xs:boolean" default="${Backup.useTwoPhaseCommit}">
       <xs:annotation>
         <xs:documentation>
-          Configures whether the replication happens in a 1PC or 2PC when using SYNC backup strategy. Defaults to "false".
+          Configures whether the replication happens in a 1PC or 2PC when using SYNC backup strategy. Defaults to "${Backup.useTwoPhaseCommit}".
           CacheConfigurationException is thrown when used with ASYNC backup strategy.
         </xs:documentation>
       </xs:annotation>

--- a/distribution/package.xml
+++ b/distribution/package.xml
@@ -152,7 +152,7 @@
          <mkdir dir="@{dir}/schema" />
          <copy todir="@{dir}/schema">
             <fileset dir="${basedir}/..">
-               <include name="**/src/main/resources/schema/*-${infinispan.core.schema.version}.xsd" />
+               <include name="**/target/classes/schema/*-${infinispan.core.schema.version}.xsd" />
                <include name="**/src/main/resources/org/infinispan/spring/config/*${infinispan.core.schema.version}.xsd" />
             </fileset>
             <mapper type="flatten" />

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -147,8 +147,8 @@
                         <echo message="Base dir: ${basedir}" />
                         <path id="xsd.fileset.path">
                            <fileset casesensitive="yes" dir="${basedir}/..">
-                              <include name="core/src/main/resources/schema/*-${infinispan.core.schema.version}.xsd" />
-                              <include name="persistence/*/src/main/resources/schema/*-${infinispan.core.schema.version}.xsd" />
+                              <include name="core/target/classes/schema/*-${infinispan.core.schema.version}.xsd" />
+                              <include name="persistence/*/target/classes/schema/*-${infinispan.core.schema.version}.xsd" />
                               <include name="spring/spring/src/main/resources/org/infinispan/spring/config/*-${infinispan.core.schema.version}.xsd" />
                            </fileset>
                         </path>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -24,7 +24,59 @@
         <jdk.docroot>https://docs.oracle.com/javase/8/docs/api</jdk.docroot>
         <javaee.docroot>https://docs.oracle.com/javaee/7/api</javaee.docroot>
         <skipTests>true</skipTests>
+        <defaults.file>${project.build.directory}/default-attributes.adoc</defaults.file>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-cachestore-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-cachestore-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-cachestore-leveldb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-cachestore-remote</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-cachestore-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan.server</groupId>
+            <artifactId>infinispan-server-commons</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan.server</groupId>
+            <artifactId>infinispan-server-jgroups</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan.server</groupId>
+            <artifactId>infinispan-server-endpoints</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan.server</groupId>
+            <artifactId>infinispan-server-infinispan</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
@@ -37,6 +89,36 @@
                         <goals>
                             <goal>parse-version</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-defaults-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>extract-defaults</id>
+                        <goals>
+                            <goal>extract-defaults</goal>
+                        </goals>
+                        <configuration>
+                            <attributeDefType>ALL</attributeDefType>
+                            <defaultsFile>${defaults.file}</defaultsFile>
+                            <outputAscii>true</outputAscii>
+                            <filterXsd>false</filterXsd>
+                            <jars>
+                                <jar>infinispan-core</jar>
+                                <jar>infinispan-cachestore-jdbc</jar>
+                                <jar>infinispan-cachestore-jpa</jar>
+                                <jar>infinispan-cachestore-leveldb</jar>
+                                <jar>infinispan-cachestore-rocksdb</jar>
+                                <jar>infinispan-cachestore-remote</jar>
+                                <jar>infinispan-cachestore-rest</jar>
+                                <jar>infinispan-server-endpoints</jar>
+                                <jar>infinispan-server-jgroups</jar>
+                                <jar>infinispan-server-infinispan</jar>
+                            </jars>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -84,6 +166,7 @@
                                 <experimental>true</experimental>
                                 <infinispanversion>${infinispan.version}</infinispanversion>
                                 <infinispanslot>ispn-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</infinispanslot>
+                                <defaults>${defaults.file}</defaults>
                                 <javadocroot>${javadoc.root}</javadocroot>
                                 <configdocroot>${configdoc.root}</configdocroot>
                                 <wildflydocroot>${wildfly.docroot}</wildflydocroot>
@@ -118,6 +201,7 @@
                                 <docinfo>true</docinfo>
                                 <experimental>true</experimental>
                                 <infinispanversion>${infinispan.version}</infinispanversion>
+                                <defaults>${defaults.file}</defaults>
                                 <infinispanslot>ispn-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</infinispanslot>
                                 <javadocroot>${javadoc.root}</javadocroot>
                                 <configdocroot>${configdoc.root}</configdocroot>

--- a/documentation/src/main/asciidoc/user_guide/user_guide.asciidoc
+++ b/documentation/src/main/asciidoc/user_guide/user_guide.asciidoc
@@ -5,6 +5,9 @@ The Infinispan community
 :toclevels: 3
 :numbered:
 
+// Load all default values here for use in all sub-chapters
+include::{defaults}[]
+
 include::introduction.adoc[]
 include::configuration.adoc[]
 include::cache_manager.adoc[]

--- a/persistence/cli/pom.xml
+++ b/persistence/cli/pom.xml
@@ -11,8 +11,6 @@
    <packaging>bundle</packaging>
    <name>Infinispan Command Line Interface persistence</name>
    <description>Infinispan Command Line Interface persistence</description>
-   <properties>
-   </properties>
 
    <dependencies>
       <dependency>
@@ -106,7 +104,18 @@
                <forkMode>once</forkMode>
             </configuration>
          </plugin>
-
+         <plugin>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-defaults-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>extract-defaults</id>
+                  <goals>
+                     <goal>extract-defaults</goal>
+                  </goals>
+               </execution>
+            </executions>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/persistence/jdbc/pom.xml
+++ b/persistence/jdbc/pom.xml
@@ -15,6 +15,12 @@
 
    <dependencies>
       <dependency>
+         <groupId>org.infinispan</groupId>
+         <artifactId>infinispan-core</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
          <groupId>org.testng</groupId>
          <artifactId>testng</artifactId>
          <scope>test</scope>
@@ -138,6 +144,18 @@
                         </artifact>
                      </artifacts>
                   </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-defaults-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>extract-defaults</id>
+                  <goals>
+                     <goal>extract-defaults</goal>
+                  </goals>
                </execution>
             </executions>
          </plugin>

--- a/persistence/jdbc/src/main/resources/schema/infinispan-cachestore-jdbc-config-9.0.xsd
+++ b/persistence/jdbc/src/main/resources/schema/infinispan-cachestore-jdbc-config-9.0.xsd
@@ -92,22 +92,22 @@
         </xs:annotation>
       </xs:element>
     </xs:sequence>
-    <xs:attribute name="fetch-size" type="xs:int" default="100">
+    <xs:attribute name="fetch-size" type="xs:int" default="${TableManipulation.fetchSize}">
       <xs:annotation>
         <xs:documentation>The fetch size used when querying from this table.  Used to avoid heap memory exhaustion when query is large.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="batch-size" type="xs:int" default="100">
+    <xs:attribute name="batch-size" type="xs:int" default="${TableManipulation.batchSize}">
       <xs:annotation>
         <xs:documentation>The statement batch size used when modifying this table.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="create-on-start" type="xs:boolean" default="true">
+    <xs:attribute name="create-on-start" type="xs:boolean" default="${TableManipulation.createOnStart}">
         <xs:annotation>
            <xs:documentation>Determines whether database tables should be created by the store on startup.</xs:documentation>
         </xs:annotation>
      </xs:attribute>
-     <xs:attribute name="drop-on-exit" type="xs:boolean" default="false">
+     <xs:attribute name="drop-on-exit" type="xs:boolean" default="${TableManipulation.dropOnExit}">
         <xs:annotation>
            <xs:documentation>Determines whether database tables should be dropped by the store on shutdown.</xs:documentation>
         </xs:annotation>

--- a/persistence/jpa/pom.xml
+++ b/persistence/jpa/pom.xml
@@ -105,6 +105,18 @@
                <threadCount>1</threadCount>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-defaults-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>extract-defaults</id>
+                  <goals>
+                     <goal>extract-defaults</goal>
+                  </goals>
+               </execution>
+            </executions>
+         </plugin>
       </plugins>
    </build>
    <dependencies>

--- a/persistence/jpa/src/main/resources/schema/infinispan-cachestore-jpa-config-9.0.xsd
+++ b/persistence/jpa/src/main/resources/schema/infinispan-cachestore-jpa-config-9.0.xsd
@@ -29,7 +29,7 @@
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="batch-size" type="xs:long" default="100">
+        <xs:attribute name="batch-size" type="xs:long" default="${JpaStore.batchSize}">
           <xs:annotation>
             <xs:documentation>
               The batch size is used during cache store streaming. Default is
@@ -37,7 +37,7 @@
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="store-metadata" type="xs:boolean" default="true">
+        <xs:attribute name="store-metadata" type="xs:boolean" default="${JpaStore.storeMetadata}">
           <xs:annotation>
             <xs:documentation>
               Store Infinispan metadata (expiration, versioning) with the

--- a/persistence/leveldb/pom.xml
+++ b/persistence/leveldb/pom.xml
@@ -114,6 +114,23 @@
                </execution>
             </executions>
          </plugin>
+         <plugin>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-defaults-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>extract-defaults</id>
+                  <goals>
+                     <goal>extract-defaults</goal>
+                  </goals>
+                  <configuration>
+                     <jars>
+                        <jar>infinispan-cachestore-rocksdb</jar>
+                     </jars>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/persistence/leveldb/src/main/resources/schema/infinispan-cachestore-leveldb-config-9.0.xsd
+++ b/persistence/leveldb/src/main/resources/schema/infinispan-cachestore-leveldb-config-9.0.xsd
@@ -47,17 +47,17 @@
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="block-size" type="xs:integer">
+        <xs:attribute name="block-size" type="xs:integer" default="${RocksDBStore.blockSize}">
           <xs:annotation>
             <xs:documentation>Cache store block size.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="cache-size" type="xs:long">
+        <xs:attribute name="cache-size" type="xs:long" default="${RocksDBStore.cacheSize}}">
           <xs:annotation>
             <xs:documentation>Cache size for the cache store.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="clear-threshold" type="xs:integer">
+        <xs:attribute name="clear-threshold" type="xs:integer" default="${RocksDBStore.clearThreshold}">
           <xs:annotation>
             <xs:documentation>Cache store cache clear threshold.</xs:documentation>
           </xs:annotation>
@@ -72,7 +72,7 @@
         <xs:documentation>The base directory in which to store expired cache state.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="queue-size" type="xs:integer" default="10000">
+    <xs:attribute name="queue-size" type="xs:integer" default="${RocksDBStore.expiryQueueSize}">
       <xs:annotation>
         <xs:documentation>Expired entry queue size.</xs:documentation>
       </xs:annotation>
@@ -80,7 +80,7 @@
   </xs:complexType>
 
   <xs:complexType name="leveldb-compression">
-    <xs:attribute name="type" type="tns:leveldb-compression-mode" default="NONE">
+    <xs:attribute name="type" type="tns:leveldb-compression-mode" default="${RocksDBStore.compressionType}">
       <xs:annotation>
         <xs:documentation>The type of compression to be used by LevelDB store.</xs:documentation>
       </xs:annotation>
@@ -103,7 +103,7 @@
   </xs:simpleType>
 
   <xs:complexType name="leveldb-implementation">
-    <xs:attribute name="type" type="tns:leveldb-implementation-type" default="AUTO">
+    <xs:attribute name="type" type="tns:leveldb-implementation-type" default="${LevelDBStore.implementationType}">
       <xs:annotation>
         <xs:documentation>The LevelDB store implementation to use.</xs:documentation>
       </xs:annotation>

--- a/persistence/remote/pom.xml
+++ b/persistence/remote/pom.xml
@@ -135,6 +135,18 @@
                </execution>
             </executions>
          </plugin>
+         <plugin>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-defaults-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>extract-defaults</id>
+                  <goals>
+                     <goal>extract-defaults</goal>
+                  </goals>
+               </execution>
+            </executions>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/AbstractRemoteStoreConfigurationChildBuilder.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/AbstractRemoteStoreConfigurationChildBuilder.java
@@ -2,6 +2,7 @@ package org.infinispan.persistence.remote.configuration;
 
 import org.infinispan.client.hotrod.ProtocolVersion;
 import org.infinispan.client.hotrod.impl.transport.TransportFactory;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.configuration.cache.AbstractStoreConfigurationChildBuilder;
 
@@ -13,9 +14,11 @@ import org.infinispan.configuration.cache.AbstractStoreConfigurationChildBuilder
  */
 public abstract class AbstractRemoteStoreConfigurationChildBuilder<S> extends AbstractStoreConfigurationChildBuilder<S> implements RemoteStoreConfigurationChildBuilder<S> {
    private final RemoteStoreConfigurationBuilder builder;
+   protected final AttributeSet attributes;
 
-   protected AbstractRemoteStoreConfigurationChildBuilder(RemoteStoreConfigurationBuilder builder) {
+   protected AbstractRemoteStoreConfigurationChildBuilder(RemoteStoreConfigurationBuilder builder, AttributeSet attributes) {
       super(builder);
+      this.attributes = attributes;
       this.builder = builder;
    }
 

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/ConnectionPoolConfiguration.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/ConnectionPoolConfiguration.java
@@ -1,65 +1,74 @@
 package org.infinispan.persistence.remote.configuration;
 
-public class ConnectionPoolConfiguration {
-   private final ExhaustedAction exhaustedAction;
-   private final int maxActive;
-   private final int maxTotal;
-   private final int maxIdle;
-   private final int minIdle;
-   private final long timeBetweenEvictionRuns;
-   private final long minEvictableIdleTime;
-   private final boolean testWhileIdle;
+import org.infinispan.commons.configuration.BuiltBy;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
 
-   ConnectionPoolConfiguration(ExhaustedAction exhaustedAction, int maxActive, int maxTotal, int maxIdle, int minIdle,
-         long timeBetweenEvictionRuns, long minEvictableIdleTime, boolean testWhileIdle) {
-      this.exhaustedAction = exhaustedAction;
-      this.maxActive = maxActive;
-      this.maxTotal = maxTotal;
-      this.maxIdle = maxIdle;
-      this.minIdle = minIdle;
-      this.timeBetweenEvictionRuns = timeBetweenEvictionRuns;
-      this.minEvictableIdleTime = minEvictableIdleTime;
-      this.testWhileIdle = testWhileIdle;
+@BuiltBy(ConnectionPoolConfigurationBuilder.class)
+public class ConnectionPoolConfiguration {
+
+   static final AttributeDefinition<ExhaustedAction> EXHAUSTED_ACTION = AttributeDefinition.builder("exhaustedAction", ExhaustedAction.WAIT, ExhaustedAction.class).immutable().build();
+   static final AttributeDefinition<Integer> MAX_ACTIVE = AttributeDefinition.builder("maxActive", -1).immutable().build();
+   static final AttributeDefinition<Integer> MAX_TOTAL = AttributeDefinition.builder("maxTotal", -1).immutable().build();
+   static final AttributeDefinition<Integer> MAX_IDLE = AttributeDefinition.builder("maxIdle", -1).immutable().build();
+   static final AttributeDefinition<Integer> MIN_IDLE = AttributeDefinition.builder("minIdle", -1).immutable().build();
+   static final AttributeDefinition<Long> TIME_BETWEEN_EVICTION_RUNS = AttributeDefinition.builder("timeBetweenEvictionRuns", 120000L).immutable().build();
+   static final AttributeDefinition<Long> MIN_EVICTABLE_IDLE_TIME = AttributeDefinition.builder("minEvictableIdleTime", 1800000L).immutable().build();
+   static final AttributeDefinition<Boolean> TEST_WHILE_IDLE = AttributeDefinition.builder("testWhileIdle", true).immutable().build();
+
+   public static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(ConnectionPoolConfiguration.class, EXHAUSTED_ACTION, MAX_ACTIVE, MAX_TOTAL, MAX_IDLE,
+            MIN_IDLE, TIME_BETWEEN_EVICTION_RUNS, MIN_EVICTABLE_IDLE_TIME, TEST_WHILE_IDLE);
+   }
+
+   private final AttributeSet attributes;
+
+   ConnectionPoolConfiguration(AttributeSet attributes) {
+      this.attributes = attributes;
+   }
+
+   AttributeSet attributes() {
+      return attributes;
    }
 
    public ExhaustedAction exhaustedAction() {
-      return exhaustedAction;
+      return attributes.attribute(EXHAUSTED_ACTION).get();
    }
 
    public int maxActive() {
-      return maxActive;
+      return attributes.attribute(MAX_ACTIVE).get();
    }
 
    public int maxTotal() {
-      return maxTotal;
+      return attributes.attribute(MAX_TOTAL).get();
    }
 
    public int maxIdle() {
-      return maxIdle;
+      return attributes.attribute(MAX_IDLE).get();
    }
 
    public int minIdle() {
-      return minIdle;
+      return attributes.attribute(MIN_IDLE).get();
    }
 
    public long timeBetweenEvictionRuns() {
-      return timeBetweenEvictionRuns;
+      return attributes.attribute(TIME_BETWEEN_EVICTION_RUNS).get();
    }
 
    public long minEvictableIdleTime() {
-      return minEvictableIdleTime;
+      return attributes.attribute(MIN_EVICTABLE_IDLE_TIME).get();
    }
 
    public boolean testWhileIdle() {
-      return testWhileIdle;
+      return attributes.attribute(TEST_WHILE_IDLE).get();
    }
 
    @Override
    public String toString() {
-      return "ConnectionPoolConfiguration [exhaustedAction=" + exhaustedAction + ", maxActive=" + maxActive
-            + ", maxTotal=" + maxTotal + ", maxIdle=" + maxIdle + ", minIdle=" + minIdle + ", timeBetweenEvictionRuns="
-            + timeBetweenEvictionRuns + ", minEvictableIdleTime=" + minEvictableIdleTime + ", testWhileIdle="
-            + testWhileIdle + "]";
+      return "ConnectionPoolConfiguration [exhaustedAction=" + exhaustedAction() + ", maxActive=" + maxActive()
+            + ", maxTotal=" + maxTotal() + ", maxIdle=" + maxIdle() + ", minIdle=" + minIdle() + ", timeBetweenEvictionRuns="
+            + timeBetweenEvictionRuns() + ", minEvictableIdleTime=" + minEvictableIdleTime() + ", testWhileIdle="
+            + testWhileIdle() + "]";
    }
 
    @Override
@@ -69,27 +78,27 @@ public class ConnectionPoolConfiguration {
 
       ConnectionPoolConfiguration that = (ConnectionPoolConfiguration) o;
 
-      if (maxActive != that.maxActive) return false;
-      if (maxTotal != that.maxTotal) return false;
-      if (maxIdle != that.maxIdle) return false;
-      if (minIdle != that.minIdle) return false;
-      if (timeBetweenEvictionRuns != that.timeBetweenEvictionRuns) return false;
-      if (minEvictableIdleTime != that.minEvictableIdleTime) return false;
-      if (testWhileIdle != that.testWhileIdle) return false;
-      return exhaustedAction == that.exhaustedAction;
+      if (maxActive() != that.maxActive()) return false;
+      if (maxTotal() != that.maxTotal()) return false;
+      if (maxIdle() != that.maxIdle()) return false;
+      if (minIdle() != that.minIdle()) return false;
+      if (timeBetweenEvictionRuns() != that.timeBetweenEvictionRuns()) return false;
+      if (minEvictableIdleTime() != that.minEvictableIdleTime()) return false;
+      if (testWhileIdle() != that.testWhileIdle()) return false;
+      return exhaustedAction() == that.exhaustedAction();
 
    }
 
    @Override
    public int hashCode() {
-      int result = exhaustedAction != null ? exhaustedAction.hashCode() : 0;
-      result = 31 * result + maxActive;
-      result = 31 * result + maxTotal;
-      result = 31 * result + maxIdle;
-      result = 31 * result + minIdle;
-      result = 31 * result + (int) (timeBetweenEvictionRuns ^ (timeBetweenEvictionRuns >>> 32));
-      result = 31 * result + (int) (minEvictableIdleTime ^ (minEvictableIdleTime >>> 32));
-      result = 31 * result + (testWhileIdle ? 1 : 0);
+      int result = exhaustedAction() != null ? exhaustedAction().hashCode() : 0;
+      result = 31 * result + maxActive();
+      result = 31 * result + maxTotal();
+      result = 31 * result + maxIdle();
+      result = 31 * result + minIdle();
+      result = 31 * result + (int) (timeBetweenEvictionRuns() ^ (timeBetweenEvictionRuns() >>> 32));
+      result = 31 * result + (int) (minEvictableIdleTime() ^ (minEvictableIdleTime() >>> 32));
+      result = 31 * result + (testWhileIdle() ? 1 : 0);
       return result;
    }
 }

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/ConnectionPoolConfigurationBuilder.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/ConnectionPoolConfigurationBuilder.java
@@ -1,5 +1,14 @@
 package org.infinispan.persistence.remote.configuration;
 
+import static org.infinispan.persistence.remote.configuration.ConnectionPoolConfiguration.EXHAUSTED_ACTION;
+import static org.infinispan.persistence.remote.configuration.ConnectionPoolConfiguration.MAX_ACTIVE;
+import static org.infinispan.persistence.remote.configuration.ConnectionPoolConfiguration.MAX_IDLE;
+import static org.infinispan.persistence.remote.configuration.ConnectionPoolConfiguration.MAX_TOTAL;
+import static org.infinispan.persistence.remote.configuration.ConnectionPoolConfiguration.MIN_EVICTABLE_IDLE_TIME;
+import static org.infinispan.persistence.remote.configuration.ConnectionPoolConfiguration.MIN_IDLE;
+import static org.infinispan.persistence.remote.configuration.ConnectionPoolConfiguration.TEST_WHILE_IDLE;
+import static org.infinispan.persistence.remote.configuration.ConnectionPoolConfiguration.TIME_BETWEEN_EVICTION_RUNS;
+
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 
@@ -11,17 +20,9 @@ import org.infinispan.configuration.global.GlobalConfiguration;
  */
 public class ConnectionPoolConfigurationBuilder extends AbstractRemoteStoreConfigurationChildBuilder<RemoteStoreConfigurationBuilder> implements
       Builder<ConnectionPoolConfiguration> {
-   private ExhaustedAction exhaustedAction = ExhaustedAction.WAIT;
-   private int maxActive = -1;
-   private int maxTotal = -1;
-   private int maxIdle = -1;
-   private int minIdle = 1;
-   private long timeBetweenEvictionRuns = 120000;
-   private long minEvictableIdleTime = 1800000;
-   private boolean testWhileIdle = true;
 
    ConnectionPoolConfigurationBuilder(RemoteStoreConfigurationBuilder builder) {
-      super(builder);
+      super(builder, ConnectionPoolConfiguration.attributeDefinitionSet());
    }
 
    /**
@@ -29,7 +30,7 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteStoreConfi
     * exhausted.
     */
    public ConnectionPoolConfigurationBuilder exhaustedAction(ExhaustedAction exhaustedAction) {
-      this.exhaustedAction = exhaustedAction;
+      this.attributes.attribute(EXHAUSTED_ACTION).set(exhaustedAction);
       return this;
    }
 
@@ -41,7 +42,7 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteStoreConfi
     * limit.
     */
    public ConnectionPoolConfigurationBuilder maxActive(int maxActive) {
-      this.maxActive = maxActive;
+      this.attributes.attribute(MAX_ACTIVE).set(maxActive);
       return this;
    }
 
@@ -52,7 +53,7 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteStoreConfi
     * exhausted. The default setting for this parameter is -1 (no limit).
     */
    public ConnectionPoolConfigurationBuilder maxTotal(int maxTotal) {
-      this.maxTotal = maxTotal;
+      this.attributes.attribute(MAX_TOTAL).set(maxTotal);
       return this;
    }
 
@@ -62,7 +63,7 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteStoreConfi
     * default setting for this parameter is -1.
     */
    public ConnectionPoolConfigurationBuilder maxIdle(int maxIdle) {
-      this.maxIdle = maxIdle;
+      this.attributes.attribute(MAX_IDLE).set(maxIdle);
       return this;
    }
 
@@ -74,7 +75,7 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteStoreConfi
     * setting for this parameter is 1.
     */
    public ConnectionPoolConfigurationBuilder minIdle(int minIdle) {
-      this.minIdle = minIdle;
+      this.attributes.attribute(MIN_IDLE).set(minIdle);
       return this;
    }
 
@@ -84,7 +85,7 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteStoreConfi
     * this parameter is 2 minutes.
     */
    public ConnectionPoolConfigurationBuilder timeBetweenEvictionRuns(long timeBetweenEvictionRuns) {
-      this.timeBetweenEvictionRuns = timeBetweenEvictionRuns;
+      this.attributes.attribute(TIME_BETWEEN_EVICTION_RUNS).set(timeBetweenEvictionRuns);
       return this;
    }
 
@@ -96,7 +97,7 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteStoreConfi
     * minutes).
     */
    public ConnectionPoolConfigurationBuilder minEvictableIdleTime(long minEvictableIdleTime) {
-      this.minEvictableIdleTime = minEvictableIdleTime;
+      this.attributes.attribute(MIN_EVICTABLE_IDLE_TIME).set(minEvictableIdleTime);
       return this;
    }
 
@@ -107,7 +108,7 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteStoreConfi
     * The default setting for this parameter is true.
     */
    public ConnectionPoolConfigurationBuilder testWhileIdle(boolean testWhileIdle) {
-      this.testWhileIdle = testWhileIdle;
+      this.attributes.attribute(TEST_WHILE_IDLE).set(testWhileIdle);
       return this;
    }
 
@@ -121,19 +122,12 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRemoteStoreConfi
 
    @Override
    public ConnectionPoolConfiguration create() {
-      return new ConnectionPoolConfiguration(exhaustedAction, maxActive, maxTotal, maxIdle, minIdle, timeBetweenEvictionRuns, minEvictableIdleTime, testWhileIdle);
+      return new ConnectionPoolConfiguration(attributes.protect());
    }
 
    @Override
    public ConnectionPoolConfigurationBuilder read(ConnectionPoolConfiguration template) {
-      exhaustedAction = template.exhaustedAction();
-      maxActive = template.maxActive();
-      maxTotal = template.maxTotal();
-      maxIdle = template.maxIdle();
-      minIdle = template.minIdle();
-      timeBetweenEvictionRuns = template.timeBetweenEvictionRuns();
-      minEvictableIdleTime = template.minEvictableIdleTime();
-      testWhileIdle = template.testWhileIdle();
+      this.attributes.read(template.attributes());
       return this;
    }
 }

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/ExecutorFactoryConfiguration.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/ExecutorFactoryConfiguration.java
@@ -9,15 +9,9 @@ import org.infinispan.executors.DefaultExecutorFactory;
 
 public class ExecutorFactoryConfiguration extends AbstractTypedPropertiesConfiguration {
    static final AttributeDefinition<ExecutorFactory> EXECUTOR_FACTORY = AttributeDefinition.builder("executorFactory", null, ExecutorFactory.class)
-         .initializer(new AttributeInitializer<ExecutorFactory>() {
+         .initializer(DefaultExecutorFactory::new).immutable().build();
 
-            @Override
-            public ExecutorFactory initialize() {
-               return new DefaultExecutorFactory();
-            }
-         }).immutable().build();
-
-   public static AttributeSet attributeSet() {
+   static AttributeSet attributeDefinitionSet() {
       return new AttributeSet(ExecutorFactoryConfiguration.class, AbstractTypedPropertiesConfiguration.attributeSet(), EXECUTOR_FACTORY);
    };
 

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/ExecutorFactoryConfigurationBuilder.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/ExecutorFactoryConfigurationBuilder.java
@@ -6,7 +6,6 @@ import static org.infinispan.persistence.remote.configuration.ExecutorFactoryCon
 import java.util.Properties;
 
 import org.infinispan.commons.configuration.Builder;
-import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.commons.executors.ExecutorFactory;
 import org.infinispan.commons.util.TypedProperties;
 import org.infinispan.configuration.global.GlobalConfiguration;
@@ -15,10 +14,8 @@ import org.infinispan.configuration.global.GlobalConfiguration;
  * Configures executor factory.
  */
 public class ExecutorFactoryConfigurationBuilder extends AbstractRemoteStoreConfigurationChildBuilder<RemoteStoreConfigurationBuilder> implements Builder<ExecutorFactoryConfiguration> {
-   private final AttributeSet attributes;
    ExecutorFactoryConfigurationBuilder(RemoteStoreConfigurationBuilder builder) {
-      super(builder);
-      attributes = ExecutorFactoryConfiguration.attributeSet();
+      super(builder, ExecutorFactoryConfiguration.attributeDefinitionSet());
    }
 
    /**

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteServerConfiguration.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteServerConfiguration.java
@@ -1,27 +1,40 @@
 package org.infinispan.persistence.remote.configuration;
 
-public class RemoteServerConfiguration {
-   private final String host;
-   private final int port;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
 
-   RemoteServerConfiguration(String host, int port) {
-      this.host = host;
-      this.port = port;
+public class RemoteServerConfiguration {
+
+   static final AttributeDefinition<String> HOST = AttributeDefinition.builder("host", null, String.class).immutable().build();
+   static final AttributeDefinition<Integer> PORT = AttributeDefinition.builder("port", 11222).immutable().build();
+
+   static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(RemoteServerConfiguration.class, HOST, PORT);
+   }
+
+   private final AttributeSet attributes;
+
+   RemoteServerConfiguration(AttributeSet attibutes) {
+      this.attributes = attibutes;
+   }
+
+   AttributeSet attributes() {
+      return attributes;
    }
 
    public String host() {
-      return host;
+      return attributes.attribute(HOST).get();
    }
 
    public int port() {
-      return port;
+      return attributes.attribute(PORT).get();
    }
 
    @Override
    public String toString() {
       return "RemoteServerConfiguration{" +
-            "host='" + host + '\'' +
-            ", port=" + port +
+            "host='" + host() + '\'' +
+            ", port=" + port() +
             '}';
    }
 
@@ -32,15 +45,15 @@ public class RemoteServerConfiguration {
 
       RemoteServerConfiguration that = (RemoteServerConfiguration) o;
 
-      if (port != that.port) return false;
-      return host != null ? host.equals(that.host) : that.host == null;
+      if (port() != that.port()) return false;
+      return host() != null ? host().equals(that.host()) : that.host() == null;
 
    }
 
    @Override
    public int hashCode() {
-      int result = host != null ? host.hashCode() : 0;
-      result = 31 * result + port;
+      int result = host() != null ? host().hashCode() : 0;
+      result = 31 * result + port();
       return result;
    }
 }

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteServerConfigurationBuilder.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/configuration/RemoteServerConfigurationBuilder.java
@@ -1,24 +1,25 @@
 package org.infinispan.persistence.remote.configuration;
 
+import static org.infinispan.persistence.remote.configuration.RemoteServerConfiguration.HOST;
+import static org.infinispan.persistence.remote.configuration.RemoteServerConfiguration.PORT;
+
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 
 public class RemoteServerConfigurationBuilder extends AbstractRemoteStoreConfigurationChildBuilder<RemoteStoreConfigurationBuilder> implements
       Builder<RemoteServerConfiguration> {
-   private String host;
-   private int port = 11222;
 
    RemoteServerConfigurationBuilder(RemoteStoreConfigurationBuilder builder) {
-      super(builder);
+      super(builder, RemoteServerConfiguration.attributeDefinitionSet());
    }
 
    public RemoteServerConfigurationBuilder host(String host) {
-      this.host = host;
+      this.attributes.attribute(HOST).set(host);
       return this;
    }
 
    public RemoteServerConfigurationBuilder port(int port) {
-      this.port = port;
+      this.attributes.attribute(PORT).set(port);
       return this;
    }
 
@@ -32,14 +33,12 @@ public class RemoteServerConfigurationBuilder extends AbstractRemoteStoreConfigu
 
    @Override
    public RemoteServerConfiguration create() {
-      return new RemoteServerConfiguration(host, port);
+      return new RemoteServerConfiguration(attributes.protect());
    }
 
    @Override
    public RemoteServerConfigurationBuilder read(RemoteServerConfiguration template) {
-      this.host = template.host();
-      this.port = template.port();
-
+      attributes.read(template.attributes());
       return this;
    }
 }

--- a/persistence/remote/src/main/resources/schema/infinispan-cachestore-remote-config-9.0.xsd
+++ b/persistence/remote/src/main/resources/schema/infinispan-cachestore-remote-config-9.0.xsd
@@ -28,7 +28,7 @@
             </xs:annotation>
           </xs:element>
         </xs:sequence>
-        <xs:attribute name="socket-timeout" type="xs:long" default="60000">
+        <xs:attribute name="socket-timeout" type="xs:long" default="${RemoteStore.socketTimeout}">
           <xs:annotation>
             <xs:documentation>
               Enable/disable SO_TIMEOUT on socket connections to remote Hot Rod servers with the specified timeout, in milliseconds.
@@ -36,49 +36,49 @@
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="tcp-no-delay" type="xs:boolean" default="true">
+        <xs:attribute name="tcp-no-delay" type="xs:boolean" default="${RemoteStore.tcpNoDelay}">
           <xs:annotation>
             <xs:documentation>
               Enable/disable TCP_NODELAY on socket connections to remote Hot Rod servers.
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="hotrod-wrapping" type="xs:boolean" default="false">
+        <xs:attribute name="hotrod-wrapping" type="xs:boolean" default="${RemoteStore.hotRodWrapping}">
           <xs:annotation>
             <xs:documentation>
               Ensures that, when entries are retrieved from the remote store, they will be wrapped in a format suitable for serving via HotRod. This flag must be enabled when performing a rolling upgrade
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="raw-values" type="xs:boolean" default="false">
+        <xs:attribute name="raw-values" type="xs:boolean" default="${RemoteStore.rawValues}">
           <xs:annotation>
             <xs:documentation>
               Enables the storage of data on the remote server in "raw" format as opposed to wrapping the entries in InternalCacheEntry. This will make the remote cache interoperable between direct RemoteCacheManager clients and RemoteCacheStore stores
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="balancing-strategy" type="xs:string" default="org.infinispan.client.hotrod.impl.transport.tcp.RoundRobinBalancingStrategy">
+        <xs:attribute name="balancing-strategy" type="xs:string" default="${RemoteStore.balancingStrategy}">
           <xs:annotation>
             <xs:documentation>
               For replicated (vs distributed) Hot Rod server clusters, the client balances requests to the servers according to this strategy.
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="connect-timeout" type="xs:int" default="60000">
+        <xs:attribute name="connect-timeout" type="xs:int" default="${RemoteStore.connectionTimeout}">
           <xs:annotation>
             <xs:documentation>
               This property defines the maximum socket connect timeout before giving up connecting to the server.
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="force-return-values" type="xs:boolean" default="false">
+        <xs:attribute name="force-return-values" type="xs:boolean" default="${RemoteStore.forceReturnValues}">
           <xs:annotation>
             <xs:documentation>
               Whether or not to implicitly FORCE_RETURN_VALUE for all calls.
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="key-size-estimate" type="xs:int" default="64">
+        <xs:attribute name="key-size-estimate" type="xs:int" default="${RemoteStore.keySizeEstimate}">
           <xs:annotation>
             <xs:documentation>
               This hint allows sizing of byte buffers when serializing and deserializing keys, to minimize array resizing. It defaults to 64.
@@ -92,7 +92,7 @@
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="protocol-version" type="xs:string" default="1.1">
+        <xs:attribute name="protocol-version" type="xs:string" default="${RemoteStore.protocolVersion}">
           <xs:annotation>
             <xs:documentation>
               This property defines the protocol version that this client should use. Defaults to 1.1. Other valid values include 1.0.
@@ -114,7 +114,7 @@
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="value-size-estimate" type="xs:int" default="512">
+        <xs:attribute name="value-size-estimate" type="xs:int" default="${RemoteStore.valueSizeEstimate}">
           <xs:annotation>
             <xs:documentation>
               This hint allows sizing of byte buffers when serializing and deserializing values, to minimize array resizing.
@@ -126,56 +126,56 @@
   </xs:complexType>
 
   <xs:complexType name="connectionPool">
-    <xs:attribute name="exhausted-action" type="tns:exhaustedAction" default="WAIT">
+    <xs:attribute name="exhausted-action" type="tns:exhaustedAction">
       <xs:annotation>
         <xs:documentation>
            Specifies what happens when asking for a connection from a server's pool, and that pool is exhausted.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="max-active" type="xs:int" default="-1">
+    <xs:attribute name="max-active" type="xs:int" default="${ConnectionPool.maxActive}">
       <xs:annotation>
         <xs:documentation>
           Controls the maximum number of connections per server that are allocated (checked out to client threads, or idle in the pool) at one time. When non-positive, there is no limit to the number of connections per server. When maxActive is reached, the connection pool for that server is said to be exhausted. The default setting for this parameter is -1, i.e. there is no limit.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="max-idle" type="xs:int" default="-1">
+    <xs:attribute name="max-idle" type="xs:int" default="${ConnectionPool.maxIdle}">
       <xs:annotation>
         <xs:documentation>
           Controls the maximum number of idle persistent connections, per server, at any time. When negative, there is no limit to the number of connections that may be idle per server. The default setting for this parameter is -1.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="max-total" type="xs:int" default="-1">
+    <xs:attribute name="max-total" type="xs:int" default="-${ConnectionPool.maxTotal}">
       <xs:annotation>
         <xs:documentation>
           Sets a global limit on the number persistent connections that can be in circulation within the combined set of servers. When non-positive, there is no limit to the total number of persistent connections in circulation. When maxTotal is exceeded, all connections pools are exhausted. The default setting for this parameter is -1 (no limit).
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="min-idle-time" type="xs:int" default="1">
+    <xs:attribute name="min-idle-time" type="xs:int" default="${ConnectionPool.minIdle}">
       <xs:annotation>
         <xs:documentation>
           Sets a target value for the minimum number of idle connections (per server) that should always be available. If this parameter is set to a positive number and timeBetweenEvictionRunsMillis > 0, each time the idle connection eviction thread runs, it will try to create enough idle instances so that there will be minIdle idle instances available for each server. The default setting for this parameter is 1.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="eviction-interval" type="xs:long" default="120000">
+    <xs:attribute name="eviction-interval" type="xs:long" default="${ConnectionPool.timeBetweenEvictionRuns}">
       <xs:annotation>
         <xs:documentation>
           Indicates how long the eviction thread should sleep before "runs" of examining idle connections. When non-positive, no eviction thread will be launched. The default setting for this parameter is 2 minutes.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="min-evictable-idle-time" type="xs:long" default="1800000">
+    <xs:attribute name="min-evictable-idle-time" type="xs:long" default="${ConnectionPool.minEvictableIdleTime}">
       <xs:annotation>
         <xs:documentation>
           Specifies the minimum amount of time that an connection may sit idle in the pool before it is eligible for eviction due to idle time. When non-positive, no connection will be dropped from the pool due to idle time alone. This setting has no effect unless timeBetweenEvictionRunsMillis > 0. The default setting for this parameter is 1800000(30 minutes).
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="test-idle" type="xs:boolean" default="true">
+    <xs:attribute name="test-idle" type="xs:boolean" default="${ConnectionPool.testWhileIdle}">
       <xs:annotation>
         <xs:documentation>
           Indicates whether or not idle connections should be validated by sending an TCP packet to the server, during idle connection eviction runs. Connections that fail to validate will be dropped from the pool. This setting has no effect unless timeBetweenEvictionRunsMillis > 0. The default setting for this parameter is true.

--- a/persistence/rest/pom.xml
+++ b/persistence/rest/pom.xml
@@ -101,6 +101,18 @@
                </instructions>
             </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-defaults-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>extract-defaults</id>
+                  <goals>
+                     <goal>extract-defaults</goal>
+                  </goals>
+               </execution>
+            </executions>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/AbstractRestStoreConfigurationChildBuilder.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/AbstractRestStoreConfigurationChildBuilder.java
@@ -1,5 +1,6 @@
 package org.infinispan.persistence.rest.configuration;
 
+import org.infinispan.commons.configuration.attributes.AttributeSet;
 import org.infinispan.configuration.cache.AbstractStoreConfigurationChildBuilder;
 import org.infinispan.persistence.keymappers.MarshallingTwoWayKey2StringMapper;
 import org.infinispan.persistence.rest.metadata.MetadataHelper;
@@ -12,9 +13,11 @@ import org.infinispan.persistence.rest.metadata.MetadataHelper;
  */
 public abstract class AbstractRestStoreConfigurationChildBuilder<S> extends AbstractStoreConfigurationChildBuilder<S> implements RestStoreConfigurationChildBuilder<S> {
    private final RestStoreConfigurationBuilder builder;
+   protected final AttributeSet attributes;
 
-   protected AbstractRestStoreConfigurationChildBuilder(RestStoreConfigurationBuilder builder) {
+   protected AbstractRestStoreConfigurationChildBuilder(RestStoreConfigurationBuilder builder, AttributeSet attributes) {
       super(builder);
+      this.attributes = attributes;
       this.builder = builder;
    }
 

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/ConnectionPoolConfiguration.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/ConnectionPoolConfiguration.java
@@ -1,58 +1,67 @@
 package org.infinispan.persistence.rest.configuration;
 
+import org.infinispan.commons.configuration.BuiltBy;
+import org.infinispan.commons.configuration.ConfigurationFor;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.configuration.serializing.SerializedWith;
+
 /**
  * ConnectionPoolConfiguration.
  *
  * @author Tristan Tarrant
  * @since 6.0
  */
+@BuiltBy(ConnectionPoolConfigurationBuilder.class)
 public class ConnectionPoolConfiguration {
-   private final int connectionTimeout;
-   private final int maxConnectionsPerHost;
-   private final int maxTotalConnections;
-   private final int bufferSize;
-   private final int socketTimeout;
-   private final boolean tcpNoDelay;
+   static final AttributeDefinition<Integer> CONNECTION_TIMEOUT = AttributeDefinition.builder("connectionTimeout", 60000).immutable().build();
+   static final AttributeDefinition<Integer> MAX_CONNECTIONS_PER_HOST = AttributeDefinition.builder("maxConnectionsPerHostTimeout", 4).immutable().build();
+   static final AttributeDefinition<Integer> MAX_TOTAL_CONNECTIONS = AttributeDefinition.builder("maxTotalConnections", 20).immutable().build();
+   static final AttributeDefinition<Integer> BUFFER_SIZE = AttributeDefinition.builder("bufferSize", 8192).immutable().build();
+   static final AttributeDefinition<Integer> SOCKET_TIMEOUT = AttributeDefinition.builder("socketTimeout", 60000).immutable().build();
+   static final AttributeDefinition<Boolean> TCP_NO_DELAY = AttributeDefinition.builder("tcpNoDelay", true).immutable().build();
 
-   ConnectionPoolConfiguration(int connectionTimeout, int maxConnectionsPerHost, int maxTotalConnections, int bufferSize, int socketTimeout,
-         boolean tcpNoDelay) {
-      this.connectionTimeout = connectionTimeout;
-      this.maxConnectionsPerHost = maxConnectionsPerHost;
-      this.maxTotalConnections = maxTotalConnections;
-      this.bufferSize = bufferSize;
-      this.socketTimeout = socketTimeout;
-      this.tcpNoDelay = tcpNoDelay;
+   static AttributeSet attributeDefinitionSet() {
+      return new AttributeSet(ConnectionPoolConfiguration.class, CONNECTION_TIMEOUT, MAX_CONNECTIONS_PER_HOST,
+            MAX_TOTAL_CONNECTIONS, BUFFER_SIZE, SOCKET_TIMEOUT, TCP_NO_DELAY);
+   }
+
+   private final AttributeSet attributes;
+
+   public ConnectionPoolConfiguration(AttributeSet attributes) {
+      this.attributes = attributes;
    }
 
    public int connectionTimeout() {
-      return connectionTimeout;
+      return attributes.attribute(CONNECTION_TIMEOUT).get();
    }
 
    public int maxConnectionsPerHost() {
-      return maxConnectionsPerHost;
+      return attributes.attribute(MAX_CONNECTIONS_PER_HOST).get();
    }
 
    public int maxTotalConnections() {
-      return maxTotalConnections;
+      return attributes.attribute(MAX_TOTAL_CONNECTIONS).get();
    }
 
    public int bufferSize() {
-      return bufferSize;
+      return attributes.attribute(BUFFER_SIZE).get();
    }
 
    public int socketTimeout() {
-      return socketTimeout;
+      return attributes.attribute(SOCKET_TIMEOUT).get();
    }
 
    public boolean tcpNoDelay() {
-      return tcpNoDelay;
+      return attributes.attribute(TCP_NO_DELAY).get();
    }
 
    @Override
    public String toString() {
-      return "ConnectionPoolConfiguration [connectionTimeout=" + connectionTimeout + ", maxConnectionsPerHost=" + maxConnectionsPerHost + ", maxTotalConnections="
-            + maxTotalConnections + ", bufferSize=" + bufferSize + ", socketTimeout=" + socketTimeout + ", tcpNoDelay="
-            + tcpNoDelay + "]";
+      return "ConnectionPoolConfiguration [connectionTimeout=" + connectionTimeout() + ", maxConnectionsPerHost=" + maxConnectionsPerHost() + ", maxTotalConnections="
+            + maxTotalConnections() + ", bufferSize=" + bufferSize() + ", socketTimeout=" + socketTimeout() + ", tcpNoDelay="
+            + tcpNoDelay() + "]";
    }
 
    @Override
@@ -62,23 +71,23 @@ public class ConnectionPoolConfiguration {
 
       ConnectionPoolConfiguration that = (ConnectionPoolConfiguration) o;
 
-      if (connectionTimeout != that.connectionTimeout) return false;
-      if (maxConnectionsPerHost != that.maxConnectionsPerHost) return false;
-      if (maxTotalConnections != that.maxTotalConnections) return false;
-      if (bufferSize != that.bufferSize) return false;
-      if (socketTimeout != that.socketTimeout) return false;
-      return tcpNoDelay == that.tcpNoDelay;
+      if (connectionTimeout() != that.connectionTimeout()) return false;
+      if (maxConnectionsPerHost() != that.maxConnectionsPerHost()) return false;
+      if (maxTotalConnections() != that.maxTotalConnections()) return false;
+      if (bufferSize() != that.bufferSize()) return false;
+      if (socketTimeout() != that.socketTimeout()) return false;
+      return tcpNoDelay() == that.tcpNoDelay();
 
    }
 
    @Override
    public int hashCode() {
-      int result = connectionTimeout;
-      result = 31 * result + maxConnectionsPerHost;
-      result = 31 * result + maxTotalConnections;
-      result = 31 * result + bufferSize;
-      result = 31 * result + socketTimeout;
-      result = 31 * result + (tcpNoDelay ? 1 : 0);
+      int result = connectionTimeout();
+      result = 31 * result + maxConnectionsPerHost();
+      result = 31 * result + maxTotalConnections();
+      result = 31 * result + bufferSize();
+      result = 31 * result + socketTimeout();
+      result = 31 * result + (tcpNoDelay() ? 1 : 0);
       return result;
    }
 }

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/ConnectionPoolConfigurationBuilder.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/configuration/ConnectionPoolConfigurationBuilder.java
@@ -18,6 +18,13 @@
  */
 package org.infinispan.persistence.rest.configuration;
 
+import static org.infinispan.persistence.rest.configuration.ConnectionPoolConfiguration.BUFFER_SIZE;
+import static org.infinispan.persistence.rest.configuration.ConnectionPoolConfiguration.CONNECTION_TIMEOUT;
+import static org.infinispan.persistence.rest.configuration.ConnectionPoolConfiguration.MAX_CONNECTIONS_PER_HOST;
+import static org.infinispan.persistence.rest.configuration.ConnectionPoolConfiguration.MAX_TOTAL_CONNECTIONS;
+import static org.infinispan.persistence.rest.configuration.ConnectionPoolConfiguration.SOCKET_TIMEOUT;
+import static org.infinispan.persistence.rest.configuration.ConnectionPoolConfiguration.TCP_NO_DELAY;
+
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 
@@ -30,47 +37,41 @@ import org.infinispan.configuration.global.GlobalConfiguration;
  */
 public class ConnectionPoolConfigurationBuilder extends AbstractRestStoreConfigurationChildBuilder<RestStoreConfigurationBuilder> implements
       Builder<ConnectionPoolConfiguration> {
-   private int connectionTimeout = 60000;
-   private int maxConnectionsPerHost = 4;
-   private int maxTotalConnections = 20;
-   private int bufferSize = 8192;
-   private int socketTimeout = 60000;
-   private boolean tcpNoDelay = true;
 
    ConnectionPoolConfigurationBuilder(RestStoreConfigurationBuilder builder) {
-      super(builder);
+      super(builder, ConnectionPoolConfiguration.attributeDefinitionSet());
    }
 
    /**
     * Controls the maximum number of connections per host.
     */
    public ConnectionPoolConfigurationBuilder maxConnectionsPerHost(int maxConnectionsPerHost) {
-      this.maxConnectionsPerHost = maxConnectionsPerHost;
+      attributes.attribute(MAX_CONNECTIONS_PER_HOST).set(maxConnectionsPerHost);
       return this;
    }
 
    public ConnectionPoolConfigurationBuilder maxTotalConnections(int maxTotalConnections) {
-      this.maxTotalConnections = maxTotalConnections;
+      attributes.attribute(MAX_TOTAL_CONNECTIONS).set(maxTotalConnections);
       return this;
    }
 
    public ConnectionPoolConfigurationBuilder connectionTimeout(int connectionTimeout) {
-      this.connectionTimeout = connectionTimeout;
+      attributes.attribute(CONNECTION_TIMEOUT).set(connectionTimeout);
       return this;
    }
 
    public ConnectionPoolConfigurationBuilder bufferSize(int bufferSize) {
-      this.bufferSize = bufferSize;
+      attributes.attribute(BUFFER_SIZE).set(bufferSize);
       return this;
    }
 
    public ConnectionPoolConfigurationBuilder socketTimeout(int socketTimeout) {
-      this.socketTimeout = socketTimeout;
+      attributes.attribute(SOCKET_TIMEOUT).set(socketTimeout);
       return this;
    }
 
    public ConnectionPoolConfigurationBuilder tcpNoDelay(boolean tcpNoDelay) {
-      this.tcpNoDelay = tcpNoDelay;
+      attributes.attribute(TCP_NO_DELAY).set(tcpNoDelay);
       return this;
    }
 
@@ -84,17 +85,17 @@ public class ConnectionPoolConfigurationBuilder extends AbstractRestStoreConfigu
 
    @Override
    public ConnectionPoolConfiguration create() {
-      return new ConnectionPoolConfiguration(connectionTimeout, maxConnectionsPerHost, maxTotalConnections, bufferSize, socketTimeout, tcpNoDelay);
+      return new ConnectionPoolConfiguration(attributes);
    }
 
    @Override
    public ConnectionPoolConfigurationBuilder read(ConnectionPoolConfiguration template) {
-      this.connectionTimeout = template.connectionTimeout();
-      this.maxConnectionsPerHost = template.maxConnectionsPerHost();
-      this.maxTotalConnections = template.maxTotalConnections();
-      this.bufferSize = template.bufferSize();
-      this.socketTimeout = template.socketTimeout();
-      this.tcpNoDelay = template.tcpNoDelay();
+      maxConnectionsPerHost(template.maxConnectionsPerHost());
+      maxTotalConnections(template.maxTotalConnections());
+      connectionTimeout(template.connectionTimeout());
+      bufferSize(template.bufferSize());
+      socketTimeout(template.socketTimeout());
+      tcpNoDelay(template.tcpNoDelay());
       return this;
    }
 }

--- a/persistence/rest/src/main/resources/schema/infinispan-cachestore-rest-config-9.0.xsd
+++ b/persistence/rest/src/main/resources/schema/infinispan-cachestore-rest-config-9.0.xsd
@@ -17,17 +17,17 @@
           <xs:element name="connection-pool" type="tns:rest-connection-pool" minOccurs="1" maxOccurs="unbounded"/>
         </xs:sequence>
 
-        <xs:attribute name="append-cache-name-to-path" type="xs:boolean" default="false">
+        <xs:attribute name="append-cache-name-to-path" type="xs:boolean" default="${RestStore.appendCacheNameToPath}">
           <xs:annotation>
             <xs:documentation>Whether to append the name of the cache to the path.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="path" type="xs:string" default="/rest/___defaultcache">
+        <xs:attribute name="path" type="xs:string" default="${RestStore.path}">
           <xs:annotation>
             <xs:documentation>The path portion of the URI of the remote REST endpoint.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="key-to-string-mapper" type="xs:string" default="org.infinispan.persistence.keymappers.MarshalledValueOrPrimitiveMapper">
+        <xs:attribute name="key-to-string-mapper" type="xs:string" default="${RestStore.key2StringMapper}">
           <xs:annotation>
             <xs:documentation>
               The name of a class to use for converting keys to strings. Defaults to
@@ -47,32 +47,32 @@
   </xs:complexType>
 
   <xs:complexType name="rest-connection-pool">
-    <xs:attribute name="buffer-size" type="xs:int" default="8192">
+    <xs:attribute name="buffer-size" type="xs:int" default="${ConnectionPool.bufferSize}">
       <xs:annotation>
         <xs:documentation>The size of the socket buffer.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="connection-timeout" type="xs:int" default="60000">
+    <xs:attribute name="connection-timeout" type="xs:int" default="${ConnectionPool.connectionTimeout}">
       <xs:annotation>
         <xs:documentation>A connection timeout for remote cache communication.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="max-connections-per-host" type="xs:int" default="4">
+    <xs:attribute name="max-connections-per-host" type="xs:int" default="${ConnectionPool.maxConnectionsPerHostTimeout}">
       <xs:annotation>
         <xs:documentation>The maximum number of connections per host.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="max-total-connections" type="xs:int" default="20">
+    <xs:attribute name="max-total-connections" type="xs:int" default="${ConnectionPool.maxTotalConnections}">
       <xs:annotation>
         <xs:documentation>The maximum number of total connections.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="socket-timeout" type="xs:int" default="60000">
+    <xs:attribute name="socket-timeout" type="xs:int" default="${ConnectionPool.socketTimeout}">
       <xs:annotation>
         <xs:documentation>A socket timeout for remote cache communication.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="tcp-no-delay" type="xs:boolean" default="true">
+    <xs:attribute name="tcp-no-delay" type="xs:boolean" default="${ConnectionPool.tcpNoDelay}">
       <xs:annotation>
         <xs:documentation>Enable/disable TCP_NODELAY on socket connections to remote Hot Rod servers.</xs:documentation>
       </xs:annotation>

--- a/persistence/rocksdb/pom.xml
+++ b/persistence/rocksdb/pom.xml
@@ -114,6 +114,18 @@
                </execution>
             </executions>
          </plugin>
+         <plugin>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-defaults-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>extract-defaults</id>
+                  <goals>
+                     <goal>extract-defaults</goal>
+                  </goals>
+               </execution>
+            </executions>
+         </plugin>
       </plugins>
    </build>
 </project>

--- a/persistence/rocksdb/src/main/resources/schema/infinispan-cachestore-rocksdb-config-9.0.xsd
+++ b/persistence/rocksdb/src/main/resources/schema/infinispan-cachestore-rocksdb-config-9.0.xsd
@@ -40,17 +40,17 @@
             </xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="block-size" type="xs:integer">
+        <xs:attribute name="block-size" type="xs:integer" default="${RocksDBStore.blockSize}">
           <xs:annotation>
             <xs:documentation>Cache store block size.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="cache-size" type="xs:long">
+        <xs:attribute name="cache-size" type="xs:long" default="${RocksDBStore.cacheSize}}">
           <xs:annotation>
             <xs:documentation>Cache size for the cache store.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="clear-threshold" type="xs:integer">
+        <xs:attribute name="clear-threshold" type="xs:integer" default="${RocksDBStore.clearThreshold}">
           <xs:annotation>
             <xs:documentation>Cache store cache clear threshold.</xs:documentation>
           </xs:annotation>
@@ -65,7 +65,7 @@
         <xs:documentation>The base directory in which to store expired cache state.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="queue-size" type="xs:integer" default="10000">
+    <xs:attribute name="queue-size" type="xs:integer" default="${RocksDBStore.expiryQueueSize}">
       <xs:annotation>
         <xs:documentation>Expired entry queue size.</xs:documentation>
       </xs:annotation>
@@ -73,7 +73,7 @@
   </xs:complexType>
 
   <xs:complexType name="rocksdb-compression">
-    <xs:attribute name="type" type="tns:rocksdb-compression-mode" default="NONE">
+    <xs:attribute name="type" type="tns:rocksdb-compression-mode" default="${RocksDBStore.compressionType}">
       <xs:annotation>
         <xs:documentation>The type of compression to be used by rocksdb store.</xs:documentation>
       </xs:annotation>

--- a/persistence/soft-index/pom.xml
+++ b/persistence/soft-index/pom.xml
@@ -15,10 +15,6 @@
 
    <dependencies>
       <dependency>
-         <groupId>${project.groupId}</groupId>
-         <artifactId>infinispan-core</artifactId>
-      </dependency>
-      <dependency>
          <groupId>org.kohsuke.metainf-services</groupId>
          <artifactId>metainf-services</artifactId>
          <optional>true</optional>
@@ -80,6 +76,18 @@
                   </Include-Resource>
                </instructions>
             </configuration>
+         </plugin>
+         <plugin>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-defaults-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>extract-defaults</id>
+                  <goals>
+                     <goal>extract-defaults</goal>
+                  </goals>
+               </execution>
+            </executions>
          </plugin>
       </plugins>
    </build>

--- a/persistence/soft-index/src/main/resources/schema/infinispan-persistence-soft-index-config-9.0.xsd
+++ b/persistence/soft-index/src/main/resources/schema/infinispan-persistence-soft-index-config-9.0.xsd
@@ -15,14 +15,14 @@
                <xs:element name="data" type="tns:data-type" minOccurs="0" maxOccurs="1" />
             </xs:sequence>
 
-            <xs:attribute name="open-files-limit" type="xs:int" default="1000">
+            <xs:attribute name="open-files-limit" type="xs:int" default="${SoftIndexFileStore.openFilesLimit}">
                <xs:annotation>
                   <xs:documentation>
                      Max number of data files opened for reading (current log file, compaction output and index segments are not included here).
                   </xs:documentation>
                </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="compaction-threshold" type="xs:double" default="0.5">
+            <xs:attribute name="compaction-threshold" type="xs:double" default="${SoftIndexFileStore.compactionThreshold}">
                <xs:annotation>
                   <xs:documentation>
                      If amount of unused space in some data file gets above this threshold, the file is compacted - entries from that file are copied to a new file and the old file is deleted.
@@ -39,21 +39,21 @@
             Configure where and how should be the entries stored - this is the persistent location.
          </xs:documentation>
       </xs:annotation>
-      <xs:attribute name="path" type="xs:string" default="Infinispan-SoftIndexFileStore-Data">
+      <xs:attribute name="path" type="xs:string" default="${SoftIndexFileStore.dataLocation}">
          <xs:annotation>
             <xs:documentation>
                A location on disk where the store writes entries. Files are written sequentially, reads are random.
             </xs:documentation>
          </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="max-file-size" type="xs:int" default="1678.016">
+      <xs:attribute name="max-file-size" type="xs:int" default="${SoftIndexFileStore.maxFileSize}">
          <xs:annotation>
             <xs:documentation>
                Max size of single file with entries, in bytes.
             </xs:documentation>
          </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="sync-writes" type="xs:boolean" default="false">
+      <xs:attribute name="sync-writes" type="xs:boolean" default="${SoftIndexFileStore.syncWrites}">
          <xs:annotation>
             <xs:documentation>
                If true, the write is confirmed only after the entry is fsynced on disk.
@@ -68,35 +68,35 @@
             Configure where and how should be the index stored.
          </xs:documentation>
       </xs:annotation>
-      <xs:attribute name="path" type="xs:string" default="Infinispan-SotfIndexFileStore-Index">
+      <xs:attribute name="path" type="xs:string" default="${SoftIndexFileStore.indexLocation}">
          <xs:annotation>
             <xs:documentation>
                A location where the store keeps index - this does not have be persistent across restarts, and SSD storage is recommended (the index is accessed randomly).
             </xs:documentation>
          </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="segments" type="xs:int" default="3">
+      <xs:attribute name="segments" type="xs:int" default="${SoftIndexFileStore.indexSegments}">
          <xs:annotation>
             <xs:documentation>
                Number of index segment files. Increasing this value improves throughput but requires more threads to be spawned.
             </xs:documentation>
          </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="max-queue-length" type="xs:int" default="1000">
+      <xs:attribute name="max-queue-length" type="xs:int" default="${SoftIndexFileStore.indexQueueLength}">
          <xs:annotation>
             <xs:documentation>
                Max number of entry writes that are waiting to be written to the index, per index segment.
             </xs:documentation>
          </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="max-node-size" type="xs:int" default="4096">
+      <xs:attribute name="max-node-size" type="xs:int" default="${SoftIndexFileStore.maxNodeSize}">
          <xs:annotation>
             <xs:documentation>
                Max size of node (continuous block on filesystem used in index implementation), in bytes.
             </xs:documentation>
          </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="min-node-size" type="xs:int" default="4096">
+      <xs:attribute name="min-node-size" type="xs:int" default="${SoftIndexFileStore.minNodeSize}">
          <xs:annotation>
             <xs:documentation>
                If the size of node (continuous block on filesystem used in index implementation) drops below this threshold, the node will try to balance its size with some neighbour node, possibly causing join of multiple nodes.

--- a/plugins/infinispan-defaults-maven-plugin/pom.xml
+++ b/plugins/infinispan-defaults-maven-plugin/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-parent</artifactId>
+        <version>9.0.0-SNAPSHOT</version>
+        <relativePath>../../parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>infinispan-defaults-maven-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+    <name>Infinispan Defaults Maven Plugin</name>
+
+    <properties>
+        <skipTests>true</skipTests>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.twdata.maven</groupId>
+            <artifactId>mojo-executor</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+            <version>${version.org.wildfly.core}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.5</version>
+                <configuration>
+                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugins/infinispan-defaults-maven-plugin/src/main/java/org/infinispan/plugins/maven/defaults/DefaultsExtractorMojo.java
+++ b/plugins/infinispan-defaults-maven-plugin/src/main/java/org/infinispan/plugins/maven/defaults/DefaultsExtractorMojo.java
@@ -1,0 +1,259 @@
+package org.infinispan.plugins.maven.defaults;
+
+import static org.twdata.maven.mojoexecutor.MojoExecutor.artifactId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.element;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executeMojo;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.executionEnvironment;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.goal;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.groupId;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.plugin;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.version;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+
+
+/**
+ * A maven plugin to extract default values from various AtributeDefinitions, output them to a specified properties/asciidoc
+ * file and process xsd files so that placeholders are replaced with the extracted defaults.
+ *
+ * @author Ryan Emerson
+ */
+@Mojo(name = "extract-defaults",
+      defaultPhase = LifecyclePhase.PROCESS_CLASSES,
+      requiresDependencyResolution = ResolutionScope.RUNTIME)
+public class DefaultsExtractorMojo extends AbstractMojo {
+
+   private enum AttributeDefType {
+      ISPN,
+      SERVER,
+      ALL
+   }
+
+   @Parameter(required = true, defaultValue = "${project.build.directory}/defaults.properties")
+   private String defaultsFile;
+
+   @Parameter(defaultValue = "ISPN")
+   private AttributeDefType attributeDefType;
+
+   @Parameter(defaultValue = "false")
+   private boolean outputAscii;
+
+   @Parameter(defaultValue = "true")
+   private boolean filterXsd;
+
+   @Parameter(defaultValue = "${project.basedir}/src/main/resources/schema")
+   private String xsdSrcPath;
+
+   @Parameter(defaultValue = "${project.build.directory}/classes/schema")
+   private String xsdTargetPath;
+
+   @Parameter
+   private List<String> jars = new ArrayList<>();
+
+   @Parameter(defaultValue = "${project}")
+   private MavenProject mavenProject;
+
+   @Parameter(defaultValue = "${session}")
+   private MavenSession mavenSession;
+
+   @Component
+   private BuildPluginManager pluginManager;
+
+   private DefaultsResolver ispnResovler = new InfinispanDefaultsResolver();
+   private DefaultsResolver serverResovler = new ServerResourceDefaultsResolver();
+   private List<String> classPaths;
+   private ClassLoader classLoader;
+
+   public void execute() throws MojoExecutionException {
+      try {
+         this.classPaths = mavenProject.getCompileClasspathElements();
+
+         URL[] classLoaderUrls = classPaths.stream()
+               .map(strPath -> FileSystems.getDefault().getPath(strPath))
+               .map(this::pathToUrl)
+               .toArray(URL[]::new);
+
+         this.classLoader = new URLClassLoader(classLoaderUrls, Thread.currentThread().getContextClassLoader());
+      } catch (DependencyResolutionRequiredException e) {
+         throw new MojoExecutionException("Exception encountered during class extraction", e);
+      }
+
+      Set<Class> configClasses = new HashSet<>();
+      getClassesFromClasspath(configClasses);
+      jars.forEach(jar -> getClassesFromJar(jar, configClasses));
+      Map<String, String> defaults = extractDefaults(configClasses);
+      writeDefaultsToFile(defaults);
+
+      if (filterXsd)
+         filterXsdSchemas();
+   }
+
+   private boolean isValidClass(String className) {
+      return ispnResovler.isValidClass(className) || serverResovler.isValidClass(className);
+   }
+
+   private Map<String, String> extractDefaults(Set<Class> classes) {
+      String separator = outputAscii ? "-" : ".";
+      Map<String, String> defaults = new HashMap<>();
+      boolean extractAll = attributeDefType == AttributeDefType.ALL;
+      if (extractAll || attributeDefType == AttributeDefType.ISPN)
+         defaults.putAll(ispnResovler.extractDefaults(classes, separator));
+
+      if (extractAll || attributeDefType == AttributeDefType.SERVER)
+         defaults.putAll(serverResovler.extractDefaults(classes, separator));
+
+      return defaults;
+   }
+
+   private URL pathToUrl(Path path) {
+      try {
+         return path.toUri().toURL();
+      } catch (MalformedURLException ignore) {
+         return null;
+      }
+   }
+
+   private void getClassesFromClasspath(Set<Class> classes) throws MojoExecutionException {
+      try {
+         FileSystem fs = FileSystems.getDefault();
+         PathMatcher classDir = fs.getPathMatcher("glob:*/**/target/classes");
+
+         List<File> packageRoots = classPaths.stream()
+               .map(fs::getPath)
+               .filter(classDir::matches)
+               .map(Path::toFile)
+               .collect(Collectors.toList());
+
+         for (File packageRoot : packageRoots)
+            getClassesInPackage(packageRoot, "", classes);
+      } catch (ClassNotFoundException e) {
+         throw new MojoExecutionException("Exception encountered during class extraction", e);
+      }
+   }
+
+   private void getClassesInPackage(File packageDir, String packageName, Set<Class> classes) throws ClassNotFoundException {
+      if (packageDir.exists()) {
+         for (File file : packageDir.listFiles()) {
+            String fileName = file.getName();
+            if (file.isDirectory()) {
+               String subpackage = packageName.isEmpty() ? fileName : packageName + "." + fileName;
+               getClassesInPackage(file, subpackage, classes);
+            } else if (isValidClass(fileName)) {
+               String className = fileName.substring(0, fileName.length() - 6);
+               classes.add(Class.forName(packageName + "." + className, true, classLoader));
+            }
+         }
+      }
+   }
+
+   private void getClassesFromJar(String jarName, Set<Class> classes) {
+      // Ignore version number, necessary as jar is loaded differently when sub module is installed in isolation
+      Optional<String> jarPath = classPaths.stream().filter(str -> str.contains(jarName)).findFirst();
+      if (jarPath.isPresent()) {
+         try {
+            ZipInputStream jar = new ZipInputStream(new FileInputStream(jarPath.get()));
+            for (ZipEntry entry = jar.getNextEntry(); entry != null; entry = jar.getNextEntry()) {
+               if (!entry.isDirectory() && isValidClass(entry.getName())) {
+                  String className = entry.getName().replace("/", ".");
+                  classes.add(Class.forName(className.substring(0, className.length() - 6), true, classLoader));
+               }
+            }
+         } catch (IOException | ClassNotFoundException e) {
+            getLog().error(String.format("Unable to process jar '%s'", jarName), e);
+         }
+      } else {
+         throw new IllegalArgumentException("Jar '" + jarName + "' not on the classpath");
+      }
+   }
+
+   private void writeDefaultsToFile(Map<String, String> defaults) throws MojoExecutionException {
+      File file = new File(defaultsFile);
+      if (file.getParentFile() != null)
+         file.getParentFile().mkdirs();
+
+      try (PrintWriter printWriter = new PrintWriter(new BufferedWriter(new FileWriter(file, true)))) {
+         defaults.entrySet().stream()
+               .map(this::formatOutput)
+               .sorted()
+               .forEach(printWriter::println);
+         printWriter.flush();
+      } catch (IOException e) {
+         throw new MojoExecutionException(String.format("Unable to write extracted defaults to the path '%s'", defaultsFile), e);
+      }
+   }
+
+   private String formatOutput(Map.Entry<String, String> entry) {
+      if (outputAscii) {
+         return ":" + entry.getKey() + ":" + entry.getValue();
+      }
+      return entry.getKey() + " = " + entry.getValue();
+   }
+
+   private void filterXsdSchemas() throws MojoExecutionException {
+      executeMojo(
+            plugin(
+                  groupId("org.apache.maven.plugins"),
+                  artifactId("maven-resources-plugin"),
+                  version("2.6")
+            ),
+            goal("copy-resources"),
+            configuration(
+                  element("overwrite", "true"),
+                  element("outputDirectory", defaultsFile),
+                  element("resources",
+                        element("resource",
+                              element("directory", xsdSrcPath),
+                              element("targetPath", xsdTargetPath),
+                              element("includes",
+                                    element("include", "*.xsd")
+                              ),
+                              element("filtering", "true")
+                        )
+                  ),
+                  element("filters",
+                        element("filter", defaultsFile)
+                  )
+            ),
+            executionEnvironment(
+                  mavenProject,
+                  mavenSession,
+                  pluginManager
+            )
+      );
+   }
+}

--- a/plugins/infinispan-defaults-maven-plugin/src/main/java/org/infinispan/plugins/maven/defaults/DefaultsResolver.java
+++ b/plugins/infinispan-defaults-maven-plugin/src/main/java/org/infinispan/plugins/maven/defaults/DefaultsResolver.java
@@ -1,0 +1,15 @@
+package org.infinispan.plugins.maven.defaults;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Interface used by {@link org.infinispan.plugins.maven.defaults.DefaultsExtractorMojo} to extract default default
+ * values from AttributeDefinitions.
+ *
+ * @author Ryan Emerson
+ */
+interface DefaultsResolver {
+   boolean isValidClass(String className);
+   Map<String, String> extractDefaults(Set<Class> classes, String separator);
+}

--- a/plugins/infinispan-defaults-maven-plugin/src/main/java/org/infinispan/plugins/maven/defaults/InfinispanDefaultsResolver.java
+++ b/plugins/infinispan-defaults-maven-plugin/src/main/java/org/infinispan/plugins/maven/defaults/InfinispanDefaultsResolver.java
@@ -1,0 +1,69 @@
+package org.infinispan.plugins.maven.defaults;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+
+/**
+ * {@link DefaultsResolver} implementation that extracts default values from ISPN {@link AttributeDefinition}s
+ *
+ * @author Ryan Emerson
+ */
+class InfinispanDefaultsResolver implements DefaultsResolver {
+
+   @Override
+   public boolean isValidClass(String className) {
+      return className.endsWith("Configuration.class") && !className.contains("$");
+   }
+
+   @Override
+   public Map<String, String> extractDefaults(Set<Class> classes, String separator) {
+      Map<String, String> map = new HashMap<>();
+      for (Class clazz : classes) {
+         AttributeSet attributeSet = getAttributeSet(clazz);
+         if (attributeSet == null)
+            continue;
+
+         attributeSet.attributes().stream()
+               .map(Attribute::getAttributeDefinition)
+               .filter(definition -> definition.getDefaultValue() != null)
+               .forEach(definition -> map.put(getOutputKey(clazz, definition, separator), getOutputValue(definition)));
+      }
+      return map;
+   }
+
+   private AttributeSet getAttributeSet(Class clazz) {
+      Field[] declaredFields = clazz.getDeclaredFields();
+      List<AttributeDefinition> attributeDefinitions = new ArrayList<>();
+      for (Field field : declaredFields) {
+         if (Modifier.isStatic(field.getModifiers()) && AttributeDefinition.class.isAssignableFrom(field.getType())) {
+            field.setAccessible(true);
+            try {
+               attributeDefinitions.add((AttributeDefinition) field.get(null));
+            } catch (IllegalAccessException ignore) {
+               // Shouldn't happen as we have setAccessible == true
+            }
+         }
+      }
+      return new AttributeSet(clazz, attributeDefinitions.toArray(new AttributeDefinition[attributeDefinitions.size()]));
+   }
+
+   private String getOutputValue(AttributeDefinition definition) {
+      // Remove @<hashcode> from toString of classes
+      return definition.getDefaultValue().toString().split("@")[0];
+   }
+
+   private String getOutputKey(Class clazz, AttributeDefinition attribute, String seperator) {
+      String className = clazz.getSimpleName();
+      String root = className.startsWith("Configuration") ? className : className.replace("Configuration", "");
+      return root + seperator + attribute.name();
+   }
+}

--- a/plugins/infinispan-defaults-maven-plugin/src/main/java/org/infinispan/plugins/maven/defaults/ServerResourceDefaultsResolver.java
+++ b/plugins/infinispan-defaults-maven-plugin/src/main/java/org/infinispan/plugins/maven/defaults/ServerResourceDefaultsResolver.java
@@ -1,0 +1,63 @@
+package org.infinispan.plugins.maven.defaults;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+
+/**
+ * {@link DefaultsResolver} implementation that extracts default values from Wildfly {@link AttributeDefinition}s
+ *
+ * @author Ryan Emerson
+ */
+class ServerResourceDefaultsResolver implements DefaultsResolver {
+
+   @Override
+   public boolean isValidClass(String className) {
+      return className.contains("Resource") && !className.contains("$");
+   }
+
+   @Override
+   public Map<String, String> extractDefaults(Set<Class> classes, String separator) {
+      Map<String, String> map = new HashMap<>();
+      for (Class clazz : classes) {
+         getSimpleAttributeDefinitions(clazz)
+               .filter(definition -> definition.getDefaultValue() != null)
+               .forEach(definition -> map.put(getOutputKey(clazz, definition, separator), getOutputValue(definition)));
+      }
+      return map;
+   }
+
+   private Stream<SimpleAttributeDefinition> getSimpleAttributeDefinitions(Class clazz) {
+      Field[] declaredFields = clazz.getDeclaredFields();
+      List<SimpleAttributeDefinition> SimpleAttributeDefinitions = new ArrayList<>();
+      for (Field field : declaredFields) {
+         if (Modifier.isStatic(field.getModifiers()) && SimpleAttributeDefinition.class.isAssignableFrom(field.getType())) {
+            field.setAccessible(true);
+            try {
+               SimpleAttributeDefinitions.add((SimpleAttributeDefinition) field.get(null));
+            } catch (IllegalAccessException ignore) {
+               // Shouldn't happen as we have setAccessible == true
+            }
+         }
+      }
+      return SimpleAttributeDefinitions.stream();
+   }
+
+   private String getOutputValue(SimpleAttributeDefinition definition) {
+      // Remove @<hashcode> from toString of classes
+      return definition.getDefaultValue().asString().split("@")[0];
+   }
+
+   private String getOutputKey(Class clazz, AttributeDefinition attribute, String seperator) {
+      String className = clazz.getSimpleName().replace("Configuration", "").replace("Resource", "");
+      return "Server." + className + seperator + attribute.getName();
+   }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
       <module>parent</module>
       <module>commons</module>
       <module>commons-test</module>
+      <module>plugins/infinispan-defaults-maven-plugin</module>
       <module>core</module>
       <module>cloud</module>
       <module>extended-statistics</module>

--- a/server/integration/endpoint/pom.xml
+++ b/server/integration/endpoint/pom.xml
@@ -15,7 +15,6 @@
 
    <build>
       <plugins>
-         
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
@@ -90,6 +89,21 @@
                </execution>
             </executions>
          </plugin>
+         <plugin>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-defaults-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>extract-defaults</id>
+                  <goals>
+                     <goal>extract-defaults</goal>
+                  </goals>
+                  <configuration>
+                     <attributeDefType>SERVER</attributeDefType>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
       </plugins>
    </build>
 
@@ -114,6 +128,12 @@
                  <groupId>org.wildfly</groupId>
              </exclusion>
          </exclusions>
+      </dependency>
+
+      <dependency>
+         <groupId>org.infinispan.server</groupId>
+         <artifactId>infinispan-server-commons</artifactId>
+         <scope>compile</scope>
       </dependency>
 
       <dependency>

--- a/server/integration/endpoint/src/main/resources/schema/jboss-infinispan-endpoint_9_0.xsd
+++ b/server/integration/endpoint/src/main/resources/schema/jboss-infinispan-endpoint_9_0.xsd
@@ -183,7 +183,7 @@
                     other nodes. Defaults to true.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="await-initial-retrieval" type="xs:boolean" use="optional" default="true">
+        <xs:attribute name="await-initial-retrieval" type="xs:boolean" use="optional" default="${Server.TopologyStateTransfer.await-initial-retrieval}">
             <xs:annotation>
                 <xs:documentation>Configures whether to initial state retrieval should happen immediately at startup. Only applies when lazy-retrieval is false. Defaults to true.</xs:documentation>
             </xs:annotation>
@@ -380,7 +380,7 @@
             <xs:element name="
             sni" type="tns:sni" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
-        <xs:attribute name="require-ssl-client-auth" type="xs:boolean" use="optional" default="false">
+        <xs:attribute name="require-ssl-client-auth" type="xs:boolean" use="optional" default="${Server.Encryption.require-ssl-client-auth}">
             <xs:annotation>
                 <xs:documentation>Whether to require client certificate authentication. Defaults to false.</xs:documentation>
             </xs:annotation>

--- a/server/integration/infinispan/pom.xml
+++ b/server/integration/infinispan/pom.xml
@@ -32,12 +32,20 @@
             <artifactId>wildfly-threads</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-transactions</artifactId>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-commons</artifactId>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
@@ -161,6 +169,9 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
+                <configuration>
+                    <workingDirectory>${project.build.directory}</workingDirectory>
+                </configuration>
                 <executions>
                     <execution>
                         <id>serialize_component_metadata</id>
@@ -182,6 +193,21 @@
                                     <value>false</value>
                                 </systemProperty>
                             </systemProperties>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-defaults-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>extract-defaults</id>
+                        <goals>
+                            <goal>extract-defaults</goal>
+                        </goals>
+                        <configuration>
+                            <attributeDefType>SERVER</attributeDefType>
                         </configuration>
                     </execution>
                 </executions>

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BaseJDBCStoreConfigurationResource.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BaseJDBCStoreConfigurationResource.java
@@ -120,6 +120,10 @@ public class BaseJDBCStoreConfigurationResource extends BaseStoreConfigurationRe
                     .setDefaultValue(new ModelNode().set("type"))
                     .build();
 
+    static final SimpleAttributeDefinition STRING_KEYED_TABLE_PREFIX = new SimpleAttributeDefinitionBuilder("stringKeyedTablePrefix", ModelType.STRING)
+          .setDefaultValue(new ModelNode().set("ispn_entry"))
+          .build();
+
     static final ObjectTypeAttributeDefinition ID_COLUMN = ObjectTypeAttributeDefinition.
             Builder.of("id-column", COLUMN_NAME, COLUMN_TYPE).
             setAllowNull(true).

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationAdd.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationAdd.java
@@ -953,10 +953,12 @@ public abstract class CacheConfigurationAdd extends AbstractAddStepHandler imple
     }
 
     private void buildStringKeyedTable(TableManipulationConfigurationBuilder<?, ?> builder, OperationContext context, ModelNode table) throws OperationFailedException {
+        String defaultTableNamePrefix = BaseJDBCStoreConfigurationResource.STRING_KEYED_TABLE_PREFIX.getDefaultValue().asString();
         ModelNode tableNamePrefix = BaseJDBCStoreConfigurationResource.PREFIX.resolveModelAttribute(context, table);
+
         builder.batchSize(BaseJDBCStoreConfigurationResource.BATCH_SIZE.resolveModelAttribute(context, table).asInt())
               .fetchSize(BaseJDBCStoreConfigurationResource.FETCH_SIZE.resolveModelAttribute(context, table).asInt())
-              .tableNamePrefix(tableNamePrefix.isDefined() ? tableNamePrefix.asString() : "ispn_entry")
+              .tableNamePrefix(tableNamePrefix.isDefined() ? tableNamePrefix.asString() : defaultTableNamePrefix)
               .idColumnName(this.getColumnProperty(context, table, ModelKeys.ID_COLUMN, BaseJDBCStoreConfigurationResource.COLUMN_NAME, "id"))
               .idColumnType(this.getColumnProperty(context, table, ModelKeys.ID_COLUMN, BaseJDBCStoreConfigurationResource.COLUMN_TYPE, "VARCHAR"))
               .dataColumnName(this.getColumnProperty(context, table, ModelKeys.DATA_COLUMN, BaseJDBCStoreConfigurationResource.COLUMN_NAME, "datum"))

--- a/server/integration/infinispan/src/main/resources/schema/jboss-infinispan-core_9_0.xsd
+++ b/server/integration/infinispan/src/main/resources/schema/jboss-infinispan-core_9_0.xsd
@@ -162,7 +162,7 @@
                 <xs:documentation>Indicates the default cache for this cache container.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="start" type="tns:controller-mode" default="LAZY">
+        <xs:attribute name="start" type="tns:controller-mode" default="${Server.CacheContainer.start}">
             <xs:annotation>
                 <xs:documentation>Should this cache container be started on server startup, or lazily when requested by a service or deployment.</xs:documentation>
             </xs:annotation>
@@ -187,12 +187,12 @@
                 <xs:documentation>Defines the executor used by the state transfer. Deprecated: please use the state-transfer-thread-pool element instead.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="module" type="xs:string" default="org.jboss.as.clustering.infinispan">
+        <xs:attribute name="module" type="xs:string" default="${Server.CacheContainer.module}">
             <xs:annotation>
                 <xs:documentation>Defines the module whose class loader should be used when building this cache container.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="statistics" type="xs:boolean" default="true">
+        <xs:attribute name="statistics" type="xs:boolean" default="${Server.CacheContainer.statistics}">
             <xs:annotation>
                 <xs:documentation>Determines whether or not the cache container should collect statistics.  Keep disabled for optimal performance.</xs:documentation>
             </xs:annotation>
@@ -220,7 +220,7 @@
                 <xs:documentation>Defines the executor used for asynchronous transport communication.  Deprecated: please use the transport-thread-pool element instead.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="lock-timeout" type="xs:long" default="240000">
+        <xs:attribute name="lock-timeout" type="xs:long" default="${Server.Transport.lock-timeout}">
             <xs:annotation>
                 <xs:documentation>
                     Infinispan uses a distributed lock to maintain a coherent transaction log during state transfer or rehashing, which means that only one cache can be doing state transfer or rehashing at the same time.
@@ -234,7 +234,7 @@
                 <xs:documentation>Defines the executor used for processing remote (non-total order) commands. Deprecated: please use the remote-command-thread-pool element instead.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="strict-peer-to-peer" type="xs:boolean" default="false">
+        <xs:attribute name="strict-peer-to-peer" type="xs:boolean" default="${Server.Transport.strict-peer-to-peer}">
             <xs:annotation>
                 <xs:documentation>
                     Makes clustered operations fail with NamedCacheNotFoundException if the named cache does not exist on remote nodes.
@@ -367,7 +367,7 @@
     </xs:complexType>
 
     <xs:complexType name="global-state-path">
-        <xs:attribute name="relative-to" type="xs:string" default="jboss.server.data.dir">
+        <xs:attribute name="relative-to" type="xs:string" default="${Server.GlobalState.relative-to}">
             <xs:annotation>
                 <xs:documentation>The base directory in which to store the state</xs:documentation>
             </xs:annotation>
@@ -507,12 +507,12 @@
                             </xs:annotation>
                         </xs:element>
                     </xs:sequence>
-                    <xs:attribute name="index" type="tns:indexing" default="NONE">
+                    <xs:attribute name="index" type="tns:indexing" default="${Server.Indexing.indexing}">
                         <xs:annotation>
                             <xs:documentation>The indexing mode of the cache. Defaults to NONE.</xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
-                    <xs:attribute name="auto-config" type="xs:boolean" default="false">
+                    <xs:attribute name="auto-config" type="xs:boolean" default="${Server.Indexing.auto-config}">
                         <xs:annotation>
                             <xs:documentation>Whether or not to apply automatic index configuration based on cache type</xs:documentation>
                         </xs:annotation>
@@ -537,12 +537,12 @@
                 <xs:documentation>The name of the cache configuration which this configuration inherits from.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="start" type="tns:controller-mode" default="LAZY">
+        <xs:attribute name="start" type="tns:controller-mode" default="${Server.CacheContainer.start}">
             <xs:annotation>
                 <xs:documentation>Should this cache be started on server startup, or lazily when requested by a service or deployment.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="batching" type="xs:boolean" default="false">
+        <xs:attribute name="batching" type="xs:boolean" default="${Server.Cache.batching}">
             <xs:annotation>
                 <xs:documentation>Enables invocation batching for this cache. Defaults to false.</xs:documentation>
             </xs:annotation>
@@ -562,12 +562,12 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="statistics" type="xs:boolean" default="false">
+        <xs:attribute name="statistics" type="xs:boolean" default="${Server.Cache.statistics}">
             <xs:annotation>
                 <xs:documentation>Determines whether or not the cache should collect statistics.  Keep disabled for optimal performance.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="statistics-available" type="xs:boolean" default="true">
+        <xs:attribute name="statistics-available" type="xs:boolean" default="${Server.Cache.statistics-available}">
             <xs:annotation>
                 <xs:documentation>If set to false, statistics gathering cannot be enabled during runtime. Keep disabled for optimal performance.</xs:documentation>
             </xs:annotation>
@@ -577,7 +577,7 @@
     <xs:complexType name="local-cache">
         <xs:complexContent>
             <xs:extension base="tns:cache">
-                <xs:attribute name="simple-cache" type="xs:boolean" default="false">
+                <xs:attribute name="simple-cache" type="xs:boolean" default="${Server.Cache.simple-cache}">
                     <xs:annotation>
                         <xs:documentation>This cache will be using optimized (faster) implementation that does not support transactions/invocation batching, persistence, custom interceptors, indexing, store-as-binary or compatibility. Also, this type of cache does not support Map-Reduce jobs or Distributed Executor framework.</xs:documentation>
                     </xs:annotation>
@@ -587,22 +587,22 @@
     </xs:complexType>
 
     <xs:complexType name="locking">
-        <xs:attribute name="isolation" type="tns:isolation" default="READ_COMMITTED">
+        <xs:attribute name="isolation" type="tns:isolation" default="${Server.Locking.isolation}">
             <xs:annotation>
                 <xs:documentation>Sets the cache locking isolation level. Defaults to READ_COMMITTED. When using REPEATABLE_READ with optimistic locking, write skew checking will be enabled.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="striping" type="xs:boolean" default="false">
+        <xs:attribute name="striping" type="xs:boolean" default="${Server.Locking.striping}">
             <xs:annotation>
                 <xs:documentation>If true, a pool of shared locks is maintained for all entries that need to be locked. Otherwise, a lock is created per entry in the cache. Lock striping helps control memory footprint but may reduce concurrency in the system.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="acquire-timeout" type="xs:long" default="15000">
+        <xs:attribute name="acquire-timeout" type="xs:long" default="${Server.Locking.acquire-timeout}">
             <xs:annotation>
                 <xs:documentation>Maximum time to attempt a particular lock acquisition.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="concurrency-level" type="xs:int" default="1000">
+        <xs:attribute name="concurrency-level" type="xs:int" default="${Server.Locking.concurrency-level}">
             <xs:annotation>
                 <xs:documentation>Concurrency level for lock containers. Adjust this value according to the number of concurrent threads interacting with Infinispan.</xs:documentation>
             </xs:annotation>
@@ -610,22 +610,22 @@
     </xs:complexType>
 
     <xs:complexType name="transaction">
-        <xs:attribute name="mode" type="tns:transaction-mode" default="NONE">
+        <xs:attribute name="mode" type="tns:transaction-mode" default="${Server.Transaction.mode}">
             <xs:annotation>
                 <xs:documentation>Sets the cache transaction mode to one of NONE, NON_XA, NON_DURABLE_XA, FULL_XA.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="stop-timeout" type="xs:long" default="30000">
+        <xs:attribute name="stop-timeout" type="xs:long" default="${Server.Transaction.stop-timeout}">
             <xs:annotation>
                 <xs:documentation>If there are any ongoing transactions when a cache is stopped, Infinispan waits for ongoing remote and local transactions to finish. The amount of time to wait for is defined by the cache stop timeout.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="locking" type="tns:locking-mode" default="OPTIMISTIC">
+        <xs:attribute name="locking" type="tns:locking-mode" default="${Server.Transaction.locking}">
             <xs:annotation>
                 <xs:documentation>The locking mode for this cache, one of OPTIMISTIC or PESSIMISTIC.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="notifications" type="xs:boolean" default="true">
+        <xs:attribute name="notifications" type="xs:boolean" default="${Server.Transaction.notifications}">
             <xs:annotation>
                 <xs:documentation>
                     Enables or disables triggering transactional notifications on cache listeners. By default is enabled.
@@ -714,17 +714,17 @@
     </xs:complexType>
 
     <xs:complexType name="expiration">
-        <xs:attribute name="max-idle" type="xs:long" default="-1">
+        <xs:attribute name="max-idle" type="xs:long" default="${Server.Expiration.max-idle}">
             <xs:annotation>
                 <xs:documentation>Maximum idle time a cache entry will be maintained in the cache, in milliseconds. If the idle time is exceeded, the entry will be expired cluster-wide. -1 means the entries never expire.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="lifespan" type="xs:long" default="-1">
+        <xs:attribute name="lifespan" type="xs:long" default="${Server.Expiration.lifespan}">
             <xs:annotation>
                 <xs:documentation>Maximum lifespan of a cache entry, after which the entry is expired cluster-wide, in milliseconds. -1 means the entries never expire.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="interval" type="xs:long" default="5000">
+        <xs:attribute name="interval" type="xs:long" default="${Server.Expiration.interval}">
             <xs:annotation>
                 <xs:documentation>Interval (in milliseconds) between subsequent runs to purge expired entries from memory and any cache stores. If you wish to disable the periodic eviction process altogether, set interval to -1.</xs:documentation>
             </xs:annotation>
@@ -732,7 +732,7 @@
     </xs:complexType>
 
     <xs:complexType name="compatibility">
-        <xs:attribute name="enabled" type="xs:boolean" default="false">
+        <xs:attribute name="enabled" type="xs:boolean" default="${Server.Compatibility.enabled}">
             <xs:annotation>
                 <xs:documentation>Enables compatibility mode for this cache. Disabled by default.</xs:documentation>
             </xs:annotation>
@@ -752,7 +752,7 @@
                         <xs:documentation>Sets the clustered cache mode, ASYNC for asynchronous operation, or SYNC for synchronous operation.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="remote-timeout" type="xs:long" default="17500">
+                <xs:attribute name="remote-timeout" type="xs:long" default="${Server.ClusteredCache.remote-timeout}">
                     <xs:annotation>
                         <xs:documentation>In SYNC mode, the timeout (in ms) used to wait for an acknowledgment when making a remote call, after which the call is aborted and an exception is thrown.</xs:documentation>
                     </xs:annotation>
@@ -802,23 +802,23 @@
                         </xs:annotation>
                     </xs:element>
                 </xs:sequence>
-                <xs:attribute name="owners" type="xs:int" default="2">
+                <xs:attribute name="owners" type="xs:int" default="${Server.DistributedCache.owners}">
                     <xs:annotation>
                         <xs:documentation>Number of cluster-wide replicas for each cache entry.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="segments" type="xs:int" default="256">
+                <xs:attribute name="segments" type="xs:int" default="${Server.DistributedCache.segments}">
                     <xs:annotation>
                         <xs:documentation>Number of hash space segments (per cluster). The recommended value is 10 * cluster size. The default value is 80</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="capacity-factor" type="xs:double" default="1">
+                <xs:attribute name="capacity-factor" type="xs:double" default="${Server.DistributedCache.capacity-factor}">
                     <xs:annotation>
                         <xs:documentation>Controls the proportion of entries that will reside on the local node,
                             compared to the other nodes in the cluster. Value must be positive. The default is 1</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="l1-lifespan" type="xs:long" default="0">
+                <xs:attribute name="l1-lifespan" type="xs:long" default="${Server.DistributedCache.l1-lifespan}">
                     <xs:annotation>
                         <xs:documentation>Maximum lifespan in milliseconds of an entry placed in the L1 cache. Defaults to 0 which means L1 is disabled.</xs:documentation>
                     </xs:annotation>
@@ -840,12 +840,12 @@
                 <xs:documentation>Uniquely identifies this loader.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="shared" type="xs:boolean" default="false">
+        <xs:attribute name="shared" type="xs:boolean" default="${Server.BaseLoader.shared}">
             <xs:annotation>
                 <xs:documentation>This setting should be set to true when multiple cache instances share the same cache store (e.g., multiple nodes in a cluster using a JDBC-based CacheStore pointing to the same, shared database.) Setting this to true avoids multiple cache instances writing the same modification multiple times. If enabled, only the node where the modification originated will write to the cache store. If disabled, each individual cache reacts to a potential remote update by storing the data to the cache store.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="preload" type="xs:boolean" default="false">
+        <xs:attribute name="preload" type="xs:boolean" default="${Server.BaseLoader.preload}">
             <xs:annotation>
                 <xs:documentation>If true, when the cache starts, data stored in the cache store will be pre-loaded into memory. This is particularly useful when data in the cache store will be needed immediately after startup and you want to avoid cache operations being delayed as a result of loading this data lazily. Can be used to provide a 'warm-cache' on startup, however there is a performance penalty as startup time is affected by this process.</xs:documentation>
             </xs:annotation>
@@ -882,7 +882,7 @@
                 <xs:documentation>Uniquely identifies this store.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="shared" type="xs:boolean" default="false">
+        <xs:attribute name="shared" type="xs:boolean" default="${Server.BaseLoader.shared}">
             <xs:annotation>
                 <xs:documentation>This setting should be set to true when multiple cache instances share the same cache store (e.g., multiple nodes in a cluster using a JDBC-based CacheStore pointing to the same, shared database.) Setting this to true avoids multiple cache instances writing the same modification multiple times. If enabled, only the node where the modification originated will write to the cache store. If disabled, each individual cache reacts to a potential remote update by storing the data to the cache store.</xs:documentation>
             </xs:annotation>
@@ -892,32 +892,32 @@
                 <xs:documentation>This setting should be set to true when the underlying cache store supports transactions and it is desirable for the underlying store and the cache to remain synchronized. With this enabled any Exceptions thrown whilst writing to the underlying store will result in both the store's and cache's transactions rollingback.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="preload" type="xs:boolean" default="false">
+        <xs:attribute name="preload" type="xs:boolean" default="${Server.BaseLoader.preload}">
             <xs:annotation>
                 <xs:documentation>If true, when the cache starts, data stored in the cache store will be pre-loaded into memory. This is particularly useful when data in the cache store will be needed immediately after startup and you want to avoid cache operations being delayed as a result of loading this data lazily. Can be used to provide a 'warm-cache' on startup, however there is a performance penalty as startup time is affected by this process.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="passivation" type="xs:boolean" default="false">
+        <xs:attribute name="passivation" type="xs:boolean" default="${Server.BaseStore.passivation}">
             <xs:annotation>
                 <xs:documentation>If true, data is only written to the cache store when it is evicted from memory, a phenomenon known as 'passivation'. Next time the data is requested, it will be 'activated' which means that data will be brought back to memory and removed from the persistent store. If false, the cache store contains a copy of the contents in memory, so writes to cache result in cache store writes. This essentially gives you a 'write-through' configuration.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="fetch-state" type="xs:boolean" default="true">
+        <xs:attribute name="fetch-state" type="xs:boolean" default="${Server.BaseStore.fetch-state}">
             <xs:annotation>
                 <xs:documentation>If true, fetch persistent state when joining a cluster. If multiple cache stores are chained, only one of them can have this property enabled.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="purge" type="xs:boolean" default="true">
+        <xs:attribute name="purge" type="xs:boolean" default="${Server.BaseStore.purge}">
             <xs:annotation>
                 <xs:documentation>If true, purges this cache store when it starts up.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="singleton" type="xs:boolean" default="false">
+        <xs:attribute name="singleton" type="xs:boolean" default="${Server.BaseStore.singleton}">
             <xs:annotation>
                 <xs:documentation>If true, the singleton store cache store is enabled. SingletonStore is a delegating cache store used for situations when only one instance in a cluster should interact with the underlying store. Deprecated: A shared store should be used instead, as this limits store writes to the primary owner of a key</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="read-only" type="xs:boolean" default="false">
+        <xs:attribute name="read-only" type="xs:boolean" default="${Server.BaseStore.read-only}">
             <xs:annotation>
                 <xs:documentation>If true, the cache store will only be used to load entries. Any modifications made to the caches will not be applied to the store.</xs:documentation>
             </xs:annotation>
@@ -925,7 +925,7 @@
     </xs:complexType>
 
     <xs:complexType name="write-behind">
-        <xs:attribute name="modification-queue-size" type="xs:int" default="1024">
+        <xs:attribute name="modification-queue-size" type="xs:int" default="${Server.StoreWriteBehind.modification-queue-size}">
             <xs:annotation>
                 <xs:documentation>
                     Maximum number of entries in the asynchronous queue. When the queue is full, the store becomes write-through.
@@ -933,7 +933,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="thread-pool-size" type="xs:int" default="1">
+        <xs:attribute name="thread-pool-size" type="xs:int" default="${Server.StoreWriteBehind.thread-pool-size}">
             <xs:annotation>
                 <xs:documentation>
                     Size of the thread pool whose threads are responsible for applying the modifications to the cache store.
@@ -968,7 +968,7 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="relative-to" type="xs:string" default="jboss.server.data.dir">
+                <xs:attribute name="relative-to" type="xs:string" default="${Server.FileStore.relative-to}">
                     <xs:annotation>
                         <xs:documentation>The base directory in which to store the cache state.</xs:documentation>
                     </xs:annotation>
@@ -996,7 +996,7 @@
                         <xs:documentation>The name of the remote cache.  If undefined, the default cache will be used.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="socket-timeout" type="xs:long" default="60000">
+                <xs:attribute name="socket-timeout" type="xs:long" default="${Server.RemoteStore.socket-timeout}">
                     <xs:annotation>
                         <xs:documentation>
                             Enable/disable SO_TIMEOUT on socket connections to remote Hot Rod servers with the specified timeout, in milliseconds.
@@ -1004,21 +1004,21 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="tcp-no-delay" type="xs:boolean" default="true">
+                <xs:attribute name="tcp-no-delay" type="xs:boolean" default="${Server.RemoteStore.tcp-no-delay}">
                     <xs:annotation>
                         <xs:documentation>
                             Enable/disable TCP_NODELAY on socket connections to remote Hot Rod servers.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="hotrod-wrapping" type="xs:boolean" default="false">
+                <xs:attribute name="hotrod-wrapping" type="xs:boolean" default="${Server.RemoteStore.hotrod-wrapping}">
                     <xs:annotation>
                         <xs:documentation>
                             Ensures that, when entries are retrieved from the remote store, they will be wrapped in a format suitable for serving via HotRod. This flag must be enabled when performing a rolling upgrade
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="raw-values" type="xs:boolean" default="false">
+                <xs:attribute name="raw-values" type="xs:boolean" default="${Server.RemoteStore.raw-values}">
                     <xs:annotation>
                         <xs:documentation>
                             Enables the storage of data on the remote server in "raw" format as opposed to wrapping the entries in InternalCacheEntry. This will make the remote cache interoperable between direct RemoteCacheManager clients and RemoteCacheStore stores
@@ -1052,12 +1052,12 @@
                     <xs:element name="connection-pool" type="tns:rest-connection-pool" minOccurs="1" maxOccurs="unbounded"/>
                 </xs:sequence>
 
-                <xs:attribute name="append-cache-name-to-path" type="xs:boolean" default="false">
+                <xs:attribute name="append-cache-name-to-path" type="xs:boolean" default="${Server.RestStore.append-cache-name-to-path}">
                     <xs:annotation>
                         <xs:documentation>Whether to append the name of the cache to the path.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="path" type="xs:string" default="/rest/___defaultcache">
+                <xs:attribute name="path" type="xs:string" default="${Server.RestStore.path}">
                     <xs:annotation>
                         <xs:documentation>The path portion of the URI of the remote REST endpoint.</xs:documentation>
                     </xs:annotation>
@@ -1067,32 +1067,32 @@
     </xs:complexType>
 
     <xs:complexType name="rest-connection-pool">
-        <xs:attribute name="buffer-size" type="xs:int" default="8192">
+        <xs:attribute name="buffer-size" type="xs:int" default="${Server.RestStore.buffer-size}">
            <xs:annotation>
                <xs:documentation>The size of the socket buffer.</xs:documentation>
            </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="connection-timeout" type="xs:int" default="60000">
+        <xs:attribute name="connection-timeout" type="xs:int" default="${Server.RestStore.connection-timeout}">
            <xs:annotation>
                <xs:documentation>A connection timeout for remote cache communication.</xs:documentation>
            </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="max-connections-per-host" type="xs:int" default="4">
+        <xs:attribute name="max-connections-per-host" type="xs:int" default="${Server.RestStore.max-connections-per-host}">
            <xs:annotation>
                <xs:documentation>The maximum number of connections per host.</xs:documentation>
            </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="max-total-connections" type="xs:int" default="20">
+        <xs:attribute name="max-total-connections" type="xs:int" default="${Server.RestStore.max-total-connections}">
            <xs:annotation>
                <xs:documentation>The maximum number of total connections.</xs:documentation>
            </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="socket-timeout" type="xs:int" default="60000">
+        <xs:attribute name="socket-timeout" type="xs:int" default="${Server.RestStore.socket-timeout}">
            <xs:annotation>
                <xs:documentation>A socket timeout for remote cache communication.</xs:documentation>
            </xs:annotation>
        </xs:attribute>
-       <xs:attribute name="tcp-no-delay" type="xs:boolean" default="true">
+       <xs:attribute name="tcp-no-delay" type="xs:boolean" default="${Server.RestStore.tcp-no-delay}">
            <xs:annotation>
                <xs:documentation>Enable/disable TCP_NODELAY on socket connections to remote Hot Rod servers.</xs:documentation>
            </xs:annotation>
@@ -1145,7 +1145,7 @@
     <xs:complexType name="string-keyed-table">
         <xs:complexContent>
             <xs:extension base="tns:table">
-                <xs:attribute name="prefix" type="xs:string" default="ispn_entry">
+                <xs:attribute name="prefix" type="xs:string" default="${Server.BaseJDBCStore.stringKeyedTablePrefix}">
                     <xs:annotation>
                         <xs:documentation>Defines the prefix prepended to the cache name used when composing the name of the cache entry table.</xs:documentation>
                     </xs:annotation>
@@ -1172,22 +1172,22 @@
                 </xs:annotation>
             </xs:element>
         </xs:sequence>
-        <xs:attribute name="fetch-size" type="xs:int" default="100">
+        <xs:attribute name="fetch-size" type="xs:int" default="${Server.BaseJDBCStore.fetch-size}">
             <xs:annotation>
                 <xs:documentation>The fetch size used when querying from this table.  Used to avoid heap memory exhaustion when query is large.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="batch-size" type="xs:int" default="100">
+        <xs:attribute name="batch-size" type="xs:int" default="${Server.BaseJDBCStore.batch-size}">
             <xs:annotation>
                 <xs:documentation>The statement batch size used when modifying this table.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="create-on-start" type="xs:boolean" default="false">
+        <xs:attribute name="create-on-start" type="xs:boolean" default="${Server.BaseJDBCStore.create-on-start}">
             <xs:annotation>
                 <xs:documentation>Determines whether database tables should be created by the store on startup.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="drop-on-exit" type="xs:boolean" default="false">
+        <xs:attribute name="drop-on-exit" type="xs:boolean" default="${Server.BaseJDBCStore.drop-on-exit}">
             <xs:annotation>
                 <xs:documentation>Determines whether database tables should be dropped by the store on shutdown.</xs:documentation>
             </xs:annotation>
@@ -1252,7 +1252,7 @@
                         </xs:annotation>
                     </xs:element>
                 </xs:sequence>
-                <xs:attribute name="relative-to" type="xs:string" default="jboss.server.data.dir">
+                <xs:attribute name="relative-to" type="xs:string" default="${Server.RocksDBStore.relative-to}">
                     <xs:annotation>
                         <xs:documentation>The base directory in which to store the cache state.</xs:documentation>
                     </xs:annotation>
@@ -1290,7 +1290,7 @@
                 <xs:documentation>The base directory in which to store expired cache state.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="queue-size" type="xs:integer" default="10000">
+        <xs:attribute name="queue-size" type="xs:integer" default="${Server.RocksDBExpiration.queue-size}">
             <xs:annotation>
                 <xs:documentation>Expired entry queue size.</xs:documentation>
             </xs:annotation>
@@ -1298,7 +1298,7 @@
     </xs:complexType>
 
     <xs:complexType name="rocksdb-compression">
-        <xs:attribute name="type" type="tns:rocksdb-compression-mode" default="NONE">
+        <xs:attribute name="type" type="tns:rocksdb-compression-mode" default="${Server.RocksDBCompression.type}">
             <xs:annotation>
                 <xs:documentation>The type of compression to be used by RocksDB store.</xs:documentation>
             </xs:annotation>
@@ -1341,22 +1341,22 @@
     </xs:simpleType>
 
     <xs:complexType name="state-transfer">
-        <xs:attribute name="enabled" type="xs:boolean" default="true">
+        <xs:attribute name="enabled" type="xs:boolean" default="${Server.StateTransfer.enabled}">
             <xs:annotation>
                 <xs:documentation>If enabled, this will cause the cache to ask neighboring caches for state when it starts up, so the cache starts 'warm', although it will impact startup time.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="timeout" type="xs:long" default="240000">
+        <xs:attribute name="timeout" type="xs:long" default="${Server.StateTransfer.timeout}">
             <xs:annotation>
                 <xs:documentation>The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="chunk-size" type="xs:integer" default="512">
+        <xs:attribute name="chunk-size" type="xs:integer" default="${Server.StateTransfer.chunk-size}">
             <xs:annotation>
                 <xs:documentation>The number of cache entries to batch in each transfer.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="await-initial-transfer" type="xs:boolean" default="true">
+        <xs:attribute name="await-initial-transfer" type="xs:boolean" default="${Server.StateTransfer.await-initial-transfer}">
             <xs:annotation>
                 <xs:documentation>If enabled, this will cause the cache to wait for initial state transfer to complete before responding to requests.</xs:documentation>
             </xs:annotation>
@@ -1364,7 +1364,7 @@
     </xs:complexType>
 
     <xs:complexType name="partition-handling">
-        <xs:attribute name="enabled" type="xs:boolean" default="true">
+        <xs:attribute name="enabled" type="xs:boolean" default="${Server.PartitionHandling.enabled}">
             <xs:annotation>
                 <xs:documentation>If enabled, the cache will enter degraded mode when it loses too many nodes.</xs:documentation>
             </xs:annotation>
@@ -1395,7 +1395,7 @@
                     </xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
-                    <xs:attribute name="chunk-size" type="xs:int" default="512">
+                    <xs:attribute name="chunk-size" type="xs:int" default="${Server.BackupSiteStateTransfer.chunk-size}">
                         <xs:annotation>
                             <xs:documentation>
                                 If &gt; 0, the state will be transferred in batches of {@code chunkSize} cache entries.
@@ -1403,7 +1403,7 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
-                    <xs:attribute name="timeout" type="xs:long" default="1200000">
+                    <xs:attribute name="timeout" type="xs:long" default="${Server.BackupSiteStateTransfer.timeout}">
                         <xs:annotation>
                             <xs:documentation>
                                 The time (in milliseconds) to wait for the backup site acknowledge the state chunk
@@ -1411,7 +1411,7 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
-                    <xs:attribute name="max-retries" type="xs:int" default="30">
+                    <xs:attribute name="max-retries" type="xs:int" default="${Server.BackupSiteStateTransfer.max-retries}">
                         <xs:annotation>
                             <xs:documentation>
                                 The maximum number of retries when a push state command fails. A value &lt;= 0 (zero) mean that
@@ -1419,7 +1419,7 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
-                    <xs:attribute name="wait-time" type="xs:long" default="2000">
+                    <xs:attribute name="wait-time" type="xs:long" default="${Server.BackupSiteStateTransfer.wait-time}">
                         <xs:annotation>
                             <xs:documentation>
                                 The waiting time (in milliseconds) between each retry. The value should be &gt; 0 (zero). Default
@@ -1435,22 +1435,22 @@
                 <xs:documentation>Name of the remote site where this cache backups data.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="strategy" type="tns:mode" default="ASYNC">
+        <xs:attribute name="strategy" type="tns:mode" default="${Server.BackupSite.strategy}">
             <xs:annotation>
                 <xs:documentation>The strategy used for backing up data: "SYNC" or "ASYNC". Defaults to "ASYNC"</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="failure-policy" type="tns:backup-failure-policy" default="WARN">
+        <xs:attribute name="failure-policy" type="tns:backup-failure-policy" default="${Server.BackupSite.failure-policy}">
             <xs:annotation>
                 <xs:documentation>Decides what the system would do in case of failure during backup. Defaults to "FAIL"</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="timeout" type="xs:long" default="10000">
+        <xs:attribute name="timeout" type="xs:long" default="${Server.BackupSite.timeout}">
             <xs:annotation>
                 <xs:documentation>The timeout(millis) to be used when backing up data remotely. Defaults to 10 secs.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="enabled" type="xs:boolean" default="true">
+        <xs:attribute name="enabled" type="xs:boolean" default="${Server.BackupSite.enabled}">
             <xs:annotation>
                 <xs:documentation>If 'false' then no data is backed up to this site. Defaults to 'true'.</xs:documentation>
             </xs:annotation>
@@ -1458,12 +1458,12 @@
     </xs:complexType>
 
     <xs:complexType name="take-offline">
-        <xs:attribute name="after-failures" type="xs:int" default="0">
+        <xs:attribute name="after-failures" type="xs:int" default="${Server.BackupSite.after-failures}">
             <xs:annotation>
                 <xs:documentation>The number of failed request operations after which this site should be taken offline. Defaults to 0 (never). A negative value would mean that the site will be taken offline after 'min-wait'.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="min-wait" type="xs:long" default="0">
+        <xs:attribute name="min-wait" type="xs:long" default="${Server.BackupSite.min-wait}">
             <xs:annotation>
                 <xs:documentation>The minimal number of millis to wait before taking this site offline, even in the case 'after-failures' is reached. If smaller or equal to 0, then only 'after-failures' is considered.</xs:documentation>
             </xs:annotation>
@@ -1794,7 +1794,7 @@
                     </xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
-                    <xs:attribute name="enabled" type="xs:boolean" default="true">
+                    <xs:attribute name="enabled" type="xs:boolean" default="${Server.CacheAuthorization.enabled}">
                         <xs:annotation>
                             <xs:documentation>
                                 Enables authorization checks for this cache. Defaults to true if the authorization element is present.

--- a/server/integration/jgroups/pom.xml
+++ b/server/integration/jgroups/pom.xml
@@ -108,6 +108,21 @@
                     <parallel>none</parallel>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-defaults-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>extract-defaults</id>
+                        <goals>
+                            <goal>extract-defaults</goal>
+                        </goals>
+                        <configuration>
+                            <attributeDefType>SERVER</attributeDefType>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <description>Infinispan Server - JGroups Subsystem</description>

--- a/server/integration/jgroups/src/main/resources/schema/jboss-as-jgroups_3_0.xsd
+++ b/server/integration/jgroups/src/main/resources/schema/jboss-as-jgroups_3_0.xsd
@@ -86,7 +86,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="module" type="xs:string" default="org.wildfly.clustering.server">
+        <xs:attribute name="module" type="xs:string" default="${Server.ChannelDefinition.module}">
             <xs:annotation>
                 <xs:documentation>Indicates the module from which to load clustering services.</xs:documentation>
             </xs:annotation>
@@ -168,7 +168,7 @@
                 <xs:documentation>Provides an address/port binding for a protocol.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="module" type="xs:string" default="org.jgroups">
+        <xs:attribute name="module" type="xs:string" default="${Server.ProtocolDefinition.module}">
             <xs:annotation>
                 <xs:documentation>Indicates the module from which to load this protocol.</xs:documentation>
             </xs:annotation>
@@ -200,7 +200,7 @@
                         </xs:annotation>
                     </xs:element>
                 </xs:sequence>
-                <xs:attribute name="shared" type="xs:boolean" default="true">
+                <xs:attribute name="shared" type="xs:boolean" default="${Server.TransportDefinition.shared}">
                     <xs:annotation>
                         <xs:documentation>Indicates whether or not the channels created for this stack should use a single, shared transport.</xs:documentation>
                     </xs:annotation>

--- a/server/integration/jgroups/src/main/resources/schema/jboss-infinispan-jgroups_9_0.xsd
+++ b/server/integration/jgroups/src/main/resources/schema/jboss-infinispan-jgroups_9_0.xsd
@@ -86,7 +86,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="module" type="xs:string" default="org.wildfly.clustering.server">
+        <xs:attribute name="module" type="xs:string" default="${Server.ChannelDefinition.module}">
             <xs:annotation>
                 <xs:documentation>Indicates the module from which to load clustering services.</xs:documentation>
             </xs:annotation>
@@ -173,7 +173,7 @@
                 <xs:documentation>Provides an address/port binding for a protocol.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="module" type="xs:string" default="org.jgroups">
+        <xs:attribute name="module" type="xs:string" default="${Server.ProtocolDefinition.module}">
             <xs:annotation>
                 <xs:documentation>Indicates the module from which to load this protocol.</xs:documentation>
             </xs:annotation>
@@ -195,7 +195,7 @@
                         </xs:annotation>
                     </xs:element>
                 </xs:sequence>
-                <xs:attribute name="shared" type="xs:boolean" default="true">
+                <xs:attribute name="shared" type="xs:boolean" default="${Server.TransportDefinition.shared}">
                     <xs:annotation>
                         <xs:documentation>Indicates whether or not the channels created for this stack should use a single, shared transport.</xs:documentation>
                     </xs:annotation>


### PR DESCRIPTION
This consists of a java program `DefaultAttributeExtractor.java`, which outputs the default values for configuration resources found on the classpath to either a propteries file or asciidoc attributes file. The process of extracting default key/values combos are provided in the specified implementation of the DefaultsResolver interface. 

Values extracted to a defaults.proprties file, on relevant modules, are then used to apply a maven-resource filter to *.xsd files where ${...} placeholders are replaced with the relevant default values.  

For asciidoctor integration, the default values are exported to a .asciidoctor file where they are defined as attributes. To use these values you simply include the defaults.asciidoctor file and call the attribute where required, e.g. for the simple cache default can be called via `{Configuration.simpleCache}`.

@tristantarrant I have updated all of the relevant *.xsd files (AFAIK) to use default placeholders, however the asciidoc files remain the same as many of the defaults are referenced in sentences etc and need more attention.
