### PR TITLE
[8.2.x] ISPN-6241 Fix compilation error in integration tests

### DIFF
--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestHotRodTest.java
@@ -3,6 +3,7 @@ package org.infinispan.it.compatibility;
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -16,8 +17,6 @@ import org.infinispan.test.AbstractInfinispanTest;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import javax.servlet.http.HttpServletResponse;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -68,7 +67,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
             "<hey>ho</hey>".getBytes(), "application/octet-stream"));
       HttpClient restClient = cacheFactory.getRestClient();
       restClient.executeMethod(put);
-      assertEquals(HttpServletResponse.SC_OK, put.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, put.getStatusCode());
       assertEquals("", put.getResponseBodyAsString().trim());
 
       // 2. Get with Embedded
@@ -92,7 +91,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 3. Get with REST
       HttpMethod get = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       cacheFactory.getRestClient().executeMethod(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertEquals("v1", get.getResponseBodyAsString());
    }
 
@@ -109,7 +108,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 3. Get with REST
       HttpMethod get = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       cacheFactory.getRestClient().executeMethod(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertEquals("v1", get.getResponseBodyAsString());
    }
 
@@ -128,7 +127,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       HttpMethod get = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       get.setRequestHeader("Accept", "application/x-java-serialized-object");
       cacheFactory.getRestClient().executeMethod(get);
-      assertEquals(get.getStatusText(), HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(get.getStatusText(), HttpStatus.SC_OK, get.getStatusCode());
       // REST finds the Java POJO in-memory and returns the Java serialized version
       assertEquals(p, new ObjectInputStream(get.getResponseBodyAsStream()).readObject());
    }
@@ -149,7 +148,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
 
       cacheFactory.getRestClient().executeMethod(get);
       assertEquals("application/x-java-serialized-object", get.getResponseHeader("Content-Type").getValue());
-      assertEquals(get.getStatusText(), HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(get.getStatusText(), HttpStatus.SC_OK, get.getStatusCode());
       // REST finds the Java POJO in-memory and returns the Java serialized version
       assertEquals(p, new ObjectInputStream(get.getResponseBodyAsStream()).readObject());
    }
@@ -165,14 +164,14 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       HttpMethod getJson = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       getJson.setRequestHeader("Accept", "application/json");
       cacheFactory.getRestClient().executeMethod(getJson);
-      assertEquals(getJson.getStatusText(), HttpServletResponse.SC_OK, getJson.getStatusCode());
+      assertEquals(getJson.getStatusText(), HttpStatus.SC_OK, getJson.getStatusCode());
       assertEquals("{\"name\":\"Anna\"}", getJson.getResponseBodyAsString());
 
       // 3. Get with REST (accept application/xml)
       HttpMethod getXml = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       getXml.setRequestHeader("Accept", "application/xml");
       cacheFactory.getRestClient().executeMethod(getXml);
-      assertEquals(getXml.getStatusText(), HttpServletResponse.SC_OK, getXml.getStatusCode());
+      assertEquals(getXml.getStatusText(), HttpStatus.SC_OK, getXml.getStatusCode());
       assertTrue(getXml.getResponseBodyAsString().contains("<name>Anna</name>"));
    }
 
@@ -188,14 +187,14 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       HttpMethod getJson = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       getJson.setRequestHeader("Accept", "application/json");
       cacheFactory.getRestClient().executeMethod(getJson);
-      assertEquals(getJson.getStatusText(), HttpServletResponse.SC_OK, getJson.getStatusCode());
+      assertEquals(getJson.getStatusText(), HttpStatus.SC_OK, getJson.getStatusCode());
       assertEquals("{\"name\":\"Jakub\"}", getJson.getResponseBodyAsString());
 
       // 3. Get with REST (accept application/xml)
       HttpMethod getXml = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       getXml.setRequestHeader("Accept", "application/xml");
       cacheFactory.getRestClient().executeMethod(getXml);
-      assertEquals(getXml.getStatusText(), HttpServletResponse.SC_OK, getXml.getStatusCode());
+      assertEquals(getXml.getStatusText(), HttpStatus.SC_OK, getXml.getStatusCode());
       assertTrue(getXml.getResponseBodyAsString().contains("<name>Jakub</name>"));
    }
 
@@ -234,7 +233,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 3. HEAD with REST key1
       HttpMethod headKey1 = new HeadMethod(cacheFactory.getRestUrl() + "/" + key1);
       cacheFactory.getRestClient().executeMethod(headKey1);
-      assertEquals(HttpServletResponse.SC_OK, headKey1.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, headKey1.getStatusCode());
       Header expires = headKey1.getResponseHeader("Expires");
       assertNotNull(expires);
       assertTrue(dateFormat.parse(expires.getValue()).after(new GregorianCalendar(2013, 1, 1).getTime()));
@@ -242,7 +241,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 4. HEAD with REST key2
       HttpMethod headKey2 = new HeadMethod(cacheFactory.getRestUrl() + "/" + key2);
       cacheFactory.getRestClient().executeMethod(headKey2);
-      assertEquals(HttpServletResponse.SC_OK, headKey2.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, headKey2.getStatusCode());
       assertNotNull(headKey2.getResponseHeader("Expires"));
    }
 
@@ -259,13 +258,13 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 3. Get with REST key
       HttpMethod get1 = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       cacheFactory.getRestClient().executeMethod(get1);
-      assertEquals(HttpServletResponse.SC_OK, get1.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get1.getStatusCode());
       assertDate(get1, "Expires");
 
       // 4. Get with REST key2
       HttpMethod get2 = new GetMethod(cacheFactory.getRestUrl() + "/" + key2);
       cacheFactory.getRestClient().executeMethod(get2);
-      assertEquals(HttpServletResponse.SC_OK, get2.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get2.getStatusCode());
       assertDate(get2, "Expires");
    }
 
@@ -282,13 +281,13 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 3. Get with REST key
       HttpMethod get1 = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       cacheFactory.getRestClient().executeMethod(get1);
-      assertEquals(HttpServletResponse.SC_OK, get1.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get1.getStatusCode());
       assertDate(get1, "Last-Modified");
 
       // 4. Get with REST key2
       HttpMethod get2 = new GetMethod(cacheFactory.getRestUrl() + "/" + key2);
       cacheFactory.getRestClient().executeMethod(get2);
-      assertEquals(HttpServletResponse.SC_OK, get2.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get2.getStatusCode());
       assertDate(get2, "Last-Modified");
    }
 
@@ -314,14 +313,14 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       // 3. Get with REST key1
       HttpMethod getHotRodValue = new GetMethod(cacheFactory.getRestUrl() + "/" + key1);
       cacheFactory.getRestClient().executeMethod(getHotRodValue);
-      assertEquals(getHotRodValue.getStatusText(), HttpServletResponse.SC_OK, getHotRodValue.getStatusCode());
+      assertEquals(getHotRodValue.getStatusText(), HttpStatus.SC_OK, getHotRodValue.getStatusCode());
       assertEquals("application/octet-stream", getHotRodValue.getResponseHeader("Content-Type").getValue());
       assertArrayEquals("v1".getBytes(), getHotRodValue.getResponseBody());
 
       // 4. Get with REST key2
       HttpMethod getEmbeddedValue = new GetMethod(cacheFactory.getRestUrl() + "/" + key2);
       cacheFactory.getRestClient().executeMethod(getEmbeddedValue);
-      assertEquals(getEmbeddedValue.getStatusText(), HttpServletResponse.SC_OK, getEmbeddedValue.getStatusCode());
+      assertEquals(getEmbeddedValue.getStatusText(), HttpStatus.SC_OK, getEmbeddedValue.getStatusCode());
       assertEquals("application/octet-stream", getEmbeddedValue.getResponseHeader("Content-Type").getValue());
       assertArrayEquals("v2".getBytes(), getEmbeddedValue.getResponseBody());
    }
