### PR TITLE
Continue to provide BaseQuery.getJPAQuery() method for backward compat

### DIFF
--- a/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseQuery.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseQuery.java
@@ -45,6 +45,22 @@ public abstract class BaseQuery implements Query {
       return queryFactory;
    }
 
+   /**
+    * Returns the query string.
+    *
+    * @return the query string
+    * @deprecated To be removed in Infinispan 10.0. Use {@link #getQueryString()} instead.
+    */
+   @Deprecated
+   public String getJPAQuery() {
+      return getQueryString();
+   }
+
+   /**
+    * Returns the query string.
+    *
+    * @return the query string
+    */
    public String getQueryString() {
       return queryString;
    }


### PR DESCRIPTION
* we provide this method temporarily to avoid sudden compatibility issues with existing clients
* this is deprecated and will be removed in Infinispan 10.0