### PR TITLE
ISPN-4323 Let ConditionalOperationsConcurrentTest run again

### DIFF
--- a/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentTest.java
+++ b/core/src/test/java/org/infinispan/api/ConditionalOperationsConcurrentTest.java
@@ -1,5 +1,6 @@
 package org.infinispan.api;
 
+import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -51,6 +52,7 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
       this.nodes = nodes;
       this.operations = operations;
       this.threads = threads;
+      this.validMoves = generateValidMoves();
    }
 
    protected final int nodes;
@@ -58,7 +60,7 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
    protected final int threads;
    private static final String SHARED_KEY = "thisIsTheKeyForConcurrentAccess";
 
-   private final String[] validMoves = generateValidMoves();
+   private final String[] validMoves;
 
    private final AtomicBoolean failed = new AtomicBoolean(false);
    private final AtomicBoolean quit = new AtomicBoolean(false);
@@ -76,6 +78,7 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
       quit.set(false);
       liveWorkers.set(0);
       failureMessage = "";
+      assertEquals(operations, validMoves.length);
    }
 
    @Override
@@ -288,7 +291,7 @@ public class ConditionalOperationsConcurrentTest extends MultipleCacheManagersTe
          if (state.isAfter()) {
             cycle++;
             log.tracef("Starting cycle %d", cycle);
-            if (cycle % (operations / 100) == 0) {
+            if (cycle % Math.max(operations / 100, 1) == 0) {
                print((cycle * 100 * threads / operations) + "%");
             }
             checkAfterState();


### PR DESCRIPTION
In a8af50b1a424951e20a3b0d66a3a4e04d7e16d16 the test was effectively disabled
by generating validMoves before operations field is initialized.