### PR TITLE
ISPN-7286: Cache stores should declare whether they can be shared.

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/configuration/attributes/AttributeSet.java
+++ b/commons/src/main/java/org/infinispan/commons/configuration/attributes/AttributeSet.java
@@ -21,12 +21,13 @@ import org.infinispan.commons.logging.LogFactory;
  */
 public class AttributeSet implements AttributeListener<Object> {
    private static final Log log = LogFactory.getLog(AttributeSet.class);
+   private final Class<?> klass;
    private final String name;
    private final Map<String, Attribute<?>> attributes;
    private boolean protect;
 
    public AttributeSet(Class<?> klass, AttributeDefinition<?>... attributeDefinitions) {
-      this(klass.getSimpleName(), attributeDefinitions);
+      this(klass, klass.getSimpleName(), null, attributeDefinitions);
    }
 
    public AttributeSet(String name, AttributeDefinition<?>... attributeDefinitions) {
@@ -34,10 +35,15 @@ public class AttributeSet implements AttributeListener<Object> {
    }
 
    public AttributeSet(Class<?> klass, AttributeSet attributeSet, AttributeDefinition<?>... attributeDefinitions) {
-      this(klass.getSimpleName(), attributeSet, attributeDefinitions);
+      this(klass, klass.getSimpleName(), attributeSet, attributeDefinitions);
    }
 
    public AttributeSet(String name, AttributeSet attributeSet, AttributeDefinition<?>[] attributeDefinitions) {
+      this(null, name, attributeSet, attributeDefinitions);
+   }
+
+   private AttributeSet(Class<?> klass, String name, AttributeSet attributeSet, AttributeDefinition<?>[] attributeDefinitions) {
+      this.klass = klass;
       this.name = name;
       if (attributeSet != null) {
          this.attributes = new LinkedHashMap<>(attributeDefinitions.length + attributeSet.attributes.size());
@@ -56,6 +62,10 @@ public class AttributeSet implements AttributeListener<Object> {
             attribute.addListener(this);
          this.attributes.put(def.name(), attribute);
       }
+   }
+
+   public Class<?> getKlass() {
+      return klass;
    }
 
    public String getName() {
@@ -130,7 +140,7 @@ public class AttributeSet implements AttributeListener<Object> {
       for (Attribute<?> attribute : attributes.values()) {
          attrDefs[i++] = attribute.getAttributeDefinition();
       }
-      AttributeSet protectedSet = new AttributeSet(name, attrDefs);
+      AttributeSet protectedSet = new AttributeSet(klass, name, null, attrDefs);
       for (Attribute<?> attribute : protectedSet.attributes.values()) {
          Attribute<?> localAttr = this.attributes.get(attribute.name());
          attribute.read((Attribute)localAttr);

--- a/commons/src/main/java/org/infinispan/commons/persistence/Store.java
+++ b/commons/src/main/java/org/infinispan/commons/persistence/Store.java
@@ -1,0 +1,21 @@
+package org.infinispan.commons.persistence;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Store. An annotation for identifying a persistent store and explicitly stating some of its characteristics.
+ *
+ * @author Ryan Emerson
+ * @since 9.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Store {
+   /**
+    * Whether the store can be shared amongst nodes in a distributed/replicated cache
+    */
+   boolean shared() default false;
+}

--- a/core/src/main/java/org/infinispan/configuration/cache/AbstractStoreConfigurationBuilder.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/AbstractStoreConfigurationBuilder.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.persistence.Store;
 import org.infinispan.commons.util.ReflectionUtil;
 import org.infinispan.commons.util.TypedProperties;
 import org.infinispan.configuration.global.GlobalConfiguration;
@@ -188,6 +189,17 @@ public abstract class AbstractStoreConfigurationBuilder<T extends StoreConfigura
       boolean preload = attributes.attribute(PRELOAD).get();
       boolean transactional = attributes.attribute(TRANSACTIONAL).get();
       ConfigurationBuilder builder = getBuilder();
+
+      Class storeClazz = attributes.getKlass();
+      if (storeClazz != null && storeClazz.isAnnotationPresent(Store.class)) {
+         Store storeProps = (Store) storeClazz.getAnnotation(Store.class);
+         if (!storeProps.shared() && shared) {
+            throw log.nonSharedStoreConfiguredAsShared(attributes.getName());
+         }
+      } else {
+         log.warnStoreAnnotationMissing(attributes.getName());
+      }
+
       if (!shared && !fetchPersistentState && !purgeOnStartup
             && builder.clustering().cacheMode().isClustered())
          log.staleEntriesWithoutFetchPersistentStateOrPurgeOnStartup();

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -1480,4 +1480,11 @@ public interface Log extends BasicLogger {
 
    @Message(value = "On key %s previous read version (%s) is different from currently read version (%s)", id = 429)
    WriteSkewException writeSkewOnRead(@Param Object key, Object key2, EntryVersion lastVersion, EntryVersion remoteVersion);
+
+   @Message(value = "%s cannot be shared", id = 430)
+   CacheConfigurationException nonSharedStoreConfiguredAsShared(String storeType);
+
+   @LogMessage(level = WARN)
+   @Message(value = "Unable to validate all properties of %s's configuration as the @Store attribute is missing", id = 431)
+   void warnStoreAnnotationMissing(String name);
 }

--- a/core/src/test/java/org/infinispan/persistence/StoreConfigurationValidationTest.java
+++ b/core/src/test/java/org/infinispan/persistence/StoreConfigurationValidationTest.java
@@ -1,0 +1,111 @@
+package org.infinispan.persistence;
+
+import org.infinispan.commons.CacheConfigurationException;
+import org.infinispan.commons.configuration.BuiltBy;
+import org.infinispan.commons.configuration.ConfigurationFor;
+import org.infinispan.commons.configuration.ConfiguredBy;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.commons.persistence.Store;
+import org.infinispan.configuration.cache.AbstractStoreConfigurationBuilder;
+import org.infinispan.configuration.cache.AsyncStoreConfiguration;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.configuration.cache.PersistenceConfigurationBuilder;
+import org.infinispan.configuration.cache.SingletonStoreConfiguration;
+import org.infinispan.persistence.dummy.DummyInMemoryStore;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfiguration;
+import org.infinispan.persistence.dummy.DummyInMemoryStoreConfigurationBuilder;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for ensuring that {@link AbstractStoreConfigurationBuilder#validate()} fails when expected.
+ *
+ * @author Ryan Emerson
+ * @since 9.0
+ */
+@Test(groups = "unit", testName = "persistence.StoreConfigurationValidationTest")
+public class StoreConfigurationValidationTest {
+
+   @Test(expectedExceptions = CacheConfigurationException.class,
+         expectedExceptionsMessageRegExp = ".* NonSharedDummyInMemoryStore cannot be shared")
+   public void testExceptionOnNonSharableStore() {
+      ConfigurationBuilder builder = TestCacheManagerFactory.getDefaultCacheConfiguration(false);
+      builder.persistence()
+            .addStore(NonSharedDummyStoreConfigurationBuilder.class)
+            .shared(true)
+            .validate();
+   }
+
+   @Test(expectedExceptions = CacheConfigurationException.class,
+         expectedExceptionsMessageRegExp = ".* It is not possible for a store to be transactional in a non-transactional cache. ")
+   public void testTxStoreInNonTxCache() {
+      ConfigurationBuilder builder = TestCacheManagerFactory.getDefaultCacheConfiguration(false);
+      builder.persistence()
+            .addStore(DummyInMemoryStoreConfigurationBuilder.class)
+            .transactional(true)
+            .validate();
+   }
+
+   @Test(expectedExceptions = CacheConfigurationException.class,
+         expectedExceptionsMessageRegExp = ".* It is not possible for a store to be transactional when passivation is enabled. ")
+   public void testTxStoreInPassivatedCache() {
+      ConfigurationBuilder builder = TestCacheManagerFactory.getDefaultCacheConfiguration(true);
+      builder.persistence()
+            .passivation(true)
+            .addStore(DummyInMemoryStoreConfigurationBuilder.class)
+            .transactional(true)
+            .validate();
+   }
+
+   @Test(expectedExceptions = CacheConfigurationException.class,
+         expectedExceptionsMessageRegExp = ".* Cannot enable 'fetchPersistentState' in invalidation caches!")
+   public void testFetchPersistentStateInInvalidationMode() {
+      ConfigurationBuilder builder = TestCacheManagerFactory.getDefaultCacheConfiguration(false);
+      builder.clustering()
+            .cacheMode(CacheMode.INVALIDATION_SYNC)
+            .persistence()
+            .addStore(DummyInMemoryStoreConfigurationBuilder.class)
+            .fetchPersistentState(true)
+            .validate();
+   }
+
+   @Store
+   @ConfiguredBy(NonSharedDummyStoreConfiguration.class)
+   static class NonSharedDummyInMemoryStore extends DummyInMemoryStore {
+      public NonSharedDummyInMemoryStore() {
+         super();
+      }
+   }
+
+   @BuiltBy(NonSharedDummyStoreConfigurationBuilder.class)
+   @ConfigurationFor(NonSharedDummyInMemoryStore.class)
+   static class NonSharedDummyStoreConfiguration extends DummyInMemoryStoreConfiguration {
+
+      public static AttributeSet attributeDefinitionSet() {
+         return new AttributeSet(NonSharedDummyInMemoryStore.class, DummyInMemoryStoreConfiguration.attributeDefinitionSet());
+      }
+
+      NonSharedDummyStoreConfiguration(AttributeSet attributes, AsyncStoreConfiguration async, SingletonStoreConfiguration singletonStore) {
+         super(attributes, async, singletonStore);
+      }
+   }
+
+   public static class NonSharedDummyStoreConfigurationBuilder
+         extends AbstractStoreConfigurationBuilder<NonSharedDummyStoreConfiguration, NonSharedDummyStoreConfigurationBuilder> {
+
+      public NonSharedDummyStoreConfigurationBuilder(PersistenceConfigurationBuilder builder) {
+         super(builder, NonSharedDummyStoreConfiguration.attributeDefinitionSet());
+      }
+
+      @Override
+      public NonSharedDummyStoreConfiguration create() {
+         return new NonSharedDummyStoreConfiguration(attributes.protect(), async.create(), singletonStore.create());
+      }
+
+      @Override
+      public NonSharedDummyStoreConfigurationBuilder self() {
+         return this;
+      }
+   }
+}

--- a/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStore.java
+++ b/core/src/test/java/org/infinispan/persistence/dummy/DummyInMemoryStore.java
@@ -16,6 +16,7 @@ import org.infinispan.Cache;
 import org.infinispan.commons.CacheException;
 import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.persistence.Store;
 import org.infinispan.commons.util.InfinispanCollections;
 import org.infinispan.commons.util.Util;
 import org.infinispan.filter.KeyFilter;
@@ -34,6 +35,7 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 @ConfiguredBy(DummyInMemoryStoreConfiguration.class)
+@Store(shared = true)
 public class DummyInMemoryStore implements AdvancedLoadWriteStore, AdvancedCacheExpirationWriter {
    private static final Log log = LogFactory.getLog(DummyInMemoryStore.class);
    private static final boolean trace = log.isTraceEnabled();

--- a/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
+++ b/persistence/jdbc/src/main/java/org/infinispan/persistence/jdbc/stringbased/JdbcStringBasedStore.java
@@ -19,6 +19,7 @@ import javax.transaction.Transaction;
 import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.io.ByteBuffer;
 import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.persistence.Store;
 import org.infinispan.commons.util.Util;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.executors.ExecutorAllCompletionService;
@@ -79,6 +80,7 @@ import org.infinispan.util.logging.LogFactory;
  * @see org.infinispan.persistence.keymappers.Key2StringMapper
  * @see org.infinispan.persistence.keymappers.DefaultTwoWayKey2StringMapper
  */
+@Store(shared = true)
 @ConfiguredBy(JdbcStringBasedStoreConfiguration.class)
 public class JdbcStringBasedStore<K,V> implements AdvancedLoadWriteStore<K,V>, TransactionalCacheWriter<K,V> {
 

--- a/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/JpaStore.java
+++ b/persistence/jpa/src/main/java/org/infinispan/persistence/jpa/JpaStore.java
@@ -29,6 +29,7 @@ import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.persistence.Store;
 import org.infinispan.executors.ExecutorAllCompletionService;
 import org.infinispan.filter.KeyFilter;
 import org.infinispan.marshall.core.MarshalledEntry;
@@ -51,6 +52,7 @@ import org.infinispan.util.logging.LogFactory;
  * @author <a href="mailto:rtsang@redhat.com">Ray Tsang</a>
  *
  */
+@Store(shared = true)
 @ConfiguredBy(JpaStoreConfiguration.class)
 public class JpaStore implements AdvancedLoadWriteStore {
    private static final Log log = LogFactory.getLog(JpaStore.class);

--- a/persistence/remote/src/main/java/org/infinispan/persistence/remote/RemoteStore.java
+++ b/persistence/remote/src/main/java/org/infinispan/persistence/remote/RemoteStore.java
@@ -15,6 +15,7 @@ import org.infinispan.commons.configuration.ConfiguredBy;
 import org.infinispan.commons.marshall.Marshaller;
 import org.infinispan.commons.marshall.WrappedByteArray;
 import org.infinispan.commons.marshall.jboss.GenericJBossMarshaller;
+import org.infinispan.commons.persistence.Store;
 import org.infinispan.commons.util.Util;
 import org.infinispan.container.InternalEntryFactory;
 import org.infinispan.container.versioning.NumericVersion;
@@ -52,6 +53,7 @@ import net.jcip.annotations.ThreadSafe;
  * @see <a href="http://community.jboss.org/wiki/JavaHotRodclient">Hotrod Java Client</a>
  * @since 4.1
  */
+@Store(shared = true)
 @ThreadSafe
 @ConfiguredBy(RemoteStoreConfiguration.class)
 public class RemoteStore implements AdvancedLoadWriteStore {

--- a/persistence/rest/src/main/java/org/infinispan/persistence/rest/RestStore.java
+++ b/persistence/rest/src/main/java/org/infinispan/persistence/rest/RestStore.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.codec.EncoderException;
 import org.apache.commons.codec.net.URLCodec;
 import org.infinispan.commons.configuration.ConfiguredBy;
+import org.infinispan.commons.persistence.Store;
 import org.infinispan.commons.util.Util;
 import org.infinispan.container.InternalEntryFactory;
 import org.infinispan.executors.ExecutorAllCompletionService;
@@ -66,6 +67,7 @@ import net.jcip.annotations.ThreadSafe;
  * @author Tristan Tarrant
  * @since 6.0
  */
+@Store(shared = true)
 @ThreadSafe
 @ConfiguredBy(RestStoreConfiguration.class)
 public class RestStore implements AdvancedLoadWriteStore {

--- a/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/RocksDBStore.java
+++ b/persistence/rocksdb/src/main/java/org/infinispan/persistence/rocksdb/RocksDBStore.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Semaphore;
 
 import org.infinispan.commons.CacheConfigurationException;
 import org.infinispan.commons.configuration.ConfiguredBy;
+import org.infinispan.commons.persistence.Store;
 import org.infinispan.commons.util.Util;
 import org.infinispan.executors.ExecutorAllCompletionService;
 import org.infinispan.filter.KeyFilter;
@@ -33,6 +34,7 @@ import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 
+@Store
 @ConfiguredBy(RocksDBStoreConfiguration.class)
 public class RocksDBStore implements AdvancedLoadWriteStore {
     private static final Log log = LogFactory.getLog(RocksDBStore.class, Log.class);

--- a/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/SoftIndexFileStore.java
+++ b/persistence/soft-index/src/main/java/org/infinispan/persistence/sifs/SoftIndexFileStore.java
@@ -9,6 +9,7 @@ import org.infinispan.commons.equivalence.Equivalence;
 import org.infinispan.commons.io.ByteBuffer;
 import org.infinispan.commons.io.ByteBufferFactory;
 import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.persistence.Store;
 import org.infinispan.filter.KeyFilter;
 import org.infinispan.marshall.core.MarshalledEntry;
 import org.infinispan.marshall.core.MarshalledEntryFactory;
@@ -97,6 +98,7 @@ import org.infinispan.util.logging.LogFactory;
  *
  * @author Radim Vansa &lt;rvansa@redhat.com&gt;
  */
+@Store
 public class SoftIndexFileStore implements AdvancedLoadWriteStore {
 
    private static final Log log = LogFactory.getLog(SoftIndexFileStore.class);


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7286

I have created a generic `@Store` annotation which currently only specifies whether a store can be shared or not (default=true), however in the future we can additional store characteristics here to help with config validation. If a store doesn't have a `@Store` annotation, e.g. third party stores, then the additional validation is simply ignored. 