### PR TITLE
ISPN-7296 Bounded Off Heap

### DIFF
--- a/core/src/main/java/org/infinispan/configuration/cache/Configuration.java
+++ b/core/src/main/java/org/infinispan/configuration/cache/Configuration.java
@@ -209,6 +209,7 @@ public class Configuration {
             ", unsafe=" + unsafeConfiguration +
             ", sites=" + sitesConfiguration +
             ", compatibility=" + compatibilityConfiguration +
+            ", memory=" + memoryConfiguration +
             '}';
    }
 

--- a/core/src/main/java/org/infinispan/container/offheap/BoundedOffHeapDataContainer.java
+++ b/core/src/main/java/org/infinispan/container/offheap/BoundedOffHeapDataContainer.java
@@ -1,0 +1,293 @@
+package org.infinispan.container.offheap;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.LongUnaryOperator;
+
+import org.infinispan.commons.marshall.WrappedBytes;
+import org.infinispan.container.DataContainer;
+import org.infinispan.container.entries.InternalCacheEntry;
+import org.infinispan.eviction.EvictionType;
+import org.infinispan.metadata.Metadata;
+
+/**
+ * Data Container implementation that stores entries in native memory (off-heap) that is also bounded.  This
+ * implementation uses a simple LRU doubly linked list off-heap guarded by a single lock.
+ * <p>
+ * The link list consists of 24 bytes (3 longs).  The first long is the actual entry address, the second is the
+ * previous pointer and lastly the next pointer.
+ * @author wburns
+ * @since 9.0
+ */
+public class BoundedOffHeapDataContainer extends OffHeapDataContainer {
+   private final long maxSize;
+   private final Lock lruLock;
+   private final LongUnaryOperator sizeCalculator;
+
+   private long currentSize;
+   private long firstAddress;
+   private long lastAddress;
+
+   public BoundedOffHeapDataContainer(int desiredSize, long maxSize, EvictionType type) {
+      super(desiredSize);
+      this.maxSize = maxSize;
+      if (type == EvictionType.COUNT) {
+         sizeCalculator = i -> 1;
+      } else {
+         // Use size of entry plus 24 for our LRU pointer node
+         sizeCalculator = i -> offHeapEntryFactory.determineSize(i) + 24;
+      }
+      this.lruLock = new ReentrantLock();
+      firstAddress = 0;
+   }
+
+   @Override
+   public void put(WrappedBytes key, WrappedBytes value, Metadata metadata) {
+      super.put(key, value, metadata);
+      // The following is called outside of the write lock specifically - since we may not have to evict and even
+      // if we did it would quite possibly need a different lock
+      ensureSize();
+   }
+
+   @Override
+   public InternalCacheEntry<WrappedBytes, WrappedBytes> compute(WrappedBytes key, ComputeAction<WrappedBytes, WrappedBytes> action) {
+      InternalCacheEntry<WrappedBytes, WrappedBytes> result = super.compute(key, action);
+      if (result != null) {
+         // Means we had a put or replace called so we have to confirm sizes
+         // The following is called outside of the write lock specifically - since we may not have to evict and even
+         // if we did it would quite possibly need a different lock
+         ensureSize();
+      }
+      return result;
+   }
+
+   @Override
+   protected void entryReplaced(long newAddress, long oldAddress) {
+      long oldSize = sizeCalculator.applyAsLong(oldAddress);
+      long newSize = sizeCalculator.applyAsLong(newAddress);
+      lruLock.lock();
+      try {
+         long lruNode = UNSAFE.getLong(oldAddress);
+         if (trace) {
+            log.tracef("Replacing LRU node: %d. OldValue: %d NewValue: %d", lruNode, oldAddress, newAddress);
+         }
+         // We have to update the lru node to point to the new address and vice versa
+         UNSAFE.putLong(newAddress, lruNode);
+         UNSAFE.putLong(lruNode, newAddress);
+
+         moveToEnd(lruNode);
+
+         currentSize += newSize;
+         currentSize -= oldSize;
+      } finally {
+         lruLock.unlock();
+      }
+      super.entryReplaced(newAddress, oldAddress);
+   }
+
+   @Override
+   protected void entryCreated(long newAddress) {
+      int hashCode = offHeapEntryFactory.getHashCodeForAddress(newAddress);
+      long newSize = sizeCalculator.applyAsLong(newAddress);
+      lruLock.lock();
+      try {
+         currentSize += newSize;
+         addEntryAddressToEnd(newAddress, hashCode);
+      } finally {
+         lruLock.unlock();
+      }
+      super.entryCreated(newAddress);
+   }
+
+   @Override
+   protected void entryRemoved(long removedAddress) {
+      long removedSize = sizeCalculator.applyAsLong(removedAddress);
+      long lruNode = UNSAFE.getLong(removedAddress);
+      lruLock.lock();
+      try {
+         // Current size has to be updated in the lock
+         currentSize -=  removedSize;
+         if (lruNode == lastAddress) {
+            if (trace) {
+               log.tracef("Removing last LRU node at %d", lruNode);
+            }
+            long previousLRUNode = UNSAFE.getLong(lruNode + 8);
+            if (previousLRUNode != 0) {
+               UNSAFE.putLong(previousLRUNode + 16, 0);
+            }
+            lastAddress = previousLRUNode;
+         } else if (lruNode == firstAddress) {
+            if (trace) {
+               log.tracef("Removing first LRU node at %d", lruNode);
+            }
+            long nextLRUNode = UNSAFE.getLong(lruNode + 16);
+            if (nextLRUNode != 0) {
+               UNSAFE.putLong(nextLRUNode + 8, 0);
+            }
+            firstAddress = nextLRUNode;
+         } else {
+            if (trace) {
+               log.tracef("Removing middle LRU node at %d", lruNode);
+            }
+            // We are a middle pointer so both of these have to be non zero
+            long previousLRUNode = UNSAFE.getLong(lruNode + 8);
+            long nextLRUNode = UNSAFE.getLong(lruNode + 16);
+            assert previousLRUNode != 0;
+            assert nextLRUNode != 0;
+            UNSAFE.putLong(previousLRUNode + 16, nextLRUNode);
+            UNSAFE.putLong(nextLRUNode + 8, previousLRUNode);
+         }
+         allocator.deallocate(lruNode, 28);
+      } finally {
+         lruLock.unlock();
+      }
+      super.entryRemoved(removedAddress);
+   }
+
+   @Override
+   protected void entryRetrieved(long entryAddress) {
+      lruLock.lock();
+      try {
+         long lruNode = UNSAFE.getLong(entryAddress);
+         if (trace) {
+            log.tracef("Moving lruNode %d to the end which points at address %d", lruNode, entryAddress);
+         }
+         moveToEnd(lruNode);
+      } finally {
+         lruLock.unlock();
+      }
+      super.entryRetrieved(entryAddress);
+   }
+
+   @Override
+   protected void performClear() {
+      if (trace) {
+         log.trace("Clearing bounded LRU entries");
+      }
+      // Technically we don't need to do lruLock since clear obtains all write locks first
+      lruLock.lock();
+      try {
+         long address = firstAddress;
+         while (address != 0) {
+            long nextAddress = UNSAFE.getLong(address + 16);
+            allocator.deallocate(address, 28);
+            address = nextAddress;
+         }
+         currentSize = 0;
+         firstAddress = 0;
+         lastAddress = 0;
+      } finally {
+         lruLock.unlock();
+      }
+      if (trace) {
+         log.trace("Cleared bounded LRU entries");
+      }
+      super.performClear();
+   }
+
+   private void ensureSize() {
+      while (true) {
+         long addressToRemove;
+         Lock entryWriteLock;
+         lruLock.lock();
+         try {
+            if (currentSize > maxSize) {
+               // Retrieve the hashCode so we can lock it to verify the address is still present
+               int hashCode = UNSAFE.getInt(firstAddress + 24);
+               entryWriteLock = locks.getLockFromHashCode(hashCode).writeLock();
+               if (!entryWriteLock.tryLock()) {
+                  // Attempts to release the lru lock and reacquire the write lock are problematic as underlying allocator
+                  // may return same memory address between points, so there is no way to verify we have same object
+                  // in an efficient way - just force loop back around to allow other threads to get lruLock
+                  addressToRemove = 0;
+               } else {
+                  addressToRemove = UNSAFE.getLong(firstAddress);
+               }
+            } else {
+               // This is the only way to break out of loop
+               break;
+            }
+         } finally {
+            lruLock.unlock();
+         }
+
+         // We can proceed with removal if it is non zero.  It would be 0 if the firstAddress changed
+         // It is assumed we own the entryWriteLock lock as well so we can read the keys.
+         if (addressToRemove != 0) {
+            if (trace) {
+               log.tracef("Removing entry: %d due to eviction due to size %d being larger than maximum of %d",
+                     addressToRemove, currentSize, maxSize);
+            }
+            try {
+               performRemove(addressToRemove, offHeapEntryFactory.getKey(addressToRemove));
+            } finally {
+               entryWriteLock.unlock();
+            }
+         } else {
+            // Just to let another thread possibly continue and release its lock
+            Thread.yield();
+         }
+      }
+   }
+
+   /**
+    * Method to be invoked when adding a new entry address to the end of the lru nodes.  This occurs for newly created
+    * entries.
+    * This method should only be invoked after acquiring the lruLock
+    * @param entryAddress the new entry address pointer *NOT* the lru node
+    */
+   private void addEntryAddressToEnd(long entryAddress, int hashCode) {
+      long nodeAddress = allocator.allocate(28);
+      if (trace) {
+         log.tracef("Creating LRU node %d for new entry %d", nodeAddress, entryAddress);
+      }
+      // First update the pointer to our new entry address
+      UNSAFE.putLong(nodeAddress, entryAddress);
+      // Also our entry address needs a pointer to its lru node
+      UNSAFE.putLong(entryAddress, nodeAddress);
+      // This means it is the first entry
+      if (lastAddress == 0) {
+         firstAddress = nodeAddress;
+         lastAddress = nodeAddress;
+         // Have to make sure the memory is cleared so we don't use unitialized values
+         UNSAFE.putLong(nodeAddress + 8, 0);
+      } else {
+         // Writes back pointer to the old lastAddress
+         UNSAFE.putLong(nodeAddress + 8, lastAddress);
+         // Write the forward pointer in old lastAddress to point to us
+         UNSAFE.putLong(lastAddress + 16, nodeAddress);
+         // Finally make us the last address
+         lastAddress = nodeAddress;
+      }
+      // Since we are last there is no pointer after us
+      UNSAFE.putLong(nodeAddress + 16, 0);
+      UNSAFE.putInt(nodeAddress + 24, hashCode);
+   }
+
+   /**
+    * Method to be invoked when moving an existing lru node to the end.  This occurs when the entry is accessed for this
+    * node.
+    * This method should only be invoked after acquiring the lruLock.
+    * @param lruNode the node to move to the end
+    */
+   private void moveToEnd(long lruNode) {
+      if (lruNode != lastAddress) {
+         long nextLruNode = UNSAFE.getLong(lruNode + 16);
+         if (lruNode == firstAddress) {
+            UNSAFE.putLong(nextLruNode + 8, 0);
+            firstAddress = nextLruNode;
+         } else {
+            long prevLruNode = UNSAFE.getLong(lruNode + 8);
+            UNSAFE.putLong(prevLruNode + 16, nextLruNode);
+            UNSAFE.putLong(nextLruNode + 8, prevLruNode);
+         }
+         // Link the previous last node to our new last node
+         UNSAFE.putLong(lastAddress + 16, lruNode);
+         // Sets the previous node of our new tail node to the previous tail node
+         UNSAFE.putLong(lruNode + 8, lastAddress);
+         UNSAFE.putLong(lruNode + 16, 0);
+         lastAddress = lruNode;
+      }
+   }
+}

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactory.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapEntryFactory.java
@@ -12,27 +12,56 @@ import org.infinispan.metadata.Metadata;
  */
 public interface OffHeapEntryFactory {
    /**
-    *
-    * @param key
-    * @param value
-    * @param metadata
-    * @return
+    * Creates an off heap entry using the provided key value and metadata
+    * @param key the key to use
+    * @param value the value to use
+    * @param metadata the metadata to use
+    * @return the address of where the entry was created
     */
    long create(WrappedBytes key, WrappedBytes value, Metadata metadata);
 
    /**
     * Returns how many bytes in memory this address location uses assuming it is an {@link InternalCacheEntry}
-    * @param address
-    * @return
+    * @param address the address of the entry
+    * @return how many bytes this address was allocated as
     */
    long determineSize(long address);
 
    /**
-    *
-    * @param address
-    * @return
+    * Returns the address to the next linked pointer if there is one for this bucket or 0 if there isn't one
+    * @param address the address of the entry
+    * @return the next address entry for this bucket or 0
+    */
+   long getNextLinkedPointerAddress(long address);
+
+   /**
+    * Called to update the next pointer index when a collision occurs requiring a linked list within the entries
+    * themselves
+    * @param address the address of the entry to update
+    * @param value the value of the linked node to set
+    */
+   void updateNextLinkedPointerAddress(long address, long value);
+
+   /**
+    * Returns the hashCode of the address.  This
+    * @param address the address of the entry
+    * @return the has code of the entry
+    */
+   int getHashCodeForAddress(long address);
+
+   /**
+    * Create an entry from the off heap pointer
+    * @param address the address of the entry to read
+    * @return the entry created on heap from off heap
     */
    InternalCacheEntry<WrappedBytes, WrappedBytes> fromMemory(long address);
+
+   /**
+    * Returns the key for the given address
+    * @param address the address pointer to find the key of
+    * @return the key of the given address pointer
+    */
+   WrappedBytes getKey(long address);
 
    /**
     * Returns whether the given key as bytes is the same key as the key stored in the entry for the given address.

--- a/core/src/main/java/org/infinispan/container/offheap/OffHeapMemoryAllocator.java
+++ b/core/src/main/java/org/infinispan/container/offheap/OffHeapMemoryAllocator.java
@@ -20,5 +20,12 @@ public interface OffHeapMemoryAllocator {
     */
    void deallocate(long memoryAddress);
 
+   /**
+    * Deallocates the memory at the given address assuming a given size
+    * @param memoryAddress the address to deallocate from
+    * @param size the total size
+    */
+   void deallocate(long memoryAddress, long size);
+
    long getAllocatedAmount();
 }

