### PR TITLE
ISPN-7127 Broken InboundTransferTask may lose segments on restart

### DIFF
--- a/core/src/main/java/org/infinispan/statetransfer/OutboundTransferTask.java
+++ b/core/src/main/java/org/infinispan/statetransfer/OutboundTransferTask.java
@@ -182,13 +182,13 @@ public class OutboundTransferTask implements Runnable {
       } catch (Throwable t) {
          // ignore eventual exceptions caused by cancellation (have InterruptedException as the root cause)
          if (isCancelled()) {
-            log.debugf("Transfer of segments %s of cache %s to node %s cancelled", segments, cacheName, destination);
+            log.tracef("Ignoring error in already cancelled transfer to node %s, segments %s", destination, segments);
          } else {
             log.failedOutBoundTransferExecution(t);
          }
       }
       if (trace) {
-         log.tracef("Outbound transfer of segments %s of cache %s to node %s is complete", segments, cacheName, destination);
+         log.tracef("Completed outbound transfer to node %s, segments %s", destination, segments);
       }
    }
 
@@ -230,9 +230,9 @@ public class OutboundTransferTask implements Runnable {
       if (!chunks.isEmpty()) {
          if (trace) {
             if (isLast) {
-               log.tracef("Sending last chunk containing %d cache entries from segments %s of cache %s to node %s", accumulatedEntries, segments, cacheName, destination);
+               log.tracef("Sending last chunk to node %s containing %d cache entries from segments %s", destination, accumulatedEntries, segments);
             } else {
-               log.tracef("Sending %d cache entries from segments %s of cache %s to node %s", accumulatedEntries, entriesBySegment.keySet(), cacheName, destination);
+               log.tracef("Sending to node %s %d cache entries from segments %s", destination, accumulatedEntries, entriesBySegment.keySet());
             }
          }
 
@@ -245,9 +245,9 @@ public class OutboundTransferTask implements Runnable {
             cancel();
          } catch (Exception e) {
             if (isCancelled()) {
-               log.debugf("Stopping cancelled transfer of segments %s of cache %s to node %s", segments, cacheName, destination);
+               log.debugf("Stopping cancelled transfer to node %s, segments %s", destination, segments);
             } else {
-               log.errorf(e, "Failed to send entries to node %s : %s", destination, e.getMessage());
+               log.errorf(e, "Failed to send entries to node %s: %s", destination, e.getMessage());
             }
          }
       }
@@ -261,8 +261,8 @@ public class OutboundTransferTask implements Runnable {
    public void cancelSegments(Set<Integer> cancelledSegments) {
       if (segments.removeAll(cancelledSegments)) {
          if (trace) {
-            log.tracef("Cancelling outbound transfer of segments %s of cache %s to node %s (remaining segments %s)",
-                  cancelledSegments, cacheName, destination, segments);
+            log.tracef("Cancelling outbound transfer to node %s, segments %s (remaining segments %s)",
+                       destination, cancelledSegments, segments);
          }
          entriesBySegment.keySet().removeAll(cancelledSegments);  // here we do not update accumulatedEntries but this inaccuracy does not cause any harm
          if (segments.isEmpty()) {
@@ -276,7 +276,7 @@ public class OutboundTransferTask implements Runnable {
     */
    public void cancel() {
       if (runnableFuture != null && !runnableFuture.isCancelled()) {
-         log.debugf("Cancelling outbound transfer of segments %s of cache %s to node %s", segments, cacheName, destination);
+         log.debugf("Cancelling outbound transfer to node %s, segments %s", destination, segments);
          runnableFuture.cancel(true);
       }
    }

--- a/core/src/main/java/org/infinispan/statetransfer/StateProviderImpl.java
+++ b/core/src/main/java/org/infinispan/statetransfer/StateProviderImpl.java
@@ -163,7 +163,8 @@ public class StateProviderImpl implements StateProvider {
 
    public List<TransactionInfo> getTransactionsForSegments(Address destination, int requestTopologyId, Set<Integer> segments) throws InterruptedException {
       if (trace) {
-         log.tracef("Received request for transactions from node %s for segments %s of cache %s with topology id %d", destination, segments, cacheName, requestTopologyId);
+         log.tracef("Received request for transactions from node %s for cache %s, topology id %d, segments %s",
+                    destination, cacheName, requestTopologyId, segments);
       }
 
       final CacheTopology cacheTopology = getCacheTopology(requestTopologyId, destination, true);
@@ -282,8 +283,8 @@ public class StateProviderImpl implements StateProvider {
    public void startOutboundTransfer(Address destination, int requestTopologyId, Set<Integer> segments)
          throws InterruptedException {
       if (trace) {
-         log.tracef("Starting outbound transfer of segments %s to node %s with topology id %d for cache %s", segments,
-               destination, requestTopologyId, cacheName);
+         log.tracef("Starting outbound transfer to node %s for cache %s, topology id %d, segments %s", destination,
+                    cacheName, requestTopologyId, segments);
       }
 
       final CacheTopology cacheTopology = getCacheTopology(requestTopologyId, destination, false);
@@ -297,7 +298,8 @@ public class StateProviderImpl implements StateProvider {
 
    private void addTransfer(OutboundTransferTask transferTask) {
       if (trace) {
-         log.tracef("Adding outbound transfer of segments %s to %s", transferTask.getSegments(), transferTask.getDestination());
+         log.tracef("Adding outbound transfer to %s for segments %s", transferTask.getDestination(),
+                    transferTask.getSegments());
       }
       synchronized (transfersByDestination) {
          List<OutboundTransferTask> transfers = transfersByDestination.get(transferTask.getDestination());
@@ -312,7 +314,8 @@ public class StateProviderImpl implements StateProvider {
    @Override
    public void cancelOutboundTransfer(Address destination, int topologyId, Set<Integer> segments) {
       if (trace) {
-         log.tracef("Cancelling outbound transfer of segments %s to node %s with topology id %d for cache %s", segments, destination, topologyId, cacheName);
+         log.tracef("Cancelling outbound transfer to node %s for cache %s, topology id %d, segments %s", destination,
+                    cacheName, topologyId, segments);
       }
       // get the outbound transfers for this address and given segments and cancel the transfers
       synchronized (transfersByDestination) {
@@ -343,8 +346,9 @@ public class StateProviderImpl implements StateProvider {
 
    void onTaskCompletion(OutboundTransferTask transferTask) {
       if (trace) {
-         log.tracef("Removing %s outbound transfer of segments %s to %s for cache %s",
-               transferTask.isCancelled() ? "cancelled" : "completed", transferTask.getSegments(), transferTask.getDestination(), cacheName);
+         log.tracef("Removing %s outbound transfer of segments to %s for cache %s, segments %s",
+                    transferTask.isCancelled() ? "cancelled" : "completed", transferTask.getDestination(),
+                    cacheName, transferTask.getSegments());
       }
 
       removeTransfer(transferTask);

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -780,16 +780,16 @@ public interface Log extends BasicLogger {
    void couldNotInterruptThread(UUID id);
 
    @LogMessage(level = ERROR)
-   @Message(value = "No live owners found for segment %d of cache %s. Current owners are:  %s. Faulty owners: %s", id=208)
+   @Message(value = "No live owners found for segment %d of cache %s. Current owners are: %s. Faulty owners: %s", id=208)
    void noLiveOwnersFoundForSegment(int segmentId, String cacheName, Collection<Address> owners, Collection<Address> faultySources);
 
    @LogMessage(level = WARN)
-   @Message(value = "Failed to retrieve transactions for segments %s of cache %s from node %s", id=209)
-   void failedToRetrieveTransactionsForSegments(Collection<Integer> segments, String cacheName, Address source, @Cause Exception e);
+   @Message(value = "Failed to retrieve transactions of cache %s from node %s, segments %s", id=209)
+   void failedToRetrieveTransactionsForSegments(String cacheName, Address source, Collection<Integer> segments, @Cause Exception e);
 
    @LogMessage(level = WARN)
-   @Message(value = "Failed to request segments %s of cache %s from node %s (node will not be retried)", id=210)
-   void failedToRequestSegments(Collection<Integer> segments, String cacheName, Address source, @Cause Throwable e);
+   @Message(value = "Failed to request state of cache %s from node %s, segments %s", id=210)
+   void failedToRequestSegments(String cacheName, Address source, Collection<Integer> segments, @Cause Throwable e);
 
    @LogMessage(level = ERROR)
    @Message(value = "Unable to load %s from any of the following classloaders: %s", id=213)

--- a/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateConsumerTest.java
@@ -41,6 +41,7 @@ import org.infinispan.distribution.TriangleOrderManager;
 import org.infinispan.distribution.ch.impl.DefaultConsistentHash;
 import org.infinispan.distribution.ch.impl.DefaultConsistentHashFactory;
 import org.infinispan.interceptors.AsyncInterceptorChain;
+import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.infinispan.remoting.inboundhandler.DeliverOrder;
@@ -126,6 +127,7 @@ public class StateConsumerTest extends AbstractInfinispanTest {
       // create dependencies
       Cache cache = mock(Cache.class);
       when(cache.getName()).thenReturn("testCache");
+      when(cache.getStatus()).thenReturn(ComponentStatus.RUNNING);
 
       pooledExecutorService = new ThreadPoolExecutor(10, 20, 0L,
                                                      TimeUnit.MILLISECONDS, new LinkedBlockingDeque<>(),

--- a/core/src/test/java/org/infinispan/statetransfer/StateTransferRestart2Test.java
+++ b/core/src/test/java/org/infinispan/statetransfer/StateTransferRestart2Test.java
@@ -1,0 +1,154 @@
+package org.infinispan.statetransfer;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+
+import org.infinispan.Cache;
+import org.infinispan.commands.ReplicableCommand;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.global.GlobalConfigurationBuilder;
+import org.infinispan.remoting.inboundhandler.DeliverOrder;
+import org.infinispan.remoting.responses.Response;
+import org.infinispan.remoting.rpc.ResponseFilter;
+import org.infinispan.remoting.rpc.ResponseMode;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
+import org.infinispan.test.MultipleCacheManagersTest;
+import org.infinispan.test.TestingUtil;
+import org.infinispan.test.fwk.CleanupAfterMethod;
+import org.infinispan.test.fwk.TransportFlags;
+import org.infinispan.transaction.lookup.DummyTransactionManagerLookup;
+import org.jgroups.protocols.DISCARD;
+import org.testng.annotations.Test;
+
+/**
+ * Tests scenario for ISPN-7127
+ *
+ * - create nodes A, B - start node C - starts state transfer from B to C
+ * - abruptly kill B before it is able to reply to the StateRequestCommand from C
+ * - C resends the request to A
+ * - finally cluster A, C is formed where all entries are properly backed up on both nodes
+ *
+ * @author Michal Linhard
+ * @author Dan Berindei
+ * @since 5.2
+ */
+@Test(groups = "functional", testName = "statetransfer.StateTransferRestartTest")
+@CleanupAfterMethod
+public class StateTransferRestart2Test extends MultipleCacheManagersTest {
+
+   private ConfigurationBuilder cfgBuilder;
+
+   private void waitForStateTransfer(Cache... caches) throws InterruptedException {
+      StateTransferManager[] stm = new StateTransferManager[caches.length];
+      for (int i = 0; i < stm.length; i++) {
+         stm[i] = TestingUtil.extractComponent(caches[i], StateTransferManager.class);
+      }
+      while (true) {
+         boolean inProgress = false;
+         for (StateTransferManager aStm : stm) {
+            if (aStm.isStateTransferInProgress()) {
+               inProgress = true;
+               break;
+            }
+         }
+         if (!inProgress) {
+            break;
+         }
+         wait(100);
+      }
+   }
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      cfgBuilder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, true);
+      cfgBuilder.transaction().transactionManagerLookup(new DummyTransactionManagerLookup());
+      cfgBuilder.clustering().hash().numOwners(2);
+      cfgBuilder.clustering().stateTransfer().fetchInMemoryState(true);
+      cfgBuilder.clustering().stateTransfer().timeout(20000);
+
+      GlobalConfigurationBuilder gcb0 = new GlobalConfigurationBuilder().clusteredDefault();
+      addClusterEnabledCacheManager(gcb0, cfgBuilder, new TransportFlags().withFD(true));
+      GlobalConfigurationBuilder gcb1 = new GlobalConfigurationBuilder().clusteredDefault();
+      addClusterEnabledCacheManager(gcb1, cfgBuilder, new TransportFlags().withFD(true));
+   }
+
+   public void testStateTransferRestart() throws Throwable {
+      final int numKeys = 100;
+
+      log.info("waiting for cluster { c0, c1 }");
+      waitForClusterToForm();
+
+      log.info("putting in data");
+      final Cache<Object, Object> c0 = cache(0);
+      final Cache<Object, Object> c1 = cache(1);
+      for (int k = 0; k < numKeys; k++) {
+         c0.put(k, k);
+      }
+      waitForStateTransfer(c0, c1);
+
+      assertEquals(numKeys, c0.entrySet().size());
+      assertEquals(numKeys, c1.entrySet().size());
+
+      GlobalConfigurationBuilder gcb2 = new GlobalConfigurationBuilder();
+      gcb2.transport().transport(new JGroupsTransport() {
+         @Override
+         public CompletableFuture<Map<Address, Response>> invokeRemotelyAsync(Collection<Address> recipients,
+                                                                              ReplicableCommand rpcCommand,
+                                                                              ResponseMode mode,
+                                                                              long timeout,
+                                                                              ResponseFilter responseFilter,
+                                                                              DeliverOrder deliverOrder,
+                                                                              boolean anycast)
+               throws Exception {
+            if (rpcCommand instanceof StateRequestCommand &&
+                  ((StateRequestCommand) rpcCommand).getType() == StateRequestCommand.Type.START_STATE_TRANSFER &&
+                  recipients.contains(address(1))) {
+               DISCARD d1 = TestingUtil.getDiscardForCache(c1);
+               d1.setDiscardAll(true);
+               d1.setExcludeItself(true);
+
+               fork(new Callable<Void>() {
+                  @Override
+                  public Void call() throws Exception {
+                     log.info("KILLING the c1 cache");
+                     try {
+                        TestingUtil.killCacheManagers(manager(c1));
+                     } catch (Exception e) {
+                        log.info("there was some exception while killing cache");
+                     }
+                     return null;
+                  }
+               });
+            }
+            return super.invokeRemotelyAsync(recipients, rpcCommand, mode, timeout, responseFilter, deliverOrder,
+                                             anycast);
+         }
+      });
+
+      log.info("adding cache c2");
+      addClusterEnabledCacheManager(gcb2, cfgBuilder, new TransportFlags().withFD(true));
+      log.info("get c2");
+      final Cache<Object, Object> c2 = cache(2);
+
+      log.info("waiting for cluster { c0, c2 }");
+      TestingUtil.blockUntilViewsChanged(10000, 2, c0, c2);
+
+      log.infof("c0 entrySet size before : %d", c0.entrySet().size());
+      log.infof("c2 entrySet size before : %d", c2.entrySet().size());
+
+      eventually(new Condition() {
+         @Override
+         public boolean isSatisfied() throws Exception {
+            return c0.entrySet().size() == numKeys && c2.entrySet().size() == numKeys;
+         }
+      });
+
+      log.info("Ending the test");
+   }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7127
- Only retry an inbound transfer when we receive a new cache topology.
- Move the segment list to the end of log messages
