### PR TITLE
Add quickstarts classes to whitelist of ExternallyMarshalable

### DIFF
--- a/core/src/main/java/org/infinispan/marshall/core/ExternallyMarshallable.java
+++ b/core/src/main/java/org/infinispan/marshall/core/ExternallyMarshallable.java
@@ -72,6 +72,7 @@ final class ExternallyMarshallable {
             || className.startsWith("org.infinispan.server.test") // test
             || className.startsWith("org.infinispan.it") // test
             || className.startsWith("org.infinispan.all") // test
+            || className.contains("org.jboss.as.quickstarts.datagrid") // quickstarts testing
             ;
    }
 


### PR DESCRIPTION
We have Selenium tests for quickstarts, which are started via maven-surefire-plugin, which enables assertions. Due to this, the assert fails on simple quickstart classes. In order not to complicate quickstarts with ExternalPojo or anything other configuration, I'm adding this package to whitelist.