### PR TITLE
Fix compilation error in integration tests

### DIFF
--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestHotRodTest.java
@@ -18,11 +18,10 @@ import java.util.Locale;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -70,7 +69,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
             "<hey>ho</hey>".getBytes(), "application/octet-stream"));
       HttpClient restClient = cacheFactory.getRestClient();
       restClient.executeMethod(put);
-      assertEquals(HttpServletResponse.SC_OK, put.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, put.getStatusCode());
       assertEquals("", put.getResponseBodyAsString().trim());
 
       // 2. Get with Embedded
@@ -94,7 +93,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 3. Get with REST
       HttpMethod get = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       cacheFactory.getRestClient().executeMethod(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertEquals("v1", get.getResponseBodyAsString());
    }
 
@@ -111,7 +110,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 3. Get with REST
       HttpMethod get = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       cacheFactory.getRestClient().executeMethod(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertEquals("v1", get.getResponseBodyAsString());
    }
 
@@ -130,7 +129,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       HttpMethod get = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       get.setRequestHeader("Accept", "application/x-java-serialized-object");
       cacheFactory.getRestClient().executeMethod(get);
-      assertEquals(get.getStatusText(), HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(get.getStatusText(), HttpStatus.SC_OK, get.getStatusCode());
       // REST finds the Java POJO in-memory and returns the Java serialized version
       assertEquals(p, new ObjectInputStream(get.getResponseBodyAsStream()).readObject());
    }
@@ -151,7 +150,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
 
       cacheFactory.getRestClient().executeMethod(get);
       assertEquals("application/x-java-serialized-object", get.getResponseHeader("Content-Type").getValue());
-      assertEquals(get.getStatusText(), HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(get.getStatusText(), HttpStatus.SC_OK, get.getStatusCode());
       // REST finds the Java POJO in-memory and returns the Java serialized version
       assertEquals(p, new ObjectInputStream(get.getResponseBodyAsStream()).readObject());
    }
@@ -167,14 +166,14 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       HttpMethod getJson = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       getJson.setRequestHeader("Accept", "application/json");
       cacheFactory.getRestClient().executeMethod(getJson);
-      assertEquals(getJson.getStatusText(), HttpServletResponse.SC_OK, getJson.getStatusCode());
+      assertEquals(getJson.getStatusText(), HttpStatus.SC_OK, getJson.getStatusCode());
       assertEquals("{\"name\":\"Anna\"}", getJson.getResponseBodyAsString());
 
       // 3. Get with REST (accept application/xml)
       HttpMethod getXml = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       getXml.setRequestHeader("Accept", "application/xml");
       cacheFactory.getRestClient().executeMethod(getXml);
-      assertEquals(getXml.getStatusText(), HttpServletResponse.SC_OK, getXml.getStatusCode());
+      assertEquals(getXml.getStatusText(), HttpStatus.SC_OK, getXml.getStatusCode());
       assertTrue(getXml.getResponseBodyAsString().contains("<name>Anna</name>"));
    }
 
@@ -190,14 +189,14 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       HttpMethod getJson = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       getJson.setRequestHeader("Accept", "application/json");
       cacheFactory.getRestClient().executeMethod(getJson);
-      assertEquals(getJson.getStatusText(), HttpServletResponse.SC_OK, getJson.getStatusCode());
+      assertEquals(getJson.getStatusText(), HttpStatus.SC_OK, getJson.getStatusCode());
       assertEquals("{\"name\":\"Jakub\"}", getJson.getResponseBodyAsString());
 
       // 3. Get with REST (accept application/xml)
       HttpMethod getXml = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       getXml.setRequestHeader("Accept", "application/xml");
       cacheFactory.getRestClient().executeMethod(getXml);
-      assertEquals(getXml.getStatusText(), HttpServletResponse.SC_OK, getXml.getStatusCode());
+      assertEquals(getXml.getStatusText(), HttpStatus.SC_OK, getXml.getStatusCode());
       assertTrue(getXml.getResponseBodyAsString().contains("<name>Jakub</name>"));
    }
 
@@ -236,7 +235,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 3. HEAD with REST key1
       HttpMethod headKey1 = new HeadMethod(cacheFactory.getRestUrl() + "/" + key1);
       cacheFactory.getRestClient().executeMethod(headKey1);
-      assertEquals(HttpServletResponse.SC_OK, headKey1.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, headKey1.getStatusCode());
       Header expires = headKey1.getResponseHeader("Expires");
       assertNotNull(expires);
       assertTrue(dateFormat.parse(expires.getValue()).after(new GregorianCalendar(2013, 1, 1).getTime()));
@@ -244,7 +243,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 4. HEAD with REST key2
       HttpMethod headKey2 = new HeadMethod(cacheFactory.getRestUrl() + "/" + key2);
       cacheFactory.getRestClient().executeMethod(headKey2);
-      assertEquals(HttpServletResponse.SC_OK, headKey2.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, headKey2.getStatusCode());
       assertNotNull(headKey2.getResponseHeader("Expires"));
    }
 
@@ -261,13 +260,13 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 3. Get with REST key
       HttpMethod get1 = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       cacheFactory.getRestClient().executeMethod(get1);
-      assertEquals(HttpServletResponse.SC_OK, get1.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get1.getStatusCode());
       assertDate(get1, "Expires");
 
       // 4. Get with REST key2
       HttpMethod get2 = new GetMethod(cacheFactory.getRestUrl() + "/" + key2);
       cacheFactory.getRestClient().executeMethod(get2);
-      assertEquals(HttpServletResponse.SC_OK, get2.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get2.getStatusCode());
       assertDate(get2, "Expires");
    }
 
@@ -284,13 +283,13 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 3. Get with REST key
       HttpMethod get1 = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       cacheFactory.getRestClient().executeMethod(get1);
-      assertEquals(HttpServletResponse.SC_OK, get1.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get1.getStatusCode());
       assertDate(get1, "Last-Modified");
 
       // 4. Get with REST key2
       HttpMethod get2 = new GetMethod(cacheFactory.getRestUrl() + "/" + key2);
       cacheFactory.getRestClient().executeMethod(get2);
-      assertEquals(HttpServletResponse.SC_OK, get2.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get2.getStatusCode());
       assertDate(get2, "Last-Modified");
    }
 
@@ -316,14 +315,14 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 3. Get with REST key1
       HttpMethod getHotRodValue = new GetMethod(cacheFactory.getRestUrl() + "/" + key1);
       cacheFactory.getRestClient().executeMethod(getHotRodValue);
-      assertEquals(getHotRodValue.getStatusText(), HttpServletResponse.SC_OK, getHotRodValue.getStatusCode());
+      assertEquals(getHotRodValue.getStatusText(), HttpStatus.SC_OK, getHotRodValue.getStatusCode());
       assertEquals("application/octet-stream", getHotRodValue.getResponseHeader("Content-Type").getValue());
       assertArrayEquals("v1".getBytes(), getHotRodValue.getResponseBody());
 
       // 4. Get with REST key2
       HttpMethod getEmbeddedValue = new GetMethod(cacheFactory.getRestUrl() + "/" + key2);
       cacheFactory.getRestClient().executeMethod(getEmbeddedValue);
-      assertEquals(getEmbeddedValue.getStatusText(), HttpServletResponse.SC_OK, getEmbeddedValue.getStatusCode());
+      assertEquals(getEmbeddedValue.getStatusText(), HttpStatus.SC_OK, getEmbeddedValue.getStatusCode());
       assertEquals("application/octet-stream", getEmbeddedValue.getResponseHeader("Content-Type").getValue());
       assertArrayEquals("v2".getBytes(), getEmbeddedValue.getResponseBody());
    }
@@ -342,13 +341,13 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       HttpMethod getKey1 = new HeadMethod(cacheFactory.getRestUrl() + "/" + key1);
       getKey1.setRequestHeader("Accept", "unknown-media-type");
       cacheFactory.getRestClient().executeMethod(getKey1);
-      assertEquals(getKey1.getStatusText(), HttpServletResponse.SC_BAD_REQUEST, getKey1.getStatusCode());
+      assertEquals(getKey1.getStatusText(), HttpStatus.SC_BAD_REQUEST, getKey1.getStatusCode());
 
       // 4. GET with REST key2
       HttpMethod getKey2 = new HeadMethod(cacheFactory.getRestUrl() + "/" + key2);
       getKey2.setRequestHeader("Accept", "unknown-media-type");
       cacheFactory.getRestClient().executeMethod(getKey2);
