### PR TITLE
Refactor query api

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatClientListenerWithDslFilterTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatClientListenerWithDslFilterTest.java
@@ -145,7 +145,7 @@ public class EmbeddedCompatClientListenerWithDslFilterTest extends MultiHotRodSe
 
       Query query = qf.from(UserPB.class)
             .having("age").lte(param("ageParam"))
-            .toBuilder().select("age")
+            .select("age")
             .build()
             .setParameter("ageParam", 32);
 
@@ -200,7 +200,7 @@ public class EmbeddedCompatClientListenerWithDslFilterTest extends MultiHotRodSe
 
       Query query = qf.from(UserPB.class)
             .having("age").lte(param("ageParam"))
-            .toBuilder().select("age")
+            .select("age")
             .build()
             .setParameter("ageParam", 32);
 
@@ -226,7 +226,7 @@ public class EmbeddedCompatClientListenerWithDslFilterTest extends MultiHotRodSe
    public void testDisallowGroupingAndAggregation() {
       Query query = Search.getQueryFactory(remoteCache).from(UserPB.class)
             .having("age").gte(20)
-            .toBuilder().select(max("age"))
+            .select(max("age"))
             .build();
 
       ClientEntryListener listener = new ClientEntryListener(ProtoStreamMarshaller.getSerializationContext(client(0)));
@@ -240,7 +240,6 @@ public class EmbeddedCompatClientListenerWithDslFilterTest extends MultiHotRodSe
    public void testRequireRawDataListener() {
       Query query = Search.getQueryFactory(remoteCache).from(UserPB.class)
             .having("age").gte(20)
-            .toBuilder()
             .build();
 
       @ClientListener(filterFactoryName = Filters.QUERY_DSL_FILTER_FACTORY_NAME,
@@ -262,7 +261,6 @@ public class EmbeddedCompatClientListenerWithDslFilterTest extends MultiHotRodSe
    public void testRequireQueryDslFilterFactoryNameForListener() {
       Query query = Search.getQueryFactory(remoteCache).from(UserPB.class)
             .having("age").gte(20)
-            .toBuilder()
             .build();
 
       @ClientListener(filterFactoryName = "some-filter-factory-name",

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatContinuousQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatContinuousQueryTest.java
@@ -121,7 +121,7 @@ public class EmbeddedCompatContinuousQueryTest extends MultiHotRodServersTest {
       Query query = Search.getQueryFactory(remoteCache).from(UserPB.class)
             .select(max("age"))
             .having("age").gte(20)
-            .toBuilder().build();
+            .build();
 
       ContinuousQuery<String, User> continuousQuery = Search.getContinuousQuery(remoteCache);
 
@@ -166,7 +166,7 @@ public class EmbeddedCompatContinuousQueryTest extends MultiHotRodServersTest {
 
       Query query = qf.from(UserPB.class)
             .having("age").lte(param("ageParam"))
-            .toBuilder().build()
+            .build()
             .setParameter("ageParam", 32);
 
       final BlockingQueue<KeyValuePair<String, User>> joined = new LinkedBlockingQueue<>();
@@ -268,7 +268,7 @@ public class EmbeddedCompatContinuousQueryTest extends MultiHotRodServersTest {
       Query query = qf.from(UserPB.class)
             .select("age")
             .having("age").lte(param("ageParam"))
-            .toBuilder().build()
+            .build()
             .setParameter("ageParam", 32);
 
       final BlockingQueue<KeyValuePair<String, Object[]>> joined = new LinkedBlockingQueue<>();
@@ -370,7 +370,7 @@ public class EmbeddedCompatContinuousQueryTest extends MultiHotRodServersTest {
       Query query = qf.from(UserPB.class)
             .select("age")
             .having("age").lte(param("ageParam"))
-            .toBuilder().build()
+            .build()
             .setParameter("ageParam", 32);
 
       final BlockingQueue<KeyValuePair<String, Object[]>> joined = new LinkedBlockingQueue<>();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteContinuousQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteContinuousQueryTest.java
@@ -108,7 +108,7 @@ public class RemoteContinuousQueryTest extends MultiHotRodServersTest {
       Query query = Search.getQueryFactory(remoteCache).from(UserPB.class)
             .select(max("age"))
             .having("age").gte(20)
-            .toBuilder().build();
+            .build();
 
       ContinuousQuery<String, User> continuousQuery = Search.getContinuousQuery(remoteCache);
 
@@ -152,7 +152,7 @@ public class RemoteContinuousQueryTest extends MultiHotRodServersTest {
 
       Query query = qf.from(UserPB.class)
             .having("age").lte(param("ageParam"))
-            .toBuilder().build()
+            .build()
             .setParameter("ageParam", 32);
 
       final BlockingQueue<KeyValuePair<String, User>> joined = new LinkedBlockingQueue<>();
@@ -270,7 +270,7 @@ public class RemoteContinuousQueryTest extends MultiHotRodServersTest {
       Query query = qf.from(UserPB.class)
             .select("age")
             .having("age").lte(param("ageParam"))
-            .toBuilder().build()
+            .build()
             .setParameter("ageParam", 32);
 
       final BlockingQueue<KeyValuePair<String, Object[]>> joined = new LinkedBlockingQueue<>();
@@ -388,7 +388,7 @@ public class RemoteContinuousQueryTest extends MultiHotRodServersTest {
       Query query = qf.from(UserPB.class)
             .select("age")
             .having("age").lte(param("ageParam"))
-            .toBuilder().build()
+            .build()
             .setParameter("ageParam", 32);
 
       final BlockingQueue<KeyValuePair<String, Object[]>> joined = new LinkedBlockingQueue<>();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteListenerWithDslFilterTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/RemoteListenerWithDslFilterTest.java
@@ -147,7 +147,7 @@ public class RemoteListenerWithDslFilterTest extends MultiHotRodServersTest {
 
       Query query = qf.from(UserPB.class)
             .having("age").lte(param("ageParam"))
-            .toBuilder().select("age")
+            .select("age")
             .build()
             .setParameter("ageParam", 32);
 
@@ -215,7 +215,7 @@ public class RemoteListenerWithDslFilterTest extends MultiHotRodServersTest {
 
       Query query = qf.from(UserPB.class)
             .having("age").lte(param("ageParam"))
-            .toBuilder().select("age")
+            .select("age")
             .build()
             .setParameter("ageParam", 32);
 
@@ -241,7 +241,7 @@ public class RemoteListenerWithDslFilterTest extends MultiHotRodServersTest {
    public void testDisallowGroupingAndAggregation() {
       Query query = Search.getQueryFactory(remoteCache).from(UserPB.class)
             .having("age").gte(20)
-            .toBuilder().select(max("age"))
+            .select(max("age"))
             .build();
 
       ClientEntryListener listener = new ClientEntryListener(ProtoStreamMarshaller.getSerializationContext(client(0)));
@@ -255,7 +255,6 @@ public class RemoteListenerWithDslFilterTest extends MultiHotRodServersTest {
    public void testRequireRawDataListener() {
       Query query = Search.getQueryFactory(remoteCache).from(UserPB.class)
             .having("age").gte(20)
-            .toBuilder()
             .build();
 
       @ClientListener(filterFactoryName = Filters.QUERY_DSL_FILTER_FACTORY_NAME,
@@ -277,7 +276,6 @@ public class RemoteListenerWithDslFilterTest extends MultiHotRodServersTest {
    public void testRequireQueryDslFilterFactoryNameForListener() {
       Query query = Search.getQueryFactory(remoteCache).from(UserPB.class)
             .having("age").gte(20)
-            .toBuilder()
             .build();
 
       @ClientListener(filterFactoryName = "some-filter-factory-name",

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/ProtobufRemoteIteratorTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/ProtobufRemoteIteratorTest.java
@@ -127,7 +127,7 @@ public class ProtobufRemoteIteratorTest extends MultiHotRodServersTest implement
 
       int lowerId = 5;
       int higherId = 8;
-      Query simpleQuery = queryFactory.from(AccountPB.class).having("id").between(lowerId, higherId).toBuilder().build();
+      Query simpleQuery = queryFactory.from(AccountPB.class).having("id").between(lowerId, higherId).build();
       Set<Entry<Object, Object>> entries = extractEntries(remoteCache.retrieveEntriesByQuery(simpleQuery, null, 10));
       Set<Integer> keys = extractKeys(entries);
 
@@ -135,7 +135,7 @@ public class ProtobufRemoteIteratorTest extends MultiHotRodServersTest implement
       assertForAll(keys, key -> key >= lowerId && key <= higherId);
       assertForAll(entries,e -> e.getValue() instanceof AccountPB);
 
-      Query projectionsQuery = queryFactory.from(AccountPB.class).select("id", "description").having("id").between(lowerId, higherId).toBuilder().build();
+      Query projectionsQuery = queryFactory.from(AccountPB.class).select("id", "description").having("id").between(lowerId, higherId).build();
       Set<Entry<Integer, Object[]>> entriesWithProjection = extractEntries(remoteCache.retrieveEntriesByQuery(projectionsQuery, null, 10));
 
       assertEquals(4, entriesWithProjection.size());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
@@ -172,7 +172,7 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
       // get account back from remote cache via query and check its attributes
       QueryFactory qf = Search.getQueryFactory(remoteCache);
       Query query = qf.from(AccountPB.class)
-            .having("description").like("%test%").toBuilder()
+            .having("description").like("%test%")
             .build();
       List<Account> list = query.list();
 
@@ -191,7 +191,7 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
       // get account back from remote cache via query and check its attributes
       QueryFactory qf = Search.getQueryFactory(remoteCache);
       Query query = qf.from(AccountPB.class)
-            .having("description").like("%test%").toBuilder()
+            .having("description").like("%test%")
             .build();
       List<Account> list = query.list();
 
@@ -212,7 +212,7 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
       // get user back from remote cache via query and check its attributes
       QueryFactory qf = Search.getQueryFactory(remoteCache);
       Query query = qf.from(UserPB.class)
-            .having("notes").like("%567%").toBuilder()
+            .having("notes").like("%567%")
             .build();
       List<User> list = query.list();
 
@@ -230,7 +230,7 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
       // get user back from remote cache via query and check its attributes
       QueryFactory qf = Search.getQueryFactory(remoteCache);
       Query query = qf.from("sample_bank_account.NotIndexed")
-            .having("notIndexedField").like("%123%").toBuilder()
+            .having("notIndexedField").like("%123%")
             .build();
       List<NotIndexed> list = query.list();
 
@@ -255,7 +255,6 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
             .having("notes").like("%567%")
             .and()
             .having("surname").eq("test surname")
-            .toBuilder()
             .build();
       List<User> list = query.list();
 
@@ -279,7 +278,7 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
       QueryFactory qf = Search.getQueryFactory(remoteCache);
       Query query = qf.from(AccountPB.class)
             .select("description", "id")
-            .having("description").like("%test%").toBuilder()
+            .having("description").like("%test%")
             .build();
       List<Object[]> list = query.list();
 
@@ -318,7 +317,7 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
       // get user back from remote cache via query and check its attributes
       QueryFactory qf = org.infinispan.query.Search.getQueryFactory(cache);
       Query query = qf.from(UserHS.class)
-            .having("notes").like("%567%").toBuilder()
+            .having("notes").like("%567%")
             .build();
       List<User> list = query.list();
 
@@ -336,7 +335,7 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
       // get user back from remote cache via query and check its attributes
       QueryFactory qf = org.infinispan.query.Search.getQueryFactory(cache);
       Query query = qf.from(NotIndexed.class)
-            .having("notIndexedField").like("%123%").toBuilder()
+            .having("notIndexedField").like("%123%")
             .build();
       List<NotIndexed> list = query.list();
 
@@ -361,7 +360,6 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
             .having("notes").like("%567%")
             .and()
             .having("surname").eq("test surname")
-            .toBuilder()
             .build();
       List<User> list = query.list();
 
@@ -432,7 +430,7 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
 
       Query q = qf.from(UserPB.class)
             .having("name").eq("")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertTrue(list.isEmpty());
@@ -449,7 +447,7 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
 
       Query q = qf.from(AccountPB.class)
             .having("description").eq("John Doe's first bank account")
-            .toBuilder().build();
+            .build();
 
       List<Account> list = q.list();
       assertEquals(1, list.size());
@@ -469,7 +467,7 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
 
       Query q = qf.from(UserHS.class)
             .having("name").eq("")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertTrue(list.isEmpty());
@@ -486,7 +484,7 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
 
       Query q = qf.from(AccountHS.class)
             .having("description").eq("John Doe's first bank account")
-            .toBuilder().build();
+            .build();
 
       List<Account> list = q.list();
       assertEquals(1, list.size());
@@ -509,7 +507,7 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
       Query q = qf.from(TransactionHS.class)
             .select("id", "isDebit", "isDebit")
             .having("description").eq("Hotel")
-            .toBuilder().build();
+            .build();
       List<Object[]> list = q.list();
 
       assertEquals(1, list.size());
@@ -535,7 +533,7 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
       Query q = qf.from(TransactionPB.class)
             .select("id", "isDebit", "isDebit")
             .having("description").eq("Hotel")
-            .toBuilder().build();
+            .build();
       List<Object[]> list = q.list();
 
       assertEquals(1, list.size());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
@@ -297,12 +297,12 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
       org.apache.lucene.search.Query query = searchManager
             .buildQueryBuilderForClass(AccountHS.class).get()
             .keyword().wildcard().onField("description").matching("*test*").createQuery();
-      CacheQuery cacheQuery = searchManager.getQuery(query);
-      List<Object> list = cacheQuery.list();
+      CacheQuery<Account> cacheQuery = searchManager.getQuery(query);
+      List<Account> list = cacheQuery.list();
 
       assertNotNull(list);
       assertEquals(1, list.size());
-      assertAccount((Account) list.get(0), AccountHS.class);
+      assertAccount(list.get(0), AccountHS.class);
    }
 
    public void testEmbeddedQueryForEmbeddedEntryOnNonIndexedField() throws Exception {

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/HotRodQueryTest.java
@@ -149,7 +149,7 @@ public class HotRodQueryTest extends SingleCacheManagerTest {
       // get user back from remote cache via query and check its attributes
       QueryFactory qf = Search.getQueryFactory(remoteCache);
       Query query = qf.from(UserPB.class)
-            .having("name").eq("Tom").toBuilder()
+            .having("name").eq("Tom")
             .build();
       List<User> list = query.list();
       assertNotNull(list);
@@ -162,7 +162,7 @@ public class HotRodQueryTest extends SingleCacheManagerTest {
       // get user back from remote cache via query and check its attributes
       QueryFactory qf = Search.getQueryFactory(remoteCache);
       Query query = qf.from(UserPB.class)
-            .having("addresses.postCode").eq("1234").toBuilder()
+            .having("addresses.postCode").eq("1234")
             .build();
       List<User> list = query.list();
       assertNotNull(list);
@@ -190,7 +190,7 @@ public class HotRodQueryTest extends SingleCacheManagerTest {
       QueryFactory qf = Search.getQueryFactory(remoteCache);
       Query query = qf.from(UserPB.class)
             .select("name", "surname")
-            .having("name").eq("Tom").toBuilder()
+            .having("name").eq("Tom")
             .build();
 
       List<Object[]> list = query.list();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultiHotRodServerQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/MultiHotRodServerQueryTest.java
@@ -127,7 +127,7 @@ public class MultiHotRodServerQueryTest extends MultiHotRodServersTest {
       // get user back from remote cache via query and check its attributes
       QueryFactory qf = Search.getQueryFactory(remoteCache1);
       Query query = qf.from(UserPB.class)
-            .having("name").eq("Tom").toBuilder()
+            .having("name").eq("Tom")
             .build();
       List<User> list = query.list();
       assertNotNull(list);
@@ -146,7 +146,7 @@ public class MultiHotRodServerQueryTest extends MultiHotRodServersTest {
       QueryFactory qf = Search.getQueryFactory(remoteCache0);
       Query query = qf.from(UserPB.class)
             .select(property("name"), count("age"))
-            .having("age").gte(5).toBuilder()
+            .having("age").gte(5)
             .groupBy("name")
             .orderBy("name")
             .build();
@@ -163,7 +163,7 @@ public class MultiHotRodServerQueryTest extends MultiHotRodServersTest {
       // get user back from remote cache via query and check its attributes
       QueryFactory qf = Search.getQueryFactory(remoteCache1);
       Query query = qf.from(UserPB.class)
-            .having("addresses.postCode").eq("1234").toBuilder()
+            .having("addresses.postCode").eq("1234")
             .build();
       List<User> list = query.list();
       assertNotNull(list);
@@ -191,7 +191,7 @@ public class MultiHotRodServerQueryTest extends MultiHotRodServersTest {
       QueryFactory qf = Search.getQueryFactory(remoteCache1);
       Query query = qf.from(UserPB.class)
             .select("name", "surname")
-            .having("name").eq("Tom").toBuilder()
+            .having("name").eq("Tom")
             .build();
 
       List<Object[]> list = query.list();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryDslConditionsTest.java
@@ -168,7 +168,7 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("date")
             .having("date").between(makeDate("2013-01-01"), makeDate("2013-01-31"))
-            .toBuilder().build();
+            .build();
 
       List<Object[]> list = q.list();
       assertEquals(4, list.size());
@@ -235,7 +235,7 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("date")
-            .having("date").between(makeDate("2013-02-15"), makeDate("2013-03-15")).toBuilder()
+            .having("date").between(makeDate("2013-02-15"), makeDate("2013-03-15"))
             .groupBy("date")
             .build();
 
@@ -254,7 +254,7 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(count("date"), min("date"))
-            .having("description").eq("Hotel").toBuilder()
+            .having("description").eq("Hotel")
             .groupBy("id")
             .build();
 
@@ -274,7 +274,7 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(min("date"), count("date"))
-            .having("description").eq("Hotel").toBuilder()
+            .having("description").eq("Hotel")
             .groupBy("id")
             .build();
 
@@ -296,7 +296,7 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("id", "date", "date")
             .having("description").eq("Hotel")
-            .toBuilder().build();
+            .build();
       List<Object[]> list = q.list();
 
       assertEquals(1, list.size());
@@ -329,7 +329,7 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(avg("amount"), sum("amount"), count("date"), min("date"), max("accountId"))
-            .having("isDebit").eq(param("param")).toBuilder()
+            .having("isDebit").eq(param("param"))
             .orderBy(avg("amount"), SortOrder.DESC).orderBy(count("date"), SortOrder.DESC)
             .orderBy(max("amount"), SortOrder.ASC)
             .build();
@@ -356,7 +356,7 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("date")
-            .having("date").between(makeDate("2013-02-15"), makeDate("2013-03-15")).toBuilder()
+            .having("date").between(makeDate("2013-02-15"), makeDate("2013-03-15"))
             .groupBy("date")
             .build();
       List<Object[]> list = q.list();
@@ -376,7 +376,7 @@ public class RemoteQueryDslConditionsTest extends QueryDslConditionsTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(count("date"), min("date"))
-            .having("description").eq("Hotel").toBuilder()
+            .having("description").eq("Hotel")
             .groupBy("id")
             .build();
       List<Object[]> list = q.list();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryJmxTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryJmxTest.java
@@ -137,7 +137,7 @@ public class RemoteQueryJmxTest extends SingleCacheManagerTest {
       // get user back from remote cache via query and check its attributes
       QueryFactory qf = Search.getQueryFactory(remoteCache);
       Query query = qf.from(UserPB.class)
-            .having("addresses.postCode").eq("1231").toBuilder()
+            .having("addresses.postCode").eq("1231")
             .build();
       List<User> list = query.list();
       assertNotNull(list);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryWithProtostreamAnnotationsTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryWithProtostreamAnnotationsTest.java
@@ -195,7 +195,7 @@ public class RemoteQueryWithProtostreamAnnotationsTest extends SingleHotRodServe
       // get memo1 back from remote cache via query and check its attributes
       QueryFactory qf = Search.getQueryFactory(remoteCache);
       Query query = qf.from(Memo.class)
-            .having("text").like("%ipsum%").toBuilder()
+            .having("text").like("%ipsum%")
             .build();
       List<Memo> list = query.list();
       assertNotNull(list);
@@ -205,7 +205,7 @@ public class RemoteQueryWithProtostreamAnnotationsTest extends SingleHotRodServe
 
       // get memo2 back from remote cache via query and check its attributes
       query = qf.from(Memo.class)
-            .having("author.name").eq("Adrian").toBuilder()
+            .having("author.name").eq("Adrian")
             .build();
       list = query.list();
       assertNotNull(list);

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/TwoCachesSharedIndexTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/TwoCachesSharedIndexTest.java
@@ -115,7 +115,7 @@ public class TwoCachesSharedIndexTest extends MultiHotRodServersTest {
       RemoteCache<Integer, UserPB> userCache = client(0).getCache(USER_CACHE);
       userCache.put(1, getUserPB());
 
-      Query query = Search.getQueryFactory(userCache).from(UserPB.class).having("name").eq("John").toBuilder().build();
+      Query query = Search.getQueryFactory(userCache).from(UserPB.class).having("name").eq("John").build();
       List<UserPB> users = query.list();
 
       assertEquals("John", users.iterator().next().getName());
@@ -126,7 +126,7 @@ public class TwoCachesSharedIndexTest extends MultiHotRodServersTest {
       RemoteCache<Integer, AccountPB> accountCache = client(0).getCache(ACCOUNT_CACHE);
       accountCache.put(1, getAccountPB());
 
-      Query query = Search.getQueryFactory(accountCache).from(AccountPB.class).having("description").eq("account1").toBuilder().build();
+      Query query = Search.getQueryFactory(accountCache).from(AccountPB.class).having("description").eq("account1").build();
       List<AccountPB> accounts = query.list();
 
       assertEquals(accounts.iterator().next().getDescription(), "account1");

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/RemoteQueryDslPerfTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/RemoteQueryDslPerfTest.java
@@ -131,8 +131,7 @@ public class RemoteQueryDslPerfTest extends MultipleCacheManagersTest {
    public void testRemoteQueryDslExecution() throws Exception {
       QueryFactory qf = org.infinispan.client.hotrod.Search.getQueryFactory(remoteCache);
       QueryBuilder qb = qf.from("sample_bank_account.User")
-            .having("name").eq("John1")
-            .toBuilder();
+            .having("name").eq("John1");
 
       final int loops = 100000;
       final long startTs = System.nanoTime();
@@ -151,8 +150,7 @@ public class RemoteQueryDslPerfTest extends MultipleCacheManagersTest {
    public void testEmbeddedQueryDslExecution() throws Exception {
       QueryFactory qf = org.infinispan.query.Search.getQueryFactory(cache);
       QueryBuilder qb = qf.from(UserHS.class)
-            .having("name").eq("John1")
-            .toBuilder();
+            .having("name").eq("John1");
 
       final int loops = 100000;
       final long startTs = System.nanoTime();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/RemoteQueryDslPerfTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/RemoteQueryDslPerfTest.java
@@ -174,10 +174,10 @@ public class RemoteQueryDslPerfTest extends MultipleCacheManagersTest {
       final int loops = 100000;
       final long startTs = System.nanoTime();
       for (int i = 0; i < loops; i++) {
-         CacheQuery cacheQuery = searchManager.getQuery(query);
-         List<Object> list = cacheQuery.list();
+         CacheQuery<User> cacheQuery = searchManager.getQuery(query);
+         List<User> list = cacheQuery.list();
          assertEquals(1, list.size());
-         assertEquals("John1", ((User) list.get(0)).getName());
+         assertEquals("John1", list.get(0).getName());
       }
       final long duration = (System.nanoTime() - startTs) / loops;
 

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/AbstractQueryTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/AbstractQueryTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractQueryTest {
       return cm;
    }
 
-   protected CacheQuery createCacheQuery(Cache m_cache, String fieldName, String searchString) {
+   protected <E> CacheQuery<E> createCacheQuery(Cache m_cache, String fieldName, String searchString) {
       QueryBuilder queryBuilder = new QueryBuilder(STANDARD_ANALYZER);
       Query query = queryBuilder.createBooleanQuery(fieldName, searchString);
       SearchManager queryFactory = Search.getSearchManager(m_cache);
@@ -70,8 +70,8 @@ public abstract class AbstractQueryTest {
       ComponentRegistry cr = ((Cache) cache).getAdvancedCache().getComponentRegistry();
       SearchIntegrator searchIntegrator = cr.getComponent(SearchIntegrator.class);
       assertNotNull(searchIntegrator);
-      HashSet<Class<?>> expectedTypes = new HashSet<Class<?>>(Arrays.asList(types));
-      HashSet<Class<?>> indexedTypes = new HashSet<Class<?>>(searchIntegrator.getIndexedTypes());
+      HashSet<Class<?>> expectedTypes = new HashSet<>(Arrays.asList(types));
+      HashSet<Class<?>> indexedTypes = new HashSet<>(searchIntegrator.getIndexedTypes());
       assertEquals(expectedTypes,  indexedTypes);
    }
 }

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/LocalCacheTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/LocalCacheTest.java
@@ -58,9 +58,8 @@ public class LocalCacheTest extends AbstractQueryTest {
    @Test
    public void testSimple() {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing" );
-
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "playing" );
+      List<?> found = cacheQuery.list();
 
       assertPeopleInList(found, person1);
       StaticTestingErrorHandler.assertAllGood(cache);
@@ -69,8 +68,8 @@ public class LocalCacheTest extends AbstractQueryTest {
    @Test
    public void testSimpleForNonField() {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "nonSearchableField", "test1");
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "nonSearchableField", "test1");
+      List<?> found = cacheQuery.list();
 
       int elems = found.size();
       assertEquals("Expected 0 but was " + elems, 0, elems);
@@ -80,9 +79,9 @@ public class LocalCacheTest extends AbstractQueryTest {
    @Test
    public void testEagerIterator() {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing" );
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "playing" );
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
 
       try {
          assertTrue(found.hasNext());
@@ -97,9 +96,9 @@ public class LocalCacheTest extends AbstractQueryTest {
    @Test(expected = UnsupportedOperationException.class)
    public void testEagerIteratorRemove() {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing" );
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "playing" );
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
 
       try {
          assertTrue(found.hasNext());
@@ -112,9 +111,9 @@ public class LocalCacheTest extends AbstractQueryTest {
    @Test(expected = NoSuchElementException.class)
    public void testEagerIteratorExCase() {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing" );
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "playing" );
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
 
       try {
          assertTrue(found.hasNext());
@@ -129,9 +128,9 @@ public class LocalCacheTest extends AbstractQueryTest {
    @Test
    public void testModified() {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing");
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "playing");
 
-      List<Object> found = cacheQuery.list();
+      List<?> found = cacheQuery.list();
       assertPeopleInList(found, person1);
 
       person1.setBlurb("Likes pizza");
@@ -149,8 +148,8 @@ public class LocalCacheTest extends AbstractQueryTest {
    public void testAdded() {
       loadTestingData();
 
-      CacheQuery cacheQuery = createCacheQuery(cache, "name", "Goat");
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "name", "Goat");
+      List<?> found = cacheQuery.list();
 
       assertPeopleInList(found, person2, person3);
 
@@ -171,8 +170,8 @@ public class LocalCacheTest extends AbstractQueryTest {
    public void testRemoved() {
       loadTestingData();
 
-      CacheQuery cacheQuery = createCacheQuery(cache, "name", "Goat");
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "name", "Goat");
+      List<?> found = cacheQuery.list();
 
       assertPeopleInList(found, person2, person3);
 
@@ -189,8 +188,8 @@ public class LocalCacheTest extends AbstractQueryTest {
    public void testUpdated() {
       loadTestingData();
 
-      CacheQuery cacheQuery = createCacheQuery(cache, "name", "Goat");
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "name", "Goat");
+      List<?> found = cacheQuery.list();
 
       assertPeopleInList(found, person2, person3);
 
@@ -210,8 +209,8 @@ public class LocalCacheTest extends AbstractQueryTest {
       Sort sort = new Sort( new SortField("age", SortField.Type.STRING));
 
       {
-         CacheQuery cacheQuery = createCacheQuery(cache, "name", "Goat");
-         List<Object> found = cacheQuery.list();
+         CacheQuery<?> cacheQuery = createCacheQuery(cache, "name", "Goat");
+         List<?> found = cacheQuery.list();
 
          assertPeopleInList(found, person2, person3);
 
@@ -229,8 +228,8 @@ public class LocalCacheTest extends AbstractQueryTest {
       cache.put(key2, person2);
 
       {
-         CacheQuery cacheQuery = createCacheQuery(cache, "name", "Goat");
-         List<Object> found = cacheQuery.list();
+         CacheQuery<?> cacheQuery = createCacheQuery(cache, "name", "Goat");
+         List<?> found = cacheQuery.list();
 
          assertPeopleInList(found, person2, person3);
 
@@ -250,8 +249,8 @@ public class LocalCacheTest extends AbstractQueryTest {
    public void testSetFilter() {
       loadTestingData();
 
-      CacheQuery cacheQuery = createCacheQuery(cache, "name", "Goat");
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "name", "Goat");
+      List<?> found = cacheQuery.list();
 
       assertPeopleInList(found, person2, person3);
 
@@ -268,9 +267,9 @@ public class LocalCacheTest extends AbstractQueryTest {
    @Test
    public void testLazyIterator() {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing");
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "playing");
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
 
       try {
          assertTrue(found.hasNext());
@@ -285,9 +284,9 @@ public class LocalCacheTest extends AbstractQueryTest {
    @Test(expected = IllegalArgumentException.class)
    public void testUnknownFetchModeIterator() {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing");
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "playing");
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions(){
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions(){
          public FetchOptions fetchMode(FetchMode fetchMode) {
             return null;
          }
@@ -305,9 +304,9 @@ public class LocalCacheTest extends AbstractQueryTest {
    @Test
    public void testIteratorWithDefaultOptions() {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing");
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "playing");
 
-      ResultIterator found = cacheQuery.iterator();
+      ResultIterator<?> found = cacheQuery.iterator();
 
       try {
          assertTrue(found.hasNext());
@@ -322,7 +321,7 @@ public class LocalCacheTest extends AbstractQueryTest {
    @Test
    public void testExplain() {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "Eats");
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "Eats");
 
       int matchCounter = 0;
       int i = 0;
@@ -354,11 +353,11 @@ public class LocalCacheTest extends AbstractQueryTest {
    public void testFullTextFilterOnOff() {
       loadTestingData();
 
-      CacheQuery query = createCacheQuery(cache, "blurb", "Eats");
+      CacheQuery<?> query = createCacheQuery(cache, "blurb", "Eats");
       FullTextFilter filter = query.enableFullTextFilter("personFilter");
       filter.setParameter("blurbText", "cheese");
 
-      List found = query.list();
+      List<?> found = query.list();
       assertPeopleInList(found, person3);
 
       //Disabling the fullTextFilter.
@@ -373,11 +372,11 @@ public class LocalCacheTest extends AbstractQueryTest {
    public void testIteratorRemove() {
       loadTestingData();
 
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "Eats");
-      ResultIterator iterator = cacheQuery.iterator();
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "Eats");
+      ResultIterator<?> iterator = cacheQuery.iterator();
       try {
          if (iterator.hasNext()) {
-            Object next = iterator.next();
+            iterator.next();
             iterator.remove();
          }
       } finally {
@@ -391,23 +390,23 @@ public class LocalCacheTest extends AbstractQueryTest {
       loadTestingData();
       Query luceneQuery = new BooleanQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(null).getQuery(luceneQuery).firstResult(1);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(null).getQuery(luceneQuery).firstResult(1);
    }
 
    @Test(expected = IllegalArgumentException.class)
    public void testLazyIteratorWithInvalidFetchSize() {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "Eats").firstResult(1);
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "Eats").firstResult(1);
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY).fetchSize(0));
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY).fetchSize(0));
    }
 
    @Test(expected = NoSuchElementException.class)
    public void testLazyIteratorWithNoElementsFound() {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "fish").firstResult(1);
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "fish").firstResult(1);
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
 
       try {
          found.next();
@@ -419,9 +418,9 @@ public class LocalCacheTest extends AbstractQueryTest {
    @Test(expected = IllegalArgumentException.class)
    public void testIteratorWithNullFetchMode() {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "Eats").firstResult(1);
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "Eats").firstResult(1);
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(null));
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions().fetchMode(null));
 
       try {
          found.next();
@@ -433,7 +432,7 @@ public class LocalCacheTest extends AbstractQueryTest {
    @Test
    public void testGetResultSize() {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing");
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "playing");
 
       assertEquals(1, cacheQuery.getResultSize());
       StaticTestingErrorHandler.assertAllGood(cache);
@@ -443,23 +442,23 @@ public class LocalCacheTest extends AbstractQueryTest {
    public void testMaxResults() {
       loadTestingData();
 
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "eats").maxResults(1);
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "eats").maxResults(1);
 
       assertEquals(2, cacheQuery.getResultSize());   // NOTE: getResultSize() ignores pagination (maxResults, firstResult)
       assertEquals(1, cacheQuery.list().size());
-      ResultIterator eagerIterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
+      ResultIterator<?> eagerIterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
       try {
          assertEquals(1, countElements(eagerIterator));
       } finally {
          eagerIterator.close();
       }
-      ResultIterator lazyIterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
+      ResultIterator<?> lazyIterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
       try {
          assertEquals(1, countElements(lazyIterator));
       } finally {
          lazyIterator.close();
       }
-      ResultIterator defaultIterator = cacheQuery.iterator();
+      ResultIterator<?> defaultIterator = cacheQuery.iterator();
       try {
          assertEquals(1, countElements(defaultIterator));
       } finally {
@@ -468,7 +467,7 @@ public class LocalCacheTest extends AbstractQueryTest {
       StaticTestingErrorHandler.assertAllGood(cache);
    }
 
-   private int countElements(ResultIterator iterator) {
+   private int countElements(ResultIterator<?> iterator) {
       int count = 0;
       while (iterator.hasNext()) {
          iterator.next();
@@ -490,7 +489,7 @@ public class LocalCacheTest extends AbstractQueryTest {
       BooleanQuery luceneQuery = new BooleanQuery();
       luceneQuery.add(new TermQuery(goat), Occur.SHOULD);
       luceneQuery.add(new TermQuery(navin), Occur.SHOULD);
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
 
       // We know that we've got all 3 hits.
       assertEquals("Expected 3, got " + cacheQuery.getResultSize(), 3, cacheQuery.getResultSize());
@@ -538,13 +537,13 @@ public class LocalCacheTest extends AbstractQueryTest {
       person3.setNonSearchableField("test3");
    }
 
-   private void assertPeopleInSortedList(List<Object> actualList, Object... expected) {
-      List<Object> expectedList = new ArrayList<Object>(Arrays.asList(expected));
+   private void assertPeopleInSortedList(List<?> actualList, Object... expected) {
+      List<?> expectedList = new ArrayList<>(Arrays.asList(expected));
       assertEquals("Result doesn't match expected result.", expectedList, actualList);
    }
 
-   private void assertPeopleInList(List<Object> actualList, Object... expected) {
-      List<Object> expectedList = new ArrayList<Object>(Arrays.asList(expected));
+   private void assertPeopleInList(List<?> actualList, Object... expected) {
+      List<?> expectedList = new ArrayList<>(Arrays.asList(expected));
       assertEquals("Size of the result doesn't match.", expected.length, actualList.size());
 
       //collections are not disjoint = they are the same

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryDslConditionsTest.java
@@ -272,7 +272,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("John")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -286,7 +286,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertTrue(list.isEmpty());
@@ -298,7 +298,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getAccountImplClass())
             .having("description").eq("John Doe's first bank account")
-            .toBuilder().build();
+            .build();
 
       List<Account> list = q.list();
       assertEquals(1, list.size());
@@ -311,7 +311,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("Jacob")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(0, list.size());
@@ -323,7 +323,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(NotIndexed.class)
             .having("notIndexedField").eq("testing 123")
-            .toBuilder().build();
+            .build();
 
       List<NotIndexed> list = q.list();
       assertEquals(1, list.size());
@@ -336,7 +336,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("notes").eq("Lorem ipsum dolor sit amet")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -350,7 +350,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("notes").eq("Lorem ipsum dolor sit amet")
             .and().having("surname").eq("Doe")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -364,7 +364,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("notes").eq("Lorem ipsum dolor sit amet")
             .and().having("surname").eq(param("surnameParam"))
-            .toBuilder().build();
+            .build();
 
       q.setParameter("surnameParam", "Doe");
 
@@ -380,7 +380,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("notes").like("%ipsum%")
             .and(qf.having("name").eq("John").or().having("name").eq("Jane"))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
 
@@ -395,7 +395,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       // all users in a given post code
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("addresses.postCode").eq("X1234")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -408,7 +408,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("addresses.postCode").eq("Y12")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -422,7 +422,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       // all rent payments made from a given account
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("description").like("%rent%")
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
@@ -436,7 +436,6 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       qf.from(getModelFactory().getTransactionImplClass())
             .having("date").between(new Object(), new Object())
-            .toBuilder()
             .build();
    }
 
@@ -447,7 +446,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       // all the transactions that happened in January 2013
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("date").between(makeDate("2013-01-01"), makeDate("2013-01-31"))
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(4, list.size());
@@ -464,7 +463,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       // all the transactions that happened in January 2013
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("date").between(makeDate("2013-01-01"), makeDate("2013-01-31")).includeUpper(false)
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(3, list.size());
@@ -481,7 +480,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       // all the transactions that happened in January 2013
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("date").between(makeDate("2013-01-01"), makeDate("2013-01-31")).includeLower(false)
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(3, list.size());
@@ -498,7 +497,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       // all the transactions greater than a given amount
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("amount").gt(1500)
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
@@ -511,7 +510,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("amount").gte(1500)
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(2, list.size());
@@ -526,7 +525,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("amount").lt(1500)
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(54, list.size());
@@ -541,7 +540,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("amount").lte(1500)
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(55, list.size());
@@ -558,7 +557,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       // all the transactions that happened in January 2013
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("description").lte("-Popcorn")
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
@@ -572,7 +571,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("Spider")
             .and().having("surname").eq("Man")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -586,7 +585,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("Spider")
             .and(qf.having("surname").eq("Man"))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -600,7 +599,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("gender").eq(User.Gender.MALE)
             .and().having("gender").eq(User.Gender.FEMALE)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(0, list.size());
@@ -615,7 +614,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .having("name").eq("Spider")
             .or(qf.having("name").eq("John"))
             .and(qf.having("surname").eq("Man"))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -628,7 +627,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("surname").eq("Man")
             .or().having("surname").eq("Woman")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -644,7 +643,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("surname").eq("Man")
             .or(qf.having("surname").eq("Woman"))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -660,7 +659,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("gender").eq(User.Gender.MALE)
             .or().having("gender").eq(User.Gender.FEMALE)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(3, list.size());
@@ -676,7 +675,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .or().having("name").eq("Spider")
             .and().having("gender").eq(User.Gender.FEMALE)
             .or().having("surname").like("%oe%")
-            .toBuilder().build();
+            .build();
       List<User> list = q.list();
 
       assertEquals(2, list.size());
@@ -693,7 +692,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .or().having("name").eq("Spider")
             .or().having("gender").eq(User.Gender.FEMALE)
             .and().having("surname").like("%oe%")
-            .toBuilder().build();
+            .build();
       List<User> list = q.list();
 
       assertEquals(1, list.size());
@@ -706,7 +705,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("name").eq("Spider")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -719,7 +718,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().not().having("surname").eq("Doe")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -734,7 +733,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("name").eq("John")
             .and().having("surname").eq("Man")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -749,7 +748,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("surname").eq("Man")
             .and().not().having("name").eq("John")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -764,7 +763,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("name").eq("Spider")
             .or().having("surname").eq("Man")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -780,7 +779,6 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       // QueryFactory.not() test
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not(qf.not(qf.having("gender").eq(User.Gender.FEMALE)))
-            .toBuilder()
             .build();
 
       List<User> list = q.list();
@@ -795,7 +793,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("gender").eq(User.Gender.FEMALE)
             .and().not(qf.having("name").eq("Spider"))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertTrue(list.isEmpty());
@@ -809,7 +807,6 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .not(
                   qf.having("name").eq("John")
                         .or(qf.having("surname").eq("Man")))
-            .toBuilder()
             .build();
 
       List<User> list = q.list();
@@ -826,7 +823,6 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .not(
                   qf.having("name").eq("John")
                         .and(qf.having("surname").eq("Doe")))
-            .toBuilder()
             .orderBy("id", SortOrder.ASC)
             .build();
 
@@ -846,7 +842,6 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .not().not(
                   qf.having("name").eq("John")
                         .or(qf.having("surname").eq("Man")))
-            .toBuilder()
             .build();
 
       List<User> list = q.list();
@@ -862,7 +857,6 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .not(qf.not(
                   qf.having("name").eq("John")
                         .or(qf.having("surname").eq("Man"))))
-            .toBuilder()
             .build();
 
       List<User> list = q.list();
@@ -886,7 +880,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").gt("A").or().having("name").lte("A")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(3, list.size());
@@ -898,7 +892,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").gt("A").and().having("name").lte("A")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertTrue(list.isEmpty());
@@ -931,7 +925,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("surname").isNull()
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(0, list.size());
@@ -943,7 +937,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("surname").isNull()
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(3, list.size());
@@ -955,7 +949,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("addresses").isNull()
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -972,7 +966,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .orderBy("surname", SortOrder.ASC)
             .orderBy("age", SortOrder.ASC)
             .having("age").isNull()
-            .toBuilder().build();
+            .build();
 
       List<Object[]> list = q.list();
       assertEquals(2, list.size());
@@ -991,7 +985,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .select("name", "age")
             .not().having("age").isNull()
-            .toBuilder().build();
+            .build();
 
       List<Object[]> list = q.list();
       assertEquals(1, list.size());
@@ -1005,7 +999,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").contains(2)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1018,7 +1012,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").contains(42)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(0, list.size());
@@ -1030,7 +1024,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").containsAll(1, 2)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1043,7 +1037,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").containsAll(Collections.singleton(1))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1056,7 +1050,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").containsAll(1, 2, 3)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(0, list.size());
@@ -1068,7 +1062,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").containsAll(Collections.emptySet())
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(3, list.size());
@@ -1081,7 +1075,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .orderBy("id", SortOrder.ASC)
             .having("accountIds").containsAny(2, 3)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1095,7 +1089,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").containsAny(4, 5)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(0, list.size());
@@ -1107,7 +1101,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").containsAny(Collections.emptySet())
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(3, list.size());
@@ -1120,7 +1114,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       List<Integer> ids = Arrays.asList(1, 3);
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("id").in(ids)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1135,7 +1129,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("id").in(4)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(0, list.size());
@@ -1180,7 +1174,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .orderBy("name", SortOrder.ASC)
             .having("gender").eq(User.Gender.MALE)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1197,7 +1191,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .orderBy("name", SortOrder.ASC)
             .not(qf.having("gender").eq(User.Gender.FEMALE))
             .and(qf.not().not(qf.having("gender").eq(User.Gender.MALE)))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1212,7 +1206,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       // all transactions that have a given description. the description contains characters that need to be escaped.
       Query q = qf.from(getModelFactory().getAccountImplClass())
             .having("description").eq("John Doe's first bank account")
-            .toBuilder().build();
+            .build();
 
       List<Account> list = q.list();
       assertEquals(1, list.size());
@@ -1242,7 +1236,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .orderBy("name", SortOrder.ASC)
             .having("gender").eq(User.Gender.MALE)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1316,7 +1310,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("John")
             .and().having("surname").eq("Doe")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1332,7 +1326,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("accountId").eq(1)
             .and().having("description").like("%rent%")
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
@@ -1348,7 +1342,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       // all the transactions that happened in January 2013
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("date").between(makeDate("2013-01-01"), makeDate("2013-01-31"))
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(4, list.size());
@@ -1366,7 +1360,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("date")
             .having("date").between(makeDate("2013-01-01"), makeDate("2013-01-31"))
-            .toBuilder().build();
+            .build();
 
       List<Object[]> list = q.list();
       assertEquals(4, list.size());
@@ -1390,7 +1384,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("accountId").eq(2)
             .and().having("amount").gt(40)
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(52, list.size());
@@ -1406,7 +1400,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .having("name").eq("John")
             .and().having("addresses.postCode").eq("X1234")
             .and(qf.having("accountIds").eq(1))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1421,7 +1415,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("accountId").eq(1)
             .and()
-            .not().having("isDebit").eq(true).toBuilder().build();
+            .not().having("isDebit").eq(true).build();
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
@@ -1434,7 +1428,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       // the user that has the bank account with id 3
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .having("accountIds").contains(3).toBuilder().build();
+            .having("accountIds").contains(3).build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1448,7 +1442,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       // the user that has all the specified bank accounts
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .having("accountIds").containsAll(2, 1).toBuilder().build();
+            .having("accountIds").containsAll(2, 1).build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1463,7 +1457,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       // the user that has at least one of the specified accounts
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .having("accountIds").containsAny(1, 3).toBuilder().build();
+            .having("accountIds").containsAny(1, 3).build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1480,7 +1474,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .startOffset(20).maxResults(10)
             .orderBy("id", SortOrder.ASC)
             .having("accountId").eq(2).and().having("description").like("Expensive%")
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(50, q.getResultSize());
@@ -1496,12 +1490,12 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       // all accounts for a user. first get the user by id and then get his account.
       Query q1 = qf.from(getModelFactory().getUserImplClass())
-            .having("id").eq(1).toBuilder().build();
+            .having("id").eq(1).build();
 
       List<User> users = q1.list();
       Query q2 = qf.from(getModelFactory().getAccountImplClass())
             .orderBy("description", SortOrder.ASC)
-            .having("id").in(users.get(0).getAccountIds()).toBuilder().build();
+            .having("id").in(users.get(0).getAccountIds()).build();
 
       List<Account> list = q2.list();
       assertEquals(2, list.size());
@@ -1518,7 +1512,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .orderBy("description", SortOrder.ASC)
             .having("accountId").eq(1)
             .and(qf.having("amount").gt(1600)
-                  .or().having("description").like("%rent%")).toBuilder().build();
+                  .or().having("description").like("%rent%")).build();
 
       List<Transaction> list = q.list();
       assertEquals(2, list.size());
@@ -1551,7 +1545,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("age").isNull()
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1565,7 +1559,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("age").isNull()
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1579,7 +1573,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .having("addresses.postCode").in("ZZ", "X1234").toBuilder().build();
+            .having("addresses.postCode").in("ZZ", "X1234").build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1592,7 +1586,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .not().having("addresses.postCode").in("X1234").toBuilder().build();
+            .not().having("addresses.postCode").in("X1234").build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1605,7 +1599,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .not().having("addresses").isNull().toBuilder().build();
+            .not().having("addresses").isNull().build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1618,7 +1612,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .not().having("addresses.postCode").like("%123%").toBuilder().build();
+            .not().having("addresses.postCode").like("%123%").build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1632,7 +1626,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("id").between(1, 2)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1645,7 +1639,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("id").between(1, 2).includeLower(false)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
 
@@ -1660,7 +1654,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("id").between(1, 2).includeUpper(false)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1674,7 +1668,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getAccountImplClass())
             .having("creationDate").eq(makeDate("2013-01-20"))
-            .toBuilder().build();
+            .build();
 
       List<Account> list = q.list();
       assertEquals(1, list.size());
@@ -1688,7 +1682,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getAccountImplClass())
             .orderBy("id", SortOrder.ASC)
             .having("creationDate").lt(makeDate("2013-01-20"))
-            .toBuilder().build();
+            .build();
 
       List<Account> list = q.list();
       assertEquals(2, list.size());
@@ -1703,7 +1697,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getAccountImplClass())
             .orderBy("id", SortOrder.ASC)
             .having("creationDate").lte(makeDate("2013-01-20"))
-            .toBuilder().build();
+            .build();
 
       List<Account> list = q.list();
       assertEquals(3, list.size());
@@ -1718,7 +1712,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getAccountImplClass())
             .having("creationDate").gt(makeDate("2013-01-04"))
-            .toBuilder().build();
+            .build();
 
       List<Account> list = q.list();
       assertEquals(1, list.size());
@@ -1729,7 +1723,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
    public void testWrongQueryBuilding1() throws Exception {
       QueryFactory qf = getQueryFactory();
 
-      Query q = qf.not().having("name").eq("John").toBuilder().build();
+      Query q = qf.not().having("name").eq("John").build();
    }
 
    @Test(expected = IllegalStateException.class)
@@ -1737,8 +1731,8 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .having("name").eq("John").toBuilder()
-            .having("surname").eq("Man").toBuilder()
+            .having("name").eq("John")
+            .having("surname").eq("Man")
             .build();
    }
 
@@ -1747,8 +1741,8 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .not().having("name").eq("John").toBuilder()
-            .not().having("surname").eq("Man").toBuilder()
+            .not().having("name").eq("John")
+            .not().having("surname").eq("Man")
             .build();
    }
 
@@ -1757,8 +1751,8 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .not(qf.having("name").eq("John")).toBuilder()
-            .not(qf.having("surname").eq("Man")).toBuilder()
+            .not(qf.having("name").eq("John"))
+            .not(qf.having("surname").eq("Man"))
             .build();
    }
 
@@ -1767,8 +1761,8 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .not(qf.having("name").eq("John")).toBuilder()
-            .not(qf.having("surname").eq("Man")).toBuilder()
+            .not(qf.having("name").eq("John"))
+            .not(qf.having("surname").eq("Man"))
             .build();
    }
 
@@ -1778,7 +1772,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("gender").eq(null)
-            .toBuilder().build();
+            .build();
    }
 
    @Test(expected = IllegalStateException.class)
@@ -2043,7 +2037,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getUserImplClass())
             .select(sum("age"))
-            .having(sum("age")).gt(10).toBuilder()
+            .having(sum("age")).gt(10)
             .build();
 
       List<Object[]> list = q.list();
@@ -2060,7 +2054,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(property("accountId"), sum("amount"))
             .groupBy("accountId")
-            .having(sum("amount")).gt(3324).toBuilder()
+            .having(sum("amount")).gt(3324)
             .orderBy("accountId")
             .build();
       List<Object[]> list = q.list();
@@ -2075,7 +2069,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(property("accountId"), avg("amount"))
             .groupBy("accountId")
-            .having(avg("amount")).lt(130.0).toBuilder()
+            .having(avg("amount")).lt(130.0)
             .orderBy("accountId")
             .build();
       List<Object[]> list = q.list();
@@ -2090,7 +2084,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(property("accountId"), min("amount"))
             .groupBy("accountId")
-            .having(min("amount")).lt(10).toBuilder()
+            .having(min("amount")).lt(10)
             .orderBy("accountId")
             .build();
       List<Object[]> list = q.list();
@@ -2105,7 +2099,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(property("accountId"), max("amount"))
             .groupBy("accountId")
-            .having(avg("amount")).lt(150).toBuilder()
+            .having(avg("amount")).lt(150)
             .orderBy("accountId")
             .build();
       List<Object[]> list = q.list();
@@ -2537,9 +2531,9 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getUserImplClass())
             .select("name")
-            .having("name").eq("John").toBuilder()
+            .having("name").eq("John")
             .groupBy("name")
-            .having("name").eq("John").toBuilder()
+            .having("name").eq("John")
             .build();
       List<Object[]> list = q.list();
       assertEquals(1, list.size());
@@ -2576,7 +2570,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("date")
-            .having("date").between(makeDate("2013-02-15"), makeDate("2013-03-15")).toBuilder()
+            .having("date").between(makeDate("2013-02-15"), makeDate("2013-03-15"))
             .groupBy("date")
             .build();
 
@@ -2591,7 +2585,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(count("date"), min("date"))
-            .having("description").eq("Hotel").toBuilder()
+            .having("description").eq("Hotel")
             .groupBy("id")
             .build();
 
@@ -2607,7 +2601,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(min("date"), count("date"))
-            .having("description").eq("Hotel").toBuilder()
+            .having("description").eq("Hotel")
             .groupBy("id")
             .build();
 
@@ -2624,7 +2618,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("gender").eq(param("param2"))
-            .toBuilder().build();
+            .build();
 
       q.setParameter("param2", User.Gender.MALE);
 
@@ -2650,7 +2644,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
             .having("gender").eq(param("param1"))
             .and()
             .having("name").eq(param("param2"))
-            .toBuilder().build();
+            .build();
 
       Map<String, Object> parameterMap = new HashMap<>(2);
       parameterMap.put("param1", User.Gender.MALE);
@@ -2683,7 +2677,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getAccountImplClass())
             .having("creationDate").eq(param("param1"))
-            .toBuilder().build().setParameter("param1", makeDate("2013-01-03"));
+            .build().setParameter("param1", makeDate("2013-01-03"));
 
       List<Account> list = q.list();
       assertEquals(1, list.size());
@@ -2696,7 +2690,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(property("accountId"), property("date"), sum("amount"))
             .groupBy("accountId", "date")
-            .having(sum("amount")).gt(param("param")).toBuilder()
+            .having(sum("amount")).gt(param("param"))
             .build();
 
       q.setParameter("param", 1801);
@@ -2713,7 +2707,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq(param("param1"))
-            .toBuilder().build();
+            .build();
 
       q.setParameter("param2", "John");
    }
@@ -2724,7 +2718,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq(param("param1"))
-            .toBuilder().build();
+            .build();
 
       Map<String, Object> parameterMap = new HashMap<>(1);
       parameterMap.put("param2", User.Gender.MALE);
@@ -2738,7 +2732,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("John")
-            .toBuilder().build().setParameter("param1", "John");
+            .build().setParameter("param1", "John");
    }
 
    @Test(expected = IllegalStateException.class)
@@ -2747,7 +2741,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("John")
-            .toBuilder().build();
+            .build();
 
       Map<String, Object> parameterMap = new HashMap<>(1);
       parameterMap.put("param1", User.Gender.MALE);
@@ -2761,7 +2755,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq(param(null))
-            .toBuilder().build();
+            .build();
 
       q.setParameter(null, "John");
    }
@@ -2772,7 +2766,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq(param(""))
-            .toBuilder().build();
+            .build();
 
       q.setParameter("", "John");
    }
@@ -2784,7 +2778,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq(param("param1"))
             .and().having("gender").eq(param("param2"))
-            .toBuilder().build();
+            .build();
 
       q.setParameter("param1", "John");
 
@@ -2798,7 +2792,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq(param("param1"))
             .and().having("gender").eq(param("param2"))
-            .toBuilder().build();
+            .build();
 
       Map<String, Object> parameterMap = new HashMap<>(1);
       parameterMap.put("param1", "John");
@@ -2814,7 +2808,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("John")
-            .toBuilder().build();
+            .build();
 
       q.setParameters(null);
    }
@@ -2824,7 +2818,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(avg("amount"), sum("amount"), count("date"), min("date"), max("accountId"))
-            .having("isDebit").eq(param("param")).toBuilder()
+            .having("isDebit").eq(param("param"))
             .orderBy(avg("amount"), SortOrder.DESC).orderBy(count("date"), SortOrder.DESC)
             .orderBy(max("amount"), SortOrder.ASC)
             .build();
@@ -2847,7 +2841,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("date")
-            .having("date").between(makeDate("2013-02-15"), makeDate("2013-03-15")).toBuilder()
+            .having("date").between(makeDate("2013-02-15"), makeDate("2013-03-15"))
             .groupBy("date")
             .build();
       List<Object[]> list = q.list();
@@ -2863,7 +2857,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(count("date"), min("date"))
-            .having("description").eq("Hotel").toBuilder()
+            .having("description").eq("Hotel")
             .groupBy("id")
             .build();
       List<Object[]> list = q.list();
@@ -2882,7 +2876,6 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("id", "isValid")
             .having("id").gte(98)
-            .toBuilder()
             .orderBy("id")
             .build();
       List<Object[]> list = q.list();
@@ -2903,7 +2896,6 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("id", "description")
             .having("id").gte(98)
-            .toBuilder()
             .orderBy("id")
             .build();
       List<Object[]> list = q.list();
@@ -2924,7 +2916,6 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("id", "isValid")
             .having("id").gte(98)
-            .toBuilder()
             .orderBy("isValid")
             .orderBy("id")
             .build();
@@ -2946,7 +2937,6 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("id", "description")
             .having("id").gte(98)
-            .toBuilder()
             .orderBy("description")
             .orderBy("id")
             .build();
@@ -2968,7 +2958,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("id", "date", "date")
             .having("description").eq("Hotel")
-            .toBuilder().build();
+            .build();
       List<Object[]> list = q.list();
 
       assertEquals(1, list.size());
@@ -2985,7 +2975,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("id", "isDebit", "isDebit")
             .having("description").eq("Hotel")
-            .toBuilder().build();
+            .build();
       List<Object[]> list = q.list();
 
       assertEquals(1, list.size());
@@ -3020,9 +3010,9 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getUserImplClass())
             .select(avg("age"), property("name"))
-            .having("name").gt("A").toBuilder()
+            .having("name").gt("A")
             .groupBy("name")
-            .having(max("addresses.street")).gt("A").toBuilder()
+            .having(max("addresses.street")).gt("A")
             .orderBy(min("addresses.street"))
             .build();
 
@@ -3040,7 +3030,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getUserImplClass())
             .select("name")
-            .having("name").eq(min("addresses.street")).toBuilder()
+            .having("name").eq(min("addresses.street"))
             .build();
       q.list();
    }
@@ -3050,7 +3040,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getUserImplClass())
             .select(min("addresses.street"))
-            .having("name").eq("Spider").toBuilder()
+            .having("name").eq("Spider")
             .build();
 
       List<Object[]> list = q.list();
@@ -3102,25 +3092,25 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
 
       // use a true wildcard
       Query q1 = qf.from(getModelFactory().getUserImplClass())
-            .having("name").like("J%n").toBuilder()
+            .having("name").like("J%n")
             .build();
       assertEquals(1, q1.list().size());
 
       // use an improper wildcard
       Query q2 = qf.from(getModelFactory().getUserImplClass())
-            .having("name").like("J*n").toBuilder()
+            .having("name").like("J*n")
             .build();
       assertEquals(0, q2.list().size());
 
       // use a true wildcard
       Query q3 = qf.from(getModelFactory().getUserImplClass())
-            .having("name").like("Jo_n").toBuilder()
+            .having("name").like("Jo_n")
             .build();
       assertEquals(1, q3.list().size());
 
       // use an improper wildcard
       Query q4 = qf.from(getModelFactory().getUserImplClass())
-            .having("name").like("Jo?n").toBuilder()
+            .having("name").like("Jo?n")
             .build();
       assertEquals(0, q4.list().size());
    }
@@ -3132,7 +3122,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .select(sum("age"))
             .groupBy("name")
-            .having(sum("age")).gt(50000).toBuilder()
+            .having(sum("age")).gt(50000)
             .build();
 
       List<Object[]> list = q.list();
@@ -3146,7 +3136,7 @@ public class QueryDslConditionsTest extends AbstractQueryTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(sum("amount"))
             .groupBy("accountId")
-            .having(sum("amount")).gt(50000).toBuilder()
+            .having(sum("amount")).gt(50000)
             .build();
 
       List<Object[]> list = q.list();

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryPhrasesTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/QueryPhrasesTest.java
@@ -54,8 +54,8 @@ public class QueryPhrasesTest extends AbstractQueryTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().bool()
             .must(queryBuilder.createBooleanQuery("name", "Goat")).not().createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<Person> found = cacheQuery.list();
 
       assertEquals(1, found.size());
       assert found.contains(person1);
@@ -82,8 +82,8 @@ public class QueryPhrasesTest extends AbstractQueryTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().bool()
             .should(queryBuilder.createBooleanQuery("name", "Goat")).should(subQuery).createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<Person> found = cacheQuery.list();
 
       assertEquals(3, found.size());
       assert found.contains(person1);
@@ -118,8 +118,8 @@ public class QueryPhrasesTest extends AbstractQueryTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().bool()
             .should(subQuery1).should(subQuery2).createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<Person> found = cacheQuery.list();
 
       assertEquals(3, found.size());
       assert found.get(0).equals(person1);
@@ -149,8 +149,8 @@ public class QueryPhrasesTest extends AbstractQueryTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().keyword().fuzzy().
             onField("name").matching("Goat").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<Person> found = cacheQuery.list();
 
       assertEquals(2, found.size());
       assert found.contains(person2);
@@ -219,8 +219,8 @@ public class QueryPhrasesTest extends AbstractQueryTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(NumericType.class)
             .get().range().onField("num1").andField("num2").below(20).excludeLimit().createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<Person> found = cacheQuery.list();
 
       assertEquals(3, found.size());  //<------ All entries should be here, because andField is executed as SHOULD;
       assert found.contains(type1);
@@ -249,8 +249,8 @@ public class QueryPhrasesTest extends AbstractQueryTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().keyword().wildcard()
             .onField("wrongname").matching("Goat").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<Person> found = cacheQuery.list();
 
       assertEquals(2, found.size());
    }
@@ -262,8 +262,8 @@ public class QueryPhrasesTest extends AbstractQueryTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(NumericType.class).get().keyword().wildcard()
             .onField("name").matching("*wildcard*").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<Person> found = cacheQuery.list();
 
       assertEquals(3, found.size());
       assert found.contains(type1);
@@ -306,8 +306,8 @@ public class QueryPhrasesTest extends AbstractQueryTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().keyword().onField("name")
             .andField("blurb").matching("Eats").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<Person> found = cacheQuery.list();
 
       assertEquals(2, found.size());
 
@@ -333,8 +333,8 @@ public class QueryPhrasesTest extends AbstractQueryTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().phrase()
             .onField("blurb").sentence("Eats grass").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<Person> found = cacheQuery.list();
 
       assertEquals(1, found.size());
       assert found.contains(person2);
@@ -357,8 +357,8 @@ public class QueryPhrasesTest extends AbstractQueryTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(NumericType.class).get().phrase()
             .onField("name").sentence("Some string").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<Person> found = cacheQuery.list();
 
       assertEquals(0, found.size());
 
@@ -378,8 +378,8 @@ public class QueryPhrasesTest extends AbstractQueryTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().phrase().withSlop(3)
             .onField("blurb").sentence("Eats grass").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<Person> found = cacheQuery.list();
 
       assertEquals(1, found.size());
       assert found.contains(person2);
@@ -428,8 +428,8 @@ public class QueryPhrasesTest extends AbstractQueryTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(NumericType.class).get().phrase().withSlop(1)
             .onField("name").sentence("Some string").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<Person> found = cacheQuery.list();
 
       assertEquals(0, found.size());
 
@@ -459,8 +459,8 @@ public class QueryPhrasesTest extends AbstractQueryTest {
 
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().all().except().createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<Person> found = cacheQuery.list();
 
       assertEquals(3, found.size());
       assert found.contains(person2);
@@ -492,8 +492,8 @@ public class QueryPhrasesTest extends AbstractQueryTest {
 
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(NumericType.class).get().all().except().createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<Person> found = cacheQuery.list();
 
       assertEquals(3, found.size());
       assert found.contains(type1);

--- a/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/SimpleFacetingTest.java
+++ b/integrationtests/all-embedded-query-it/src/test/java/org/infinispan/all/embeddedquery/SimpleFacetingTest.java
@@ -58,7 +58,7 @@ public class SimpleFacetingTest extends AbstractQueryTest {
 
       Query luceneQuery = queryBuilder.all().createQuery();
 
-      CacheQuery query = qf.getQuery(luceneQuery);
+      CacheQuery<?> query = qf.getQuery(luceneQuery);
 
       query.getFacetManager().enableFaceting( request );
 

--- a/integrationtests/security-manager-it/src/test/java/org/infinispan/security/QueryAuthorizationTest.java
+++ b/integrationtests/security-manager-it/src/test/java/org/infinispan/security/QueryAuthorizationTest.java
@@ -102,7 +102,7 @@ public class QueryAuthorizationTest extends SingleCacheManagerTest {
       SearchManager sm = Search.getSearchManager(cache);
       Query query = sm.buildQueryBuilderForClass(TestEntity.class)
             .get().keyword().onField("name").matching("Henry").createQuery();
-      CacheQuery q = sm.getQuery(query);
+      CacheQuery<TestEntity> q = sm.getQuery(query);
       assertEquals(1, q.getResultSize());
       assertEquals(TestEntity.class, q.list().get(0).getClass());
    }

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/client/BaseHotRodQueryIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/client/BaseHotRodQueryIT.java
@@ -58,7 +58,7 @@ public class BaseHotRodQueryIT {
 
       QueryFactory qf = Search.getQueryFactory(cache);
       Query query = qf.from(Person.class)
-            .having("name").eq("Adrian").toBuilder()
+            .having("name").eq("Adrian")
             .build();
       List<Person> list = query.list();
       assertNotNull(list);

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/query/DSLQueryIT.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/query/DSLQueryIT.java
@@ -54,7 +54,7 @@ public class DSLQueryIT {
    @Test
    public void testDSLQuery() throws Exception {
       service.store("00123", new Book("Functional Programming in Scala", "manning", new Date()), true);
-      List<Object> results = service.findByPublisher("manning");
+      List<Book> results = service.findByPublisher("manning");
       Assert.assertEquals(1, results.size());
    }
 }

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/query/GridService.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/query/GridService.java
@@ -51,7 +51,7 @@ public class GridService {
             .from(Book.class)
             .having("publisher")
             .eq(publisher)
-            .toBuilder().build();
+            .build();
       return query.list();
    }
 

--- a/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/query/GridService.java
+++ b/integrationtests/wildfly-modules/src/test/java/org/infinispan/test/integration/as/query/GridService.java
@@ -19,7 +19,7 @@ import org.infinispan.query.SearchManager;
 public class GridService {
 
    @Inject
-   private Cache<String,Book> bookshelf;
+   private Cache<String, Book> bookshelf;
 
    public void store(String isbn, Book book, boolean index) {
       if (index) {
@@ -34,7 +34,7 @@ public class GridService {
       return bookshelf.get(isbn);
    }
 
-   public List<Object> findFullText(String phrase) {
+   public List<Book> findFullText(String phrase) {
       SearchManager sm = Search.getSearchManager(bookshelf);
       QueryBuilder queryBuilder = sm.buildQueryBuilderForClass(Book.class).get();
       Query query = queryBuilder
@@ -42,11 +42,11 @@ public class GridService {
                .onField("title")
                .sentence(phrase)
                .createQuery();
-      CacheQuery cacheQuery = sm.getQuery(query);
+      CacheQuery<Book> cacheQuery = sm.getQuery(query);
       return cacheQuery.list();
    }
 
-   public List<Object> findByPublisher(String publisher) {
+   public List<Book> findByPublisher(String publisher) {
       org.infinispan.query.dsl.Query query = Search.getQueryFactory(bookshelf)
             .from(Book.class)
             .having("publisher")

--- a/object-filter/src/test/java/org/infinispan/objectfilter/test/AbstractMatcherTest.java
+++ b/object-filter/src/test/java/org/infinispan/objectfilter/test/AbstractMatcherTest.java
@@ -359,7 +359,7 @@ public abstract class AbstractMatcherTest {
    public void testDSL() throws Exception {
       QueryFactory qf = createQueryFactory();
       Query q = qf.from(Person.class)
-            .having("phoneNumbers.number").eq("004012345").toBuilder().build();
+            .having("phoneNumbers.number").eq("004012345").build();
       assertTrue(match(q, createPerson1()));
    }
 
@@ -415,7 +415,7 @@ public abstract class AbstractMatcherTest {
             .having("id").lt(1000)
             .and()
             .having("age").lt(1000)
-            .toBuilder().build();
+            .build();
 
       ObjectFilter objectFilter = matcher.getObjectFilter(q);
 
@@ -435,7 +435,7 @@ public abstract class AbstractMatcherTest {
       Query q = qf.from(Person.class)
             .having("name").like("Jo%")
             .and(qf.not().having("name").like("Jo%").or().having("id").lt(1000))
-            .toBuilder().build();
+            .build();
 
       ObjectFilter objectFilter = matcher.getObjectFilter(q);
 
@@ -451,7 +451,7 @@ public abstract class AbstractMatcherTest {
 
       QueryFactory qf = createQueryFactory();
       Query q = qf.from(Person.class)
-            .having("name").eq("John").toBuilder().build();
+            .having("name").eq("John").build();
 
       final boolean b[] = new boolean[1];
 
@@ -480,7 +480,7 @@ public abstract class AbstractMatcherTest {
 
       QueryFactory qf = createQueryFactory();
       Query q = qf.from(Person.class)
-            .having("name").eq("John").toBuilder().build();
+            .having("name").eq("John").build();
 
       ObjectFilter objectFilter = matcher.getObjectFilter(q);
 

--- a/object-filter/src/test/java/org/infinispan/objectfilter/test/RowMatcherTest.java
+++ b/object-filter/src/test/java/org/infinispan/objectfilter/test/RowMatcherTest.java
@@ -263,7 +263,7 @@ public class RowMatcherTest {
    @Test
    public void testDSL() throws Exception {
       Query q = queryFactory.from(Person.class)
-            .having("name").eq("John").toBuilder().build();
+            .having("name").eq("John").build();
       assertTrue(match(q, createPerson1()));
    }
 
@@ -317,7 +317,7 @@ public class RowMatcherTest {
             .having("id").lt(1000)
             .and()
             .having("age").lt(1000)
-            .toBuilder().build();
+            .build();
 
       ObjectFilter objectFilter = matcher.getObjectFilter(q);
 
@@ -335,7 +335,7 @@ public class RowMatcherTest {
       Query q = queryFactory.from(Person.class)
             .having("name").like("Jo%")
             .and(queryFactory.not().having("name").like("Jo%").or().having("id").lt(1000))
-            .toBuilder().build();
+            .build();
 
       ObjectFilter objectFilter = matcher.getObjectFilter(q);
 
@@ -350,7 +350,7 @@ public class RowMatcherTest {
       Object person = createPerson1();
 
       Query q = queryFactory.from(Person.class)
-            .having("name").eq("John").toBuilder().build();
+            .having("name").eq("John").build();
 
       final boolean b[] = new boolean[1];
 
@@ -378,7 +378,7 @@ public class RowMatcherTest {
       Object person = createPerson1();
 
       Query q = queryFactory.from(Person.class)
-            .having("name").eq("John").toBuilder().build();
+            .having("name").eq("John").build();
 
       ObjectFilter objectFilter = matcher.getObjectFilter(q);
 

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/FilterConditionBeginContext.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/FilterConditionBeginContext.java
@@ -1,7 +1,8 @@
 package org.infinispan.query.dsl;
 
 /**
- * The beginning context of an incomplete condition. It exposes methods for specifying the left hand side of the condition.
+ * The beginning context of an incomplete condition. It exposes methods for specifying the left hand side of the
+ * condition.
  *
  * @author anistor@redhat.com
  * @since 6.0
@@ -12,7 +13,7 @@ public interface FilterConditionBeginContext {
 
    FilterConditionEndContext having(Expression expression);
 
-   FilterConditionBeginContext not();
+   <T extends FilterConditionContext & QueryBuilder> T not();
 
-   FilterConditionContext not(FilterConditionContext fcc);
+   <T extends FilterConditionContext & QueryBuilder> T not(FilterConditionContext fcc);
 }

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/FilterConditionContext.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/FilterConditionContext.java
@@ -28,7 +28,7 @@ public interface FilterConditionContext {
     * @param rightCondition the second condition
     * @return the new context
     */
-   FilterConditionContext and(FilterConditionContext rightCondition);
+   <T extends FilterConditionContext & QueryBuilder> T and(FilterConditionContext rightCondition);
 
    /**
     * Creates a new context and connects it with the current one using boolean OR. The new context is added after the
@@ -49,12 +49,14 @@ public interface FilterConditionContext {
     * @param rightCondition the second condition
     * @return the new context
     */
-   FilterConditionContext or(FilterConditionContext rightCondition);
+   <T extends FilterConditionContext & QueryBuilder> T or(FilterConditionContext rightCondition);
 
    /**
-    * Get the {@link QueryBuilder} that created this context.
+    * Get the {@link QueryBuilder} that created this context. As of Infinispan 9.0 this is no longer needed.
     *
     * @return the parent builder
+    * @deprecated To be removed in Infinispan 10.0 without replacement.
     */
+   @Deprecated
    QueryBuilder toBuilder();
 }

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/FilterConditionEndContext.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/FilterConditionEndContext.java
@@ -17,7 +17,7 @@ public interface FilterConditionEndContext {
     * @param values the list of values
     * @return the completed context
     */
-   FilterConditionContext in(Object... values);
+   <T extends FilterConditionContext & QueryBuilder> T in(Object... values);
 
    /**
     * Checks that the left operand is equal to one of the elements from the Collection of values given as argument.
@@ -25,7 +25,7 @@ public interface FilterConditionEndContext {
     * @param values the collection of values
     * @return the completed context
     */
-   FilterConditionContext in(Collection values);
+   <T extends FilterConditionContext & QueryBuilder> T in(Collection values);
 
    /**
     * Checks that the left argument (which is expected to be a String) matches a wildcard pattern that follows the JPA
@@ -34,7 +34,7 @@ public interface FilterConditionEndContext {
     * @param pattern the wildcard pattern
     * @return the completed context
     */
-   FilterConditionContext like(String pattern);
+   <T extends FilterConditionContext & QueryBuilder> T like(String pattern);
 
    /**
     * Checks that the left argument (which is expected to be an array or a Collection) contains the given element.
@@ -42,7 +42,7 @@ public interface FilterConditionEndContext {
     * @param value the value to check
     * @return the completed context
     */
-   FilterConditionContext contains(Object value);
+   <T extends FilterConditionContext & QueryBuilder> T contains(Object value);
 
    /**
     * Checks that the left argument (which is expected to be an array or a Collection) contains all of the the given
@@ -51,7 +51,7 @@ public interface FilterConditionEndContext {
     * @param values the list of elements to check
     * @return the completed context
     */
-   FilterConditionContext containsAll(Object... values);
+   <T extends FilterConditionContext & QueryBuilder> T containsAll(Object... values);
 
    /**
     * Checks that the left argument (which is expected to be an array or a Collection) contains all the elements of the
@@ -60,7 +60,7 @@ public interface FilterConditionEndContext {
     * @param values the Collection of elements to check
     * @return the completed context
     */
-   FilterConditionContext containsAll(Collection values);
+   <T extends FilterConditionContext & QueryBuilder> T containsAll(Collection values);
 
    /**
     * Checks that the left argument (which is expected to be an array or a Collection) contains any of the the given
@@ -69,7 +69,7 @@ public interface FilterConditionEndContext {
     * @param values the list of elements to check
     * @return the completed context
     */
-   FilterConditionContext containsAny(Object... values);
+   <T extends FilterConditionContext & QueryBuilder> T containsAny(Object... values);
 
    /**
     * Checks that the left argument (which is expected to be an array or a Collection) contains any of the elements of
@@ -78,14 +78,14 @@ public interface FilterConditionEndContext {
     * @param values the Collection of elements to check
     * @return the completed context
     */
-   FilterConditionContext containsAny(Collection values);
+   <T extends FilterConditionContext & QueryBuilder> T containsAny(Collection values);
 
    /**
     * Checks that the left argument is null.
     *
     * @return the completed context
     */
-   FilterConditionContext isNull();
+   <T extends FilterConditionContext & QueryBuilder> T isNull();
 
    /**
     * Checks that the left argument is equal to the given value.
@@ -93,12 +93,12 @@ public interface FilterConditionEndContext {
     * @param value the value to compare with
     * @return the completed context
     */
-   FilterConditionContext eq(Object value);
+   <T extends QueryBuilder & FilterConditionContext> T eq(Object value);
 
    /**
     * Alias for {@link #eq(Object)}
     */
-   FilterConditionContext equal(Object value);
+   <T extends FilterConditionContext & QueryBuilder> T equal(Object value);
 
    /**
     * Checks that the left argument is less than the given value.
@@ -106,7 +106,7 @@ public interface FilterConditionEndContext {
     * @param value the value to compare with
     * @return the completed context
     */
-   FilterConditionContext lt(Object value);
+   <T extends FilterConditionContext & QueryBuilder> T lt(Object value);
 
    /**
     * Checks that the left argument is less than or equal to the given value.
@@ -114,7 +114,7 @@ public interface FilterConditionEndContext {
     * @param value the value to compare with
     * @return the completed context
     */
-   FilterConditionContext lte(Object value);
+   <T extends FilterConditionContext & QueryBuilder> T lte(Object value);
 
    /**
     * Checks that the left argument is greater than the given value.
@@ -122,7 +122,7 @@ public interface FilterConditionEndContext {
     * @param value the value to compare with
     * @return the completed context
     */
-   FilterConditionContext gt(Object value);
+   <T extends FilterConditionContext & QueryBuilder> T gt(Object value);
 
    /**
     * Checks that the left argument is greater than or equal to the given value.
@@ -130,7 +130,7 @@ public interface FilterConditionEndContext {
     * @param value the value to compare with
     * @return the completed context
     */
-   FilterConditionContext gte(Object value);
+   <T extends FilterConditionContext & QueryBuilder> T gte(Object value);
 
    /**
     * Checks that the left argument is between the given range limits. The limits are inclusive by default, but this can
@@ -140,5 +140,5 @@ public interface FilterConditionEndContext {
     * @param to   the end of the range
     * @return the RangeConditionContext context
     */
-   RangeConditionContext between(Object from, Object to);
+   <T extends RangeConditionContext & QueryBuilder> T between(Object from, Object to);
 }

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/PaginationContext.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/PaginationContext.java
@@ -1,0 +1,12 @@
+package org.infinispan.query.dsl;
+
+/**
+ * @author anistor@redhat.com
+ * @since 9.0
+ */
+public interface PaginationContext<Context extends PaginationContext> {
+
+   Context startOffset(long startOffset);
+
+   Context maxResults(int maxResults);
+}

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/ParameterContext.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/ParameterContext.java
@@ -1,0 +1,16 @@
+package org.infinispan.query.dsl;
+
+import java.util.Map;
+
+/**
+ * @author anistor@redhat.com
+ * @since 9.0
+ */
+public interface ParameterContext<Context extends ParameterContext> {
+
+   Map<String, Object> getParameters();
+
+   Context setParameter(String paramName, Object paramValue);
+
+   Context setParameters(Map<String, Object> paramValues);
+}

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/Query.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/Query.java
@@ -1,7 +1,6 @@
 package org.infinispan.query.dsl;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * An immutable object representing both the query and the result. The result is obtained lazily when one of the methods
@@ -12,13 +11,7 @@ import java.util.Map;
  * @author anistor@redhat.com
  * @since 6.0
  */
-public interface Query {
-
-   Map<String, Object> getParameters();
-
-   Query setParameter(String paramName, Object paramValue);
-
-   Query setParameters(Map<String, Object> paramValues);
+public interface Query extends PaginationContext<Query>, ParameterContext<Query> {
 
    /**
     * Returns the results of a search as a list.

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/QueryBuilder.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/QueryBuilder.java
@@ -2,13 +2,11 @@ package org.infinispan.query.dsl;
 
 /**
  * A builder for {@link Query} objects. An instance of this class can be obtained from {@link QueryFactory}.
- * <p>
- * Type parameter Q will be removed in Infinispan 9.0
  *
  * @author anistor@redhat.com
  * @since 6.0
  */
-public interface QueryBuilder extends FilterConditionBeginContext {
+public interface QueryBuilder extends FilterConditionBeginContext, PaginationContext<QueryBuilder> {
 
    QueryBuilder orderBy(Expression expression);
 
@@ -24,12 +22,8 @@ public interface QueryBuilder extends FilterConditionBeginContext {
 
    QueryBuilder groupBy(String... attributePath);
 
-   QueryBuilder startOffset(long startOffset);
-
-   QueryBuilder maxResults(int maxResults);
-
    /**
-    * Builds the query object. Once built, the query is immutable and can be executed only once.
+    * Builds the query object. Once built, the query is immutable (except for the named parameters).
     *
     * @return the Query
     */

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/QueryFactory.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/QueryFactory.java
@@ -4,8 +4,6 @@ package org.infinispan.query.dsl;
  * Factory for query DSL objects. Query construction starts here, usually by invoking the {@link #from} method which
  * returns a {@link QueryBuilder} capable of constructing {@link Query} objects. The other methods are use for creating
  * sub-conditions.
- * <p>
- * Type parameter Q will be removed in Infinispan 9.0
  *
  * @author anistor@redhat.com
  * @since 6.0

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/RangeConditionContext.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/RangeConditionContext.java
@@ -9,7 +9,7 @@ package org.infinispan.query.dsl;
  */
 public interface RangeConditionContext extends FilterConditionContext {
 
-   RangeConditionContext includeLower(boolean includeLower);
+   <T extends RangeConditionContext & QueryBuilder> T includeLower(boolean includeLower);
 
-   RangeConditionContext includeUpper(boolean includeUpper);
+   <T extends RangeConditionContext & QueryBuilder> T includeUpper(boolean includeUpper);
 }

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/impl/AttributeCondition.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/impl/AttributeCondition.java
@@ -3,7 +3,6 @@ package org.infinispan.query.dsl.impl;
 import java.util.Collection;
 
 import org.infinispan.query.dsl.Expression;
-import org.infinispan.query.dsl.FilterConditionContext;
 import org.infinispan.query.dsl.FilterConditionEndContext;
 import org.infinispan.query.dsl.QueryFactory;
 import org.infinispan.query.dsl.RangeConditionContext;
@@ -46,7 +45,7 @@ class AttributeCondition extends BaseCondition implements FilterConditionEndCont
    }
 
    @Override
-   public FilterConditionContext in(Object... values) {
+   public BaseCondition in(Object... values) {
       if (values == null || values.length == 0) {
          throw log.listOfValuesForInCannotBeNulOrEmpty();
       }
@@ -55,7 +54,7 @@ class AttributeCondition extends BaseCondition implements FilterConditionEndCont
    }
 
    @Override
-   public FilterConditionContext in(Collection values) {
+   public BaseCondition in(Collection values) {
       if (values == null || values.isEmpty()) {
          throw log.listOfValuesForInCannotBeNulOrEmpty();
       }
@@ -64,97 +63,97 @@ class AttributeCondition extends BaseCondition implements FilterConditionEndCont
    }
 
    @Override
-   public FilterConditionContext like(String pattern) {
+   public BaseCondition like(String pattern) {
       setOperatorAndArgument(new LikeOperator(this, pattern));
       return this;
    }
 
    @Override
-   public FilterConditionContext contains(Object value) {
+   public BaseCondition contains(Object value) {
       setOperatorAndArgument(new ContainsOperator(this, value));
       return this;
    }
 
    @Override
-   public FilterConditionContext containsAll(Object... values) {
+   public BaseCondition containsAll(Object... values) {
       setOperatorAndArgument(new ContainsAllOperator(this, values));
       return this;
    }
 
    @Override
-   public FilterConditionContext containsAll(Collection values) {
+   public BaseCondition containsAll(Collection values) {
       setOperatorAndArgument(new ContainsAllOperator(this, values));
       return this;
    }
 
    @Override
-   public FilterConditionContext containsAny(Object... values) {
+   public BaseCondition containsAny(Object... values) {
       setOperatorAndArgument(new ContainsAnyOperator(this, values));
       return this;
    }
 
    @Override
-   public FilterConditionContext containsAny(Collection values) {
+   public BaseCondition containsAny(Collection values) {
       setOperatorAndArgument(new ContainsAnyOperator(this, values));
       return this;
    }
 
    @Override
-   public FilterConditionContext isNull() {
+   public BaseCondition isNull() {
       setOperatorAndArgument(new IsNullOperator(this));
       return this;
    }
 
    @Override
-   public FilterConditionContext eq(Object value) {
+   public BaseCondition eq(Object value) {
       setOperatorAndArgument(new EqOperator(this, value));
       return this;
    }
 
    @Override
-   public FilterConditionContext equal(Object value) {
+   public BaseCondition equal(Object value) {
       return eq(value);
    }
 
    @Override
-   public FilterConditionContext lt(Object value) {
+   public BaseCondition lt(Object value) {
       setOperatorAndArgument(new LtOperator(this, value));
       return this;
    }
 
    @Override
-   public FilterConditionContext lte(Object value) {
+   public BaseCondition lte(Object value) {
       setOperatorAndArgument(new LteOperator(this, value));
       return this;
    }
 
    @Override
-   public FilterConditionContext gt(Object value) {
+   public BaseCondition gt(Object value) {
       setOperatorAndArgument(new GtOperator(this, value));
       return this;
    }
 
    @Override
-   public FilterConditionContext gte(Object value) {
+   public BaseCondition gte(Object value) {
       setOperatorAndArgument(new GteOperator(this, value));
       return this;
    }
 
    @Override
-   public RangeConditionContext between(Object from, Object to) {
+   public AttributeCondition between(Object from, Object to) {
       setOperatorAndArgument(new BetweenOperator(this, new ValueRange(from, to)));
       return this;
    }
 
    @Override
-   public RangeConditionContext includeLower(boolean includeLower) {
+   public AttributeCondition includeLower(boolean includeLower) {
       ValueRange valueRange = (ValueRange) operatorAndArgument.getArgument();
       valueRange.setIncludeLower(includeLower);
       return this;
    }
 
    @Override
-   public RangeConditionContext includeUpper(boolean includeUpper) {
+   public AttributeCondition includeUpper(boolean includeUpper) {
       ValueRange valueRange = (ValueRange) operatorAndArgument.getArgument();
       valueRange.setIncludeUpper(includeUpper);
       return this;

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseCondition.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseCondition.java
@@ -1,9 +1,13 @@
 package org.infinispan.query.dsl.impl;
 
+import org.infinispan.query.dsl.Expression;
 import org.infinispan.query.dsl.FilterConditionBeginContext;
 import org.infinispan.query.dsl.FilterConditionContext;
+import org.infinispan.query.dsl.FilterConditionEndContext;
+import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.QueryBuilder;
 import org.infinispan.query.dsl.QueryFactory;
+import org.infinispan.query.dsl.SortOrder;
 import org.infinispan.query.dsl.impl.logging.Log;
 import org.jboss.logging.Logger;
 
@@ -11,7 +15,7 @@ import org.jboss.logging.Logger;
  * @author anistor@redhat.com
  * @since 6.0
  */
-abstract class BaseCondition implements FilterConditionContext, Visitable {
+abstract class BaseCondition implements FilterConditionContext, QueryBuilder, Visitable {
 
    private static final Log log = Logger.getMessageLogger(Log.class, BaseCondition.class.getName());
 
@@ -27,6 +31,10 @@ abstract class BaseCondition implements FilterConditionContext, Visitable {
 
    @Override
    public QueryBuilder toBuilder() {
+      return getQueryBuilder();
+   }
+
+   QueryBuilder getQueryBuilder() {
       if (queryBuilder == null) {
          throw log.subQueryDoesNotBelongToAParentQueryBuilder();
       }
@@ -82,7 +90,7 @@ abstract class BaseCondition implements FilterConditionContext, Visitable {
    }
 
    @Override
-   public FilterConditionContext or(FilterConditionContext rightCondition) {
+   public BaseCondition or(FilterConditionContext rightCondition) {
       combine(false, rightCondition);
       return this;
    }
@@ -114,5 +122,77 @@ abstract class BaseCondition implements FilterConditionContext, Visitable {
       }
 
       rightCondition.setQueryBuilder(queryBuilder);
+   }
+
+   //////////////////////////////// Delegate to parent QueryBuilder ///////////////////////////
+
+   @Override
+   public QueryBuilder startOffset(long startOffset) {
+      return getQueryBuilder().startOffset(startOffset);
+   }
+
+   @Override
+   public QueryBuilder maxResults(int maxResults) {
+      return getQueryBuilder().maxResults(maxResults);
+   }
+
+   @Override
+   public QueryBuilder select(Expression... projection) {
+      return getQueryBuilder().select(projection);
+   }
+
+   @Override
+   public QueryBuilder select(String... attributePath) {
+      return getQueryBuilder().select(attributePath);
+   }
+
+   @Override
+   public QueryBuilder groupBy(String... attributePath) {
+      return getQueryBuilder().groupBy(attributePath);
+   }
+
+   @Override
+   public QueryBuilder orderBy(Expression expression) {
+      return getQueryBuilder().orderBy(expression);
+   }
+
+   @Override
+   public QueryBuilder orderBy(Expression expression, SortOrder sortOrder) {
+      return getQueryBuilder().orderBy(expression);
+   }
+
+   @Override
+   public QueryBuilder orderBy(String attributePath) {
+      return getQueryBuilder().orderBy(attributePath);
+   }
+
+   @Override
+   public QueryBuilder orderBy(String attributePath, SortOrder sortOrder) {
+      return getQueryBuilder().orderBy(attributePath, sortOrder);
+   }
+
+   @Override
+   public FilterConditionEndContext having(String attributePath) {
+      return getQueryBuilder().having(attributePath);
+   }
+
+   @Override
+   public FilterConditionEndContext having(Expression expression) {
+      return getQueryBuilder().having(expression);
+   }
+
+   @Override
+   public <T extends FilterConditionContext & QueryBuilder> T not() {
+      return getQueryBuilder().not();
+   }
+
+   @Override
+   public <T extends FilterConditionContext & QueryBuilder> T not(FilterConditionContext fcc) {
+      return getQueryBuilder().not(fcc);
+   }
+
+   @Override
+   public Query build() {
+      return getQueryBuilder().build();
    }
 }

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseQuery.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseQuery.java
@@ -26,9 +26,9 @@ public abstract class BaseQuery implements Query {
 
    protected final String[] projection;
 
-   protected final int startOffset;
+   protected int startOffset;
 
-   protected final int maxResults;
+   protected int maxResults;
 
    //todo [anistor] can startOffset really be a long or it really has to be int due to limitations in query module?
    protected BaseQuery(QueryFactory queryFactory, String queryString, Map<String, Object> namedParameters, String[] projection,
@@ -140,5 +140,17 @@ public abstract class BaseQuery implements Query {
 
    public int getMaxResults() {
       return maxResults;
+   }
+
+   @Override
+   public Query startOffset(long startOffset) {
+      this.startOffset = (int) startOffset;    //todo [anistor] why????
+      return this;
+   }
+
+   @Override
+   public Query maxResults(int maxResults) {
+      this.maxResults = maxResults;
+      return this;
    }
 }

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseQueryBuilder.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/impl/BaseQueryBuilder.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.infinispan.query.dsl.Expression;
-import org.infinispan.query.dsl.FilterConditionBeginContext;
 import org.infinispan.query.dsl.FilterConditionContext;
 import org.infinispan.query.dsl.FilterConditionEndContext;
 import org.infinispan.query.dsl.QueryBuilder;
@@ -197,7 +196,7 @@ public abstract class BaseQueryBuilder implements QueryBuilder, Visitable {
    }
 
    @Override
-   public FilterConditionBeginContext not() {
+   public BaseCondition not() {
       if (filterCondition != null) {
          throw log.cannotUseOperatorAgain("not()");
       }
@@ -208,7 +207,7 @@ public abstract class BaseQueryBuilder implements QueryBuilder, Visitable {
    }
 
    @Override
-   public FilterConditionContext not(FilterConditionContext fcc) {
+   public BaseCondition not(FilterConditionContext fcc) {
       if (fcc == null) {
          throw log.argumentCannotBeNull();
       }

--- a/query-dsl/src/main/java/org/infinispan/query/dsl/impl/IncompleteCondition.java
+++ b/query-dsl/src/main/java/org/infinispan/query/dsl/impl/IncompleteCondition.java
@@ -61,7 +61,7 @@ class IncompleteCondition extends BaseCondition implements FilterConditionBeginC
    }
 
    @Override
-   public FilterConditionBeginContext not() {
+   public BaseCondition not() {
       if (filterCondition != null) {
          throw log.cannotUseOperatorAgain("not()");
       }
@@ -71,7 +71,7 @@ class IncompleteCondition extends BaseCondition implements FilterConditionBeginC
    }
 
    @Override
-   public FilterConditionContext not(FilterConditionContext fcc) {
+   public BaseCondition not(FilterConditionContext fcc) {
       if (fcc == null) {
          throw log.argumentCannotBeNull();
       }

--- a/query-dsl/src/test/java/org/infinispan/query/dsl/impl/CreationTest.java
+++ b/query-dsl/src/test/java/org/infinispan/query/dsl/impl/CreationTest.java
@@ -62,7 +62,7 @@ public class CreationTest {
 
       Query q1 = qf1.from("MyDummyType")
             .not(fcc)
-            .toBuilder().build();
+            .build();
 
       expectedException.expect(IllegalArgumentException.class);
       expectedException.expectMessage("The given condition is already in use by another builder");
@@ -79,7 +79,7 @@ public class CreationTest {
 
       Query q1 = qf1.from("MyDummyType")
             .not(fcc)
-            .toBuilder().build();
+            .build();
 
       expectedException.expect(IllegalArgumentException.class);
       expectedException.expectMessage("The given condition is already in use by another builder");
@@ -97,7 +97,7 @@ public class CreationTest {
 
       Query q1 = qf1.from("MyDummyType")
             .not(fcc)
-            .toBuilder().build();
+            .build();
 
       expectedException.expect(IllegalArgumentException.class);
       expectedException.expectMessage("The given condition is already in use by another builder");

--- a/query-dsl/src/test/java/org/infinispan/query/dsl/impl/DummyQuery.java
+++ b/query-dsl/src/test/java/org/infinispan/query/dsl/impl/DummyQuery.java
@@ -36,4 +36,14 @@ class DummyQuery implements Query {
    public int getResultSize() {
       return 0;
    }
+
+   @Override
+   public Query startOffset(long startOffset) {
+      return this;
+   }
+
+   @Override
+   public Query maxResults(int maxResults) {
+      return this;
+   }
 }

--- a/query/src/main/java/org/infinispan/query/CacheQuery.java
+++ b/query/src/main/java/org/infinispan/query/CacheQuery.java
@@ -20,14 +20,14 @@ import org.hibernate.search.query.engine.spi.FacetManager;
  * @author Marko Luksa
  * @see org.infinispan.query.impl.SearchManagerImpl#getQuery(org.apache.lucene.search.Query, Class...)
  */
-public interface CacheQuery extends Iterable<Object> {
+public interface CacheQuery<E> extends Iterable<E> {
 
    /**
     * Returns the results of a search as a list.
     *
     * @return list of objects that were found from the search.
     */
-   List<Object> list();
+   List<E> list();
 
    /**
     * Returns the results of a search as a {@link ResultIterator}.
@@ -38,7 +38,7 @@ public interface CacheQuery extends Iterable<Object> {
     * @param fetchOptions how to fetch results (see @link FetchOptions)
     * @return a QueryResultIterator which can be used to iterate through the results that were found.
     */
-   ResultIterator iterator(FetchOptions fetchOptions);
+   ResultIterator<E> iterator(FetchOptions fetchOptions);
 
    /**
     * Returns the results of a search as a {@link ResultIterator}. This calls {@link CacheQuery#iterator(FetchOptions fetchOptions)}
@@ -47,7 +47,7 @@ public interface CacheQuery extends Iterable<Object> {
     * @return a ResultIterator which can be used to iterate through the results that were found.
     */
    @Override
-   ResultIterator iterator();
+   ResultIterator<E> iterator();
 
    /**
     * Sets a result with a given index to the first result.
@@ -55,14 +55,14 @@ public interface CacheQuery extends Iterable<Object> {
     * @param index of result to be set to the first.
     * @throws IllegalArgumentException if the index given is less than zero.
     */
-   CacheQuery firstResult(int index);
+   CacheQuery<E> firstResult(int index);
 
    /**
     * Sets the maximum number of results to the number passed in as a parameter.
     *
     * @param numResults that are to be set to the maxResults.
     */
-   CacheQuery maxResults(int numResults);
+   CacheQuery<E> maxResults(int numResults);
 
    /**
     * @return return the manager for all faceting related operations
@@ -91,7 +91,7 @@ public interface CacheQuery extends Iterable<Object> {
     *
     * @param s - lucene sort object
     */
-   CacheQuery sort(Sort s);
+   CacheQuery<E> sort(Sort s);
 
    /**
     * Defines the Lucene field names projected and returned in a query result
@@ -103,9 +103,9 @@ public interface CacheQuery extends Iterable<Object> {
     * If the projected field is not a projectable field, null is returned in the object[]
     *
     * @param fields the projected field names
-    * @return {@code this}  to allow for method chaining
+    * @return {@code this} to allow for method chaining, but the type parameter now becomes {@code Object[]}
     */
-   CacheQuery projection(String... fields);
+   CacheQuery<Object[]> projection(String... fields);
 
    /**
     * Enable a given filter by its name.
@@ -120,14 +120,14 @@ public interface CacheQuery extends Iterable<Object> {
     *
     * @param name of filter.
     */
-   CacheQuery disableFullTextFilter(String name);
+   CacheQuery<E> disableFullTextFilter(String name);
 
    /**
     * Allows lucene to filter the results.
     *
     * @param f - lucene filter
     */
-   CacheQuery filter(Filter f);
+   CacheQuery<E> filter(Filter f);
 
    /**
     * Set the timeout for this query. If the query hasn't finished processing before the timeout,
@@ -137,5 +137,5 @@ public interface CacheQuery extends Iterable<Object> {
     * @param timeUnit the time unit of the timeout parameter
     * @return
     */
-   CacheQuery timeout(long timeout, TimeUnit timeUnit);
+   CacheQuery<E> timeout(long timeout, TimeUnit timeUnit);
 }

--- a/query/src/main/java/org/infinispan/query/ResultIterator.java
+++ b/query/src/main/java/org/infinispan/query/ResultIterator.java
@@ -9,11 +9,12 @@ import java.util.Iterator;
  *
  * @author Marko Luksa
  */
-public interface ResultIterator extends Iterator<Object>, Closeable {
+public interface ResultIterator<E> extends Iterator<E>, Closeable {
 
    /**
     * This method must be called on your iterator once you have finished so that any local
     * or remote resources can be freed up.
     */
+   @Override
    void close();
 }

--- a/query/src/main/java/org/infinispan/query/SearchManager.java
+++ b/query/src/main/java/org/infinispan/query/SearchManager.java
@@ -22,7 +22,7 @@ public interface SearchManager {
     * @param classes - optionally only return results of type that matches this list of acceptable types
     * @return the CacheQuery object which can be used to iterate through results
     */
-   CacheQuery getQuery(Query luceneQuery, Class<?>... classes);
+   <E> CacheQuery<E> getQuery(Query luceneQuery, Class<?>... classes);
 
    /**
     * Experimental.
@@ -39,7 +39,7 @@ public interface SearchManager {
     * @param classes
     * @return
     */
-   CacheQuery getClusteredQuery(Query luceneQuery, Class<?>... classes);
+   <E> CacheQuery<E> getClusteredQuery(Query luceneQuery, Class<?>... classes);
 
    /**
     * The MassIndexer can be used to rebuild the Lucene indexes from

--- a/query/src/main/java/org/infinispan/query/clustered/ClusteredCacheQueryImpl.java
+++ b/query/src/main/java/org/infinispan/query/clustered/ClusteredCacheQueryImpl.java
@@ -24,7 +24,7 @@ import org.infinispan.query.impl.CacheQueryImpl;
  * @author Israel Lacerra <israeldl@gmail.com>
  * @since 5.1
  */
-public class ClusteredCacheQueryImpl extends CacheQueryImpl {
+public class ClusteredCacheQueryImpl<E> extends CacheQueryImpl<E> {
 
    private Sort sort;
 
@@ -46,19 +46,19 @@ public class ClusteredCacheQueryImpl extends CacheQueryImpl {
    }
 
    @Override
-   public CacheQuery maxResults(int maxResults) {
+   public CacheQuery<E> maxResults(int maxResults) {
       this.maxResults = maxResults;
       return super.maxResults(maxResults);
    }
 
    @Override
-   public CacheQuery firstResult(int firstResult) {
+   public CacheQuery<E> firstResult(int firstResult) {
       this.firstResult = firstResult;
       return this;
    }
 
    @Override
-   public CacheQuery sort(Sort sort) {
+   public CacheQuery<E> sort(Sort sort) {
       this.sort = sort;
       return super.sort(sort);
    }
@@ -84,14 +84,14 @@ public class ClusteredCacheQueryImpl extends CacheQueryImpl {
    }
 
    @Override
-   public ResultIterator iterator(FetchOptions fetchOptions) throws SearchException {
+   public ResultIterator<E> iterator(FetchOptions fetchOptions) throws SearchException {
       hSearchQuery.maxResults(getNodeMaxResults());
       switch (fetchOptions.getFetchMode()) {
          case EAGER: {
             ClusteredQueryCommand command = ClusteredQueryCommand.createEagerIterator(hSearchQuery, cache);
             HashMap<UUID, ClusteredTopDocs> topDocsResponses = broadcastQuery(command);
 
-            return new DistributedIterator(sort,
+            return new DistributedIterator<>(sort,
                   fetchOptions.getFetchSize(), this.resultSize, maxResults,
                   firstResult, topDocsResponses, cache);
          }
@@ -101,7 +101,7 @@ public class ClusteredCacheQueryImpl extends CacheQueryImpl {
             HashMap<UUID, ClusteredTopDocs> topDocsResponses = broadcastQuery(command);
 
             // Make a sort copy to avoid reversed results
-            return new DistributedLazyIterator(sort,
+            return new DistributedLazyIterator<>(sort,
                   fetchOptions.getFetchSize(), this.resultSize, maxResults,
                   firstResult, lazyItId, topDocsResponses, asyncExecutor, cache);
          }
@@ -118,7 +118,7 @@ public class ClusteredCacheQueryImpl extends CacheQueryImpl {
    private HashMap<UUID, ClusteredTopDocs> broadcastQuery(ClusteredQueryCommand command) {
       ClusteredQueryInvoker invoker = new ClusteredQueryInvoker(cache, asyncExecutor);
 
-      HashMap<UUID, ClusteredTopDocs> topDocsResponses = new HashMap<UUID, ClusteredTopDocs>();
+      HashMap<UUID, ClusteredTopDocs> topDocsResponses = new HashMap<>();
       int resultSize = 0;
       List<QueryResponse> responses = invoker.broadcast(command);
 
@@ -135,18 +135,18 @@ public class ClusteredCacheQueryImpl extends CacheQueryImpl {
    }
 
    @Override
-   public List<Object> list() throws SearchException {
-      ResultIterator iterator = iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
-      List<Object> values = new ArrayList<Object>();
-      while (iterator.hasNext()) {
-         values.add(iterator.next());
+   public List<E> list() throws SearchException {
+      List<E> values = new ArrayList<>();
+      try (ResultIterator<E> iterator = iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER))) {
+         while (iterator.hasNext()) {
+            values.add(iterator.next());
+         }
       }
-
       return values;
    }
 
    @Override
-   public CacheQuery timeout(long timeout, TimeUnit timeUnit) {
+   public CacheQuery<E> timeout(long timeout, TimeUnit timeUnit) {
       throw new UnsupportedOperationException("Clustered queries do not support timeouts yet.");   // TODO
    }
 }

--- a/query/src/main/java/org/infinispan/query/clustered/DistributedIterator.java
+++ b/query/src/main/java/org/infinispan/query/clustered/DistributedIterator.java
@@ -25,7 +25,7 @@ import org.infinispan.util.logging.LogFactory;
  * @author Sanne Grinovero
  * @since 5.1
  */
-public class DistributedIterator implements ResultIterator {
+public class DistributedIterator<E> implements ResultIterator<E> {
 
    private static final Log log = LogFactory.getLog(DistributedIterator.class, Log.class);
 
@@ -74,7 +74,7 @@ public class DistributedIterator implements ResultIterator {
    }
 
    @Override
-   public Object next() {
+   public E next() {
       if (!hasNext())
          throw new NoSuchElementException("Out of boundaries");
       currentIndex++;
@@ -86,9 +86,9 @@ public class DistributedIterator implements ResultIterator {
       return fetchValue(specificPosition, partialResults[index]);
    }
 
-   public Object fetchValue(int scoreIndex, ClusteredTopDocs topDoc) {
-      NodeTopDocs eagerTopDocs = (NodeTopDocs) topDoc.getNodeTopDocs();
-      return cache.get(eagerTopDocs.keys[scoreIndex]);
+   protected E fetchValue(int scoreIndex, ClusteredTopDocs topDoc) {
+      NodeTopDocs eagerTopDocs = topDoc.getNodeTopDocs();
+      return (E) cache.get(eagerTopDocs.keys[scoreIndex]);
    }
 
    @Override

--- a/query/src/main/java/org/infinispan/query/clustered/DistributedLazyIterator.java
+++ b/query/src/main/java/org/infinispan/query/clustered/DistributedLazyIterator.java
@@ -17,7 +17,7 @@ import org.infinispan.util.logging.LogFactory;
  * @author Israel Lacerra <israeldl@gmail.com>
  * @since 5.1
  */
-public class DistributedLazyIterator extends DistributedIterator {
+public class DistributedLazyIterator<E> extends DistributedIterator<E> {
 
    private final UUID queryId;
    private final ExecutorService asyncExecutor;
@@ -45,14 +45,14 @@ public class DistributedLazyIterator extends DistributedIterator {
    }
 
    @Override
-   public Object fetchValue(int scoreIndex, ClusteredTopDocs topDoc) {
+   protected E fetchValue(int scoreIndex, ClusteredTopDocs topDoc) {
       Object value = null;
       try {
          value = invoker.getValue(scoreIndex, topDoc.getNodeAddress(), queryId);
       } catch (Exception e) {
          log.error("Error while trying to remoting fetch next value: " + e.getMessage());
       }
-      return value;
+      return (E) value;
    }
 
 }

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/EmbeddedLuceneQuery.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/EmbeddedLuceneQuery.java
@@ -16,19 +16,19 @@ import org.infinispan.query.dsl.impl.BaseQuery;
  * @author anistor@redhat.com
  * @since 6.0
  */
-final class EmbeddedLuceneQuery extends BaseQuery {
+final class EmbeddedLuceneQuery<TypeMetadata> extends BaseQuery {
 
    private final QueryEngine queryEngine;
 
    private final ResultProcessor resultProcessor;
 
-   private final FilterParsingResult<?> parsingResult;
+   private final FilterParsingResult<TypeMetadata> parsingResult;
 
    /**
     * An Infinispan Cache query that wraps an actual Lucene query object. This is built lazily when the query is
     * executed first.
     */
-   private CacheQuery cacheQuery;
+   private CacheQuery<Object> cacheQuery;
 
    /**
     * The cached results, lazily evaluated.
@@ -36,7 +36,7 @@ final class EmbeddedLuceneQuery extends BaseQuery {
    private List<Object> results;
 
    EmbeddedLuceneQuery(QueryEngine queryEngine, QueryFactory queryFactory,
-                       Map<String, Object> namedParameters, FilterParsingResult<?> parsingResult,
+                       Map<String, Object> namedParameters, FilterParsingResult<TypeMetadata> parsingResult,
                        String[] projection, ResultProcessor resultProcessor,
                        long startOffset, int maxResults) {
       super(queryFactory, parsingResult.getQueryString(), namedParameters, projection, startOffset, maxResults);
@@ -54,7 +54,7 @@ final class EmbeddedLuceneQuery extends BaseQuery {
       cacheQuery = null;
    }
 
-   private CacheQuery createCacheQuery() {
+   private CacheQuery<Object> createCacheQuery() {
       // query is created first time only
       if (cacheQuery == null) {
          cacheQuery = queryEngine.buildLuceneQuery(parsingResult, namedParameters, startOffset, maxResults);

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryEngine.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/QueryEngine.java
@@ -605,22 +605,22 @@ public class QueryEngine {
                      };
                      PropertyPath[] deduplicatedProjection = projectionsMap.keySet().toArray(new PropertyPath[projectionsMap.size()]);
                      FilterParsingResult<?> fpr = makeFilterParsingResult(parsingResult, normalizedWhereClause, deduplicatedProjection, projectedTypes, sortFields);
-                     return new EmbeddedLuceneQuery(this, queryFactory, namedParameters, fpr, parsingResult.getProjections(), makeResultProcessor(rowProcessor), startOffset, maxResults);
+                     return new EmbeddedLuceneQuery<>(this, queryFactory, namedParameters, fpr, parsingResult.getProjections(), makeResultProcessor(rowProcessor), startOffset, maxResults);
                   } else {
                      rowProcessor = makeProjectionProcessor(parsingResult.getProjectedTypes());
                   }
                }
-               return new EmbeddedLuceneQuery(this, queryFactory, namedParameters, parsingResult, parsingResult.getProjections(), makeResultProcessor(rowProcessor), startOffset, maxResults);
+               return new EmbeddedLuceneQuery<>(this, queryFactory, namedParameters, parsingResult, parsingResult.getProjections(), makeResultProcessor(rowProcessor), startOffset, maxResults);
             } else {
                FilterParsingResult<?> fpr = makeFilterParsingResult(parsingResult, normalizedWhereClause, null, null, sortFields);
-               Query indexQuery = new EmbeddedLuceneQuery(this, queryFactory, namedParameters, fpr, null, makeResultProcessor(null), startOffset, maxResults);
+               Query indexQuery = new EmbeddedLuceneQuery<>(this, queryFactory, namedParameters, fpr, null, makeResultProcessor(null), startOffset, maxResults);
                String projectionQueryStr = JPATreePrinter.printTree(parsingResult.getTargetEntityName(), parsingResult.getProjectedPaths(), null, null);
                return new HybridQuery(queryFactory, cache, projectionQueryStr, null, getObjectFilter(matcher, projectionQueryStr, null, null), -1, -1, indexQuery);
             }
          } else {
             // projections may be stored but some sort fields are not so we need to query the index and then execute in-memory sorting and projecting in a second phase
             FilterParsingResult<?> fpr = makeFilterParsingResult(parsingResult, normalizedWhereClause, null, null, null);
-            Query indexQuery = new EmbeddedLuceneQuery(this, queryFactory, namedParameters, fpr, null, makeResultProcessor(null), -1, -1);
+            Query indexQuery = new EmbeddedLuceneQuery<>(this, queryFactory, namedParameters, fpr, null, makeResultProcessor(null), -1, -1);
             String projectionQueryStr = JPATreePrinter.printTree(parsingResult.getTargetEntityName(), parsingResult.getProjectedPaths(), null, sortFields);
             return new HybridQuery(queryFactory, cache, projectionQueryStr, null, getObjectFilter(matcher, projectionQueryStr, null, null), startOffset, maxResults, indexQuery);
          }
@@ -633,7 +633,7 @@ public class QueryEngine {
 
       // some fields are indexed, run a hybrid query
       FilterParsingResult<?> fpr = makeFilterParsingResult(parsingResult, expansion, null, null, null);
-      Query expandedQuery = new EmbeddedLuceneQuery(this, queryFactory, namedParameters, fpr, null, makeResultProcessor(null), -1, -1);
+      Query expandedQuery = new EmbeddedLuceneQuery<>(this, queryFactory, namedParameters, fpr, null, makeResultProcessor(null), -1, -1);
       return new HybridQuery(queryFactory, cache, queryString, namedParameters, getObjectFilter(matcher, queryString, namedParameters, null), startOffset, maxResults, expandedQuery);
    }
 
@@ -644,7 +644,7 @@ public class QueryEngine {
    private FilterParsingResult<?> makeFilterParsingResult(FilterParsingResult<?> parsingResult, BooleanExpr normalizedWhereClause,
                                                           PropertyPath[] projection, Class<?>[] projectedTypes, SortField[] sortFields) {
       String queryString = JPATreePrinter.printTree(parsingResult.getTargetEntityName(), projection, normalizedWhereClause, sortFields);
-      return new FilterParsingResult(queryString, parsingResult.getParameterNames(),
+      return new FilterParsingResult<>(queryString, parsingResult.getParameterNames(),
             normalizedWhereClause, null,
             parsingResult.getTargetEntityName(), parsingResult.getTargetEntityMetadata(),
             projection, projectedTypes, null, sortFields);
@@ -711,7 +711,7 @@ public class QueryEngine {
    /**
     * Build a Lucene index query.
     */
-   protected CacheQuery buildLuceneQuery(FilterParsingResult<?> filterParsingResult, Map<String, Object> namedParameters, long startOffset, int maxResults) {
+   protected <E> CacheQuery<E> buildLuceneQuery(FilterParsingResult<?> filterParsingResult, Map<String, Object> namedParameters, long startOffset, int maxResults) {
       if (log.isDebugEnabled()) {
          log.debugf("Building Lucene query for : %s", filterParsingResult.getQueryString());
       }
@@ -729,7 +729,7 @@ public class QueryEngine {
          log.debugf("The resulting Lucene query is : %s", luceneQuery.toString());
       }
 
-      CacheQuery cacheQuery = getSearchManager().getQuery(luceneQuery, getTargetedClass(filterParsingResult));
+      CacheQuery<?> cacheQuery = getSearchManager().getQuery(luceneQuery, getTargetedClass(filterParsingResult));
 
       if (luceneParsingResult.getSort() != null) {
          cacheQuery = cacheQuery.sort(luceneParsingResult.getSort());
@@ -744,7 +744,7 @@ public class QueryEngine {
          cacheQuery = cacheQuery.maxResults(maxResults);
       }
 
-      return cacheQuery;
+      return (CacheQuery<E>) cacheQuery;
    }
 
    protected org.apache.lucene.search.Query makeTypeQuery(org.apache.lucene.search.Query query, String targetEntityName) {

--- a/query/src/main/java/org/infinispan/query/impl/AbstractIterator.java
+++ b/query/src/main/java/org/infinispan/query/impl/AbstractIterator.java
@@ -15,7 +15,7 @@ import org.infinispan.query.ResultIterator;
  * @see org.infinispan.query.impl.LazyIterator
  * @since 4.0
  */
-public abstract class AbstractIterator implements ResultIterator {
+public abstract class AbstractIterator<E> implements ResultIterator<E> {
 
    private final Object[] buffer;
 
@@ -62,7 +62,7 @@ public abstract class AbstractIterator implements ResultIterator {
    }
 
    @Override
-   public Object next() {
+   public E next() {
       if (!hasNext()) throw new NoSuchElementException("Out of boundaries. There is no next");
 
       if (mustInitializeBuffer()) {
@@ -71,7 +71,7 @@ public abstract class AbstractIterator implements ResultIterator {
 
       int indexToReturn = index - bufferIndex;
       index++;
-      return buffer[indexToReturn];
+      return (E) buffer[indexToReturn];
    }
 
    private boolean mustInitializeBuffer() {

--- a/query/src/main/java/org/infinispan/query/impl/CacheQueryImpl.java
+++ b/query/src/main/java/org/infinispan/query/impl/CacheQueryImpl.java
@@ -30,7 +30,7 @@ import org.infinispan.query.backend.KeyTransformationHandler;
  * @author Sanne Grinovero <sanne@hibernate.org> (C) 2011 Red Hat Inc.
  * @author Marko Luksa
  */
-public class CacheQueryImpl implements CacheQuery {
+public class CacheQueryImpl<E> implements CacheQuery<E> {
 
    /**
     * Since CacheQuery extends {@link Iterable} it is possible to implicitly invoke
@@ -69,7 +69,7 @@ public class CacheQueryImpl implements CacheQuery {
     * @param filter - lucene filter
     */
    @Override
-   public CacheQuery filter(Filter filter) {
+   public CacheQuery<E> filter(Filter filter) {
       hSearchQuery.filter(filter);
       return this;
    }
@@ -83,7 +83,7 @@ public class CacheQueryImpl implements CacheQuery {
    }
 
    @Override
-   public CacheQuery sort(Sort sort) {
+   public CacheQuery<E> sort(Sort sort) {
       hSearchQuery.sort(sort);
       return this;
    }
@@ -105,7 +105,7 @@ public class CacheQueryImpl implements CacheQuery {
     * @param name of filter.
     */
    @Override
-   public CacheQuery disableFullTextFilter(String name) {
+   public CacheQuery<E> disableFullTextFilter(String name) {
       hSearchQuery.disableFullTextFilter(name);
       return this;
    }
@@ -117,45 +117,45 @@ public class CacheQueryImpl implements CacheQuery {
     * @throws IllegalArgumentException if the index given is less than zero.
     */
    @Override
-   public CacheQuery firstResult(int firstResult) {
+   public CacheQuery<E> firstResult(int firstResult) {
       hSearchQuery.firstResult(firstResult);
       return this;
    }
 
    @Override
-   public CacheQuery maxResults(int maxResults) {
+   public CacheQuery<E> maxResults(int maxResults) {
       hSearchQuery.maxResults(maxResults);
       return this;
    }
 
    @Override
-   public ResultIterator iterator() throws SearchException {
+   public ResultIterator<E> iterator() throws SearchException {
       return iterator(DEFAULT_FETCH_OPTIONS);
    }
 
    @Override
-   public ResultIterator iterator(FetchOptions fetchOptions) throws SearchException {
+   public ResultIterator<E> iterator(FetchOptions fetchOptions) throws SearchException {
       if (fetchOptions.getFetchMode() == FetchOptions.FetchMode.EAGER) {
          hSearchQuery.getTimeoutManager().start();
          List<EntityInfo> entityInfos = hSearchQuery.queryEntityInfos();
-         return filterNulls(new EagerIterator(entityInfos, getResultLoader(), fetchOptions.getFetchSize()));
+         return filterNulls(new EagerIterator<>(entityInfos, getResultLoader(), fetchOptions.getFetchSize()));
       } else if (fetchOptions.getFetchMode() == FetchOptions.FetchMode.LAZY) {
          DocumentExtractor extractor = hSearchQuery.queryDocumentExtractor();   //triggers actual Lucene search
-         return filterNulls(new LazyIterator(extractor, getResultLoader(), fetchOptions.getFetchSize()));
+         return filterNulls(new LazyIterator<>(extractor, getResultLoader(), fetchOptions.getFetchSize()));
       } else {
          throw new IllegalArgumentException("Unknown FetchMode " + fetchOptions.getFetchMode());
       }
    }
 
-   private ResultIterator filterNulls(ResultIterator iterator) {
-      return new NullFilteringResultIterator(iterator);
+   private ResultIterator<E> filterNulls(ResultIterator<E> iterator) {
+      return new NullFilteringResultIterator<>(iterator);
    }
 
    @Override
-   public List<Object> list() throws SearchException {
+   public List<E> list() throws SearchException {
       hSearchQuery.getTimeoutManager().start();
       final List<EntityInfo> entityInfos = hSearchQuery.queryEntityInfos();
-      return getResultLoader().load(entityInfos);
+      return (List<E>) getResultLoader().load(entityInfos);
    }
 
    private QueryResultLoader getResultLoader() {
@@ -185,14 +185,14 @@ public class CacheQueryImpl implements CacheQuery {
    }
 
    @Override
-   public CacheQuery projection(String... fields) {
+   public CacheQuery<Object[]> projection(String... fields) {
       this.projectionConverter = new ProjectionConverter(fields, cache, keyTransformationHandler);
       hSearchQuery.projection(projectionConverter.getHSearchProjection());
-      return this;
+      return (CacheQuery<Object[]>) this;
    }
 
    @Override
-   public CacheQuery timeout(long timeout, TimeUnit timeUnit) {
+   public CacheQuery<E> timeout(long timeout, TimeUnit timeUnit) {
       hSearchQuery.getTimeoutManager().setTimeout(timeout, timeUnit);
       return this;
    }

--- a/query/src/main/java/org/infinispan/query/impl/EagerIterator.java
+++ b/query/src/main/java/org/infinispan/query/impl/EagerIterator.java
@@ -16,7 +16,7 @@ import net.jcip.annotations.NotThreadSafe;
  * @author Marko Luksa
  */
 @NotThreadSafe
-public class EagerIterator extends AbstractIterator {
+public class EagerIterator<E> extends AbstractIterator<E> {
 
    private List<EntityInfo> entityInfos;
 

--- a/query/src/main/java/org/infinispan/query/impl/LazyIterator.java
+++ b/query/src/main/java/org/infinispan/query/impl/LazyIterator.java
@@ -17,7 +17,7 @@ import net.jcip.annotations.NotThreadSafe;
  * @author Ales Justin
  */
 @NotThreadSafe
-public class LazyIterator extends AbstractIterator {
+public class LazyIterator<E> extends AbstractIterator<E> {
 
    private final DocumentExtractor extractor;
 

--- a/query/src/main/java/org/infinispan/query/impl/NullFilteringResultIterator.java
+++ b/query/src/main/java/org/infinispan/query/impl/NullFilteringResultIterator.java
@@ -5,11 +5,11 @@ import org.infinispan.query.ResultIterator;
 /**
  * @author Marko Luksa
  */
-public class NullFilteringResultIterator extends NullFilteringIterator<Object> implements ResultIterator {
+public class NullFilteringResultIterator<E> extends NullFilteringIterator<E> implements ResultIterator<E> {
 
-   private final ResultIterator delegate;
+   private final ResultIterator<E> delegate;
 
-   public NullFilteringResultIterator(ResultIterator delegate) {
+   public NullFilteringResultIterator(ResultIterator<E> delegate) {
       super(delegate);
       this.delegate = delegate;
    }

--- a/query/src/main/java/org/infinispan/query/impl/SearchManagerImpl.java
+++ b/query/src/main/java/org/infinispan/query/impl/SearchManagerImpl.java
@@ -45,9 +45,9 @@ public class SearchManagerImpl implements SearchManagerImplementor {
     * @see org.infinispan.query.SearchManager#getQuery(org.apache.lucene.search.Query, java.lang.Class)
     */
    @Override
-   public CacheQuery getQuery(Query luceneQuery, Class<?>... classes) {
+   public <E> CacheQuery<E> getQuery(Query luceneQuery, Class<?>... classes) {
       queryInterceptor.enableClasses(classes);
-      return new CacheQueryImpl(luceneQuery, searchFactory, cache,
+      return new CacheQueryImpl<>(luceneQuery, searchFactory, cache,
          queryInterceptor.getKeyTransformationHandler(), timeoutExceptionFactory, classes);
    }
 
@@ -60,10 +60,10 @@ public class SearchManagerImpl implements SearchManagerImplementor {
     * @return
     */
    @Override
-   public CacheQuery getClusteredQuery(Query luceneQuery, Class<?>... classes) {
+   public <E> CacheQuery<E> getClusteredQuery(Query luceneQuery, Class<?>... classes) {
       queryInterceptor.enableClasses(classes);
       ExecutorService asyncExecutor = queryInterceptor.getAsyncExecutor();
-      return new ClusteredCacheQueryImpl(luceneQuery, searchFactory, asyncExecutor, cache, queryInterceptor.getKeyTransformationHandler(), classes);
+      return new ClusteredCacheQueryImpl<>(luceneQuery, searchFactory, asyncExecutor, cache, queryInterceptor.getKeyTransformationHandler(), classes);
    }
 
    @Override

--- a/query/src/test/java/org/infinispan/query/affinity/AffinityTest.java
+++ b/query/src/test/java/org/infinispan/query/affinity/AffinityTest.java
@@ -51,7 +51,7 @@ public class AffinityTest extends BaseAffinityTest {
 
       assertEquals(pickCache().size(), numThreads * ENTRIES);
       cacheList.forEach(c -> {
-         CacheQuery q = Search.getSearchManager(c).getQuery(new MatchAllDocsQuery(), Entity.class);
+         CacheQuery<Entity> q = Search.getSearchManager(c).getQuery(new MatchAllDocsQuery(), Entity.class);
          eventuallyEquals(numThreads * ENTRIES, () -> q.list().size());
       });
 
@@ -65,7 +65,7 @@ public class AffinityTest extends BaseAffinityTest {
       populate(ENTRIES / 2 + 1, ENTRIES);
       checkAffinity();
 
-      CacheQuery q = Search.getSearchManager(pickCache()).getQuery(new MatchAllDocsQuery(), Entity.class);
+      CacheQuery<Entity> q = Search.getSearchManager(pickCache()).getQuery(new MatchAllDocsQuery(), Entity.class);
       assertEquals(ENTRIES, pickCache().size());
       assertEquals(ENTRIES, q.list().size());
 

--- a/query/src/test/java/org/infinispan/query/affinity/AffinityTopologyChangeTest.java
+++ b/query/src/test/java/org/infinispan/query/affinity/AffinityTopologyChangeTest.java
@@ -73,7 +73,7 @@ public class AffinityTopologyChangeTest extends BaseAffinityTest {
       CompletableFuture.allOf(f1, f2, f3, f4).join();
 
       eventually(() -> {
-         CacheQuery query = Search.getSearchManager(pickCache()).getQuery(new MatchAllDocsQuery()).projection("val");
+         CacheQuery<Object[]> query = Search.getSearchManager(pickCache()).getQuery(new MatchAllDocsQuery()).projection("val");
          Set<Integer> indexedDocsIds = query.list().stream().map(EXTRACT_PROJECTION).collect(Collectors.toSet());
          int resultSize = indexedDocsIds.size();
          rangeClosed(1, ENTRIES).boxed().filter(idx -> !indexedDocsIds.contains(idx))
@@ -160,7 +160,7 @@ public class AffinityTopologyChangeTest extends BaseAffinityTest {
       @Override
       void executeTask() {
          int id = globalCounter.get();
-         CacheQuery q = Search.getSearchManager(cache).getQuery(new MatchAllDocsQuery(), Entity.class);
+         CacheQuery<?> q = Search.getSearchManager(cache).getQuery(new MatchAllDocsQuery(), Entity.class);
          while (id <= ENTRIES) {
             int size = q.list().size();
             assertTrue(size > 0 && size <= ENTRIES);

--- a/query/src/test/java/org/infinispan/query/api/ManualIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/api/ManualIndexingTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 public class ManualIndexingTest extends MultipleCacheManagersTest {
 
    protected static final int NUM_NODES = 4;
-   protected List<Cache<String, Car>> caches = new ArrayList<Cache<String, Car>>(NUM_NODES);
+   protected List<Cache<String, Car>> caches = new ArrayList<>(NUM_NODES);
 
    protected static final String[] neededCacheNames = {
          BasicCacheContainer.DEFAULT_CACHE_NAME,
@@ -60,7 +60,7 @@ public class ManualIndexingTest extends MultipleCacheManagersTest {
       for (Cache cache : caches) {
          SearchManager sm = Search.getSearchManager(cache);
          Query query = sm.buildQueryBuilderForClass(Car.class).get().keyword().onField("make").matching(carMake).createQuery();
-         CacheQuery cacheQuery = sm.getQuery(query, Car.class);
+         CacheQuery<Car> cacheQuery = sm.getQuery(query, Car.class);
          assertEquals("Expected count not met on cache " + cache, expectedCount, cacheQuery.getResultSize());
          assertEquals("Expected count not met on cache " + cache, expectedCount, cacheQuery.list().size());
       }

--- a/query/src/test/java/org/infinispan/query/api/PutAllTest.java
+++ b/query/src/test/java/org/infinispan/query/api/PutAllTest.java
@@ -42,11 +42,11 @@ public class PutAllTest extends SingleCacheManagerTest {
 
       cache.put(id, new NotIndexedType("name1"));
 
-      Map<Object, Object> map = new HashMap<Object, Object>();
+      Map<Object, Object> map = new HashMap<>();
       map.put(id, new TestEntity("name2", "surname2", id, "note"));
       cache.putAll(map);
 
-      CacheQuery q1 = queryByNameField("name2", AnotherTestEntity.class);
+      CacheQuery<?> q1 = queryByNameField("name2", AnotherTestEntity.class);
       assertEquals(1, q1.getResultSize());
       assertEquals(TestEntity.class, q1.list().get(0).getClass());
       StaticTestingErrorHandler.assertAllGood(cache);
@@ -57,12 +57,12 @@ public class PutAllTest extends SingleCacheManagerTest {
 
       cache.put(id, new NotIndexedType("name1"));
 
-      Map<Object, Object> map = new HashMap<Object, Object>();
+      Map<Object, Object> map = new HashMap<>();
       map.put(id, new TestEntity("name2", "surname2", id, "note"));
       Future futureTask = cache.putAllAsync(map);
       futureTask.get();
       assertTrue(futureTask.isDone());
-      CacheQuery q1 = queryByNameField("name2", AnotherTestEntity.class);
+      CacheQuery<?> q1 = queryByNameField("name2", AnotherTestEntity.class);
       assertEquals(1, q1.getResultSize());
       assertEquals(TestEntity.class, q1.list().get(0).getClass());
       StaticTestingErrorHandler.assertAllGood(cache);
@@ -72,18 +72,18 @@ public class PutAllTest extends SingleCacheManagerTest {
       final long id = 10;
 
       cache.put(id, new TestEntity("name1", "surname1", id, "note"));
-      CacheQuery q1 = queryByNameField("name1", TestEntity.class);
+      CacheQuery<?> q1 = queryByNameField("name1", TestEntity.class);
       assertEquals(1, q1.getResultSize());
       assertEquals(TestEntity.class, q1.list().get(0).getClass());
 
-      Map<Object, Object> map = new HashMap<Object, Object>();
+      Map<Object, Object> map = new HashMap<>();
       map.put(id, new NotIndexedType("name2"));
       cache.putAll(map);
 
-      CacheQuery q2 = queryByNameField("name1", TestEntity.class);
+      CacheQuery<?> q2 = queryByNameField("name1", TestEntity.class);
       assertEquals(0, q2.getResultSize());
 
-      CacheQuery q3 = queryByNameField("name2", TestEntity.class);
+      CacheQuery<?> q3 = queryByNameField("name2", TestEntity.class);
       assertEquals(0, q3.getResultSize());
       StaticTestingErrorHandler.assertAllGood(cache);
    }
@@ -92,19 +92,19 @@ public class PutAllTest extends SingleCacheManagerTest {
       final long id = 10;
 
       cache.put(id, new TestEntity("name1", "surname1", id, "note"));
-      CacheQuery q1 = queryByNameField("name1", TestEntity.class);
+      CacheQuery<?> q1 = queryByNameField("name1", TestEntity.class);
       assertEquals(1, q1.getResultSize());
       assertEquals(TestEntity.class, q1.list().get(0).getClass());
 
-      Map<Object, Object> map = new HashMap<Object, Object>();
+      Map<Object, Object> map = new HashMap<>();
       map.put(id, new NotIndexedType("name2"));
       Future futureTask = cache.putAllAsync(map);
       futureTask.get();
       assertTrue(futureTask.isDone());
-      CacheQuery q2 = queryByNameField("name1", TestEntity.class);
+      CacheQuery<?> q2 = queryByNameField("name1", TestEntity.class);
       assertEquals(0, q2.getResultSize());
 
-      CacheQuery q3 = queryByNameField("name2", TestEntity.class);
+      CacheQuery<?> q3 = queryByNameField("name2", TestEntity.class);
       assertEquals(0, q3.getResultSize());
       StaticTestingErrorHandler.assertAllGood(cache);
    }
@@ -114,24 +114,24 @@ public class PutAllTest extends SingleCacheManagerTest {
 
       cache.put(id, new TestEntity("name1", "surname1", id, "note"));
 
-      CacheQuery q1 = queryByNameField("name1", TestEntity.class);
+      CacheQuery<?> q1 = queryByNameField("name1", TestEntity.class);
       assertEquals(1, q1.getResultSize());
       assertEquals(TestEntity.class, q1.list().get(0).getClass());
 
-      Map<Object, Object> map = new HashMap<Object, Object>();
+      Map<Object, Object> map = new HashMap<>();
       map.put(id, new AnotherTestEntity("name2"));
       cache.putAll(map);
 
-      CacheQuery q2 = queryByNameField("name1", TestEntity.class);
+      CacheQuery<?> q2 = queryByNameField("name1", TestEntity.class);
       assertEquals(0, q2.getResultSize());
 
-      CacheQuery q3 = queryByNameField("name2", AnotherTestEntity.class);
+      CacheQuery<?> q3 = queryByNameField("name2", AnotherTestEntity.class);
       assertEquals(1, q3.getResultSize());
       assertEquals(AnotherTestEntity.class, q3.list().get(0).getClass());
       StaticTestingErrorHandler.assertAllGood(cache);
    }
 
-   private CacheQuery queryByNameField(String name, Class<?> entity) {
+   private <T> CacheQuery<T> queryByNameField(String name, Class<T> entity) {
       SearchManager sm = Search.getSearchManager(cache);
       Query query = sm.buildQueryBuilderForClass(entity)
             .get().keyword().onField("name").matching(name).createQuery();

--- a/query/src/test/java/org/infinispan/query/backend/IndexCacheStopTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/IndexCacheStopTest.java
@@ -161,7 +161,7 @@ public class IndexCacheStopTest extends AbstractInfinispanTest {
    }
 
    private <T> void assertIndexPopulated(Cache<Integer, T> cache, Class<T> clazz) {
-      CacheQuery query = Search.getSearchManager(cache).getQuery(new MatchAllDocsQuery(), clazz);
+      CacheQuery<T> query = Search.getSearchManager(cache).getQuery(new MatchAllDocsQuery(), clazz);
       assertEquals(query.list().size(), CACHE_SIZE);
    }
 

--- a/query/src/test/java/org/infinispan/query/backend/MergeTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/MergeTest.java
@@ -107,7 +107,7 @@ public class MergeTest extends MultipleCacheManagersTest {
       assertAllGood(cache1, cache2);
       System.out.println("Load took: " + (System.currentTimeMillis() - start) / 1000 + " s");
       SearchManager searchManager = Search.getSearchManager(cache1);
-      final CacheQuery query = searchManager.getQuery(new MatchAllDocsQuery(), Person.class);
+      final CacheQuery<Person> query = searchManager.getQuery(new MatchAllDocsQuery(), Person.class);
       final int total = NUMBER_OF_THREADS * OBJECT_COUNT;
       eventually(new Condition() {
          @Override

--- a/query/src/test/java/org/infinispan/query/backend/MultipleEntitiesTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/MultipleEntitiesTest.java
@@ -60,13 +60,13 @@ public class MultipleEntitiesTest extends SingleCacheManagerTest {
       cache.put(223456, new Bond(new Date(System.currentTimeMillis()), 550L));
       assertEfficientIndexingUsed(searchManager.unwrap(SearchIntegrator.class), Bond.class);
 
-      CacheQuery query = searchManager.getQuery(new MatchAllDocsQuery(), Bond.class, Debenture.class);
+      CacheQuery<?> query = searchManager.getQuery(new MatchAllDocsQuery(), Bond.class, Debenture.class);
       assertEquals(query.list().size(), 3);
 
-      CacheQuery queryBond = searchManager.getQuery(new MatchAllDocsQuery(), Bond.class);
+      CacheQuery<?> queryBond = searchManager.getQuery(new MatchAllDocsQuery(), Bond.class);
       assertEquals(queryBond.getResultSize(), 2);
 
-      CacheQuery queryDeb = searchManager.getQuery(new MatchAllDocsQuery(), Debenture.class);
+      CacheQuery<?> queryDeb = searchManager.getQuery(new MatchAllDocsQuery(), Debenture.class);
       assertEquals(queryDeb.getResultSize(), 1);
    }
 

--- a/query/src/test/java/org/infinispan/query/backend/QueryInterceptorIndexingOperationsTest.java
+++ b/query/src/test/java/org/infinispan/query/backend/QueryInterceptorIndexingOperationsTest.java
@@ -150,7 +150,7 @@ public class QueryInterceptorIndexingOperationsTest extends SingleCacheManagerTe
    }
 
    private int countIndexedDocuments(Class<?> clazz) {
-      CacheQuery query = Search.getSearchManager(cache).getQuery(new MatchAllDocsQuery(), clazz);
+      CacheQuery<?> query = Search.getSearchManager(cache).getQuery(new MatchAllDocsQuery(), clazz);
       return query.list().size();
    }
 

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheTest.java
@@ -43,14 +43,15 @@ import org.testng.annotations.Test;
 @Test(groups = {"functional", "smoke"}, testName = "query.blackbox.ClusteredCacheTest")
 public class ClusteredCacheTest extends MultipleCacheManagersTest {
 
-   Cache cache1, cache2;
+   Cache cache1;
+   Cache cache2;
    Person person1;
    Person person2;
    Person person3;
    Person person4;
    QueryParser queryParser;
    Query luceneQuery;
-   CacheQuery cacheQuery;
+   CacheQuery<Person> cacheQuery;
    final String key1 = "Navin";
    final String key2 = "BigGoat";
    final String key3 = "MiniGoat";
@@ -118,7 +119,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       prepareTestData();
       cacheQuery = createCacheQuery(cache2, "blurb", "playing");
 
-      List<Object> found = cacheQuery.list();
+      List<Person> found = cacheQuery.list();
 
       assert found.size() == 1;
 
@@ -129,7 +130,6 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
             log.warn("Person p1 is null in sc2 and cannot actually see the data of person1 in sc1");
          } else {
             log.trace("p1 name is  " + p1.getName());
-
          }
       }
 
@@ -151,7 +151,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       luceneQuery = queryParser.parse("playing");
       cacheQuery = Search.getSearchManager(cache2).getQuery(luceneQuery);
 
-      List<Object> found = cacheQuery.list();
+      List<Person> found = cacheQuery.list();
 
       assert found.size() == 1 : "Expected list of size 1, was of size " + found.size();
       assert found.get(0).equals(person1);
@@ -176,7 +176,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
 
       luceneQuery = queryParser.parse("eats");
       cacheQuery = Search.getSearchManager(cache2).getQuery(luceneQuery);
-      List<Object> found = cacheQuery.list();
+      List<Person> found = cacheQuery.list();
 
       AssertJUnit.assertEquals(2, found.size());
       assert found.contains(person2);
@@ -205,7 +205,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       queryParser = createQueryParser("blurb");
       luceneQuery = queryParser.parse("eats");
       cacheQuery = Search.getSearchManager(cache2).getQuery(luceneQuery);
-      List<Object> found = cacheQuery.list();
+      List<Person> found = cacheQuery.list();
 
       assert found.size() == 2;
       assert found.contains(person2);
@@ -225,7 +225,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       queryParser = createQueryParser("blurb");
       luceneQuery = queryParser.parse("playing");
       cacheQuery = Search.getSearchManager(cache2).getQuery(luceneQuery);
-      List<Object> found = cacheQuery.list();
+      List<Person> found = cacheQuery.list();
 
       AssertJUnit.assertEquals(1, found.size());
       StaticTestingErrorHandler.assertAllGood(cache1, cache2);
@@ -246,11 +246,11 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       allWrites.put(key3, person3);
 
       cache2.putAll(allWrites);
-      List found = searchManager.getQuery(allQuery, Person.class).list();
+      List<Person> found = searchManager.<Person>getQuery(allQuery, Person.class).list();
       AssertJUnit.assertEquals(3, found.size());
 
       cache2.putAll(allWrites);
-      found = searchManager.getQuery(allQuery, Person.class).list();
+      found = searchManager.<Person>getQuery(allQuery, Person.class).list();
       AssertJUnit.assertEquals(3, found.size());
       StaticTestingErrorHandler.assertAllGood(cache1, cache2);
    }
@@ -277,14 +277,14 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       Future futureTask = cache2.putAllAsync(allWrites);
       futureTask.get();
       assert futureTask.isDone();
-      List found = searchManager.getQuery(allQuery, Person.class).list();
+      List<Person> found = searchManager.<Person>getQuery(allQuery, Person.class).list();
       AssertJUnit.assertEquals(4, found.size());
       assert found.contains(person4);
 
       futureTask = cache1.putAllAsync(allWrites);
       futureTask.get();
       assert futureTask.isDone();
-      found = searchManager.getQuery(allQuery, Person.class).list();
+      found = searchManager.<Person>getQuery(allQuery, Person.class).list();
       AssertJUnit.assertEquals(4, found.size());
       assert found.contains(person4);
       StaticTestingErrorHandler.assertAllGood(cache1, cache2);
@@ -305,7 +305,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
 
       cache2.putForExternalRead("newGoat", person4);
       eventually(() -> cache2.get("newGoat") != null);
-      List found = searchManager.getQuery(allQuery, Person.class).list();
+      List<Person> found = searchManager.<Person>getQuery(allQuery, Person.class).list();
       AssertJUnit.assertEquals(4, found.size());
 
       assert found.contains(person4);
@@ -315,7 +315,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       person5.setBlurb("Plays with grass.");
       cache2.putForExternalRead("newGoat", person5);
 
-      found = searchManager.getQuery(allQuery, Person.class).list();
+      found = searchManager.<Person>getQuery(allQuery, Person.class).list();
       AssertJUnit.assertEquals(4, found.size());
 
       assert !found.contains(person5);
@@ -338,7 +338,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
 
       cache2.putIfAbsent("newGoat", person4);
 
-      List found = searchManager.getQuery(allQuery, Person.class).list();
+      List<Person> found = searchManager.<Person>getQuery(allQuery, Person.class).list();
       AssertJUnit.assertEquals(4, found.size());
 
       assert found.contains(person4);
@@ -348,7 +348,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       person5.setBlurb("Plays with grass.");
       cache2.putIfAbsent("newGoat", person5);
 
-      found = searchManager.getQuery(allQuery, Person.class).list();
+      found = searchManager.<Person>getQuery(allQuery, Person.class).list();
       AssertJUnit.assertEquals(4, found.size());
 
       assert !found.contains(person5);
@@ -372,7 +372,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       Future futureTask = cache2.putIfAbsentAsync("newGoat", person4);
       futureTask.get();
       assert futureTask.isDone();
-      List found = searchManager.getQuery(allQuery, Person.class).list();
+      List<Person> found = searchManager.<Person>getQuery(allQuery, Person.class).list();
       AssertJUnit.assertEquals(4, found.size());
       assert found.contains(person4);
 
@@ -382,7 +382,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       futureTask = cache2.putIfAbsentAsync("newGoat", person5);
       futureTask.get();
       assert futureTask.isDone();
-      found = searchManager.getQuery(allQuery, Person.class).list();
+      found = searchManager.<Person>getQuery(allQuery, Person.class).list();
       AssertJUnit.assertEquals(4, found.size());
       assert !found.contains(person5);
       assert found.contains(person4);
@@ -405,7 +405,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       Future f = cache2.putAsync("newGoat", person4);
       f.get();
       assert f.isDone();
-      List found = searchManager.getQuery(allQuery, Person.class).list();
+      List<Person> found = searchManager.<Person>getQuery(allQuery, Person.class).list();
       AssertJUnit.assertEquals(4, found.size());
       assert found.contains(person4);
 
@@ -415,7 +415,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       f = cache2.putAsync("newGoat", person5);
       f.get();
       assert f.isDone();
-      found = searchManager.getQuery(allQuery, Person.class).list();
+      found = searchManager.<Person>getQuery(allQuery, Person.class).list();
       AssertJUnit.assertEquals(4, found.size());
       assert !found.contains(person4);
       assert found.contains(person5);
@@ -430,7 +430,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
               .add(queryParser.parse("eats"), Occur.SHOULD)
               .add(queryParser.parse("playing"), Occur.SHOULD)
               .build();
-      CacheQuery cacheQuery = Search.getSearchManager(cache1).getQuery(luceneQuery);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache1).getQuery(luceneQuery);
       AssertJUnit.assertEquals(3, cacheQuery.getResultSize());
 
       cache2.clear();
@@ -447,14 +447,14 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("eats");
 
-      CacheQuery query = Search.getSearchManager(cache1).getQuery(luceneQuery);
+      CacheQuery<Person> query = Search.getSearchManager(cache1).getQuery(luceneQuery);
       FullTextFilter filter = query.enableFullTextFilter("personFilter");
       filter.setParameter("blurbText", "cheese");
 
       AssertJUnit.assertEquals(1, query.getResultSize());
-      List result = query.list();
+      List<Person> result = query.list();
 
-      Person person = (Person) result.get(0);
+      Person person = result.get(0);
       AssertJUnit.assertEquals("MiniGoat", person.getName());
       AssertJUnit.assertEquals("Eats cheese", person.getBlurb());
 
@@ -476,7 +476,7 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("eats");
 
-      CacheQuery query = Search.getSearchManager(cache1).getQuery(luceneQuery);
+      CacheQuery<Person> query = Search.getSearchManager(cache1).getQuery(luceneQuery);
       FullTextFilter filter = query.enableFullTextFilter("personFilter");
       filter.setParameter("blurbText", "grass");
 
@@ -486,9 +486,9 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       ageFilter.setParameter("age", 70);
 
       AssertJUnit.assertEquals(1, query.getResultSize());
-      List result = query.list();
+      List<Person> result = query.list();
 
-      Person person = (Person) result.get(0);
+      Person person = result.get(0);
       AssertJUnit.assertEquals("ExtraGoat", person.getName());
       AssertJUnit.assertEquals(70, person.getAge());
 
@@ -523,10 +523,10 @@ public class ClusteredCacheTest extends MultipleCacheManagersTest {
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("Eats");
 
-      CacheQuery cacheQuery = manager.getQuery(luceneQuery);
+      CacheQuery<Person> cacheQuery = manager.getQuery(luceneQuery);
 
       int counter = 0;
-      try (ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY))) {
+      try (ResultIterator<Person> found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY))) {
          while (found.hasNext()) {
             found.next();
             counter++;

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithLongIndexNameTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredCacheWithLongIndexNameTest.java
@@ -69,7 +69,7 @@ public class ClusteredCacheWithLongIndexNameTest extends MultipleCacheManagersTe
       SearchManager sm = Search.getSearchManager(cache3);
       QueryBuilder qb = sm.buildQueryBuilderForClass(VeryLongIndexNamedClass.class).get();
       Query q = qb.keyword().wildcard().onField("name").matching("value*").createQuery();
-      CacheQuery cq = sm.getQuery(q, VeryLongIndexNamedClass.class);
+      CacheQuery<?> cq = sm.getQuery(q, VeryLongIndexNamedClass.class);
 
       assertEquals(100, cq.getResultSize());
 

--- a/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/ClusteredQueryTest.java
@@ -39,7 +39,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    private final QueryParser queryParser = createQueryParser("blurb");
 
    Cache<String, Person> cacheAMachine1, cacheAMachine2;
-   CacheQuery cacheQuery;
+   CacheQuery<Person> cacheQuery;
 
    public ClusteredQueryTest() {
       // BasicConfigurator.configure();
@@ -110,13 +110,13 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       cacheQuery.sort(sort);
 
       for (int i = 0; i < 2; i ++) {
-         ResultIterator iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
+         ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
          try {
             assert cacheQuery.getResultSize() == 4 : cacheQuery.getResultSize();
 
             int previousAge = 0;
             while (iterator.hasNext()) {
-               Person person = (Person) iterator.next();
+               Person person = iterator.next();
                assert person.getAge() > previousAge;
                previousAge = person.getAge();
             }
@@ -131,7 +131,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
    public void testLazyNonOrdered() throws ParseException {
       populateCache();
 
-      ResultIterator iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
+      ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
       try {
          assert cacheQuery.getResultSize() == 4 : cacheQuery.getResultSize();
       }
@@ -145,11 +145,11 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       populateCache();
 
       final SearchManager searchManager1 = Search.getSearchManager(cacheAMachine1);
-      final CacheQuery localQuery1 = searchManager1.getQuery(createLuceneQuery());
+      final CacheQuery<?> localQuery1 = searchManager1.getQuery(createLuceneQuery());
       assertEquals(3, localQuery1.getResultSize());
 
       final SearchManager searchManager2 = Search.getSearchManager(cacheAMachine2);
-      final CacheQuery localQuery2 = searchManager2.getQuery(createLuceneQuery());
+      final CacheQuery<?> localQuery2 = searchManager2.getQuery(createLuceneQuery());
       assertEquals(1, localQuery2.getResultSize());
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
@@ -162,13 +162,13 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       Sort sort = new Sort(sortField);
       cacheQuery.sort(sort);
 
-      ResultIterator iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
+      ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
       try {
          assertEquals(4, cacheQuery.getResultSize());
 
          int previousAge = 0;
          while (iterator.hasNext()) {
-            Person person = (Person) iterator.next();
+            Person person = iterator.next();
             assert person.getAge() > previousAge;
             previousAge = person.getAge();
          }
@@ -183,7 +183,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       populateCache();
 
       cacheQuery.maxResults(1);
-      ResultIterator iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
+      ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
       try {
          assert iterator.hasNext();
          iterator.next();
@@ -201,7 +201,7 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       populateCache();
 
       cacheQuery.maxResults(1);
-      ResultIterator iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
+      ResultIterator<Person> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
       try {
          assert iterator.hasNext();
          iterator.remove();
@@ -219,12 +219,11 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       Sort sort = new Sort(sortField);
       cacheQuery.sort(sort);
 
-      List<Object> results = cacheQuery.list();
+      List<Person> results = cacheQuery.list();
       assert results.size() == 4 : cacheQuery.getResultSize();
 
       int previousAge = 0;
-      for (Object result : results) {
-         Person person = (Person) result;
+      for (Person person : results) {
          assert person.getAge() > previousAge;
          previousAge = person.getAge();
       }
@@ -247,17 +246,17 @@ public class ClusteredQueryTest extends MultipleCacheManagersTest {
       Sort sort = new Sort(sortField);
       cacheQuery.sort(sort);
 
-      List<Object> results = cacheQuery.list();
+      List<Person> results = cacheQuery.list();
       assertEquals(1, results.size());
       assertEquals(4, cacheQuery.getResultSize());
-      Person result = (Person) results.get(0);
+      Person result = results.get(0);
       assertEquals(45, result.getAge());
       StaticTestingErrorHandler.assertAllGood(cacheAMachine1, cacheAMachine2);
    }
 
    public void testQueryAll() throws ParseException {
       populateCache();
-      CacheQuery clusteredQuery = Search.getSearchManager(cacheAMachine1)
+      CacheQuery<Person> clusteredQuery = Search.getSearchManager(cacheAMachine1)
             .getClusteredQuery(new MatchAllDocsQuery(), Person.class);
 
       assertEquals(4, clusteredQuery.list().size());

--- a/query/src/test/java/org/infinispan/query/blackbox/KeyTypeTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/KeyTypeTest.java
@@ -75,10 +75,10 @@ public class KeyTypeTest extends SingleCacheManagerTest {
 
       // Going to search the 'blurb' field for 'owns'
       Term term = new Term("blurb", "owns");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(new TermQuery(term));
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(new TermQuery(term));
       assert cacheQuery.getResultSize() == 9;
 
-      List<Object> found = cacheQuery.list();
+      List<Person> found = cacheQuery.list();
       for (int i = 0; i < 9; i++){
          assert found.get(i).equals(person1);
       }
@@ -95,7 +95,7 @@ public class KeyTypeTest extends SingleCacheManagerTest {
       cache.put(key3, person1);
 
       Term term = new Term("blurb", "owns");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(new TermQuery(term));
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(new TermQuery(term));
       int i;
       assert (i = cacheQuery.getResultSize()) == 3 : "Expected 3, was " + i;
    }

--- a/query/src/test/java/org/infinispan/query/blackbox/LocalCacheTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/LocalCacheTest.java
@@ -63,22 +63,22 @@ public class LocalCacheTest extends SingleCacheManagerTest {
 
    public void testSimple() throws ParseException {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing" );
+      CacheQuery<Person> cacheQuery = createCacheQuery(cache, "blurb", "playing" );
 
-      List<Object> found = cacheQuery.list();
+      List<Person> found = cacheQuery.list();
 
       int elems = found.size();
       assert elems == 1 : "Expected 1 but was " + elems;
 
-      Object val = found.get(0);
+      Person val = found.get(0);
       assert val.equals(person1) : "Expected " + person1 + " but was " + val;
       StaticTestingErrorHandler.assertAllGood(cache);
    }
 
    public void testSimpleForNonField() throws ParseException {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "nonSearchableField", "test1" );
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "nonSearchableField", "test1" );
+      List<?> found = cacheQuery.list();
 
       int elems = found.size();
       assert elems == 0 : "Expected 0 but was " + elems;
@@ -87,9 +87,9 @@ public class LocalCacheTest extends SingleCacheManagerTest {
 
    public void testEagerIterator() throws ParseException {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing");
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "playing");
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
 
       try {
          assert found.hasNext();
@@ -104,9 +104,9 @@ public class LocalCacheTest extends SingleCacheManagerTest {
    @Test(expectedExceptions = UnsupportedOperationException.class)
    public void testEagerIteratorRemove() throws ParseException {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing");
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "playing");
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
 
       try {
          assert found.hasNext();
@@ -119,9 +119,9 @@ public class LocalCacheTest extends SingleCacheManagerTest {
    @Test(expectedExceptions = NoSuchElementException.class)
    public void testEagerIteratorExCase() throws ParseException {
       loadTestingData();
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing");
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "playing");
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
 
       try {
          assert found.hasNext();
@@ -138,8 +138,8 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       queryParser = createQueryParser("name");
 
       Query luceneQuery = queryParser.parse("goat");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      List<Person> found = cacheQuery.list();
 
       assert found.size() == 2;
       assertTrue(found.contains(person2));
@@ -151,9 +151,9 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       loadTestingData();
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("playing");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
 
-      List<Object> found = cacheQuery.list();
+      List<Person> found = cacheQuery.list();
 
       assert found.size() == 1;
       assert found.get(0).equals(person1);
@@ -177,8 +177,8 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       queryParser = createQueryParser("name");
 
       Query luceneQuery = queryParser.parse("Goat");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      List<Person> found = cacheQuery.list();
 
       assert found.size() == 2 : "Size of list should be 2";
       assert found.contains(person2);
@@ -207,8 +207,8 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       queryParser = createQueryParser("name");
 
       Query luceneQuery = queryParser.parse("Goat");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      List<Person> found = cacheQuery.list();
 
       assert found.size() == 2;
       assert found.contains(person2);
@@ -231,8 +231,8 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       queryParser = createQueryParser("name");
 
       Query luceneQuery = queryParser.parse("Goat");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      List<Person> found = cacheQuery.list();
 
       assert found.size() == 2 : "Size of list should be 2";
       assert found.contains(person2) : "The search should have person2";
@@ -258,8 +258,8 @@ public class LocalCacheTest extends SingleCacheManagerTest {
 
       Query luceneQuery = queryParser.parse("Goat");
       {
-         CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
-         List<Object> found = cacheQuery.list();
+         CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+         List<Person> found = cacheQuery.list();
 
          assert found.size() == 2;
 
@@ -278,8 +278,8 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       cache.put(key2, person2);
 
       {
-         CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
-         List<Object> found = cacheQuery.list();
+         CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+         List<Person> found = cacheQuery.list();
 
          assert found.size() == 2;
 
@@ -299,8 +299,8 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       queryParser = createQueryParser("name");
 
       Query luceneQuery = queryParser.parse("goat");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      List<?> found = cacheQuery.list();
 
       assert found.size() == 2;
 
@@ -318,9 +318,9 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       loadTestingData();
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("playing");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
 
       try {
          assert found.hasNext();
@@ -337,9 +337,9 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       loadTestingData();
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("playing");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions(){
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions(){
          public FetchOptions fetchMode(FetchMode fetchMode) {
             return null;
          }
@@ -358,9 +358,9 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       loadTestingData();
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("playing");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
 
-      ResultIterator found = cacheQuery.iterator();
+      ResultIterator<?> found = cacheQuery.iterator();
 
       try {
          assert found.hasNext();
@@ -376,7 +376,7 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       loadTestingData();
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("Eats");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
 
       int matchCounter = 0;
       int i = 0;
@@ -407,14 +407,14 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("Eats");
 
-      CacheQuery query = Search.getSearchManager(cache).getQuery(luceneQuery);
+      CacheQuery<Person> query = Search.getSearchManager(cache).getQuery(luceneQuery);
       FullTextFilter filter = query.enableFullTextFilter("personFilter");
       filter.setParameter("blurbText", "cheese");
 
       assertEquals(1, query.getResultSize());
-      List result = query.list();
+      List<Person> result = query.list();
 
-      Person person = (Person) result.get(0);
+      Person person = result.get(0);
       assertEquals("Mini Goat", person.getName());
       assertEquals("Eats cheese", person.getBlurb());
 
@@ -431,11 +431,11 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("Eats");
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
-      ResultIterator iterator = cacheQuery.iterator();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      ResultIterator<?> iterator = cacheQuery.iterator();
       try {
          if (iterator.hasNext()) {
-            Object next = iterator.next();
+            iterator.next();
             iterator.remove();
          }
       } finally {
@@ -448,9 +448,9 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       loadTestingData();
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("Eats");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery).firstResult(1);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).<Person>getQuery(luceneQuery).firstResult(1);
 
-      ResultIterator iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
+      ResultIterator<?> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
       try {
          assertEquals(2, countElements(iterator));
       } finally {
@@ -464,7 +464,7 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       loadTestingData();
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("fish");
-      CacheQuery cacheQuery = Search.getSearchManager(null).getQuery(luceneQuery).firstResult(1);
+      Search.getSearchManager(null).getQuery(luceneQuery).firstResult(1);
    }
 
    @Test(expectedExceptions = IllegalArgumentException.class)
@@ -472,9 +472,9 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       loadTestingData();
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("Eats");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery).firstResult(1);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).<Person>getQuery(luceneQuery).firstResult(1);
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY).fetchSize(0));
+      cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY).fetchSize(0));
    }
 
    @Test(expectedExceptions = NoSuchElementException.class)
@@ -482,9 +482,9 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       loadTestingData();
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("fish");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery).firstResult(1);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).<Person>getQuery(luceneQuery).firstResult(1);
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
 
       try {
          found.next();
@@ -498,9 +498,9 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       loadTestingData();
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("Eats");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery).firstResult(1);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).<Person>getQuery(luceneQuery).firstResult(1);
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(null));
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions().fetchMode(null));
 
       try {
          found.next();
@@ -517,9 +517,9 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("Eats");
 
-      CacheQuery cacheQuery = manager.getQuery(luceneQuery);
+      CacheQuery<?> cacheQuery = manager.getQuery(luceneQuery);
 
-      ResultIterator iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
+      ResultIterator<?> iterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
       try {
          assertEquals(3, countElements(iterator));
       } finally {
@@ -543,9 +543,9 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("playing");
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
 
-      ResultIterator found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.valueOf("LAZY")));
+      ResultIterator<?> found = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.valueOf("LAZY")));
 
       try {
          assert found.hasNext();
@@ -560,7 +560,7 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       loadTestingData();
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("playing");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
 
       assert cacheQuery.getResultSize() == 1;
       StaticTestingErrorHandler.assertAllGood(cache);
@@ -572,24 +572,24 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("eats");
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery)
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery)
             .maxResults(1);
 
       assertEquals(3, cacheQuery.getResultSize());   // NOTE: getResultSize() ignores pagination (maxResults, firstResult)
       assertEquals(1, cacheQuery.list().size());
-      ResultIterator eagerIterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
+      ResultIterator<?> eagerIterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
       try {
          assertEquals(1, countElements(eagerIterator));
       } finally {
          eagerIterator.close();
       }
-      ResultIterator lazyIterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
+      ResultIterator<?> lazyIterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
       try {
          assertEquals(1, countElements(lazyIterator));
       } finally {
          lazyIterator.close();
       }
-      ResultIterator defaultIterator = cacheQuery.iterator();
+      ResultIterator<?> defaultIterator = cacheQuery.iterator();
       try {
          assertEquals(1, countElements(defaultIterator));
       } finally {
@@ -598,7 +598,7 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       StaticTestingErrorHandler.assertAllGood(cache);
    }
 
-   private int countElements(ResultIterator iterator) {
+   private int countElements(ResultIterator<?> iterator) {
       int count = 0;
       while (iterator.hasNext()) {
          iterator.next();
@@ -620,7 +620,7 @@ public class LocalCacheTest extends SingleCacheManagerTest {
               .add(new TermQuery(goat), Occur.SHOULD)
               .add(new TermQuery(navin), Occur.SHOULD)
               .build();
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      CacheQuery<Person> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
 
       // We know that we've got all 3 hits.
       assert cacheQuery.getResultSize() == 3 : "Expected 3, got " + cacheQuery.getResultSize();
@@ -637,9 +637,9 @@ public class LocalCacheTest extends SingleCacheManagerTest {
       loadTestingData();
       queryParser = createQueryParser("blurb");
       Query luceneQuery = queryParser.parse("grass");
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery);
 
-      List<Object> found = cacheQuery.list();
+      List<?> found = cacheQuery.list();
 
       assert found.size() == 2;
       assert found.containsAll(asList(person2, anotherGrassEater));

--- a/query/src/test/java/org/infinispan/query/blackbox/QueryCacheRestartTest.java
+++ b/query/src/test/java/org/infinispan/query/blackbox/QueryCacheRestartTest.java
@@ -94,8 +94,8 @@ public class QueryCacheRestartTest extends AbstractInfinispanTest {
       SearchManager searchManager = Search.getSearchManager(cache);
       QueryBuilder queryBuilder = searchManager.buildQueryBuilderForClass(Book.class).get();
       Query luceneQuery = queryBuilder.keyword().onField("title").matching("infinispan").createQuery();
-      CacheQuery cacheQuery = searchManager.getQuery(luceneQuery);
-      List<Object> list = cacheQuery.list();
+      CacheQuery<Book> cacheQuery = searchManager.getQuery(luceneQuery);
+      List<Book> list = cacheQuery.list();
       assertEquals(1, list.size());
    }
 

--- a/query/src/test/java/org/infinispan/query/config/DeclarativeConfigTest.java
+++ b/query/src/test/java/org/infinispan/query/config/DeclarativeConfigTest.java
@@ -52,11 +52,11 @@ public class DeclarativeConfigTest extends SingleCacheManagerTest {
 
    public void simpleIndexTest() throws ParseException {
       cache.put("1", new Person("A Person's Name", "A paragraph containing some text", 75));
-      CacheQuery cq = TestQueryHelperFactory.createCacheQuery(cache, "name", "Name");
+      CacheQuery<Person> cq = TestQueryHelperFactory.createCacheQuery(cache, "name", "Name");
       assertEquals(1, cq.getResultSize());
-      List<Object> l =  cq.list();
+      List<Person> l =  cq.list();
       assertEquals(1, l.size());
-      Person p = (Person) l.get(0);
+      Person p = l.get(0);
       assertEquals("A Person's Name", p.getName());
       assertEquals("A paragraph containing some text", p.getBlurb());
       assertEquals(75, p.getAge());

--- a/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/config/MultipleCachesTest.java
@@ -62,11 +62,11 @@ public class MultipleCachesTest extends SingleCacheManagerTest {
    public void queryNotIndexedCache() throws ParseException {
       final Cache<Object, Object> notIndexedCache = cacheManager.getCache("notIndexedA");
       notIndexedCache.put("1", new Person("A Person's Name", "A paragraph containing some text", 75));
-      CacheQuery cq = TestQueryHelperFactory.createCacheQuery(cache, "name", "Name");
+      CacheQuery<Person> cq = TestQueryHelperFactory.createCacheQuery(cache, "name", "Name");
       assertEquals(1, cq.getResultSize());
-      List<Object> l =  cq.list();
+      List<Person> l =  cq.list();
       assertEquals(1, l.size());
-      Person p = (Person) l.get(0);
+      Person p = l.get(0);
       assertEquals("A Person's Name", p.getName());
       assertEquals("A paragraph containing some text", p.getBlurb());
       assertEquals(75, p.getAge());
@@ -87,9 +87,9 @@ public class MultipleCachesTest extends SingleCacheManagerTest {
 
    private void useQuery(Cache<Object, Object> indexedCache) throws ParseException {
       indexedCache.put("1", new Person("A Person's Name", "A paragraph containing some text", 75));
-      CacheQuery cq = TestQueryHelperFactory.createCacheQuery(indexedCache, "name", "Name");
+      CacheQuery<Person> cq = TestQueryHelperFactory.createCacheQuery(indexedCache, "name", "Name");
       assertEquals(1, cq.getResultSize());
-      List<Object> l =  cq.list();
+      List<Person> l =  cq.list();
       assertEquals(1, l.size());
       Person p = (Person) l.get(0);
       assertEquals("A Person's Name", p.getName());

--- a/query/src/test/java/org/infinispan/query/continuous/AbstractCQMultipleCachesTest.java
+++ b/query/src/test/java/org/infinispan/query/continuous/AbstractCQMultipleCachesTest.java
@@ -50,7 +50,7 @@ public abstract class AbstractCQMultipleCachesTest extends MultipleCacheManagers
 
       Query query = qf.from(Person.class)
             .having("age").lte(30)
-            .toBuilder().build();
+            .build();
 
       CallCountingCQResultListener<Object, Object> listener = new CallCountingCQResultListener<>();
       ContinuousQuery<Object, Object> cq = Search.getContinuousQuery(cache(0));

--- a/query/src/test/java/org/infinispan/query/continuous/ContinuousQueryProfilingTest.java
+++ b/query/src/test/java/org/infinispan/query/continuous/ContinuousQueryProfilingTest.java
@@ -85,6 +85,6 @@ public class ContinuousQueryProfilingTest extends MultipleCacheManagersTest {
       QueryFactory qf = Search.getQueryFactory(c);
       return qf.from(Person.class)
             .having("age").gte(18)
-            .toBuilder().build();
+            .build();
    }
 }

--- a/query/src/test/java/org/infinispan/query/continuous/ContinuousQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/continuous/ContinuousQueryTest.java
@@ -48,7 +48,7 @@ public class ContinuousQueryTest extends SingleCacheManagerTest {
       Query query = Search.getQueryFactory(cache()).from(Person.class)
             .select(max("age"))
             .having("age").gte(20)
-            .toBuilder().build();
+            .build();
 
       ContinuousQuery<Object, Object> cq = Search.getContinuousQuery(cache());
       cq.addContinuousQueryListener(query, new CallCountingCQResultListener<>());
@@ -69,7 +69,7 @@ public class ContinuousQueryTest extends SingleCacheManagerTest {
       Query query = qf.from(Person.class)
             .select("age")
             .having("age").lte(param("ageParam"))
-            .toBuilder().build().setParameter("ageParam", 30);
+            .build().setParameter("ageParam", 30);
 
       CallCountingCQResultListener<Object, Object> listener = new CallCountingCQResultListener<>();
       cq.addContinuousQueryListener(query, listener);
@@ -173,7 +173,7 @@ public class ContinuousQueryTest extends SingleCacheManagerTest {
       Query query = qf.from(Person.class)
             .select("age")
             .having("age").lte(param("ageParam"))
-            .toBuilder().build();
+            .build();
 
       query.setParameter("ageParam", 30);
 
@@ -213,13 +213,13 @@ public class ContinuousQueryTest extends SingleCacheManagerTest {
       Query query1 = qf.from(Person.class)
             .having("age").lte(30)
             .and().having("name").eq("John").or().having("name").eq("Johny")
-            .toBuilder().build();
+            .build();
       ContinuousQuery<Object, Object> cq1 = Search.getContinuousQuery(cache());
       cq1.addContinuousQueryListener(query1, listener);
 
       Query query2 = qf.from(Person.class)
             .having("age").lte(30).or().having("name").eq("Joe")
-            .toBuilder().build();
+            .build();
       ContinuousQuery<Object, Object> cq2 = Search.getContinuousQuery(cache());
       cq2.addContinuousQueryListener(query2, listener);
 

--- a/query/src/test/java/org/infinispan/query/distributed/AsyncMassIndexPerfTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/AsyncMassIndexPerfTest.java
@@ -183,7 +183,7 @@ public class AsyncMassIndexPerfTest extends MultipleCacheManagersTest {
 
    protected int countIndex() {
       SearchManager searchManager = Search.getSearchManager(cache1);
-      CacheQuery q = searchManager.getQuery(new MatchAllDocsQuery(), Transaction.class);
+      CacheQuery<?> q = searchManager.getQuery(new MatchAllDocsQuery(), Transaction.class);
       return q.getResultSize();
    }
 

--- a/query/src/test/java/org/infinispan/query/distributed/AsyncMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/AsyncMassIndexTest.java
@@ -83,7 +83,7 @@ public class AsyncMassIndexTest extends MultipleCacheManagersTest {
    protected void checkIndex(int expectedNumber, Class<?> entity) {
       Cache<Integer, Transaction> c = caches.get(0);
       SearchManager searchManager = Search.getSearchManager(c);
-      CacheQuery q = searchManager.getQuery(new MatchAllDocsQuery(), entity);
+      CacheQuery<?> q = searchManager.getQuery(new MatchAllDocsQuery(), entity);
       int resultSize = q.getResultSize();
       assertEquals(expectedNumber, resultSize);
    }

--- a/query/src/test/java/org/infinispan/query/distributed/ClusteredQueryMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/ClusteredQueryMassIndexingTest.java
@@ -21,7 +21,7 @@ public class ClusteredQueryMassIndexingTest extends DistributedMassIndexingTest 
    }
 
    protected void verifyFindsCar(Cache cache, int expectedCount, String carMake) {
-      CacheQuery cacheQuery = Search.getSearchManager(cache)
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache)
             .getClusteredQuery(new TermQuery(new Term("make", carMake)));
 
       assertEquals(expectedCount, cacheQuery.getResultSize());

--- a/query/src/test/java/org/infinispan/query/distributed/DistProgrammaticMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/DistProgrammaticMassIndexTest.java
@@ -56,7 +56,7 @@ public class DistProgrammaticMassIndexTest extends DistributedMassIndexingTest {
       QueryParser queryParser = createQueryParser("make");
 
       Query luceneQuery = queryParser.parse(carMake);
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery, Car.class);
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(luceneQuery, Car.class);
 
       assertEquals(count, cacheQuery.getResultSize());
 

--- a/query/src/test/java/org/infinispan/query/distributed/DistributedMassIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/DistributedMassIndexingTest.java
@@ -92,7 +92,7 @@ public class DistributedMassIndexingTest extends MultipleCacheManagersTest {
       SearchManager searchManager = Search.getSearchManager(cache);
       QueryBuilder carQueryBuilder = searchManager.buildQueryBuilderForClass(Car.class).get();
       Query fullTextQuery = carQueryBuilder.keyword().onField("make").matching(carMake).createQuery();
-      CacheQuery cacheQuery = searchManager.getQuery(fullTextQuery, Car.class);
+      CacheQuery<Car> cacheQuery = searchManager.getQuery(fullTextQuery, Car.class);
       assertEquals(expectedCount, cacheQuery.getResultSize());
    }
 }

--- a/query/src/test/java/org/infinispan/query/distributed/IndexManagerLocalTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/IndexManagerLocalTest.java
@@ -69,7 +69,7 @@ public class IndexManagerLocalTest extends SingleCacheManagerTest {
 
    protected void assertIndexSize(int expectedIndexSize) {
       SearchManager searchManager = Search.getSearchManager(cache);
-      CacheQuery query = searchManager.getQuery(new MatchAllDocsQuery(), Person.class);
+      CacheQuery<Person> query = searchManager.getQuery(new MatchAllDocsQuery(), Person.class);
       assertEquals(expectedIndexSize, query.list().size());
       StaticTestingErrorHandler.assertAllGood(cache);
    }

--- a/query/src/test/java/org/infinispan/query/distributed/MultiNodeDistributedTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/MultiNodeDistributedTest.java
@@ -94,7 +94,7 @@ public class MultiNodeDistributedTest extends AbstractInfinispanTest {
       for (Cache cache : cluster.iterateAllCaches()) {
          StaticTestingErrorHandler.assertAllGood(cache);
          SearchManager searchManager = Search.getSearchManager(cache);
-         CacheQuery query = searchManager.getQuery(new MatchAllDocsQuery(), Person.class);
+         CacheQuery<Person> query = searchManager.getQuery(new MatchAllDocsQuery(), Person.class);
          assertEquals(expectedIndexSize, query.list().size());
       }
    }

--- a/query/src/test/java/org/infinispan/query/distributed/MultipleEntitiesMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/MultipleEntitiesMassIndexTest.java
@@ -113,7 +113,7 @@ public class MultipleEntitiesMassIndexTest extends DistributedMassIndexingTest {
       for (Cache cache : caches) {
          StaticTestingErrorHandler.assertAllGood(cache);
          SearchManager searchManager = Search.getSearchManager(cache);
-         CacheQuery cacheQuery = searchManager.getQuery(luceneQuery, entity);
+         CacheQuery<?> cacheQuery = searchManager.getQuery(luceneQuery, entity);
          assertEquals(expectedCount, cacheQuery.getResultSize());
       }
    }

--- a/query/src/test/java/org/infinispan/query/distributed/OverlappingIndexMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/OverlappingIndexMassIndexTest.java
@@ -82,8 +82,8 @@ public class OverlappingIndexMassIndexTest extends MultipleCacheManagersTest {
    protected void checkIndex(int expectedNumber, Class<?> entity, int otherExpected, Class<?> otherEntity) {
       for (Cache<?, ?> c : caches) {
          SearchManager searchManager = Search.getSearchManager(c);
-         CacheQuery query1 = searchManager.getQuery(new MatchAllDocsQuery(), entity);
-         CacheQuery query2 = searchManager.getQuery(new MatchAllDocsQuery(), otherEntity);
+         CacheQuery<?> query1 = searchManager.getQuery(new MatchAllDocsQuery(), entity);
+         CacheQuery<?> query2 = searchManager.getQuery(new MatchAllDocsQuery(), otherEntity);
          assertEquals(expectedNumber, query1.getResultSize());
          assertEquals(otherExpected, query2.getResultSize());
       }

--- a/query/src/test/java/org/infinispan/query/distributed/PerfTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/PerfTest.java
@@ -95,7 +95,7 @@ public class PerfTest extends MultipleCacheManagersTest {
       SearchManager searchManager = Search.getSearchManager(cache);
       QueryBuilder carQueryBuilder = searchManager.buildQueryBuilderForClass(Car.class).get();
       Query fullTextQuery = carQueryBuilder.keyword().onField("make").matching(carMake).createQuery();
-      CacheQuery cacheQuery = searchManager.getQuery(fullTextQuery, Car.class);
+      CacheQuery<?> cacheQuery = searchManager.getQuery(fullTextQuery, Car.class);
       assertEquals(expectedCount, cacheQuery.getResultSize());
    }
 

--- a/query/src/test/java/org/infinispan/query/distributed/UnsharedDistMassIndexTest.java
+++ b/query/src/test/java/org/infinispan/query/distributed/UnsharedDistMassIndexTest.java
@@ -27,7 +27,7 @@ public class UnsharedDistMassIndexTest extends DistributedMassIndexingTest {
    @Override
    protected void verifyFindsCar(Cache cache, int expectedCount, String carMake) {
       SearchManager searchManager = Search.getSearchManager(cache);
-      CacheQuery cacheQuery = searchManager.getClusteredQuery(new TermQuery(new Term("make", carMake)));
+      CacheQuery<?> cacheQuery = searchManager.getClusteredQuery(new TermQuery(new Term("make", carMake)));
       assertEquals(expectedCount, cacheQuery.getResultSize());
    }
 }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/ClusteredListenerWithDslFilterProfilingTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/ClusteredListenerWithDslFilterProfilingTest.java
@@ -89,7 +89,7 @@ public class ClusteredListenerWithDslFilterProfilingTest extends MultipleCacheMa
       QueryFactory qf = Search.getQueryFactory(c);
       return qf.from(Person.class)
             .having("age").gte(18)
-            .toBuilder().build();
+            .build();
    }
 
    @Listener(clustered = true)

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/ClusteredListenerWithDslFilterTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/ClusteredListenerWithDslFilterTest.java
@@ -46,7 +46,7 @@ public class ClusteredListenerWithDslFilterTest extends MultipleCacheManagersTes
 
       Query query = qf.from(org.infinispan.query.test.Person.class)
             .having("age").lte(31)
-            .toBuilder().build();
+            .build();
 
       EntryListener listener = new EntryListener();
 
@@ -97,7 +97,6 @@ public class ClusteredListenerWithDslFilterTest extends MultipleCacheManagersTes
 
       Query query = qf.from(org.infinispan.query.test.Person.class)
             .having("age").lte(31)
-            .toBuilder()
             .select("name", "age")
             .build();
 
@@ -141,7 +140,7 @@ public class ClusteredListenerWithDslFilterTest extends MultipleCacheManagersTes
    public void testDisallowGroupingAndAggregation() {
       Query query = Search.getQueryFactory(cache(0)).from(Person.class)
             .having("age").gte(20)
-            .toBuilder().select(max("age"))
+            .select(max("age"))
             .build();
 
       cache(0).addListener(new EntryListener(), Search.makeFilter(query), null);

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/ListenerWithDslFilterProfilingTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/ListenerWithDslFilterProfilingTest.java
@@ -35,7 +35,7 @@ public class ListenerWithDslFilterProfilingTest extends SingleCacheManagerTest {
 
       Query query = qf.from(Person.class)
             .having("age").lte(31)
-            .toBuilder().build();
+            .build();
 
       final int numEntries = 100000;
       final int numListeners = 1000;

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/ListenerWithDslFilterTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/ListenerWithDslFilterTest.java
@@ -63,7 +63,7 @@ public class ListenerWithDslFilterTest extends SingleCacheManagerTest {
 
       Query query = qf.from(Person.class)
             .having("age").lte(param("ageParam"))
-            .toBuilder().build().setParameter("ageParam", 31);
+            .build().setParameter("ageParam", 31);
 
       EntryListener listener = new EntryListener();
 
@@ -118,7 +118,7 @@ public class ListenerWithDslFilterTest extends SingleCacheManagerTest {
 
       Query query = qf.from(Person.class)
             .having("age").lte(param("ageParam"))
-            .toBuilder().build().setParameter("ageParam", 31);
+            .build().setParameter("ageParam", 31);
 
       EntryListener listener = new EntryListener();
 
@@ -179,7 +179,6 @@ public class ListenerWithDslFilterTest extends SingleCacheManagerTest {
 
       Query query = qf.from(Person.class)
             .having("age").lte(31)
-            .toBuilder()
             .select("name", "age")
             .build();
 
@@ -216,7 +215,7 @@ public class ListenerWithDslFilterTest extends SingleCacheManagerTest {
    public void testDisallowGroupingAndAggregation() {
       Query query = Search.getQueryFactory(cache()).from(Person.class)
             .having("age").gte(20)
-            .toBuilder().select(max("age"))
+            .select(max("age"))
             .build();
 
       cache().addListener(new EntryListener(), Search.makeFilter(query), null);

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NamedParamsPerfTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NamedParamsPerfTest.java
@@ -93,7 +93,7 @@ public class NamedParamsPerfTest extends AbstractQueryDslTest {
             .or()
             .having("id").gte(Expression.param("idParam1"))
             .or()
-            .having("id").lt(Expression.param("idParam2")).toBuilder()
+            .having("id").lt(Expression.param("idParam2"))
             .build();
 
       final int iterations = 1000;

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedQueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/NonIndexedQueryDslConditionsTest.java
@@ -44,7 +44,6 @@ public class NonIndexedQueryDslConditionsTest extends QueryDslConditionsTest {
          public List call() throws Exception {
             Query q = getQueryFactory().from(getModelFactory().getUserImplClass())
                   .not().having("age").eq(20)
-                  .toBuilder()
                   .build();
 
             cache(0).put("new_user_" + newUser.getId(), newUser);
@@ -75,7 +74,7 @@ public class NonIndexedQueryDslConditionsTest extends QueryDslConditionsTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("id").lt(1000)
             .and().having("age").lt(1000)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryDslConditionsTest.java
@@ -240,7 +240,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("John")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -253,7 +253,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertTrue(list.isEmpty());
@@ -264,7 +264,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getAccountImplClass())
             .having("description").eq("John Doe's first bank account")
-            .toBuilder().build();
+            .build();
 
       List<Account> list = q.list();
       assertEquals(1, list.size());
@@ -276,7 +276,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("Jacob")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(0, list.size());
@@ -287,7 +287,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(NotIndexed.class)
             .having("notIndexedField").eq("testing 123")
-            .toBuilder().build();
+            .build();
 
       List<NotIndexed> list = q.list();
       assertEquals(1, list.size());
@@ -299,7 +299,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("notes").eq("Lorem ipsum dolor sit amet")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -312,7 +312,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("notes").eq("Lorem ipsum dolor sit amet")
             .and().having("surname").eq("Doe")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -325,7 +325,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("notes").eq("Lorem ipsum dolor sit amet")
             .and().having("surname").eq(param("surnameParam"))
-            .toBuilder().build();
+            .build();
 
       q.setParameter("surnameParam", "Doe");
 
@@ -340,7 +340,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("notes").like("%ipsum%")
             .and(qf.having("name").eq("John").or().having("name").eq("Jane"))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
 
@@ -354,7 +354,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       // all users in a given post code
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("addresses.postCode").eq("X1234")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -366,7 +366,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("addresses.postCode").eq("Y12")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -379,7 +379,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       // all rent payments made from a given account
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("description").like("%rent%")
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
@@ -393,7 +393,6 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       qf.from(getModelFactory().getTransactionImplClass())
             .having("date").between(new Object(), new Object())
-            .toBuilder()
             .build();
    }
 
@@ -403,7 +402,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       // all the transactions that happened in January 2013
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("date").between(makeDate("2013-01-01"), makeDate("2013-01-31"))
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(4, list.size());
@@ -419,7 +418,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       // all the transactions that happened in January 2013
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("date").between(makeDate("2013-01-01"), makeDate("2013-01-31")).includeUpper(false)
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(3, list.size());
@@ -435,7 +434,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       // all the transactions that happened in January 2013
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("date").between(makeDate("2013-01-01"), makeDate("2013-01-31")).includeLower(false)
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(3, list.size());
@@ -451,7 +450,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       // all the transactions greater than a given amount
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("amount").gt(1500)
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
@@ -463,7 +462,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("amount").gte(1500)
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(2, list.size());
@@ -477,7 +476,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("amount").lt(1500)
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(54, list.size());
@@ -491,7 +490,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("amount").lte(1500)
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(55, list.size());
@@ -507,7 +506,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       // all the transactions that happened in January 2013
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("description").lte("-Popcorn")
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
@@ -520,7 +519,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("Spider")
             .and().having("surname").eq("Man")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -533,7 +532,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("Spider")
             .and(qf.having("surname").eq("Man"))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -546,7 +545,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("gender").eq(User.Gender.MALE)
             .and().having("gender").eq(User.Gender.FEMALE)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(0, list.size());
@@ -560,7 +559,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .having("name").eq("Spider")
             .or(qf.having("name").eq("John"))
             .and(qf.having("surname").eq("Man"))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -572,7 +571,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("surname").eq("Man")
             .or().having("surname").eq("Woman")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -587,7 +586,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("surname").eq("Man")
             .or(qf.having("surname").eq("Woman"))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -602,7 +601,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("gender").eq(User.Gender.MALE)
             .or().having("gender").eq(User.Gender.FEMALE)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(3, list.size());
@@ -617,7 +616,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .or().having("name").eq("Spider")
             .and().having("gender").eq(User.Gender.FEMALE)
             .or().having("surname").like("%oe%")
-            .toBuilder().build();
+            .build();
       List<User> list = q.list();
 
       assertEquals(2, list.size());
@@ -633,7 +632,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .or().having("name").eq("Spider")
             .or().having("gender").eq(User.Gender.FEMALE)
             .and().having("surname").like("%oe%")
-            .toBuilder().build();
+            .build();
       List<User> list = q.list();
 
       assertEquals(1, list.size());
@@ -645,7 +644,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("name").eq("Spider")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -657,7 +656,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().not().having("surname").eq("Doe")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -671,7 +670,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("name").eq("John")
             .and().having("surname").eq("Man")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -685,7 +684,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("surname").eq("Man")
             .and().not().having("name").eq("John")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -699,7 +698,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("name").eq("Spider")
             .or().having("surname").eq("Man")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -714,7 +713,6 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       // QueryFactory.not() test
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not(qf.not(qf.having("gender").eq(User.Gender.FEMALE)))
-            .toBuilder()
             .build();
 
       List<User> list = q.list();
@@ -728,7 +726,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("gender").eq(User.Gender.FEMALE)
             .and().not(qf.having("name").eq("Spider"))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertTrue(list.isEmpty());
@@ -741,7 +739,6 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .not(
                   qf.having("name").eq("John")
                         .or(qf.having("surname").eq("Man")))
-            .toBuilder()
             .build();
 
       List<User> list = q.list();
@@ -757,7 +754,6 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .not(
                   qf.having("name").eq("John")
                         .and(qf.having("surname").eq("Doe")))
-            .toBuilder()
             .orderBy("id", SortOrder.ASC)
             .build();
 
@@ -776,7 +772,6 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .not().not(
                   qf.having("name").eq("John")
                         .or(qf.having("surname").eq("Man")))
-            .toBuilder()
             .build();
 
       List<User> list = q.list();
@@ -791,7 +786,6 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .not(qf.not(
                   qf.having("name").eq("John")
                         .or(qf.having("surname").eq("Man"))))
-            .toBuilder()
             .build();
 
       List<User> list = q.list();
@@ -813,7 +807,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").gt("A").or().having("name").lte("A")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(3, list.size());
@@ -824,7 +818,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").gt("A").and().having("name").lte("A")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertTrue(list.isEmpty());
@@ -856,7 +850,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("surname").isNull()
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(0, list.size());
@@ -867,7 +861,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("surname").isNull()
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(3, list.size());
@@ -878,7 +872,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("addresses").isNull()
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -894,7 +888,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .orderBy("surname", SortOrder.ASC)
             .orderBy("age", SortOrder.ASC)
             .having("age").isNull()
-            .toBuilder().build();
+            .build();
 
       List<Object[]> list = q.list();
       assertEquals(2, list.size());
@@ -912,7 +906,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .select("name", "age")
             .not().having("age").isNull()
-            .toBuilder().build();
+            .build();
 
       List<Object[]> list = q.list();
       assertEquals(1, list.size());
@@ -925,7 +919,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").contains(2)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -937,7 +931,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").contains(42)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(0, list.size());
@@ -948,7 +942,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").containsAll(1, 2)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -960,7 +954,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").containsAll(Collections.singleton(1))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -972,7 +966,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").containsAll(1, 2, 3)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(0, list.size());
@@ -983,7 +977,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").containsAll(Collections.emptySet())
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(3, list.size());
@@ -995,7 +989,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .orderBy("id", SortOrder.ASC)
             .having("accountIds").containsAny(2, 3)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1008,7 +1002,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").containsAny(4, 5)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(0, list.size());
@@ -1019,7 +1013,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("accountIds").containsAny(Collections.emptySet())
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(3, list.size());
@@ -1031,7 +1025,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       List<Integer> ids = Arrays.asList(1, 3);
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("id").in(ids)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1045,7 +1039,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("id").in(4)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(0, list.size());
@@ -1089,7 +1083,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .orderBy("name", SortOrder.ASC)
             .having("gender").eq(User.Gender.MALE)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1105,7 +1099,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .orderBy("name", SortOrder.ASC)
             .not(qf.having("gender").eq(User.Gender.FEMALE))
             .and(qf.not().not(qf.having("gender").eq(User.Gender.MALE)))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1119,7 +1113,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       // all transactions that have a given description. the description contains characters that need to be escaped.
       Query q = qf.from(getModelFactory().getAccountImplClass())
             .having("description").eq("John Doe's first bank account")
-            .toBuilder().build();
+            .build();
 
       List<Account> list = q.list();
       assertEquals(1, list.size());
@@ -1147,7 +1141,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .orderBy("name", SortOrder.ASC)
             .having("gender").eq(User.Gender.MALE)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1217,7 +1211,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("John")
             .and().having("surname").eq("Doe")
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1232,7 +1226,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("accountId").eq(1)
             .and().having("description").like("%rent%")
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
@@ -1247,7 +1241,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       // all the transactions that happened in January 2013
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("date").between(makeDate("2013-01-01"), makeDate("2013-01-31"))
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(4, list.size());
@@ -1264,7 +1258,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("date")
             .having("date").between(makeDate("2013-01-01"), makeDate("2013-01-31"))
-            .toBuilder().build();
+            .build();
 
       List<Object[]> list = q.list();
       assertEquals(4, list.size());
@@ -1287,7 +1281,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("accountId").eq(2)
             .and().having("amount").gt(40)
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(52, list.size());
@@ -1302,7 +1296,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .having("name").eq("John")
             .and().having("addresses.postCode").eq("X1234")
             .and(qf.having("accountIds").eq(1))
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1316,7 +1310,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .having("accountId").eq(1)
             .and()
-            .not().having("isDebit").eq(true).toBuilder().build();
+            .not().having("isDebit").eq(true).build();
 
       List<Transaction> list = q.list();
       assertEquals(1, list.size());
@@ -1328,7 +1322,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       // the user that has the bank account with id 3
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .having("accountIds").contains(3).toBuilder().build();
+            .having("accountIds").contains(3).build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1341,7 +1335,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       // the user that has all the specified bank accounts
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .having("accountIds").containsAll(2, 1).toBuilder().build();
+            .having("accountIds").containsAll(2, 1).build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1355,7 +1349,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       // the user that has at least one of the specified accounts
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .having("accountIds").containsAny(1, 3).toBuilder().build();
+            .having("accountIds").containsAny(1, 3).build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1371,7 +1365,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .startOffset(20).maxResults(10)
             .orderBy("id", SortOrder.ASC)
             .having("accountId").eq(2).and().having("description").like("Expensive%")
-            .toBuilder().build();
+            .build();
 
       List<Transaction> list = q.list();
       assertEquals(50, q.getResultSize());
@@ -1386,12 +1380,12 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       // all accounts for a user. first get the user by id and then get his account.
       Query q1 = qf.from(getModelFactory().getUserImplClass())
-            .having("id").eq(1).toBuilder().build();
+            .having("id").eq(1).build();
 
       List<User> users = q1.list();
       Query q2 = qf.from(getModelFactory().getAccountImplClass())
             .orderBy("description", SortOrder.ASC)
-            .having("id").in(users.get(0).getAccountIds()).toBuilder().build();
+            .having("id").in(users.get(0).getAccountIds()).build();
 
       List<Account> list = q2.list();
       assertEquals(2, list.size());
@@ -1407,7 +1401,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .orderBy("description", SortOrder.ASC)
             .having("accountId").eq(1)
             .and(qf.having("amount").gt(1600)
-                  .or().having("description").like("%rent%")).toBuilder().build();
+                  .or().having("description").like("%rent%")).build();
 
       List<Transaction> list = q.list();
       assertEquals(2, list.size());
@@ -1438,7 +1432,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("age").isNull()
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1451,7 +1445,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("age").isNull()
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1464,7 +1458,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .having("addresses.postCode").in("ZZ", "X1234").toBuilder().build();
+            .having("addresses.postCode").in("ZZ", "X1234").build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1476,7 +1470,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .not().having("addresses.postCode").in("X1234").toBuilder().build();
+            .not().having("addresses.postCode").in("X1234").build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1488,7 +1482,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .not().having("addresses").isNull().toBuilder().build();
+            .not().having("addresses").isNull().build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1500,7 +1494,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .not().having("addresses.postCode").like("%123%").toBuilder().build();
+            .not().having("addresses.postCode").like("%123%").build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1513,7 +1507,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("id").between(1, 2)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(1, list.size());
@@ -1525,7 +1519,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("id").between(1, 2).includeLower(false)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
 
@@ -1539,7 +1533,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .not().having("id").between(1, 2).includeUpper(false)
-            .toBuilder().build();
+            .build();
 
       List<User> list = q.list();
       assertEquals(2, list.size());
@@ -1552,7 +1546,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getAccountImplClass())
             .having("creationDate").eq(makeDate("2013-01-20"))
-            .toBuilder().build();
+            .build();
 
       List<Account> list = q.list();
       assertEquals(1, list.size());
@@ -1565,7 +1559,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getAccountImplClass())
             .orderBy("id", SortOrder.ASC)
             .having("creationDate").lt(makeDate("2013-01-20"))
-            .toBuilder().build();
+            .build();
 
       List<Account> list = q.list();
       assertEquals(2, list.size());
@@ -1579,7 +1573,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getAccountImplClass())
             .orderBy("id", SortOrder.ASC)
             .having("creationDate").lte(makeDate("2013-01-20"))
-            .toBuilder().build();
+            .build();
 
       List<Account> list = q.list();
       assertEquals(3, list.size());
@@ -1593,7 +1587,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getAccountImplClass())
             .having("creationDate").gt(makeDate("2013-01-04"))
-            .toBuilder().build();
+            .build();
 
       List<Account> list = q.list();
       assertEquals(1, list.size());
@@ -1604,7 +1598,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
    public void testWrongQueryBuilding1() throws Exception {
       QueryFactory qf = getQueryFactory();
 
-      Query q = qf.not().having("name").eq("John").toBuilder().build();
+      Query q = qf.not().having("name").eq("John").build();
    }
 
    @Test(expectedExceptions = IllegalStateException.class)
@@ -1612,8 +1606,8 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .having("name").eq("John").toBuilder()
-            .having("surname").eq("Man").toBuilder()
+            .having("name").eq("John")
+            .having("surname").eq("Man")
             .build();
    }
 
@@ -1622,8 +1616,8 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .not().having("name").eq("John").toBuilder()
-            .not().having("surname").eq("Man").toBuilder()
+            .not().having("name").eq("John")
+            .not().having("surname").eq("Man")
             .build();
    }
 
@@ -1632,8 +1626,8 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .not(qf.having("name").eq("John")).toBuilder()
-            .not(qf.having("surname").eq("Man")).toBuilder()
+            .not(qf.having("name").eq("John"))
+            .not(qf.having("surname").eq("Man"))
             .build();
    }
 
@@ -1642,8 +1636,8 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.from(getModelFactory().getUserImplClass())
-            .not(qf.having("name").eq("John")).toBuilder()
-            .not(qf.having("surname").eq("Man")).toBuilder()
+            .not(qf.having("name").eq("John"))
+            .not(qf.having("surname").eq("Man"))
             .build();
    }
 
@@ -1653,7 +1647,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("gender").eq(null)
-            .toBuilder().build();
+            .build();
    }
 
    @Test(expectedExceptions = IllegalStateException.class)
@@ -1905,7 +1899,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getUserImplClass())
             .select(sum("age"))
-            .having(sum("age")).gt(10).toBuilder()
+            .having(sum("age")).gt(10)
             .build();
 
       List<Object[]> list = q.list();
@@ -1921,7 +1915,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(property("accountId"), sum("amount"))
             .groupBy("accountId")
-            .having(sum("amount")).gt(3324).toBuilder()
+            .having(sum("amount")).gt(3324)
             .orderBy("accountId")
             .build();
       List<Object[]> list = q.list();
@@ -1935,7 +1929,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(property("accountId"), avg("amount"))
             .groupBy("accountId")
-            .having(avg("amount")).lt(130.0).toBuilder()
+            .having(avg("amount")).lt(130.0)
             .orderBy("accountId")
             .build();
       List<Object[]> list = q.list();
@@ -1949,7 +1943,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(property("accountId"), min("amount"))
             .groupBy("accountId")
-            .having(min("amount")).lt(10).toBuilder()
+            .having(min("amount")).lt(10)
             .orderBy("accountId")
             .build();
       List<Object[]> list = q.list();
@@ -1963,7 +1957,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(property("accountId"), max("amount"))
             .groupBy("accountId")
-            .having(avg("amount")).lt(150).toBuilder()
+            .having(avg("amount")).lt(150)
             .orderBy("accountId")
             .build();
       List<Object[]> list = q.list();
@@ -2367,9 +2361,9 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getUserImplClass())
             .select("name")
-            .having("name").eq("John").toBuilder()
+            .having("name").eq("John")
             .groupBy("name")
-            .having("name").eq("John").toBuilder()
+            .having("name").eq("John")
             .build();
       List<Object[]> list = q.list();
       assertEquals(1, list.size());
@@ -2403,7 +2397,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("date")
-            .having("date").between(makeDate("2013-02-15"), makeDate("2013-03-15")).toBuilder()
+            .having("date").between(makeDate("2013-02-15"), makeDate("2013-03-15"))
             .groupBy("date")
             .build();
 
@@ -2417,7 +2411,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(count("date"), min("date"))
-            .having("description").eq("Hotel").toBuilder()
+            .having("description").eq("Hotel")
             .groupBy("id")
             .build();
 
@@ -2432,7 +2426,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(min("date"), count("date"))
-            .having("description").eq("Hotel").toBuilder()
+            .having("description").eq("Hotel")
             .groupBy("id")
             .build();
 
@@ -2448,7 +2442,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("gender").eq(param("param2"))
-            .toBuilder().build();
+            .build();
 
       q.setParameter("param2", User.Gender.MALE);
 
@@ -2473,7 +2467,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
             .having("gender").eq(param("param1"))
             .and()
             .having("name").eq(param("param2"))
-            .toBuilder().build();
+            .build();
 
       Map<String, Object> parameterMap = new HashMap<>(2);
       parameterMap.put("param1", User.Gender.MALE);
@@ -2505,7 +2499,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getAccountImplClass())
             .having("creationDate").eq(param("param1"))
-            .toBuilder().build().setParameter("param1", makeDate("2013-01-03"));
+            .build().setParameter("param1", makeDate("2013-01-03"));
 
       List<Account> list = q.list();
       assertEquals(1, list.size());
@@ -2517,7 +2511,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(property("accountId"), property("date"), sum("amount"))
             .groupBy("accountId", "date")
-            .having(sum("amount")).gt(param("param")).toBuilder()
+            .having(sum("amount")).gt(param("param"))
             .build();
 
       q.setParameter("param", 1801);
@@ -2534,7 +2528,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq(param("param1"))
-            .toBuilder().build();
+            .build();
 
       q.setParameter("param2", "John");
    }
@@ -2545,7 +2539,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq(param("param1"))
-            .toBuilder().build();
+            .build();
 
       Map<String, Object> parameterMap = new HashMap<>(1);
       parameterMap.put("param2", User.Gender.MALE);
@@ -2559,7 +2553,8 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("John")
-            .toBuilder().build().setParameter("param1", "John");
+            .build()
+            .setParameter("param1", "John");
    }
 
    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "ISPN014804: Query does not have parameters")
@@ -2568,7 +2563,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("John")
-            .toBuilder().build();
+            .build();
 
       Map<String, Object> parameterMap = new HashMap<>(1);
       parameterMap.put("param1", User.Gender.MALE);
@@ -2582,7 +2577,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq(param(null))
-            .toBuilder().build();
+            .build();
 
       q.setParameter(null, "John");
    }
@@ -2593,7 +2588,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq(param(""))
-            .toBuilder().build();
+            .build();
 
       q.setParameter("", "John");
    }
@@ -2605,7 +2600,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq(param("param1"))
             .and().having("gender").eq(param("param2"))
-            .toBuilder().build();
+            .build();
 
       q.setParameter("param1", "John");
 
@@ -2619,7 +2614,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq(param("param1"))
             .and().having("gender").eq(param("param2"))
-            .toBuilder().build();
+            .build();
 
       Map<String, Object> parameterMap = new HashMap<>(1);
       parameterMap.put("param1", "John");
@@ -2635,7 +2630,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       Query q = qf.from(getModelFactory().getUserImplClass())
             .having("name").eq("John")
-            .toBuilder().build();
+            .build();
 
       q.setParameters(null);
    }
@@ -2645,7 +2640,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(avg("amount"), sum("amount"), count("date"), min("date"), max("accountId"))
-            .having("isDebit").eq(param("param")).toBuilder()
+            .having("isDebit").eq(param("param"))
             .orderBy(avg("amount"), SortOrder.DESC).orderBy(count("date"), SortOrder.DESC)
             .orderBy(max("amount"), SortOrder.ASC)
             .build();
@@ -2667,7 +2662,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("date")
-            .having("date").between(makeDate("2013-02-15"), makeDate("2013-03-15")).toBuilder()
+            .having("date").between(makeDate("2013-02-15"), makeDate("2013-03-15"))
             .groupBy("date")
             .build();
       List<Object[]> list = q.list();
@@ -2682,7 +2677,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(count("date"), min("date"))
-            .having("description").eq("Hotel").toBuilder()
+            .having("description").eq("Hotel")
             .groupBy("id")
             .build();
       List<Object[]> list = q.list();
@@ -2700,7 +2695,6 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("id", "isValid")
             .having("id").gte(98)
-            .toBuilder()
             .orderBy("id")
             .build();
       List<Object[]> list = q.list();
@@ -2720,7 +2714,6 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("id", "description")
             .having("id").gte(98)
-            .toBuilder()
             .orderBy("id")
             .build();
       List<Object[]> list = q.list();
@@ -2740,7 +2733,6 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("id", "isValid")
             .having("id").gte(98)
-            .toBuilder()
             .orderBy("isValid")
             .orderBy("id")
             .build();
@@ -2761,7 +2753,6 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("id", "description")
             .having("id").gte(98)
-            .toBuilder()
             .orderBy("description")
             .orderBy("id")
             .build();
@@ -2782,7 +2773,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("id", "date", "date")
             .having("description").eq("Hotel")
-            .toBuilder().build();
+            .build();
       List<Object[]> list = q.list();
 
       assertEquals(1, list.size());
@@ -2798,7 +2789,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select("id", "isDebit", "isDebit")
             .having("description").eq("Hotel")
-            .toBuilder().build();
+            .build();
       List<Object[]> list = q.list();
 
       assertEquals(1, list.size());
@@ -2832,9 +2823,9 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getUserImplClass())
             .select(avg("age"), property("name"))
-            .having("name").gt("A").toBuilder()
+            .having("name").gt("A")
             .groupBy("name")
-            .having(max("addresses.street")).gt("A").toBuilder()
+            .having(max("addresses.street")).gt("A")
             .orderBy(min("addresses.street"))
             .build();
 
@@ -2852,7 +2843,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getUserImplClass())
             .select("name")
-            .having("name").eq(min("addresses.street")).toBuilder()
+            .having("name").eq(min("addresses.street"))
             .build();
       q.list();
    }
@@ -2861,7 +2852,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
       Query q = qf.from(getModelFactory().getUserImplClass())
             .select(min("addresses.street"))
-            .having("name").eq("Spider").toBuilder()
+            .having("name").eq("Spider")
             .build();
 
       List<Object[]> list = q.list();
@@ -2910,25 +2901,25 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
 
       // use a true wildcard
       Query q1 = qf.from(getModelFactory().getUserImplClass())
-            .having("name").like("J%n").toBuilder()
+            .having("name").like("J%n")
             .build();
       assertEquals(1, q1.list().size());
 
       // use an improper wildcard
       Query q2 = qf.from(getModelFactory().getUserImplClass())
-            .having("name").like("J*n").toBuilder()
+            .having("name").like("J*n")
             .build();
       assertEquals(0, q2.list().size());
 
       // use a true wildcard
       Query q3 = qf.from(getModelFactory().getUserImplClass())
-            .having("name").like("Jo_n").toBuilder()
+            .having("name").like("Jo_n")
             .build();
       assertEquals(1, q3.list().size());
 
       // use an improper wildcard
       Query q4 = qf.from(getModelFactory().getUserImplClass())
-            .having("name").like("Jo?n").toBuilder()
+            .having("name").like("Jo?n")
             .build();
       assertEquals(0, q4.list().size());
    }
@@ -2939,7 +2930,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getUserImplClass())
             .select(sum("age"))
             .groupBy("name")
-            .having(sum("age")).gt(50000).toBuilder()
+            .having(sum("age")).gt(50000)
             .build();
 
       List<Object[]> list = q.list();
@@ -2952,7 +2943,7 @@ public class QueryDslConditionsTest extends AbstractQueryDslTest {
       Query q = qf.from(getModelFactory().getTransactionImplClass())
             .select(sum("amount"))
             .groupBy("accountId")
-            .having(sum("amount")).gt(50000).toBuilder()
+            .having(sum("amount")).gt(50000)
             .build();
 
       List<Object[]> list = q.list();

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/SingleClassDSLQueryTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/SingleClassDSLQueryTest.java
@@ -44,7 +44,7 @@ public class SingleClassDSLQueryTest extends SingleCacheManagerTest {
       Cache<String, Person> cache = cacheManager.getCache();
       cache.put("person1", new Person("William", "Shakespeare"));
       QueryFactory queryFactory = Search.getQueryFactory(cache);
-      Query query = queryFactory.from(Person.class).having("name").eq("William").toBuilder().build();
+      Query query = queryFactory.from(Person.class).having("name").eq("William").build();
       List<Person> matches = query.list();
       assertEquals(1, matches.size());
    }

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/impl/QueryEngineTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/impl/QueryEngineTest.java
@@ -330,15 +330,15 @@ public class QueryEngineTest extends MultipleCacheManagersTest {
 
    public void testBuildLuceneQuery() {
       FilterParsingResult<?> parsingResult = qe.matcher.getParser().parse("select name from org.infinispan.query.dsl.embedded.testdomain.hsearch.UserHS", qe.matcher.getPropertyHelper());
-      CacheQuery q = qe.buildLuceneQuery(parsingResult, null, -1, -1);
-      List<Object> list = q.list();
+      CacheQuery<UserHS> q = qe.buildLuceneQuery(parsingResult, null, -1, -1);
+      List<?> list = q.list();
       assertEquals(3, list.size());
    }
 
    @Test(expectedExceptions = SearchException.class, expectedExceptionsMessageRegExp = "Unable to find field notes in org.infinispan.query.dsl.embedded.testdomain.hsearch.UserHS")
    public void testBuildLuceneQueryOnNonIndexedField() {
       FilterParsingResult<?> parsingResult = qe.matcher.getParser().parse("select notes from org.infinispan.query.dsl.embedded.testdomain.hsearch.UserHS where notes like 'TBD%'", qe.matcher.getPropertyHelper());
-      CacheQuery q = qe.buildLuceneQuery(parsingResult, null, -1, -1);
+      CacheQuery<?> q = qe.buildLuceneQuery(parsingResult, null, -1, -1);
    }
 
    public void testGlobalCount() {

--- a/query/src/test/java/org/infinispan/query/dynamicexample/DynamicPropertiesTest.java
+++ b/query/src/test/java/org/infinispan/query/dynamicexample/DynamicPropertiesTest.java
@@ -63,7 +63,7 @@ public class DynamicPropertiesTest extends SingleCacheManagerTest {
                .sentence("London")
             .createQuery();
 
-      List list = qf.getQuery(query).list();
+      List<?> list = qf.getQuery(query).list();
       assert list.size() == 1;
       DynamicPropertiesEntity result = (DynamicPropertiesEntity) list.get(0);
       assert result.getProperties().get("name").equals("JUDCon London 2011");

--- a/query/src/test/java/org/infinispan/query/helper/TestQueryHelperFactory.java
+++ b/query/src/test/java/org/infinispan/query/helper/TestQueryHelperFactory.java
@@ -46,12 +46,11 @@ public class TestQueryHelperFactory {
       return Version.LATEST; //Change as needed
    }
 
-   public static CacheQuery createCacheQuery(Cache m_cache, String fieldName, String searchString) throws ParseException {
+   public static <E> CacheQuery<E> createCacheQuery(Cache m_cache, String fieldName, String searchString) throws ParseException {
       QueryParser qp = createQueryParser(fieldName);
       Query parsedQuery = qp.parse(searchString);
       SearchManager queryFactory = Search.getSearchManager(m_cache);
-      CacheQuery cacheQuery = queryFactory.getQuery(parsedQuery);
-      return cacheQuery;
+      return queryFactory.getQuery(parsedQuery);
    }
 
    public static SearchIntegrator extractSearchFactory(Cache cache) {

--- a/query/src/test/java/org/infinispan/query/impl/EagerIteratorTest.java
+++ b/query/src/test/java/org/infinispan/query/impl/EagerIteratorTest.java
@@ -31,17 +31,17 @@ public class EagerIteratorTest {
    List<String> keys;
    List<EntityInfo> entityInfos;
    Map<String, String> dummyResults;
-   ResultIterator iterator;
+   ResultIterator<Object> iterator;
    AdvancedCache<String, String> cache;
    private KeyTransformationHandler keyTransformationHandler;
 
    @BeforeMethod
    public void setUp() throws Exception {
 
-      keys = new ArrayList<String>();
-      dummyResults = new HashMap<String, String>();
+      keys = new ArrayList<>();
+      dummyResults = new HashMap<>();
 
-      entityInfos = new ArrayList<EntityInfo>();
+      entityInfos = new ArrayList<>();
       keyTransformationHandler = new KeyTransformationHandler();
 
       for (int i = 1; i <= 10; i++) {
@@ -63,7 +63,7 @@ public class EagerIteratorTest {
 
       });
 
-      iterator = new EagerIterator(entityInfos, new EntityLoader(cache, keyTransformationHandler), getFetchSize());
+      iterator = new EagerIterator<>(entityInfos, new EntityLoader(cache, keyTransformationHandler), getFetchSize());
    }
 
    protected int getFetchSize() {

--- a/query/src/test/java/org/infinispan/query/impl/InvalidIteratorTest.java
+++ b/query/src/test/java/org/infinispan/query/impl/InvalidIteratorTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
  */
 @Test(groups = "functional", testName = "query.impl.InvalidIteratorTest")
 public class InvalidIteratorTest {
-   private List<EntityInfo> entityInfos = new ArrayList<EntityInfo>();
+   private List<EntityInfo> entityInfos = new ArrayList<>();
    private AdvancedCache<String, String> cache;
 
    @Test(expectedExceptions = IllegalArgumentException.class)
@@ -38,13 +38,13 @@ public class InvalidIteratorTest {
       });
 
       cache = mock(AdvancedCache.class);
-      new LazyIterator(extractor, new EntityLoader(cache, new KeyTransformationHandler()), getFetchSize());
+      new LazyIterator<>(extractor, new EntityLoader(cache, new KeyTransformationHandler()), getFetchSize());
    }
 
    @Test(expectedExceptions = IllegalArgumentException.class)
    public void testEagerIteratorInitWithInvalidFetchSize() throws IOException {
       cache = mock(AdvancedCache.class);
-      new EagerIterator(entityInfos, new EntityLoader(cache, new KeyTransformationHandler()), getFetchSize());
+      new EagerIterator<>(entityInfos, new EntityLoader(cache, new KeyTransformationHandler()), getFetchSize());
    }
 
    private int getFetchSize() {

--- a/query/src/test/java/org/infinispan/query/impl/LazyIteratorTest.java
+++ b/query/src/test/java/org/infinispan/query/impl/LazyIteratorTest.java
@@ -37,7 +37,7 @@ public class LazyIteratorTest extends EagerIteratorTest {
          }
       });
 
-      iterator = new LazyIterator(extractor, new EntityLoader(cache, new KeyTransformationHandler()), getFetchSize());
+      iterator = new LazyIterator<>(extractor, new EntityLoader(cache, new KeyTransformationHandler()), getFetchSize());
    }
 
    @AfterMethod(alwaysRun = false)

--- a/query/src/test/java/org/infinispan/query/impl/QueryCacheEmbeddedTest.java
+++ b/query/src/test/java/org/infinispan/query/impl/QueryCacheEmbeddedTest.java
@@ -68,10 +68,9 @@ public class QueryCacheEmbeddedTest extends SingleCacheManagerTest {
       // obtain the query factory and create a query builder
       QueryFactory qf = Search.getQueryFactory(cache);
       QueryBuilder queryQueryBuilder = qf.from(UserHS.class)
-            .having("name").eq("John")
-            .toBuilder();
+            .having("name").eq("John").toBuilder();
 
-      // compute the same jpa query as it would be generated for the above query
+      // obtain the query string
       String queryString = ((BaseQueryBuilder) queryQueryBuilder).accept(new JPAQueryGenerator());
 
       // everything set up, test follows ...

--- a/query/src/test/java/org/infinispan/query/impl/VeryLargeFetchSizeTest.java
+++ b/query/src/test/java/org/infinispan/query/impl/VeryLargeFetchSizeTest.java
@@ -23,20 +23,20 @@ public class VeryLargeFetchSizeTest {
 
    private static final int VERY_LARGE_FETCH_SIZE = Integer.MAX_VALUE;
 
-   private List<EntityInfo> entityInfos = new ArrayList<EntityInfo>();
+   private List<EntityInfo> entityInfos = new ArrayList<>();
    private AdvancedCache<String, String> cache;
 
    @Test
    public void testLazyIteratorHandlesVeryLargeFetchSize() throws IOException {
       cache = mock(AdvancedCache.class);
       DocumentExtractor extractor = mock(DocumentExtractor.class);
-      new LazyIterator(extractor, new EntityLoader(cache, new KeyTransformationHandler()), VERY_LARGE_FETCH_SIZE);
+      new LazyIterator<>(extractor, new EntityLoader(cache, new KeyTransformationHandler()), VERY_LARGE_FETCH_SIZE);
    }
 
    @Test
    public void testEagerIteratorHandlesVeryLargeFetchSize() throws IOException {
       cache = mock(AdvancedCache.class);
-      new EagerIterator(entityInfos, new EntityLoader(cache, new KeyTransformationHandler()), VERY_LARGE_FETCH_SIZE);
+      new EagerIterator<>(entityInfos, new EntityLoader(cache, new KeyTransformationHandler()), VERY_LARGE_FETCH_SIZE);
    }
 
 }

--- a/query/src/test/java/org/infinispan/query/indexedembedded/BooksExampleTest.java
+++ b/query/src/test/java/org/infinispan/query/indexedembedded/BooksExampleTest.java
@@ -56,7 +56,7 @@ public class BooksExampleTest extends SingleCacheManagerTest {
                .sentence("in action")
             .createQuery();
 
-      List<Object> list = qf.getQuery(luceneQuery).list();
+      List<?> list = qf.getQuery(luceneQuery).list();
       assert list.size() == 2;
    }
 

--- a/query/src/test/java/org/infinispan/query/jmx/QueryMBeanTest.java
+++ b/query/src/test/java/org/infinispan/query/jmx/QueryMBeanTest.java
@@ -111,8 +111,8 @@ public class QueryMBeanTest extends SingleCacheManagerTest {
 
          QueryParser queryParser = createQueryParser("blurb");
          Query luceneQuery = queryParser.parse("value");
-         CacheQuery cacheQuery = searchManager.getQuery(luceneQuery);
-         List<Object> found = cacheQuery.list(); //Executing first query
+         CacheQuery<?> cacheQuery = searchManager.getQuery(luceneQuery);
+         List<?> found = cacheQuery.list(); //Executing first query
 
          assertEquals(1L, server.getAttribute(name, "SearchQueryExecutionCount"));
 

--- a/query/src/test/java/org/infinispan/query/nulls/NullCollectionElementsClusteredTest.java
+++ b/query/src/test/java/org/infinispan/query/nulls/NullCollectionElementsClusteredTest.java
@@ -68,7 +68,7 @@ public class NullCollectionElementsClusteredTest extends MultipleCacheManagersTe
             searchManager = Search.getSearchManager(cache1);
 
             Query query = createQueryBuilder().keyword().onField("bar").matching("1").createQuery();
-            ResultIterator iterator = searchManager.getQuery(query).iterator(new FetchOptions().fetchMode(EAGER));
+            ResultIterator<?> iterator = searchManager.getQuery(query).iterator(new FetchOptions().fetchMode(EAGER));
             assertFalse("Iterator should not have elements.", iterator.hasNext());
             try {
                iterator.next();
@@ -92,7 +92,7 @@ public class NullCollectionElementsClusteredTest extends MultipleCacheManagersTe
             searchManager = Search.getSearchManager(cache1);
 
             Query query = createQueryBuilder().keyword().onField("bar").matching("1").createQuery();
-            ResultIterator iterator = searchManager.getQuery(query).iterator();
+            ResultIterator<?> iterator = searchManager.getQuery(query).iterator();
             assertFalse(iterator.hasNext());
             try {
                iterator.next();
@@ -116,7 +116,7 @@ public class NullCollectionElementsClusteredTest extends MultipleCacheManagersTe
             searchManager = Search.getSearchManager(cache1);
 
             Query query = createQueryBuilder().keyword().onField("bar").matching("1").createQuery();
-            CacheQuery cacheQuery = searchManager.getQuery(query);
+            CacheQuery<?> cacheQuery = searchManager.getQuery(query);
             //pruivo: the result size includes the null elements...
             assertEquals("Wrong result size.", 1, cacheQuery.getResultSize());
 
@@ -139,7 +139,7 @@ public class NullCollectionElementsClusteredTest extends MultipleCacheManagersTe
             searchManager = Search.getSearchManager(cache1);
 
             Query query = createQueryBuilder().keyword().onField("bar").matching("2").createQuery();
-            ResultIterator iterator = searchManager.getQuery(query).iterator(new FetchOptions().fetchMode(LAZY));
+            ResultIterator<?> iterator = searchManager.getQuery(query).iterator(new FetchOptions().fetchMode(LAZY));
             assertFalse(iterator.hasNext());
             try {
                iterator.next();
@@ -162,10 +162,10 @@ public class NullCollectionElementsClusteredTest extends MultipleCacheManagersTe
             searchManager = Search.getSearchManager(cache1);
 
             Query query = createQueryBuilder().keyword().onField("bar").matching("1").createQuery();
-            ResultIterator iterator = searchManager.getQuery(query).projection(ProjectionConstants.VALUE, "bar")
+            ResultIterator<Object[]> iterator = searchManager.getQuery(query).projection(ProjectionConstants.VALUE, "bar")
                   .iterator(new FetchOptions().fetchMode(LAZY));
             assertTrue("Expected an element in iterator.", iterator.hasNext());
-            Object[] projection = (Object[]) iterator.next();
+            Object[] projection = iterator.next();
             assertNull(projection[0]);
             assertEquals("1", projection[1]);
             return null;

--- a/query/src/test/java/org/infinispan/query/nulls/NullCollectionElementsTest.java
+++ b/query/src/test/java/org/infinispan/query/nulls/NullCollectionElementsTest.java
@@ -90,7 +90,7 @@ public class NullCollectionElementsTest extends SingleCacheManagerTest {
          public Void call() throws Exception {
             cache.remove("1");   // cache will now be out of sync with the index
             Query query = createQueryBuilder().keyword().onField("bar").matching("1").createQuery();
-            ResultIterator iterator = searchManager.getQuery(query).iterator(new FetchOptions().fetchMode(EAGER));
+            ResultIterator<?> iterator = searchManager.getQuery(query).iterator(new FetchOptions().fetchMode(EAGER));
             assertFalse(iterator.hasNext());
             try {
                iterator.next();
@@ -110,9 +110,9 @@ public class NullCollectionElementsTest extends SingleCacheManagerTest {
          public Void call() throws Exception {
             cache.remove("1");   // cache will now be out of sync with the index
             Query query = createQueryBuilder().keyword().onField("bar").matching("1").createQuery();
-            CacheQuery cacheQuery = searchManager.getQuery(query);
+            CacheQuery<?> cacheQuery = searchManager.getQuery(query);
             assertEquals(1, cacheQuery.getResultSize());
-            ResultIterator iterator = cacheQuery.iterator();
+            ResultIterator<?> iterator = cacheQuery.iterator();
             assertFalse(iterator.hasNext());
             try {
                iterator.next();
@@ -132,7 +132,7 @@ public class NullCollectionElementsTest extends SingleCacheManagerTest {
          public Void call() throws Exception {
             cache.remove("1");   // cache will now be out of sync with the index
             Query query = createQueryBuilder().keyword().onField("bar").matching("1").createQuery();
-            ResultIterator iterator = searchManager.getQuery(query).iterator(new FetchOptions().fetchMode(LAZY));
+            ResultIterator<?> iterator = searchManager.getQuery(query).iterator(new FetchOptions().fetchMode(LAZY));
             assertFalse(iterator.hasNext());
             try {
                iterator.next();
@@ -152,9 +152,9 @@ public class NullCollectionElementsTest extends SingleCacheManagerTest {
          public Void call() throws Exception {
             cache.remove("1");   // cache will now be out of sync with the index
             Query query = createQueryBuilder().keyword().onField("bar").matching("1").createQuery();
-            ResultIterator iterator = searchManager.getQuery(query).projection(ProjectionConstants.VALUE, "bar").iterator(new FetchOptions().fetchMode(LAZY));
+            ResultIterator<Object[]> iterator = searchManager.getQuery(query).projection(ProjectionConstants.VALUE, "bar").iterator(new FetchOptions().fetchMode(LAZY));
             assertTrue(iterator.hasNext());
-            Object[] projection = (Object[]) iterator.next();
+            Object[] projection = iterator.next();
             assertNull(projection[0]);
             assertEquals("1", projection[1]);
             return null;

--- a/query/src/test/java/org/infinispan/query/persistence/InconsistentIndexesAfterRestartTest.java
+++ b/query/src/test/java/org/infinispan/query/persistence/InconsistentIndexesAfterRestartTest.java
@@ -106,9 +106,9 @@ public class InconsistentIndexesAfterRestartTest extends AbstractInfinispanTest 
 
     private List searchByName(String name, Cache c) {
         SearchManager sm = Search.getSearchManager(c);
-        CacheQuery q = sm.getQuery(SEntity.searchByName(name), SEntity.class);
+        CacheQuery<?> q = sm.getQuery(SEntity.searchByName(name), SEntity.class);
         int resultSize = q.getResultSize();
-        List l = q.list();
+        List<?> l = q.list();
         assert l.size() == resultSize;
         return q.list();
     }

--- a/query/src/test/java/org/infinispan/query/programmaticmapping/SearchMappingTest.java
+++ b/query/src/test/java/org/infinispan/query/programmaticmapping/SearchMappingTest.java
@@ -68,7 +68,7 @@ public class SearchMappingTest extends AbstractInfinispanTest {
             final QueryBuilder qb = sm.buildQueryBuilderForClass(BondPVO.class).get();
             final Query q = qb.keyword().onField("name").matching("Test")
                   .createQuery();
-            final CacheQuery cq = sm.getQuery(q, BondPVO.class);
+            final CacheQuery<?> cq = sm.getQuery(q, BondPVO.class);
             Assert.assertEquals(cq.getResultSize(), 1);
          }
       });
@@ -136,7 +136,7 @@ public class SearchMappingTest extends AbstractInfinispanTest {
                   .get();
             final Query q = qb.keyword().onField("name").matching("Test")
                   .createQuery();
-            final CacheQuery cq = sm.getQuery(q, BondPVO2.class);
+            final CacheQuery<?> cq = sm.getQuery(q, BondPVO2.class);
             Assert.assertEquals(cq.getResultSize(), 1);
          }
       });

--- a/query/src/test/java/org/infinispan/query/projection/ProjectionTest.java
+++ b/query/src/test/java/org/infinispan/query/projection/ProjectionTest.java
@@ -45,21 +45,21 @@ public class ProjectionTest extends SingleCacheManagerTest {
    @Test
    public void testQueryProjectionWithSingleField() throws Exception {
       cache.put("1", new Foo("bar1", "baz1"));
-      CacheQuery cacheQuery = createProjectionQuery("bar");
+      CacheQuery<?> cacheQuery = createProjectionQuery("bar");
       assertQueryReturns(cacheQuery, new Object[] { "bar1" });
    }
 
    @Test
    public void testQueryProjectionWithMultipleFields() throws Exception {
       cache.put("1", new Foo("bar1", "baz1"));
-      CacheQuery cacheQuery = createProjectionQuery("bar", "baz");
+      CacheQuery<?> cacheQuery = createProjectionQuery("bar", "baz");
       assertQueryReturns(cacheQuery, new Object[] { "bar1", "baz1" });
    }
 
    @Test
    public void testKeyProjectionConstant() throws Exception {
       cache.put("1", new Foo("bar1", "baz1"));
-      CacheQuery cacheQuery = createProjectionQuery(ProjectionConstants.KEY);
+      CacheQuery<?> cacheQuery = createProjectionQuery(ProjectionConstants.KEY);
       assertQueryReturns(cacheQuery, new Object[] { "1" });
    }
 
@@ -67,7 +67,7 @@ public class ProjectionTest extends SingleCacheManagerTest {
    public void testValueProjectionConstant() throws Exception {
       Foo foo = new Foo("bar1", "baz1");
       cache.put("1", foo);
-      CacheQuery cacheQuery = createProjectionQuery(ProjectionConstants.VALUE);
+      CacheQuery<?> cacheQuery = createProjectionQuery(ProjectionConstants.VALUE);
       assertQueryReturns(cacheQuery, new Object[] { foo });
    }
 
@@ -75,7 +75,7 @@ public class ProjectionTest extends SingleCacheManagerTest {
    public void testMixedProjections() throws Exception {
       Foo foo = new Foo("bar1", "baz4");
       cache.put("1", foo);
-      CacheQuery cacheQuery = createProjectionQuery(
+      CacheQuery<?> cacheQuery = createProjectionQuery(
             ProjectionConstants.KEY,
             ProjectionConstants.VALUE,
             ProjectionConstants.VALUE,
@@ -86,39 +86,29 @@ public class ProjectionTest extends SingleCacheManagerTest {
       assertQueryReturns(cacheQuery, new Object[] { "1", foo, foo, foo.getClass(), foo.baz, foo.bar });
    }
 
-   private CacheQuery createProjectionQuery(String... projection) {
+   private CacheQuery<?> createProjectionQuery(String... projection) {
       QueryBuilder queryBuilder = searchManager.buildQueryBuilderForClass(Foo.class).get();
       Query query = queryBuilder.keyword().onField("bar").matching("bar1").createQuery();
-      CacheQuery cacheQuery = searchManager.getQuery(query);
-      cacheQuery.projection(projection);
-      return cacheQuery;
+      return searchManager.getQuery(query).projection(projection);
    }
 
-   private void assertQueryReturns(CacheQuery cacheQuery, Object[] expected) {
+   private void assertQueryReturns(CacheQuery<?> cacheQuery, Object[] expected) {
       assertQueryListContains(cacheQuery.list(), expected);
-      final ResultIterator eagerIterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER));
-      try {
+      try (ResultIterator<?> eagerIterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.EAGER))) {
          assertQueryIteratorContains(eagerIterator, expected);
       }
-      finally {
-         eagerIterator.close();
-      }
-      final ResultIterator lazyIterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY));
-      try {
+      try (ResultIterator<?> lazyIterator = cacheQuery.iterator(new FetchOptions().fetchMode(FetchOptions.FetchMode.LAZY))) {
          assertQueryIteratorContains(lazyIterator, expected);
-      }
-      finally {
-         lazyIterator.close();
       }
    }
 
-   private void assertQueryListContains(List list, Object[] expected) {
+   private void assertQueryListContains(List<?> list, Object[] expected) {
       assert list.size() == 1;
       Object[] array = (Object[]) list.get(0);
       assertArrayEquals(expected, array);
    }
 
-   private void assertQueryIteratorContains(ResultIterator iterator, Object[] expected) {
+   private void assertQueryIteratorContains(ResultIterator<?> iterator, Object[] expected) {
       assert iterator.hasNext();
       Object[] array = (Object[]) iterator.next();
       assert Arrays.equals(array, expected);

--- a/query/src/test/java/org/infinispan/query/queries/faceting/SimpleFacetingTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/faceting/SimpleFacetingTest.java
@@ -69,7 +69,7 @@ public class SimpleFacetingTest extends SingleCacheManagerTest {
 
       Query luceneQuery = queryBuilder.all().createQuery();
 
-      CacheQuery query = qf.getQuery(luceneQuery);
+      CacheQuery<?> query = qf.getQuery(luceneQuery);
 
       query.getFacetManager().enableFaceting(request);
 

--- a/query/src/test/java/org/infinispan/query/queries/phrases/QueryPhrasesTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/phrases/QueryPhrasesTest.java
@@ -63,8 +63,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().bool()
             .must(createQueryParser("name").parse("Goat")).not().createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(1, found.size());
       assert found.contains(person1);
@@ -92,8 +92,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(AnotherGrassEater.class).get().bool()
             .should(createQueryParser("name").parse("grass")).should(subQuery).createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(2, found.size());
       assert found.contains(person1);
@@ -108,8 +108,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().bool()
             .should(createQueryParser("name").parse("Goat")).should(subQuery).createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(3, found.size());
       assert found.contains(person1);
@@ -143,8 +143,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().bool()
             .should(subQuery1).should(subQuery2).createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(3, found.size());
       assert found.get(0).equals(person1);
@@ -173,8 +173,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().keyword().fuzzy().
             onField("name").matching("Goat").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(2, found.size());
       assert found.contains(person2);
@@ -198,7 +198,7 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
 
       query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().keyword().fuzzy().
             onFields("name", "blurb").matching("goat").createQuery();
-      List<Object> foundOnFields = Search.getSearchManager(cache).getQuery(query).list();
+      List<?> foundOnFields = Search.getSearchManager(cache).getQuery(query).list();
 
       assertEquals(3, found.size());
       assert found.contains(person2);
@@ -242,8 +242,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(NumericType.class)
             .get().range().onField("num1").andField("num2").below(20).excludeLimit().createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(3, found.size());  //<------ All entries should be here, because andField is executed as SHOULD;
       assert found.contains(type1);
@@ -272,8 +272,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().keyword().wildcard()
             .onField("wrongname").matching("Goat").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(2, found.size());
    }
@@ -284,8 +284,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(NumericType.class).get().keyword().wildcard()
             .onField("name").matching("*wildcard*").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(3, found.size());
       assert found.contains(type1);
@@ -327,8 +327,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().keyword().onField("name")
             .andField("blurb").matching("Eats").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(2, found.size());
 
@@ -353,8 +353,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().phrase()
             .onField("blurb").sentence("Eats grass").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(1, found.size());
       assert found.contains(person2);
@@ -376,8 +376,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(NumericType.class).get().phrase()
             .onField("name").sentence("Some string").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(0, found.size());
 
@@ -396,8 +396,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().phrase().withSlop(3)
             .onField("blurb").sentence("Eats grass").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(1, found.size());
       assert found.contains(person2);
@@ -445,8 +445,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(NumericType.class).get().phrase().withSlop(1)
             .onField("name").sentence("Some string").createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(0, found.size());
 
@@ -475,8 +475,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
 
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class).get().all().except().createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(3, found.size());
       assert found.contains(person2);
@@ -507,8 +507,8 @@ public class QueryPhrasesTest extends SingleCacheManagerTest {
 
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(NumericType.class).get().all().except().createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(3, found.size());
       assert found.contains(type1);

--- a/query/src/test/java/org/infinispan/query/queries/ranges/QueryRangesTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/ranges/QueryRangesTest.java
@@ -63,8 +63,8 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class)
             .get().range().onField("age").below(30).excludeLimit().createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(2, found.size());
       assert found.contains(person1);
@@ -93,8 +93,8 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class)
             .get().range().onField("age").below(30).createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(3, found.size());
       assert found.contains(person1);
@@ -125,8 +125,8 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class)
             .get().range().onField("age").above(30).excludeLimit().createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(0, found.size());
 
@@ -162,8 +162,8 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class)
             .get().range().onField("age").above(30).excludeLimit().createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(0, found.size());
 
@@ -201,8 +201,8 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class)
             .get().range().onField("age").from(20).excludeLimit().to(30).excludeLimit().createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(1, found.size());
       assert found.contains(person3);
@@ -229,8 +229,8 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class)
             .get().range().onField("age").from(20).to(30).createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(3, found.size());
       assert found.contains(person1);
@@ -277,8 +277,8 @@ public class QueryRangesTest extends SingleCacheManagerTest {
       Query query = Search.getSearchManager(cache).buildQueryBuilderForClass(Person.class)
             .get().range().onField("age").from(20).excludeLimit().to(30).createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(2, found.size());
       assert found.contains(person2);
@@ -334,8 +334,8 @@ public class QueryRangesTest extends SingleCacheManagerTest {
             .range().onField("dateOfGraduation").from(formatDate("May 5, 2002")).excludeLimit().to(formatDate("June 30, 2012"))
             .createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(2, found.size());
       assert found.contains(person1);

--- a/query/src/test/java/org/infinispan/query/queries/spatial/QuerySpatialTest.java
+++ b/query/src/test/java/org/infinispan/query/queries/spatial/QuerySpatialTest.java
@@ -56,8 +56,8 @@ public class QuerySpatialTest extends SingleCacheManagerTest {
          .onField("city_location")
          .within(50, Unit.KM).ofLatitude(centerLatitude).andLongitude(centerLongitude).createQuery();
 
-      CacheQuery cacheQuery = Search.getSearchManager(cache).getQuery(query);
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = Search.getSearchManager(cache).getQuery(query);
+      List<?> found = cacheQuery.list();
 
       assertEquals(0, found.size());
 

--- a/query/src/test/java/org/infinispan/query/searchmanager/ClusteredCacheQueryTimeoutTest.java
+++ b/query/src/test/java/org/infinispan/query/searchmanager/ClusteredCacheQueryTimeoutTest.java
@@ -48,7 +48,7 @@ public class ClusteredCacheQueryTimeoutTest extends MultipleCacheManagersTest {
       QueryParser queryParser = createQueryParser("bar");
 
       org.apache.lucene.search.Query luceneQuery = queryParser.parse("fakebar");
-      CacheQuery query = searchManager.getClusteredQuery(luceneQuery, Foo.class);
+      CacheQuery<?> query = searchManager.getClusteredQuery(luceneQuery, Foo.class);
       query.timeout(1, TimeUnit.NANOSECONDS);
    }
 

--- a/query/src/test/java/org/infinispan/query/searchmanager/TimeoutTest.java
+++ b/query/src/test/java/org/infinispan/query/searchmanager/TimeoutTest.java
@@ -44,7 +44,7 @@ public class TimeoutTest extends SingleCacheManagerTest {
             .keyword().onField("bar").matching("1")
             .createQuery();
 
-      CacheQuery cacheQuery = searchManager.getQuery(query);
+      CacheQuery<?> cacheQuery = searchManager.getQuery(query);
       cacheQuery.timeout(1, TimeUnit.NANOSECONDS);
 
       try {

--- a/query/src/test/java/org/infinispan/query/statetransfer/BaseReIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/statetransfer/BaseReIndexingTest.java
@@ -52,8 +52,8 @@ public abstract class BaseReIndexingTest extends MultipleCacheManagersTest {
    }
 
    protected void executeSimpleQuery(Cache<String, Person> cache) throws ParseException {
-      CacheQuery cacheQuery = createCacheQuery(cache, "blurb", "playing");
-      List<Object> found = cacheQuery.list();
+      CacheQuery<?> cacheQuery = createCacheQuery(cache, "blurb", "playing");
+      List<?> found = cacheQuery.list();
       int elems = found.size();
       assertEquals(1, elems);
       Object val = found.get(0);

--- a/query/src/test/java/org/infinispan/query/tx/NonLocalIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/tx/NonLocalIndexingTest.java
@@ -72,7 +72,7 @@ public class NonLocalIndexingTest extends MultipleCacheManagersTest {
    private static void assertFind(Cache cache, String keyword, int expectedCount) {
       SearchManager queryFactory = Search.getSearchManager(cache);
       Query luceneQuery = new TermQuery(new Term("blurb", keyword));
-      CacheQuery cacheQuery = queryFactory.getQuery(luceneQuery);
+      CacheQuery<?> cacheQuery = queryFactory.getQuery(luceneQuery);
       int resultSize = cacheQuery.getResultSize();
       Assert.assertEquals(resultSize, expectedCount);
    }

--- a/query/src/test/java/org/infinispan/query/tx/TwoPhaseCommitIndexingTest.java
+++ b/query/src/test/java/org/infinispan/query/tx/TwoPhaseCommitIndexingTest.java
@@ -71,7 +71,7 @@ public class TwoPhaseCommitIndexingTest extends SingleCacheManagerTest {
    private static void assertFind(Cache cache, String keyword, int expectedCount) {
       SearchManager queryFactory = Search.getSearchManager(cache);
       Query luceneQuery = new TermQuery(new Term("blurb", keyword));
-      CacheQuery cacheQuery = queryFactory.getQuery(luceneQuery, Person.class);
+      CacheQuery<?> cacheQuery = queryFactory.getQuery(luceneQuery, Person.class);
       int resultSize = cacheQuery.getResultSize();
       Assert.assertEquals(resultSize, expectedCount);
    }

--- a/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/indexing/ProtobufWrapperIndexingTest.java
+++ b/remote-query/remote-query-server/src/test/java/org/infinispan/query/remote/impl/indexing/ProtobufWrapperIndexingTest.java
@@ -65,9 +65,9 @@ public class ProtobufWrapperIndexingTest extends SingleCacheManagerTest {
             .matching("Adrian")
             .createQuery();
 
-      List<Object> list = sm.getQuery(luceneQuery).list();
+      List<ProtobufValueWrapper> list = sm.<ProtobufValueWrapper>getQuery(luceneQuery).list();
       assertEquals(1, list.size());
-      ProtobufValueWrapper pvw = (ProtobufValueWrapper) list.get(0);
+      ProtobufValueWrapper pvw = list.get(0);
       User unwrapped = (User) ProtobufUtil.fromWrappedByteArray(ProtobufMetadataManagerImpl.getSerializationContextInternal(cacheManager), pvw.getBinary());
       assertEquals("Adrian", unwrapped.getName());
 

--- a/server/integration/event-logger/src/main/java/org/infinispan/server/eventlogger/ServerEventLogger.java
+++ b/server/integration/event-logger/src/main/java/org/infinispan/server/eventlogger/ServerEventLogger.java
@@ -15,7 +15,6 @@ import org.infinispan.commons.util.Util;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.Search;
 import org.infinispan.query.dsl.FilterConditionContext;
-import org.infinispan.query.dsl.QueryBuilder;
 import org.infinispan.query.dsl.QueryFactory;
 import org.infinispan.query.dsl.SortOrder;
 import org.infinispan.util.TimeService;
@@ -101,8 +100,10 @@ public class ServerEventLogger implements EventLogger {
          cacheManager.executor().submitConsumer(m -> {
             Cache<Object, Object> cache = m.getCache(EVENT_LOG_CACHE);
             QueryFactory queryFactory = Search.getQueryFactory(cache);
-            QueryBuilder query = queryFactory.from(ServerEventImpl.class).orderBy("when", SortOrder.DESC).maxResults(count);
-            FilterConditionContext filter = query.having("when").lte(start);
+            FilterConditionContext filter = queryFactory.from(ServerEventImpl.class)
+                  .orderBy("when", SortOrder.DESC)
+                  .maxResults(count)
+                  .having("when").lte(start);
             category.map(c -> filter.and(queryFactory.having("category").eq(c)));
             level.map(l -> filter.and(queryFactory.having("level").eq(l)));
             List<EventLog> nodeEvents = filter.toBuilder().build().list();

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/osgi/RemoteCacheOsgiIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/client/hotrod/osgi/RemoteCacheOsgiIT.java
@@ -162,7 +162,7 @@ public class RemoteCacheOsgiIT extends KarafTestSupport {
 
       // get User back from remote cache via query and check its attributes
       QueryFactory qf = Search.getQueryFactory(cache);
-      Query query = qf.from(User.class).having("name").eq("Tom").toBuilder().build();
+      Query query = qf.from(User.class).having("name").eq("Tom").build();
       List list = query.list();
       assertNotNull(list);
       assertEquals(1, list.size());
@@ -170,7 +170,7 @@ public class RemoteCacheOsgiIT extends KarafTestSupport {
       assertUser((User) list.get(0));
 
       // get Note back from remote cache via query and check its attributes
-      query = qf.from(Note.class).having("author.name").eq("name").toBuilder().build();
+      query = qf.from(Note.class).having("author.name").eq("name").build();
       list = query.list();
       assertNotNull(list);
       assertEquals(1, list.size());

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/ManualIndexingIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/ManualIndexingIT.java
@@ -59,7 +59,7 @@ public class ManualIndexingIT extends RemoteQueryBaseIT {
     @Test
     public void testManualIndexing() throws Exception {
         QueryBuilder qb = Search.getQueryFactory(remoteCache).from(User.class)
-                .having("name").eq("Tom").toBuilder();
+                .having("name").eq("Tom");
 
         User user = new User();
         user.setId(1);

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteContinuousQueryIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteContinuousQueryIT.java
@@ -52,7 +52,7 @@ public class RemoteContinuousQueryIT extends RemoteQueryBaseIT {
       assertEquals(3, remoteCache.size());
 
       QueryFactory qf = Search.getQueryFactory(remoteCache);
-      Query query = qf.from(User.class).having("name").eq("user1").and().having("age").gt(20).toBuilder().build();
+      Query query = qf.from(User.class).having("name").eq("user1").and().having("age").gt(20).build();
 
       final BlockingQueue<Integer> joined = new LinkedBlockingQueue<>();
       final BlockingQueue<Integer> updated = new LinkedBlockingQueue<>();

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteListenerWithDslFilterIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteListenerWithDslFilterIT.java
@@ -112,7 +112,7 @@ public class RemoteListenerWithDslFilterIT extends RemoteQueryBaseIT {
 
       Query query = qf.from(User.class)
             .having("age").lte(param("ageParam"))
-            .toBuilder().select("age")
+            .select("age")
             .build()
             .setParameter("ageParam", 32);
 

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryIT.java
@@ -61,7 +61,7 @@ public class RemoteQueryIT extends RemoteQueryBaseIT {
         // get user back from remote cache via query and check its attributes
         QueryFactory qf = Search.getQueryFactory(remoteCache);
         Query query = qf.from(User.class)
-                .having("name").eq("Tom").toBuilder()
+                .having("name").eq("Tom")
                 .build();
         List<User> list = query.list();
         assertNotNull(list);
@@ -78,7 +78,7 @@ public class RemoteQueryIT extends RemoteQueryBaseIT {
         // get user back from remote cache via query and check its attributes
         QueryFactory qf = Search.getQueryFactory(remoteCache);
         Query query = qf.from(User.class)
-                .having("addresses.postCode").eq("1234").toBuilder()
+                .having("addresses.postCode").eq("1234")
                 .build();
         List<User> list = query.list();
         assertNotNull(list);
@@ -100,7 +100,7 @@ public class RemoteQueryIT extends RemoteQueryBaseIT {
         QueryFactory qf = Search.getQueryFactory(remoteCache);
         Query query = qf.from(User.class)
                 .select("name", "surname")
-                .having("name").eq("Tom").toBuilder()
+                .having("name").eq("Tom")
                 .build();
         List<Object[]> list = query.list();
         assertNotNull(list);
@@ -116,7 +116,7 @@ public class RemoteQueryIT extends RemoteQueryBaseIT {
         remoteCache.put(2, createUser2());
 
         QueryFactory qf = Search.getQueryFactory(remoteCache);
-        Query simpleQuery = qf.from(User.class).having("name").eq("Tom").toBuilder().build();
+        Query simpleQuery = qf.from(User.class).having("name").eq("Tom").build();
 
         List<Map.Entry<Object, Object>> entries = new ArrayList<>(1);
         try (CloseableIterator<Map.Entry<Object, Object>> iter = remoteCache.retrieveEntriesByQuery(simpleQuery, null, 3)) {
@@ -134,7 +134,7 @@ public class RemoteQueryIT extends RemoteQueryBaseIT {
         remoteCache.put(2, createUser2());
 
         QueryFactory qf = Search.getQueryFactory(remoteCache);
-        Query simpleQuery = qf.from(User.class).select("surname", "name").having("name").eq("Tom").toBuilder().build();
+        Query simpleQuery = qf.from(User.class).select("surname", "name").having("name").eq("Tom").build();
 
         List<Map.Entry<Object, Object>> entries = new ArrayList<>(1);
         try (CloseableIterator<Map.Entry<Object, Object>> iter = remoteCache.retrieveEntriesByQuery(simpleQuery, null, 3)) {

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQuerySecurityIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQuerySecurityIT.java
@@ -174,7 +174,7 @@ public class RemoteQuerySecurityIT {
       RemoteCache<Object, Object> cache = remoteCacheManagers.get(userLogin).getCache(cacheName);
       QueryFactory qf = Search.getQueryFactory(cache);
       Query query = qf.from(User.class)
-            .having("name").eq("Tom").toBuilder()
+            .having("name").eq("Tom")
             .build();
       List<User> list = query.list();
       assertNotNull(list);

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryWithProtostreamAnnotationsIT.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/query/RemoteQueryWithProtostreamAnnotationsIT.java
@@ -172,7 +172,7 @@ public class RemoteQueryWithProtostreamAnnotationsIT {
       // get user1 back from remote cache via query and check its attributes
       QueryFactory qf = Search.getQueryFactory(remoteCache);
       Query query = qf.from(AnnotatedUser.class)
-            .having("name").eq("Tom").toBuilder()
+            .having("name").eq("Tom")
             .build();
       List<AnnotatedUser> list = query.list();
       assertNotNull(list);
@@ -182,7 +182,7 @@ public class RemoteQueryWithProtostreamAnnotationsIT {
 
       // get user2 back from remote cache via query and check its attributes
       query = qf.from(AnnotatedUser.class)
-            .having("address.postCode").eq("Xyz").toBuilder()
+            .having("address.postCode").eq("Xyz")
             .build();
       list = query.list();
       assertNotNull(list);


### PR DESCRIPTION
* https://issues.jboss.org/browse/ISPN-2826
  CacheQuery and ResultIterator now have a type parameter. If the query targets multiple types it is the user's responsibility to choose an actual type which is a common super type of all targeted types or CCE will occur during fetching. If no such suitable type exists then the user can specify Object or just declare it raw.
As an exception, ```CacheQuery.projection``` method does not use the type parameter of the class and instead it returns ```CacheQuery<Object[]>```.

* https://issues.jboss.org/browse/ISPN-7205
The query DSL was modified to avoid the need to call ```toBuilder()```. 

* PLEASE pay attention to backward compat. All API changes are intended to be backward source-compatible (possibly binary too, but binary is not an absolute must).
