### PR TITLE
Tests for ISPN-7300 and ISPN-7301 and extending query testsuite

### DIFF
--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryStringTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/query/RemoteQueryStringTest.java
@@ -119,6 +119,20 @@ public class RemoteQueryStringTest extends QueryStringTest {
       super.testFullTextRegexpFuzzyNotAllowed();
    }
 
+   @Test(expectedExceptions = HotRodClientException.class, expectedExceptionsMessageRegExp = ".*property is analyzed.*")
+   @Override
+   public void testExactMatchOnAnalyzedFieldNotAllowed() throws Exception {
+      // exception is wrapped in HotRodClientException
+      super.testExactMatchOnAnalyzedFieldNotAllowed();
+   }
+
+   @Test(expectedExceptions = HotRodClientException.class, expectedExceptionsMessageRegExp = ".*unless the property is indexed and analyzed.*")
+   @Override
+   public void testFullTextTermOnNonAnalyzedFieldNotAllowed() throws Exception {
+      // exception is wrapped in HotRodClientException
+      super.testFullTextTermOnNonAnalyzedFieldNotAllowed();
+   }
+
    @AfterClass(alwaysRun = true)
    public void release() {
       killRemoteCacheManager(remoteCacheManager);

--- a/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
+++ b/query/src/test/java/org/infinispan/query/dsl/embedded/QueryStringTest.java
@@ -28,13 +28,13 @@ public class QueryStringTest extends AbstractQueryDslTest {
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder cfg = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
       cfg.transaction()
-            .transactionMode(TransactionMode.TRANSACTIONAL)
-            .indexing().index(Index.ALL)
-            .addIndexedEntity(getModelFactory().getUserImplClass())
-            .addIndexedEntity(getModelFactory().getAccountImplClass())
-            .addIndexedEntity(getModelFactory().getTransactionImplClass())
-            .addProperty("default.directory_provider", "ram")
-            .addProperty("lucene_version", "LUCENE_CURRENT");
+              .transactionMode(TransactionMode.TRANSACTIONAL)
+              .indexing().index(Index.ALL)
+              .addIndexedEntity(getModelFactory().getUserImplClass())
+              .addIndexedEntity(getModelFactory().getAccountImplClass())
+              .addIndexedEntity(getModelFactory().getTransactionImplClass())
+              .addProperty("default.directory_provider", "ram")
+              .addProperty("lucene_version", "LUCENE_CURRENT");
       createClusteredCaches(1, cfg);
    }
 
@@ -149,6 +149,15 @@ public class QueryStringTest extends AbstractQueryDslTest {
       assertEquals(1, list.size());
    }
 
+   public void testFullTextTermRightOperandAnalyzed() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where longDescription:'RENT'");
+
+      List<Transaction> list = q.list();
+      assertEquals(1, list.size());
+   }
+
    public void testFullTextTermBoost() throws Exception {
       QueryFactory qf = getQueryFactory();
 
@@ -171,7 +180,7 @@ public class QueryStringTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.create("select t.accountId, max(t.amount), max(t.description) from " + getModelFactory().getTransactionTypeName()
-            + " t where t.longDescription : (+'beer' -'food') group by t.accountId");
+              + " t where t.longDescription : (+'beer' -'food') group by t.accountId");
 
       List<Object[]> list = q.list();
       assertEquals(1, list.size());
@@ -196,6 +205,15 @@ public class QueryStringTest extends AbstractQueryDslTest {
 
       List<Transaction> list = q.list();
       assertEquals(56, list.size());
+   }
+
+   public void testFullTextTermDoesntOccur() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : (-'really')");
+
+      List<Transaction> list = q.list();
+      assertEquals(6, list.size());
    }
 
    public void testFullTextRange() throws Exception {
@@ -243,6 +261,35 @@ public class QueryStringTest extends AbstractQueryDslTest {
       assertEquals(1, list.size());
    }
 
+   public void testFullTextFuzzyDefaultEdits() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      // default number of edits should be 2
+      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'ertn'~");
+
+      List<Transaction> list = q.list();
+      assertEquals(1, list.size());
+
+      q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'ajunayr'~");
+
+      list = q.list();
+      assertEquals(0, list.size());
+   }
+
+   public void testFullTextFuzzySpecifiedEdits() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'ajnuary'~1");
+
+      List<Transaction> list = q.list();
+      assertEquals(1, list.size());
+
+      q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : 'ajunary'~1");
+
+      list = q.list();
+      assertEquals(0, list.size());
+   }
+
    public void testFullTextRegexp() throws Exception {
       QueryFactory qf = getQueryFactory();
 
@@ -257,6 +304,24 @@ public class QueryStringTest extends AbstractQueryDslTest {
       QueryFactory qf = getQueryFactory();
 
       Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " t where t.longDescription : /[R|r]ent/~2");
+
+      q.list();
+   }
+
+   @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = ".*property is analyzed.*")
+   public void testExactMatchOnAnalyzedFieldNotAllowed() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where longDescription = 'Birthday present'");
+
+      q.list();
+   }
+
+   @Test(expectedExceptions = ParsingException.class, expectedExceptionsMessageRegExp = ".*unless the property is indexed and analyzed.*")
+   public void testFullTextTermOnNonAnalyzedFieldNotAllowed() throws Exception {
+      QueryFactory qf = getQueryFactory();
+
+      Query q = qf.create("from " + getModelFactory().getTransactionTypeName() + " where description:'rent'");
 
       q.list();
    }


### PR DESCRIPTION
Extending query testsuite and tests for:
https://issues.jboss.org/browse/ISPN-7300
https://issues.jboss.org/browse/ISPN-7301

Tests testFullTextTermDoesntOccur and testFullTextTermRightOperandAnalyzed should be failing because of the above mentioned issues.