-      assertEquals(getKey2.getStatusText(), HttpServletResponse.SC_BAD_REQUEST, getKey2.getStatusCode());
+      assertEquals(getKey2.getStatusText(), HttpStatus.SC_BAD_REQUEST, getKey2.getStatusCode());
    }
 
    public void testHotRodEmbeddedPutRestGetCacheControlHeader() throws Exception {
@@ -365,13 +364,13 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       HttpMethod getKey1 = new GetMethod(cacheFactory.getRestUrl() + "/" + key1);
       getKey1.setRequestHeader("Cache-Control", "min-fresh=20");
       cacheFactory.getRestClient().executeMethod(getKey1);
-      assertEquals(getKey1.getStatusText(), HttpServletResponse.SC_NOT_FOUND, getKey1.getStatusCode());
+      assertEquals(getKey1.getStatusText(), HttpStatus.SC_NOT_FOUND, getKey1.getStatusCode());
 
       // 4. GET with REST key2, long min-fresh
       HttpMethod getKey2 = new GetMethod(cacheFactory.getRestUrl() + "/" + key2);
       getKey2.setRequestHeader("Cache-Control", "min-fresh=20");
       cacheFactory.getRestClient().executeMethod(getKey2);
-      assertEquals(getKey2.getStatusText(), HttpServletResponse.SC_NOT_FOUND, getKey2.getStatusCode());
+      assertEquals(getKey2.getStatusText(), HttpStatus.SC_NOT_FOUND, getKey2.getStatusCode());
 
       // 5. GET with REST key1, short min-fresh
       getKey1 = new GetMethod(cacheFactory.getRestUrl() + "/" + key1);
@@ -379,7 +378,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       cacheFactory.getRestClient().executeMethod(getKey1);
       assertNotNull(getKey1.getResponseHeader("Cache-Control"));
       assertTrue(getKey1.getResponseHeader("Cache-Control").getValue().contains("max-age"));
-      assertEquals(getKey1.getStatusText(), HttpServletResponse.SC_OK, getKey1.getStatusCode());
+      assertEquals(getKey1.getStatusText(), HttpStatus.SC_OK, getKey1.getStatusCode());
       assertEquals("v1", getKey1.getResponseBodyAsString());
 
       // 6. GET with REST key2, short min-fresh
@@ -387,7 +386,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       getKey2.setRequestHeader("Cache-Control", "min-fresh=3");
       cacheFactory.getRestClient().executeMethod(getKey2);
       assertTrue(getKey2.getResponseHeader("Cache-Control").getValue().contains("max-age"));
-      assertEquals(getKey2.getStatusText(), HttpServletResponse.SC_OK, getKey2.getStatusCode());
+      assertEquals(getKey2.getStatusText(), HttpStatus.SC_OK, getKey2.getStatusCode());
       assertEquals("v2", getKey2.getResponseBodyAsString());
    }
 

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestMemcachedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestMemcachedHotRodTest.java
@@ -7,10 +7,9 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -69,7 +68,7 @@ public class EmbeddedRestMemcachedHotRodTest extends AbstractInfinispanTest {
       // 3. Get with REST
       HttpMethod get = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       cacheFactory.getRestClient().executeMethod(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertEquals("text/plain", get.getResponseHeader("Content-Type").getValue());
       assertEquals("v1", get.getResponseBodyAsString());
 
@@ -89,7 +88,7 @@ public class EmbeddedRestMemcachedHotRodTest extends AbstractInfinispanTest {
       // 3. Get with REST
       HttpMethod get = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       cacheFactory.getRestClient().executeMethod(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertEquals("v1", get.getResponseBodyAsString());
 
       // 4. Get with Hot Rod
@@ -105,7 +104,7 @@ public class EmbeddedRestMemcachedHotRodTest extends AbstractInfinispanTest {
             "<hey>ho</hey>".getBytes(), "application/octet-stream"));
       HttpClient restClient = cacheFactory.getRestClient();
       restClient.executeMethod(put);
-      assertEquals(HttpServletResponse.SC_OK, put.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, put.getStatusCode());
       assertEquals("", put.getResponseBodyAsString().trim());
 
       // 2. Get with Embedded (given a marshaller, it can unmarshall the result)
@@ -137,7 +136,7 @@ public class EmbeddedRestMemcachedHotRodTest extends AbstractInfinispanTest {
       // 4. Get with REST
       HttpMethod get = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       cacheFactory.getRestClient().executeMethod(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertEquals("v1", get.getResponseBodyAsString());
    }
 

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/ReplEmbeddedRestHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/ReplEmbeddedRestHotRodTest.java
@@ -3,10 +3,9 @@ package org.infinispan.it.compatibility;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -53,7 +52,7 @@ public class ReplEmbeddedRestHotRodTest extends AbstractInfinispanTest {
             "<hey>ho</hey>".getBytes(), "application/octet-stream"));
       HttpClient restClient = cacheFactory1.getRestClient();
       restClient.executeMethod(put);
-      assertEquals(HttpServletResponse.SC_OK, put.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, put.getStatusCode());
       assertEquals("", put.getResponseBodyAsString().trim());
 
       // 2. Get with Embedded
@@ -77,7 +76,7 @@ public class ReplEmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 3. Get with REST
       HttpMethod get = new GetMethod(cacheFactory2.getRestUrl() + "/" + key);
       cacheFactory2.getRestClient().executeMethod(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertEquals("v1", get.getResponseBodyAsString());
    }
 
@@ -94,7 +93,7 @@ public class ReplEmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 3. Get with REST
       HttpMethod get = new GetMethod(cacheFactory2.getRestUrl() + "/" + key);
       cacheFactory2.getRestClient().executeMethod(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertEquals("v1", get.getResponseBodyAsString());
    }
 }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/AbstractRESTAsyncIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/AbstractRESTAsyncIT.java
@@ -16,8 +16,7 @@ import static org.junit.Assert.assertTrue;
 import java.net.URI;
 import java.util.List;
 
-import javax.servlet.http.HttpServletResponse;
-
+import org.apache.http.HttpStatus;
 import org.infinispan.arquillian.core.RemoteInfinispanServer;
 import org.junit.After;
 import org.junit.Before;
@@ -45,7 +44,7 @@ public abstract class AbstractRESTAsyncIT {
             RESTHelper.addServer(getServers().get(1).getRESTEndpoint().getInetAddress().getHostName(), getServers().get(1).getRESTEndpoint().getContextPath());
         }
         delete(fullPathKey(KEY_A));
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(KEY_A), HttpStatus.SC_NOT_FOUND);
     }
 
     @After
@@ -68,7 +67,7 @@ public abstract class AbstractRESTAsyncIT {
 
         long t1 = System.currentTimeMillis();
         for (int i = 0; i < NUM_OPERATIONS; i++) {
-            put(fullPathKey, initialXML, "application/octet-stream", HttpServletResponse.SC_OK, "performAsync", "false");
+            put(fullPathKey, initialXML, "application/octet-stream", HttpStatus.SC_OK, "performAsync", "false");
         }
         long putSyncTime = System.currentTimeMillis() - t1;
 
@@ -76,12 +75,12 @@ public abstract class AbstractRESTAsyncIT {
 
         t1 = System.currentTimeMillis();
         for (int i = 0; i < NUM_OPERATIONS; i++) {
-            put(fullPathKey, initialXML, "application/octet-stream", HttpServletResponse.SC_OK, "performAsync", "true");
+            put(fullPathKey, initialXML, "application/octet-stream", HttpStatus.SC_OK, "performAsync", "true");
         }
         long putAsyncTime = System.currentTimeMillis() - t1;
 
         assertTrue("PUT : async- " + putAsyncTime + ", sync- " + putSyncTime, putAsyncTime < putSyncTime);
-        get(fullPathKey, initialXML, HttpServletResponse.SC_OK, true, "performAsync", "true");
+        get(fullPathKey, initialXML, HttpStatus.SC_OK, true, "performAsync", "true");
     }
 
     @Test
@@ -95,11 +94,11 @@ public abstract class AbstractRESTAsyncIT {
         }
 
         for (int i = 0; i < NUM_OPERATIONS; i++) {
-            put(fullPathKey(String.valueOf(i)), bytes, "application/octet-stream", HttpServletResponse.SC_OK, "performAsync", "false");
+            put(fullPathKey(String.valueOf(i)), bytes, "application/octet-stream", HttpStatus.SC_OK, "performAsync", "false");
         }
 
         for (int i = 0; i < NUM_OPERATIONS; i++) {
-            delete(fullPathKey(String.valueOf(i)), HttpServletResponse.SC_OK, "performAsync", "true");
+            delete(fullPathKey(String.valueOf(i)), HttpStatus.SC_OK, "performAsync", "true");
         }
 
         for (int i = 0; i < NUM_OPERATIONS; i++) {
@@ -108,20 +107,20 @@ public abstract class AbstractRESTAsyncIT {
             eventually(new Condition() {
                 @Override
                 public boolean isSatisfied() throws Exception {
-                    return getWithoutAssert(fullPathKey(String.valueOf(iter)), null, HttpServletResponse.SC_NOT_FOUND, true, "performAsync", "true");
+                    return getWithoutAssert(fullPathKey(String.valueOf(iter)), null, HttpStatus.SC_NOT_FOUND, true, "performAsync", "true");
                 }
             }, 5000, 10);
         }
 
         put(fullPathKey(KEY_A), KEY_A, "application/octet-stream");
         put(fullPathKey(KEY_B), KEY_B, "application/octet-stream");
-        delete(fullPathKey(null), HttpServletResponse.SC_OK, "performAsync", "true");
+        delete(fullPathKey(null), HttpStatus.SC_OK, "performAsync", "true");
 
         eventually(new Condition() {
             @Override
             public boolean isSatisfied() throws Exception {
-                return getWithoutAssert(fullPathKey(KEY_A), null, HttpServletResponse.SC_NOT_FOUND, true) &&
-                       getWithoutAssert(fullPathKey(KEY_B), null, HttpServletResponse.SC_NOT_FOUND, true);
+                return getWithoutAssert(fullPathKey(KEY_A), null, HttpStatus.SC_NOT_FOUND, true) &&
+                       getWithoutAssert(fullPathKey(KEY_B), null, HttpStatus.SC_NOT_FOUND, true);
             }
         }, 5000, 10);
     }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/AbstractRESTClientIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/AbstractRESTClientIT.java
@@ -28,9 +28,8 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.util.Arrays;
 
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.util.EntityUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -71,10 +70,10 @@ public abstract class AbstractRESTClientIT {
         delete(fullPathKey(KEY_C));
         delete(fullPathKey(REST_NAMED_CACHE, KEY_A));
 
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(KEY_B), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(KEY_C), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(REST_NAMED_CACHE, KEY_A), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(KEY_A), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(KEY_B), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(KEY_C), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(REST_NAMED_CACHE, KEY_A), HttpStatus.SC_NOT_FOUND);
     }
 
     @After
