### PR TITLE
ISPN-7230 ISPN-7231 Expose XSite view

### DIFF
--- a/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
+++ b/core/src/main/java/org/infinispan/remoting/rpc/RpcManagerImpl.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -369,6 +370,12 @@ public class RpcManagerImpl implements RpcManager, JmxStatisticsExposer {
          return 0;
       }
       return totalReplicationTime.get() / replicationCount.get();
+   }
+
+   @ManagedAttribute(description = "Retrieves the x-site view.", displayName = "Cross site (x-site) view", dataType = DataType.TRAIT)
+   public String getSitesView() {
+      Set<String> sitesView = t.getSitesView();
+      return sitesView != null ? sitesView.toString() : "N/A";
    }
 
    // mainly for unit testing

--- a/core/src/main/java/org/infinispan/remoting/transport/AbstractDelegatingTransport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/AbstractDelegatingTransport.java
@@ -3,6 +3,7 @@ package org.infinispan.remoting.transport;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commands.ReplicableCommand;
@@ -175,4 +176,10 @@ public abstract class AbstractDelegatingTransport implements Transport {
    protected BackupResponse afterBackupRemotely(ReplicableCommand command, BackupResponse response) {
       return response;
    }
+
+   @Override
+   public Set<String> getSitesView() {
+      return actual.getSitesView();
+   }
+
 }

--- a/core/src/main/java/org/infinispan/remoting/transport/Transport.java
+++ b/core/src/main/java/org/infinispan/remoting/transport/Transport.java
@@ -3,6 +3,7 @@ package org.infinispan.remoting.transport;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.infinispan.commands.ReplicableCommand;
@@ -154,4 +155,18 @@ public interface Transport extends Lifecycle {
     * protocol stack.
     */
    void checkTotalOrderSupported();
+
+   /**
+    * Get the view of interconnected sites.
+    * If no cross site replication has been configured, this method returns null.
+    *
+    * Inspecting the site view can be useful to see if the different sites
+    * have managed to join each other, which is pre-requisite to get cross
+    * replication working.
+    *
+    * @return set containing the connected sites, or null if no cross site
+    *         replication has been enabled.
+    */
+   Set<String> getSitesView();
+
 }

--- a/core/src/main/java/org/infinispan/util/logging/Log.java
+++ b/core/src/main/java/org/infinispan/util/logging/Log.java
@@ -16,6 +16,7 @@ import java.security.Permission;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -1512,4 +1513,8 @@ public interface Log extends BasicLogger {
    @Message(value = "Cache with name %s is defined more than once!", id = 438)
    CacheConfigurationException duplicateCacheName(String name);
 
+   @LogMessage(level = INFO)
+   @Message(value = "Received new x-site view: %s", id = 439)
+   void receivedXSiteClusterView(Set<String> view);
+   
 }

--- a/core/src/test/java/org/infinispan/xsite/XSiteAdminOperationsTest.java
+++ b/core/src/test/java/org/infinispan/xsite/XSiteAdminOperationsTest.java
@@ -2,6 +2,9 @@ package org.infinispan.xsite;
 
 import static org.testng.AssertJUnit.assertEquals;
 
+import java.util.Arrays;
+import java.util.HashSet;
+
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.TakeOfflineConfigurationBuilder;
@@ -74,6 +77,13 @@ public class XSiteAdminOperationsTest extends AbstractTwoSitesTest {
       assertEquals(admin("LON", 0).status(), "NYC[ONLINE]");
       assertEquals(admin("LON", 1).status(), "NYC[ONLINE]");
 
+   }
+
+   public void testSitesView() {
+      assertEquals(new HashSet<>(Arrays.asList("LON", "NYC")),
+            site("LON").cacheManagers().get(0).getTransport().getSitesView());
+      assertEquals(new HashSet<>(Arrays.asList("LON", "NYC")),
+            site("NYC").cacheManagers().get(0).getTransport().getSitesView());
    }
 
    private BackupSenderImpl backupSender(String site, int cache) {

--- a/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/SecurityActions.java
+++ b/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/SecurityActions.java
@@ -6,6 +6,7 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
@@ -43,6 +44,7 @@ import org.infinispan.server.infinispan.actions.GetDefinedCacheNamesAction;
 import org.infinispan.server.infinispan.actions.GetMembersAction;
 import org.infinispan.server.infinispan.actions.GetRunningCacheCountAction;
 import org.infinispan.server.infinispan.actions.GetSearchManagerAction;
+import org.infinispan.server.infinispan.actions.GetSitesViewAction;
 import org.infinispan.server.infinispan.actions.ResetComponentJmxStatisticsAction;
 import org.infinispan.server.infinispan.actions.ResetInterceptorJmxStatisticsAction;
 import org.infinispan.server.infinispan.actions.StartCacheAction;
@@ -299,4 +301,10 @@ public final class SecurityActions {
         GetGlobalComponentRegistryAction action = new GetGlobalComponentRegistryAction(cacheManager);
         return doPrivileged(action);
     }
+
+    public static Set<String> getSitesView(DefaultCacheContainer cacheManager) {
+        GetSitesViewAction action = new GetSitesViewAction(cacheManager);
+        return doPrivileged(action);
+    }
+
 }