@@ -340,13 +339,13 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       HttpMethod getKey1 = new HeadMethod(cacheFactory.getRestUrl() + "/" + key1);
       getKey1.setRequestHeader("Accept", "unknown-media-type");
       cacheFactory.getRestClient().executeMethod(getKey1);
-      assertEquals(getKey1.getStatusText(), HttpServletResponse.SC_BAD_REQUEST, getKey1.getStatusCode());
+      assertEquals(getKey1.getStatusText(), HttpStatus.SC_BAD_REQUEST, getKey1.getStatusCode());
 
       // 4. GET with REST key2
       HttpMethod getKey2 = new HeadMethod(cacheFactory.getRestUrl() + "/" + key2);
       getKey2.setRequestHeader("Accept", "unknown-media-type");
       cacheFactory.getRestClient().executeMethod(getKey2);
-      assertEquals(getKey2.getStatusText(), HttpServletResponse.SC_BAD_REQUEST, getKey2.getStatusCode());
+      assertEquals(getKey2.getStatusText(), HttpStatus.SC_BAD_REQUEST, getKey2.getStatusCode());
    }
 
    public void testHotRodEmbeddedPutRestGetCacheControlHeader() throws Exception {
@@ -363,13 +362,13 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       HttpMethod getKey1 = new GetMethod(cacheFactory.getRestUrl() + "/" + key1);
       getKey1.setRequestHeader("Cache-Control", "min-fresh=20");
       cacheFactory.getRestClient().executeMethod(getKey1);
-      assertEquals(getKey1.getStatusText(), HttpServletResponse.SC_NOT_FOUND, getKey1.getStatusCode());
+      assertEquals(getKey1.getStatusText(), HttpStatus.SC_NOT_FOUND, getKey1.getStatusCode());
 
       // 4. GET with REST key2, long min-fresh
       HttpMethod getKey2 = new GetMethod(cacheFactory.getRestUrl() + "/" + key2);
       getKey2.setRequestHeader("Cache-Control", "min-fresh=20");
       cacheFactory.getRestClient().executeMethod(getKey2);
-      assertEquals(getKey2.getStatusText(), HttpServletResponse.SC_NOT_FOUND, getKey2.getStatusCode());
+      assertEquals(getKey2.getStatusText(), HttpStatus.SC_NOT_FOUND, getKey2.getStatusCode());
 
       // 5. GET with REST key1, short min-fresh
       getKey1 = new GetMethod(cacheFactory.getRestUrl() + "/" + key1);
@@ -377,7 +376,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       cacheFactory.getRestClient().executeMethod(getKey1);
       assertNotNull(getKey1.getResponseHeader("Cache-Control"));
       assertTrue(getKey1.getResponseHeader("Cache-Control").getValue().contains("max-age"));
-      assertEquals(getKey1.getStatusText(), HttpServletResponse.SC_OK, getKey1.getStatusCode());
+      assertEquals(getKey1.getStatusText(), HttpStatus.SC_OK, getKey1.getStatusCode());
       assertEquals("v1", getKey1.getResponseBodyAsString());
 
       // 6. GET with REST key2, short min-fresh
@@ -385,7 +384,7 @@ public class EmbeddedRestHotRodTest extends AbstractInfinispanTest {
       getKey2.setRequestHeader("Cache-Control", "min-fresh=3");
       cacheFactory.getRestClient().executeMethod(getKey2);
       assertTrue(getKey2.getResponseHeader("Cache-Control").getValue().contains("max-age"));
-      assertEquals(getKey2.getStatusText(), HttpServletResponse.SC_OK, getKey2.getStatusCode());
+      assertEquals(getKey2.getStatusText(), HttpStatus.SC_OK, getKey2.getStatusCode());
       assertEquals("v2", getKey2.getResponseBodyAsString());
    }
 

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestMemcachedHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/EmbeddedRestMemcachedHotRodTest.java
@@ -6,6 +6,7 @@ import net.spy.memcached.transcoders.SerializingTranscoder;
 import net.spy.memcached.transcoders.Transcoder;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -21,7 +22,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import javax.servlet.http.HttpServletResponse;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -64,7 +64,7 @@ public class EmbeddedRestMemcachedHotRodTest {
       // 3. Get with REST
       HttpMethod get = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       cacheFactory.getRestClient().executeMethod(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertEquals("text/plain", get.getResponseHeader("Content-Type").getValue());
       assertEquals("v1", get.getResponseBodyAsString());
 
@@ -84,7 +84,7 @@ public class EmbeddedRestMemcachedHotRodTest {
       // 3. Get with REST
       HttpMethod get = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       cacheFactory.getRestClient().executeMethod(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertEquals("v1", get.getResponseBodyAsString());
 
       // 4. Get with Hot Rod
@@ -100,7 +100,7 @@ public class EmbeddedRestMemcachedHotRodTest {
             "<hey>ho</hey>".getBytes(), "application/octet-stream"));
       HttpClient restClient = cacheFactory.getRestClient();
       restClient.executeMethod(put);
-      assertEquals(HttpServletResponse.SC_OK, put.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, put.getStatusCode());
       assertEquals("", put.getResponseBodyAsString().trim());
 
       // 2. Get with Embedded (given a marshaller, it can unmarshall the result)
@@ -132,7 +132,7 @@ public class EmbeddedRestMemcachedHotRodTest {
       // 4. Get with REST
       HttpMethod get = new GetMethod(cacheFactory.getRestUrl() + "/" + key);
       cacheFactory.getRestClient().executeMethod(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertEquals("v1", get.getResponseBodyAsString());
    }
 

--- a/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/ReplEmbeddedRestHotRodTest.java
+++ b/integrationtests/compatibility-mode-it/src/test/java/org/infinispan/it/compatibility/ReplEmbeddedRestHotRodTest.java
@@ -2,22 +2,19 @@ package org.infinispan.it.compatibility;
 
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
 import org.infinispan.client.hotrod.Flag;
 import org.infinispan.client.hotrod.RemoteCache;
-import org.infinispan.client.hotrod.VersionedValue;
 import org.infinispan.configuration.cache.CacheMode;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import javax.servlet.http.HttpServletResponse;
-
 import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
 /**
@@ -54,7 +51,7 @@ public class ReplEmbeddedRestHotRodTest {
             "<hey>ho</hey>".getBytes(), "application/octet-stream"));
       HttpClient restClient = cacheFactory1.getRestClient();
       restClient.executeMethod(put);
-      assertEquals(HttpServletResponse.SC_OK, put.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, put.getStatusCode());
       assertEquals("", put.getResponseBodyAsString().trim());
 
       // 2. Get with Embedded
@@ -78,7 +75,7 @@ public class ReplEmbeddedRestHotRodTest {
       // 3. Get with REST
       HttpMethod get = new GetMethod(cacheFactory2.getRestUrl() + "/" + key);
       cacheFactory2.getRestClient().executeMethod(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertEquals("v1", get.getResponseBodyAsString());
    }
 
@@ -95,7 +92,7 @@ public class ReplEmbeddedRestHotRodTest {
       // 3. Get with REST
       HttpMethod get = new GetMethod(cacheFactory2.getRestUrl() + "/" + key);
       cacheFactory2.getRestClient().executeMethod(get);
-      assertEquals(HttpServletResponse.SC_OK, get.getStatusCode());
+      assertEquals(HttpStatus.SC_OK, get.getStatusCode());
       assertEquals("v1", get.getResponseBodyAsString());
    }
 }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/AbstractRESTClientIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/AbstractRESTClientIT.java
@@ -1,12 +1,12 @@
 package org.infinispan.server.test.client.rest;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.util.EntityUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -54,10 +54,10 @@ public abstract class AbstractRESTClientIT {
         delete(fullPathKey(KEY_C));
         delete(fullPathKey(DEFAULT_NAMED_CACHE, KEY_A));
 
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(KEY_B), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(KEY_C), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(DEFAULT_NAMED_CACHE, KEY_A), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(KEY_A), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(KEY_B), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(KEY_C), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(DEFAULT_NAMED_CACHE, KEY_A), HttpStatus.SC_NOT_FOUND);
     }
 
     @After
@@ -81,13 +81,13 @@ public abstract class AbstractRESTClientIT {
         assertEquals("application/octet-stream", get.getHeaders("Content-Type")[0].getValue());
 
         delete(fullPathKey);
-        get(fullPathKey, HttpServletResponse.SC_NOT_FOUND);
+        get(fullPathKey, HttpStatus.SC_NOT_FOUND);
 
         put(fullPathKey, initialXML, "application/octet-stream");
         get(fullPathKey, initialXML);
 
         delete(fullPathKey(null));
-        get(fullPathKey, HttpServletResponse.SC_NOT_FOUND);
+        get(fullPathKey, HttpStatus.SC_NOT_FOUND);
 
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         ObjectOutputStream oo = new ObjectOutputStream(bout);
@@ -106,7 +106,7 @@ public abstract class AbstractRESTClientIT {
 
     @Test
     public void testEmptyGet() throws Exception {
-        get(fullPathKey("nodata"), HttpServletResponse.SC_NOT_FOUND);
+        get(fullPathKey("nodata"), HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -151,7 +151,7 @@ public abstract class AbstractRESTClientIT {
 
         post(fullPathKey, "data", "application/text");
         // second post, returns 409
-        post(fullPathKey, "data", "application/text", HttpServletResponse.SC_CONFLICT);
+        post(fullPathKey, "data", "application/text", HttpStatus.SC_CONFLICT);
         // Should be all ok as its a put
         put(fullPathKey, "data", "application/text");
     }
@@ -160,21 +160,21 @@ public abstract class AbstractRESTClientIT {
     public void testPutDataWithTimeToLive() throws Exception {
         URI fullPathKey = fullPathKey(KEY_A);
 
-        post(fullPathKey, "data", "application/text", HttpServletResponse.SC_OK,
+        post(fullPathKey, "data", "application/text", HttpStatus.SC_OK,
                 // headers
                 "Content-Type", "application/text", "timeToLiveSeconds", "2");
 
         get(fullPathKey, "data");
         sleepForSecs(2.1);
         // should be evicted
-        head(fullPathKey, HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey, HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
     public void testPutDataWithMaxIdleTime() throws Exception {
         URI fullPathKey = fullPathKey(KEY_A);
 
-        post(fullPathKey, "data", "application/text", HttpServletResponse.SC_OK,
+        post(fullPathKey, "data", "application/text", HttpStatus.SC_OK,
                 // headers
                 "Content-Type", "application/text", "maxIdleTimeSeconds", "2");
 
@@ -189,14 +189,14 @@ public abstract class AbstractRESTClientIT {
         // idle for 2 seconds
         sleepForSecs(2.1);
         // should be evicted
-        head(fullPathKey, HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey, HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
     public void testPutDataTTLMaxIdleCombo1() throws Exception {
         URI fullPathKey = fullPathKey(KEY_A);
 
-        post(fullPathKey, "data", "application/text", HttpServletResponse.SC_OK,
+        post(fullPathKey, "data", "application/text", HttpStatus.SC_OK,
                 // headers
                 "Content-Type", "application/text", "timeToLiveSeconds", "10", "maxIdleTimeSeconds", "2");
 
@@ -211,21 +211,21 @@ public abstract class AbstractRESTClientIT {
         // idle for 2 seconds
         sleepForSecs(2.1);
         // should be evicted
-        head(fullPathKey, HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey, HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
     public void testPutDataTTLMaxIdleCombo2() throws Exception {
         URI fullPathKey = fullPathKey(KEY_A);
 
-        post(fullPathKey, "data", "application/text", HttpServletResponse.SC_OK,
+        post(fullPathKey, "data", "application/text", HttpStatus.SC_OK,
                 // headers
                 "Content-Type", "application/text", "timeToLiveSeconds", "2", "maxIdleTimeSeconds", "10");
 
         get(fullPathKey, "data");
         sleepForSecs(2.1);
         // should be evicted
-        head(fullPathKey, HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey, HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -234,7 +234,7 @@ public abstract class AbstractRESTClientIT {
         post(fullPathKey, "data", "application/text");
         head(fullPathKey);
         delete(fullPathKey);
-        head(fullPathKey, HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey, HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -244,8 +244,8 @@ public abstract class AbstractRESTClientIT {
         head(fullPathKey(KEY_A));
         head(fullPathKey(KEY_B));
         delete(fullPathKey(null));
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(KEY_B), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(KEY_A), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(KEY_B), HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -258,7 +258,7 @@ public abstract class AbstractRESTClientIT {
         oo.flush();
         byte[] byteData = bout.toByteArray();
         put(fullPathKey, byteData, "application/x-java-serialized-object");
-        HttpResponse resp = get(fullPathKey, null, HttpServletResponse.SC_OK, false, "Accept", "application/x-java-serialized-object");
+        HttpResponse resp = get(fullPathKey, null, HttpStatus.SC_OK, false, "Accept", "application/x-java-serialized-object");
         ObjectInputStream oin = new ObjectInputStream(resp.getEntity().getContent());
         TestSerializable ts = (TestSerializable) oin.readObject();
         EntityUtils.consume(resp.getEntity());
@@ -275,7 +275,7 @@ public abstract class AbstractRESTClientIT {
         oo.flush();
         byte[] byteData = bout.toByteArray();
         put(fullPathKey, byteData, "application/x-java-serialized-object");
-        HttpResponse resp = get(fullPathKey, null, HttpServletResponse.SC_OK, false, "Accept", "application/x-java-serialized-object");
+        HttpResponse resp = get(fullPathKey, null, HttpStatus.SC_OK, false, "Accept", "application/x-java-serialized-object");
         ObjectInputStream oin = new ObjectInputStream(resp.getEntity().getContent());
         Integer i2 = (Integer) oin.readObject();
         EntityUtils.consume(resp.getEntity());
@@ -300,9 +300,9 @@ public abstract class AbstractRESTClientIT {
         //show that "application/text" works for delete
         URI fullPathKey1 = fullPathKey("j");
         put(fullPathKey1, "data1", "application/text");
-        head(fullPathKey1, HttpServletResponse.SC_OK);
+        head(fullPathKey1, HttpStatus.SC_OK);
         delete(fullPathKey1);
-        head(fullPathKey1, HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey1, HttpStatus.SC_NOT_FOUND);
 
         URI fullPathKey2 = fullPathKey("k");
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -312,9 +312,9 @@ public abstract class AbstractRESTClientIT {
         oo.flush();
         byte[] byteData = bout.toByteArray();
         put(fullPathKey2, byteData, "application/x-java-serialized-object");
-        head(fullPathKey2, HttpServletResponse.SC_OK);
+        head(fullPathKey2, HttpStatus.SC_OK);
         delete(fullPathKey2);
-        head(fullPathKey2, HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey2, HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -326,15 +326,15 @@ public abstract class AbstractRESTClientIT {
         String dateMinus = addDay(dateLast, -1);
         String datePlus = addDay(dateLast, 1);
 
-        get(fullPathKey, "data", HttpServletResponse.SC_OK, true,
+        get(fullPathKey, "data", HttpStatus.SC_OK, true,
                 // resource has been modified since
                 "If-Modified-Since", dateMinus);
 
-        get(fullPathKey, null, HttpServletResponse.SC_NOT_MODIFIED, true,
+        get(fullPathKey, null, HttpStatus.SC_NOT_MODIFIED, true,
                 // exact same date as stored one
                 "If-Modified-Since", dateLast);
 
-        get(fullPathKey, null, HttpServletResponse.SC_NOT_MODIFIED, true,
+        get(fullPathKey, null, HttpStatus.SC_NOT_MODIFIED, true,
                 // resource hasn't been modified since
                 "If-Modified-Since", datePlus);
     }
@@ -349,11 +349,11 @@ public abstract class AbstractRESTClientIT {
         String dateMinus = addDay(dateLast, -1);
         String datePlus = addDay(dateLast, 1);
 
-        get(fullPathKey, "data", HttpServletResponse.SC_OK, true, "If-Unmodified-Since", dateLast);
+        get(fullPathKey, "data", HttpStatus.SC_OK, true, "If-Unmodified-Since", dateLast);
 
-        get(fullPathKey, "data", HttpServletResponse.SC_OK, true, "If-Unmodified-Since", datePlus);
+        get(fullPathKey, "data", HttpStatus.SC_OK, true, "If-Unmodified-Since", datePlus);
 
-        get(fullPathKey, null, HttpServletResponse.SC_PRECONDITION_FAILED, true, "If-Unmodified-Since", dateMinus);
+        get(fullPathKey, null, HttpStatus.SC_PRECONDITION_FAILED, true, "If-Unmodified-Since", dateMinus);
     }
 
     @Test
@@ -363,9 +363,9 @@ public abstract class AbstractRESTClientIT {
         HttpResponse resp = get(fullPathKey);
         String eTag = resp.getHeaders("ETag")[0].getValue();
 
-        get(fullPathKey, null, HttpServletResponse.SC_NOT_MODIFIED, true, "If-None-Match", eTag);
+        get(fullPathKey, null, HttpStatus.SC_NOT_MODIFIED, true, "If-None-Match", eTag);
 
-        get(fullPathKey, "data", HttpServletResponse.SC_OK, true, "If-None-Match", eTag + "garbage");
+        get(fullPathKey, "data", HttpStatus.SC_OK, true, "If-None-Match", eTag + "garbage");
     }
 
     @Test
@@ -376,19 +376,19 @@ public abstract class AbstractRESTClientIT {
 
         String eTag = resp.getHeaders("ETag")[0].getValue();
         // test GET with If-Match behaviour
-        get(fullPathKey, "data", HttpServletResponse.SC_OK, true, "If-Match", eTag);
+        get(fullPathKey, "data", HttpStatus.SC_OK, true, "If-Match", eTag);
 
-        get(fullPathKey, null, HttpServletResponse.SC_PRECONDITION_FAILED, true, "If-Match", eTag + "garbage");
+        get(fullPathKey, null, HttpStatus.SC_PRECONDITION_FAILED, true, "If-Match", eTag + "garbage");
 
         // test HEAD with If-Match behaviour
-        head(fullPathKey, HttpServletResponse.SC_OK, new String[][]{{"If-Match", eTag}});
-        head(fullPathKey, HttpServletResponse.SC_PRECONDITION_FAILED, new String[][]{{"If-Match", eTag + "garbage"}});
+        head(fullPathKey, HttpStatus.SC_OK, new String[][]{{"If-Match", eTag}});
+        head(fullPathKey, HttpStatus.SC_PRECONDITION_FAILED, new String[][]{{"If-Match", eTag + "garbage"}});
     }
 
     @Test
     public void testNonExistentCache() throws Exception {
-        head(fullPathKey("nonexistentcache", "nodata"), HttpServletResponse.SC_NOT_FOUND);
-        get(fullPathKey("nonexistentcache", "nodata"), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey("nonexistentcache", "nodata"), HttpStatus.SC_NOT_FOUND);
+        get(fullPathKey("nonexistentcache", "nodata"), HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -404,7 +404,7 @@ public abstract class AbstractRESTClientIT {
         byte[] serializedData = bout.toByteArray();
         put(fullPathKey(0, KEY_Z), serializedData, "application/x-java-serialized-object");
 
-        HttpResponse resp = get(fullPathKey(0, KEY_Z), null, HttpServletResponse.SC_OK, false, "Accept",
+        HttpResponse resp = get(fullPathKey(0, KEY_Z), null, HttpStatus.SC_OK, false, "Accept",
                 "application/x-java-serialized-object");
         ObjectInputStream oin = new ObjectInputStream(resp.getEntity().getContent());
         byte[] dataBack = (byte[]) oin.readObject();

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/RESTAsyncIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/RESTAsyncIT.java
@@ -2,8 +2,7 @@ package org.infinispan.server.test.client.rest;
 
 import java.net.URI;
 
-import javax.servlet.http.HttpServletResponse;
-
+import org.apache.http.HttpStatus;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServer;
 import org.infinispan.server.test.category.RESTClustered;
@@ -48,7 +47,7 @@ public class RESTAsyncIT {
         RESTHelper.addServer(server2.getRESTEndpoint().getInetAddress().getHostName(), server2.getRESTEndpoint().getContextPath());
 
         delete(fullPathKey(KEY_A));
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(KEY_A), HttpStatus.SC_NOT_FOUND);
     }
 
     @After
@@ -70,7 +69,7 @@ public class RESTAsyncIT {
 
         long t1 = System.currentTimeMillis();
         for (int i = 0; i < NUM_OPERATIONS; i++) {
-            put(fullPathKey, initialXML, "application/octet-stream", HttpServletResponse.SC_OK, "performAsync", "false");
+            put(fullPathKey, initialXML, "application/octet-stream", HttpStatus.SC_OK, "performAsync", "false");
         }
         long putSyncTime = System.currentTimeMillis() - t1;
 
@@ -78,12 +77,12 @@ public class RESTAsyncIT {
 
         t1 = System.currentTimeMillis();
         for (int i = 0; i < NUM_OPERATIONS; i++) {
-            put(fullPathKey, initialXML, "application/octet-stream", HttpServletResponse.SC_OK, "performAsync", "true");
+            put(fullPathKey, initialXML, "application/octet-stream", HttpStatus.SC_OK, "performAsync", "true");
         }
         long putAsyncTime = System.currentTimeMillis() - t1;
 
         assertTrue("PUT : async- " + putAsyncTime + ", sync- " + putSyncTime, putAsyncTime < putSyncTime);
-        get(fullPathKey, initialXML, HttpServletResponse.SC_OK, true, "performAsync", "true");
+        get(fullPathKey, initialXML, HttpStatus.SC_OK, true, "performAsync", "true");
     }
 
     @Test
@@ -97,11 +96,11 @@ public class RESTAsyncIT {
         }
 
         for (int i = 0; i < NUM_OPERATIONS; i++) {
-            put(fullPathKey(String.valueOf(i)), bytes, "application/octet-stream", HttpServletResponse.SC_OK, "performAsync", "false");
+            put(fullPathKey(String.valueOf(i)), bytes, "application/octet-stream", HttpStatus.SC_OK, "performAsync", "false");
         }
 
         for (int i = 0; i < NUM_OPERATIONS; i++) {
-            delete(fullPathKey(String.valueOf(i)), HttpServletResponse.SC_OK, "performAsync", "true");
+            delete(fullPathKey(String.valueOf(i)), HttpStatus.SC_OK, "performAsync", "true");
         }
 
         for (int i = 0; i < NUM_OPERATIONS; i++) {
@@ -110,20 +109,20 @@ public class RESTAsyncIT {
             eventually(new ITestUtils.Condition() {
                 @Override
                 public boolean isSatisfied() throws Exception {
-                    return getWithoutAssert(fullPathKey(String.valueOf(iter)), null, HttpServletResponse.SC_NOT_FOUND, true, "performAsync", "true");
+                    return getWithoutAssert(fullPathKey(String.valueOf(iter)), null, HttpStatus.SC_NOT_FOUND, true, "performAsync", "true");
                 }
             }, 5000, 10);
         }
 
         put(fullPathKey(KEY_A), KEY_A, "application/octet-stream");
         put(fullPathKey(KEY_B), KEY_B, "application/octet-stream");
-        delete(fullPathKey(null), HttpServletResponse.SC_OK, "performAsync", "true");
+        delete(fullPathKey(null), HttpStatus.SC_OK, "performAsync", "true");
 
         eventually(new ITestUtils.Condition() {
             @Override
             public boolean isSatisfied() throws Exception {
-                return getWithoutAssert(fullPathKey(KEY_A), null, HttpServletResponse.SC_NOT_FOUND, true) &&
-                       getWithoutAssert(fullPathKey(KEY_B), null, HttpServletResponse.SC_NOT_FOUND, true);
+                return getWithoutAssert(fullPathKey(KEY_A), null, HttpStatus.SC_NOT_FOUND, true) &&
+                       getWithoutAssert(fullPathKey(KEY_B), null, HttpStatus.SC_NOT_FOUND, true);
             }
         }, 5000, 10);
     }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/RESTHelper.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/RESTHelper.java
@@ -1,6 +1,7 @@
 package org.infinispan.server.test.client.rest;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -17,7 +18,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 
-import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -72,11 +72,11 @@ public class RESTHelper {
     }
 
     public static HttpResponse head(URI uri) throws Exception {
-        return head(uri, HttpServletResponse.SC_OK);
+        return head(uri, HttpStatus.SC_OK);
     }
 
     public static HttpResponse headWithoutClose(URI uri) throws Exception {
-        return head(uri, HttpServletResponse.SC_OK);
+        return head(uri, HttpStatus.SC_OK);
     }
 
     public static HttpResponse head(URI uri, int expectedCode) throws Exception {
@@ -113,19 +113,19 @@ public class RESTHelper {
     }
 
     public static HttpResponse get(URI uri) throws Exception {
-        return get(uri, HttpServletResponse.SC_OK);
+        return get(uri, HttpStatus.SC_OK);
     }
 
     public static HttpResponse getWithoutClose(URI uri) throws Exception {
-        return getWithoutClose(uri, HttpServletResponse.SC_OK);
+        return getWithoutClose(uri, HttpStatus.SC_OK);
     }
 
     public static HttpResponse get(URI uri, String expectedResponseBody) throws Exception {
-        return get(uri, expectedResponseBody, HttpServletResponse.SC_OK, true);
+        return get(uri, expectedResponseBody, HttpStatus.SC_OK, true);
     }
 
     public static HttpResponse getWithoutClose(URI uri, String expectedResponseBody) throws Exception {
-        return get(uri, expectedResponseBody, HttpServletResponse.SC_OK, false);
+        return get(uri, expectedResponseBody, HttpStatus.SC_OK, false);
     }
 
     public static HttpResponse get(URI uri, int expectedCode) throws Exception {
@@ -182,9 +182,9 @@ public class RESTHelper {
         }
         return true;
     }
-    
+
     public static HttpResponse put(URI uri, Object data, String contentType) throws Exception {
-        return put(uri, data, contentType, HttpServletResponse.SC_OK);
+        return put(uri, data, contentType, HttpStatus.SC_OK);
     }
 
     public static HttpResponse put(URI uri, Object data, String contentType, int expectedCode) throws Exception {
@@ -226,7 +226,7 @@ public class RESTHelper {
     }
 
     public static HttpResponse post(URI uri, Object data, String contentType) throws Exception {
-        return post(uri, data, contentType, HttpServletResponse.SC_OK);
+        return post(uri, data, contentType, HttpStatus.SC_OK);
     }
 
     public static HttpResponse post(URI uri, Object data, String contentType, int expectedCode) throws Exception {

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/RESTReplicationIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/rest/RESTReplicationIT.java
@@ -1,7 +1,6 @@
 package org.infinispan.server.test.client.rest;
 
-import javax.servlet.http.HttpServletResponse;
-
+import org.apache.http.HttpStatus;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServer;
 import org.infinispan.server.test.category.RESTClustered;
@@ -50,9 +49,9 @@ public class RESTReplicationIT {
         delete(fullPathKey(KEY_B));
         delete(fullPathKey(KEY_C));
 
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(KEY_B), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(KEY_C), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(KEY_A), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(KEY_B), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(KEY_C), HttpStatus.SC_NOT_FOUND);
     }
 
     @After
@@ -79,7 +78,7 @@ public class RESTReplicationIT {
         post(fullPathKey(0, KEY_A), "data", "text/plain");
         get(fullPathKey(1, KEY_A), "data");
         delete(fullPathKey(0, KEY_A));
-        head(fullPathKey(1, KEY_A), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_A), HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -89,18 +88,18 @@ public class RESTReplicationIT {
         head(fullPathKey(0, KEY_A));
         head(fullPathKey(0, KEY_B));
         delete(fullPathKey(0, null));
-        head(fullPathKey(1, KEY_A), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(1, KEY_B), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_A), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_B), HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
     public void testReplicationTTL() throws Exception {
-        post(fullPathKey(0, KEY_A), "data", "application/text", HttpServletResponse.SC_OK,
+        post(fullPathKey(0, KEY_A), "data", "application/text", HttpStatus.SC_OK,
                 // headers
                 "Content-Type", "application/text", "timeToLiveSeconds", "2");
         head(fullPathKey(1, KEY_A));
         sleepForSecs(2.1);
         // should be evicted
-        head(fullPathKey(1, KEY_A), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_A), HttpStatus.SC_NOT_FOUND);
     }
 }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/configs/ExampleConfigsIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/configs/ExampleConfigsIT.java
@@ -8,9 +8,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.management.ObjectName;
-import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ByteArrayEntity;
@@ -195,7 +195,7 @@ public class ExampleConfigsIT {
             post(fullPathKey(0, DEFAULT_CACHE_NAME, "disconnected", PORT_OFFSET), "source", "application/text");
 
             //Source node entries should NOT be accessible from target node
-            get(fullPathKey(1, DEFAULT_CACHE_NAME, "disconnected", 0), HttpServletResponse.SC_NOT_FOUND);
+            get(fullPathKey(1, DEFAULT_CACHE_NAME, "disconnected", 0), HttpStatus.SC_NOT_FOUND);
 
             //All remaining entries migrated?
             for (int i = 0; i < 50; i++) {
@@ -233,7 +233,7 @@ public class ExampleConfigsIT {
             // 2. Get with REST
             HttpGet get = new HttpGet(restUrl + "/" + key);
             HttpResponse getResponse = restClient.execute(get);
-            assertEquals(HttpServletResponse.SC_OK, getResponse.getStatusLine().getStatusCode());
+            assertEquals(HttpStatus.SC_OK, getResponse.getStatusLine().getStatusCode());
             assertArrayEquals("v1".getBytes(), EntityUtils.toByteArray(getResponse.getEntity()));
 
             // 3. Get with Memcached
@@ -245,7 +245,7 @@ public class ExampleConfigsIT {
             HttpPut put = new HttpPut(restUrl + "/" + key);
             put.setEntity(new ByteArrayEntity("<hey>ho</hey>".getBytes(), ContentType.APPLICATION_OCTET_STREAM));
             HttpResponse putResponse = restClient.execute(put);
-            assertEquals(HttpServletResponse.SC_OK, putResponse.getStatusLine().getStatusCode());
+            assertEquals(HttpStatus.SC_OK, putResponse.getStatusLine().getStatusCode());
 
             // 2. Get with Hot Rod
             assertArrayEquals("<hey>ho</hey>".getBytes(), (byte[]) s1Cache.get(key));
@@ -524,23 +524,23 @@ public class ExampleConfigsIT {
         post(fullPathKey(0, KEY_A), "data", "text/plain");
         get(fullPathKey(1, KEY_A), "data");
         delete(fullPathKey(0, KEY_A));
-        head(fullPathKey(1, KEY_A), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_A), HttpStatus.SC_NOT_FOUND);
         setUpREST(s1.server, s2.server);
         post(fullPathKey(0, KEY_A), "data", "text/plain");
         post(fullPathKey(0, KEY_B), "data", "text/plain");
         head(fullPathKey(0, KEY_A));
         head(fullPathKey(0, KEY_B));
         delete(fullPathKey(0, null));
-        head(fullPathKey(1, KEY_A), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(1, KEY_B), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_A), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_B), HttpStatus.SC_NOT_FOUND);
         setUpREST(s1.server, s2.server);
-        post(fullPathKey(0, KEY_A), "data", "application/text", HttpServletResponse.SC_OK,
+        post(fullPathKey(0, KEY_A), "data", "application/text", HttpStatus.SC_OK,
                 // headers
                 "Content-Type", "application/text", "timeToLiveSeconds", "2");
         head(fullPathKey(1, KEY_A));
         sleepForSecs(2.1);
         // should be evicted
-        head(fullPathKey(1, KEY_A), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(1, KEY_A), HttpStatus.SC_NOT_FOUND);
     }
 
     @Test
@@ -579,10 +579,10 @@ public class ExampleConfigsIT {
         delete(fullPathKey(KEY_C));
         delete(fullPathKey(NAMED_CACHE_NAME, KEY_A));
 
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(KEY_B), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(KEY_C), HttpServletResponse.SC_NOT_FOUND);
-        head(fullPathKey(NAMED_CACHE_NAME, KEY_A), HttpServletResponse.SC_NOT_FOUND);
+        head(fullPathKey(KEY_A), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(KEY_B), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(KEY_C), HttpStatus.SC_NOT_FOUND);
+        head(fullPathKey(NAMED_CACHE_NAME, KEY_A), HttpStatus.SC_NOT_FOUND);
     }
 
     private void addServer(RemoteInfinispanServer server) {

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/expiration/ExpirationIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/expiration/ExpirationIT.java
@@ -3,8 +3,7 @@ package org.infinispan.server.test.expiration;
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
-import javax.servlet.http.HttpServletResponse;
-
+import org.apache.http.HttpStatus;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServer;
 import org.infinispan.arquillian.core.RunningServer;
@@ -57,14 +56,14 @@ public class ExpirationIT {
         URI key4Path = fullPathKey(0, "k4");
         Assert.assertEquals(2, server1.getCacheManager("clustered").getClusterSize());
         // specific entry timeToLiveSeconds and maxIdleTimeSeconds that overrides the default
-        post(key1Path, "v1", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text",
+        post(key1Path, "v1", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text",
                 "timeToLiveSeconds", "3", "maxIdleTimeSeconds", "3");
         // no value means never expire
-        post(key2Path, "v2", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text");
+        post(key2Path, "v2", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text");
         // 0 value means use default
-        post(key3Path, "v3", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text",
+        post(key3Path, "v3", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text",
                 "timeToLiveSeconds", "0", "maxIdleTimeSeconds", "0");
-        post(key4Path, "v4", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text",
+        post(key4Path, "v4", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text",
                 "timeToLiveSeconds", "0", "maxIdleTimeSeconds", "2");
 
         sleepForSecs(1);
@@ -74,14 +73,14 @@ public class ExpirationIT {
         sleepForSecs(1.1);
         // k3 and k4 expired
         get(key1Path, "v1");
-        head(key3Path, HttpServletResponse.SC_NOT_FOUND);
-        head(key4Path, HttpServletResponse.SC_NOT_FOUND);
+        head(key3Path, HttpStatus.SC_NOT_FOUND);
+        head(key4Path, HttpStatus.SC_NOT_FOUND);
         sleepForSecs(1);
         // k1 expired
-        head(key1Path, HttpServletResponse.SC_NOT_FOUND);
+        head(key1Path, HttpStatus.SC_NOT_FOUND);
         // k2 should not be expired because without timeToLive/maxIdle parameters,
         // the entries live forever. To use default values, 0 must be passed in.
-        head(key2Path, HttpServletResponse.SC_OK);
+        head(key2Path, HttpStatus.SC_OK);
     }
 
     @Test

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/RestRollingUpgradesDistIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/RestRollingUpgradesDistIT.java
@@ -1,8 +1,8 @@
 package org.infinispan.server.test.rollingupgrades;
 
 import javax.management.ObjectName;
-import javax.servlet.http.HttpServletResponse;
 
+import org.apache.http.HttpStatus;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServers;
 import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
@@ -128,10 +128,10 @@ public class RestRollingUpgradesDistIT {
 
             // is RemoteCacheStore really disconnected?
             // source node entries should NOT be accessible from target node now
-            get(fullPathKey(2, DEFAULT_CACHE_NAME, "disconnected", 0), HttpServletResponse.SC_NOT_FOUND);
-            get(fullPathKey(3, DEFAULT_CACHE_NAME, "disconnected", PORT_OFFSET), HttpServletResponse.SC_NOT_FOUND);
-            get(fullPathKey(2, DEFAULT_CACHE_NAME, "disconnectedx", 0), HttpServletResponse.SC_NOT_FOUND);
-            get(fullPathKey(3, DEFAULT_CACHE_NAME, "disconnectedx", PORT_OFFSET), HttpServletResponse.SC_NOT_FOUND);
+            get(fullPathKey(2, DEFAULT_CACHE_NAME, "disconnected", 0), HttpStatus.SC_NOT_FOUND);
+            get(fullPathKey(3, DEFAULT_CACHE_NAME, "disconnected", PORT_OFFSET), HttpStatus.SC_NOT_FOUND);
+            get(fullPathKey(2, DEFAULT_CACHE_NAME, "disconnectedx", 0), HttpStatus.SC_NOT_FOUND);
+            get(fullPathKey(3, DEFAULT_CACHE_NAME, "disconnectedx", PORT_OFFSET), HttpStatus.SC_NOT_FOUND);
 
             // all entries migrated?
             get(fullPathKey(2, DEFAULT_CACHE_NAME, "key1", 0), "data");

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/RestRollingUpgradesIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/rollingupgrades/RestRollingUpgradesIT.java
@@ -1,8 +1,8 @@
 package org.infinispan.server.test.rollingupgrades;
 
 import javax.management.ObjectName;
-import javax.servlet.http.HttpServletResponse;
 
+import org.apache.http.HttpStatus;
 import org.infinispan.arquillian.core.InfinispanResource;
 import org.infinispan.arquillian.core.RemoteInfinispanServers;
 import org.infinispan.arquillian.utils.MBeanServerConnectionProvider;
@@ -92,7 +92,7 @@ public class RestRollingUpgradesIT {
             post(fullPathKey(0, DEFAULT_CACHE_NAME, "disconnected", PORT_OFFSET), "source", "application/text");
 
             //Source node entries should NOT be accessible from target node
-            get(fullPathKey(1, DEFAULT_CACHE_NAME, "disconnected", 0), HttpServletResponse.SC_NOT_FOUND);
+            get(fullPathKey(1, DEFAULT_CACHE_NAME, "disconnected", 0), HttpStatus.SC_NOT_FOUND);
 
             //All remaining entries migrated?
             for (int i = 0; i < 50; i++) {

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/security/rest/AbstractBasicSecurity.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/security/rest/AbstractBasicSecurity.java
@@ -1,9 +1,5 @@
 package org.infinispan.server.test.security.rest;
 
-import javax.servlet.http.HttpServletResponse;
-
-import org.infinispan.server.test.client.rest.RESTHelper;
-
 import static org.infinispan.server.test.client.rest.RESTHelper.KEY_A;
 import static org.infinispan.server.test.client.rest.RESTHelper.KEY_B;
 import static org.infinispan.server.test.client.rest.RESTHelper.KEY_C;
@@ -13,6 +9,9 @@ import static org.infinispan.server.test.client.rest.RESTHelper.get;
 import static org.infinispan.server.test.client.rest.RESTHelper.head;
 import static org.infinispan.server.test.client.rest.RESTHelper.post;
 import static org.infinispan.server.test.client.rest.RESTHelper.put;
+
+import org.apache.http.HttpStatus;
+import org.infinispan.server.test.client.rest.RESTHelper;
 
 /**
  * @author <a href="mailto:vchepeli@redhat.com">Vitalii Chepeliuk</a>
@@ -27,43 +26,43 @@ public abstract class AbstractBasicSecurity {
 
     protected void securedWriteOperations() throws Exception {
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
-        put(fullPathKey(KEY_A), "data", "application/text", HttpServletResponse.SC_OK);
+        put(fullPathKey(KEY_A), "data", "application/text", HttpStatus.SC_OK);
         RESTHelper.clearCredentials();
-        put(fullPathKey(KEY_B), "data", "application/text", HttpServletResponse.SC_UNAUTHORIZED);
+        put(fullPathKey(KEY_B), "data", "application/text", HttpStatus.SC_UNAUTHORIZED);
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
-        post(fullPathKey(KEY_C), "data", "application/text", HttpServletResponse.SC_OK);
+        post(fullPathKey(KEY_C), "data", "application/text", HttpStatus.SC_OK);
         RESTHelper.clearCredentials();
-        post(fullPathKey(KEY_D), "data", "application/text", HttpServletResponse.SC_UNAUTHORIZED);
+        post(fullPathKey(KEY_D), "data", "application/text", HttpStatus.SC_UNAUTHORIZED);
         get(fullPathKey(KEY_A), "data");
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_OK);
-        delete(fullPathKey(KEY_A), HttpServletResponse.SC_UNAUTHORIZED);
+        head(fullPathKey(KEY_A), HttpStatus.SC_OK);
+        delete(fullPathKey(KEY_A), HttpStatus.SC_UNAUTHORIZED);
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
-        delete(fullPathKey(KEY_A), HttpServletResponse.SC_OK);
-        delete(fullPathKey(KEY_C), HttpServletResponse.SC_OK);
+        delete(fullPathKey(KEY_A), HttpStatus.SC_OK);
+        delete(fullPathKey(KEY_C), HttpStatus.SC_OK);
         RESTHelper.clearCredentials();
     }
 
     protected void securedReadWriteOperations() throws Exception {
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
-        put(fullPathKey(KEY_A), "data", "application/text", HttpServletResponse.SC_OK);
+        put(fullPathKey(KEY_A), "data", "application/text", HttpStatus.SC_OK);
         RESTHelper.clearCredentials();
-        put(fullPathKey(KEY_B), "data", "application/text", HttpServletResponse.SC_UNAUTHORIZED);
+        put(fullPathKey(KEY_B), "data", "application/text", HttpStatus.SC_UNAUTHORIZED);
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
-        post(fullPathKey(KEY_C), "data", "application/text", HttpServletResponse.SC_OK);
+        post(fullPathKey(KEY_C), "data", "application/text", HttpStatus.SC_OK);
         RESTHelper.clearCredentials();
-        post(fullPathKey(KEY_D), "data", "application/text", HttpServletResponse.SC_UNAUTHORIZED);
-        get(fullPathKey(KEY_A), HttpServletResponse.SC_UNAUTHORIZED);
+        post(fullPathKey(KEY_D), "data", "application/text", HttpStatus.SC_UNAUTHORIZED);
+        get(fullPathKey(KEY_A), HttpStatus.SC_UNAUTHORIZED);
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
         get(fullPathKey(KEY_A), "data");
         RESTHelper.clearCredentials();
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_UNAUTHORIZED);
+        head(fullPathKey(KEY_A), HttpStatus.SC_UNAUTHORIZED);
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
-        head(fullPathKey(KEY_A), HttpServletResponse.SC_OK);
+        head(fullPathKey(KEY_A), HttpStatus.SC_OK);
         RESTHelper.clearCredentials();
-        delete(fullPathKey(KEY_A), HttpServletResponse.SC_UNAUTHORIZED);
+        delete(fullPathKey(KEY_A), HttpStatus.SC_UNAUTHORIZED);
         RESTHelper.setCredentials(TEST_USER_NAME, TEST_USER_PASSWORD);
-        delete(fullPathKey(KEY_A), HttpServletResponse.SC_OK);
-        delete(fullPathKey(KEY_C), HttpServletResponse.SC_OK);
+        delete(fullPathKey(KEY_A), HttpStatus.SC_OK);
+        delete(fullPathKey(KEY_C), HttpStatus.SC_OK);
         RESTHelper.clearCredentials();
     }
 }

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/security/rest/RESTCertSecurityIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/security/rest/RESTCertSecurityIT.java
@@ -12,9 +12,9 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.TrustManager;
-import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
@@ -81,49 +81,49 @@ public class RESTCertSecurityIT {
     @WithRunningServer({@RunningServer(name = CONTAINER, config = "testsuite/rest-sec-cert-wr.xml")})
     public void testSecuredWriteOperations() throws Exception {
         //correct alias for the certificate
-        put(securedClient(testAlias), keyAddress(KEY_A), HttpServletResponse.SC_OK);
+        put(securedClient(testAlias), keyAddress(KEY_A), HttpStatus.SC_OK);
         //test wrong authorization, 1. wrong alias for the certificate
-        put(securedClient(test2Alias), keyAddress(KEY_B), HttpServletResponse.SC_FORBIDDEN);
+        put(securedClient(test2Alias), keyAddress(KEY_B), HttpStatus.SC_FORBIDDEN);
         //2. access over 8080
-        put(securedClient(testAlias), keyAddressUnsecured(KEY_B), HttpServletResponse.SC_UNAUTHORIZED);
-        post(securedClient(testAlias), keyAddress(KEY_C), HttpServletResponse.SC_OK);
-        post(securedClient(test2Alias), keyAddress(KEY_D), HttpServletResponse.SC_FORBIDDEN);
+        put(securedClient(testAlias), keyAddressUnsecured(KEY_B), HttpStatus.SC_UNAUTHORIZED);
+        post(securedClient(testAlias), keyAddress(KEY_C), HttpStatus.SC_OK);
+        post(securedClient(test2Alias), keyAddress(KEY_D), HttpStatus.SC_FORBIDDEN);
         //get is not secured, should be working over 8080
-        HttpResponse resp = get(securedClient(test2Alias), keyAddressUnsecured(KEY_A), HttpServletResponse.SC_OK);
+        HttpResponse resp = get(securedClient(test2Alias), keyAddressUnsecured(KEY_A), HttpStatus.SC_OK);
         String content = new BufferedReader(new InputStreamReader(resp.getEntity().getContent())).readLine();
         assertEquals("data", content);
-        head(securedClient(test2Alias), keyAddressUnsecured(KEY_A), HttpServletResponse.SC_OK);
-        delete(securedClient(test2Alias), keyAddress(KEY_A), HttpServletResponse.SC_FORBIDDEN);
-        delete(securedClient(testAlias), keyAddress(KEY_A), HttpServletResponse.SC_OK);
-        delete(securedClient(testAlias), keyAddress(KEY_C), HttpServletResponse.SC_OK);
+        head(securedClient(test2Alias), keyAddressUnsecured(KEY_A), HttpStatus.SC_OK);
+        delete(securedClient(test2Alias), keyAddress(KEY_A), HttpStatus.SC_FORBIDDEN);
+        delete(securedClient(testAlias), keyAddress(KEY_A), HttpStatus.SC_OK);
+        delete(securedClient(testAlias), keyAddress(KEY_C), HttpStatus.SC_OK);
     }
 
     @Test
     @WithRunningServer({@RunningServer(name = CONTAINER, config = "testsuite/rest-sec-cert-rw.xml")})
     public void testSecuredReadWriteOperations() throws Exception {
         //correct alias for the certificate
-        put(securedClient(testAlias), keyAddress(KEY_A), HttpServletResponse.SC_OK);
+        put(securedClient(testAlias), keyAddress(KEY_A), HttpStatus.SC_OK);
         //test wrong authorization, 1. wrong alias for the certificate
-        put(securedClient(test2Alias), keyAddress(KEY_B), HttpServletResponse.SC_FORBIDDEN);
+        put(securedClient(test2Alias), keyAddress(KEY_B), HttpStatus.SC_FORBIDDEN);
         //2. access over 8080
-        put(securedClient(testAlias), keyAddressUnsecured(KEY_B), HttpServletResponse.SC_UNAUTHORIZED);
-        post(securedClient(testAlias), keyAddress(KEY_C), HttpServletResponse.SC_OK);
-        post(securedClient(test2Alias), keyAddress(KEY_D), HttpServletResponse.SC_FORBIDDEN);
+        put(securedClient(testAlias), keyAddressUnsecured(KEY_B), HttpStatus.SC_UNAUTHORIZED);
+        post(securedClient(testAlias), keyAddress(KEY_C), HttpStatus.SC_OK);
+        post(securedClient(test2Alias), keyAddress(KEY_D), HttpStatus.SC_FORBIDDEN);
         //get is secured too
-        HttpResponse resp = get(securedClient(testAlias), keyAddress(KEY_A), HttpServletResponse.SC_OK);
+        HttpResponse resp = get(securedClient(testAlias), keyAddress(KEY_A), HttpStatus.SC_OK);
         String content = new BufferedReader(new InputStreamReader(resp.getEntity().getContent())).readLine();
         assertEquals("data", content);
         //test wrong authorization, 1. wrong alias for the certificate
-        get(securedClient(test2Alias), keyAddress(KEY_A), HttpServletResponse.SC_FORBIDDEN);
+        get(securedClient(test2Alias), keyAddress(KEY_A), HttpStatus.SC_FORBIDDEN);
         //2. access over 8080
-        get(securedClient(testAlias), keyAddressUnsecured(KEY_A), HttpServletResponse.SC_UNAUTHORIZED);
-        head(securedClient(test2Alias), keyAddress(KEY_A), HttpServletResponse.SC_FORBIDDEN);
+        get(securedClient(testAlias), keyAddressUnsecured(KEY_A), HttpStatus.SC_UNAUTHORIZED);
+        head(securedClient(test2Alias), keyAddress(KEY_A), HttpStatus.SC_FORBIDDEN);
         //access over 8080
-        head(securedClient(testAlias), keyAddressUnsecured(KEY_A), HttpServletResponse.SC_UNAUTHORIZED);
-        head(securedClient(testAlias), keyAddress(KEY_A), HttpServletResponse.SC_OK);
-        delete(securedClient(test2Alias), keyAddress(KEY_A), HttpServletResponse.SC_FORBIDDEN);
-        delete(securedClient(testAlias), keyAddress(KEY_A), HttpServletResponse.SC_OK);
-        delete(securedClient(testAlias), keyAddress(KEY_C), HttpServletResponse.SC_OK);
+        head(securedClient(testAlias), keyAddressUnsecured(KEY_A), HttpStatus.SC_UNAUTHORIZED);
+        head(securedClient(testAlias), keyAddress(KEY_A), HttpStatus.SC_OK);
+        delete(securedClient(test2Alias), keyAddress(KEY_A), HttpStatus.SC_FORBIDDEN);
+        delete(securedClient(testAlias), keyAddress(KEY_A), HttpStatus.SC_OK);
+        delete(securedClient(testAlias), keyAddress(KEY_C), HttpStatus.SC_OK);
     }
 
     private String keyAddress(String key) {

--- a/server/rest/src/test/scala/org/infinispan/rest/TwoServerTest.java
+++ b/server/rest/src/test/scala/org/infinispan/rest/TwoServerTest.java
@@ -3,9 +3,8 @@ package org.infinispan.rest;
 import static org.junit.Assert.assertEquals;
 import static org.testng.Assert.*;
 
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.httpclient.Header;
+import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.HeadMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
@@ -75,15 +74,15 @@ public class TwoServerTest extends RestServerTestBase {
       PutMethod put = new PutMethod(PATH1 + "a");
       put.setRequestEntity(new StringRequestEntity("data", "application/text", null));
       call(put);
-      assertEquals(put.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(put.getStatusCode(), HttpStatus.SC_OK);
       put.releaseConnection();
       GetMethod get = new GetMethod(PATH1 + "a");
       call(get);
-      assertEquals(get.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(get.getStatusCode(), HttpStatus.SC_OK);
       get.releaseConnection();
       get = new GetMethod(PATH2 + "a");
       call(get);
-      assertEquals(get.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(get.getStatusCode(), HttpStatus.SC_OK);
       assertEquals("data", get.getResponseBodyAsString());
       get.releaseConnection();
    }
@@ -92,16 +91,16 @@ public class TwoServerTest extends RestServerTestBase {
       PutMethod put = new PutMethod(PATH1 + "testReplace");
       put.setRequestEntity(new StringRequestEntity("data", "application/text", null));
       call(put);
-      assertEquals(put.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(put.getStatusCode(), HttpStatus.SC_OK);
       put.releaseConnection();
       put = new PutMethod(PATH1 + "testReplace");
       put.setRequestEntity(new StringRequestEntity("data2", "application/text", null));
       call(put);
-      assertEquals(put.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(put.getStatusCode(), HttpStatus.SC_OK);
       put.releaseConnection();
       GetMethod get = new GetMethod(PATH2 + "testReplace");
       call(get);
-      assertEquals(get.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(get.getStatusCode(), HttpStatus.SC_OK);
       assertEquals("data2", get.getResponseBodyAsString());
       get.releaseConnection();
    }
@@ -110,11 +109,11 @@ public class TwoServerTest extends RestServerTestBase {
       PutMethod put = new PutMethod(PATH1 + "testExtendedHeaders");
       put.setRequestEntity(new StringRequestEntity("data", "application/text", null));
       call(put);
-      assertEquals(put.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(put.getStatusCode(), HttpStatus.SC_OK);
       put.releaseConnection();
       GetMethod get = new GetMethod(PATH2 + "testExtendedHeaders?extended");
       call(get);
-      assertEquals(get.getStatusCode(), HttpServletResponse.SC_OK);
+      assertEquals(get.getStatusCode(), HttpStatus.SC_OK);
       Header po = get.getResponseHeader("Cluster-Primary-Owner");
       assertNotNull(po);
       Address primaryLocation = getCacheManager("1").getCache(BasicCacheContainer.DEFAULT_CACHE_NAME).getAdvancedCache().getDistributionManager().getPrimaryLocation("testExtendedHeaders");
@@ -135,14 +134,14 @@ public class TwoServerTest extends RestServerTestBase {
       String key3Path = EXPIRY_PATH1 + "k3";
       String key4Path = EXPIRY_PATH1 + "k4";
       // specific entry timeToLiveSeconds and maxIdleTimeSeconds that overrides the default
-      post(key1Path, "v1", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text",
+      post(key1Path, "v1", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text",
          "timeToLiveSeconds", "3", "maxIdleTimeSeconds", "3");
       // no value means never expire
-      post(key2Path, "v2", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text");
+      post(key2Path, "v2", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text");
       // 0 value means use default
-      post(key3Path, "v3", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text",
+      post(key3Path, "v3", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text",
          "timeToLiveSeconds", "0", "maxIdleTimeSeconds", "0");
-      post(key4Path, "v4", "application/text", HttpServletResponse.SC_OK, "Content-Type", "application/text",
+      post(key4Path, "v4", "application/text", HttpStatus.SC_OK, "Content-Type", "application/text",
          "timeToLiveSeconds", "0", "maxIdleTimeSeconds", "2");
 
       TestingUtil.sleepThread(1000);
@@ -152,14 +151,14 @@ public class TwoServerTest extends RestServerTestBase {
       TestingUtil.sleepThread(1100);
       // k3 and k4 expired
       get(key1Path, "v1");
-      head(key3Path, HttpServletResponse.SC_NOT_FOUND);
-      head(key4Path, HttpServletResponse.SC_NOT_FOUND);
+      head(key3Path, HttpStatus.SC_NOT_FOUND);
+      head(key4Path, HttpStatus.SC_NOT_FOUND);
       TestingUtil.sleepThread(1000);
       // k1 expired
-      head(key1Path, HttpServletResponse.SC_NOT_FOUND);
+      head(key1Path, HttpStatus.SC_NOT_FOUND);
       // k2 should not be expired because without timeToLive/maxIdle parameters,
       // the entries live forever. To use default values, 0 must be passed in.
-      head(key2Path, HttpServletResponse.SC_OK);
+      head(key2Path, HttpStatus.SC_OK);
    }
 
    private void post(String uri, String data, String contentType, int expectedCode, Object... headers) throws Exception {


### PR DESCRIPTION
commons-logging 1.1 was exposing HTTPServletResponse, but
commons-logging 1.2 made the servlet-api dependency optional.