### PR TITLE
ISPN-7283 Finer grained remote event listeners

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/ProtocolVersion.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/ProtocolVersion.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
  */
 public enum ProtocolVersion {
 
+   PROTOCOL_VERSION_26(2, 6),
    PROTOCOL_VERSION_25(2, 5),
    PROTOCOL_VERSION_24(2, 4),
    PROTOCOL_VERSION_23(2, 3),

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/event/ClientListenerNotifier.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/event/ClientListenerNotifier.java
@@ -180,7 +180,7 @@ public class ClientListenerNotifier {
       return null;
    }
 
-   private Map<Class<? extends Annotation>, List<ClientListenerInvocation>> findMethods(Object listener) {
+   public Map<Class<? extends Annotation>, List<ClientListenerInvocation>> findMethods(Object listener) {
       Map<Class<? extends Annotation>, List<ClientListenerInvocation>> listenerMethodMap = new HashMap<>(4, 0.99f);
 
       for (Method m : listener.getClass().getMethods()) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AddClientListenerOperation.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/operations/AddClientListenerOperation.java
@@ -87,6 +87,7 @@ public class AddClientListenerOperation extends RetryOnFailureOperation<Short> {
       HeaderParams params = writeHeader(transport, ADD_CLIENT_LISTENER_REQUEST);
       transport.writeArray(listenerId);
       codec.writeClientListenerParams(transport, clientListener, filterFactoryParams, converterFactoryParams);
+      codec.writeClientListenerInterests(transport, listenerNotifier.findMethods(this.listener).keySet());
       transport.flush();
 
       listenerNotifier.addClientListener(this);

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec.java
@@ -2,6 +2,8 @@ package org.infinispan.client.hotrod.impl.protocol;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.client.hotrod.VersionedMetadata;
@@ -11,7 +13,6 @@ import org.infinispan.client.hotrod.impl.transport.Transport;
 import org.infinispan.client.hotrod.logging.Log;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.util.Either;
-import org.jboss.marshalling.Version;
 
 /**
  * A Hot Rod protocol encoder/decoder.
@@ -69,4 +70,7 @@ public interface Codec {
     * Writes a stream of data
     */
    OutputStream writeAsStream(Transport transport, Runnable afterClose);
+
+   void writeClientListenerInterests(Transport transport, Set<Class<? extends Annotation>> classes);
+
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec10.java
@@ -4,6 +4,7 @@ import static org.infinispan.commons.util.Util.hexDump;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.annotation.Annotation;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.HashSet;
@@ -177,6 +178,10 @@ public class Codec10 implements Codec {
    @Override
    public OutputStream writeAsStream(Transport transport, Runnable afterClose) {
       throw new UnsupportedOperationException();
+   }
+
+   public void writeClientListenerInterests(Transport transport, Set<Class<? extends Annotation>> classes) {
+      // No-op
    }
 
    protected void checkForErrorsInResponseStatus(Transport transport, HeaderParams params, short status) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec20.java
@@ -5,11 +5,13 @@ import static org.infinispan.commons.util.Util.printArray;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.annotation.Annotation;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -60,6 +62,10 @@ public class Codec20 implements Codec, HotRodConstants {
    @Override
    public OutputStream writeAsStream(Transport transport, Runnable afterClose) {
       return new TransportOutputStream(transport, afterClose);
+   }
+
+   public void writeClientListenerInterests(Transport transport, Set<Class<? extends Annotation>> classes) {
+      // No-op
    }
 
    @Override

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec26.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/Codec26.java
@@ -1,0 +1,37 @@
+package org.infinispan.client.hotrod.impl.protocol;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryExpired;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryModified;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryRemoved;
+import org.infinispan.client.hotrod.impl.transport.Transport;
+
+/**
+ * @since 8.2
+ */
+public class Codec26 extends Codec25 {
+
+   @Override
+   public HeaderParams writeHeader(Transport transport, HeaderParams params) {
+      return writeHeader(transport, params, HotRodConstants.VERSION_26);
+   }
+
+   @Override
+   public void writeClientListenerInterests(Transport transport, Set<Class<? extends Annotation>> classes) {
+      byte listenerInterests = 0;
+      if (classes.contains(ClientCacheEntryCreated.class))
+         listenerInterests = (byte) (listenerInterests | 0x01);
+      if (classes.contains(ClientCacheEntryModified.class))
+         listenerInterests = (byte) (listenerInterests | 0x02);
+      if (classes.contains(ClientCacheEntryRemoved.class))
+         listenerInterests = (byte) (listenerInterests | 0x04);
+      if (classes.contains(ClientCacheEntryExpired.class))
+         listenerInterests = (byte) (listenerInterests | 0x08);
+
+      transport.writeVInt(listenerInterests);
+   }
+
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/CodecFactory.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/CodecFactory.java
@@ -12,6 +12,7 @@ import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_22;
 import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_23;
 import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_24;
 import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_25;
+import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_26;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,6 +36,7 @@ public class CodecFactory {
    private static final Codec CODEC_23 = new Codec23();
    private static final Codec CODEC_24 = new Codec24();
    private static final Codec CODEC_25 = new Codec25();
+   private static final Codec CODEC_26 = new Codec26();
 
    static {
       codecMap = new HashMap<>();
@@ -48,6 +50,7 @@ public class CodecFactory {
       codecMap.put(PROTOCOL_VERSION_23, CODEC_23);
       codecMap.put(PROTOCOL_VERSION_24, CODEC_24);
       codecMap.put(PROTOCOL_VERSION_25, CODEC_25);
+      codecMap.put(PROTOCOL_VERSION_26, CODEC_26);
    }
 
    public static boolean isVersionDefined(String version) {

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HotRodConstants.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/protocol/HotRodConstants.java
@@ -23,6 +23,7 @@ public interface HotRodConstants {
    byte VERSION_23 = 23;
    byte VERSION_24 = 24;
    byte VERSION_25 = 25;
+   byte VERSION_26 = 26;
 
    //requests
    byte PUT_REQUEST = 0x01;

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/ClusterClientEventStressTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/ClusterClientEventStressTest.java
@@ -1,0 +1,285 @@
+package org.infinispan.client.hotrod.stress;
+
+import static org.infinispan.client.hotrod.test.HotRodClientTestingUtil.toBytes;
+import static org.infinispan.distribution.DistributionTestHelper.isFirstOwner;
+import static org.infinispan.distribution.DistributionTestHelper.isOwner;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtil.hotRodCacheConfiguration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.infinispan.Cache;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryCreated;
+import org.infinispan.client.hotrod.annotation.ClientCacheEntryModified;
+import org.infinispan.client.hotrod.annotation.ClientListener;
+import org.infinispan.client.hotrod.event.ClientEvent;
+import org.infinispan.client.hotrod.logging.Log;
+import org.infinispan.client.hotrod.logging.LogFactory;
+import org.infinispan.client.hotrod.test.InternalRemoteCacheManager;
+import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
+import org.infinispan.commons.util.concurrent.ConcurrentHashSet;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.testng.annotations.Test;
+
+@Test(groups = "stress", testName = "client.hotrod.event.ClusterClientEventStressTest")
+public class ClusterClientEventStressTest extends MultiHotRodServersTest {
+
+   private static final Log log = LogFactory.getLog(ClusterClientEventStressTest.class);
+
+   static final int NUM_SERVERS = 3;
+   static final int NUM_OWNERS = 2;
+
+   static final int NUM_CLIENTS = 1;
+   static final int NUM_THREADS_PER_CLIENT = 6;
+//   static final int NUM_THREADS_PER_CLIENT = 36;
+
+   static final int NUM_OPERATIONS = 1_000; // per thread, per client
+//   static final int NUM_OPERATIONS = 300; // per thread, per client
+//   static final int NUM_OPERATIONS = 600; // per thread, per client
+
+   static final int NUM_EVENTS = NUM_OPERATIONS * NUM_THREADS_PER_CLIENT * NUM_CLIENTS * NUM_CLIENTS;
+
+//   public static final int NUM_STORES = NUM_OPERATIONS * NUM_CLIENTS * NUM_THREADS_PER_CLIENT;
+//   public static final int NUM_STORES_PER_SERVER = NUM_STORES / NUM_SERVERS;
+//   public static final int NUM_ENTRIES_PER_SERVER = (NUM_STORES * NUM_OWNERS) / NUM_SERVERS;
+
+   static Set<String> ALL_KEYS = new ConcurrentHashSet<>();
+
+   static ExecutorService EXEC = Executors.newCachedThreadPool();
+
+   static ClientEntryListener listener;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      createHotRodServers(NUM_SERVERS, getCacheConfiguration());
+   }
+
+   private ConfigurationBuilder getCacheConfiguration() {
+      ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false);
+      builder.clustering().hash().numOwners(NUM_OWNERS)
+//            .expiration().lifespan(1000).maxIdle(1000).wakeUpInterval(5000)
+            .expiration().maxIdle(1000).wakeUpInterval(5000)
+            .jmxStatistics().enable();
+      return hotRodCacheConfiguration(builder);
+   }
+
+   RemoteCacheManager getRemoteCacheManager(int port) {
+      org.infinispan.client.hotrod.configuration.ConfigurationBuilder builder =
+            new org.infinispan.client.hotrod.configuration.ConfigurationBuilder();
+      builder.addServer().host("127.0.0.1").port(port);
+      RemoteCacheManager rcm = new InternalRemoteCacheManager(builder.build());
+      rcm.getCache();
+      return rcm;
+   }
+
+   Map<String, RemoteCacheManager> createClients() {
+      Map<String, RemoteCacheManager> remotecms = new HashMap<>(NUM_CLIENTS);
+      for (int i = 0; i < NUM_CLIENTS; i++)
+         remotecms.put("c" + i, getRemoteCacheManager(server(0).getPort()));
+
+      return remotecms;
+   }
+
+   public void testAddClientListenerDuringOperations() {
+      CyclicBarrier barrier = new CyclicBarrier((NUM_CLIENTS * NUM_THREADS_PER_CLIENT) + 1);
+      List<Future<Void>> futures = new ArrayList<>(NUM_CLIENTS * NUM_THREADS_PER_CLIENT);
+      List<ClientEntryListener> listeners = new ArrayList<>(NUM_CLIENTS);
+      Map<String, RemoteCacheManager> remotecms = createClients();
+
+//      assertStatsBefore(remotecms);
+
+      for (Entry<String, RemoteCacheManager> e : remotecms.entrySet()) {
+         RemoteCache<String, String> remote = e.getValue().getCache();
+
+//         ClientEntryListener listener = new ClientEntryListener();
+//         listeners.add(listener);
+//         remote.addClientListener(listener);
+
+         for (int i = 0; i < NUM_THREADS_PER_CLIENT; i++) {
+            String prefix = String.format("%s-t%d-", e.getKey(), i);
+            Callable<Void> call = new Put(prefix, barrier, remote, servers);
+            futures.add(EXEC.submit(call));
+         }
+      }
+
+      barrierAwait(barrier); // wait for all threads to be ready
+      barrierAwait(barrier); // wait for all threads to finish
+
+      for (Future<Void> f : futures)
+         futureGet(f);
+
+//      log.debugf("Put operations completed, assert statistics");
+//      assertStatsAfter(remotecms);
+
+//      log.debugf("Stats asserted, wait for events...");
+//      eventuallyEquals(NUM_EVENTS, () -> countEvents(listeners));
+   }
+
+   int countEvents(List<ClientEntryListener> listeners) {
+      Integer count = listeners.stream().reduce(0, (acc, l) -> acc + l.count.get(), (x, y) -> x + y);
+      log.infof("Event count is %d, target %d%n", (int) count, NUM_EVENTS);
+      return count;
+   }
+
+//   void assertStatsBefore(Map<String, RemoteCacheManager> remotecms) {
+//      RemoteCacheManager client = remotecms.values().iterator().next();
+//      IntStream.range(0, NUM_SERVERS)
+//            .forEach(x -> {
+//               ServerStatistics stat = client.getCache().stats();
+//               assertEquals(0, stat.getIntStatistic(STORES).intValue());
+//               assertEquals(0, stat.getIntStatistic(CURRENT_NR_OF_ENTRIES).intValue());
+//            });
+//   }
+//
+//   void assertStatsAfter(Map<String, RemoteCacheManager> remotecms) {
+//      RemoteCacheManager client = remotecms.values().iterator().next();
+//      IntStream.range(0, NUM_SERVERS)
+//            .forEach(x -> {
+//               ServerStatistics stat = client.getCache().stats();
+//               int stores = stat.getIntStatistic(STORES);
+//               System.out.println("Number of stores: " + stores);
+//               assertEquals(NUM_STORES_PER_SERVER, stores);
+//               int entries = stat.getIntStatistic(CURRENT_NR_OF_ENTRIES);
+//               assertEquals(NUM_ENTRIES_PER_SERVER, entries);
+//            });
+//   }
+
+   static class Put implements Callable<Void> {
+      static final ThreadLocalRandom R = ThreadLocalRandom.current();
+
+      final CyclicBarrier barrier;
+      final RemoteCache<String, String> remote;
+      final List<HotRodServer> servers;
+      final List<String> keys;
+
+      public Put(String prefix, CyclicBarrier barrier,
+            RemoteCache<String, String> remote, List<HotRodServer> servers) {
+         this.barrier = barrier;
+         this.remote = remote;
+         this.servers = servers;
+         this.keys = generateKeys(prefix, servers, R);
+         Collections.shuffle(this.keys);
+      }
+
+      @Override
+      public Void call() throws Exception {
+         barrierAwait(barrier);
+         try {
+            for (int i = 0; i < NUM_OPERATIONS; i++) {
+               String value = keys.get(i);
+               remote.put(value, value);
+               if (value.startsWith("c0-t0") && i == (NUM_OPERATIONS / 2)) {
+                  listener = new ClientEntryListener();
+                  remote.addClientListener(listener);
+               }
+            }
+            return null;
+         } finally {
+            barrierAwait(barrier);
+         }
+      }
+   }
+
+   static List<String> generateKeys(String prefix, List<HotRodServer> servers, ThreadLocalRandom r) {
+      List<String> keys = new ArrayList<>();
+      List<HotRodServer[]> combos = Arrays.asList(
+            new HotRodServer[]{servers.get(0), servers.get(1)},
+            new HotRodServer[]{servers.get(1), servers.get(0)},
+            new HotRodServer[]{servers.get(1), servers.get(2)},
+            new HotRodServer[]{servers.get(2), servers.get(1)},
+            new HotRodServer[]{servers.get(2), servers.get(0)},
+            new HotRodServer[]{servers.get(0), servers.get(2)}
+      );
+
+      for (int i = 0; i < NUM_OPERATIONS; i++) {
+         HotRodServer[] owners = combos.get(i % combos.size());
+         String key = getStringKey(prefix, owners, r);
+         if (ALL_KEYS.contains(key))
+            throw new AssertionError("Key already in use: " + key);
+
+         keys.add(key);
+         ALL_KEYS.add(key);
+      }
+      return keys;
+   }
+
+   static String getStringKey(String prefix, HotRodServer[] owners, ThreadLocalRandom r) {
+      Cache<?, ?> firstOwnerCache = owners[0].getCacheManager().getCache();
+      Cache<?, ?> otherOwnerCache = owners[1].getCacheManager().getCache();
+
+//      Random r = new Random();
+      byte[] dummy;
+      String dummyKey;
+      int attemptsLeft = 1000;
+      do {
+         Integer dummyInt = r.nextInt();
+         dummyKey = prefix + dummyInt;
+         dummy = toBytes(dummyKey);
+         attemptsLeft--;
+      } while (!(isFirstOwner(firstOwnerCache, dummy) && isOwner(otherOwnerCache, dummy))
+            && attemptsLeft >= 0);
+
+      if (attemptsLeft < 0)
+         throw new IllegalStateException("Could not find any key owned by "
+               + firstOwnerCache + " as primary owner and "
+               + otherOwnerCache + " as secondary owner");
+
+      log.infof("Integer key %s hashes to primary [cluster=%s,hotrod=%s] and secondary [cluster=%s,hotrod=%s]",
+            dummyKey,
+            firstOwnerCache.getCacheManager().getAddress(), owners[0].getAddress(),
+            otherOwnerCache.getCacheManager().getAddress(), owners[1].getAddress());
+
+      return dummyKey;
+   }
+
+   static int barrierAwait(CyclicBarrier barrier) {
+      try {
+         return barrier.await();
+      } catch (InterruptedException | BrokenBarrierException e) {
+         throw new AssertionError(e);
+      }
+   }
+
+   static <T> T futureGet(Future<T> future) {
+      try {
+         return future.get();
+      } catch (InterruptedException | ExecutionException e) {
+         throw new AssertionError(e);
+      }
+   }
+
+   @ClientListener
+   static class ClientEntryListener {
+      final AtomicInteger count = new AtomicInteger();
+
+      @ClientCacheEntryCreated
+      @ClientCacheEntryModified
+      @SuppressWarnings("unused")
+      public void handleClientEvent(ClientEvent event) {
+         int countSoFar;
+         if ((countSoFar = count.incrementAndGet()) % 100 == 0) {
+            log.debugf("Reached %s", countSoFar);
+         }
+      }
+   }
+
+}

--- a/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingCache.java
+++ b/core/src/main/java/org/infinispan/cache/impl/AbstractDelegatingCache.java
@@ -1,5 +1,6 @@
 package org.infinispan.cache.impl;
 
+import java.lang.annotation.Annotation;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -452,6 +453,13 @@ public abstract class AbstractDelegatingCache<K, V> implements Cache<K, V> {
    @Override
    public Set<Object> getListeners() {
       return cache.getListeners();
+   }
+
+   @Override
+   public <C> void addFilteredListener(Object listener,
+         CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter,
+         Set<Class<? extends Annotation>> filterAnnotations) {
+      cache.addFilteredListener(listener, filter, converter, filterAnnotations);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/CacheImpl.java
@@ -9,6 +9,7 @@ import static org.infinispan.context.Flag.ZERO_LOCK_ACQUISITION_TIMEOUT;
 import static org.infinispan.context.InvocationContextFactory.UNBOUNDED;
 import static org.infinispan.factories.KnownComponentNames.ASYNC_OPERATIONS_EXECUTOR;
 
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -707,6 +708,13 @@ public class CacheImpl<K, V> implements AdvancedCache<K, V> {
    @Override
    public Set<Object> getListeners() {
       return notifier.getListeners();
+   }
+
+   @Override
+   public <C> void addFilteredListener(Object listener,
+         CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter,
+         Set<Class<? extends Annotation>> filterAnnotations) {
+      notifier.addFilteredListener(listener, filter, converter, filterAnnotations);
    }
 
    private InvocationContext getInvocationContextForWrite(int keyCount, boolean isPutForExternalRead) {

--- a/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
+++ b/core/src/main/java/org/infinispan/cache/impl/SimpleCacheImpl.java
@@ -914,6 +914,16 @@ public class SimpleCacheImpl<K, V> implements AdvancedCache<K, V> {
       return cacheNotifier.getListeners();
    }
 
+   @Override
+   public <C> void addFilteredListener(Object listener,
+         CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter,
+         Set<Class<? extends Annotation>> filterAnnotations) {
+      cacheNotifier.addFilteredListener(listener, filter, converter, filterAnnotations);
+      if (!hasListeners && canFire(listener)) {
+         hasListeners = true;
+      }
+   }
+
    private boolean canFire(Object listener) {
       for (Method m : listener.getClass().getMethods()) {
          for (Class<? extends Annotation> annotation : FIRED_EVENTS) {

--- a/core/src/main/java/org/infinispan/notifications/FilteringListenable.java
+++ b/core/src/main/java/org/infinispan/notifications/FilteringListenable.java
@@ -1,6 +1,13 @@
 package org.infinispan.notifications;
 
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
 import org.infinispan.filter.KeyFilter;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryExpired;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
 import org.infinispan.notifications.cachelistener.filter.CacheEventConverter;
 import org.infinispan.notifications.cachelistener.filter.CacheEventFilter;
 
@@ -38,4 +45,32 @@ public interface FilteringListenable<K, V> extends Listenable {
     * @throws NullPointerException if the specified listener is null
     */
    <C> void addListener(Object listener, CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter);
+
+   /**
+    * Registers a listener limiting the cache-entry specific events only to
+    * annotations that are passed in as parameter.
+    * <p/>
+    * For example, if the listener passed in contains callbacks for
+    * {@link CacheEntryCreated} and {@link CacheEntryModified},
+    * and filtered annotations contains only {@link CacheEntryCreated},
+    * then the listener will be registered only for {@link CacheEntryCreated}
+    * callbacks.
+    * <p/>
+    * Callback filtering only applies to {@link CacheEntryCreated},
+    * {@link CacheEntryModified}, {@link CacheEntryRemoved}
+    * and {@link CacheEntryExpired} annotations.
+    * If the listener contains other annotations, these are preserved.
+    * <p/>
+    * This methods enables dynamic registration of listener interests at
+    * runtime without the need to create several different listener classes.
+    *
+    * @param listener The listener to callback upon event notifications.  Must not be null.
+    * @param filter The filter to see if the notification should be sent to the listener.  Can be null.
+    * @param converter The converter to apply to the entry before being sent to the listener.  Can be null.
+    * @param filterAnnotations cache-entry annotations to allow listener to be registered on. Must not be null.
+    * @param <C> The type of the resultant value after being converted
+    */
+   <C> void addFilteredListener(Object listener, CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter,
+         Set<Class<? extends Annotation>> filterAnnotations);
+
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheEntryListenerInvocation.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheEntryListenerInvocation.java
@@ -1,6 +1,7 @@
 package org.infinispan.notifications.cachelistener;
 
 import java.lang.annotation.Annotation;
+import java.util.Set;
 import java.util.UUID;
 
 import org.infinispan.notifications.Listener;
@@ -35,4 +36,5 @@ public interface CacheEntryListenerInvocation<K, V> extends ListenerInvocation<E
 
    <C> CacheEventConverter<? super K, ? super V, C> getConverter();
 
+   Set<Class<? extends Annotation>> getFilterAnnotations();
 }

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/CacheNotifierImpl.java
@@ -764,15 +764,19 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
          if (!enlistedAlready.contains(listener.getTarget())) {
             // If clustered means it is local - so use our address
             if (listener.isClustered()) {
+               Set<Class<? extends Annotation>> filterAnnotations = listener.getFilterAnnotations();
                callables.add(new ClusterListenerReplicateCallable(listener.getIdentifier(),
                                                                   cache.getCacheManager().getAddress(), listener.getFilter(),
-                                                                  listener.getConverter(), listener.isSync()));
+                                                                  listener.getConverter(), listener.isSync(),
+                                                                  filterAnnotations));
                enlistedAlready.add(listener.getTarget());
             }
             else if (listener.getTarget() instanceof RemoteClusterListener) {
                RemoteClusterListener lcl = (RemoteClusterListener)listener.getTarget();
+               Set<Class<? extends Annotation>> filterAnnotations = listener.getFilterAnnotations();
                callables.add(new ClusterListenerReplicateCallable(lcl.getId(), lcl.getOwnerAddress(), listener.getFilter(),
-                                                                  listener.getConverter(), listener.isSync()));
+                                                                  listener.getConverter(), listener.isSync(),
+                                                                  filterAnnotations));
                enlistedAlready.add(listener.getTarget());
             }
          }
@@ -847,6 +851,11 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
                .setConverter(converter)
                .setIdentifier(generatedId)
                .setClassLoader(classLoader);
+
+         if (l.clustered()) {
+            builder.setFilterAnnotations(findListenerCallbacks(listener));
+         }
+
          foundMethods = validateAndAddListenerInvocations(listener, builder);
       }
 
@@ -869,7 +878,9 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
                   log.tracef("Replicating cluster listener to other nodes %s for cluster listener with id %s",
                              members, generatedId);
                }
-               Callable callable = new ClusterListenerReplicateCallable(generatedId, ourAddress, filter, converter, l.sync());
+               Callable callable = new ClusterListenerReplicateCallable(
+                     generatedId, ourAddress, filter, converter, l.sync(),
+                     findListenerCallbacks(listener));
                for (Address member : members) {
                   if (!member.equals(ourAddress)) {
                      decs.submit(member, callable);
@@ -1023,6 +1034,175 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
       addListener(listener, filter, converter, null);
    }
 
+   @Override
+   public <C> void addFilteredListener(Object listener, CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter,
+         Set<Class<? extends Annotation>> filterAnnotations) {
+      final Listener l = testListenerClassValidity(listener.getClass());
+      final UUID generatedId = UUID.randomUUID();
+      final CacheMode cacheMode = config.clustering().cacheMode();
+
+      FilterIndexingServiceProvider indexingProvider = null;
+      boolean foundMethods = false;
+      if (filter instanceof IndexedFilter) {
+         IndexedFilter indexedFilter = (IndexedFilter) filter;
+         indexingProvider = findIndexingServiceProvider(indexedFilter);
+         if (indexingProvider != null) {
+            DelegatingCacheInvocationBuilder builder = new DelegatingCacheInvocationBuilder(indexingProvider);
+            builder
+                  .setFilterAnnotations(filterAnnotations)
+                  .setIncludeCurrentState(l.includeCurrentState())
+                  .setClustered(l.clustered())
+                  .setOnlyPrimary(l.clustered() ? cacheMode.isDistributed() : l.primaryOnly())
+                  .setObservation(l.clustered() ? Listener.Observation.POST : l.observation())
+                  .setFilter(filter)
+                  .setConverter(converter)
+                  .setIdentifier(generatedId)
+                  .setClassLoader(null);
+            foundMethods = validateAndAddFilterListenerInvocations(listener, builder, filterAnnotations);
+            builder.registerListenerInvocations();
+         }
+      }
+      if (indexingProvider == null) {
+         CacheInvocationBuilder builder = new CacheInvocationBuilder();
+         builder
+               .setFilterAnnotations(filterAnnotations)
+               .setIncludeCurrentState(l.includeCurrentState())
+               .setClustered(l.clustered())
+               .setOnlyPrimary(l.clustered() ? cacheMode.isDistributed() : l.primaryOnly())
+               .setObservation(l.clustered() ? Listener.Observation.POST : l.observation())
+               .setFilter(filter)
+               .setConverter(converter)
+               .setIdentifier(generatedId)
+               .setClassLoader(null);
+
+         if (l.clustered()) {
+            builder.setFilterAnnotations(findListenerCallbacks(listener));
+         }
+
+         foundMethods = validateAndAddFilterListenerInvocations(listener, builder, filterAnnotations);
+      }
+
+      if (foundMethods && l.clustered()) {
+         if (l.observation() == Listener.Observation.PRE) {
+            throw log.clusterListenerRegisteredWithOnlyPreEvents(listener.getClass());
+         } else if (cacheMode.isInvalidation()) {
+            throw new UnsupportedOperationException("Cluster listeners cannot be used with Invalidation Caches!");
+         } else if (cacheMode.isDistributed()) {
+            clusterListenerIDs.put(listener, generatedId);
+            EmbeddedCacheManager manager = cache.getCacheManager();
+            Address ourAddress = manager.getAddress();
+
+            List<Address> members = manager.getMembers();
+            // If we are the only member don't even worry about sending listeners
+            if (members != null && members.size() > 1) {
+               DistributedExecutionCompletionService decs = new DistributedExecutionCompletionService(distExecutorService);
+
+               if (trace) {
+                  log.tracef("Replicating cluster listener to other nodes %s for cluster listener with id %s",
+                        members, generatedId);
+               }
+               Callable callable = new ClusterListenerReplicateCallable(
+                     generatedId, ourAddress, filter, converter, l.sync(),
+                     filterAnnotations);
+               for (Address member : members) {
+                  if (!member.equals(ourAddress)) {
+                     decs.submit(member, callable);
+                  }
+               }
+
+               for (int i = 0; i < members.size() - 1; ++i) {
+                  try {
+                     decs.take().get();
+                  } catch (InterruptedException e) {
+                     throw new CacheListenerException(e);
+                  } catch (ExecutionException e) {
+                     Throwable cause = e.getCause();
+                     // If we got a SuspectException it means the remote node hasn't started this cache yet.
+                     // Just ignore, when it joins it will retrieve the listener
+                     if (!(cause instanceof SuspectException)) {
+                        throw new CacheListenerException(cause);
+                     }
+                  }
+               }
+
+               int extraCount = 0;
+               // If anyone else joined since we sent these we have to send the listeners again, since they may have queried
+               // before the other nodes got the new listener
+               List<Address> membersAfter = manager.getMembers();
+               for (Address member : membersAfter) {
+                  if (!members.contains(member) && !member.equals(ourAddress)) {
+                     if (trace) {
+                        log.tracef("Found additional node %s that joined during replication of cluster listener with id %s",
+                              member, generatedId);
+                     }
+                     extraCount++;
+                     decs.submit(member, callable);
+                  }
+               }
+
+               for (int i = 0; i < extraCount; ++i) {
+                  try {
+                     decs.take().get();
+                  } catch (InterruptedException e) {
+                     throw new CacheListenerException(e);
+                  } catch (ExecutionException e) {
+                     throw new CacheListenerException(e);
+                  }
+               }
+            }
+         }
+      }
+
+      // If we have a segment listener handler, it means we have to do initial state
+      QueueingSegmentListener handler = segmentHandler.remove(generatedId);
+      if (handler != null) {
+         if (trace) {
+            log.tracef("Listener %s requests initial state for cache", generatedId);
+         }
+
+         try (CacheStream<CacheEntry<K, V>> entryStream = cache.getAdvancedCache().cacheEntrySet().stream()) {
+            Stream<CacheEntry<K, V>> usedStream = entryStream.segmentCompletionListener(handler);
+
+            if (filter instanceof CacheEventFilterConverter && (filter == converter || converter == null)) {
+               // Hacky cast to prevent other casts
+               usedStream = CacheFilters.filterAndConvert(usedStream,
+                     new CacheEventFilterConverterAsKeyValueFilterConverter<>((CacheEventFilterConverter<K, V, V>) filter));
+            } else {
+               usedStream = filter == null ? usedStream : usedStream.filter(CacheFilters.predicate(
+                     new CacheEventFilterAsKeyValueFilter<>(filter)));
+               usedStream = converter == null ? usedStream : usedStream.map(CacheFilters.function(
+                     new CacheEventConverterAsConverter(converter)));
+            }
+
+            Iterator<CacheEntry<K, V>> iterator = usedStream.iterator();
+            while (iterator.hasNext()) {
+               CacheEntry<K, V> entry = iterator.next();
+               // Mark the key as processed and see if we had a concurrent update
+               Object value = handler.markKeyAsProcessing(entry.getKey());
+               if (value == BaseQueueingSegmentListener.REMOVED) {
+                  // Don't process this value if we had a concurrent remove
+                  continue;
+               }
+               raiseEventForInitialTransfer(generatedId, entry, l.clustered());
+
+               handler.notifiedKey(entry.getKey());
+            }
+         }
+
+         Set<CacheEntry> entries = handler.findCreatedEntries();
+
+         for (CacheEntry entry : entries) {
+            raiseEventForInitialTransfer(generatedId, entry, l.clustered());
+         }
+
+         if (trace) {
+            log.tracef("Listener %s initial state for cache completed", generatedId);
+         }
+
+         handler.transferComplete();
+      }
+   }
+
    protected class CacheInvocationBuilder extends AbstractInvocationBuilder {
       CacheEventFilter<? super K, ? super V> filter;
       CacheEventConverter<? super K, ? super V, ?> converter;
@@ -1031,6 +1211,7 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
       boolean includeCurrentState;
       UUID identifier;
       Listener.Observation observation;
+      Set<Class<? extends Annotation>> filterAnnotations;
 
       public CacheEventFilter<? super K, ? super V> getFilter() {
          return filter;
@@ -1095,6 +1276,11 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
          return this;
       }
 
+      public CacheInvocationBuilder setFilterAnnotations(Set<Class<? extends Annotation>> filterAnnotations) {
+         this.filterAnnotations = filterAnnotations;
+         return this;
+      }
+
       @Override
       public CacheEntryListenerInvocation<K, V> build() {
          ListenerInvocation<Event<K, V>> invocation = new ListenerInvocationImpl(target, method, sync, classLoader,
@@ -1122,7 +1308,7 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
                   }
                }
                returnValue = new ClusteredListenerInvocation<>(invocation, handler, filter, converter, annotation,
-                                                                   onlyPrimary, identifier, sync, observation);
+                                                                   onlyPrimary, identifier, sync, observation, filterAnnotations);
             } else {
 //               TODO: this is removed until non cluster listeners are supported
 //               QueueingSegmentListener handler = segmentHandler.get(identifier);
@@ -1136,13 +1322,13 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
 //               returnValue = new NonClusteredListenerInvocation(invocation, handler, filter, converter, annotation,
 //                                                                onlyPrimary, identifier, sync);
                returnValue = new BaseCacheEntryListenerInvocation(invocation, filter, converter, annotation,
-                                                                  onlyPrimary, clustered, identifier, sync, observation);
+                                                                  onlyPrimary, clustered, identifier, sync, observation, filterAnnotations);
             }
          } else {
             // If no includeCurrentState just use the base listener invocation which immediately passes all notifications
             // off
             returnValue = new BaseCacheEntryListenerInvocation(invocation, filter, converter, annotation, onlyPrimary,
-                                                               clustered, identifier, sync, observation);
+                                                               clustered, identifier, sync, observation, filterAnnotations);
          }
          return returnValue;
       }
@@ -1196,8 +1382,9 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
                                                CacheEventFilter<? super K, ? super V> filter,
                                                CacheEventConverter<? super K, ? super V, ?> converter,
                                                Class<? extends Annotation> annotation, boolean onlyPrimary,
-                                               UUID identifier, boolean sync, Listener.Observation observation) {
-         super(invocation, filter, converter, annotation, onlyPrimary, false, identifier, sync, observation);
+                                               UUID identifier, boolean sync, Listener.Observation observation,
+                                               Set<Class<? extends Annotation>> filterAnnotations) {
+         super(invocation, filter, converter, annotation, onlyPrimary, false, identifier, sync, observation, filterAnnotations);
          this.handler = handler;
       }
 
@@ -1221,8 +1408,9 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
                                          CacheEventFilter<? super K, ? super V> filter,
                                          CacheEventConverter<? super K, ? super V, ?> converter,
                                          Class<? extends Annotation> annotation, boolean onlyPrimary,
-                                         UUID identifier, boolean sync, Listener.Observation observation) {
-         super(invocation, filter, converter, annotation, onlyPrimary, true, identifier, sync, observation);
+                                         UUID identifier, boolean sync, Listener.Observation observation,
+                                         Set<Class<? extends Annotation>> filterAnnotations) {
+         super(invocation, filter, converter, annotation, onlyPrimary, true, identifier, sync, observation, filterAnnotations);
          this.handler = handler;
       }
 
@@ -1252,6 +1440,7 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
       protected final boolean sync;
       protected final boolean filterAndConvert;
       protected final Listener.Observation observation;
+      protected final Set<Class<? extends Annotation>> filterAnnotations;
 
 
       protected BaseCacheEntryListenerInvocation(ListenerInvocation<Event<K, V>> invocation,
@@ -1259,7 +1448,8 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
                                                  CacheEventConverter<? super K, ? super V, ?> converter,
                                                  Class<? extends Annotation> annotation, boolean onlyPrimary,
                                                  boolean clustered, UUID identifier, boolean sync,
-                                                 Listener.Observation observation)  {
+                                                 Listener.Observation observation,
+                                                 Set<Class<? extends Annotation>> filterAnnotations)  {
          this.invocation = invocation;
          this.filter = filter;
          this.converter = converter;
@@ -1270,6 +1460,7 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
          this.annotation = annotation;
          this.sync = sync;
          this.observation = observation;
+         this.filterAnnotations = filterAnnotations;
       }
 
       @Override
@@ -1384,6 +1575,11 @@ public final class CacheNotifierImpl<K, V> extends AbstractListenerImpl<Event<K,
       @Override
       public CacheEventFilter<? super K, ? super V> getFilter() {
          return filter;
+      }
+
+      @Override
+      public Set<Class<? extends Annotation>> getFilterAnnotations() {
+         return filterAnnotations;
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplicateCallable.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/cluster/ClusterListenerReplicateCallable.java
@@ -3,12 +3,15 @@ package org.infinispan.notifications.cachelistener.cluster;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.lang.annotation.Annotation;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.marshall.AbstractExternalizer;
+import org.infinispan.commons.marshall.MarshallUtil;
 import org.infinispan.distexec.DistributedCallable;
 import org.infinispan.distexec.DistributedExecutorService;
 import org.infinispan.factories.ComponentRegistry;
@@ -47,14 +50,19 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
    private final CacheEventConverter<K, V, ?> converter;
    private final Address origin;
    private final boolean sync;
+   private final Set<Class<? extends Annotation>> filterAnnotations;
 
    public ClusterListenerReplicateCallable(UUID identifier, Address origin, CacheEventFilter<K, V> filter,
-                                           CacheEventConverter<K, V, ?> converter, boolean sync) {
+                                           CacheEventConverter<K, V, ?> converter, boolean sync,
+                                           Set<Class<? extends Annotation>> filterAnnotations) {
       this.identifier = identifier;
       this.origin = origin;
       this.filter = filter;
       this.converter = converter;
       this.sync = sync;
+      this.filterAnnotations = filterAnnotations;
+      if (trace)
+         log.tracef("Created clustered listener replicate callable for: %s", filterAnnotations);
    }
 
    @Override
@@ -96,7 +104,7 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
                if (!alreadyInstalled) {
                   RemoteClusterListener listener = new RemoteClusterListener(identifier, origin, distExecutor, cacheNotifier,
                                                                              cacheManagerNotifier, eventManager, sync);
-                  cacheNotifier.addListener(listener, filter, converter);
+                  cacheNotifier.addFilteredListener(listener, filter, converter, filterAnnotations);
                   cacheManagerNotifier.addListener(listener);
                   // It is possible the member is now gone after registered, if so we have to remove just to be sure
                   if (!cacheManager.getMembers().contains(origin)) {
@@ -142,6 +150,7 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
             output.writeObject(object.converter);
          }
          output.writeBoolean(object.sync);
+         MarshallUtil.marshallCollection(object.filterAnnotations, output);
       }
 
       @Override
@@ -157,7 +166,8 @@ public class ClusterListenerReplicateCallable<K, V> implements DistributedCallab
             converter = (CacheEventConverter)input.readObject();
          }
          boolean sync = input.readBoolean();
-         return new ClusterListenerReplicateCallable(id, address, filter, converter, sync);
+         Set<Class<? extends Annotation>> listenerAnnots = MarshallUtil.unmarshallCollection(input, HashSet::new);
+         return new ClusterListenerReplicateCallable(id, address, filter, converter, sync, listenerAnnots);
       }
 
       @Override

--- a/core/src/main/java/org/infinispan/notifications/cachelistener/filter/DelegatingCacheEntryListenerInvocation.java
+++ b/core/src/main/java/org/infinispan/notifications/cachelistener/filter/DelegatingCacheEntryListenerInvocation.java
@@ -1,6 +1,7 @@
 package org.infinispan.notifications.cachelistener.filter;
 
 import java.lang.annotation.Annotation;
+import java.util.Set;
 import java.util.UUID;
 
 import org.infinispan.notifications.Listener;
@@ -85,5 +86,10 @@ public abstract class DelegatingCacheEntryListenerInvocation<K, V> implements Ca
    @Override
    public <C> CacheEventConverter<? super K, ? super V, C> getConverter() {
       return invocation.getConverter();
+   }
+
+   @Override
+   public Set<Class<? extends Annotation>> getFilterAnnotations() {
+      return invocation.getFilterAnnotations();
    }
 }

--- a/core/src/main/java/org/infinispan/notifications/impl/AbstractListenerImpl.java
+++ b/core/src/main/java/org/infinispan/notifications/impl/AbstractListenerImpl.java
@@ -28,9 +28,14 @@ import org.infinispan.factories.annotations.Start;
 import org.infinispan.factories.annotations.Stop;
 import org.infinispan.notifications.IncorrectListenerException;
 import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryExpired;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
 import org.infinispan.security.Security;
 import org.infinispan.util.concurrent.WithinThreadExecutor;
 import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 /**
  * Functionality common to both {@link org.infinispan.notifications.cachemanagerlistener.CacheManagerNotifierImpl} and
@@ -41,6 +46,9 @@ import org.infinispan.util.logging.Log;
  * @author William Burns
  */
 public abstract class AbstractListenerImpl<T, L extends ListenerInvocation<T>> {
+
+   private static final Log log = LogFactory.getLog(AbstractListenerImpl.class);
+   private static final boolean trace = log.isTraceEnabled();
 
    protected final Map<Class<? extends Annotation>, List<L>> listenersMap = new HashMap<>(16, 0.99f);
 
@@ -207,6 +215,10 @@ public abstract class AbstractListenerImpl<T, L extends ListenerInvocation<T>> {
                   builder.setMethod(m);
                   builder.setAnnotation(annotationClass);
                   L invocation = builder.build();
+
+                  if (trace)
+                     log.tracef("Add listener invocation %s for %s", invocation, annotationClass);
+
                   getListenerCollectionForAnnotation(annotationClass).add(invocation);
                   foundMethods = true;
                }
@@ -217,6 +229,93 @@ public abstract class AbstractListenerImpl<T, L extends ListenerInvocation<T>> {
       if (!foundMethods)
          getLog().noAnnotateMethodsFoundInListener(listener.getClass());
       return foundMethods;
+   }
+
+   protected boolean validateAndAddFilterListenerInvocations(Object listener,
+         AbstractInvocationBuilder builder, Set<Class<? extends Annotation>> filterAnnotations) {
+      Listener l = testListenerClassValidity(listener.getClass());
+      boolean foundMethods = false;
+      builder.setTarget(listener);
+      builder.setSubject(Security.getSubject());
+      builder.setSync(l.sync());
+      Map<Class<? extends Annotation>, Class<?>> allowedListeners = getAllowedMethodAnnotations(l);
+      // now try all methods on the listener for anything that we like.  Note that only PUBLIC methods are scanned.
+      for (Method m : listener.getClass().getMethods()) {
+         // Skip bridge methods as we don't want to count them as well.
+         if (!m.isSynthetic() || !m.isBridge()) {
+            // loop through all valid method annotations
+            for (Map.Entry<Class<? extends Annotation>, Class<?>> annotationEntry : allowedListeners.entrySet()) {
+               final Class<? extends Annotation> annotationClass = annotationEntry.getKey();
+               if (m.isAnnotationPresent(annotationClass) && canApply(filterAnnotations, annotationClass)) {
+                  final Class<?> eventClass = annotationEntry.getValue();
+                  testListenerMethodValidity(m, eventClass, annotationClass.getName());
+
+                  if (System.getSecurityManager() == null) {
+                     m.setAccessible(true);
+                  } else {
+                     AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                        m.setAccessible(true);
+                        return null;
+                     });
+                  }
+
+                  builder.setMethod(m);
+                  builder.setAnnotation(annotationClass);
+                  L invocation = builder.build();
+                  if (trace)
+                     log.tracef("Add listener invocation %s for %s", invocation, annotationClass);
+
+                  getListenerCollectionForAnnotation(annotationClass).add(invocation);
+                  foundMethods = true;
+               }
+            }
+         }
+      }
+
+      if (!foundMethods)
+         getLog().noAnnotateMethodsFoundInListener(listener.getClass());
+      return foundMethods;
+   }
+
+   public boolean canApply(Set<Class<? extends Annotation>> filterAnnotations, Class<? extends Annotation> annotationClass) {
+      // Annotations such ViewChange or TransactionCompleted should be applied regardless
+      return (annotationClass != CacheEntryCreated.class
+            && annotationClass != CacheEntryModified.class
+            && annotationClass != CacheEntryRemoved.class
+            && annotationClass != CacheEntryExpired.class)
+            || (filterAnnotations.contains(annotationClass));
+   }
+
+   protected Set<Class<? extends Annotation>> findListenerCallbacks(Object listener) {
+      // TODO: Partly duplicates validateAndAddListenerInvocations
+      Set<Class<? extends Annotation>> listenerInterests = new HashSet<>();
+      Listener l = testListenerClassValidity(listener.getClass());
+      Map<Class<? extends Annotation>, Class<?>> allowedListeners = getAllowedMethodAnnotations(l);
+      for (Method m : listener.getClass().getMethods()) {
+         // Skip bridge methods as we don't want to count them as well.
+         if (!m.isSynthetic() || !m.isBridge()) {
+            // loop through all valid method annotations
+            for (Map.Entry<Class<? extends Annotation>, Class<?>> annotationEntry : allowedListeners.entrySet()) {
+               final Class<? extends Annotation> annotationClass = annotationEntry.getKey();
+               if (m.isAnnotationPresent(annotationClass)) {
+                  final Class<?> eventClass = annotationEntry.getValue();
+                  testListenerMethodValidity(m, eventClass, annotationClass.getName());
+
+                  if (System.getSecurityManager() == null) {
+                     m.setAccessible(true);
+                  } else {
+                     AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                        m.setAccessible(true);
+                        return null;
+                     });
+                  }
+
+                  listenerInterests.add(annotationClass);
+               }
+            }
+         }
+      }
+      return listenerInterests;
    }
 
    /**

--- a/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
+++ b/core/src/main/java/org/infinispan/security/impl/SecureCacheImpl.java
@@ -1,5 +1,6 @@
 package org.infinispan.security.impl;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -84,6 +85,14 @@ public final class SecureCacheImpl<K, V> implements SecureCache<K, V> {
    public void addListener(Object listener) {
       authzManager.checkPermission(AuthorizationPermission.LISTEN);
       delegate.addListener(listener);
+   }
+
+   @Override
+   public <C> void addFilteredListener(Object listener,
+         CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter,
+         Set<Class<? extends Annotation>> filterAnnotations) {
+      authzManager.checkPermission(AuthorizationPermission.LISTEN);
+      delegate.addFilteredListener(listener, filter, converter, filterAnnotations);
    }
 
    @Override

--- a/core/src/test/java/org/infinispan/functional/decorators/FunctionalAdvancedCache.java
+++ b/core/src/test/java/org/infinispan/functional/decorators/FunctionalAdvancedCache.java
@@ -7,6 +7,7 @@ import static org.infinispan.commons.marshall.MarshallableFunctions.setValueMeta
 import static org.infinispan.commons.marshall.MarshallableFunctions.setValueMetasIfPresentReturnPrevOrNull;
 import static org.infinispan.commons.marshall.MarshallableFunctions.setValueMetasReturnPrevOrNull;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -643,6 +644,13 @@ public final class FunctionalAdvancedCache<K, V> implements AdvancedCache<K, V> 
    @Override
    public Set<Object> getListeners() {
       return null;  // TODO: Customise this generated block
+   }
+
+   @Override
+   public <C> void addFilteredListener(Object listener,
+         CacheEventFilter<? super K, ? super V> filter, CacheEventConverter<? super K, ? super V, C> converter,
+         Set<Class<? extends Annotation>> filterAnnotations) {
+      // TODO: Customise this generated block
    }
 
    public static <T> T await(CompletableFuture<T> cf) {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/cluster/AbstractClusterListenerUtilTest.java
@@ -15,6 +15,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.infinispan.Cache;
@@ -320,7 +321,7 @@ public abstract class AbstractClusterListenerUtilTest extends MultipleCacheManag
             // Now wait until main thread lets us through
             checkPoint.awaitStrict("post_add_listener_release_" + cache, 10, TimeUnit.SECONDS);
          }
-      }).when(mockNotifier).addListener(anyObject(), any(CacheEventFilter.class), any(CacheEventConverter.class));
+      }).when(mockNotifier).addFilteredListener(anyObject(), any(CacheEventFilter.class), any(CacheEventConverter.class), any(Set.class));
       TestingUtil.replaceComponent(cache, CacheNotifier.class, mockNotifier, true);
    }
 

--- a/core/src/test/java/org/infinispan/security/SecureCacheTestDriver.java
+++ b/core/src/test/java/org/infinispan/security/SecureCacheTestDriver.java
@@ -670,4 +670,10 @@ public class SecureCacheTestDriver {
       cache.shutdown();
       cache.start();
    }
+
+   @TestCachePermission(AuthorizationPermission.LISTEN)
+   public void testAddFilteredListener_Object_CacheEventFilter_CacheEventConverter_Set(SecureCache<String, String> cache) {
+      cache.addFilteredListener(listener, keyValueFilter, converter, Collections.emptySet());
+   }
+
 }

--- a/documentation/src/main/asciidoc/user_guide/server_protocols_hotrod_wire.adoc
+++ b/documentation/src/main/asciidoc/user_guide/server_protocols_hotrod_wire.adoc
@@ -1945,6 +1945,74 @@ Response (0x3A):
 | Header | variable | Response header
 |==============================================================================
 
+On top of these additions, this Hot Rod protocol version improves remote listener registration by adding a byte that indicates at a global level, which type of events the client is interested in.
+For example, a client can indicate that only created events, or only expiration and removal events...etc.
+More fine grained event interests, e.g. per key, can be defined using the key/value filter parameter.
+
+So, the new add listener request looks like this:
+
+.Add client listener for remote events
+
+Request (0x25):
+
+[cols="3,^2,10",options="header"]
+|==============================================================================
+| Field Name          | Size       | Value
+| Header | variable | Request header
+| Listener ID   | byte array   | Listener identifier
+| Include state | byte         | When this byte is set to `1`, cached state is
+sent back to remote clients when either adding a cache listener for the first
+time, or when the node where a remote listener is registered changes in a clustered
+environment. When enabled, state is sent back as cache entry created events to
+the clients. If set to `0`, no state is sent back to the client when adding a listener,
+nor it gets state when the node where the listener is registered changes.
+| Key/value filter factory name | string | Optional name of the key/value filter
+factory to be used with this listener. The factory is used to create key/value
+filter instances which allow events to be filtered directly in the Hot Rod
+server, avoiding sending events that the client is not interested in. If no
+factory is to be used, the length of the string is `0`.
+| Key/value filter factory parameter count | byte | The key/value filter
+factory, when creating a filter instance, can take an arbitrary number of
+parameters, enabling the factory to be used to create different filter
+instances dynamically. This count field indicates how many parameters will be
+passed to the factory. If no factory name was provided, this field is not
+present in the request.
+| Key/value filter factory parameter 1 | byte array | First key/value filter
+factory parameter
+| Key/value filter factory parameter 2 | byte array | Second key/value filter
+factory parameter
+| ... | |
+| Converter factory name | string | Optional name of the converter
+factory to be used with this listener. The factory is used to transform the
+contents of the events sent to clients. By default, when no converter is in use,
+events are well defined, according to the type of event generated. However,
+there might be situations where users want to add extra information to the event,
+or they want to reduce the size of the events. In these cases, a converter can
+be used to transform the event contents. The given converter factory name
+produces converter instances to do this job. If no factory is to be used, the
+length of the string is `0`.
+| Converter factory parameter count | byte | The converter
+factory, when creating a converter instance, can take an arbitrary number of
+parameters, enabling the factory to be used to create different converter
+instances dynamically. This count field indicates how many parameters will be
+passed to the factory. If no factory name was provided, this field is not
+present in the request.
+| Converter factory parameter 1 | byte array | First converter factory parameter
+| Converter factory parameter 2 | byte array | Second converter factory parameter
+| ... | |
+| Listener even type interests  | vInt       |  A variable length number representing listener event type interests.
+Each event type is represented by a bit.
+Each flags is represented by a bit.
+Note that since this field is sent as variable length, the most significant bit in a byte is used to determine whether more bytes need to be read, hence this bit does not represent any flag.
+Using this model allows for flags to be combined in a short space.
+Here are the current values for each flag: +
++0x01+ = cache entry created events
++0x02+ = cache entry modified events
++0x04+ = cache entry removed events
++0x08+ = cache entry expired events
+|==============================================================================
+
+
 ==== Hot Rod Hash Functions
 Infinispan makes use of a consistent hash function to place nodes on a hash
 wheel, and to place keys of entries on the same wheel to determine where

--- a/query/src/main/java/org/infinispan/query/dsl/embedded/impl/BaseJPAFilterIndexingServiceProvider.java
+++ b/query/src/main/java/org/infinispan/query/dsl/embedded/impl/BaseJPAFilterIndexingServiceProvider.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -332,6 +333,11 @@ public abstract class BaseJPAFilterIndexingServiceProvider implements FilterInde
 
       @Override
       public <C> CacheEventConverter<? super K, ? super V, C> getConverter() {
+         return null;
+      }
+
+      @Override
+      public Set<Class<? extends Annotation>> getFilterAnnotations() {
          return null;
       }
    }

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/Constants.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/Constants.java
@@ -23,6 +23,7 @@ public class Constants {
    static final public byte VERSION_23 = 23;
    static final public byte VERSION_24 = 24;
    static final public byte VERSION_25 = 25;
+   static final public byte VERSION_26 = 26;
    static final public byte DEFAULT_CONSISTENT_HASH_VERSION_1x = 2;
    static final public byte DEFAULT_CONSISTENT_HASH_VERSION = 3;
 
@@ -56,7 +57,7 @@ public class Constants {
    }
 
    static final public boolean isVersion2x(byte v) {
-      return v >= VERSION_20 && v <= VERSION_25;
+      return v >= VERSION_20 && v <= VERSION_26;
    }
 
    static final public boolean isVersionKnown(byte v) {
@@ -81,10 +82,15 @@ public class Constants {
     * Is version previous post, and not including, 2.0?
     */
    static public boolean isVersionPost20(byte v) {
-      return v >= VERSION_21 && v <= VERSION_25;
+      return v >= VERSION_21 && v <= VERSION_26;
    }
 
    static public boolean isVersionPost24(byte v) {
       return v > VERSION_24;
    }
