### PR TITLE
ISPN-7283 Make cluster and client listeners more fine grained

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/event/ClientListenerNotifier.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/event/ClientListenerNotifier.java
@@ -166,7 +166,7 @@ public class ClientListenerNotifier {
       return null;
    }
 
-   private Map<Class<? extends Annotation>, List<ClientListenerInvocation>> findMethods(Object listener) {
+   public Map<Class<? extends Annotation>, List<ClientListenerInvocation>> findMethods(Object listener) {
       Map<Class<? extends Annotation>, List<ClientListenerInvocation>> listenerMethodMap =
             new HashMap<Class<? extends Annotation>, List<ClientListenerInvocation>>(4, 0.99f);
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
@@ -52,6 +52,7 @@ public class ConfigurationProperties {
    public static final int DEFAULT_SO_TIMEOUT = 60000;
    public static final int DEFAULT_CONNECT_TIMEOUT = 60000;
    public static final int DEFAULT_MAX_RETRIES = 10;
+   public static final String PROTOCOL_VERSION_26 = "2.6";
    public static final String PROTOCOL_VERSION_25 = "2.5";
    public static final String PROTOCOL_VERSION_24 = "2.4";
    public static final String PROTOCOL_VERSION_23 = "2.3";
@@ -62,7 +63,7 @@ public class ConfigurationProperties {
    public static final String PROTOCOL_VERSION_12 = "1.2";
    public static final String PROTOCOL_VERSION_11 = "1.1";
    public static final String PROTOCOL_VERSION_10 = "1.0";
-   public static final String DEFAULT_PROTOCOL_VERSION = PROTOCOL_VERSION_25;
+   public static final String DEFAULT_PROTOCOL_VERSION = PROTOCOL_VERSION_26;
 
    private final TypedProperties props;
 

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AddClientListenerOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AddClientListenerOperation.java
@@ -86,6 +86,7 @@ public class AddClientListenerOperation extends RetryOnFailureOperation<Short> {
       HeaderParams params = writeHeader(transport, ADD_CLIENT_LISTENER_REQUEST);
       transport.writeArray(listenerId);
       codec.writeClientListenerParams(transport, clientListener, filterFactoryParams, converterFactoryParams);
+      codec.writeClientListenerInterests(transport, listenerNotifier.findMethods(this.listener).keySet());
       transport.flush();
 
       listenerNotifier.addClientListener(this);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
@@ -1,5 +1,7 @@
 package org.infinispan.client.hotrod.impl.protocol;
 
+import java.lang.annotation.Annotation;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.client.hotrod.annotation.ClientListener;
@@ -55,4 +57,6 @@ public interface Codec {
     * Read and unmarshall byte array.
     */
    <T> T readUnmarshallByteArray(Transport transport, short status);
+
+   void writeClientListenerInterests(Transport transport, Set<Class<? extends Annotation>> classes);
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
@@ -2,6 +2,7 @@ package org.infinispan.client.hotrod.impl.protocol;
 
 import static org.infinispan.commons.util.Util.hexDump;
 
+import java.lang.annotation.Annotation;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.HashSet;
@@ -164,6 +165,11 @@ public class Codec10 implements Codec {
    @Override
    public <T> T readUnmarshallByteArray(Transport transport, short status) {
       return CodecUtils.readUnmarshallByteArray(transport, status);
+   }
+
+   @Override
+   public void writeClientListenerInterests(Transport transport, Set<Class<? extends Annotation>> classes) {
+      // No-op
    }
 
    protected void checkForErrorsInResponseStatus(Transport transport, HeaderParams params, short status) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
@@ -18,11 +18,13 @@ import org.infinispan.client.hotrod.marshall.MarshallerUtil;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.Either;
 
+import java.lang.annotation.Annotation;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -46,6 +48,11 @@ public class Codec20 implements Codec, HotRodConstants {
    @Override
    public <T> T readUnmarshallByteArray(Transport transport, short status) {
       return CodecUtils.readUnmarshallByteArray(transport, status);
+   }
+
+   @Override
+   public void writeClientListenerInterests(Transport transport, Set<Class<? extends Annotation>> classes) {
+      // No-op
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec26.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec26.java
@@ -1,0 +1,37 @@
+package org.infinispan.client.hotrod.impl.protocol;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryExpired;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryModified;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryRemoved;
+import org.infinispan.client.hotrod.impl.transport.Transport;
+
+/**
+ * @since 8.2
+ */
+public class Codec26 extends Codec25 {
+
+   @Override
+   public HeaderParams writeHeader(Transport transport, HeaderParams params) {
+      return writeHeader(transport, params, HotRodConstants.VERSION_26);
+   }
+
+   @Override
+   public void writeClientListenerInterests(Transport transport, Set<Class<? extends Annotation>> classes) {
+      byte listenerInterests = 0;
+      if (classes.contains(ClientCacheEntryCreated.class))
+         listenerInterests = (byte) (listenerInterests | 0x01);
+      if (classes.contains(ClientCacheEntryModified.class))
+         listenerInterests = (byte) (listenerInterests | 0x02);
+      if (classes.contains(ClientCacheEntryRemoved.class))
+         listenerInterests = (byte) (listenerInterests | 0x04);
+      if (classes.contains(ClientCacheEntryExpired.class))
+         listenerInterests = (byte) (listenerInterests | 0x08);
+
+      transport.writeVInt(listenerInterests);
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/CodecFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/CodecFactory.java
@@ -13,6 +13,7 @@ import static org.infinispan.client.hotrod.impl.ConfigurationProperties.PROTOCOL
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.PROTOCOL_VERSION_23;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.PROTOCOL_VERSION_24;
 import static org.infinispan.client.hotrod.impl.ConfigurationProperties.PROTOCOL_VERSION_25;
+import static org.infinispan.client.hotrod.impl.ConfigurationProperties.PROTOCOL_VERSION_26;
 
 /**
  * Code factory.
@@ -33,6 +34,7 @@ public class CodecFactory {
    private static final Codec CODEC_23 = new Codec23();
    private static final Codec CODEC_24 = new Codec24();
    private static final Codec CODEC_25 = new Codec25();
+   private static final Codec CODEC_26 = new Codec26();
 
    static {
       codecMap = new HashMap<String, Codec>();
@@ -46,6 +48,7 @@ public class CodecFactory {
       codecMap.put(PROTOCOL_VERSION_23, CODEC_23);
       codecMap.put(PROTOCOL_VERSION_24, CODEC_24);
       codecMap.put(PROTOCOL_VERSION_25, CODEC_25);
+      codecMap.put(PROTOCOL_VERSION_26, CODEC_26);
    }
 
    public static boolean isVersionDefined(String version) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HotRodConstants.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HotRodConstants.java
@@ -23,6 +23,7 @@ public interface HotRodConstants {
    static final byte VERSION_23 = 23;
    static final byte VERSION_24 = 24;
    static final byte VERSION_25 = 25;
+   static final byte VERSION_26 = 26;
 
    //requests
    static final byte PUT_REQUEST = 0x01;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/ClusterClientEventStressTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/ClusterClientEventStressTest.java
@@ -1,0 +1,285 @@
+package org.infinispan.client.hotrod.stress;
+
+import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.toBytes;
+import static org.infinispan.distribution.DistributionTestHelper.isFirstOwner;
+import static org.infinispan.distribution.DistributionTestHelper.isOwner;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.infinispan.Cache;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryModified;
+import org.infinispan.client.hotrod.annotation.ClientListener;
+import org.infinispan.client.hotrod.event.ClientEvent;
+import org.infinispan.client.hotrod.logging.Log;
+import org.infinispan.client.hotrod.logging.LogFactory;
+import org.infinispan.client.hotrod.test.InternalRemoteCacheManager;
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.util.concurrent.ConcurrentHashSet;
+import org.testng.annotations.Test;
+
+@Test(groups = "stress", testName = "client.hotrod.event.ClusterClientEventStressTest")
+public class ClusterClientEventStressTest extends MultiHotRodServersTest {
+
+   private static final Log log = LogFactory.getLog(ClusterClientEventStressTest.class);
+
+   static final int NUM_SERVERS = 3;
+   static final int NUM_OWNERS = 2;
+
+   static final int NUM_CLIENTS = 1;
+   static final int NUM_THREADS_PER_CLIENT = 6;
+//   static final int NUM_THREADS_PER_CLIENT = 36;
+
+   static final int NUM_OPERATIONS = 1_000; // per thread, per client
+//   static final int NUM_OPERATIONS = 300; // per thread, per client
+//   static final int NUM_OPERATIONS = 600; // per thread, per client
+
+   static final int NUM_EVENTS = NUM_OPERATIONS * NUM_THREADS_PER_CLIENT * NUM_CLIENTS * NUM_CLIENTS;
+
+//   public static final int NUM_STORES = NUM_OPERATIONS * NUM_CLIENTS * NUM_THREADS_PER_CLIENT;
+//   public static final int NUM_STORES_PER_SERVER = NUM_STORES / NUM_SERVERS;
+//   public static final int NUM_ENTRIES_PER_SERVER = (NUM_STORES * NUM_OWNERS) / NUM_SERVERS;
+
+   static Set<String> ALL_KEYS = new ConcurrentHashSet<>();
+
+   static ExecutorService EXEC = Executors.newCachedThreadPool();
+
+   static ClientEntryListener listener;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createHotRodServers(NUM_SERVERS, getCacheConfiguration());
+   }
+
+   private ConfigurationBuilder getCacheConfiguration() {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      builder.clustering().hash().numOwners(NUM_OWNERS)
+//            .expiration().lifespan(1000).maxIdle(1000).wakeUpInterval(5000)
+            .expiration().maxIdle(1000).wakeUpInterval(5000)
+            .jmxStatistics().enable();
+      return hotRodCacheConfiguration(builder);
+   }
+
+   RemoteCacheManager getRemoteCacheManager(int port) {
+      org.infinispan.client.hotrod.configuration.ConfigurationBuilder builder =
+            new org.infinispan.client.hotrod.configuration.ConfigurationBuilder();
+      builder.addServer().host("127.0.0.1").port(port);
+      RemoteCacheManager rcm = new InternalRemoteCacheManager(builder.build());
+      rcm.getCache();
+      return rcm;
+   }
+
+   Map<String, RemoteCacheManager> createClients() {
+      Map<String, RemoteCacheManager> remotecms = new HashMap<>(NUM_CLIENTS);
+      for (int i = 0; i < NUM_CLIENTS; i++)
+         remotecms.put("c" + i, getRemoteCacheManager(server(0).getPort()));
+
+      return remotecms;
+   }
+
+   public void testAddClientListenerDuringOperations() {
+      CyclicBarrier barrier = new CyclicBarrier((NUM_CLIENTS * NUM_THREADS_PER_CLIENT) + 1);
+      List<Future<Void>> futures = new ArrayList<>(NUM_CLIENTS * NUM_THREADS_PER_CLIENT);
+      List<ClientEntryListener> listeners = new ArrayList<>(NUM_CLIENTS);
+      Map<String, RemoteCacheManager> remotecms = createClients();
+
+//      assertStatsBefore(remotecms);
+
+      for (Entry<String, RemoteCacheManager> e : remotecms.entrySet()) {
+         RemoteCache<String, String> remote = e.getValue().getCache();
+
+//         ClientEntryListener listener = new ClientEntryListener();
+//         listeners.add(listener);
+//         remote.addClientListener(listener);
+
+         for (int i = 0; i < NUM_THREADS_PER_CLIENT; i++) {
+            String prefix = String.format("%s-t%d-", e.getKey(), i);
+            Callable<Void> call = new Put(prefix, barrier, remote, servers);
+            futures.add(EXEC.submit(call));
+         }
+      }
+
+      barrierAwait(barrier); // wait for all threads to be ready
+      barrierAwait(barrier); // wait for all threads to finish
+
+      for (Future<Void> f : futures)
+         futureGet(f);
+
+//      log.debugf("Put operations completed, assert statistics");
+//      assertStatsAfter(remotecms);
+
+//      log.debugf("Stats asserted, wait for events...");
+//      eventuallyEquals(NUM_EVENTS, () -> countEvents(listeners));
+   }
+
+   int countEvents(List<ClientEntryListener> listeners) {
+      Integer count = listeners.stream().reduce(0, (acc, l) -> acc + l.count.get(), (x, y) -> x + y);
+      log.infof("Event count is %d, target %d%n", (int) count, NUM_EVENTS);
+      return count;
+   }
+
+//   void assertStatsBefore(Map<String, RemoteCacheManager> remotecms) {
+//      RemoteCacheManager client = remotecms.values().iterator().next();
+//      IntStream.range(0, NUM_SERVERS)
+//            .forEach(x -> {
+//               ServerStatistics stat = client.getCache().stats();
+//               assertEquals(0, stat.getIntStatistic(STORES).intValue());
+//               assertEquals(0, stat.getIntStatistic(CURRENT_NR_OF_ENTRIES).intValue());
+//            });
+//   }
+//
+//   void assertStatsAfter(Map<String, RemoteCacheManager> remotecms) {
+//      RemoteCacheManager client = remotecms.values().iterator().next();
+//      IntStream.range(0, NUM_SERVERS)
+//            .forEach(x -> {
+//               ServerStatistics stat = client.getCache().stats();
+//               int stores = stat.getIntStatistic(STORES);
+//               System.out.println("Number of stores: " + stores);
+//               assertEquals(NUM_STORES_PER_SERVER, stores);
+//               int entries = stat.getIntStatistic(CURRENT_NR_OF_ENTRIES);
+//               assertEquals(NUM_ENTRIES_PER_SERVER, entries);
+//            });
+//   }
+
+   static class Put implements Callable<Void> {
+      static final ThreadLocalRandom R = ThreadLocalRandom.current();
+
+      final CyclicBarrier barrier;
+      final RemoteCache<String, String> remote;
+      final List<HotRodServer> servers;
+      final List<String> keys;
+
+      public Put(String prefix, CyclicBarrier barrier,
+            RemoteCache<String, String> remote, List<HotRodServer> servers) {
+         this.barrier = barrier;
+         this.remote = remote;
+         this.servers = servers;
+         this.keys = generateKeys(prefix, servers, R);
+         Collections.shuffle(this.keys);
+      }
+
+      @Override
+      public Void call() throws Exception {
+         barrierAwait(barrier);
+         try {
+            for (int i = 0; i < NUM_OPERATIONS; i++) {
+               String value = keys.get(i);
+               remote.put(value, value);
+               if (value.startsWith("c0-t0") && i == (NUM_OPERATIONS / 2)) {
+                  listener = new ClientEntryListener();
+                  remote.addClientListener(listener);
+               }
+            }
+            return null;
+         } finally {
+            barrierAwait(barrier);
+         }
+      }
+   }
+
+   static List<String> generateKeys(String prefix, List<HotRodServer> servers, ThreadLocalRandom r) {
+      List<String> keys = new ArrayList<>();
+      List<HotRodServer[]> combos = Arrays.asList(
+            new HotRodServer[]{servers.get(0), servers.get(1)},
+            new HotRodServer[]{servers.get(1), servers.get(0)},
+            new HotRodServer[]{servers.get(1), servers.get(2)},
+            new HotRodServer[]{servers.get(2), servers.get(1)},
+            new HotRodServer[]{servers.get(2), servers.get(0)},
+            new HotRodServer[]{servers.get(0), servers.get(2)}
+      );
+
+      for (int i = 0; i < NUM_OPERATIONS; i++) {
+         HotRodServer[] owners = combos.get(i % combos.size());
+         String key = getStringKey(prefix, owners, r);
+         if (ALL_KEYS.contains(key))
+            throw new AssertionError("Key already in use: " + key);
+
+         keys.add(key);
+         ALL_KEYS.add(key);
+      }
+      return keys;
+   }
+
+   static String getStringKey(String prefix, HotRodServer[] owners, ThreadLocalRandom r) {
+      Cache<?, ?> firstOwnerCache = owners[0].getCacheManager().getCache();
+      Cache<?, ?> otherOwnerCache = owners[1].getCacheManager().getCache();
+
+//      Random r = new Random();
+      byte[] dummy;
+      String dummyKey;
+      int attemptsLeft = 1000;
+      do {
+         Integer dummyInt = r.nextInt();
+         dummyKey = prefix + dummyInt;
+         dummy = toBytes(dummyKey);
+         attemptsLeft--;
+      } while (!(isFirstOwner(firstOwnerCache, dummy) && isOwner(otherOwnerCache, dummy))
+            && attemptsLeft >= 0);
+
+      if (attemptsLeft < 0)
+         throw new IllegalStateException("Could not find any key owned by "
+               + firstOwnerCache + " as primary owner and "
+               + otherOwnerCache + " as secondary owner");
+
+      log.infof("Integer key %s hashes to primary [cluster=%s,hotrod=%s] and secondary [cluster=%s,hotrod=%s]",
+            dummyKey,
+            firstOwnerCache.getCacheManager().getAddress(), owners[0].getAddress(),
+            otherOwnerCache.getCacheManager().getAddress(), owners[1].getAddress());
+
+      return dummyKey;
+   }
+
+   static int barrierAwait(CyclicBarrier barrier) {
+      try {
+         return barrier.await();
+      } catch (InterruptedException | BrokenBarrierException e) {
+         throw new AssertionError(e);
+      }
+   }
+
+   static <T> T futureGet(Future<T> future) {
+      try {
+         return future.get();
+      } catch (InterruptedException | ExecutionException e) {
+         throw new AssertionError(e);
+      }
+   }
+
+   @ClientListener
+   static class ClientEntryListener {
+      final AtomicInteger count = new AtomicInteger();
+
+      @ClientCacheEntryCreated
+      @ClientCacheEntryModified
+      @SuppressWarnings("unused")
+      public void handleClientEvent(ClientEvent event) {
+         int countSoFar;
+         if ((countSoFar = count.incrementAndGet()) % 100 == 0) {
+            log.debugf("Reached %s", countSoFar);
+         }
+      }
+   }
+
+}

--- a/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingCache.java
@@ -11,6 +11,7 @@ import org.infinispan.commons.util.concurrent.NotifyingFuture;
 import org.infinispan.notifications.cachelistener.filter.CacheEventConverter;
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilter;
 
+import java.lang.annotation.Annotation;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -355,6 +356,13 @@ public abstract class AbstractDelegatingCache<K, V> implements Cache<K, V> {
    @Override
    public Set<Object> getListeners() {
       return cache.getListeners();
+   }
+
+   @Override
+   public <C> void addFilteredListener(Object listener,
+         CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter,
+         Set<Class<? extends Annotation>> filterAnnotations) {
+      cache.addFilteredListener(listener, filter, converter, filterAnnotations);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -93,6 +93,7 @@ import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAResource;
 
+import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -735,6 +736,13 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    @Override
    public Set<Object> getListeners() {
       return notifier.getListeners();
+   }
+
+   @Override
+   public <C> void addFilteredListener(Object listener,
+         CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter,
+         Set<Class<? extends Annotation>> filterAnnotations) {
+      notifier.addFilteredListener(listener, filter, converter, filterAnnotations);
    }
 
    private InvocationContext getInvocationContextForWrite(ClassLoader explicitClassLoader, int keyCount, boolean isPutForExternalRead) {

--- a/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
@@ -894,6 +894,16 @@ public class SimpleCacheImpl<K, V> implements AdvancedCache<K, V> {
       return cacheNotifier.getListeners();
    }
 
+   @Override
+   public <C> void addFilteredListener(Object listener,
+         CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter,
+         Set<Class<? extends Annotation>> filterAnnotations) {
+      cacheNotifier.addFilteredListener(listener, filter, converter, filterAnnotations);
+      if (!hasListeners && canFire(listener)) {
+         hasListeners = true;
+      }
+   }
+
    private boolean canFire(Object listener) {
       for (Method m : listener.getClass().getMethods()) {
          for (Class<? extends Annotation> annotation : FIRED_EVENTS) {

--- a/core/src/main/java/org/infinispan/notifications/FilteringListenable.java
+++ b/core/src/main/java/org/infinispan/notifications/FilteringListenable.java
@@ -1,6 +1,13 @@
 package org.infinispan.notifications;
 
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
 import org.infinispan.filter.KeyFilter;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryExpired;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
 import org.infinispan.notifications.cachelistener.filter.CacheEventConverter;
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilter;
 
@@ -38,4 +45,32 @@ public interface FilteringListenable<K, V> extends Listenable {
     * @throws NullPointerException if the specified listener is null
     */
    <C> void addListener(Object listener, CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter);
+
+   /**
+    * Registers a listener limiting the cache-entry specific events only to
+    * annotations that are passed in as parameter.
+    * <p/>
+    * For example, if the listener passed in contains callbacks for
+    * {@link CacheEntryCreated} and {@link CacheEntryModified},
+    * and filtered annotations contains only {@link CacheEntryCreated},
+    * then the listener will be registered only for {@link CacheEntryCreated}
+    * callbacks.
+    * <p/>
+    * Callback filtering only applies to {@link CacheEntryCreated},
+    * {@link CacheEntryModified}, {@link CacheEntryRemoved}
+    * and {@link CacheEntryExpired} annotations.
+    * If the listener contains other annotations, these are preserved.
+    * <p/>
+    * This methods enables dynamic registration of listener interests at
+    * runtime without the need to create several different listener classes.
+    *
+    * @param listener The listener to callback upon event notifications.  Must not be null.
+    * @param filter The filter to see if the notification should be sent to the listener.  Can be null.
+    * @param converter The converter to apply to the entry before being sent to the listener.  Can be null.
+    * @param filterAnnotations cache-entry annotations to allow listener to be registered on. Must not be null.
+    * @param <C> The type of the resultant value after being converted
+    */
+   <C> void addFilteredListener(Object listener, CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter,
+         Set<Class<? extends Annotation>> filterAnnotations);
+
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheEntryListenerInvocation.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheEntryListenerInvocation.java
@@ -1,6 +1,7 @@
 package org.infinispan.notifications.cachelistener;
 
 import java.lang.annotation.Annotation;
+import java.util.Set;
 import java.util.UUID;
 
 import org.infinispan.notifications.Listener;
@@ -34,4 +35,6 @@ public interface CacheEntryListenerInvocation<K, V> extends ListenerInvocation<E
    CacheEventFilter<? super K, ? super V> getFilter();
 
    <C> CacheEventConverter<? super K, ? super V, C> getConverter();
+
+   Set<Class<? extends Annotation>> getFilterAnnotations();
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplicateCallable.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplicateCallable.java
@@ -2,6 +2,7 @@ package org.infinispan.notifications.cachelistener.cluster;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.commons.util.Util;
 import org.infinispan.distexec.DistributedCallable;
 import org.infinispan.distexec.DistributedExecutorService;
@@ -20,6 +21,8 @@ import org.infinispan.util.logging.LogFactory;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -47,14 +50,19 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
    private final CacheEventConverter<K, V, ?> converter;
    private final Address origin;
    private final boolean sync;
+   private final Set<Class<? extends Annotation>> filterAnnotations;
 
    public ClusterListenerReplicateCallable(UUID identifier, Address origin, CacheEventFilter<K, V> filter,
-                                           CacheEventConverter<K, V, ?> converter, boolean sync) {
+                                           CacheEventConverter<K, V, ?> converter, boolean sync,
+                                           Set<Class<? extends Annotation>> filterAnnotations) {
       this.identifier = identifier;
       this.origin = origin;
       this.filter = filter;
       this.converter = converter;
       this.sync = sync;
+      this.filterAnnotations = filterAnnotations;
+      if (trace)
+         log.tracef("Created clustered listener replicate callable for: %s", filterAnnotations);
    }
 
    @Override
@@ -96,7 +104,7 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
                if (!alreadyInstalled) {
                   RemoteClusterListener listener = new RemoteClusterListener(identifier, origin, distExecutor, cacheNotifier,
                                                                              cacheManagerNotifier, eventManager, sync);
-                  cacheNotifier.addListener(listener, filter, converter);
+                  cacheNotifier.addFilteredListener(listener, filter, converter, filterAnnotations);
                   cacheManagerNotifier.addListener(listener);
                   // It is possible the member is now gone after registered, if so we have to remove just to be sure
                   if (!cacheManager.getMembers().contains(origin)) {
@@ -142,6 +150,7 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
             output.writeObject(object.converter);
          }
          output.writeBoolean(object.sync);
+         MarshallUtil.marshallCollection(object.filterAnnotations, output);
       }
 
       @Override
@@ -157,7 +166,8 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
             converter = (CacheEventConverter)input.readObject();
          }
          boolean sync = input.readBoolean();
-         return new ClusterListenerReplicateCallable(id, address, filter, converter, sync);
+         Set<Class<? extends Annotation>> listenerAnnots = MarshallUtil.unmarshallCollection(input, HashSet::new);
+         return new ClusterListenerReplicateCallable(id, address, filter, converter, sync, listenerAnnots);
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/filter/DelegatingCacheEntryListenerInvocation.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/filter/DelegatingCacheEntryListenerInvocation.java
@@ -6,6 +6,7 @@ import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
 import org.infinispan.notifications.cachelistener.event.Event;
 
 import java.lang.annotation.Annotation;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -84,5 +85,10 @@ public abstract class DelegatingCacheEntryListenerInvocation<K, V> implements Ca
    @Override
    public <C> CacheEventConverter<? super K, ? super V, C> getConverter() {
       return invocation.getConverter();
+   }
+
+   @Override
+   public Set<Class<? extends Annotation>> getFilterAnnotations() {
+      return invocation.getFilterAnnotations();
    }
 }

--- a/core/src/main/java/org/infinispan/notifications/impl/AbstractListenerImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/impl/AbstractListenerImpl.java
@@ -1,21 +1,5 @@
 package org.infinispan.notifications.impl;
 
-import org.infinispan.commons.CacheException;
-import org.infinispan.commons.util.ReflectionUtil;
-import org.infinispan.factories.KnownComponentNames;
-import org.infinispan.factories.annotations.ComponentName;
-import org.infinispan.factories.annotations.Inject;
-import org.infinispan.factories.annotations.Start;
-import org.infinispan.factories.annotations.Stop;
-import org.infinispan.notifications.IncorrectListenerException;
-import org.infinispan.notifications.Listener;
-import org.infinispan.security.Security;
-import org.infinispan.util.concurrent.WithinThreadExecutor;
-import org.infinispan.util.logging.Log;
-
-import javax.security.auth.Subject;
-import javax.transaction.Transaction;
-
 import java.lang.annotation.Annotation;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
@@ -32,6 +16,27 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
+import javax.security.auth.Subject;
+import javax.transaction.Transaction;
+
+import org.infinispan.commons.CacheException;
+import org.infinispan.commons.util.ReflectionUtil;
+import org.infinispan.factories.KnownComponentNames;
+import org.infinispan.factories.annotations.ComponentName;
+import org.infinispan.factories.annotations.Inject;
+import org.infinispan.factories.annotations.Start;
+import org.infinispan.factories.annotations.Stop;
+import org.infinispan.notifications.IncorrectListenerException;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryExpired;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
+import org.infinispan.security.Security;
+import org.infinispan.util.concurrent.WithinThreadExecutor;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
 /**
  * Functionality common to both {@link org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifierImpl} and
  * {@link org.infinispan.notifications.cachelistener.CacheNotifierImpl}
@@ -41,6 +46,9 @@ import java.util.concurrent.ExecutorService;
  * @author William Burns
  */
 public abstract class AbstractListenerImpl<T, L extends ListenerInvocation<T>> {
+
+   private static final Log log = LogFactory.getLog(AbstractListenerImpl.class);
+   private static final boolean trace = log.isTraceEnabled();
 
    protected final Map<Class<? extends Annotation>, List<L>> listenersMap = new HashMap<>(16, 0.99f);
 
@@ -207,6 +215,10 @@ public abstract class AbstractListenerImpl<T, L extends ListenerInvocation<T>> {
                   builder.setMethod(m);
                   builder.setAnnotation(annotationClass);
                   L invocation = builder.build();
+
+                  if (trace)
+                     log.tracef("Add listener invocation %s for %s", invocation, annotationClass);
+
                   getListenerCollectionForAnnotation(annotationClass).add(invocation);
                   foundMethods = true;
                }
@@ -217,6 +229,93 @@ public abstract class AbstractListenerImpl<T, L extends ListenerInvocation<T>> {
       if (!foundMethods)
          getLog().noAnnotateMethodsFoundInListener(listener.getClass());
       return foundMethods;
+   }
+
+   protected boolean validateAndAddFilterListenerInvocations(Object listener,
+         AbstractInvocationBuilder builder, Set<Class<? extends Annotation>> filterAnnotations) {
+      Listener l = testListenerClassValidity(listener.getClass());
+      boolean foundMethods = false;
+      builder.setTarget(listener);
+      builder.setSubject(Security.getSubject());
+      builder.setSync(l.sync());
+      Map<Class<? extends Annotation>, Class<?>> allowedListeners = getAllowedMethodAnnotations(l);
+      // now try all methods on the listener for anything that we like.  Note that only PUBLIC methods are scanned.
+      for (Method m : listener.getClass().getMethods()) {
+         // Skip bridge methods as we don't want to count them as well.
+         if (!m.isSynthetic() || !m.isBridge()) {
+            // loop through all valid method annotations
+            for (Map.Entry<Class<? extends Annotation>, Class<?>> annotationEntry : allowedListeners.entrySet()) {
+               final Class<? extends Annotation> annotationClass = annotationEntry.getKey();
+               if (m.isAnnotationPresent(annotationClass) && canApply(filterAnnotations, annotationClass)) {
+                  final Class<?> eventClass = annotationEntry.getValue();
+                  testListenerMethodValidity(m, eventClass, annotationClass.getName());
+
+                  if (System.getSecurityManager() == null) {
+                     m.setAccessible(true);
+                  } else {
+                     AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                        m.setAccessible(true);
+                        return null;
+                     });
+                  }
+
+                  builder.setMethod(m);
+                  builder.setAnnotation(annotationClass);
+                  L invocation = builder.build();
+                  if (trace)
+                     log.tracef("Add listener invocation %s for %s", invocation, annotationClass);
+
+                  getListenerCollectionForAnnotation(annotationClass).add(invocation);
+                  foundMethods = true;
+               }
+            }
+         }
+      }
+
+      if (!foundMethods)
+         getLog().noAnnotateMethodsFoundInListener(listener.getClass());
+      return foundMethods;
+   }
+
+   public boolean canApply(Set<Class<? extends Annotation>> filterAnnotations, Class<? extends Annotation> annotationClass) {
+      // Annotations such ViewChange or TransactionCompleted should be applied regardless
+      return (annotationClass != CacheEntryCreated.class
+            && annotationClass != CacheEntryModified.class
+            && annotationClass != CacheEntryRemoved.class
+            && annotationClass != CacheEntryExpired.class)
+            || (filterAnnotations.contains(annotationClass));
+   }
+
+   protected Set<Class<? extends Annotation>> findListenerCallbacks(Object listener) {
+      // TODO: Partly duplicates validateAndAddListenerInvocations
+      Set<Class<? extends Annotation>> listenerInterests = new HashSet<>();
+      Listener l = testListenerClassValidity(listener.getClass());
+      Map<Class<? extends Annotation>, Class<?>> allowedListeners = getAllowedMethodAnnotations(l);
+      for (Method m : listener.getClass().getMethods()) {
+         // Skip bridge methods as we don't want to count them as well.
+         if (!m.isSynthetic() || !m.isBridge()) {
+            // loop through all valid method annotations
+            for (Map.Entry<Class<? extends Annotation>, Class<?>> annotationEntry : allowedListeners.entrySet()) {
+               final Class<? extends Annotation> annotationClass = annotationEntry.getKey();
+               if (m.isAnnotationPresent(annotationClass)) {
+                  final Class<?> eventClass = annotationEntry.getValue();
+                  testListenerMethodValidity(m, eventClass, annotationClass.getName());
+
+                  if (System.getSecurityManager() == null) {
+                     m.setAccessible(true);
+                  } else {
+                     AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                        m.setAccessible(true);
+                        return null;
+                     });
+                  }
+
+                  listenerInterests.add(annotationClass);
+               }
+            }
+         }
+      }
+      return listenerInterests;
    }
 
    /**

--- a/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
+++ b/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
@@ -1,5 +1,6 @@
 package org.infinispan.security.impl;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +86,14 @@ public final class SecureCacheImpl<K, V> implements SecureCache<K, V> {
    public void addListener(Object listener) {
       authzManager.checkPermission(AuthorizationPermission.LISTEN);
       delegate.addListener(listener);
+   }
+
+   @Override
+   public <C> void addFilteredListener(Object listener,
+         CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter,
+         Set<Class<? extends Annotation>> filterAnnotations) {
+      authzManager.checkPermission(AuthorizationPermission.LISTEN);
+      delegate.addFilteredListener(listener, filter, converter, filterAnnotations);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/functional/decorators/FunctionalAdvancedCache.java
+++ b/core/src/test/java/org/infinispan/functional/decorators/FunctionalAdvancedCache.java
@@ -45,6 +45,8 @@ import org.infinispan.util.concurrent.locks.LockManager;
 
 import javax.transaction.TransactionManager;
 import javax.transaction.xa.XAResource;
+
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -637,6 +639,13 @@ public final class FunctionalAdvancedCache<K, V> implements AdvancedCache<K, V> 
    @Override
    public Set<Object> getListeners() {
       return null;  // TODO: Customise this generated block
+   }
+
+   @Override
+   public <C> void addFilteredListener(Object listener,
+         CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter,
+         Set<Class<? extends Annotation>> filterAnnotations) {
+      // TODO: Customise this generated block
    }
 
    public static <T> T await(CompletableFuture<T> cf) {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
@@ -41,6 +41,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Matchers.any;
@@ -329,7 +330,7 @@ public abstract class AbstractClusterListenerUtilTest extends MultipleCacheManag
                checkPoint.awaitStrict("post_add_listener_release_" + cache, 10, TimeUnit.SECONDS);
             }
          }
-      }).when(mockNotifier).addListener(anyObject(), any(CacheEventFilter.class), any(CacheEventConverter.class));
+      }).when(mockNotifier).addFilteredListener(anyObject(), any(CacheEventFilter.class), any(CacheEventConverter.class), any(Set.class));
       TestingUtil.replaceComponent(cache, CacheNotifier.class, mockNotifier, true);
    }
 

--- a/documentation/src/main/asciidoc/user_guide/chapter-64-Hot_Rod_Protocol.adoc
+++ b/documentation/src/main/asciidoc/user_guide/chapter-64-Hot_Rod_Protocol.adoc
@@ -12,6 +12,7 @@ the custom TCP client/server Hot Rod protocol.
 * link:$$#_hot_rod_protocol_2_3$$[Hot Rod Protocol 2.3]
 * link:$$#_hot_rod_protocol_2_4$$[Hot Rod Protocol 2.4]
 * link:$$#_hot_rod_protocol_2_5$$[Hot Rod Protocol 2.5]
+* link:$$#_hot_rod_protocol_2_6$$[Hot Rod Protocol 2.6]
 
 ===== Hot Rod Protocol 1.0
 
@@ -1770,7 +1771,7 @@ returned:
 ===== Hot Rod Protocol 2.5
 
 .Infinispan versions
-TIP: This version of the protocol is implemented since Infinispan 8.2
+TIP: This version of the protocol is implemented since Infinispan 8.2.0
 
 This Hot Rod protocol version adds support for metadata retrieval along with entries in the iterator.
 It includes two changes:
@@ -1841,6 +1842,78 @@ maxIdle of the entry in seconds. This value is returned only if the flag's
 | Value 2 Length           | vInt       |
 | Value 2                  | byte array |
 |... continues until entry count is reached ||
+|==============================================================================
+
+===== Hot Rod Protocol 2.6
+
+.Infinispan versions
+TIP: This version of the protocol is implemented since Infinispan 8.2.6
+
+This Hot Rod protocol version improves remote listener registration by adding a byte that indicates at a global level, which type of events the client is interested in.
+For example, a client can indicate that only created events, or only expiration and removal events...etc.
+More fine grained event interests, e.g. per key, can be defined using the key/value filter parameter.
+
+So, the new add listener request looks like this:
+
+.Add client listener for remote events
+
+Request (0x25):
+
+[cols="3,^2,10",options="header"]
+|==============================================================================
+| Field Name          | Size       | Value
+| Header | variable | Request header
+| Listener ID   | byte array   | Listener identifier
+| Include state | byte         | When this byte is set to `1`, cached state is
+sent back to remote clients when either adding a cache listener for the first
+time, or when the node where a remote listener is registered changes in a clustered
+environment. When enabled, state is sent back as cache entry created events to
+the clients. If set to `0`, no state is sent back to the client when adding a listener,
+nor it gets state when the node where the listener is registered changes.
+| Key/value filter factory name | string | Optional name of the key/value filter
+factory to be used with this listener. The factory is used to create key/value
+filter instances which allow events to be filtered directly in the Hot Rod
+server, avoiding sending events that the client is not interested in. If no
+factory is to be used, the length of the string is `0`.
+| Key/value filter factory parameter count | byte | The key/value filter
+factory, when creating a filter instance, can take an arbitrary number of
+parameters, enabling the factory to be used to create different filter
+instances dynamically. This count field indicates how many parameters will be
+passed to the factory. If no factory name was provided, this field is not
+present in the request.
+| Key/value filter factory parameter 1 | byte array | First key/value filter
+factory parameter
+| Key/value filter factory parameter 2 | byte array | Second key/value filter
+factory parameter
+| ... | |
+| Converter factory name | string | Optional name of the converter
+factory to be used with this listener. The factory is used to transform the
+contents of the events sent to clients. By default, when no converter is in use,
+events are well defined, according to the type of event generated. However,
+there might be situations where users want to add extra information to the event,
+or they want to reduce the size of the events. In these cases, a converter can
+be used to transform the event contents. The given converter factory name
+produces converter instances to do this job. If no factory is to be used, the
+length of the string is `0`.
+| Converter factory parameter count | byte | The converter
+factory, when creating a converter instance, can take an arbitrary number of
+parameters, enabling the factory to be used to create different converter
+instances dynamically. This count field indicates how many parameters will be
+passed to the factory. If no factory name was provided, this field is not
+present in the request.
+| Converter factory parameter 1 | byte array | First converter factory parameter
+| Converter factory parameter 2 | byte array | Second converter factory parameter
+| ... | |
+| Listener even type interests  | vInt       |  A variable length number representing listener event type interests.
+Each event type is represented by a bit.
+Each flags is represented by a bit.
+Note that since this field is sent as variable length, the most significant bit in a byte is used to determine whether more bytes need to be read, hence this bit does not represent any flag.
+Using this model allows for flags to be combined in a short space.
+Here are the current values for each flag: +
++0x01+ = cache entry created events
++0x02+ = cache entry modified events
++0x04+ = cache entry removed events
++0x08+ = cache entry expired events
 |==============================================================================
 
 

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/BaseJPAFilterIndexingServiceProvider.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/BaseJPAFilterIndexingServiceProvider.java
@@ -32,6 +32,7 @@ import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -336,6 +337,11 @@ public abstract class BaseJPAFilterIndexingServiceProvider implements FilterInde
 
       @Override
       public <C> CacheEventConverter<? super K, ? super V, C> getConverter() {
+         return null;
+      }
+
+      @Override
+      public Set<Class<? extends Annotation>> getFilterAnnotations() {
          return null;
       }
    }

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/ContextHandler.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/ContextHandler.java
@@ -152,7 +152,7 @@ public class ContextHandler extends SimpleChannelInboundHandler<CacheDecodeConte
             ClientListenerRequestContext clientContext = (ClientListenerRequestContext) msg.operationDecodeContext();
             server.getClientListenerRegistry().addClientListener(msg.decoder(), ctx.channel(), h, clientContext.listenerId(),
                     msg.cache(), clientContext.includeCurrentState(), new Tuple2<>(clientContext.filterFactoryInfo(),
-                            clientContext.converterFactoryInfo()), clientContext.useRawData());
+                            clientContext.converterFactoryInfo()), clientContext.useRawData(), clientContext.listenerInterests());
             break;
          case RemoveClientListenerRequest:
             byte[] listenerId = (byte[]) msg.operationDecodeContext();

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Constants.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Constants.scala
@@ -20,6 +20,7 @@ trait Constants {
    val VERSION_23: Byte = 23
    val VERSION_24: Byte = 24
    val VERSION_25: Byte = 25
+   val VERSION_26: Byte = 26
    val DEFAULT_CONSISTENT_HASH_VERSION_1x: Byte = 2
    val DEFAULT_CONSISTENT_HASH_VERSION: Byte = 3
 
@@ -38,7 +39,7 @@ object Constants extends Constants {
    def isVersion12(v: Byte): Boolean = v == VERSION_12
    def isVersion13(v: Byte): Boolean = v == VERSION_13
    def isVersion1x(v: Byte): Boolean = v >= VERSION_10 && v <= VERSION_13
-   def isVersion2x(v: Byte): Boolean = v >= VERSION_20 && v <= VERSION_25
+   def isVersion2x(v: Byte): Boolean = v >= VERSION_20 && v <= VERSION_26
    def isVersionKnown(v: Byte): Boolean = isVersion1x(v) || isVersion2x(v)
 
    /**
@@ -54,9 +55,10 @@ object Constants extends Constants {
    /**
     * Is version previous post, and not including, 2.0?
     */
-   def isVersionPost20(v: Byte): Boolean = v >= VERSION_21 && v <= VERSION_25
+   def isVersionPost20(v: Byte): Boolean = v >= VERSION_21 && v <= VERSION_26
 
    def isVersionPost24(v: Byte) = v > VERSION_24
 
+   def isVersionPost25(v: Byte) = v > VERSION_25
 
 }

--- a/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
+++ b/server/hotrod/src/main/scala/org/infinispan/server/hotrod/Decoder2x.scala
@@ -206,9 +206,14 @@ object Decoder2x extends AbstractVersionedDecoder with Log with Constants {
                   case ver if Constants.isVersion2x(ver) => readMaybeByte(buffer).map(b => b == 1)
                   case _ => Some(false)
                }
+               listenerInterests <- h.version match {
+                  case ver if Constants.isVersionPost25(ver) => readMaybeVInt(buffer)
+                  case _ => Some(0)
+               }
             } yield {
                execCtx.converterFactoryInfo = converter
                execCtx.useRawData = useRawData
+               execCtx.listenerInterests = listenerInterests
 
                buffer.markReaderIndex()
                out.add(hrCtx)
@@ -498,4 +503,5 @@ class ClientListenerRequestContext(val listenerId: Bytes, val includeCurrentStat
    var filterFactoryInfo: NamedFactory = _
    var converterFactoryInfo: NamedFactory = _
    var useRawData: Boolean = _
+   var listenerInterests: Int = 0
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7283

Replaces #4711

* Cluster listener installed for remote listener is now more fine
  grained, only adding listener callbacks for those events that the
  client is interested in.
* To find out which callbacks the client is interested in, the Hot Rod
  protocol has been changed to add a byte indicating the event types
  interested in.
* Added addFilteredListener which allows the caller to decide which
  cache-entry specific events the listener is interested in.