### PR TITLE
ISPN-6802 Remove remaining equivalence references

### DIFF
--- a/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/event/CacheEventTest.java
+++ b/cdi/embedded/src/test/java/org/infinispan/cdi/embedded/test/event/CacheEventTest.java
@@ -10,7 +10,6 @@ import javax.inject.Inject;
 import org.infinispan.AdvancedCache;
 import org.infinispan.cdi.embedded.test.DefaultTestEmbeddedCacheManagerProducer;
 import org.infinispan.cdi.embedded.test.assertions.ObserverAssertion;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.context.impl.NonTxInvocationContext;
 import org.infinispan.distribution.ch.ConsistentHash;
 import org.infinispan.notifications.cachelistener.CacheNotifier;
@@ -39,7 +38,7 @@ import org.testng.annotations.Test;
 @Test(groups = "functional", testName = "cdi.test.event.CacheEventTest")
 public class CacheEventTest extends Arquillian {
 
-   private final NonTxInvocationContext invocationContext = new NonTxInvocationContext(null, AnyEquivalence.getInstance());
+   private final NonTxInvocationContext invocationContext = new NonTxInvocationContext(null);
 
    @Inject
    @Cache1

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/ExecTest.java
@@ -62,8 +62,6 @@ public class ExecTest extends MultiHotRodServersTest {
    private void defineInAll(String cacheName, CacheMode mode) {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(mode, true);
       builder.dataContainer()
-            .keyEquivalence(new AnyServerEquivalence())
-            .valueEquivalence(new AnyServerEquivalence())
             .compatibility().enable()
             .marshaller(new GenericJBossMarshaller());
       defineInAll(cacheName, builder);
@@ -106,7 +104,7 @@ public class ExecTest extends MultiHotRodServersTest {
    public void testScriptExecutionWithPassingParams(CacheMode cacheMode) throws IOException {
       String cacheName = "testScriptExecutionWithPassingParams_" + cacheMode.toString();
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(cacheMode, true);
-      builder.dataContainer().keyEquivalence(new AnyServerEquivalence()).valueEquivalence(new AnyServerEquivalence()).compatibility().enable().marshaller(new GenericJBossMarshaller());
+      builder.dataContainer().compatibility().enable().marshaller(new GenericJBossMarshaller());
       defineInAll(cacheName, builder);
       try (InputStream is = this.getClass().getResourceAsStream("/distExec.js")) {
          String script = TestingUtil.loadFileAsString(is);
@@ -137,8 +135,7 @@ public class ExecTest extends MultiHotRodServersTest {
    public void testRemoteMapReduceWithStreams(CacheMode cacheMode) throws Exception {
       String cacheName = "testRemoteMapReduce_Streams_dist_" + cacheMode.toString();
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(cacheMode, true);
-      builder.dataContainer().keyEquivalence(new AnyServerEquivalence()).valueEquivalence(new AnyServerEquivalence())
-              .compatibility().enable().marshaller(new GenericJBossMarshaller());
+      builder.dataContainer() .compatibility().enable().marshaller(new GenericJBossMarshaller());
       defineInAll(cacheName, builder);
       waitForClusterToForm(cacheName);
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/MixedExpiryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/MixedExpiryTest.java
@@ -23,7 +23,6 @@ public class MixedExpiryTest extends MultiHotRodServersTest {
    @Override
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder builder = getDefaultClusteredCacheConfig(CacheMode.REPL_SYNC, false);
-      builder.dataContainer().keyEquivalence(new AnyServerEquivalence());
       configure(builder);
       createHotRodServers(1, builder);
    }

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SecureExecTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/SecureExecTest.java
@@ -58,9 +58,6 @@ public class SecureExecTest extends AbstractAuthenticationTest {
 
       ConfigurationBuilder config = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
       config
-         .dataContainer()
-            .keyEquivalence(new AnyServerEquivalence())
-            .valueEquivalence(new AnyServerEquivalence())
          .security().authorization().enable().role("admin").role("RWEuser").role("RWuser");
       cacheManager = TestCacheManagerFactory.createCacheManager(global, config);
       cacheManager.defineConfiguration(CACHE_NAME, config.build());

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatClientListenerWithDslFilterTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatClientListenerWithDslFilterTest.java
@@ -31,7 +31,6 @@ import org.infinispan.client.hotrod.query.testdomain.protobuf.UserPB;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.GenderMarshaller;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.MarshallerRegistration;
 import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -95,7 +94,6 @@ public class EmbeddedCompatClientListenerWithDslFilterTest extends MultiHotRodSe
 
    protected ConfigurationBuilder getConfigurationBuilder() {
       ConfigurationBuilder cfgBuilder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
-      cfgBuilder.dataContainer().keyEquivalence(AnyEquivalence.getInstance());
       cfgBuilder.compatibility().enable().marshaller(new CompatibilityProtoStreamMarshaller());
       cfgBuilder.indexing().index(Index.ALL)
             .addProperty("default.directory_provider", "ram")

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatContinuousQueryTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/event/EmbeddedCompatContinuousQueryTest.java
@@ -29,7 +29,6 @@ import org.infinispan.client.hotrod.query.testdomain.protobuf.UserPB;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.GenderMarshaller;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.MarshallerRegistration;
 import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -98,7 +97,6 @@ public class EmbeddedCompatContinuousQueryTest extends MultiHotRodServersTest {
 
    protected ConfigurationBuilder getConfigurationBuilder() {
       ConfigurationBuilder cfgBuilder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
-      cfgBuilder.dataContainer().keyEquivalence(AnyEquivalence.getInstance());
       cfgBuilder.compatibility().enable().marshaller(new CompatibilityProtoStreamMarshaller());
       cfgBuilder.indexing().index(Index.ALL)
             .addProperty("default.directory_provider", "ram")

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/MultiServerCompatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/impl/iteration/MultiServerCompatTest.java
@@ -8,7 +8,6 @@ import java.util.Set;
 
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.test.MultiHotRodServersTest;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.testng.annotations.Test;
@@ -28,7 +27,6 @@ public class MultiServerCompatTest extends MultiHotRodServersTest implements Abs
       ConfigurationBuilder builder = hotRodCacheConfiguration(getDefaultClusteredCacheConfig(CacheMode.DIST_SYNC, false));
       builder.clustering().hash().numSegments(60).numOwners(1);
       builder.compatibility().enable();
-      builder.dataContainer().keyEquivalence(AnyEquivalence.getInstance());
       return builder;
    }
 

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/EmbeddedCompatTest.java
@@ -26,7 +26,6 @@ import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.Gender
 import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.MarshallerRegistration;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.NotIndexedMarshaller;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.util.CloseableIterator;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.Index;
@@ -78,8 +77,6 @@ public class EmbeddedCompatTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       org.infinispan.configuration.cache.ConfigurationBuilder builder = createConfigBuilder();
-      // the default key equivalence works only for byte[] so we need to override it with one that works for Object
-      builder.dataContainer().keyEquivalence(AnyEquivalence.getInstance());
 
       cacheManager = TestCacheManagerFactory.createCacheManager(builder);
       cache = cacheManager.getCache();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/PrimitiveEmbeddedCompatTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/marshall/PrimitiveEmbeddedCompatTest.java
@@ -10,7 +10,6 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.query.remote.CompatibilityProtoStreamMarshaller;
 import org.infinispan.server.hotrod.HotRodServer;
@@ -35,8 +34,6 @@ public class PrimitiveEmbeddedCompatTest extends SingleCacheManagerTest {
    @Override
    protected EmbeddedCacheManager createCacheManager() throws Exception {
       org.infinispan.configuration.cache.ConfigurationBuilder builder = createConfigBuilder();
-      // the default key equivalence works only for byte[] so we need to override it with one that works for Object
-      builder.dataContainer().keyEquivalence(AnyEquivalence.getInstance());
 
       cacheManager = TestCacheManagerFactory.createCacheManager(builder);
       cache = cacheManager.getCache();

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/RemoteQueryDslPerfTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/stress/RemoteQueryDslPerfTest.java
@@ -19,7 +19,6 @@ import org.infinispan.client.hotrod.marshall.EmbeddedUserMarshaller;
 import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
 import org.infinispan.client.hotrod.query.testdomain.protobuf.marshallers.MarshallerRegistration;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
@@ -62,7 +61,6 @@ public class RemoteQueryDslPerfTest extends MultipleCacheManagersTest {
    protected void createCacheManagers() throws Throwable {
       ConfigurationBuilder builder = hotRodCacheConfiguration();
       builder.compatibility().enable().marshaller(new CompatibilityProtoStreamMarshaller());
-      builder.dataContainer().keyEquivalence(AnyEquivalence.getInstance());
       builder.indexing().index(Index.ALL)
             .addProperty("default.directory_provider", "ram")
             .addProperty("lucene_version", "LUCENE_CURRENT");

--- a/commons/src/main/java/org/infinispan/commons/equivalence/Equivalence.java
+++ b/commons/src/main/java/org/infinispan/commons/equivalence/Equivalence.java
@@ -15,8 +15,9 @@ import java.io.Serializable;
  *
  * @author Galder Zamarreño
  * @since 5.3
- * @Deprecated Equivalence is to be removed (byte[] are directly supported)
+ * @Deprecated Since 9.0, Equivalence is to be removed (byte[] are directly supported)
  */
+@Deprecated
 public interface Equivalence<T> extends Serializable {
 
    /**
@@ -24,7 +25,7 @@ public interface Equivalence<T> extends Serializable {
     *
     * As an example, implementors can provide an alternative implementation
     * for the hash code calculation for arrays. So, instead of relying on
-    * {@link Object#hashCode()}, call {@link java.util.Arrays.hashCode()}.
+    * {@link Object#hashCode()}, call {@link java.util.Arrays#hashCode()}.
     *
     * @param obj instance to calculate hash code for
     * @return a hash code value for the object passed as parameter
@@ -36,7 +37,7 @@ public interface Equivalence<T> extends Serializable {
     *
     * As an example, implementors can provide an alternative implementation
     * for the equals for arrays. So, instead of relying on
-    * {@link Object#equals(Object)}}, call {@link java.util.Arrays.equals())}.
+    * {@link Object#equals(Object)}}, call {@link java.util.Arrays#equals(Object[], Object[])}.
     *
     * @param obj to be compared with second parameter
     * @param otherObj to be compared with first parameter

--- a/commons/src/main/java/org/infinispan/commons/util/CollectionFactory.java
+++ b/commons/src/main/java/org/infinispan/commons/util/CollectionFactory.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.equivalence.Equivalence;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -54,26 +53,70 @@ public class CollectionFactory {
       return new ConcurrentHashMap<>(initCapacity, loadFactor, concurrencyLevel);
    }
 
+   public static <K, V> Map<K, V> makeMap() {
+      return new HashMap<>();
+   }
+
+   public static <K, V> Map<K, V> makeMap(int initialCapacity) {
+      return new HashMap<>(initialCapacity);
+   }
+
+   public static <K, V> Map<K, V> makeMap(Map<? extends K, ? extends V> entries) {
+      return new HashMap<>(entries);
+   }
+
+   public static <K, V> Map<K, V> makeLinkedMap(int initialCapacity, float loadFactor, boolean accessOrder) {
+      return new LinkedHashMap<>(initialCapacity, loadFactor, accessOrder);
+   }
+
+   public static <T> Set<T> makeSet() {
+      return new HashSet<>();
+   }
+
+   public static <T> Set<T> makeSet(int initialCapacity) {
+      return new HashSet<>(initialCapacity);
+   }
+
+   /**
+    * @deprecated Since 9.0, please use {@link #makeConcurrentMap()} instead.
+    */
+   @Deprecated
    public static <K, V> ConcurrentMap<K, V> makeConcurrentMap(
          Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       return makeConcurrentMap();
    }
 
+   /**
+    * @deprecated Since 9.0, please use {@link #makeConcurrentMap(int)} instead.
+    */
+   @Deprecated
    public static <K, V> ConcurrentMap<K, V> makeConcurrentMap(
          int initCapacity, Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       return makeConcurrentMap(initCapacity);
    }
 
+   /**
+    * @deprecated Since 9.0, please use {@link #makeConcurrentMap(int, int)} instead.
+    */
+   @Deprecated
    public static <K, V> ConcurrentMap<K, V> makeConcurrentMap(
          int initCapacity, int concurrencyLevel, Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       return makeConcurrentMap(initCapacity, concurrencyLevel);
    }
 
+   /**
+    * @deprecated Since 9.0, please use {@link #makeConcurrentParallelMap(int, int)} instead.
+    */
+   @Deprecated
    public static <K, V> ConcurrentMap<K, V> makeConcurrentParallelMap(
          int initCapacity, int concurrencyLevel, Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       return makeConcurrentParallelMap(initCapacity, concurrencyLevel);
    }
 
+   /**
+    * @deprecated Since 9.0, please use {@link #makeConcurrentMap(int, float, int)} instead.
+    */
+   @Deprecated
    public static <K, V> ConcurrentMap<K, V> makeConcurrentMap(
          int initCapacity, float loadFactor, int concurrencyLevel,
          Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
@@ -85,31 +128,55 @@ public class CollectionFactory {
       return cache.asMap();
    }
 
+   /**
+    * @deprecated Since 9.0, please use {@link #makeMap()} instead.
+    */
+   @Deprecated
    public static <K, V> Map<K, V> makeMap(
          Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       return new HashMap<>();
    }
 
+   /**
+    * @deprecated Since 9.0, please use {@link #makeMap(int)} instead.
+    */
+   @Deprecated
    public static <K, V> Map<K, V> makeMap(
          int initialCapacity, Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       return new HashMap<>(initialCapacity);
    }
 
+   /**
+    * @deprecated Since 9.0, please use {@link #makeMap(Map)} instead.
+    */
+   @Deprecated
    public static <K, V> Map<K, V> makeMap(
          Map<? extends K, ? extends V> entries, Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       return new HashMap<>(entries);
    }
 
+   /**
+    * @deprecated Since 9.0, please use {@link #makeSet(int)} instead.
+    */
+   @Deprecated
    public static <K, V> Map<K, V> makeLinkedMap(int initialCapacity,
          float loadFactor, boolean accessOrder,
          Equivalence<? super K> keyEq, Equivalence<? super V> valueEq) {
       return new LinkedHashMap<>(initialCapacity, loadFactor, accessOrder);
    }
 
+   /**
+    * @deprecated Since 9.0, please use {@link #makeSet()} instead.
+    */
+   @Deprecated
    public static <T> Set<T> makeSet(Equivalence<? super T> entryEq) {
       return new HashSet<>();
    }
 
+   /**
+    * @deprecated Since 9.0, please use {@link #makeSet(int)} instead.
+    */
+   @Deprecated
    public static <T> Set<T> makeSet(int initialCapacity, Equivalence<? super T> entryEq) {
       return new HashSet<>(initialCapacity);
    }

--- a/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
+++ b/core/src/main/java/org/infinispan/commands/remote/ClusteredGetCommand.java
@@ -3,11 +3,11 @@ package org.infinispan.commands.remote;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commands.CommandsFactory;
 import org.infinispan.commands.read.GetCacheEntryCommand;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.util.EnumUtil;
 import org.infinispan.container.InternalEntryFactory;
 import org.infinispan.container.entries.InternalCacheEntry;
@@ -125,12 +125,12 @@ public class ClusteredGetCommand extends BaseClusteredReadCommand {
 
       ClusteredGetCommand that = (ClusteredGetCommand) o;
 
-      return AnyEquivalence.getInstance().equals(key, that.key);
+      return Objects.equals(key, that.key);
    }
 
    @Override
    public int hashCode() {
-      return AnyEquivalence.getInstance().hashCode(key);
+      return Objects.hashCode(key);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/commands/write/ValueMatcher.java
+++ b/core/src/main/java/org/infinispan/commands/write/ValueMatcher.java
@@ -1,7 +1,8 @@
 package org.infinispan.commands.write;
 
+import java.util.Objects;
+
 import org.infinispan.Cache;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 
 /**
  * A policy for determining if a write command should be executed based on the current value in the cache.
@@ -137,12 +138,16 @@ public enum ValueMatcher {
 
    public abstract boolean matches(Object existingValue, Object expectedValue, Object newValue);
 
+   /**
+    * @deprecated Since 9.0, no longer used.
+    */
+   @Deprecated
    public abstract boolean nonExistentEntryCanMatch();
 
    public abstract ValueMatcher matcherForRetry();
 
    protected boolean equal(Object a, Object b) {
-      return AnyEquivalence.getInstance().equals(a, b);
+      return Objects.equals(a, b);
    }
 
    private static final ValueMatcher[] CACHED_VALUES = values();

--- a/core/src/main/java/org/infinispan/configuration/cache/DataContainerConfiguration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/DataContainerConfiguration.java
@@ -8,7 +8,6 @@ import org.infinispan.commons.configuration.attributes.IdentityAttributeCopier;
 import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.container.DataContainer;
-import org.infinispan.container.StorageType;
 
 /**
  * Controls the data container for the cache.

--- a/core/src/main/java/org/infinispan/context/NonTransactionalInvocationContextFactory.java
+++ b/core/src/main/java/org/infinispan/context/NonTransactionalInvocationContextFactory.java
@@ -34,9 +34,9 @@ public class NonTransactionalInvocationContextFactory extends AbstractInvocation
    @Override
    public InvocationContext createInvocationContext(boolean isWrite, int keyCount) {
       if (keyCount == 1) {
-         return new SingleKeyNonTxInvocationContext(null, keyEq);
+         return new SingleKeyNonTxInvocationContext(null);
       } else if (keyCount > 0) {
-         return new NonTxInvocationContext(keyCount, null, keyEq);
+         return new NonTxInvocationContext(keyCount, null);
       }
       return createInvocationContext(null, false);
    }
@@ -48,17 +48,17 @@ public class NonTransactionalInvocationContextFactory extends AbstractInvocation
 
    @Override
    public NonTxInvocationContext createNonTxInvocationContext() {
-      return new NonTxInvocationContext(null, keyEq);
+      return new NonTxInvocationContext(null);
    }
 
    @Override
    public InvocationContext createSingleKeyNonTxInvocationContext() {
-      return new SingleKeyNonTxInvocationContext(null, keyEq);
+      return new SingleKeyNonTxInvocationContext(null);
    }
 
    @Override
    public NonTxInvocationContext createRemoteInvocationContext(Address origin) {
-      return new NonTxInvocationContext(origin, keyEq);
+      return new NonTxInvocationContext(origin);
    }
 
    @Override
@@ -80,7 +80,7 @@ public class NonTransactionalInvocationContextFactory extends AbstractInvocation
    public InvocationContext createRemoteInvocationContextForCommand(VisitableCommand cacheCommand,
                                                                           Address origin) {
       if (cacheCommand instanceof DataCommand && !(cacheCommand instanceof InvalidateCommand)) {
-         return new SingleKeyNonTxInvocationContext(origin, keyEq);
+         return new SingleKeyNonTxInvocationContext(origin);
       } else {
          return super.createRemoteInvocationContextForCommand(cacheCommand, origin);
       }

--- a/core/src/main/java/org/infinispan/context/SingleKeyNonTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/SingleKeyNonTxInvocationContext.java
@@ -2,9 +2,9 @@ package org.infinispan.context;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
-import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.remoting.transport.Address;
 
@@ -25,17 +25,14 @@ public final class SingleKeyNonTxInvocationContext implements InvocationContext 
 
    private CacheEntry cacheEntry;
 
-   //TODO move reference to Equivalence to InvocationContextFactory (Memory allocation cost)
-   private final Equivalence keyEquivalence;
    //TODO move the Origin's address to the InvocationContextFactory when isOriginLocal=true -> all addresses are the same  (Memory allocation cost)
    //(verify if this is worth it by looking at object alignment - would need a different implementation as pointing to null wouldn't help)
    private final Address origin;
 
    private Object lockOwner;
 
-   public SingleKeyNonTxInvocationContext(final Address origin, final Equivalence<Object> keyEquivalence) {
+   public SingleKeyNonTxInvocationContext(final Address origin) {
       this.origin = origin;
-      this.keyEquivalence = keyEquivalence;
    }
 
    @Override
@@ -85,7 +82,7 @@ public final class SingleKeyNonTxInvocationContext implements InvocationContext 
       if (this.key == null) {
          // Set the key here
          this.key = key;
-      } else if (!keyEquivalence.equals(key, this.key)) {
+      } else if (!Objects.equals(key, this.key)) {
          throw illegalStateException();
       }
 
@@ -98,7 +95,7 @@ public final class SingleKeyNonTxInvocationContext implements InvocationContext 
 
    @Override
    public CacheEntry lookupEntry(final Object key) {
-      if (keyEquivalence.equals(key, this.key))
+      if (Objects.equals(key, this.key))
          return cacheEntry;
 
       return null;
@@ -114,7 +111,7 @@ public final class SingleKeyNonTxInvocationContext implements InvocationContext 
       if (this.key == null) {
          // Set the key here
          this.key = key;
-      } else if (!keyEquivalence.equals(key, this.key)) {
+      } else if (!Objects.equals(key, this.key)) {
          throw illegalStateException();
       }
 
@@ -123,7 +120,7 @@ public final class SingleKeyNonTxInvocationContext implements InvocationContext 
 
    @Override
    public void removeLookedUpEntry(final Object key) {
-      if (keyEquivalence.equals(key, this.key)) {
+      if (Objects.equals(key, this.key)) {
          this.cacheEntry = null;
       }
    }
@@ -153,7 +150,7 @@ public final class SingleKeyNonTxInvocationContext implements InvocationContext 
 
    @Override
    public boolean hasLockedKey(final Object key) {
-      return isLocked && keyEquivalence.equals(this.key, key);
+      return isLocked && Objects.equals(this.key, key);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/context/TransactionalInvocationContextFactory.java
+++ b/core/src/main/java/org/infinispan/context/TransactionalInvocationContextFactory.java
@@ -50,7 +50,7 @@ public class TransactionalInvocationContextFactory extends AbstractInvocationCon
 
    @Override
    public InvocationContext createSingleKeyNonTxInvocationContext() {
-      return new SingleKeyNonTxInvocationContext(null, keyEq);
+      return new SingleKeyNonTxInvocationContext(null);
    }
 
    @Override
@@ -107,7 +107,7 @@ public class TransactionalInvocationContextFactory extends AbstractInvocationCon
    }
 
    protected final NonTxInvocationContext newNonTxInvocationContext(Address origin) {
-      NonTxInvocationContext ctx = new NonTxInvocationContext(origin, keyEq);
+      NonTxInvocationContext ctx = new NonTxInvocationContext(origin);
       return ctx;
    }
 
@@ -115,7 +115,7 @@ public class TransactionalInvocationContextFactory extends AbstractInvocationCon
    public InvocationContext createRemoteInvocationContextForCommand(VisitableCommand cacheCommand,
          Address origin) {
       if (cacheCommand instanceof DataCommand && !(cacheCommand instanceof InvalidateCommand)) {
-         return new SingleKeyNonTxInvocationContext(origin, keyEq);
+         return new SingleKeyNonTxInvocationContext(origin);
       } else {
          return super.createRemoteInvocationContextForCommand(cacheCommand, origin);
       }

--- a/core/src/main/java/org/infinispan/context/impl/NonTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/impl/NonTxInvocationContext.java
@@ -4,8 +4,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-import org.infinispan.commons.equivalence.AnyEquivalence;
-import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.remoting.transport.Address;
@@ -21,21 +19,18 @@ public class NonTxInvocationContext extends AbstractInvocationContext {
    private static final int INITIAL_CAPACITY = 4;
 
    private final Map<Object, CacheEntry> lookedUpEntries;
-   private final Equivalence<Object> keyEq;
    private Set<Object> lockedKeys;
    private Object lockOwner;
 
 
-   public NonTxInvocationContext(int numEntries, Address origin, Equivalence<Object> keyEq) {
+   public NonTxInvocationContext(int numEntries, Address origin) {
       super(origin);
-      lookedUpEntries = CollectionFactory.makeMap(CollectionFactory.computeCapacity(numEntries), keyEq, AnyEquivalence.getInstance());
-      this.keyEq = keyEq;
+      lookedUpEntries = CollectionFactory.makeMap(CollectionFactory.computeCapacity(numEntries));
    }
 
-   public NonTxInvocationContext(Address origin, Equivalence<Object> keyEq) {
+   public NonTxInvocationContext(Address origin) {
       super(origin);
-      lookedUpEntries = CollectionFactory.makeMap(INITIAL_CAPACITY, keyEq, AnyEquivalence.getInstance());
-      this.keyEq = keyEq;
+      lookedUpEntries = CollectionFactory.makeMap(INITIAL_CAPACITY);
    }
 
    @Override
@@ -86,7 +81,7 @@ public class NonTxInvocationContext extends AbstractInvocationContext {
    @Override
    public void addLockedKey(Object key) {
       if (lockedKeys == null)
-         lockedKeys = CollectionFactory.makeSet(INITIAL_CAPACITY, keyEq);
+         lockedKeys = CollectionFactory.makeSet(INITIAL_CAPACITY);
 
       lockedKeys.add(key);
    }

--- a/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
+++ b/core/src/main/java/org/infinispan/persistence/file/SingleFileStore.java
@@ -20,9 +20,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.infinispan.commons.configuration.ConfiguredBy;
-import org.infinispan.commons.equivalence.AnyEquivalence;
-import org.infinispan.commons.equivalence.Equivalence;
-import org.infinispan.commons.equivalence.EquivalentLinkedHashMap;
 import org.infinispan.commons.io.ByteBufferFactory;
 import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.configuration.cache.SingleFileStoreConfiguration;
@@ -139,11 +136,10 @@ public class SingleFileStore<K, V> implements AdvancedLoadWriteStore<K, V> {
    private <Key> Map<Key, FileEntry> newEntryMap() {
       // only use LinkedHashMap (LRU) for entries when cache store is bounded
       final Map<Key, FileEntry> entryMap;
-      Equivalence<Object> keyEq = ctx.getCache().getCacheConfiguration().dataContainer().keyEquivalence();
       if (configuration.maxEntries() > 0)
-         entryMap = CollectionFactory.makeLinkedMap(16, 0.75f, true, null, null);
+         entryMap = CollectionFactory.makeLinkedMap(16, 0.75f, true);
       else
-         entryMap = CollectionFactory.makeMap(keyEq, AnyEquivalence.<FileEntry>getInstance());
+         entryMap = CollectionFactory.makeMap();
 
       return Collections.synchronizedMap(entryMap);
    }

--- a/core/src/main/java/org/infinispan/transaction/impl/LocalTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/LocalTransaction.java
@@ -12,8 +12,6 @@ import javax.transaction.Transaction;
 import org.infinispan.commands.write.ClearCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.CacheException;
-import org.infinispan.commons.equivalence.AnyEquivalence;
-import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.context.Flag;
@@ -47,9 +45,9 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
    private boolean prepareSent;
    private boolean commitOrRollbackSent;
 
-   public LocalTransaction(Transaction transaction, GlobalTransaction tx,
-         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
-      super(tx, topologyId, keyEquivalence, txCreationTime);
+   public LocalTransaction(Transaction transaction, GlobalTransaction tx, boolean implicitTransaction, int topologyId,
+                           long txCreationTime) {
+      super(tx, topologyId, txCreationTime);
       this.transaction = transaction;
       this.implicitTransaction = implicitTransaction;
    }
@@ -69,7 +67,7 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
    public void locksAcquired(Collection<Address> nodes) {
       if (trace) log.tracef("Adding remote locks on %s. Remote locks are %s", nodes, remoteLockedNodes);
       if (remoteLockedNodes == null)
-         remoteLockedNodes = new HashSet<Address>(nodes);
+         remoteLockedNodes = new HashSet<>(nodes);
       else
          remoteLockedNodes.addAll(nodes);
    }
@@ -89,7 +87,7 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
 
    @Override
    public Map<Object, CacheEntry> getLookedUpEntries() {
-      return lookedUpEntries == null ? Collections.<Object, CacheEntry>emptyMap() : lookedUpEntries;
+      return lookedUpEntries == null ? Collections.emptyMap() : lookedUpEntries;
    }
 
    public boolean isImplicitTransaction() {
@@ -102,7 +100,7 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
          throw new CacheException("This transaction is marked for rollback and cannot acquire locks!");
       }
       if (lookedUpEntries == null)
-         lookedUpEntries = CollectionFactory.makeMap(4, keyEquivalence, AnyEquivalence.<CacheEntry>getInstance());
+         lookedUpEntries = CollectionFactory.makeMap(4);
 
       lookedUpEntries.put(key, e);
    }
@@ -113,7 +111,7 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
          throw new CacheException("This transaction is marked for rollback and cannot acquire locks!");
       }
       if (lookedUpEntries == null) {
-         lookedUpEntries = CollectionFactory.makeMap(entries, keyEquivalence, AnyEquivalence.<CacheEntry>getInstance());
+         lookedUpEntries = CollectionFactory.makeMap(entries);
       } else {
          lookedUpEntries.putAll(entries);
       }
@@ -155,7 +153,7 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
 
    @Override
    public void addReadKey(Object key) {
-      if (readKeys == null) readKeys = new HashSet<Object>(2);
+      if (readKeys == null) readKeys = new HashSet<>(2);
       readKeys.add(key);
    }
 
@@ -206,7 +204,7 @@ public abstract class LocalTransaction extends AbstractCacheTransaction {
       if (getTopologyId() == currentTopologyId) {
          return recipients;
       }
-      Set<Address> allRecipients = new HashSet<Address>(getRemoteLocksAcquired());
+      Set<Address> allRecipients = new HashSet<>(getRemoteLocksAcquired());
       allRecipients.addAll(recipients);
       allRecipients.retainAll(members);
       if (trace) log.tracef("The merged list of nodes to send commit/rollback is %s", allRecipients);

--- a/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
+++ b/core/src/main/java/org/infinispan/transaction/impl/TransactionTable.java
@@ -34,8 +34,6 @@ import org.infinispan.commands.remote.recovery.TxCompletionNotificationCommand;
 import org.infinispan.commands.tx.RollbackCommand;
 import org.infinispan.commands.write.WriteCommand;
 import org.infinispan.commons.CacheException;
-import org.infinispan.commons.equivalence.AnyEquivalence;
-import org.infinispan.commons.equivalence.IdentityEquivalence;
 import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.cache.Configuration;
@@ -152,9 +150,7 @@ public class TransactionTable implements org.infinispan.transaction.TransactionT
       final int concurrencyLevel = configuration.locking().concurrencyLevel();
       //use the IdentityEquivalence because some Transaction implementation does not have a stable hash code function
       //and it can cause some leaks in the concurrent map.
-      localTransactions = CollectionFactory.makeConcurrentMap(concurrencyLevel, 0.75f, concurrencyLevel,
-                                                              new IdentityEquivalence<>(),
-            AnyEquivalence.getInstance());
+      localTransactions = CollectionFactory.makeConcurrentMap(concurrencyLevel, 0.75f, concurrencyLevel);
       globalToLocalTransactions = CollectionFactory.makeConcurrentMap(concurrencyLevel, 0.75f, concurrencyLevel);
 
       boolean transactional = configuration.transaction().transactionMode().isTransactional();

--- a/core/src/main/java/org/infinispan/transaction/synchronization/SyncLocalTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/synchronization/SyncLocalTransaction.java
@@ -2,7 +2,6 @@ package org.infinispan.transaction.synchronization;
 
 import javax.transaction.Transaction;
 
-import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
 
@@ -14,9 +13,9 @@ import org.infinispan.transaction.xa.GlobalTransaction;
  */
 public class SyncLocalTransaction extends LocalTransaction {
 
-   public SyncLocalTransaction(Transaction transaction, GlobalTransaction tx,
-         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
-      super(transaction, tx, implicitTransaction, topologyId, keyEquivalence, txCreationTime);
+   public SyncLocalTransaction(Transaction transaction, GlobalTransaction tx, boolean implicitTransaction,
+                               int topologyId, long txCreationTime) {
+      super(transaction, tx, implicitTransaction, topologyId, txCreationTime);
    }
 
    private boolean enlisted;

--- a/core/src/main/java/org/infinispan/transaction/xa/LocalXaTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/LocalXaTransaction.java
@@ -3,7 +3,6 @@ package org.infinispan.transaction.xa;
 import javax.transaction.Transaction;
 import javax.transaction.xa.Xid;
 
-import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.transaction.impl.LocalTransaction;
 import org.infinispan.transaction.xa.recovery.RecoverableTransactionIdentifier;
 
@@ -17,9 +16,9 @@ public class LocalXaTransaction extends LocalTransaction {
 
    private Xid xid;
 
-   public LocalXaTransaction(Transaction transaction, GlobalTransaction tx,
-         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
-      super(transaction, tx, implicitTransaction, topologyId, keyEquivalence, txCreationTime);
+   public LocalXaTransaction(Transaction transaction, GlobalTransaction tx, boolean implicitTransaction, int topologyId,
+                             long txCreationTime) {
+      super(transaction, tx, implicitTransaction, topologyId, txCreationTime);
    }
 
    public void setXid(Xid xid) {

--- a/core/src/main/java/org/infinispan/transaction/xa/TransactionFactory.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/TransactionFactory.java
@@ -5,7 +5,6 @@ import java.util.Random;
 import javax.transaction.Transaction;
 
 import org.infinispan.commands.write.WriteCommand;
-import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.versioning.NumericVersion;
 import org.infinispan.container.versioning.VersionGenerator;
@@ -40,15 +39,15 @@ public class TransactionFactory {
    private VersionGenerator clusterIdGenerator;
    private TimeService timeService;
    private boolean isClustered;
-   private Equivalence<Object> keyEquivalence;
 
    public enum TxFactoryEnum {
 
       DLD_RECOVERY_XA {
          @Override
-         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId,
-               Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new RecoveryAwareLocalTransaction(tx, gtx, implicitTransaction, topologyId, keyEquivalence, txCreationTime);
+         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction,
+                                                     int topologyId,
+                                                     long txCreationTime) {
+            return new RecoveryAwareLocalTransaction(tx, gtx, implicitTransaction, topologyId, txCreationTime);
          }
 
          @Override
@@ -65,22 +64,24 @@ public class TransactionFactory {
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId,
-                                                       Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new RecoveryAwareRemoteTransaction(modifications, tx, topologyId, keyEquivalence, txCreationTime);
+         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx,
+                                                       int topologyId, long txCreationTime) {
+            return new RecoveryAwareRemoteTransaction(modifications, tx, topologyId, txCreationTime);
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new RecoveryAwareRemoteTransaction(tx, topologyId, keyEquivalence, txCreationTime);
+         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId,
+                                                       long txCreationTime) {
+            return new RecoveryAwareRemoteTransaction(tx, topologyId, txCreationTime);
          }
       },
 
       DLD_NORECOVERY_XA {
          @Override
-         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId,
-               Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new LocalXaTransaction(tx, gtx, implicitTransaction, topologyId, keyEquivalence, txCreationTime);
+         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction,
+                                                     int topologyId,
+                                                     long txCreationTime) {
+            return new LocalXaTransaction(tx, gtx, implicitTransaction, topologyId, txCreationTime);
          }
 
          @Override
@@ -94,22 +95,25 @@ public class TransactionFactory {
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId,
-                                                       Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new RemoteTransaction(modifications, tx, topologyId, keyEquivalence, txCreationTime);
+         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx,
+                                                       int topologyId,
+                                                       long txCreationTime) {
+            return new RemoteTransaction(modifications, tx, topologyId, txCreationTime);
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new RemoteTransaction(tx, topologyId, keyEquivalence, txCreationTime);
+         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId,
+                                                       long txCreationTime) {
+            return new RemoteTransaction(tx, topologyId, txCreationTime);
          }
       },
 
       DLD_NORECOVERY_NOXA {
          @Override
-         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId,
-                                                     Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new SyncLocalTransaction(tx, gtx, implicitTransaction, topologyId, keyEquivalence, txCreationTime);
+         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction,
+                                                     int topologyId,
+                                                     long txCreationTime) {
+            return new SyncLocalTransaction(tx, gtx, implicitTransaction, topologyId, txCreationTime);
          }
 
          @Override
@@ -123,21 +127,24 @@ public class TransactionFactory {
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId,
-                                                       Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new RemoteTransaction(modifications, tx, topologyId, keyEquivalence, txCreationTime);
+         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx,
+                                                       int topologyId,
+                                                       long txCreationTime) {
+            return new RemoteTransaction(modifications, tx, topologyId, txCreationTime);
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new RemoteTransaction(tx, topologyId, keyEquivalence, txCreationTime);
+         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId,
+                                                       long txCreationTime) {
+            return new RemoteTransaction(tx, topologyId, txCreationTime);
          }
       },
       NODLD_RECOVERY_XA {
          @Override
-         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId,
-                                                     Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new RecoveryAwareLocalTransaction(tx, gtx, implicitTransaction, topologyId, keyEquivalence, txCreationTime);
+         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction,
+                                                     int topologyId,
+                                                     long txCreationTime) {
+            return new RecoveryAwareLocalTransaction(tx, gtx, implicitTransaction, topologyId, txCreationTime);
          }
 
          @Override
@@ -154,21 +161,24 @@ public class TransactionFactory {
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId,
-                                                       Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new RecoveryAwareRemoteTransaction(modifications, tx, topologyId, keyEquivalence, txCreationTime);
+         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx,
+                                                       int topologyId,
+                                                       long txCreationTime) {
+            return new RecoveryAwareRemoteTransaction(modifications, tx, topologyId, txCreationTime);
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new RecoveryAwareRemoteTransaction(tx, topologyId, keyEquivalence, txCreationTime);
+         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId,
+                                                       long txCreationTime) {
+            return new RecoveryAwareRemoteTransaction(tx, topologyId, txCreationTime);
          }
       },
       NODLD_NORECOVERY_XA {
          @Override
-         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId,
-               Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new LocalXaTransaction(tx, gtx, implicitTransaction, topologyId, keyEquivalence, txCreationTime);
+         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction,
+                                                     int topologyId,
+                                                     long txCreationTime) {
+            return new LocalXaTransaction(tx, gtx, implicitTransaction, topologyId, txCreationTime);
          }
 
          @Override
@@ -182,21 +192,24 @@ public class TransactionFactory {
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId,
-                                                       Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new RemoteTransaction(modifications, tx, topologyId, keyEquivalence, txCreationTime);
+         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx,
+                                                       int topologyId,
+                                                       long txCreationTime) {
+            return new RemoteTransaction(modifications, tx, topologyId, txCreationTime);
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new RemoteTransaction(tx, topologyId, keyEquivalence, txCreationTime);
+         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId,
+                                                       long txCreationTime) {
+            return new RemoteTransaction(tx, topologyId, txCreationTime);
          }
       },
       NODLD_NORECOVERY_NOXA {
          @Override
-         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId,
-               Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new SyncLocalTransaction(tx, gtx, implicitTransaction, topologyId, keyEquivalence, txCreationTime);
+         public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction,
+                                                     int topologyId,
+                                                     long txCreationTime) {
+            return new SyncLocalTransaction(tx, gtx, implicitTransaction, topologyId, txCreationTime);
          }
 
          @Override
@@ -210,19 +223,23 @@ public class TransactionFactory {
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId,
-                                                       Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new RemoteTransaction(modifications, tx, topologyId, keyEquivalence, txCreationTime);
+         public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx,
+                                                       int topologyId,
+                                                       long txCreationTime) {
+            return new RemoteTransaction(modifications, tx, topologyId, txCreationTime);
          }
 
          @Override
-         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
-            return new RemoteTransaction(tx, topologyId, keyEquivalence, txCreationTime);
+         public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId,
+                                                       long txCreationTime) {
+            return new RemoteTransaction(tx, topologyId, txCreationTime);
          }
       };
 
-      public abstract LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId,
-            Equivalence<Object> keyEquivalence, long txCreationTime);
+      public abstract LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx,
+                                                           boolean implicitTransaction, int topologyId,
+                                                           long txCreationTime);
+
       public abstract GlobalTransaction newGlobalTransaction(Address addr, boolean remote, VersionGenerator clusterIdGenerator, boolean clustered);
       public abstract GlobalTransaction newGlobalTransaction();
 
@@ -240,11 +257,10 @@ public class TransactionFactory {
        */
       private final Random rnd = new Random();
 
-      public abstract RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId,
-                                                             Equivalence<Object> keyEquivalence, long txCreationTime);
+      public abstract RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx,
+                                                             int topologyId, long txCreationTime);
 
-      public abstract RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId,
-                                                             Equivalence<Object> keyEquivalence, long txCreationTime);
+      public abstract RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId, long txCreationTime);
    }
 
 
@@ -257,15 +273,15 @@ public class TransactionFactory {
    }
 
    public LocalTransaction newLocalTransaction(Transaction tx, GlobalTransaction gtx, boolean implicitTransaction, int topologyId) {
-      return txFactoryEnum.newLocalTransaction(tx, gtx, implicitTransaction, topologyId, keyEquivalence, timeService.time());
+      return txFactoryEnum.newLocalTransaction(tx, gtx, implicitTransaction, topologyId, timeService.time());
    }
 
    public RemoteTransaction newRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId) {
-      return txFactoryEnum.newRemoteTransaction(modifications, tx, topologyId, keyEquivalence, timeService.time());
+      return txFactoryEnum.newRemoteTransaction(modifications, tx, topologyId, timeService.time());
    }
 
    public RemoteTransaction newRemoteTransaction(GlobalTransaction tx, int topologyId) {
-      return txFactoryEnum.newRemoteTransaction(tx, topologyId, keyEquivalence, timeService.time());
+      return txFactoryEnum.newRemoteTransaction(tx, topologyId, timeService.time());
    }
 
    @Inject
@@ -285,7 +301,6 @@ public class TransactionFactory {
       boolean batchingEnabled = configuration.invocationBatching().enabled();
       init(dldEnabled, recoveryEnabled, xa, batchingEnabled);
       isClustered = configuration.clustering().cacheMode().isClustered();
-      keyEquivalence = configuration.dataContainer().keyEquivalence();
    }
 
    public void init(boolean dldEnabled, boolean recoveryEnabled, boolean xa, boolean batchingEnabled) {

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareLocalTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareLocalTransaction.java
@@ -2,7 +2,6 @@ package org.infinispan.transaction.xa.recovery;
 
 import javax.transaction.Transaction;
 
-import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.transaction.xa.GlobalTransaction;
 import org.infinispan.transaction.xa.LocalXaTransaction;
 
@@ -18,9 +17,9 @@ public class RecoveryAwareLocalTransaction extends LocalXaTransaction implements
 
    private boolean completionFailed;
 
-   public RecoveryAwareLocalTransaction(Transaction transaction, GlobalTransaction tx,
-         boolean implicitTransaction, int topologyId, Equivalence<Object> keyEquivalence, long txCreationTime) {
-      super(transaction, tx, implicitTransaction, topologyId, keyEquivalence, txCreationTime);
+   public RecoveryAwareLocalTransaction(Transaction transaction, GlobalTransaction tx, boolean implicitTransaction,
+                                        int topologyId, long txCreationTime) {
+      super(transaction, tx, implicitTransaction, topologyId, txCreationTime);
    }
 
    @Override

--- a/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareRemoteTransaction.java
+++ b/core/src/main/java/org/infinispan/transaction/xa/recovery/RecoveryAwareRemoteTransaction.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import javax.transaction.Status;
 
 import org.infinispan.commands.write.WriteCommand;
-import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.remoting.transport.Address;
 import org.infinispan.transaction.impl.RemoteTransaction;
 import org.infinispan.transaction.xa.GlobalTransaction;
@@ -30,13 +29,12 @@ public class RecoveryAwareRemoteTransaction extends RemoteTransaction implements
    private Integer status;
 
    public RecoveryAwareRemoteTransaction(WriteCommand[] modifications, GlobalTransaction tx, int topologyId,
-                                         Equivalence<Object> keyEquivalence, long txCreationTime) {
-      super(modifications, tx, topologyId, keyEquivalence, txCreationTime);
+                                         long txCreationTime) {
+      super(modifications, tx, topologyId, txCreationTime);
    }
 
-   public RecoveryAwareRemoteTransaction(GlobalTransaction tx, int topologyId, Equivalence<Object> keyEquivalence,
-                                         long txCreationTime) {
-      super(tx, topologyId, keyEquivalence, txCreationTime);
+   public RecoveryAwareRemoteTransaction(GlobalTransaction tx, int topologyId, long txCreationTime) {
+      super(tx, topologyId, txCreationTime);
    }
 
    /**

--- a/core/src/test/java/org/infinispan/interceptors/impl/AsyncInterceptorChainInvocationTest.java
+++ b/core/src/test/java/org/infinispan/interceptors/impl/AsyncInterceptorChainInvocationTest.java
@@ -7,15 +7,12 @@ import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.control.LockControlCommand;
 import org.infinispan.commands.read.GetKeyValueCommand;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.context.SingleKeyNonTxInvocationContext;
 import org.infinispan.factories.components.ComponentMetadataRepo;
@@ -485,7 +482,7 @@ public class AsyncInterceptorChainInvocationTest extends AbstractInfinispanTest 
 
    private SingleKeyNonTxInvocationContext newInvocationContext() {
       // Actual implementation doesn't matter, we are only testing the BaseAsyncInvocationContext methods
-      return new SingleKeyNonTxInvocationContext(null, AnyEquivalence.getInstance());
+      return new SingleKeyNonTxInvocationContext(null);
    }
 
    private AsyncInterceptorChain newInterceptorChain(AsyncInterceptor... interceptors) {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/BaseCacheNotifierImplInitialTransferTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/BaseCacheNotifierImplInitialTransferTest.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeoutException;
 
 import org.infinispan.Cache;
 import org.infinispan.CacheStream;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.compat.TypeConverter;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
@@ -118,7 +117,6 @@ public abstract class BaseCacheNotifierImplInitialTransferTest extends AbstractI
       mockCache = mock(Cache.class, RETURNS_DEEP_STUBS);
       Configuration config = mock(Configuration.class, RETURNS_DEEP_STUBS);
       when(config.clustering().cacheMode()).thenReturn(cacheMode);
-      when(config.dataContainer().keyEquivalence()).thenReturn(AnyEquivalence.getInstance());
       when(mockCache.getAdvancedCache().getStatus()).thenReturn(ComponentStatus.INITIALIZING);
 
       Answer answer = i -> Mockito.mock((Class) i.getArguments()[0]);
@@ -130,7 +128,7 @@ public abstract class BaseCacheNotifierImplInitialTransferTest extends AbstractI
                            mock(DistributionManager.class), new InternalEntryFactoryImpl(),
                            mock(ClusterEventManager.class));
       n.start();
-      ctx = new NonTxInvocationContext(null, AnyEquivalence.getInstance());
+      ctx = new NonTxInvocationContext(null);
    }
 
 //   TODO: commented out until local listners support includeCurrentState

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/CacheNotifierImplTest.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.infinispan.Cache;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.compat.TypeConverter;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.InternalEntryFactory;
@@ -78,7 +77,7 @@ public class CacheNotifierImplTest extends AbstractInfinispanTest {
       cl = new CacheListener();
       n.start();
       n.addListener(cl);
-      ctx = new NonTxInvocationContext(null, AnyEquivalence.getInstance());
+      ctx = new NonTxInvocationContext(null);
    }
 
    public void testNotifyCacheEntryCreated() {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/KeyFilterTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/KeyFilterTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.infinispan.Cache;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.compat.TypeConverter;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.InternalEntryFactory;
@@ -64,7 +63,7 @@ public class KeyFilterTest extends AbstractInfinispanTest {
       cl = new CacheListener();
       n.start();
       n.addListener(cl, kf);
-      ctx = new NonTxInvocationContext(null, AnyEquivalence.getInstance());
+      ctx = new NonTxInvocationContext(null);
    }
 
    public void testFilters() {

--- a/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
+++ b/core/src/test/java/org/infinispan/notifications/cachelistener/OnlyPrimaryOwnerTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 import org.infinispan.Cache;
 import org.infinispan.commands.FlagAffectedCommand;
 import org.infinispan.commands.tx.VersionedPrepareCommand;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.compat.TypeConverter;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.container.InternalEntryFactory;
@@ -67,7 +66,7 @@ public class OnlyPrimaryOwnerTest {
       cl = new PrimaryOwnerCacheListener();
       n.start();
       n.addListener(cl);
-      ctx = new NonTxInvocationContext(null, AnyEquivalence.getInstance());
+      ctx = new NonTxInvocationContext(null);
    }
 
    private static class MockCDL implements ClusteringDependentLogic {

--- a/core/src/test/java/org/infinispan/stream/DistributedStreamTxEquivalenceTest.java
+++ b/core/src/test/java/org/infinispan/stream/DistributedStreamTxEquivalenceTest.java
@@ -39,7 +39,6 @@ public class DistributedStreamTxEquivalenceTest extends BaseSetupStreamIteratorT
    @Override
    protected void enhanceConfiguration(ConfigurationBuilder builder) {
       super.enhanceConfiguration(builder);
-      builder.dataContainer().keyEquivalence(new AnyServerEquivalence());
    }
 
    enum OwnerMode {

--- a/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
+++ b/core/src/test/java/org/infinispan/tx/TransactionXaAdapterTmIntegrationTest.java
@@ -10,7 +10,6 @@ import javax.transaction.xa.XAResource;
 
 import org.infinispan.Cache;
 import org.infinispan.commands.CommandsFactory;
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -54,7 +53,7 @@ public class TransactionXaAdapterTmIntegrationTest {
       gtf.init(false, false, true, false);
       GlobalTransaction globalTransaction = gtf.newGlobalTransaction(null, false);
       DummyBaseTransactionManager tm = new DummyBaseTransactionManager();
-      localTx = new LocalXaTransaction(new DummyTransaction(tm), globalTransaction, false, 1, AnyEquivalence.getInstance(), 0);
+      localTx = new LocalXaTransaction(new DummyTransaction(tm), globalTransaction, false, 1, 0);
       xid = new DummyXid(uuid);
 
       InvocationContextFactory icf = new TransactionalInvocationContextFactory();

--- a/integrationtests/spring-boot-it/src/test/java/org/infinispan/integrationtests/spring/boot/session/remote/RemoteSpringSessionTest.java
+++ b/integrationtests/spring-boot-it/src/test/java/org/infinispan/integrationtests/spring/boot/session/remote/RemoteSpringSessionTest.java
@@ -30,7 +30,6 @@ public class RemoteSpringSessionTest extends AbstractSpringSessionTCK {
       globalConfigurationBuilder.globalJmxStatistics().jmxDomain("infinispan-" + UUID.randomUUID());
 
       ConfigurationBuilder cacheConfiguration = new ConfigurationBuilder();
-      cacheConfiguration.dataContainer().keyEquivalence(new AnyServerEquivalence());
 
       serverCache = new DefaultCacheManager(globalConfigurationBuilder.build());
       serverCache.defineConfiguration("sessions", cacheConfiguration.build());

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/SoftIndexFileStore.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/SoftIndexFileStore.java
@@ -135,7 +135,7 @@ public class SoftIndexFileStore implements AdvancedLoadWriteStore {
          throw new IllegalStateException("This store is already started!");
       }
       started = true;
-      temporaryTable = new TemporaryTable(configuration.indexQueueLength() * configuration.indexSegments(), keyEquivalence);
+      temporaryTable = new TemporaryTable(configuration.indexQueueLength() * configuration.indexSegments());
       storeQueue = new SyncProcessingQueue<LogRequest>();
       indexQueue = new IndexQueue(configuration.indexSegments(), configuration.indexQueueLength(), keyEquivalence);
       fileProvider = new FileProvider(configuration.dataLocation(), configuration.openFilesLimit());

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/TemporaryTable.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/TemporaryTable.java
@@ -2,8 +2,6 @@ package org.infinispan.persistence.sifs;
 
 import java.util.concurrent.ConcurrentMap;
 
-import org.infinispan.commons.equivalence.AnyEquivalence;
-import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.util.CollectionFactory;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
@@ -18,8 +16,8 @@ public class TemporaryTable {
    private static boolean trace = log.isTraceEnabled();
    private ConcurrentMap<Object, Entry> table;
 
-   public TemporaryTable(int capacity, Equivalence<Object> keyEquivalence) {
-      table = CollectionFactory.makeConcurrentMap(capacity, keyEquivalence, AnyEquivalence.getInstance());
+   public TemporaryTable(int capacity) {
+      table = CollectionFactory.makeConcurrentMap(capacity);
    }
 
    public void set(Object key, int file, int offset) {

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodServer.java
@@ -284,11 +284,7 @@ public class HotRodServer extends AbstractProtocolServer<HotRodServerConfigurati
       builder.clustering().cacheMode(CacheMode.REPL_SYNC).remoteTimeout(configuration.topologyReplTimeout())
             .locking().lockAcquisitionTimeout(configuration.topologyLockTimeout())
             .eviction().strategy(EvictionStrategy.NONE)
-            .expiration().lifespan(-1).maxIdle(-1)
-            // Topology cache uses Object based equals/hashCodes
-            .dataContainer()
-            .keyEquivalence(AnyEquivalence.getInstance())
-            .valueEquivalence(AnyEquivalence.getInstance());
+            .expiration().lifespan(-1).maxIdle(-1);
 
       if (configuration.topologyStateTransfer()) {
          builder

--- a/server/integration/testsuite/src/test/java/org/infinispan/server/test/util/jdbc/DBServer.java
+++ b/server/integration/testsuite/src/test/java/org/infinispan/server/test/util/jdbc/DBServer.java
@@ -9,9 +9,9 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 
-import org.infinispan.commons.equivalence.AnyEquivalence;
 import org.infinispan.commons.equivalence.ByteArrayEquivalence;
 
 /**
@@ -160,7 +160,7 @@ public class DBServer {
         * with same hash value will be stored into same row (=bucket).
         */
         public Object getBucketByKey(Object key) throws Exception {
-            int keyHash = AnyEquivalence.getInstance().hashCode(key) & 0xfffffc00; //computation taken from BucketBasedCacheStore
+            int keyHash = Objects.hashCode(key) & 0xfffffc00; //computation taken from BucketBasedCacheStore
             Connection connection = factory.getConnection();
             final PreparedStatement ps = connection.prepareStatement(getRowByKeySql);
             Object result = null;

--- a/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/session/InfinispanRemoteSessionRepositoryTest.java
+++ b/spring/spring4/spring4-remote/src/test/java/org/infinispan/spring/session/InfinispanRemoteSessionRepositoryTest.java
@@ -2,7 +2,6 @@ package org.infinispan.spring.session;
 
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
-import org.infinispan.commons.equivalence.AnyServerEquivalence;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.hotrod.HotRodServer;
 import org.infinispan.server.hotrod.test.HotRodTestingUtil;
@@ -24,7 +23,6 @@ public class InfinispanRemoteSessionRepositoryTest extends InfinispanSessionRepo
    @BeforeClass
    public void beforeClass() {
       org.infinispan.configuration.cache.ConfigurationBuilder cacheConfiguration = new org.infinispan.configuration.cache.ConfigurationBuilder();
-      cacheConfiguration.dataContainer().keyEquivalence(new AnyServerEquivalence());
       embeddedCacheManager = TestCacheManagerFactory.createCacheManager(cacheConfiguration);
       hotrodServer = HotRodTestingUtil.startHotRodServer(embeddedCacheManager, 19723);
       ConfigurationBuilder builder = new ConfigurationBuilder();


### PR DESCRIPTION
The invocation context implementations and the transaction
implementations still have a reference to AnyEquivalence.