+
+   static public boolean isVersionPost25(byte v) {
+      return v > VERSION_25;
+   }
+
 }

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/ContextHandler.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/ContextHandler.java
@@ -153,7 +153,7 @@ public class ContextHandler extends SimpleChannelInboundHandler<CacheDecodeConte
             ClientListenerRequestContext clientContext = (ClientListenerRequestContext) msg.operationDecodeContext;
             server.getClientListenerRegistry().addClientListener(msg.decoder, ctx.channel(), h, clientContext.getListenerId(),
                   msg.cache, clientContext.isIncludeCurrentState(), new KeyValuePair<>(clientContext.getFilterFactoryInfo(),
-                        clientContext.getConverterFactoryInfo()), clientContext.isUseRawData());
+                        clientContext.getConverterFactoryInfo()), clientContext.isUseRawData(), clientContext.getListenerInterests());
             break;
          case REMOVE_CLIENT_LISTENER:
             byte[] listenerId = (byte[]) msg.operationDecodeContext;

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/Decoder2x.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/Decoder2x.java
@@ -405,12 +405,20 @@ class Decoder2x implements VersionedDecoder {
                requestCtx.setUseRawData(useRawData);
 
                buffer.markReaderIndex();
-               out.add(hrCtx);
 
                return requestCtx;
             }).isPresent()) {
                return;
             }