@@ -100,13 +99,13 @@ public abstract class AbstractRESTClientIT {
         assertEquals("application/octet-stream", get.getHeaders("Content-Type")[0].getValue());
 
         delete(fullPathKey);
-        get(fullPathKey, HttpServletResponse.SC_NOT_FOUND);
+        get(fullPathKey, HttpStatus.SC_NOT_FOUND);
 
         put(fullPathKey, initialXML, "application/octet-stream");
         get(fullPathKey, initialXML);
 
         delete(fullPathKey(null));
-        get(fullPathKey, HttpServletResponse.SC_NOT_FOUND);
+        get(fullPathKey, HttpStatus.SC_NOT_FOUND);
 
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         ObjectOutputStream oo = new ObjectOutputStream(bout);
@@ -125,7 +124,7 @@ public abstract class AbstractRESTClientIT {
 
     @Test
     public void testEmptyGet() throws Exception {
-        get(fullPathKey("nodata"), HttpServletResponse.SC_NOT_FOUND);
+        get(fullPathKey("nodata"), HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -170,7 +169,7 @@ public abstract class AbstractRESTClientIT {
 
         post(fullPathKey, "data", "application/text");
         // second post, returns 409
-        post(fullPathKey, "data", "application/text", HttpServletResponse.SC_CONFLICT);
+        post(fullPathKey, "data", "application/text", HttpStatus.SC_CONFLICT);
         // Should be all ok as its a put
         put(fullPathKey, "data", "application/text");
     }
@@ -179,21 +178,21 @@ public abstract class AbstractRESTClientIT {
     public void testPutDataWithTimeToLive() throws Exception {
         URI fullPathKey = fullPathKey(KEY_A);
 
-        post(fullPathKey, "data", "application/text", HttpServletResponse.SC_OK,
+        post(fullPathKey, "data", "application/text", HttpStatus.SC_OK,
                 // headers
                 "Content-Type", "application/text", "timeToLiveSeconds", "2");
 
         get(fullPathKey, "data");
         sleepForSecs(2.1);
         // should be evicted
-        head(fullPathKey, HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey, HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
     public void testPutDataWithMaxIdleTime() throws Exception {
         URI fullPathKey = fullPathKey(KEY_A);
 
-        post(fullPathKey, "data", "application/text", HttpServletResponse.SC_OK,
+        post(fullPathKey, "data", "application/text", HttpStatus.SC_OK,
                 // headers
                 "Content-Type", "application/text", "maxIdleTimeSeconds", "2");
 
@@ -208,14 +207,14 @@ public abstract class AbstractRESTClientIT {
         // idle for 2 seconds
         sleepForSecs(2.1);
         // should be evicted
-        head(fullPathKey, HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey, HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
     public void testPutDataTTLMaxIdleCombo1() throws Exception {
         URI fullPathKey = fullPathKey(KEY_A);
 
-        post(fullPathKey, "data", "application/text", HttpServletResponse.SC_OK,
+        post(fullPathKey, "data", "application/text", HttpStatus.SC_OK,
                 // headers
                 "Content-Type", "application/text", "timeToLiveSeconds", "10", "maxIdleTimeSeconds", "2");
 
@@ -230,21 +229,21 @@ public abstract class AbstractRESTClientIT {
         // idle for 2 seconds
         sleepForSecs(2.1);
         // should be evicted
-        head(fullPathKey, HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey, HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
     public void testPutDataTTLMaxIdleCombo2() throws Exception {
         URI fullPathKey = fullPathKey(KEY_A);
 
-        post(fullPathKey, "data", "application/text", HttpServletResponse.SC_OK,
+        post(fullPathKey, "data", "application/text", HttpStatus.SC_OK,
                 // headers
                 "Content-Type", "application/text", "timeToLiveSeconds", "2", "maxIdleTimeSeconds", "10");
 
         get(fullPathKey, "data");
         sleepForSecs(2.1);
         // should be evicted
-        head(fullPathKey, HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey, HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -253,7 +252,7 @@ public abstract class AbstractRESTClientIT {
         post(fullPathKey, "data", "application/text");
         head(fullPathKey);
         delete(fullPathKey);
-        head(fullPathKey, HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey, HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -263,8 +262,8 @@ public abstract class AbstractRESTClientIT {
         head(fullPathKey(KEY_A));
         head(fullPathKey(KEY_B));
         delete(fullPathKey(null));
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(KEY_B), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(KEY_A), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(KEY_B), HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -277,7 +276,7 @@ public abstract class AbstractRESTClientIT {
         oo.flush();
         byte[] byteData = bout.toByteArray();
         put(fullPathKey, byteData, "application/x-java-serialized-object");
-        HttpResponse resp = get(fullPathKey, null, HttpServletResponse.SC_OK, false, "Accept", "application/x-java-serialized-object");
+        HttpResponse resp = get(fullPathKey, null, HttpStatus.SC_OK, false, "Accept", "application/x-java-serialized-object");
         ObjectInputStream oin = new ObjectInputStream(resp.getEntity().getContent());
         TestSerializable ts = (TestSerializable) oin.readObject();
         EntityUtils.consume(resp.getEntity());
@@ -294,7 +293,7 @@ public abstract class AbstractRESTClientIT {
         oo.flush();
         byte[] byteData = bout.toByteArray();
         put(fullPathKey, byteData, "application/x-java-serialized-object");
-        HttpResponse resp = get(fullPathKey, null, HttpServletResponse.SC_OK, false, "Accept", "application/x-java-serialized-object");
+        HttpResponse resp = get(fullPathKey, null, HttpStatus.SC_OK, false, "Accept", "application/x-java-serialized-object");
         ObjectInputStream oin = new ObjectInputStream(resp.getEntity().getContent());
         Integer i2 = (Integer) oin.readObject();
         EntityUtils.consume(resp.getEntity());
@@ -319,9 +318,9 @@ public abstract class AbstractRESTClientIT {
         //show that "application/text" works for delete
         URI fullPathKey1 = fullPathKey("j");
         put(fullPathKey1, "data1", "application/text");
-        head(fullPathKey1, HttpServletResponse.SC_OK);
+        head(fullPathKey1, HttpStatus.SC_OK);
         delete(fullPathKey1);
-        head(fullPathKey1, HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey1, HttpStatus.SC_NOT_FOUND);
 
         URI fullPathKey2 = fullPathKey("k");
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -331,9 +330,9 @@ public abstract class AbstractRESTClientIT {
         oo.flush();
         byte[] byteData = bout.toByteArray();
         put(fullPathKey2, byteData, "application/x-java-serialized-object");
-        head(fullPathKey2, HttpServletResponse.SC_OK);
+        head(fullPathKey2, HttpStatus.SC_OK);
         delete(fullPathKey2);
-        head(fullPathKey2, HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey2, HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -345,15 +344,15 @@ public abstract class AbstractRESTClientIT {
         String dateMinus = addDay(dateLast, -1);
         String datePlus = addDay(dateLast, 1);
 
-        get(fullPathKey, "data", HttpServletResponse.SC_OK, true,
+        get(fullPathKey, "data", HttpStatus.SC_OK, true,
                 // resource has been modified since
                 "If-Modified-Since", dateMinus);
 
-        get(fullPathKey, null, HttpServletResponse.SC_NOT_MODIFIED, true,
+        get(fullPathKey, null, HttpStatus.SC_NOT_MODIFIED, true,
                 // exact same date as stored one
                 "If-Modified-Since", dateLast);
 
-        get(fullPathKey, null, HttpServletResponse.SC_NOT_MODIFIED, true,
+        get(fullPathKey, null, HttpStatus.SC_NOT_MODIFIED, true,
                 // resource hasn't been modified since
                 "If-Modified-Since", datePlus);
     }
@@ -368,11 +367,11 @@ public abstract class AbstractRESTClientIT {
         String dateMinus = addDay(dateLast, -1);
         String datePlus = addDay(dateLast, 1);
 
-        get(fullPathKey, "data", HttpServletResponse.SC_OK, true, "If-Unmodified-Since", dateLast);
+        get(fullPathKey, "data", HttpStatus.SC_OK, true, "If-Unmodified-Since", dateLast);
 
-        get(fullPathKey, "data", HttpServletResponse.SC_OK, true, "If-Unmodified-Since", datePlus);
+        get(fullPathKey, "data", HttpStatus.SC_OK, true, "If-Unmodified-Since", datePlus);
 
-        get(fullPathKey, null, HttpServletResponse.SC_PRECONDITION_FAILED, true, "If-Unmodified-Since", dateMinus);
+        get(fullPathKey, null, HttpStatus.SC_PRECONDITION_FAILED, true, "If-Unmodified-Since", dateMinus);
     }
 
     @Test
@@ -382,9 +381,9 @@ public abstract class AbstractRESTClientIT {
         HttpResponse resp = get(fullPathKey);
         String eTag = resp.getHeaders("ETag")[0].getValue();
 
-        get(fullPathKey, null, HttpServletResponse.SC_NOT_MODIFIED, true, "If-None-Match", eTag);
+        get(fullPathKey, null, HttpStatus.SC_NOT_MODIFIED, true, "If-None-Match", eTag);
 
-        get(fullPathKey, "data", HttpServletResponse.SC_OK, true, "If-None-Match", eTag + "garbage");
+        get(fullPathKey, "data", HttpStatus.SC_OK, true, "If-None-Match", eTag + "garbage");
     }
 
     @Test
@@ -395,21 +394,21 @@ public abstract class AbstractRESTClientIT {
 
         String eTag = resp.getHeaders("ETag")[0].getValue();
         // test GET with If-Match behaviour
-        get(fullPathKey, "data", HttpServletResponse.SC_OK, true, "If-Match", eTag);
+        get(fullPathKey, "data", HttpStatus.SC_OK, true, "If-Match", eTag);
 
-        get(fullPathKey, null, HttpServletResponse.SC_PRECONDITION_FAILED, true, "If-Match", eTag + "garbage");
+        get(fullPathKey, null, HttpStatus.SC_PRECONDITION_FAILED, true, "If-Match", eTag + "garbage");
 
         // test HEAD with If-Match behaviour
-        head(fullPathKey, HttpServletResponse.SC_OK, new String[][]{{"If-Match", eTag}});
-        head(fullPathKey, HttpServletResponse.SC_PRECONDITION_FAILED, new String[][]{{"If-Match", eTag + "garbage"}});
+        head(fullPathKey, HttpStatus.SC_OK, new String[][]{{"If-Match", eTag}});
+        head(fullPathKey, HttpStatus.SC_PRECONDITION_FAILED, new String[][]{{"If-Match", eTag + "garbage"}});
     }
 
     @Test
     public void testNonExistentCache() throws Exception {
-        head(fullPathKey("nonexistentcache", "nodata"), HttpServletResponse.SC_NOT_FOUND);
-        get(fullPathKey("nonexistentcache", "nodata"), HttpServletResponse.SC_NOT_FOUND);
-        put(fullPathKey("nonexistentcache", "nodata"), "data", "application/text", HttpServletResponse.SC_NOT_FOUND);
-        delete(fullPathKey("nonexistentcache", "nodata"), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey("nonexistentcache", "nodata"), HttpStatus.SC_NOT_FOUND);
+        get(fullPathKey("nonexistentcache", "nodata"), HttpStatus.SC_NOT_FOUND);
+        put(fullPathKey("nonexistentcache", "nodata"), "data", "application/text", HttpStatus.SC_NOT_FOUND);
+        delete(fullPathKey("nonexistentcache", "nodata"), HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -425,7 +424,7 @@ public abstract class AbstractRESTClientIT {
         byte[] serializedData = bout.toByteArray();
         put(fullPathKey(0, KEY_Z), serializedData, "application/x-java-serialized-object");
 
-        HttpResponse resp = get(fullPathKey(0, KEY_Z), null, HttpServletResponse.SC_OK, false, "Accept",
+        HttpResponse resp = get(fullPathKey(0, KEY_Z), null, HttpStatus.SC_OK, false, "Accept",
                 "application/x-java-serialized-object");
         ObjectInputStream oin = new ObjectInputStream(resp.getEntity().getContent());
         byte[] dataBack = (byte[]) oin.readObject();

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/AbstractRESTClusteredIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/AbstractRESTClusteredIT.java
@@ -14,8 +14,7 @@ import static org.infinispan.server.test.util.ITestUtils.sleepForSecs;
 
 import java.util.List;
 
-import javax.servlet.http.HttpServletResponse;
-
+import org.apache.http.HttpStatus;
 import org.infinispan.arquillian.core.RemoteInfinispanServer;
 import org.junit.After;
 import org.junit.Before;
@@ -49,9 +48,9 @@ public abstract class AbstractRESTClusteredIT {
         delete(fullPathKey(KEY_B));
         delete(fullPathKey(KEY_C));
 
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(KEY_B), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(KEY_C), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(KEY_A), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(KEY_B), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(KEY_C), HttpStatus.SC_NOT_FOUND);
     }
 
     @After
@@ -79,7 +78,7 @@ public abstract class AbstractRESTClusteredIT {
         post(fullPathKey(0, KEY_A), "data", "text/plain");
         get(fullPathKey(1, KEY_A), "data");
         delete(fullPathKey(0, KEY_A));
-        head(fullPathKey(1, KEY_A), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_A), HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -89,18 +88,18 @@ public abstract class AbstractRESTClusteredIT {
         head(fullPathKey(0, KEY_A));
         head(fullPathKey(0, KEY_B));
         delete(fullPathKey(0, null));
-        head(fullPathKey(1, KEY_A), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(1, KEY_B), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_A), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_B), HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
     public void testReplicationTTL() throws Exception {
-        post(fullPathKey(0, KEY_A), "data", "application/text", HttpServletResponse.SC_OK,
+        post(fullPathKey(0, KEY_A), "data", "application/text", HttpStatus.SC_OK,
                 // headers
                 "Content-Type", "application/text", "timeToLiveSeconds", "2");
         head(fullPathKey(1, KEY_A));
         sleepForSecs(2.1);
         // should be evicted
-        head(fullPathKey(1, KEY_A), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_A), HttpStatus.SC_NOT_FOUND);
     }
 }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/RESTHelper.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/RESTHelper.java
@@ -20,9 +20,9 @@ import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
-import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -84,11 +84,11 @@ public class RESTHelper {
     }
 
     public static HttpResponse head(URI uri) throws Exception {
-        return head(uri, HttpServletResponse.SC_OK);
+        return head(uri, HttpStatus.SC_OK);
     }
 
     public static HttpResponse headWithoutClose(URI uri) throws Exception {
-        return head(uri, HttpServletResponse.SC_OK);
+        return head(uri, HttpStatus.SC_OK);
     }
 
     public static HttpResponse head(URI uri, int expectedCode) throws Exception {
@@ -125,19 +125,19 @@ public class RESTHelper {
     }
 
     public static HttpResponse get(URI uri) throws Exception {
-        return get(uri, HttpServletResponse.SC_OK);
+        return get(uri, HttpStatus.SC_OK);
     }
 
     public static HttpResponse getWithoutClose(URI uri) throws Exception {
-        return getWithoutClose(uri, HttpServletResponse.SC_OK);
+        return getWithoutClose(uri, HttpStatus.SC_OK);
     }
 
     public static HttpResponse get(URI uri, String expectedResponseBody) throws Exception {
-        return get(uri, expectedResponseBody, HttpServletResponse.SC_OK, true);
+        return get(uri, expectedResponseBody, HttpStatus.SC_OK, true);
     }
 
     public static HttpResponse getWithoutClose(URI uri, String expectedResponseBody) throws Exception {
-        return get(uri, expectedResponseBody, HttpServletResponse.SC_OK, false);
+        return get(uri, expectedResponseBody, HttpStatus.SC_OK, false);
     }
 
     public static HttpResponse get(URI uri, int expectedCode) throws Exception {
@@ -196,7 +196,7 @@ public class RESTHelper {
     }
 
     public static HttpResponse put(URI uri, Object data, String contentType) throws Exception {
-        return put(uri, data, contentType, HttpServletResponse.SC_OK);
+        return put(uri, data, contentType, HttpStatus.SC_OK);
     }
 
     public static HttpResponse put(URI uri, Object data, String contentType, int expectedCode) throws Exception {
@@ -251,7 +251,7 @@ public class RESTHelper {
     }
 
     public static HttpResponse post(URI uri, Object data, String contentType) throws Exception {
-        return post(uri, data, contentType, HttpServletResponse.SC_OK);
+        return post(uri, data, contentType, HttpStatus.SC_OK);
     }
 
     public static HttpResponse post(URI uri, Object data, String contentType, int expectedCode) throws Exception {

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/configs/ExampleConfigsIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/configs/ExampleConfigsIT.java
@@ -30,9 +30,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.management.ObjectName;
-import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ByteArrayEntity;
@@ -214,7 +214,7 @@ public class ExampleConfigsIT {
             post(fullPathKey(0, DEFAULT_CACHE_NAME, "disconnected", PORT_OFFSET), "source", "application/text");
 
             //Source node entries should NOT be accessible from target node
-            get(fullPathKey(1, DEFAULT_CACHE_NAME, "disconnected", 0), HttpServletResponse.SC_NOT_FOUND);
+            get(fullPathKey(1, DEFAULT_CACHE_NAME, "disconnected", 0), HttpStatus.SC_NOT_FOUND);
 
             //All remaining entries migrated?
             for (int i = 0; i < 50; i++) {
@@ -252,7 +252,7 @@ public class ExampleConfigsIT {
             // 2. Get with REST
             HttpGet get = new HttpGet(restUrl + "/" + key);
             HttpResponse getResponse = restClient.execute(get);
-            assertEquals(HttpServletResponse.SC_OK, getResponse.getStatusLine().getStatusCode());
+            assertEquals(HttpStatus.SC_OK, getResponse.getStatusLine().getStatusCode());
             assertArrayEquals("v1".getBytes(), EntityUtils.toByteArray(getResponse.getEntity()));
 
             // 3. Get with Memcached
@@ -264,7 +264,7 @@ public class ExampleConfigsIT {
             HttpPut put = new HttpPut(restUrl + "/" + key);
             put.setEntity(new ByteArrayEntity("<hey>ho</hey>".getBytes(), ContentType.APPLICATION_OCTET_STREAM));
             HttpResponse putResponse = restClient.execute(put);
-            assertEquals(HttpServletResponse.SC_OK, putResponse.getStatusLine().getStatusCode());
+            assertEquals(HttpStatus.SC_OK, putResponse.getStatusLine().getStatusCode());
 
             // 2. Get with Hot Rod
             assertArrayEquals("<hey>ho</hey>".getBytes(), (byte[]) s1Cache.get(key));
@@ -543,23 +543,23 @@ public class ExampleConfigsIT {
         post(fullPathKey(0, KEY_A), "data", "text/plain");
         get(fullPathKey(1, KEY_A), "data");
         delete(fullPathKey(0, KEY_A));
-        head(fullPathKey(1, KEY_A), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_A), HttpStatus.SC_NOT_FOUND);
         setUpREST(s1.server, s2.server);
         post(fullPathKey(0, KEY_A), "data", "text/plain");
         post(fullPathKey(0, KEY_B), "data", "text/plain");
         head(fullPathKey(0, KEY_A));
         head(fullPathKey(0, KEY_B));
         delete(fullPathKey(0, null));
-        head(fullPathKey(1, KEY_A), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(1, KEY_B), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_A), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_B), HttpStatus.SC_NOT_FOUND);
         setUpREST(s1.server, s2.server);
-        post(fullPathKey(0, KEY_A), "data", "application/text", HttpServletResponse.SC_OK,
+        post(fullPathKey(0, KEY_A), "data", "application/text", HttpStatus.SC_OK,
                 // headers
                 "Content-Type", "application/text", "timeToLiveSeconds", "2");
         head(fullPathKey(1, KEY_A));
         sleepForSecs(2.1);
         // should be evicted
-        head(fullPathKey(1, KEY_A), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_A), HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -597,9 +597,9 @@ public class ExampleConfigsIT {
         delete(fullPathKey(KEY_B));
         delete(fullPathKey(KEY_C));
 
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(KEY_B), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(KEY_C), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(KEY_A), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(KEY_B), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(KEY_C), HttpStatus.SC_NOT_FOUND);
     }
 
     private void addServer(RemoteInfinispanServer server) {

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/expiration/ExpirationIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/expiration/ExpirationIT.java
@@ -11,8 +11,7 @@ import static org.junit.Assert.assertTrue;
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
-import javax.servlet.http.HttpServletResponse;
-
+import org.apache.http.HttpStatus;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServer;
 import org.infinispan.arquillian.core.RunningServer;
@@ -63,14 +62,14 @@ public class ExpirationIT {
         URI key4Path = fullPathKey(0, "k4");
         Assert.assertEquals(2, server1.getCacheManager("clustered").getClusterSize());
         // specific entry timeToLiveSeconds and maxIdleTimeSeconds that overrides the default
-        post(key1Path, "v1", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text",
-                "timeToLiveSeconds", "4", "maxIdleTimeSeconds", "4");
+        post(key1Path, "v1", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text",
+             "timeToLiveSeconds", "4", "maxIdleTimeSeconds", "4");
         // no value means never expire
-        post(key2Path, "v2", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text");
+        post(key2Path, "v2", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text");
         // 0 value means use default
-        post(key3Path, "v3", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text",
+        post(key3Path, "v3", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text",
                 "timeToLiveSeconds", "0", "maxIdleTimeSeconds", "0");
-        post(key4Path, "v4", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text",
+        post(key4Path, "v4", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text",
                 "timeToLiveSeconds", "0", "maxIdleTimeSeconds", "2");
 
         sleepForSecs(1);
@@ -80,14 +79,14 @@ public class ExpirationIT {
         sleepForSecs(2);
         // k3 and k4 expired
         get(key1Path, "v1");
-        head(key3Path, HttpServletResponse.SC_NOT_FOUND);
-        head(key4Path, HttpServletResponse.SC_NOT_FOUND);
+        head(key3Path, HttpStatus.SC_NOT_FOUND);
+        head(key4Path, HttpStatus.SC_NOT_FOUND);
         sleepForSecs(1);
         // k1 expired
-        head(key1Path, HttpServletResponse.SC_NOT_FOUND);
+        head(key1Path, HttpStatus.SC_NOT_FOUND);
         // k2 should not be expired because without timeToLive/maxIdle parameters,
         // the entries live forever. To use default values, 0 must be passed in.
-        head(key2Path, HttpServletResponse.SC_OK);
+        head(key2Path, HttpStatus.SC_OK);
     }
 
     @Test

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/RestRollingUpgradesDistIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/RestRollingUpgradesDistIT.java
@@ -5,8 +5,8 @@ import static org.infinispan.server.test.client.rest.RESTHelper.get;
 import static org.infinispan.server.test.client.rest.RESTHelper.post;
 
 import javax.management.ObjectName;
-import javax.servlet.http.HttpServletResponse;
 
+import org.apache.http.HttpStatus;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServers;
 import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
@@ -134,10 +134,10 @@ public class RestRollingUpgradesDistIT {
 
             // is RemoteCacheStore really disconnected?
             // source node entries should NOT be accessible from target node now
-            get(fullPathKey(2, DEFAULT_CACHE_NAME, "disconnected", 0), HttpServletResponse.SC_NOT_FOUND);
-            get(fullPathKey(3, DEFAULT_CACHE_NAME, "disconnected", PORT_OFFSET), HttpServletResponse.SC_NOT_FOUND);
-            get(fullPathKey(2, DEFAULT_CACHE_NAME, "disconnectedx", 0), HttpServletResponse.SC_NOT_FOUND);
-            get(fullPathKey(3, DEFAULT_CACHE_NAME, "disconnectedx", PORT_OFFSET), HttpServletResponse.SC_NOT_FOUND);
+            get(fullPathKey(2, DEFAULT_CACHE_NAME, "disconnected", 0), HttpStatus.SC_NOT_FOUND);
+            get(fullPathKey(3, DEFAULT_CACHE_NAME, "disconnected", PORT_OFFSET), HttpStatus.SC_NOT_FOUND);
+            get(fullPathKey(2, DEFAULT_CACHE_NAME, "disconnectedx", 0), HttpStatus.SC_NOT_FOUND);
+            get(fullPathKey(3, DEFAULT_CACHE_NAME, "disconnectedx", PORT_OFFSET), HttpStatus.SC_NOT_FOUND);
 
             // all entries migrated?
             get(fullPathKey(2, DEFAULT_CACHE_NAME, "key1", 0), "data");

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/RestRollingUpgradesIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/RestRollingUpgradesIT.java
@@ -5,8 +5,8 @@ import static org.infinispan.server.test.client.rest.RESTHelper.get;
 import static org.infinispan.server.test.client.rest.RESTHelper.post;
 
 import javax.management.ObjectName;
-import javax.servlet.http.HttpServletResponse;
 
+import org.apache.http.HttpStatus;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServers;
 import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
@@ -98,7 +98,7 @@ public class RestRollingUpgradesIT {
             post(fullPathKey(0, DEFAULT_CACHE_NAME, "disconnected", PORT_OFFSET), "source", "application/text");
 
             //Source node entries should NOT be accessible from target node
-            get(fullPathKey(1, DEFAULT_CACHE_NAME, "disconnected", 0), HttpServletResponse.SC_NOT_FOUND);
+            get(fullPathKey(1, DEFAULT_CACHE_NAME, "disconnected", 0), HttpStatus.SC_NOT_FOUND);
 
             //All remaining entries migrated?
             for (int i = 0; i < 50; i++) {

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/security/rest/AbstractBasicSecurity.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/security/rest/AbstractBasicSecurity.java
@@ -10,8 +10,7 @@ import static org.infinispan.server.test.client.rest.RESTHelper.head;
 import static org.infinispan.server.test.client.rest.RESTHelper.post;
 import static org.infinispan.server.test.client.rest.RESTHelper.put;
 
-import javax.servlet.http.HttpServletResponse;
-
+import org.apache.http.HttpStatus;
 import org.infinispan.server.test.client.rest.RESTHelper;
 
 /**
@@ -27,43 +26,43 @@ public abstract class AbstractBasicSecurity {
 
     protected void securedWriteOperations() throws Exception {
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
-        put(fullPathKey(KEY_A), "data", "application/text", HttpServletResponse.SC_OK);
+        put(fullPathKey(KEY_A), "data", "application/text", HttpStatus.SC_OK);
         RESTHelper.clearCredentials();
-        put(fullPathKey(KEY_B), "data", "application/text", HttpServletResponse.SC_UNAUTHORIZED);
+        put(fullPathKey(KEY_B), "data", "application/text", HttpStatus.SC_UNAUTHORIZED);
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
-        post(fullPathKey(KEY_C), "data", "application/text", HttpServletResponse.SC_OK);
+        post(fullPathKey(KEY_C), "data", "application/text", HttpStatus.SC_OK);
         RESTHelper.clearCredentials();
-        post(fullPathKey(KEY_D), "data", "application/text", HttpServletResponse.SC_UNAUTHORIZED);
+        post(fullPathKey(KEY_D), "data", "application/text", HttpStatus.SC_UNAUTHORIZED);
         get(fullPathKey(KEY_A), "data");
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_OK);
-        delete(fullPathKey(KEY_A), HttpServletResponse.SC_UNAUTHORIZED);
+        head(fullPathKey(KEY_A), HttpStatus.SC_OK);
+        delete(fullPathKey(KEY_A), HttpStatus.SC_UNAUTHORIZED);
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
-        delete(fullPathKey(KEY_A), HttpServletResponse.SC_OK);
-        delete(fullPathKey(KEY_C), HttpServletResponse.SC_OK);
+        delete(fullPathKey(KEY_A), HttpStatus.SC_OK);
+        delete(fullPathKey(KEY_C), HttpStatus.SC_OK);
         RESTHelper.clearCredentials();
     }
 
     protected void securedReadWriteOperations() throws Exception {
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
-        put(fullPathKey(KEY_A), "data", "application/text", HttpServletResponse.SC_OK);
+        put(fullPathKey(KEY_A), "data", "application/text", HttpStatus.SC_OK);
         RESTHelper.clearCredentials();
-        put(fullPathKey(KEY_B), "data", "application/text", HttpServletResponse.SC_UNAUTHORIZED);
+        put(fullPathKey(KEY_B), "data", "application/text", HttpStatus.SC_UNAUTHORIZED);
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
-        post(fullPathKey(KEY_C), "data", "application/text", HttpServletResponse.SC_OK);
+        post(fullPathKey(KEY_C), "data", "application/text", HttpStatus.SC_OK);
         RESTHelper.clearCredentials();
-        post(fullPathKey(KEY_D), "data", "application/text", HttpServletResponse.SC_UNAUTHORIZED);
-        get(fullPathKey(KEY_A), HttpServletResponse.SC_UNAUTHORIZED);
+        post(fullPathKey(KEY_D), "data", "application/text", HttpStatus.SC_UNAUTHORIZED);
+        get(fullPathKey(KEY_A), HttpStatus.SC_UNAUTHORIZED);
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
         get(fullPathKey(KEY_A), "data");
         RESTHelper.clearCredentials();
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_UNAUTHORIZED);
+        head(fullPathKey(KEY_A), HttpStatus.SC_UNAUTHORIZED);
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_OK);
+        head(fullPathKey(KEY_A), HttpStatus.SC_OK);
         RESTHelper.clearCredentials();
-        delete(fullPathKey(KEY_A), HttpServletResponse.SC_UNAUTHORIZED);
+        delete(fullPathKey(KEY_A), HttpStatus.SC_UNAUTHORIZED);
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
-        delete(fullPathKey(KEY_A), HttpServletResponse.SC_OK);
-        delete(fullPathKey(KEY_C), HttpServletResponse.SC_OK);
+        delete(fullPathKey(KEY_A), HttpStatus.SC_OK);
+        delete(fullPathKey(KEY_C), HttpStatus.SC_OK);
         RESTHelper.clearCredentials();
     }
 }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/security/rest/RESTCertSecurityIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/security/rest/RESTCertSecurityIT.java
@@ -14,9 +14,9 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.TrustManager;
-import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
@@ -81,49 +81,49 @@ public class RESTCertSecurityIT {
     @WithRunningServer({@RunningServer(name = CONTAINER, config = "testsuite/rest-sec-cert-wr.xml")})
     public void testSecuredWriteOperations() throws Exception {
         //correct alias for the certificate
-        put(securedClient(testAlias), keyAddress(KEY_A), HttpServletResponse.SC_OK);
+        put(securedClient(testAlias), keyAddress(KEY_A), HttpStatus.SC_OK);
         //test wrong authorization, 1. wrong alias for the certificate
-        put(securedClient(test2Alias), keyAddress(KEY_B), HttpServletResponse.SC_FORBIDDEN);
+        put(securedClient(test2Alias), keyAddress(KEY_B), HttpStatus.SC_FORBIDDEN);
         //2. access over 8080
-        put(securedClient(testAlias), keyAddressUnsecured(KEY_B), HttpServletResponse.SC_UNAUTHORIZED);
-        post(securedClient(testAlias), keyAddress(KEY_C), HttpServletResponse.SC_OK);
-        post(securedClient(test2Alias), keyAddress(KEY_D), HttpServletResponse.SC_FORBIDDEN);
+        put(securedClient(testAlias), keyAddressUnsecured(KEY_B), HttpStatus.SC_UNAUTHORIZED);
+        post(securedClient(testAlias), keyAddress(KEY_C), HttpStatus.SC_OK);
+        post(securedClient(test2Alias), keyAddress(KEY_D), HttpStatus.SC_FORBIDDEN);
         //get is not secured, should be working over 8080
-        HttpResponse resp = get(securedClient(test2Alias), keyAddressUnsecured(KEY_A), HttpServletResponse.SC_OK);
+        HttpResponse resp = get(securedClient(test2Alias), keyAddressUnsecured(KEY_A), HttpStatus.SC_OK);
         String content = new BufferedReader(new InputStreamReader(resp.getEntity().getContent())).readLine();
         assertEquals("data", content);
-        head(securedClient(test2Alias), keyAddressUnsecured(KEY_A), HttpServletResponse.SC_OK);
-        delete(securedClient(test2Alias), keyAddress(KEY_A), HttpServletResponse.SC_FORBIDDEN);
-        delete(securedClient(testAlias), keyAddress(KEY_A), HttpServletResponse.SC_OK);
-        delete(securedClient(testAlias), keyAddress(KEY_C), HttpServletResponse.SC_OK);
+        head(securedClient(test2Alias), keyAddressUnsecured(KEY_A), HttpStatus.SC_OK);
+        delete(securedClient(test2Alias), keyAddress(KEY_A), HttpStatus.SC_FORBIDDEN);
+        delete(securedClient(testAlias), keyAddress(KEY_A), HttpStatus.SC_OK);
+        delete(securedClient(testAlias), keyAddress(KEY_C), HttpStatus.SC_OK);
     }
 
     @Test
     @WithRunningServer({@RunningServer(name = CONTAINER, config = "testsuite/rest-sec-cert-rw.xml")})
     public void testSecuredReadWriteOperations() throws Exception {
         //correct alias for the certificate
-        put(securedClient(testAlias), keyAddress(KEY_A), HttpServletResponse.SC_OK);
+        put(securedClient(testAlias), keyAddress(KEY_A), HttpStatus.SC_OK);
         //test wrong authorization, 1. wrong alias for the certificate
-        put(securedClient(test2Alias), keyAddress(KEY_B), HttpServletResponse.SC_FORBIDDEN);
+        put(securedClient(test2Alias), keyAddress(KEY_B), HttpStatus.SC_FORBIDDEN);
         //2. access over 8080
-        put(securedClient(testAlias), keyAddressUnsecured(KEY_B), HttpServletResponse.SC_UNAUTHORIZED);
-        post(securedClient(testAlias), keyAddress(KEY_C), HttpServletResponse.SC_OK);
-        post(securedClient(test2Alias), keyAddress(KEY_D), HttpServletResponse.SC_FORBIDDEN);
+        put(securedClient(testAlias), keyAddressUnsecured(KEY_B), HttpStatus.SC_UNAUTHORIZED);
+        post(securedClient(testAlias), keyAddress(KEY_C), HttpStatus.SC_OK);
+        post(securedClient(test2Alias), keyAddress(KEY_D), HttpStatus.SC_FORBIDDEN);
         //get is secured too
-        HttpResponse resp = get(securedClient(testAlias), keyAddress(KEY_A), HttpServletResponse.SC_OK);
+        HttpResponse resp = get(securedClient(testAlias), keyAddress(KEY_A), HttpStatus.SC_OK);
         String content = new BufferedReader(new InputStreamReader(resp.getEntity().getContent())).readLine();
         assertEquals("data", content);
         //test wrong authorization, 1. wrong alias for the certificate
-        get(securedClient(test2Alias), keyAddress(KEY_A), HttpServletResponse.SC_FORBIDDEN);
+        get(securedClient(test2Alias), keyAddress(KEY_A), HttpStatus.SC_FORBIDDEN);
         //2. access over 8080
-        get(securedClient(testAlias), keyAddressUnsecured(KEY_A), HttpServletResponse.SC_UNAUTHORIZED);
-        head(securedClient(test2Alias), keyAddress(KEY_A), HttpServletResponse.SC_FORBIDDEN);
+        get(securedClient(testAlias), keyAddressUnsecured(KEY_A), HttpStatus.SC_UNAUTHORIZED);
+        head(securedClient(test2Alias), keyAddress(KEY_A), HttpStatus.SC_FORBIDDEN);
         //access over 8080
-        head(securedClient(testAlias), keyAddressUnsecured(KEY_A), HttpServletResponse.SC_UNAUTHORIZED);
-        head(securedClient(testAlias), keyAddress(KEY_A), HttpServletResponse.SC_OK);
-        delete(securedClient(test2Alias), keyAddress(KEY_A), HttpServletResponse.SC_FORBIDDEN);
-        delete(securedClient(testAlias), keyAddress(KEY_A), HttpServletResponse.SC_OK);
-        delete(securedClient(testAlias), keyAddress(KEY_C), HttpServletResponse.SC_OK);
+        head(securedClient(testAlias), keyAddressUnsecured(KEY_A), HttpStatus.SC_UNAUTHORIZED);
+        head(securedClient(testAlias), keyAddress(KEY_A), HttpStatus.SC_OK);
+        delete(securedClient(test2Alias), keyAddress(KEY_A), HttpStatus.SC_FORBIDDEN);
+        delete(securedClient(testAlias), keyAddress(KEY_A), HttpStatus.SC_OK);
+        delete(securedClient(testAlias), keyAddress(KEY_C), HttpStatus.SC_OK);
     }
 
     private String keyAddress(String key) {

--- a/server/rest/src/test/java/org/infinispan/rest/IntegrationTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/IntegrationTest.java
@@ -1,8 +1,5 @@
 package org.infinispan.rest;
 
-import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
-import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
@@ -31,13 +28,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.CacheControl;
 
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
 import org.apache.commons.httpclient.HttpMethodBase;
+import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
 import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -115,7 +112,7 @@ public class IntegrationTest extends RestServerTestBase {
       call(insert);
 
       assertEquals("", insert.getResponseBodyAsString().trim());
-      assertEquals(HttpServletResponse.SC_OK, insert.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, insert.getStatusCode());
 
       GetMethod get = new GetMethod(fullPathKey);
       call(get);
@@ -129,17 +126,17 @@ public class IntegrationTest extends RestServerTestBase {
       call(remove);
       call(get);
 
-      assertEquals(HttpServletResponse.SC_NOT_FOUND, get.getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_FOUND, get.getStatusCode());
 
       call(insert);
       call(get);
       assertEquals(initialXML, get.getResponseBodyAsString());
 
       DeleteMethod removeAll = new DeleteMethod(fullPath);
-      assertEquals(HttpServletResponse.SC_OK, call(removeAll).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(removeAll).getStatusCode());
 
       call(get);
-      assertEquals(HttpServletResponse.SC_NOT_FOUND, get.getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_FOUND, get.getStatusCode());
 
       ByteArrayOutputStream bout = new ByteArrayOutputStream();
       ObjectOutputStream oo = new ObjectOutputStream(bout);
@@ -166,14 +163,14 @@ public class IntegrationTest extends RestServerTestBase {
 
    public void testEmptyGet() throws Exception {
       assertEquals(
-            HttpServletResponse.SC_NOT_FOUND,
+            HttpStatus.SC_NOT_FOUND,
             call(new GetMethod(HOST + "/rest/" + cacheName + "/nodata")).getStatusCode()
       );
    }
 
    public void testDeleteNonExistent() throws Exception {
       assertEquals(
-            HttpServletResponse.SC_NOT_FOUND,
+            HttpStatus.SC_NOT_FOUND,
             call(new DeleteMethod(HOST + "/rest/" + cacheName + "/nodata")).getStatusCode()
       );
    }
@@ -232,7 +229,7 @@ public class IntegrationTest extends RestServerTestBase {
       GetMethod get = new GetMethod(fullPath);
       get.addRequestHeader("Accept", variant);
       HttpMethodBase coll = call(get);
-      assertEquals(HttpServletResponse.SC_OK, coll.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, coll.getStatusCode());
       assertEquals(variant, coll.getResponseHeader("Content-Type").getValue());
       return coll.getResponseBodyAsString();
    }
@@ -244,7 +241,7 @@ public class IntegrationTest extends RestServerTestBase {
       call(post);
 
       HttpMethodBase get = call(new GetMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertNotNull(get.getResponseHeader("ETag").getValue());
       assertNotNull(get.getResponseHeader("Last-Modified").getValue());
       assertEquals("application/text", get.getResponseHeader("Content-Type").getValue());
@@ -258,7 +255,7 @@ public class IntegrationTest extends RestServerTestBase {
       call(post);
 
       HttpMethodBase get = call(new HeadMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertNotNull(get.getResponseHeader("ETag").getValue());
       assertNotNull(get.getResponseHeader("Last-Modified").getValue());
       assertEquals("application/text", get.getResponseHeader("Content-Type").getValue());
@@ -273,7 +270,7 @@ public class IntegrationTest extends RestServerTestBase {
       call(post);
 
       HttpMethodBase get = call(new GetMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertNotNull(get.getResponseHeader("ETag").getValue());
       String lastMod = get.getResponseHeader("Last-Modified").getValue();
       assertNotNull(lastMod);
@@ -284,7 +281,7 @@ public class IntegrationTest extends RestServerTestBase {
       GetMethod getAgain = new GetMethod(fullPathKey);
       getAgain.addRequestHeader("If-Unmodified-Since", lastMod);
       get = call(getAgain);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertNotNull(get.getResponseHeader("ETag").getValue());
       assertNotNull(get.getResponseHeader("Last-Modified").getValue());
       assertEquals("application/text", get.getResponseHeader("Content-Type").getValue());
@@ -298,13 +295,13 @@ public class IntegrationTest extends RestServerTestBase {
       call(post);
 
       //Should get a conflict as its a DUPE post
-      assertEquals(HttpServletResponse.SC_CONFLICT, call(post).getStatusCode());
+      assertEquals(HttpStatus.SC_CONFLICT, call(post).getStatusCode());
 
       PutMethod put = new PutMethod(fullPathKey);
       put.setRequestEntity(new StringRequestEntity("data", "application/text", "UTF-8"));
 
       //Should be all ok as its a put
-      assertEquals(HttpServletResponse.SC_OK, call(put).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(put).getStatusCode());
    }
 
    public void testPutDataWithTimeToLive(Method m) throws Exception {
@@ -341,7 +338,7 @@ public class IntegrationTest extends RestServerTestBase {
 
       TestingUtil.sleepThread((maxWaitTime + 1) * 1000);
       call(get);
-      assertEquals(HttpServletResponse.SC_NOT_FOUND, get.getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_FOUND, get.getStatusCode());
    }
 
    public void testPutDataWithIfMatch(Method m) throws Exception {
@@ -353,20 +350,20 @@ public class IntegrationTest extends RestServerTestBase {
 
       // Now get it to retrieve some attributes
       HttpMethodBase get = call(new GetMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       String etag = get.getResponseHeader("ETag").getValue();
 
       // Put again using the If-Match with the ETag we got back from the get
       PutMethod reput = new PutMethod(fullPathKey);
       reput.setRequestHeader("If-Match", etag);
       reput.setRequestEntity(new StringRequestEntity("data", "application/text", "UTF-8"));
-      assertEquals(HttpServletResponse.SC_OK, call(reput).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(reput).getStatusCode());
 
       // Try to put again, but with a different ETag
       PutMethod reputAgain = new PutMethod(fullPathKey);
       reputAgain.setRequestHeader("If-Match", "x");
       reputAgain.setRequestEntity(new StringRequestEntity("data", "application/text", "UTF-8"));
-      assertEquals(HttpServletResponse.SC_PRECONDITION_FAILED, call(reputAgain).getStatusCode());
+      assertEquals(HttpStatus.SC_PRECONDITION_FAILED, call(reputAgain).getStatusCode());
    }
 
    public void testPutDataWithIfNoneMatch(Method m) throws Exception {
@@ -378,20 +375,20 @@ public class IntegrationTest extends RestServerTestBase {
 
       // Now get it to retrieve some attributes
       HttpMethodBase get = call(new GetMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       String etag = get.getResponseHeader("ETag").getValue();
 
       // Put again using the If-Match with the ETag we got back from the get
       PutMethod reput = new PutMethod(fullPathKey);
       reput.setRequestHeader("If-None-Match", "x");
       reput.setRequestEntity(new StringRequestEntity("data", "application/text", "UTF-8"));
-      assertEquals(HttpServletResponse.SC_OK, call(reput).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(reput).getStatusCode());
 
       // Try to put again, but with a different ETag
       PutMethod reputAgain = new PutMethod(fullPathKey);
       reputAgain.setRequestHeader("If-None-Match", etag);
       reputAgain.setRequestEntity(new StringRequestEntity("data", "application/text", "UTF-8"));
-      assertEquals(HttpServletResponse.SC_PRECONDITION_FAILED, call(reputAgain).getStatusCode());
+      assertEquals(HttpStatus.SC_PRECONDITION_FAILED, call(reputAgain).getStatusCode());
    }
 
    public void testPutDataWithIfModifiedSince(Method m) throws Exception {
@@ -403,21 +400,21 @@ public class IntegrationTest extends RestServerTestBase {
 
       // Now get it to retrieve some attributes
       HttpMethodBase get = call(new GetMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       String lastMod = get.getResponseHeader("Last-Modified").getValue();
 
       // Put again using the If-Modified-Since with the lastMod we got back from the get
       PutMethod reput = new PutMethod(fullPathKey);
       reput.setRequestHeader("If-Modified-Since", lastMod);
       reput.setRequestEntity(new StringRequestEntity("data", "application/text", "UTF-8"));
-      assertEquals(HttpServletResponse.SC_NOT_MODIFIED, call(reput).getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_MODIFIED, call(reput).getStatusCode());
 
       // Try to put again, but with an older last modification date
       PutMethod reputAgain = new PutMethod(fullPathKey);
       String dateMinus = addDay(lastMod, -1);
       reputAgain.setRequestHeader("If-Modified-Since", dateMinus);
       reputAgain.setRequestEntity(new StringRequestEntity("data", "application/text", "UTF-8"));
-      assertEquals(HttpServletResponse.SC_OK, call(reputAgain).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(reputAgain).getStatusCode());
    }
 
    public void testPutDataWithIfUnModifiedSince(Method m) throws Exception {
@@ -429,7 +426,7 @@ public class IntegrationTest extends RestServerTestBase {
 
       // Now get it to retrieve some attributes
       HttpMethodBase get = call(new GetMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       String lastMod = get.getResponseHeader("Last-Modified").getValue();
 
       // Put again using the If-Unmodified-Since with a date earlier than the one we got back from the GET
@@ -437,13 +434,13 @@ public class IntegrationTest extends RestServerTestBase {
       String dateMinus = addDay(lastMod, -1);
       reput.setRequestHeader("If-Unmodified-Since", dateMinus);
       reput.setRequestEntity(new StringRequestEntity("data", "application/text", "UTF-8"));
-      assertEquals(HttpServletResponse.SC_PRECONDITION_FAILED, call(reput).getStatusCode());
+      assertEquals(HttpStatus.SC_PRECONDITION_FAILED, call(reput).getStatusCode());
 
       // Try to put again, but using the date returned by the GET
       PutMethod reputAgain = new PutMethod(fullPathKey);
       reputAgain.setRequestHeader("If-Unmodified-Since", lastMod);
       reputAgain.setRequestEntity(new StringRequestEntity("data", "application/text", "UTF-8"));
-      assertEquals(HttpServletResponse.SC_OK, call(reputAgain).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(reputAgain).getStatusCode());
    }
 
    public void testDeleteDataWithIfMatch(Method m) throws Exception {
@@ -455,18 +452,18 @@ public class IntegrationTest extends RestServerTestBase {
 
       // Now get it to retrieve some attributes
       HttpMethodBase get = call(new GetMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       String etag = get.getResponseHeader("ETag").getValue();
 
       // Attempt to delete with a wrong ETag
       DeleteMethod delete = new DeleteMethod(fullPathKey);
       delete.setRequestHeader("If-Match", "x");
-      assertEquals(HttpServletResponse.SC_PRECONDITION_FAILED, call(delete).getStatusCode());
+      assertEquals(HttpStatus.SC_PRECONDITION_FAILED, call(delete).getStatusCode());
 
       // Try to delete again, but with the proper ETag
       DeleteMethod deleteAgain = new DeleteMethod(fullPathKey);
       deleteAgain.setRequestHeader("If-Match", etag);
-      assertEquals(HttpServletResponse.SC_OK, call(deleteAgain).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(deleteAgain).getStatusCode());
    }
 
    public void testDeleteDataWithIfNoneMatch(Method m) throws Exception {
@@ -478,18 +475,18 @@ public class IntegrationTest extends RestServerTestBase {
 
       // Now get it to retrieve some attributes
       HttpMethodBase get = call(new GetMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       String etag = get.getResponseHeader("ETag").getValue();
 
       // Attempt to delete with the ETag
       DeleteMethod delete = new DeleteMethod(fullPathKey);
       delete.setRequestHeader("If-None-Match", etag);
-      assertEquals(HttpServletResponse.SC_PRECONDITION_FAILED, call(delete).getStatusCode());
+      assertEquals(HttpStatus.SC_PRECONDITION_FAILED, call(delete).getStatusCode());
 
       // Try to delete again, but with a non-matching ETag
       DeleteMethod deleteAgain = new DeleteMethod(fullPathKey);
       deleteAgain.setRequestHeader("If-None-Match", "x");
-      assertEquals(HttpServletResponse.SC_OK, call(deleteAgain).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(deleteAgain).getStatusCode());
    }
 
    public void testDeleteDataWithIfModifiedSince(Method m) throws Exception {
@@ -501,19 +498,19 @@ public class IntegrationTest extends RestServerTestBase {
 
       // Now get it to retrieve some attributes
       HttpMethodBase get = call(new GetMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       String lastMod = get.getResponseHeader("Last-Modified").getValue();
 
       // Attempt to delete using the If-Modified-Since header with the lastMod we got back from the get
       DeleteMethod delete = new DeleteMethod(fullPathKey);
       delete.setRequestHeader("If-Modified-Since", lastMod);
-      assertEquals(HttpServletResponse.SC_NOT_MODIFIED, call(delete).getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_MODIFIED, call(delete).getStatusCode());
 
       // Try to delete again, but with an older last modification date
       DeleteMethod deleteAgain = new DeleteMethod(fullPathKey);
       String dateMinus = addDay(lastMod, -1);
       deleteAgain.setRequestHeader("If-Modified-Since", dateMinus);
-      assertEquals(HttpServletResponse.SC_OK, call(deleteAgain).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(deleteAgain).getStatusCode());
    }
 
    public void testDeleteDataWithIfUnmodifiedSince(Method m) throws Exception {
@@ -525,19 +522,19 @@ public class IntegrationTest extends RestServerTestBase {
 
       // Now get it to retrieve some attributes
       HttpMethodBase get = call(new GetMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       String lastMod = get.getResponseHeader("Last-Modified").getValue();
 
       // Attempt to delete using the If-Unmodified-Since header with a date earlier than the one we got back from the GET
       DeleteMethod delete = new DeleteMethod(fullPathKey);
       String dateMinus = addDay(lastMod, -1);
       delete.setRequestHeader("If-Unmodified-Since", dateMinus);
-      assertEquals(HttpServletResponse.SC_PRECONDITION_FAILED, call(delete).getStatusCode());
+      assertEquals(HttpStatus.SC_PRECONDITION_FAILED, call(delete).getStatusCode());
 
       // Try to delete again, but with an older last modification date
       DeleteMethod deleteAgain = new DeleteMethod(fullPathKey);
       deleteAgain.setRequestHeader("If-Unmodified-Since", lastMod);
-      assertEquals(HttpServletResponse.SC_OK, call(deleteAgain).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(deleteAgain).getStatusCode());
    }
 
    public void testDeleteCachePreconditionUnimplemented(Method m) throws Exception {
@@ -572,10 +569,10 @@ public class IntegrationTest extends RestServerTestBase {
       put.setRequestEntity(new StringRequestEntity("data", "application/text", "UTF-8"));
       call(put);
 
-      assertEquals(HttpServletResponse.SC_OK, call(new HeadMethod(fullPathKey)).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(new HeadMethod(fullPathKey)).getStatusCode());
 
       call(new DeleteMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_NOT_FOUND, call(new HeadMethod(fullPathKey)).getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_FOUND, call(new HeadMethod(fullPathKey)).getStatusCode());
    }
 
    public void testWipeCacheBucket(Method m) throws Exception {
@@ -588,9 +585,9 @@ public class IntegrationTest extends RestServerTestBase {
       put_.setRequestEntity(new StringRequestEntity("data", "application/text", "UTF-8"));
       call(put_);
 
-      assertEquals(HttpServletResponse.SC_OK, call(new HeadMethod(fullPathKey)).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(new HeadMethod(fullPathKey)).getStatusCode());
       call(new DeleteMethod(fullPath));
-      assertEquals(HttpServletResponse.SC_NOT_FOUND, call(new HeadMethod(fullPathKey)).getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_FOUND, call(new HeadMethod(fullPathKey)).getStatusCode());
    }
 
    public void testAsyncAddRemove(Method m) throws Exception {
@@ -601,13 +598,13 @@ public class IntegrationTest extends RestServerTestBase {
       call(put);
 
       Thread.sleep(50);
-      assertEquals(HttpServletResponse.SC_OK, call(new HeadMethod(fullPathKey)).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(new HeadMethod(fullPathKey)).getStatusCode());
 
       DeleteMethod del = new DeleteMethod(fullPathKey);
       del.setRequestHeader("performAsync", "true");
       call(del);
       Thread.sleep(50);
-      assertEquals(HttpServletResponse.SC_NOT_FOUND, call(new HeadMethod(fullPathKey)).getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_FOUND, call(new HeadMethod(fullPathKey)).getStatusCode());
    }
 
    public void testShouldCopeWithSerializable(Method m) throws Exception {
@@ -624,7 +621,7 @@ public class IntegrationTest extends RestServerTestBase {
       GetMethod get = new GetMethod(fullPathKey);
       get.setRequestHeader("Accept", "application/x-java-serialized-object");
       call(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       ObjectInputStream in = new ObjectInputStream(get.getResponseBodyAsStream());
       MySer res = (MySer) in.readObject();
       assertNotNull(res);
@@ -667,15 +664,15 @@ public class IntegrationTest extends RestServerTestBase {
       String fullPathKey = HOST + "/rest/nonexistent/" + m.getName();
       GetMethod get = new GetMethod(fullPathKey);
       call(get);
-      assertEquals(HttpServletResponse.SC_NOT_FOUND, get.getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_FOUND, get.getStatusCode());
 
       HttpMethodBase head = call(new HeadMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_NOT_FOUND, head.getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_FOUND, head.getStatusCode());
 
       PostMethod put = new PostMethod(fullPathKey);
       put.setRequestEntity(new StringRequestEntity("data", "application/text", "UTF-8"));
       call(put);
-      assertEquals(HttpServletResponse.SC_NOT_FOUND, put.getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_FOUND, put.getStatusCode());
    }
 
    public void testByteArrayAsSerializedObjects(Method m) throws Exception {
@@ -704,7 +701,7 @@ public class IntegrationTest extends RestServerTestBase {
       String datePlus = addDay(dateLast, 1);
       assertNotNull(get(m, Optional.of(dateLast)).getResponseBodyAsString());
       assertNotNull(get(m, Optional.of(datePlus)).getResponseBodyAsString());
-      result = get(m, Optional.of(dateMinus), Optional.empty(), HttpServletResponse.SC_PRECONDITION_FAILED);
+      result = get(m, Optional.of(dateMinus), Optional.empty(), HttpStatus.SC_PRECONDITION_FAILED);
    }
 
    public void testETagChanges(Method m) throws Exception {
@@ -738,7 +735,7 @@ public class IntegrationTest extends RestServerTestBase {
             put.setRequestHeader("Content-Type", "application/text");
             put.setRequestEntity(new StringRequestEntity("data2", null, null));
             newClient.executeMethod(put);
-            assertEquals(HttpServletResponse.SC_OK, put.getStatusCode());
+            assertEquals(HttpStatus.SC_OK, put.getStatusCode());
 
             // 5. v2 applied, let v3 finish
             v2FinishLatch.countDown();
@@ -752,7 +749,7 @@ public class IntegrationTest extends RestServerTestBase {
          put.setRequestHeader("Content-Type", "application/text");
          put.setRequestEntity(new StringRequestEntity("data3", null, null));
          call(put);
-         assertEquals(HttpServletResponse.SC_PRECONDITION_FAILED,
+         assertEquals(HttpStatus.SC_PRECONDITION_FAILED,
                put.getStatusCode());
 
          // Wait for replace to happen
@@ -822,7 +819,7 @@ public class IntegrationTest extends RestServerTestBase {
 
       // Make sure that in the next 20 secs data is removed
       waitNotFound(startTime, lifespan, fullPathKey);
-      assertEquals(SC_NOT_FOUND, call(new GetMethod(fullPathKey)).getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_FOUND, call(new GetMethod(fullPathKey)).getStatusCode());
 
       startTime = System.currentTimeMillis();
       lifespan = 0;
@@ -837,7 +834,7 @@ public class IntegrationTest extends RestServerTestBase {
       String response = get.getResponseBodyAsString();
       assertEquals("data3", response);
       Thread.sleep(2000);
-      assertEquals(HttpServletResponse.SC_NOT_FOUND, call(new GetMethod(fullPathKey)).getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_FOUND, call(new GetMethod(fullPathKey)).getStatusCode());
 
       fullPathKey = "%s-4".format(fullPathKey);
       post = new PostMethod(fullPathKey);
@@ -847,7 +844,7 @@ public class IntegrationTest extends RestServerTestBase {
       call(post);
       // Sleep way beyond the default in the config
       Thread.sleep(2500);
-      assertEquals(HttpServletResponse.SC_NOT_FOUND, call(new GetMethod(fullPathKey)).getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_FOUND, call(new GetMethod(fullPathKey)).getStatusCode());
    }
 
    public void testCacheControlResponseHeader(Method m) throws Exception {
@@ -879,7 +876,7 @@ public class IntegrationTest extends RestServerTestBase {
       GetMethod getLongMinFresh = new GetMethod(fullPathKey);
       getLongMinFresh.addRequestHeader("Cache-Control", "no-transform, min-fresh=20");
       HttpMethodBase getResp = call(getLongMinFresh);
-      assertEquals(HttpServletResponse.SC_NOT_FOUND, getResp.getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_FOUND, getResp.getStatusCode());
 
       GetMethod getShortMinFresh = new GetMethod(fullPathKey);
       getShortMinFresh.addRequestHeader("Cache-Control", "no-transform, min-fresh=2");
@@ -906,7 +903,7 @@ public class IntegrationTest extends RestServerTestBase {
       HeadMethod headLongMinFresh = new HeadMethod(fullPathKey);
       headLongMinFresh.addRequestHeader("Cache-Control", "no-transform, min-fresh=20");
       HttpMethodBase headResp = call(headLongMinFresh);
-      assertEquals(HttpServletResponse.SC_NOT_FOUND, headResp.getStatusCode());
+      assertEquals(HttpStatus.SC_NOT_FOUND, headResp.getStatusCode());
 
       HeadMethod headShortMinFresh = new HeadMethod(fullPathKey);
       headShortMinFresh.addRequestHeader("Cache-Control", "no-transform, min-fresh=2");
@@ -925,14 +922,14 @@ public class IntegrationTest extends RestServerTestBase {
       byte[] data = new byte[]{42, 42, 42};
 
       put.setRequestEntity(new ByteArrayRequestEntity(data, "application/x-java-serialized-object"));
-      assertEquals(HttpServletResponse.SC_OK, call(put).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(put).getStatusCode());
 
       HttpMethodBase get = call(new GetMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
 
       PutMethod reput = new PutMethod(fullPathKey);
       reput.setRequestEntity(new ByteArrayRequestEntity(data, "application/x-java-serialized-object"));
-      assertEquals(HttpServletResponse.SC_OK, call(reput).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(reput).getStatusCode());
    }
 
    public void testDeleteSerializedObject(Method m) throws Exception {
@@ -941,31 +938,31 @@ public class IntegrationTest extends RestServerTestBase {
       byte[] data = new byte[]{42, 42, 42};
 
       put.setRequestEntity(new ByteArrayRequestEntity(data, "application/x-java-serialized-object"));
-      assertEquals(HttpServletResponse.SC_OK, call(put).getStatusCode());
+      assertEquals(HttpStatus.SC_OK, call(put).getStatusCode());
 
       HttpMethodBase get = call(new GetMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
 
       HttpMethodBase delete = call(new DeleteMethod(fullPathKey));
-      assertEquals(HttpServletResponse.SC_OK, delete.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, delete.getStatusCode());
    }
 
    public void testDisableCache(Method m) throws Exception {
       Callable<HttpMethodBase> doGet = () -> call(new GetMethod(fullPathKey(m)));
 
       put(m);
-      assertEquals(SC_OK, doGet.call().getStatusCode());
+      assertEquals(HttpStatus.SC_OK, doGet.call().getStatusCode());
 
       ignoreCache(cacheName);
-      assertEquals(SC_INTERNAL_SERVER_ERROR, doGet.call().getStatusCode());
+      assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, doGet.call().getStatusCode());
 
       enableCache(cacheName);
-      assertEquals(SC_OK, doGet.call().getStatusCode());
+      assertEquals(HttpStatus.SC_OK, doGet.call().getStatusCode());
    }
 
    private void waitNotFound(Long startTime, int lifespan, String fullPathKey) throws Exception {
       if (System.currentTimeMillis() < startTime + lifespan + 20000) {
-         if (SC_NOT_FOUND != (call(new GetMethod(fullPathKey)).getStatusCode())) {
+         if (HttpStatus.SC_NOT_FOUND != (call(new GetMethod(fullPathKey)).getStatusCode())) {
             Thread.sleep(100);
             waitNotFound(startTime, lifespan, fullPathKey); // Good ol' tail recursion :);
          }
@@ -993,7 +990,7 @@ public class IntegrationTest extends RestServerTestBase {
       }
       put.setRequestEntity(reqEntity);
       call(put);
-      assertEquals(HttpServletResponse.SC_OK, put.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, put.getStatusCode());
       return put;
    }
 
@@ -1002,11 +999,11 @@ public class IntegrationTest extends RestServerTestBase {
    }
 
    private HttpMethodBase get(Method m, Optional<String> unmodSince) throws Exception {
-      return get(m, unmodSince, Optional.empty(), HttpServletResponse.SC_OK);
+      return get(m, unmodSince, Optional.empty(), HttpStatus.SC_OK);
    }
 
    private HttpMethodBase get(Method m, Optional<String> unmodSince, Optional<String> acceptType) throws Exception {
-      return get(m, unmodSince, acceptType, HttpServletResponse.SC_OK);
+      return get(m, unmodSince, acceptType, HttpStatus.SC_OK);
    }
 
    private HttpMethodBase get(Method m, Optional<String> unmodSince, Optional<String> acceptType, int expCode) throws Exception {

--- a/server/rest/src/test/java/org/infinispan/rest/TwoServerTest.java
+++ b/server/rest/src/test/java/org/infinispan/rest/TwoServerTest.java
@@ -3,9 +3,8 @@ package org.infinispan.rest;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.httpclient.Header;
+import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.HeadMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
@@ -75,15 +74,15 @@ public class TwoServerTest extends RestServerTestBase {
       PutMethod put = new PutMethod(PATH1 + "a");
       put.setRequestEntity(new StringRequestEntity("data", "application/text", null));
       call(put);
-      assertEquals(put.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(put.getStatusCode(), HttpStatus.SC_OK);
       put.releaseConnection();
       GetMethod get = new GetMethod(PATH1 + "a");
       call(get);
-      assertEquals(get.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(get.getStatusCode(), HttpStatus.SC_OK);
       get.releaseConnection();
       get = new GetMethod(PATH2 + "a");
       call(get);
-      assertEquals(get.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(get.getStatusCode(), HttpStatus.SC_OK);
       assertEquals("data", get.getResponseBodyAsString());
       get.releaseConnection();
    }
@@ -92,16 +91,16 @@ public class TwoServerTest extends RestServerTestBase {
       PutMethod put = new PutMethod(PATH1 + "testReplace");
       put.setRequestEntity(new StringRequestEntity("data", "application/text", null));
       call(put);
-      assertEquals(put.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(put.getStatusCode(), HttpStatus.SC_OK);
       put.releaseConnection();
       put = new PutMethod(PATH1 + "testReplace");
       put.setRequestEntity(new StringRequestEntity("data2", "application/text", null));
       call(put);
-      assertEquals(put.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(put.getStatusCode(), HttpStatus.SC_OK);
       put.releaseConnection();
       GetMethod get = new GetMethod(PATH2 + "testReplace");
       call(get);
-      assertEquals(get.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(get.getStatusCode(), HttpStatus.SC_OK);
       assertEquals("data2", get.getResponseBodyAsString());
       get.releaseConnection();
    }
@@ -110,11 +109,11 @@ public class TwoServerTest extends RestServerTestBase {
       PutMethod put = new PutMethod(PATH1 + "testExtendedHeaders");
       put.setRequestEntity(new StringRequestEntity("data", "application/text", null));
       call(put);
-      assertEquals(put.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(put.getStatusCode(), HttpStatus.SC_OK);
       put.releaseConnection();
       GetMethod get = new GetMethod(PATH2 + "testExtendedHeaders?extended");
       call(get);
-      assertEquals(get.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(get.getStatusCode(), HttpStatus.SC_OK);
       Header po = get.getResponseHeader("Cluster-Primary-Owner");
       assertNotNull(po);
       Address primaryLocation = getCacheManager("1").getCache(BasicCacheContainer.DEFAULT_CACHE_NAME).getAdvancedCache().getDistributionManager().getPrimaryLocation("testExtendedHeaders");
@@ -135,14 +134,14 @@ public class TwoServerTest extends RestServerTestBase {
       String key3Path = EXPIRY_PATH1 + "k3";
       String key4Path = EXPIRY_PATH1 + "k4";
       // specific entry timeToLiveSeconds and maxIdleTimeSeconds that overrides the default
-      post(key1Path, "v1", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text",
+      post(key1Path, "v1", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text",
             "timeToLiveSeconds", "3", "maxIdleTimeSeconds", "3");
       // no value means never expire
-      post(key2Path, "v2", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text");
+      post(key2Path, "v2", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text");
       // 0 value means use default
-      post(key3Path, "v3", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text",
+      post(key3Path, "v3", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text",
             "timeToLiveSeconds", "0", "maxIdleTimeSeconds", "0");
-      post(key4Path, "v4", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text",
+      post(key4Path, "v4", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text",
             "timeToLiveSeconds", "0", "maxIdleTimeSeconds", "2");
 
       TestingUtil.sleepThread(1000);
@@ -152,14 +151,14 @@ public class TwoServerTest extends RestServerTestBase {
       TestingUtil.sleepThread(1100);
       // k3 and k4 expired
       get(key1Path, "v1");
-      head(key3Path, HttpServletResponse.SC_NOT_FOUND);
-      head(key4Path, HttpServletResponse.SC_NOT_FOUND);
+      head(key3Path, HttpStatus.SC_NOT_FOUND);
+      head(key4Path, HttpStatus.SC_NOT_FOUND);
       TestingUtil.sleepThread(1000);
       // k1 expired
-      head(key1Path, HttpServletResponse.SC_NOT_FOUND);
+      head(key1Path, HttpStatus.SC_NOT_FOUND);
       // k2 should not be expired because without timeToLive/maxIdle parameters,
       // the entries live forever. To use default values, 0 must be passed in.
-      head(key2Path, HttpServletResponse.SC_OK);
+      head(key2Path, HttpStatus.SC_OK);
    }
 
    private void post(String uri, String data, String contentType, int expectedCode, Object... headers) throws Exception {


### PR DESCRIPTION
commons-logging 1.1 was exposing HTTPServletResponse, but
commons-logging 1.2 made the servlet-api dependency optional.