### PR TITLE
ISPN-7238 Eliminate timeout task allocation for SingleResponseFuture

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/transport/jgroups/RspListFuture.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/jgroups/RspListFuture.java
@@ -41,7 +41,10 @@ public class RspListFuture extends CompletableFuture<Responses>
 
    @Override
    public void accept(RspList<Response> rsps, Throwable throwable) {
-      // The response is done
+      requestDone(rsps, throwable);
+   }
+
+   private void requestDone(RspList<Response> rsps, Throwable throwable) {
       if (throwable == null) {
          complete(new Responses(rsps));
       } else {


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7238