+            if (Constants.isVersionPost25(header.version)) {
+               int listenerInterests = ExtendedByteBufJava.readMaybeVInt(buffer);
+               if (listenerInterests == Integer.MIN_VALUE)
+                  return;
+
+               requestCtx.setListenerInterests(listenerInterests);
+               buffer.markReaderIndex();
+            }
+            out.add(hrCtx);
             break;
          case REMOVE_CLIENT_LISTENER:
             ExtendedByteBuf.readMaybeRangedBytes(buffer).ifPresent(listenerId -> {
@@ -727,6 +735,7 @@ class ClientListenerRequestContext {
    private Optional<KeyValuePair<String, List<byte[]>>> filterFactoryInfo;
    private Optional<KeyValuePair<String, List<byte[]>>> converterFactoryInfo;
    private boolean useRawData;
+   private int listenerInterests;
 
    ClientListenerRequestContext(byte[] listenerId, boolean includeCurrentState) {
       this.listenerId = listenerId;
@@ -763,6 +772,14 @@ class ClientListenerRequestContext {
 
    public void setUseRawData(boolean useRawData) {
       this.useRawData = useRawData;
+   }
+
+   public int getListenerInterests() {
+      return listenerInterests;
+   }
+
+   public void setListenerInterests(int listenerInterests) {
+      this.listenerInterests = listenerInterests;
    }
 }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7283

* Cluster listener installed for remote listener is now more fine
  grained, only adding listener callbacks for those events that the
  client is interested in.
* To find out which callbacks the client is interested in, the Hot Rod
  protocol has been changed to add a byte indicating the event types
  interested in.
* Added addFilteredListener which allows the caller to decide which
  cache-entry specific events the listener is interested in.