--- a/core/src/main/java/org/infinispan/container/offheap/StripedLock.java
+++ b/core/src/main/java/org/infinispan/container/offheap/StripedLock.java
@@ -6,6 +6,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
+ * Holder for read write locks that provides ability to retrieve them by offset and hashCode
  * @author wburns
  * @since 9.0
  */
@@ -26,12 +27,32 @@ public class StripedLock {
       }
    }
 
+   /**
+    * Retrieves the read write lock attributed to the given object using its hashCode for lookup.
+    * @param obj the object to use to find the lock
+    * @return the lock associated with the object
+    */
    public ReadWriteLock getLock(Object obj) {
-      int h = spread(obj.hashCode());
+      return getLockFromHashCode(obj.hashCode());
+   }
+
+   /**
+    * Retrieves the lock associated with the given hashCode
+    * @param hashCode the hashCode to retrieve the lock for
+    * @return the lock associated with the given hashCode
+    */
+   public ReadWriteLock getLockFromHashCode(int hashCode) {
+      int h = spread(hashCode);
       int offset = h & (locks.length - 1);
       return locks[offset];
    }
 
+   /**
+    * Retrieves the given lock at a provided offset.  Note this is not hashCode based.  This method requires care
+    * and the knowledge of how many locks there are.  This is useful when iterating over all locks
+    * @param offset the offset of the lock to find
+    * @return the lock at the given offset
+    */
    public ReadWriteLock getLockWithOffset(int offset) {
       if (offset >= locks.length) {
          throw new ArrayIndexOutOfBoundsException();
@@ -39,12 +60,18 @@ public class StripedLock {
       return locks[offset];
    }
 
-   void lockAll() {
+   /**
+    * Locks all write locks.  Ensure that {@link StripedLock#unlockAll()} is called in a proper finally block
+    */
+   public void lockAll() {
       for (int i = 0; i < locks.length; ++i) {
          locks[i].writeLock().lock();
       }
    }
 
+   /**
+    * Unlocks all write locks, useful after {@link StripedLock#lockAll()} was invoked.
+    */
    void unlockAll() {
       for (int i = 0; i < locks.length; ++i) {
          locks[i].writeLock().unlock();

--- a/core/src/main/java/org/infinispan/container/offheap/UnpooledOffHeapMemoryAllocator.java
+++ b/core/src/main/java/org/infinispan/container/offheap/UnpooledOffHeapMemoryAllocator.java
@@ -4,6 +4,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongUnaryOperator;
 
 import org.infinispan.factories.annotations.Inject;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
 
 import sun.misc.Unsafe;
 
@@ -14,6 +16,8 @@ import sun.misc.Unsafe;
  */
 public class UnpooledOffHeapMemoryAllocator implements OffHeapMemoryAllocator {
    private static final Unsafe UNSAFE = UnsafeHolder.UNSAFE;
+   private static final Log log = LogFactory.getLog(UnpooledOffHeapMemoryAllocator.class, Log.class);
+   private static final boolean trace = log.isTraceEnabled();
    private final AtomicLong amountAllocated = new AtomicLong();
    private LongUnaryOperator sizeCalculator;
 
@@ -25,13 +29,26 @@ public class UnpooledOffHeapMemoryAllocator implements OffHeapMemoryAllocator {
    @Override
    public long allocate(long memoryLength) {
       long memoryLocation = UNSAFE.allocateMemory(memoryLength);
-      amountAllocated.addAndGet(memoryLength);
+      long currentSize = amountAllocated.addAndGet(memoryLength);
+      if (trace) {
+         log.tracef("Allocated off heap memory at %d with %d bytes.  Total size: %d", memoryLocation, memoryLength,
+               currentSize);
+      }
       return memoryLocation;
    }
 
    @Override
    public void deallocate(long memoryAddress) {
-      amountAllocated.addAndGet(- sizeCalculator.applyAsLong(memoryAddress));
+      deallocate(memoryAddress, sizeCalculator.applyAsLong(memoryAddress));
+   }
+
+   @Override
+   public void deallocate(long memoryAddress, long size) {
+      long currentSize = amountAllocated.addAndGet(- size);
+      if (trace) {
+         log.tracef("Deallocating off heap memory at %d with %d bytes.  Total size: %d", memoryAddress, size,
+               currentSize);
+      }
       UNSAFE.freeMemory(memoryAddress);
    }
 

--- a/core/src/main/java/org/infinispan/container/offheap/UnsafeWrapper.java
+++ b/core/src/main/java/org/infinispan/container/offheap/UnsafeWrapper.java
@@ -1,0 +1,63 @@
+package org.infinispan.container.offheap;
+
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import sun.misc.Unsafe;
+
+/**
+ * Simple wrapper around Unsafe to provide for trace messages for method calls.
+ * @author wburns
+ * @since 9.0
+ */
+public class UnsafeWrapper {
+   protected static final Log log = LogFactory.getLog(UnsafeWrapper.class);
+   protected static final boolean trace = log.isTraceEnabled();
+
+   protected static final Unsafe UNSAFE = UnsafeHolder.UNSAFE;
+
+   static final UnsafeWrapper INSTANCE = new UnsafeWrapper();
+
+   private UnsafeWrapper() { }
+
+   public void putLong(long var1, long var3) {
+      if (trace) {
+         log.tracef("Wrote long value %d to address %d", var3, var1);
+      }
+      UNSAFE.putLong(var1, var3);
+   }
+
+   public void putInt(long var1, int var3) {
+      if (trace) {
+         log.tracef("Wrote int value %d to address %d", var3, var1);
+      }
+      UNSAFE.putInt(var1, var3);
+   }
+
+   public long getLong(long var1) {
+      long var3 = UNSAFE.getLong(var1);
+      if (trace) {
+         log.tracef("Retrieved long value %d from address %d", var3, var1);
+      }
+      return var3;
+   }
+
+   public int getInt(long var1) {
+      int var3 = UNSAFE.getInt(var1);
+      if (trace) {
+         log.tracef("Retrieved int value %d from address %d", var3, var1);
+      }
+      return var3;
+   }
+
+   public int arrayBaseOffset(Class<?> var1) {
+      return UNSAFE.arrayBaseOffset(var1);
+   }
+
+   public void copyMemory(Object var1, long var2, Object var4, long var5, long var7) {
+      if (trace) {
+         log.tracef("Copying memory of object %s offset by %d to %s offset by %d with a total of %d bytes", var1, var2, var4, var5, var7);
+      }
+      UNSAFE.copyMemory(var1, var2, var4, var5, var7);
+   }
+}

--- a/core/src/main/java/org/infinispan/factories/DataContainerFactory.java
+++ b/core/src/main/java/org/infinispan/factories/DataContainerFactory.java
@@ -8,6 +8,7 @@ import org.infinispan.container.DataContainer;
 import org.infinispan.container.DefaultDataContainer;
 import org.infinispan.container.StorageType;
 import org.infinispan.container.entries.PrimitiveEntrySizeCalculator;
+import org.infinispan.container.offheap.BoundedOffHeapDataContainer;
 import org.infinispan.container.offheap.OffHeapDataContainer;
 import org.infinispan.eviction.EvictionType;
 import org.infinispan.factories.annotations.DefaultFactoryFor;
@@ -46,15 +47,11 @@ public class DataContainerFactory extends AbstractNamedCacheComponentFactory imp
 
          DataContainer dataContainer;
          if (configuration.memory().storageType() == StorageType.OFF_HEAP) {
-            if (configuration.eviction().type() == EvictionType.MEMORY) {
-               // TODO: need to bound container
-               dataContainer = new OffHeapDataContainer(configuration.memory().addressCount());
-            } else {
-               dataContainer = new OffHeapDataContainer(configuration.memory().addressCount());
-            }
+            dataContainer = new BoundedOffHeapDataContainer(configuration.memory().addressCount(), thresholdSize,
+                  configuration.memory().evictionType());
          } else {
             dataContainer = DefaultDataContainer.boundedDataContainer(level, thresholdSize,
-                  configuration.eviction().type());
+                  configuration.memory().evictionType());
          }
          configuration.eviction().attributes().attribute(EvictionConfiguration.SIZE).addListener((newSize, old) ->
                configuration.memory().size(newSize.get()));

--- a/core/src/main/resources/schema/infinispan-config-9.0.xsd
+++ b/core/src/main/resources/schema/infinispan-config-9.0.xsd
@@ -1134,7 +1134,7 @@
           in bytes can be stored.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="eviction">
+    <xs:attribute name="eviction" type="tns:eviction-type">
       <xs:annotation>
         <xs:documentation>The eviction type to use whether it is COUNT or MEMORY.  COUNT will limit the cache based on
         the number of entries.  MEMORY will limit the cache by how much memory the entries use</xs:documentation>
@@ -1150,7 +1150,7 @@
           in bytes can be stored.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="eviction">
+    <xs:attribute name="eviction" type="tns:eviction-type">
       <xs:annotation>
         <xs:documentation>The eviction type to use whether it is COUNT or MEMORY.  COUNT will limit the cache based on
           the number of entries.  MEMORY will limit the cache by how much memory the entries use</xs:documentation>

--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapBoundedSingleNodeTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapBoundedSingleNodeTest.java
@@ -1,0 +1,86 @@
+package org.infinispan.container.offheap;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.fail;
+
+import java.io.IOException;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.infinispan.Cache;
+import org.infinispan.commons.marshall.Marshaller;
+import org.infinispan.commons.marshall.WrappedByteArray;
+import org.infinispan.commons.marshall.WrappedBytes;
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.container.StorageType;
+import org.infinispan.eviction.EvictionType;
+import org.infinispan.filter.KeyFilter;
+import org.testng.annotations.Test;
+
+/**
+ */
+@Test(groups = "functional", testName = "container.offheap.OffHeapBoundedSingleNodeTest")
+public class OffHeapBoundedSingleNodeTest extends OffHeapSingleNodeTest {
+
+   protected static final int COUNT = 100;
+
+   @Override
+   protected void createCacheManagers() throws Throwable {
+      ConfigurationBuilder dcc = getDefaultClusteredCacheConfig(CacheMode.LOCAL, true);
+      dcc.memory().storageType(StorageType.OFF_HEAP).size(COUNT).evictionType(EvictionType.COUNT);
+      // Only start up the 1 cache
+      addClusterEnabledCacheManager(dcc);
+   }
+
+   public void testMoreWriteThanSize() {
+      Cache<String, String> cache = cache(0);
+
+      for (int i = 0; i < COUNT + 5; ++i) {
+         cache.put("key" + i, "value" + i);
+      }
+
+      assertEquals(COUNT, cache.size());
+   }
+
+   public void testMultiThreaded() throws ExecutionException, InterruptedException, TimeoutException {
+      Cache<String, String> cache = cache(0);
+
+      AtomicInteger offset = new AtomicInteger();
+      AtomicBoolean collision = new AtomicBoolean();
+      int threadCount = 5;
+      Future[] futures = new Future[threadCount];
+
+      for (int i = 0; i < threadCount; ++i) {
+         futures[i] = fork(() -> {
+            boolean collide = collision.get();
+            // We could have overrides, that is fine
+            collision.set(!collide);
+            int value = collide ? offset.get() : offset.incrementAndGet();
+            for (int j = 0; j < COUNT * 10; ++j) {
+               String key = "key" + value + "-" + j;
+               cache.put(key, "value" + value + "-" + j);
+            }
+         });
+      }
+
+      for (Future future : futures) {
+         future.get(10, TimeUnit.SECONDS);
+      }
+
+      int cacheSize = cache.size();
+      if (cacheSize > COUNT) {
+         log.fatal("Entries were: " + cache.entrySet().stream().map(Object::toString).collect(Collectors.joining(",")));
+      }
+      assertTrue("Cache size was " + cacheSize, cacheSize <= COUNT);
+   }
+}

--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapMultiNodeTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapMultiNodeTest.java
@@ -59,7 +59,7 @@ public class OffHeapMultiNodeTest extends MultipleCacheManagersTest {
 
       assertNull(map.put(key, value));
 
-      for (int i = 0; i < 100; ++i) {
+      for (int i = 0; i < 50; ++i) {
          map.put(randomBytes(KEY_SIZE), value);
       }
 

--- a/core/src/test/java/org/infinispan/container/offheap/OffHeapSingleNodeTest.java
+++ b/core/src/test/java/org/infinispan/container/offheap/OffHeapSingleNodeTest.java
@@ -30,6 +30,7 @@ import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.container.DataContainer;
 import org.infinispan.container.StorageType;
+import org.infinispan.eviction.EvictionType;
 import org.infinispan.filter.KeyFilter;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.SingleCacheManagerTest;
@@ -93,5 +94,14 @@ public class OffHeapSingleNodeTest extends OffHeapMultiNodeTest {
       barrier.await(10, TimeUnit.SECONDS);
       future.get(10, TimeUnit.SECONDS);
       assertEquals(value, putFuture.get(10, TimeUnit.SECONDS));
+   }
+
+   public void testLotsOfWrites() {
+      Cache<String, String> cache = cache(0);
+
+      for (int i = 0; i < 100000; ++i) {
+         cache.put("key" + i, "value" + i);
+      }
+
    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7296

This uses a simple LRU bounded cache which is applied to all entries in a given cache.  There is a lru lock that is required to be acquired whenever reading or writing to the lru based attributes or nodes off heap.

The eviction is done by acquiring the said lru lock to test the size and then if it is deemed to needed removal it read the head node of the lru stack and then try to acquire the write lock for the segment of that key.  If it can it will then remove it otherwise it must release the lru lock and try again.  This could be costly if there are a lot of failures to acquire the write lock.  Unfortunately due to deadlocking issues lruLock must be obtained after the write lock of a given segment (thus why a try lock must be used)