### PR TITLE
ISPN-7128 JMX attribute configurationAsProperties cannot be read on s…

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/format/PropertyFormatter.java
+++ b/core/src/main/java/org/infinispan/configuration/format/PropertyFormatter.java
@@ -92,7 +92,8 @@ public class PropertyFormatter {
          if (cls.getName().startsWith("org.infinispan.config") && !cls.isEnum()) {
             for (Method m : getMethods(obj.getClass())) {
                if (m.getParameterTypes().length != 0 || "toString".equals(m.getName())
-                     || "hashCode".equals(m.getName()) || "toProperties".equals(m.getName())) {
+                     || "hashCode".equals(m.getName()) || "toProperties".equals(m.getName())
+                     || m.isAnnotationPresent(Deprecated.class)) {
                   continue;
                }
                try {


### PR DESCRIPTION
…ome caches

This fix is definitely hacky, but at least fast to come up with.
Other option would be to fix the problematic InterceptorConfiguration.interceptor method, but I don't know if we want to spend time fixing deprecated methods...