### PR TITLE
ISPN-7283 Make cluster and client listeners more fine grained

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/event/ClientListenerNotifier.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/event/ClientListenerNotifier.java
@@ -166,7 +166,7 @@ public class ClientListenerNotifier {
       return null;
    }
 
-   private Map<Class<? extends Annotation>, List<ClientListenerInvocation>> findMethods(Object listener) {
+   public Map<Class<? extends Annotation>, List<ClientListenerInvocation>> findMethods(Object listener) {
       Map<Class<? extends Annotation>, List<ClientListenerInvocation>> listenerMethodMap =
             new HashMap<Class<? extends Annotation>, List<ClientListenerInvocation>>(4, 0.99f);
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
@@ -52,6 +52,7 @@ public class ConfigurationProperties {
    public static final int DEFAULT_SO_TIMEOUT = 60000;
    public static final int DEFAULT_CONNECT_TIMEOUT = 60000;
    public static final int DEFAULT_MAX_RETRIES = 10;
+   public static final String PROTOCOL_VERSION_26 = "2.6";
    public static final String PROTOCOL_VERSION_25 = "2.5";
    public static final String PROTOCOL_VERSION_24 = "2.4";
    public static final String PROTOCOL_VERSION_23 = "2.3";
@@ -62,7 +63,7 @@ public class ConfigurationProperties {
    public static final String PROTOCOL_VERSION_12 = "1.2";
    public static final String PROTOCOL_VERSION_11 = "1.1";
    public static final String PROTOCOL_VERSION_10 = "1.0";
-   public static final String DEFAULT_PROTOCOL_VERSION = PROTOCOL_VERSION_25;
+   public static final String DEFAULT_PROTOCOL_VERSION = PROTOCOL_VERSION_26;
 
    private final TypedProperties props;
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AddClientListenerOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AddClientListenerOperation.java
@@ -86,6 +86,7 @@ public class AddClientListenerOperation extends RetryOnFailureOperation<Short> {
       HeaderParams params = writeHeader(transport, ADD_CLIENT_LISTENER_REQUEST);
       transport.writeArray(listenerId);
       codec.writeClientListenerParams(transport, clientListener, filterFactoryParams, converterFactoryParams);
+      codec.writeClientListenerInterests(transport, listenerNotifier.findMethods(this.listener).keySet());
       transport.flush();
 
       listenerNotifier.addClientListener(this);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
@@ -1,5 +1,7 @@
 package org.infinispan.client.hotrod.impl.protocol;
 
+import java.lang.annotation.Annotation;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.client.hotrod.annotation.ClientListener;
@@ -55,4 +57,6 @@ public interface Codec {
     * Read and unmarshall byte array.
     */
    <T> T readUnmarshallByteArray(Transport transport, short status);
+
+   void writeClientListenerInterests(Transport transport, Set<Class<? extends Annotation>> classes);
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod.impl.protocol;
 
 import static org.infinispan.commons.util.Util.hexDump;
 
+import java.lang.annotation.Annotation;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.HashSet;
@@ -164,6 +165,11 @@ public class Codec10 implements Codec {
    @Override
    public <T> T readUnmarshallByteArray(Transport transport, short status) {
       return CodecUtils.readUnmarshallByteArray(transport, status);
+   }
+
+   @Override
+   public void writeClientListenerInterests(Transport transport, Set<Class<? extends Annotation>> classes) {
+      // No-op
    }
 
    protected void checkForErrorsInResponseStatus(Transport transport, HeaderParams params, short status) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
@@ -18,11 +18,13 @@ import org.infinispan.client.hotrod.marshall.MarshallerUtil;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.Either;
 
+import java.lang.annotation.Annotation;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -46,6 +48,11 @@ public class Codec20 implements Codec, HotRodConstants {
    @Override
    public <T> T readUnmarshallByteArray(Transport transport, short status) {
       return CodecUtils.readUnmarshallByteArray(transport, status);
+   }
+
+   @Override
+   public void writeClientListenerInterests(Transport transport, Set<Class<? extends Annotation>> classes) {
+      // No-op
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec26.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec26.java
@@ -1,0 +1,37 @@
+package org.infinispan.client.hotrod.impl.protocol;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryExpired;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryModified;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryRemoved;
+import org.infinispan.client.hotrod.impl.transport.Transport;
+
+/**
+ * @since 8.2
+ */
+public class Codec26 extends Codec25 {
+
+   @Override
+   public HeaderParams writeHeader(Transport transport, HeaderParams params) {
+      return writeHeader(transport, params, HotRodConstants.VERSION_26);
+   }
+
+   @Override
+   public void writeClientListenerInterests(Transport transport, Set<Class<? extends Annotation>> classes) {
+      byte listenerInterests = 0;
+      if (classes.contains(ClientCacheEntryCreated.class))
+         listenerInterests = (byte) (listenerInterests | 0x01);
+      if (classes.contains(ClientCacheEntryModified.class))
+         listenerInterests = (byte) (listenerInterests | 0x02);
+      if (classes.contains(ClientCacheEntryRemoved.class))
+         listenerInterests = (byte) (listenerInterests | 0x04);
+      if (classes.contains(ClientCacheEntryExpired.class))
+         listenerInterests = (byte) (listenerInterests | 0x08);
+
+      transport.writeByte(listenerInterests);
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/CodecFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/CodecFactory.java
@@ -13,6 +13,7 @@ import static org.infinispan.client.hotrod.impl.ConfigurationProperties.PROTOCOL
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.PROTOCOL_VERSION_23;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.PROTOCOL_VERSION_24;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.PROTOCOL_VERSION_25;
+import static org.infinispan.client.hotrod.impl.ConfigurationProperties.PROTOCOL_VERSION_26;
 
 /**
  * Code factory.
@@ -33,6 +34,7 @@ public class CodecFactory {
    private static final Codec CODEC_23 = new Codec23();
    private static final Codec CODEC_24 = new Codec24();
    private static final Codec CODEC_25 = new Codec25();
+   private static final Codec CODEC_26 = new Codec26();
 
    static {
       codecMap = new HashMap<String, Codec>();
@@ -46,6 +48,7 @@ public class CodecFactory {
       codecMap.put(PROTOCOL_VERSION_23, CODEC_23);
       codecMap.put(PROTOCOL_VERSION_24, CODEC_24);
       codecMap.put(PROTOCOL_VERSION_25, CODEC_25);
+      codecMap.put(PROTOCOL_VERSION_26, CODEC_26);
    }
 
    public static boolean isVersionDefined(String version) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HotRodConstants.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HotRodConstants.java
@@ -23,6 +23,7 @@ public interface HotRodConstants {
    static final byte VERSION_23 = 23;
    static final byte VERSION_24 = 24;
    static final byte VERSION_25 = 25;
+   static final byte VERSION_26 = 26;
 
    //requests
    static final byte PUT_REQUEST = 0x01;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/ClusterClientEventStressTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/ClusterClientEventStressTest.java
@@ -1,0 +1,285 @@
+package org.infinispan.client.hotrod.stress;
+
+import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.toBytes;
+import static org.infinispan.distribution.DistributionTestHelper.isFirstOwner;
+import static org.infinispan.distribution.DistributionTestHelper.isOwner;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.infinispan.Cache;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryModified;
+import org.infinispan.client.hotrod.annotation.ClientListener;
+import org.infinispan.client.hotrod.event.ClientEvent;
+import org.infinispan.client.hotrod.logging.Log;
+import org.infinispan.client.hotrod.logging.LogFactory;
+import org.infinispan.client.hotrod.test.InternalRemoteCacheManager;
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.util.concurrent.ConcurrentHashSet;
+import org.testng.annotations.Test;
+
+@Test(groups = "stress", testName = "client.hotrod.event.ClusterClientEventStressTest")
+public class ClusterClientEventStressTest extends MultiHotRodServersTest {
+
+   private static final Log log = LogFactory.getLog(ClusterClientEventStressTest.class);
+
+   static final int NUM_SERVERS = 3;
+   static final int NUM_OWNERS = 2;
+
+   static final int NUM_CLIENTS = 1;
+   static final int NUM_THREADS_PER_CLIENT = 6;
+//   static final int NUM_THREADS_PER_CLIENT = 36;
+
+   static final int NUM_OPERATIONS = 1_000; // per thread, per client
+//   static final int NUM_OPERATIONS = 300; // per thread, per client
+//   static final int NUM_OPERATIONS = 600; // per thread, per client
+
+   static final int NUM_EVENTS = NUM_OPERATIONS * NUM_THREADS_PER_CLIENT * NUM_CLIENTS * NUM_CLIENTS;
+
+//   public static final int NUM_STORES = NUM_OPERATIONS * NUM_CLIENTS * NUM_THREADS_PER_CLIENT;
+//   public static final int NUM_STORES_PER_SERVER = NUM_STORES / NUM_SERVERS;
+//   public static final int NUM_ENTRIES_PER_SERVER = (NUM_STORES * NUM_OWNERS) / NUM_SERVERS;
+
+   static Set<String> ALL_KEYS = new ConcurrentHashSet<>();
+
+   static ExecutorService EXEC = Executors.newCachedThreadPool();
+
+   static ClientEntryListener listener;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createHotRodServers(NUM_SERVERS, getCacheConfiguration());
+   }
+
+   private ConfigurationBuilder getCacheConfiguration() {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      builder.clustering().hash().numOwners(NUM_OWNERS)
+//            .expiration().lifespan(1000).maxIdle(1000).wakeUpInterval(5000)
+            .expiration().maxIdle(1000).wakeUpInterval(5000)
+            .jmxStatistics().enable();
+      return hotRodCacheConfiguration(builder);
+   }
+
+   RemoteCacheManager getRemoteCacheManager(int port) {
+      org.infinispan.client.hotrod.configuration.ConfigurationBuilder builder =
+            new org.infinispan.client.hotrod.configuration.ConfigurationBuilder();
+      builder.addServer().host("127.0.0.1").port(port);
+      RemoteCacheManager rcm = new InternalRemoteCacheManager(builder.build());
+      rcm.getCache();
+      return rcm;
+   }
+
+   Map<String, RemoteCacheManager> createClients() {
+      Map<String, RemoteCacheManager> remotecms = new HashMap<>(NUM_CLIENTS);
+      for (int i = 0; i < NUM_CLIENTS; i++)
+         remotecms.put("c" + i, getRemoteCacheManager(server(0).getPort()));
+
+      return remotecms;
+   }
+
+   public void testAddClientListenerDuringOperations() {
+      CyclicBarrier barrier = new CyclicBarrier((NUM_CLIENTS * NUM_THREADS_PER_CLIENT) + 1);
+      List<Future<Void>> futures = new ArrayList<>(NUM_CLIENTS * NUM_THREADS_PER_CLIENT);
+      List<ClientEntryListener> listeners = new ArrayList<>(NUM_CLIENTS);
+      Map<String, RemoteCacheManager> remotecms = createClients();
+
+//      assertStatsBefore(remotecms);
+
+      for (Entry<String, RemoteCacheManager> e : remotecms.entrySet()) {
+         RemoteCache<String, String> remote = e.getValue().getCache();
+
+//         ClientEntryListener listener = new ClientEntryListener();
+//         listeners.add(listener);
+//         remote.addClientListener(listener);
+
+         for (int i = 0; i < NUM_THREADS_PER_CLIENT; i++) {
+            String prefix = String.format("%s-t%d-", e.getKey(), i);
+            Callable<Void> call = new Put(prefix, barrier, remote, servers);
+            futures.add(EXEC.submit(call));
+         }
+      }
+
+      barrierAwait(barrier); // wait for all threads to be ready
+      barrierAwait(barrier); // wait for all threads to finish
+
+      for (Future<Void> f : futures)
+         futureGet(f);
+
+//      log.debugf("Put operations completed, assert statistics");
+//      assertStatsAfter(remotecms);
+
+//      log.debugf("Stats asserted, wait for events...");
+//      eventuallyEquals(NUM_EVENTS, () -> countEvents(listeners));
+   }
+
+   int countEvents(List<ClientEntryListener> listeners) {
+      Integer count = listeners.stream().reduce(0, (acc, l) -> acc + l.count.get(), (x, y) -> x + y);
+      log.infof("Event count is %d, target %d%n", (int) count, NUM_EVENTS);
+      return count;
+   }
+
+//   void assertStatsBefore(Map<String, RemoteCacheManager> remotecms) {
+//      RemoteCacheManager client = remotecms.values().iterator().next();
+//      IntStream.range(0, NUM_SERVERS)
+//            .forEach(x -> {
+//               ServerStatistics stat = client.getCache().stats();
+//               assertEquals(0, stat.getIntStatistic(STORES).intValue());
+//               assertEquals(0, stat.getIntStatistic(CURRENT_NR_OF_ENTRIES).intValue());
+//            });
+//   }
+//
+//   void assertStatsAfter(Map<String, RemoteCacheManager> remotecms) {
+//      RemoteCacheManager client = remotecms.values().iterator().next();
+//      IntStream.range(0, NUM_SERVERS)
+//            .forEach(x -> {
+//               ServerStatistics stat = client.getCache().stats();
+//               int stores = stat.getIntStatistic(STORES);
+//               System.out.println("Number of stores: " + stores);
+//               assertEquals(NUM_STORES_PER_SERVER, stores);
+//               int entries = stat.getIntStatistic(CURRENT_NR_OF_ENTRIES);
+//               assertEquals(NUM_ENTRIES_PER_SERVER, entries);
+//            });
+//   }
+
+   static class Put implements Callable<Void> {
+      static final ThreadLocalRandom R = ThreadLocalRandom.current();
+
+      final CyclicBarrier barrier;
+      final RemoteCache<String, String> remote;
+      final List<HotRodServer> servers;
+      final List<String> keys;
+
+      public Put(String prefix, CyclicBarrier barrier,
+            RemoteCache<String, String> remote, List<HotRodServer> servers) {
+         this.barrier = barrier;
+         this.remote = remote;
+         this.servers = servers;
+         this.keys = generateKeys(prefix, servers, R);
+         Collections.shuffle(this.keys);
+      }
+
+      @Override
+      public Void call() throws Exception {
+         barrierAwait(barrier);
+         try {
+            for (int i = 0; i < NUM_OPERATIONS; i++) {
+               String value = keys.get(i);
+               remote.put(value, value);
+               if (value.startsWith("c0-t0") && i == (NUM_OPERATIONS / 2)) {
+                  listener = new ClientEntryListener();
+                  remote.addClientListener(listener);
+               }
+            }
+            return null;
+         } finally {
+            barrierAwait(barrier);
+         }
+      }
+   }
+
+   static List<String> generateKeys(String prefix, List<HotRodServer> servers, ThreadLocalRandom r) {
+      List<String> keys = new ArrayList<>();
+      List<HotRodServer[]> combos = Arrays.asList(
+            new HotRodServer[]{servers.get(0), servers.get(1)},
+            new HotRodServer[]{servers.get(1), servers.get(0)},
+            new HotRodServer[]{servers.get(1), servers.get(2)},
+            new HotRodServer[]{servers.get(2), servers.get(1)},
+            new HotRodServer[]{servers.get(2), servers.get(0)},
+            new HotRodServer[]{servers.get(0), servers.get(2)}
+      );
+
+      for (int i = 0; i < NUM_OPERATIONS; i++) {
+         HotRodServer[] owners = combos.get(i % combos.size());
+         String key = getStringKey(prefix, owners, r);
+         if (ALL_KEYS.contains(key))
+            throw new AssertionError("Key already in use: " + key);
+
+         keys.add(key);
+         ALL_KEYS.add(key);
+      }
+      return keys;
+   }
+
+   static String getStringKey(String prefix, HotRodServer[] owners, ThreadLocalRandom r) {
+      Cache<?, ?> firstOwnerCache = owners[0].getCacheManager().getCache();
+      Cache<?, ?> otherOwnerCache = owners[1].getCacheManager().getCache();
+
+//      Random r = new Random();
+      byte[] dummy;
+      String dummyKey;
+      int attemptsLeft = 1000;
+      do {
+         Integer dummyInt = r.nextInt();
+         dummyKey = prefix + dummyInt;
+         dummy = toBytes(dummyKey);
+         attemptsLeft--;
+      } while (!(isFirstOwner(firstOwnerCache, dummy) && isOwner(otherOwnerCache, dummy))
+            && attemptsLeft >= 0);
+
+      if (attemptsLeft < 0)
+         throw new IllegalStateException("Could not find any key owned by "
+               + firstOwnerCache + " as primary owner and "
+               + otherOwnerCache + " as secondary owner");
+
+      log.infof("Integer key %s hashes to primary [cluster=%s,hotrod=%s] and secondary [cluster=%s,hotrod=%s]",
+            dummyKey,
+            firstOwnerCache.getCacheManager().getAddress(), owners[0].getAddress(),
+            otherOwnerCache.getCacheManager().getAddress(), owners[1].getAddress());
+
+      return dummyKey;
+   }
+
+   static int barrierAwait(CyclicBarrier barrier) {
+      try {
+         return barrier.await();
+      } catch (InterruptedException | BrokenBarrierException e) {
+         throw new AssertionError(e);
+      }
+   }
+
+   static <T> T futureGet(Future<T> future) {
+      try {
+         return future.get();
+      } catch (InterruptedException | ExecutionException e) {
+         throw new AssertionError(e);
+      }
+   }
+
+   @ClientListener
+   static class ClientEntryListener {
+      final AtomicInteger count = new AtomicInteger();
+
+      @ClientCacheEntryCreated
+      @ClientCacheEntryModified
+      @SuppressWarnings("unused")
+      public void handleClientEvent(ClientEvent event) {
+         int countSoFar;
+         if ((countSoFar = count.incrementAndGet()) % 100 == 0) {
+            log.debugf("Reached %s", countSoFar);
+         }
+      }
+   }
+
+}

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheEntryListenerInvocation.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheEntryListenerInvocation.java
@@ -1,6 +1,7 @@
 package org.infinispan.notifications.cachelistener;
 
 import java.lang.annotation.Annotation;
+import java.util.Set;
 import java.util.UUID;
 
 import org.infinispan.notifications.Listener;
@@ -34,4 +35,6 @@ public interface CacheEntryListenerInvocation<K, V> extends ListenerInvocation<E
    CacheEventFilter<? super K, ? super V> getFilter();
 
    <C> CacheEventConverter<? super K, ? super V, C> getConverter();
+
+   Set<Class<? extends Annotation>> getFilterAnnotations();
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifier.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifier.java
@@ -10,11 +10,15 @@ import org.infinispan.factories.scopes.Scopes;
 import org.infinispan.metadata.Metadata;
 import org.infinispan.notifications.ClassLoaderAwareFilteringListenable;
 import org.infinispan.notifications.ClassLoaderAwareListenable;
+import org.infinispan.notifications.cachelistener.filter.CacheEventConverter;
+import org.infinispan.notifications.cachelistener.filter.CacheEventFilter;
 import org.infinispan.partitionhandling.AvailabilityMode;
 import org.infinispan.topology.CacheTopology;
 import org.infinispan.transaction.xa.GlobalTransaction;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
+import java.util.Set;
 
 /**
  * Public interface with all allowed notifications.
@@ -110,4 +114,14 @@ public interface CacheNotifier<K, V> extends ClassLoaderAwareFilteringListenable
     * @param typeConverter the converter instance; can be {@code null}
     */
    void setTypeConverter(TypeConverter typeConverter);
+
+   /**
+    * Add a listener limiting cache entry specific callbacks only to those
+    * annotations that are present in the annotation filter collection.
+    */
+   <C> void addFilteredListener(Object listener,
+         CacheEventFilter<? super K, ? super V> filter,
+         CacheEventConverter<? super K, ? super V, C> converter,
+         Set<Class<? extends Annotation>> filterAnnotations);
+
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplicateCallable.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplicateCallable.java
@@ -2,6 +2,7 @@ package org.infinispan.notifications.cachelistener.cluster;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.util.Util;
 import org.infinispan.distexec.DistributedCallable;
 import org.infinispan.distexec.DistributedExecutorService;
@@ -20,6 +21,8 @@ import org.infinispan.util.logging.LogFactory;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -47,14 +50,19 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
    private final CacheEventConverter<K, V, ?> converter;
    private final Address origin;
    private final boolean sync;
+   private final Set<Class<? extends Annotation>> filterAnnotations;
 
    public ClusterListenerReplicateCallable(UUID identifier, Address origin, CacheEventFilter<K, V> filter,
-                                           CacheEventConverter<K, V, ?> converter, boolean sync) {
+                                           CacheEventConverter<K, V, ?> converter, boolean sync,
+                                           Set<Class<? extends Annotation>> filterAnnotations) {
       this.identifier = identifier;
       this.origin = origin;
       this.filter = filter;
       this.converter = converter;
       this.sync = sync;
+      this.filterAnnotations = filterAnnotations;
+      if (trace)
+         log.tracef("Created clustered listener replicate callable for: %s", filterAnnotations);
    }
 
    @Override
@@ -96,7 +104,7 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
                if (!alreadyInstalled) {
                   RemoteClusterListener listener = new RemoteClusterListener(identifier, origin, distExecutor, cacheNotifier,
                                                                              cacheManagerNotifier, eventManager, sync);
-                  cacheNotifier.addListener(listener, filter, converter);
+                  cacheNotifier.addFilteredListener(listener, filter, converter, filterAnnotations);
                   cacheManagerNotifier.addListener(listener);
                   // It is possible the member is now gone after registered, if so we have to remove just to be sure
                   if (!cacheManager.getMembers().contains(origin)) {
@@ -142,6 +150,7 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
             output.writeObject(object.converter);
          }
          output.writeBoolean(object.sync);
+         MarshallUtil.marshallCollection(object.filterAnnotations, output);
       }
 
       @Override
@@ -157,7 +166,8 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
             converter = (CacheEventConverter)input.readObject();
          }
          boolean sync = input.readBoolean();
-         return new ClusterListenerReplicateCallable(id, address, filter, converter, sync);
+         Set<Class<? extends Annotation>> listenerAnnots = MarshallUtil.unmarshallCollection(input, HashSet::new);
+         return new ClusterListenerReplicateCallable(id, address, filter, converter, sync, listenerAnnots);
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplicateCallable.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplicateCallable.java
@@ -105,6 +105,7 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
                   RemoteClusterListener listener = new RemoteClusterListener(identifier, origin, distExecutor, cacheNotifier,
                                                                              cacheManagerNotifier, eventManager, sync);
                   cacheNotifier.addFilteredListener(listener, filter, converter, filterAnnotations);
+//                  cacheNotifier.addListener(listener, filter, converter);
                   cacheManagerNotifier.addListener(listener);
                   // It is possible the member is now gone after registered, if so we have to remove just to be sure
                   if (!cacheManager.getMembers().contains(origin)) {

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/filter/DelegatingCacheEntryListenerInvocation.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/filter/DelegatingCacheEntryListenerInvocation.java
@@ -6,6 +6,7 @@ import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
 import org.infinispan.notifications.cachelistener.event.Event;
 
 import java.lang.annotation.Annotation;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -84,5 +85,10 @@ public abstract class DelegatingCacheEntryListenerInvocation<K, V> implements Ca
    @Override
    public <C> CacheEventConverter<? super K, ? super V, C> getConverter() {
       return invocation.getConverter();
+   }
+
+   @Override
+   public Set<Class<? extends Annotation>> getFilterAnnotations() {
+      return invocation.getFilterAnnotations();
    }
 }

--- a/core/src/main/java/org/infinispan/notifications/impl/AbstractListenerImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/impl/AbstractListenerImpl.java
@@ -1,22 +1,5 @@
 package org.infinispan.notifications.impl;
 
-import org.infinispan.commons.CacheException;
-import org.infinispan.commons.util.ReflectionUtil;
-import org.infinispan.factories.KnownComponentNames;
-import org.infinispan.factories.annotations.ComponentName;
-import org.infinispan.factories.annotations.Inject;
-import org.infinispan.factories.annotations.Start;
-import org.infinispan.factories.annotations.Stop;
-import org.infinispan.notifications.IncorrectListenerException;
-import org.infinispan.notifications.Listener;
-import org.infinispan.security.Security;
-import org.infinispan.util.concurrent.WithinThreadExecutor;
-import org.infinispan.util.logging.Log;
-import org.infinispan.util.logging.LogFactory;
-
-import javax.security.auth.Subject;
-import javax.transaction.Transaction;
-
 import java.lang.annotation.Annotation;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
@@ -33,6 +16,27 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
+import javax.security.auth.Subject;
+import javax.transaction.Transaction;
+
+import org.infinispan.commons.CacheException;
+import org.infinispan.commons.util.ReflectionUtil;
+import org.infinispan.factories.KnownComponentNames;
+import org.infinispan.factories.annotations.ComponentName;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.Stop;
+import org.infinispan.notifications.IncorrectListenerException;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryExpired;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
+import org.infinispan.security.Security;
+import org.infinispan.util.concurrent.WithinThreadExecutor;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
 /**
  * Functionality common to both {@link org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifierImpl} and
  * {@link org.infinispan.notifications.cachelistener.CacheNotifierImpl}
@@ -44,6 +48,7 @@ import java.util.concurrent.ExecutorService;
 public abstract class AbstractListenerImpl<T, L extends ListenerInvocation<T>> {
 
    private static final Log log = LogFactory.getLog(AbstractListenerImpl.class);
+   private static final boolean trace = log.isTraceEnabled();
 
    protected final Map<Class<? extends Annotation>, List<L>> listenersMap = new HashMap<>(16, 0.99f);
 
@@ -224,6 +229,61 @@ public abstract class AbstractListenerImpl<T, L extends ListenerInvocation<T>> {
       if (!foundMethods)
          getLog().noAnnotateMethodsFoundInListener(listener.getClass());
       return foundMethods;
+   }
+
+   protected boolean validateAndAddFilterListenerInvocations(Object listener,
+         AbstractInvocationBuilder builder, Set<Class<? extends Annotation>> filterAnnotations) {
+      Listener l = testListenerClassValidity(listener.getClass());
+      boolean foundMethods = false;
+      builder.setTarget(listener);
+      builder.setSubject(Security.getSubject());
+      builder.setSync(l.sync());
+      Map<Class<? extends Annotation>, Class<?>> allowedListeners = getAllowedMethodAnnotations(l);
+      // now try all methods on the listener for anything that we like.  Note that only PUBLIC methods are scanned.
+      for (Method m : listener.getClass().getMethods()) {
+         // Skip bridge methods as we don't want to count them as well.
+         if (!m.isSynthetic() || !m.isBridge()) {
+            // loop through all valid method annotations
+            for (Map.Entry<Class<? extends Annotation>, Class<?>> annotationEntry : allowedListeners.entrySet()) {
+               final Class<? extends Annotation> annotationClass = annotationEntry.getKey();
+               if (m.isAnnotationPresent(annotationClass) && canApply(filterAnnotations, annotationClass)) {
+                  final Class<?> eventClass = annotationEntry.getValue();
+                  testListenerMethodValidity(m, eventClass, annotationClass.getName());
+
+                  if (System.getSecurityManager() == null) {
+                     m.setAccessible(true);
+                  } else {
+                     AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                        m.setAccessible(true);
+                        return null;
+                     });
+                  }
+
+                  builder.setMethod(m);
+                  builder.setAnnotation(annotationClass);
+                  L invocation = builder.build();
+                  if (trace)
+                     log.tracef("Add listener invocation %s for %s", invocation, annotationClass);
+
+                  getListenerCollectionForAnnotation(annotationClass).add(invocation);
+                  foundMethods = true;
+               }
+            }
+         }
+      }
+
+      if (!foundMethods)
+         getLog().noAnnotateMethodsFoundInListener(listener.getClass());
+      return foundMethods;
+   }
+
+   public boolean canApply(Set<Class<? extends Annotation>> filterAnnotations, Class<? extends Annotation> annotationClass) {
+      // Annotations such ViewChange or TransactionCompleted should be applied regardless
+      return (annotationClass != CacheEntryCreated.class
+            && annotationClass != CacheEntryModified.class
+            && annotationClass != CacheEntryRemoved.class
+            && annotationClass != CacheEntryExpired.class)
+            || (filterAnnotations.contains(annotationClass));
    }
 
    protected Set<Class<? extends Annotation>> findListenerCallbacks(Object listener) {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
@@ -101,12 +101,12 @@ public abstract class AbstractClusterListenerUtilTest extends MultipleCacheManag
       TestingUtil.replaceComponent(manager(2), TimeService.class, ts2, true);
    }
 
-   @AfterMethod
-   public void resetTimeServices() {
-      ts0.advance(-ts0.wallClockTime());
-      ts1.advance(-ts1.wallClockTime());
-      ts2.advance(-ts2.wallClockTime());
-   }
+//   @AfterMethod
+//   public void resetTimeServices() {
+//      ts0.advance(-ts0.wallClockTime());
+//      ts1.advance(-ts1.wallClockTime());
+//      ts2.advance(-ts2.wallClockTime());
+//   }
 
    @Listener(clustered = true)
    protected class ClusterListener {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
@@ -41,6 +41,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Matchers.any;
@@ -329,7 +330,7 @@ public abstract class AbstractClusterListenerUtilTest extends MultipleCacheManag
                checkPoint.awaitStrict("post_add_listener_release_" + cache, 10, TimeUnit.SECONDS);
             }
          }
-      }).when(mockNotifier).addListener(anyObject(), any(CacheEventFilter.class), any(CacheEventConverter.class));
+      }).when(mockNotifier).addFilteredListener(anyObject(), any(CacheEventFilter.class), any(CacheEventConverter.class), any(Set.class));
       TestingUtil.replaceComponent(cache, CacheNotifier.class, mockNotifier, true);
    }
 

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/BaseJPAFilterIndexingServiceProvider.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/BaseJPAFilterIndexingServiceProvider.java
@@ -32,6 +32,7 @@ import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -336,6 +337,11 @@ public abstract class BaseJPAFilterIndexingServiceProvider implements FilterInde
 
       @Override
       public <C> CacheEventConverter<? super K, ? super V, C> getConverter() {
+         return null;
+      }
+
+      @Override
+      public Set<Class<? extends Annotation>> getFilterAnnotations() {
          return null;
       }
    }

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/ContextHandler.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/ContextHandler.java
@@ -152,7 +152,7 @@ public class ContextHandler extends SimpleChannelInboundHandler<CacheDecodeConte
             ClientListenerRequestContext clientContext = (ClientListenerRequestContext) msg.operationDecodeContext();
             server.getClientListenerRegistry().addClientListener(msg.decoder(), ctx.channel(), h, clientContext.listenerId(),
                     msg.cache(), clientContext.includeCurrentState(), new Tuple2<>(clientContext.filterFactoryInfo(),
-                            clientContext.converterFactoryInfo()), clientContext.useRawData());
+                            clientContext.converterFactoryInfo()), clientContext.useRawData(), clientContext.listenerInterests());
             break;
          case RemoveClientListenerRequest:
             byte[] listenerId = (byte[]) msg.operationDecodeContext();

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ClientEventSenders.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/ClientEventSenders.scala
@@ -1,0 +1,392 @@
+package org.infinispan.server.hotrod
+
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.atomic.AtomicLong
+
+import io.netty.channel.Channel
+import org.infinispan.container.versioning.NumericVersion
+import org.infinispan.notifications.Listener
+import org.infinispan.notifications.cachelistener.annotation.{CacheEntryCreated, CacheEntryExpired, CacheEntryModified, CacheEntryRemoved}
+import org.infinispan.notifications.cachelistener.event.Event.Type
+import org.infinispan.notifications.cachelistener.event.{CacheEntryCreatedEvent, CacheEntryEvent, CacheEntryModifiedEvent, CacheEntryRemovedEvent}
+import org.infinispan.server.hotrod.ClientListenerRegistry.{CustomRaw, CustomPlain, Plain, ClientEventType}
+import org.infinispan.server.hotrod.Events.{CustomEvent, CustomRawEvent, KeyEvent, KeyWithVersionEvent}
+import org.infinispan.server.hotrod.OperationResponse._
+import org.infinispan.server.hotrod.logging.Log
+
+object ClientEventSenders extends Log {
+
+  val isTrace = isTraceEnabled
+
+  private val messageId = new AtomicLong()
+
+  def createClientSender(includeState: Boolean, ch: Channel, version: Byte,
+            cache: Cache, listenerId: Bytes, eventType: ClientEventType, listenerInterests: Byte): AnyRef = {
+    val compatibility = cache.getCacheConfiguration.compatibility()
+    (includeState, compatibility.enabled()) match {
+      case (false, false) =>
+        createStatelessClientEventSender(ch, listenerId, version, eventType, listenerInterests)
+      case (true, false) =>
+        createStatefulClientEventSender(ch, listenerId, version, eventType, listenerInterests)
+      case (false, true) =>
+        val delegate = new StatelessClientEventSender(ch, listenerId, version, eventType)
+        createStatelessCompatibilityClientEventSender(delegate, HotRodTypeConverter(compatibility.marshaller()), listenerInterests)
+      case (true, true) =>
+        val delegate = new StatelessClientEventSender(ch, listenerId, version, eventType)
+        createStatefulCompatibilityClientEventSender(delegate, HotRodTypeConverter(compatibility.marshaller()), listenerInterests)
+    }
+  }
+
+  def createStatelessClientEventSender(ch: Channel, listenerId: Bytes, version: Byte, eventType: ClientEventType, listenerInterests: Byte) = {
+    listenerInterests match {
+      case 0x00 =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with CreatedSender with ModifiedSender with RemovedSender
+      case 0x01 =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with CreatedSender
+      case 0x02 =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with ModifiedSender
+      case 0x03 =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with CreatedSender with ModifiedSender
+      case 0x04 =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with RemovedSender
+      case 0x05 =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with CreatedSender with RemovedSender
+      case 0x06 =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with ModifiedSender with RemovedSender
+      case 0x07 =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with CreatedSender with ModifiedSender with RemovedSender
+      case 0x08 =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with ExpiredSender
+      case 0x09 =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with CreatedSender
+      case 0x0A =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with ModifiedSender
+      case 0x0B =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with CreatedSender with ModifiedSender
+      case 0x0C =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with RemovedSender
+      case 0x0D =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with CreatedSender with RemovedSender
+      case 0x0E =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with ModifiedSender with RemovedSender
+      case 0x0F =>
+        new StatelessClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with CreatedSender with ModifiedSender with RemovedSender
+    }
+  }
+
+  def createStatefulClientEventSender(ch: Channel, listenerId: Bytes, version: Byte, eventType: ClientEventType, listenerInterests: Byte) = {
+    listenerInterests match {
+      case 0x00 =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with CreatedSender with ModifiedSender with RemovedSender
+      case 0x01 =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with CreatedSender
+      case 0x02 =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with ModifiedSender
+      case 0x03 =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with CreatedSender with ModifiedSender
+      case 0x04 =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with RemovedSender
+      case 0x05 =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with CreatedSender with RemovedSender
+      case 0x06 =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with ModifiedSender with RemovedSender
+      case 0x07 =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with CreatedSender with ModifiedSender with RemovedSender
+      case 0x08 =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with ExpiredSender
+      case 0x09 =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with CreatedSender
+      case 0x0A =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with ModifiedSender
+      case 0x0B =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with CreatedSender with ModifiedSender
+      case 0x0C =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with RemovedSender
+      case 0x0D =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with CreatedSender with RemovedSender
+      case 0x0E =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with ModifiedSender with RemovedSender
+      case 0x0F =>
+        new StatefulClientEventSender(ch, listenerId, version, eventType) with ExpiredSender with CreatedSender with ModifiedSender with RemovedSender
+    }
+  }
+
+  def createStatelessCompatibilityClientEventSender(delegate: BaseClientEventSender, converter: HotRodTypeConverter, listenerInterests: Byte) = {
+    listenerInterests match {
+      case 0x00 =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatCreatedSender with CompatModifiedSender with CompatRemovedSender
+      case 0x01 =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatCreatedSender
+      case 0x02 =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatModifiedSender
+      case 0x03 =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatCreatedSender with CompatModifiedSender
+      case 0x04 =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatRemovedSender
+      case 0x05 =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatCreatedSender with CompatRemovedSender
+      case 0x06 =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatModifiedSender with CompatRemovedSender
+      case 0x07 =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatCreatedSender with CompatModifiedSender with CompatRemovedSender
+      case 0x08 =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender
+      case 0x09 =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatCreatedSender
+      case 0x0A =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatModifiedSender
+      case 0x0B =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatCreatedSender with CompatModifiedSender
+      case 0x0C =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatRemovedSender
+      case 0x0D =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatCreatedSender with CompatRemovedSender
+      case 0x0E =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatModifiedSender with CompatRemovedSender
+      case 0x0F =>
+        new StatelessCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatCreatedSender with CompatModifiedSender with CompatRemovedSender
+    }
+  }
+
+  def createStatefulCompatibilityClientEventSender(delegate: BaseClientEventSender, converter: HotRodTypeConverter, listenerInterests: Byte) = {
+    listenerInterests match {
+      case 0x00 =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatCreatedSender with CompatModifiedSender with CompatRemovedSender
+      case 0x01 =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatCreatedSender
+      case 0x02 =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatModifiedSender
+      case 0x03 =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatCreatedSender with CompatModifiedSender
+      case 0x04 =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatRemovedSender
+      case 0x05 =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatCreatedSender with CompatRemovedSender
+      case 0x06 =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatModifiedSender with CompatRemovedSender
+      case 0x07 =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatCreatedSender with CompatModifiedSender with CompatRemovedSender
+      case 0x08 =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender
+      case 0x09 =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatCreatedSender
+      case 0x0A =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatModifiedSender
+      case 0x0B =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatCreatedSender with CompatModifiedSender
+      case 0x0C =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatRemovedSender
+      case 0x0D =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatCreatedSender with CompatRemovedSender
+      case 0x0E =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatModifiedSender with CompatRemovedSender
+      case 0x0F =>
+        new StatefulCompatibilityClientEventSender(delegate, converter) with CompatExpiredSender with CompatCreatedSender with CompatModifiedSender with CompatRemovedSender
+    }
+  }
+
+  // Do not make sync=false, instead move cache operation causing
+  // listener calls out of the Netty event loop thread
+  @Listener(clustered = true, includeCurrentState = true)
+  class StatefulClientEventSender(ch: Channel, listenerId: Bytes, version: Byte, targetEventType: ClientEventType)
+    extends BaseClientEventSender(ch, listenerId, version, targetEventType)
+
+  @Listener(clustered = true, includeCurrentState = false)
+  class StatelessClientEventSender(ch: Channel, listenerId: Bytes, version: Byte, targetEventType: ClientEventType)
+    extends BaseClientEventSender(ch, listenerId, version, targetEventType)
+
+  @Listener(clustered = true, includeCurrentState = true)
+  class StatefulCompatibilityClientEventSender(
+      delegate: BaseClientEventSender, converter: HotRodTypeConverter)
+    extends BaseCompatibilityClientEventSender(delegate, converter)
+
+  @Listener(clustered = true, includeCurrentState = false)
+  class StatelessCompatibilityClientEventSender(
+      delegate: BaseClientEventSender, converter: HotRodTypeConverter)
+    extends BaseCompatibilityClientEventSender(delegate, converter)
+
+  abstract class BaseCompatibilityClientEventSender(
+      delegate: BaseClientEventSender, converter: HotRodTypeConverter) {
+//    @CacheEntryCreated
+//    @CacheEntryModified
+//    @CacheEntryRemoved
+//    @CacheEntryExpired
+    def onCompatCacheEvent(event: CacheEntryEvent[AnyRef, AnyRef]) {
+      val key = converter.unboxKey(event.getKey)
+      val value = converter.unboxValue(event.getValue)
+      if (delegate.isSendEvent(event)) {
+        // In compatibility mode, version could be null if stored via embedded
+        val version = event.getMetadata.version()
+        val dataVersion = if (version == null) 0 else version.asInstanceOf[NumericVersion].getVersion
+        delegate.sendEvent(key.asInstanceOf[Array[Byte]], value.asInstanceOf[Array[Byte]], dataVersion, event)
+      }
+    }
+  }
+
+  trait Sender {
+    def onCacheEvent(event: CacheEntryEvent[Bytes, Bytes])
+  }
+
+  trait CreatedSender extends Sender {
+    @CacheEntryCreated
+    def onCreated(event: CacheEntryEvent[Bytes, Bytes]): Unit = onCacheEvent(event)
+  }
+
+  trait ModifiedSender extends Sender {
+    @CacheEntryModified
+    def onModified(event: CacheEntryEvent[Bytes, Bytes]): Unit = onCacheEvent(event)
+  }
+
+  trait RemovedSender extends Sender {
+    @CacheEntryRemoved
+    def onRemoved(event: CacheEntryEvent[Bytes, Bytes]): Unit = onCacheEvent(event)
+  }
+
+  trait ExpiredSender extends Sender {
+    @CacheEntryExpired
+    def onExpired(event: CacheEntryEvent[Bytes, Bytes]): Unit = onCacheEvent(event)
+  }
+
+  trait CompatSender {
+    def onCompatCacheEvent(event: CacheEntryEvent[AnyRef, AnyRef])
+  }
+
+  trait CompatCreatedSender extends CompatSender {
+    @CacheEntryCreated
+    def onCompatCreated(event: CacheEntryEvent[AnyRef, AnyRef]): Unit = onCompatCacheEvent(event)
+  }
+
+  trait CompatModifiedSender extends CompatSender {
+    @CacheEntryModified
+    def onCompatModified(event: CacheEntryEvent[AnyRef, AnyRef]): Unit = onCompatCacheEvent(event)
+  }
+
+  trait CompatRemovedSender extends CompatSender {
+    @CacheEntryRemoved
+    def onRemoved(event: CacheEntryEvent[AnyRef, AnyRef]): Unit = onCompatCacheEvent(event)
+  }
+
+  trait CompatExpiredSender extends CompatSender {
+    @CacheEntryExpired
+    def onExpired(event: CacheEntryEvent[AnyRef, AnyRef]): Unit = onCompatCacheEvent(event)
+  }
+
+
+  //  sealed trait ClientEventType
+//  case object Plain extends ClientEventType
+//  case object CustomPlain extends ClientEventType
+//  case object CustomRaw extends ClientEventType
+
+  abstract class BaseClientEventSender(ch: Channel, listenerId: Bytes, version: Byte, targetEventType: ClientEventType) {
+    val eventQueue = new LinkedBlockingQueue[AnyRef](100)
+
+    def hasChannel(channel: Channel): Boolean = ch == channel
+
+    def writeEventsIfPossible(): Unit = {
+      var written = false
+      while(!eventQueue.isEmpty && ch.isWritable) {
+        val event = eventQueue.poll()
+        if (isTrace) tracef("Write event: %s to channel %s", event, ch)
+        ch.write(event, ch.voidPromise)
+        written = true
+      }
+      if (written) {
+        ch.flush()
+      }
+    }
+
+//    @CacheEntryCreated
+//    @CacheEntryModified
+//    @CacheEntryRemoved
+//    @CacheEntryExpired
+    def onCacheEvent(event: CacheEntryEvent[Bytes, Bytes]) {
+      if (isSendEvent(event)) {
+        sendEvent(event.getKey, event.getValue, Option(event.getMetadata)
+          .map(_.version().asInstanceOf[NumericVersion].getVersion)
+          .getOrElse(null.asInstanceOf[Long]), event)
+
+      }
+    }
+
+    def isSendEvent(event: CacheEntryEvent[_, _]): Boolean = {
+      if (isChannelDisconnected()) {
+        log.debug("Channel disconnected, remove event sender listener")
+        event.getCache.removeListener(this)
+        false
+      } else {
+        event.getType match {
+          case Type.CACHE_ENTRY_CREATED | Type.CACHE_ENTRY_MODIFIED => !event.isPre
+          case Type.CACHE_ENTRY_REMOVED =>
+            val removedEvent = event.asInstanceOf[CacheEntryRemovedEvent[_, _]]
+            !event.isPre && removedEvent.getOldValue != null
+          case Type.CACHE_ENTRY_EXPIRED =>
+            true;
+          case _ =>
+            throw unexpectedEvent(event)
+        }
+      }
+    }
+
+    def isChannelDisconnected(): Boolean = !ch.isOpen
+
+    def sendEvent(key: Bytes, value: Bytes, dataVersion: Long, event: CacheEntryEvent[_, _]) {
+      val remoteEvent = createRemoteEvent(key, value, dataVersion, event)
+      if (isTrace)
+        log.tracef("Queue event %s, before queuing event queue size is %d", remoteEvent, eventQueue.size())
+
+      val waitingForFlush = !ch.isWritable
+      eventQueue.put(remoteEvent)
+
+      if (!waitingForFlush) {
+        // Make sure we write any event in main event loop
+        ch.eventLoop().submit(() => writeEventsIfPossible())
+      }
+    }
+
+    private def createRemoteEvent(key: Bytes, value: Bytes, dataVersion: Long, event: CacheEntryEvent[_, _]): AnyRef = {
+      messageId.incrementAndGet() // increment message id
+      // Embedded listener event implementation implements all interfaces,
+      // so can't pattern match on the event instance itself. Instead, pattern
+      // match on the type and the cast down to the expected event instance type
+      targetEventType match {
+        case Plain =>
+          event.getType match {
+            case Type.CACHE_ENTRY_CREATED | Type.CACHE_ENTRY_MODIFIED =>
+              val (op, isRetried) = getEventResponseType(event)
+              keyWithVersionEvent(key, dataVersion, op, isRetried)
+            case Type.CACHE_ENTRY_REMOVED | Type.CACHE_ENTRY_EXPIRED =>
+              val (op, isRetried) = getEventResponseType(event)
+              KeyEvent(version, messageId.get(), op, listenerId, isRetried, key)
+            case _ =>
+              throw unexpectedEvent(event)
+          }
+        case CustomPlain =>
+          val (op, isRetried) = getEventResponseType(event)
+          CustomEvent(version, messageId.get(), op, listenerId, isRetried, value)
+        case CustomRaw =>
+          val (op, isRetried) = getEventResponseType(event)
+          CustomRawEvent(version, messageId.get(), op, listenerId, isRetried, value)
+      }
+    }
+
+    private def getEventResponseType(event: CacheEntryEvent[_, _]): (OperationResponse, Boolean) = {
+      event.getType match {
+        case Type.CACHE_ENTRY_CREATED =>
+          (CacheEntryCreatedEventResponse, event.asInstanceOf[CacheEntryCreatedEvent[_, _]].isCommandRetried)
+        case Type.CACHE_ENTRY_MODIFIED =>
+          (CacheEntryModifiedEventResponse, event.asInstanceOf[CacheEntryModifiedEvent[_, _]].isCommandRetried)
+        case Type.CACHE_ENTRY_REMOVED =>
+          (CacheEntryRemovedEventResponse, event.asInstanceOf[CacheEntryRemovedEvent[_, _]].isCommandRetried)
+        case Type.CACHE_ENTRY_EXPIRED =>
+          (CacheEntryExpiredEventResponse, false)
+        case _ => throw unexpectedEvent(event)
+      }
+    }
+
+    private def keyWithVersionEvent(key: Bytes, dataVersion: Long, op: OperationResponse, isRetried: Boolean): KeyWithVersionEvent = {
+      KeyWithVersionEvent(version, messageId.get(), op, listenerId, isRetried, key, dataVersion)
+    }
+
+  }
+
+}

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Constants.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Constants.scala
@@ -20,6 +20,7 @@ trait Constants {
    val VERSION_23: Byte = 23
    val VERSION_24: Byte = 24
    val VERSION_25: Byte = 25
+   val VERSION_26: Byte = 26
    val DEFAULT_CONSISTENT_HASH_VERSION_1x: Byte = 2
    val DEFAULT_CONSISTENT_HASH_VERSION: Byte = 3
 
@@ -38,7 +39,7 @@ object Constants extends Constants {
    def isVersion12(v: Byte): Boolean = v == VERSION_12
    def isVersion13(v: Byte): Boolean = v == VERSION_13
    def isVersion1x(v: Byte): Boolean = v >= VERSION_10 && v <= VERSION_13
-   def isVersion2x(v: Byte): Boolean = v >= VERSION_20 && v <= VERSION_25
+   def isVersion2x(v: Byte): Boolean = v >= VERSION_20 && v <= VERSION_26
    def isVersionKnown(v: Byte): Boolean = isVersion1x(v) || isVersion2x(v)
 
    /**
@@ -54,9 +55,10 @@ object Constants extends Constants {
    /**
     * Is version previous post, and not including, 2.0?
     */
-   def isVersionPost20(v: Byte): Boolean = v >= VERSION_21 && v <= VERSION_25
+   def isVersionPost20(v: Byte): Boolean = v >= VERSION_21 && v <= VERSION_26
 
    def isVersionPost24(v: Byte) = v > VERSION_24
 
+   def isVersionPost25(v: Byte) = v > VERSION_25
 
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
@@ -206,9 +206,14 @@ object Decoder2x extends AbstractVersionedDecoder with Log with Constants {
                   case ver if Constants.isVersion2x(ver) => readMaybeByte(buffer).map(b => b == 1)
                   case _ => Some(false)
                }
+               listenerInterests <- h.version match {
+                  case ver if Constants.isVersionPost25(ver) => readMaybeByte(buffer)
+                  case _ => Some(0.toByte)
+               }
             } yield {
                execCtx.converterFactoryInfo = converter
                execCtx.useRawData = useRawData
+               execCtx.listenerInterests = listenerInterests
 
                buffer.markReaderIndex()
                out.add(hrCtx)
@@ -498,4 +503,5 @@ class ClientListenerRequestContext(val listenerId: Bytes, val includeCurrentStat
    var filterFactoryInfo: NamedFactory = _
    var converterFactoryInfo: NamedFactory = _
    var useRawData: Boolean = _
+   var listenerInterests: Byte = 0
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7283

This is an unpolished preview PR, please bear that in mind when reviewing.

To understand this initial solution, it's important to understand that I started by thinking this was just a problem of server/hotrod, where we were not being as fine grained as possible WRT client interests. So, I started by adding those listener interests to the Hot Rod protocol with a single byte, so that requires a HR protocol change. Then in server, I went for the tedious option of having multiple listener impls depending on which annotation combo I was interested. I knew this wouldn't scale very well if more listener events were added in the future, but I just wanted to get something going...

Then, I realised that this was enough because the cluster listener is installed around, RemoteClusterListener, listens for everything. So, not only the changes in server/hotrod were needed, but core needed changing too.

So, then I started looking into how I could have listener class but have a way to define which, of all the annotations present in that class, I was interested in registering the listener for. This led to the creation of `addFilteredListener` method. I think this is the best concept going forward, rather than having to create N possible listener classes depending on which annotations we're interested in. This of course means that a lot of the new code in server/hotrod can probably go if I can simply call `addFilteredListener` from there.

So, if everyone agrees with my approach, a key aspect here is defining where and how this method to add filtered listener should look like. Right now it looks like this:

```
   /**
    * Add a listener limiting cache entry specific callbacks only to those
    * annotations that are present in the annotation filter collection.
    */
   <C> void addFilteredListener(Object listener,
         CacheEventFilter<? super K, ? super V> filter,
         CacheEventConverter<? super K, ? super V, C> converter,
         Set<Class<? extends Annotation>> filterAnnotations);
```

So, the API is slightly clunky right now because those filter annotations can only filter `CacheEntryCreated`, `CacheEntryModified`, `CacheEntryExpired` and `CacheEntryRemoved` annotations. So, what this means if a listener has methods with all these four annotations, and I pass a filterAnnotation containing `CacheEntryCreated` and `CacheEntryModified`, then it will only listen for those. However, a key aspect here is that if the listener had other non cache-entry specific callbacks, e.g. `ViewChanged` or `TransactionCompleted`, I wanted to live those still there (this was actually needed to get `RemoteClusterListener` to work properly).

If anyone has other ideas of how this API should look like I'd love to hear. Also, to be able to easily consume this API from server/hotrod, it might be better if it lived in `FilteringListenable`. Would users find this API useful? Otherwise, `CacheNotifier` instance can always be retrieved via `AdvancedCache.getComponentRegistry(...)`.

Finally, fixes in `CacheNotifierImpl` and `AbstractListenerImpl` contain a lot of code duplication which would need to be sorted out. The code is a bit messy in these classes and in the end, having tried multiple things and debugged odd behaviours, I found the safest thing to do but was to copy/paste some methods and adjust them. Not great :|