### PR TITLE
ISPN-7358 Fix Hot Rod server request pipelining

### DIFF
--- a/commons/src/main/java/org/infinispan/commons/util/Util.java
+++ b/commons/src/main/java/org/infinispan/commons/util/Util.java
@@ -552,7 +552,7 @@ public final class Util {
    }
 
    public static String toHexString(byte input[]) {
-      return toHexString(input, input.length);
+      return input != null ? toHexString(input, input.length) : "null";
    }
 
    public static String toHexString(byte input[], int limit) {
@@ -561,7 +561,7 @@ public final class Util {
          return null;
 
       char lookup[] = {'0', '1', '2', '3', '4', '5', '6', '7',
-                       '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+                       '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
       char[] result = new char[(input.length < limit ? input.length : limit) * 2];
 

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/CacheDecodeContext.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/CacheDecodeContext.java
@@ -1,9 +1,12 @@
 package org.infinispan.server.hotrod;
 
+import java.util.Arrays;
+
 import javax.security.auth.Subject;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
+import org.infinispan.commons.util.Util;
 import org.infinispan.container.entries.CacheEntry;
 import org.infinispan.container.versioning.EntryVersion;
 import org.infinispan.container.versioning.NumericVersion;
@@ -283,6 +286,16 @@ public final class CacheDecodeContext {
 
    ComponentRegistry getCacheRegistry(String cacheName) {
       return server.getCacheRegistry(cacheName);
+   }
+
+   @Override
+   public String toString() {
+      return "CacheDecodeContext{" +
+            "header=" + header +
+            ", subject=" + subject +
+            ", key=" + Util.toHexString(key) +
+            ", params=" + params +
+            '}';
    }
 
    static class ExpirationParam {

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/Decoder2x.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/Decoder2x.java
@@ -62,7 +62,13 @@ class Decoder2x implements VersionedDecoder {
             return false;
          }
          byte streamOp = buffer.readByte();
+         if (CacheDecodeContext.isTrace)
+            log.tracef("Header op: %d", streamOp);
+
          int length = ExtendedByteBufJava.readMaybeVInt(buffer);
+         if (CacheDecodeContext.isTrace)
+            log.tracef("Header cache name length: %d", length);
+
          // Didn't have enough bytes for VInt or the length is too long for remaining
          if (length == Integer.MIN_VALUE || length > buffer.readableBytes()) {
             return false;
@@ -79,21 +85,42 @@ class Decoder2x implements VersionedDecoder {
          }
          buffer.markReaderIndex();
       }
-      int flag = ExtendedByteBufJava.readMaybeVInt(buffer);
-      if (flag == Integer.MIN_VALUE) {
-         return false;
+
+      if (header.flag == null) {
+         int flag = ExtendedByteBufJava.readMaybeVInt(buffer);
+         if (CacheDecodeContext.isTrace)
+            log.tracef("Header flag: %d", flag);
+
+         if (flag == Integer.MIN_VALUE) {
+            return false;
+         }
+
+         header.flag = flag;
       }
+
       if (buffer.readableBytes() < 2) {
          return false;
       }
-      byte clientIntelligence = buffer.readByte();
-      int topologyId = ExtendedByteBufJava.readMaybeVInt(buffer);
-      if (topologyId == Integer.MIN_VALUE) {
-         return false;
+
+      if (header.clientIntel == null) {
+         byte clientIntelligence = buffer.readByte();
+         if (CacheDecodeContext.isTrace)
+            log.tracef("Header client intelligence: %d", clientIntelligence);
+
+         header.clientIntel = clientIntelligence;
       }
-      header.flag = flag;
-      header.clientIntel = clientIntelligence;
-      header.topologyId = topologyId;
+
+      if (header.topologyId == null) {
+         int topologyId = ExtendedByteBufJava.readMaybeVInt(buffer);
+         if (CacheDecodeContext.isTrace)
+            log.tracef("Header topology id: %d", topologyId);
+
+         if (topologyId == Integer.MIN_VALUE) {
+            return false;
+         }
+
+         header.topologyId = topologyId;
+      }
 
       buffer.markReaderIndex();
       return true;

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodDecoder.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodDecoder.java
@@ -5,12 +5,14 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import org.infinispan.commons.logging.LogFactory;
+import org.infinispan.commons.util.Util;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.server.core.logging.Log;
 import org.infinispan.server.core.transport.ExtendedByteBufJava;
 import org.infinispan.server.core.transport.NettyTransport;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 
@@ -76,6 +78,8 @@ public class HotRodDecoder extends ByteToMessageDecoder {
          }
 
          if (resetRequested) {
+            if (CacheDecodeContext.isTrace)
+               log.tracef("Reset cached decoder data: %s", decodeCtx);
             resetNow();
          }
 
@@ -171,8 +175,12 @@ public class HotRodDecoder extends ByteToMessageDecoder {
             return false;
          }
          short magic = buffer.readUnsignedByte();
+         if (CacheDecodeContext.isTrace)
+            log.tracef("Header magic: %d", magic);
+
          if (magic != Constants.MAGIC_REQ) {
             if (previousException == null) {
+               dumpBuffer("Invalid magic id", buffer);
                throw new InvalidMagicIdException("Error reading magic byte or message id: " + magic);
             } else {
                log.tracef("Error happened previously, ignoring %d byte until we find the magic number again", magic);
@@ -183,7 +191,10 @@ public class HotRodDecoder extends ByteToMessageDecoder {
          }
 
          long messageId = ExtendedByteBufJava.readMaybeVLong(buffer);
-         if (messageId == Integer.MIN_VALUE) {
+         if (CacheDecodeContext.isTrace)
+            log.tracef("Header message id: %d", messageId);
+
+         if (messageId == Long.MIN_VALUE) {
             return false;
          }
          header.messageId = messageId;
@@ -193,12 +204,15 @@ public class HotRodDecoder extends ByteToMessageDecoder {
          }
          byte version = (byte) buffer.readUnsignedByte();
          header.version = version;
+         if (CacheDecodeContext.isTrace)
+            log.tracef("Header version: %d", version);
 
          if (Constants.isVersion2x(version)) {
             decoder = new Decoder2x();
          } else if (Constants.isVersion1x(version)) {
             decoder = new Decoder10();
          } else {
+            dumpBuffer("Unknown version", buffer);
             throw new UnknownVersionException("Unknown version:" + version, version, messageId);
          }
          decodeCtx.decoder = decoder;
@@ -221,6 +235,13 @@ public class HotRodDecoder extends ByteToMessageDecoder {
       }
    }
 
+   private void dumpBuffer(String prefix, ByteBuf in) {
+      if (log.isTraceEnabled()) {
+         String dump = ByteBufUtil.hexDump(in).toUpperCase();
+         log.tracef("%s error encountered, the buffer contains: %s", prefix, dump);
+      }
+   }
+
    private void readCustomHeader(ByteBuf in, List<Object> out) {
       decodeCtx.decoder.customReadHeader(decodeCtx.header, in, decodeCtx, out);
       // If out was written to, it means we read everything, else we have to reread again
@@ -234,6 +255,9 @@ public class HotRodDecoder extends ByteToMessageDecoder {
       // If we want a single key read that - else we do try for custom read
       if (op.requiresKey()) {
          byte[] bytes = ExtendedByteBufJava.readMaybeRangedBytes(in);
+         if (CacheDecodeContext.isTrace)
+            log.tracef("Body key: %s", Util.toHexString(bytes));
+
          // If the bytes don't exist then we need to reread
          if (bytes != null) {
             decodeCtx.key = bytes;
@@ -265,6 +289,9 @@ public class HotRodDecoder extends ByteToMessageDecoder {
 
    boolean decodeParameters(ByteBuf in, List<Object> out) {
       CacheDecodeContext.RequestParameters params = decodeCtx.decoder.readParameters(decodeCtx.header, in);
+      if (CacheDecodeContext.isTrace)
+         log.tracef("Body parameters: %s", params);
+
       if (params != null) {
          decodeCtx.params = params;
          if (decodeCtx.header.op.getDecoderRequirements() == DecoderRequirements.PARAMETERS) {
@@ -288,6 +315,8 @@ public class HotRodDecoder extends ByteToMessageDecoder {
          byte[] bytes = new byte[valueLength];
          in.readBytes(bytes);
          decodeCtx.operationDecodeContext = bytes;
+         if (CacheDecodeContext.isTrace)
+            log.tracef("Body value: %s", Util.toHexString(bytes));
       }
       switch (op.getDecoderRequirements()) {
          case VALUE_CUSTOM:

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodHeader.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/HotRodHeader.java
@@ -9,9 +9,9 @@ public class HotRodHeader {
    byte version;
    long messageId;
    String cacheName;
-   int flag;
-   short clientIntel;
-   int topologyId;
+   Integer flag = null;
+   Byte clientIntel = null;
+   Integer topologyId = null;
 
    public HotRodOperation getOp() {
       return op;

--- a/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodPipeTest.java
+++ b/server/hotrod/src/test/java/org/infinispan/server/hotrod/test/HotRodPipeTest.java
@@ -1,0 +1,190 @@
+package org.infinispan.server.hotrod.test;
+
+import static org.infinispan.server.core.test.ServerTestingUtil.killServer;
+import static org.infinispan.server.hotrod.test.HotRodTestingUtils.host;
+import static org.infinispan.server.hotrod.transport.ExtendedByteBuf.readString;
+import static org.infinispan.server.hotrod.transport.ExtendedByteBuf.readUnsignedLong;
+import static org.infinispan.server.hotrod.transport.ExtendedByteBuf.writeUnsignedLong;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.infinispan.commons.util.Either;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.server.hotrod.HotRodServer;
+import org.infinispan.test.SingleCacheManagerTest;
+import org.infinispan.test.fwk.TestCacheManagerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.handler.codec.ReplayingDecoder;
+
+@Test(testName = "server.hotrod.test.HotRodPipeTest")
+public class HotRodPipeTest extends SingleCacheManagerTest {
+
+   HotRodServer server;
+
+   @Override
+   protected EmbeddedCacheManager createCacheManager() throws Exception {
+      return TestCacheManagerFactory.createCacheManager();
+   }
+
+   @Test(enabled = false) // Disable explicitly to avoid TestNG thinking this is a test!!
+   @Override
+   protected void setup() throws Exception {
+      super.setup();
+      server = HotRodTestingUtils.startHotRodServer(cacheManager);
+   }
+
+   @AfterClass(alwaysRun = true)
+   public void destroyAfterClass() {
+      log.debug("Test finished, close cache and Hot Rod server");
+      super.destroyAfterClass();
+      killServer(server);
+   }
+
+   public void testPipeRequests() {
+      final int numPipeReqs = 10_000;
+      BatchingClient client = new BatchingClient(server.getPort());
+      try {
+         client.start();
+         client.writeN(numPipeReqs);
+         eventually(() -> {
+            Either<List<String>, Integer> either = client.readN(numPipeReqs);
+            switch (either.type()) {
+               case LEFT:
+                  throw new AssertionError(either.left().get(0));
+               case RIGHT:
+                  return either.right() == numPipeReqs;
+               default:
+                  throw new IllegalStateException("Either can only be left or right");
+            }
+         });
+      } finally {
+         client.stop();
+      }
+   }
+
+   static final class BatchingClient {
+
+      final EventLoopGroup group = new NioEventLoopGroup();
+      final int port;
+
+      Channel ch;
+
+      BatchingClient(int port) {
+         this.port = port;
+      }
+
+      void start() {
+         Bootstrap b = new Bootstrap();
+         b.group(group)
+            .channel(NioSocketChannel.class)
+            .option(ChannelOption.TCP_NODELAY, true)
+            .handler(new ChannelInitializer<Channel>() {
+               @Override
+               protected void initChannel(Channel ch) throws Exception {
+                  ChannelPipeline p = ch.pipeline();
+                  p.addLast(new BatchingDecoder());
+                  p.addLast(new BatchingEncoder());
+                  p.addLast(new BatchingClientHandler());
+               }
+            });
+
+         try {
+            ChannelFuture f = b.connect(host, port).sync();
+            ch = f.channel();
+         } catch (InterruptedException e) {
+            throw new AssertionError(e);
+         }
+      }
+
+      void stop() {
+         group.shutdownGracefully();
+      }
+
+      void writeN(int n) {
+         ch.writeAndFlush(n);
+      }
+
+      Either<List<String>, Integer> readN(int n) {
+         BatchingClientHandler last = (BatchingClientHandler) ch.pipeline().last();
+         return last.errors.isEmpty()
+               ? Either.newRight(last.n)
+               : Either.newLeft(last.errors);
+      }
+
+      private static final class BatchingEncoder extends MessageToByteEncoder {
+         @Override
+         protected void encode(ChannelHandlerContext ctx, Object msg, ByteBuf out) throws Exception {
+            int n = (int) msg;
+            IntStream.range(0, n).forEach(i -> {
+               out.writeByte(0xA0);          // magic
+               writeUnsignedLong(i, out);    // message id
+               out.writeByte(0x19);          // version
+               out.writeByte(0x01);          // op code
+               out.writeByte(0x00);          // cache name empty
+               out.writeByte(0x00);          // flags
+               out.writeByte(0x03);          // client intelligence
+               out.writeByte(0x00);          // topology id
+               out.writeBytes(new byte[] {   // operation parameters
+                  0x03, 0x31, 0x30, 0x30, 0x77, 0x03, 0x31, 0x30, 0x30
+               });
+            });
+         }
+      }
+
+      private static final class BatchingDecoder extends ReplayingDecoder {
+
+         @Override
+         protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+            in.readUnsignedByte();                 // magic byte
+            long id = readUnsignedLong(in);        // message id
+            short op = in.readUnsignedByte();      // op code
+            in.readUnsignedByte();                 // status code
+            in.readUnsignedByte();                 // topology marker
+
+            switch (op) {
+               case 0x02: // normal response
+                  out.add(id);
+                  break;
+               case 0x50: // error response
+                  String error = readString(in);
+                  out.add(error);
+                  break;
+            }
+         }
+
+      }
+
+      private static final class BatchingClientHandler extends SimpleChannelInboundHandler<Object> {
+         int n;
+         List<String> errors = new ArrayList<>();
+
+         @Override
+         protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
+            if (msg instanceof String) {
+               errors.add((String) msg);
+            } else {
+               n++;
+            }
+         }
+      }
+
+   }
+
+}


### PR DESCRIPTION
* Header parameters might be read twice unless there's a check to see if
  the header value has already been assigned.
* Message id comparison to see if there were not enough bytes should be
  done against Long.MIN_VALUE and not Integer.MIN_VALUE because message
  id is a long.
* Added a basic pipelining test that uses a simplified Hot Rod client
  for sending many operations in one go.