### PR TITLE
ISPN-6802 Fix tests broken by equivalence removal

### DIFF
--- a/core/src/main/java/org/infinispan/commands/write/RemoveExpiredCommand.java
+++ b/core/src/main/java/org/infinispan/commands/write/RemoveExpiredCommand.java
@@ -58,14 +58,14 @@ public class RemoveExpiredCommand extends RemoveCommand {
          // If the provided lifespan is null, that means it is a store removal command, so we can't compare lifespan
          Object prevValue = e.getValue();
          if (lifespan == null) {
-            if (valueMatcher.matches(prevValue, value, e.getValue())) {
+            if (valueMatcher.matches(prevValue, value, null)) {
                e.setExpired(true);
                return performRemove(e, prevValue, ctx);
             }
          } else if (e.getMetadata() == null) {
             // If there is no metadata and no value that means it is gone currently or not shown due to expired
             // If we have a value though we should verify it matches the value as well
-            if (value == null || valueMatcher.matches(prevValue, value, e.getValue())) {
+            if (value == null || valueMatcher.matches(prevValue, value, null)) {
                e.setExpired(true);
                return performRemove(e, prevValue, ctx);
             }
@@ -73,7 +73,7 @@ public class RemoveExpiredCommand extends RemoveCommand {
             // If the entries lifespan is not positive that means it can't expire so don't even try to remove it
             // Lastly if there is metadata we have to verify it equals our lifespan and the value match.
             // TODO: add a threshold to verify this wasn't just created with the same value/lifespan just before expiring
-            if (valueMatcher.matches(prevValue, value, e.getValue())) {
+            if (valueMatcher.matches(prevValue, value, null)) {
                e.setExpired(true);
                return performRemove(e, prevValue, ctx);
             }

--- a/core/src/main/java/org/infinispan/commands/write/ValueMatcher.java
+++ b/core/src/main/java/org/infinispan/commands/write/ValueMatcher.java
@@ -1,7 +1,5 @@
 package org.infinispan.commands.write;
 
-import java.util.Objects;
-
 import org.infinispan.Cache;
 
 /**
@@ -45,7 +43,7 @@ public enum ValueMatcher {
    MATCH_EXPECTED() {
       @Override
       public boolean matches(Object existingValue, Object expectedValue, Object newValue) {
-         return equal(existingValue, expectedValue);
+         return existingValue == null ? expectedValue == null : existingValue.equals(expectedValue);
       }
 
       @Override
@@ -65,8 +63,10 @@ public enum ValueMatcher {
    MATCH_EXPECTED_OR_NEW() {
       @Override
       public boolean matches(Object existingValue, Object expectedValue, Object newValue) {
-         return equal(existingValue, expectedValue) ||
-               equal(existingValue, newValue);
+         if (existingValue == null)
+            return expectedValue == null || newValue == null;
+         else
+            return existingValue.equals(expectedValue) || existingValue.equals(newValue);
       }
 
       @Override
@@ -83,7 +83,7 @@ public enum ValueMatcher {
    MATCH_EXPECTED_OR_NULL() {
       @Override
       public boolean matches(Object existingValue, Object expectedValue, Object newValue) {
-         return newValue == null || equal(existingValue, expectedValue);
+         return existingValue == null || existingValue.equals(expectedValue);
       }
 
       @Override
@@ -145,10 +145,6 @@ public enum ValueMatcher {
    public abstract boolean nonExistentEntryCanMatch();
 
    public abstract ValueMatcher matcherForRetry();
-
-   protected boolean equal(Object a, Object b) {
-      return Objects.equals(a, b);
-   }
 
    private static final ValueMatcher[] CACHED_VALUES = values();
 

--- a/core/src/main/java/org/infinispan/context/SingleKeyNonTxInvocationContext.java
+++ b/core/src/main/java/org/infinispan/context/SingleKeyNonTxInvocationContext.java
@@ -82,7 +82,7 @@ public final class SingleKeyNonTxInvocationContext implements InvocationContext 
       if (this.key == null) {
          // Set the key here
          this.key = key;
-      } else if (!Objects.equals(key, this.key)) {
+      } else if (!this.key.equals(key)) {
          throw illegalStateException();
       }
 
@@ -95,7 +95,7 @@ public final class SingleKeyNonTxInvocationContext implements InvocationContext 
 
    @Override
    public CacheEntry lookupEntry(final Object key) {
-      if (Objects.equals(key, this.key))
+      if (this.key != null && this.key.equals(key))
          return cacheEntry;
 
       return null;
@@ -111,7 +111,7 @@ public final class SingleKeyNonTxInvocationContext implements InvocationContext 
       if (this.key == null) {
          // Set the key here
          this.key = key;
-      } else if (!Objects.equals(key, this.key)) {
+      } else if (!this.key.equals(key)) {
          throw illegalStateException();
       }
 
@@ -120,7 +120,7 @@ public final class SingleKeyNonTxInvocationContext implements InvocationContext 
 
    @Override
    public void removeLookedUpEntry(final Object key) {
-      if (Objects.equals(key, this.key)) {
+      if (this.key != null && this.key.equals(key)) {
          this.cacheEntry = null;
       }
    }
@@ -150,7 +150,7 @@ public final class SingleKeyNonTxInvocationContext implements InvocationContext 
 
    @Override
    public boolean hasLockedKey(final Object key) {
-      return isLocked && Objects.equals(this.key, key);
+      return isLocked && this.key.equals(key);
    }
 
    @Override

--- a/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodMarshallingTest.scala
+++ b/server/hotrod/src/test/scala/org/infinispan/server/hotrod/HotRodMarshallingTest.scala
@@ -6,6 +6,7 @@ import org.testng.Assert._
 import org.infinispan.commands.remote.ClusteredGetCommand
 import org.infinispan.server.core.AbstractMarshallingTest
 import org.infinispan.commons.api.BasicCacheContainer
+import org.infinispan.commons.marshall.WrappedByteArray
 import org.infinispan.util.ByteString
 
 /**
@@ -26,7 +27,7 @@ class HotRodMarshallingTest extends AbstractMarshallingTest {
 
    def testMarshallingCommandWithBigByteArrayKey() {
       val cacheKey = getBigByteArray
-      val command = new ClusteredGetCommand(cacheKey,
+      val command = new ClusteredGetCommand(new WrappedByteArray(cacheKey),
          ByteString.fromString(BasicCacheContainer.DEFAULT_CACHE_NAME), EnumUtil.EMPTY_BIT_SET)
       val bytes = marshaller.objectToByteBuffer(command)
       val readCommand = marshaller.objectFromByteBuffer(bytes).asInstanceOf[ClusteredGetCommand]


### PR DESCRIPTION
 * Wrap the key in HotRodMarshallingTest
 * Never call key.equals(null) in SingleKeyNonTxInvocationContext,
    because the JCache has some keys that don't implement it correctly.
 * Remove Objects.equals() usage in value matchers
 * Check the existing value instead of the new value in
    MATCH_EXPECTED_OR_NULL