--- a/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/actions/GetSitesViewAction.java
+++ b/server/integration/infinispan/src/main/java/org/infinispan/server/infinispan/actions/GetSitesViewAction.java
@@ -1,0 +1,18 @@
+package org.infinispan.server.infinispan.actions;
+
+import java.util.Set;
+
+import org.jboss.as.clustering.infinispan.DefaultCacheContainer;
+
+public class GetSitesViewAction extends AbstractDefaultCacheContainerAction<Set<String>> {
+
+   public GetSitesViewAction(DefaultCacheContainer cacheManager) {
+      super(cacheManager);
+   }
+
+   @Override
+   public Set<String> run() {
+      return cacheManager.getTransport().getSitesView();
+   }
+
+}

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerMetricsHandler.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerMetricsHandler.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.infinispan.Version;
 import org.infinispan.factories.GlobalComponentRegistry;
@@ -75,6 +76,7 @@ public class CacheContainerMetricsHandler extends AbstractRuntimeOnlyHandler {
         ONLINE_SITES(MetricKeys.SITES_ONLINE, ModelType.LIST, ModelType.STRING, false),
         OFFLINE_SITES(MetricKeys.SITES_OFFLINE, ModelType.LIST, ModelType.STRING, false),
         MIXED_SITES(MetricKeys.SITES_MIXED, ModelType.LIST, ModelType.STRING, false),
+        SITES_VIEW(MetricKeys.SITES_VIEW, ModelType.STRING, true, true),
 
         // see org.infinispan.stats.CacheContainerStats
         AVERAGE_READ_TIME(MetricKeys.AVERAGE_READ_TIME, ModelType.LONG, true),
@@ -267,6 +269,10 @@ public class CacheContainerMetricsHandler extends AbstractRuntimeOnlyHandler {
                     }
                     break;
                 }
+                case SITES_VIEW:
+                    Set<String> sitesView = SecurityActions.getSitesView(cacheManager);
+                    result.set(sitesView != null ? sitesView.toString() : "N/A");
+                    break;
                 default:
                     context.getFailureDescription().set(String.format("Unknown metric %s", metric));
                     break;

--- a/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/MetricKeys.java
+++ b/server/integration/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/MetricKeys.java
@@ -91,6 +91,7 @@ public class MetricKeys {
     public static final String SITES_ONLINE = "sites-online";
     public static final String SITES_OFFLINE = "sites-offline";
     public static final String SITES_MIXED = "sites-mixed";
+    public static final String SITES_VIEW = "sites-view";
 
     public static final String NUMBER_OF_CPUS = "number-of-cpus";
     public static final String TOTAL_MEMORY_KB = "total-memory";

--- a/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/logging/JGroupsLogger.java
+++ b/server/integration/jgroups/src/main/java/org/infinispan/server/jgroups/logging/JGroupsLogger.java
@@ -28,6 +28,7 @@ import static org.jboss.logging.Logger.Level.TRACE;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.net.URL;
+import java.util.Set;
 
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.logging.BasicLogger;
@@ -137,4 +138,9 @@ public interface JGroupsLogger extends BasicLogger {
 
     @Message(id = 100, value = "Unauthorized node %s attempting to join cluster.")
     SecurityException unauthorizedNodeJoin(String nodeName);
+
+    @LogMessage(level = INFO)
+    @Message(id = 101, value = "Received new x-site view: %s")
+    void receivedXSiteClusterView(Set<String> view);
+
 }


### PR DESCRIPTION
* Expose x-site view as INFO log message, JMX and DMR attribute.
* Two route status listeners have been created for handling embedded and
  in-server set ups who track the x-site view members.