### PR TITLE
ISPN-7371: infinispan-defaults - Rocksdb jar not found for leveldb.

### DIFF
--- a/plugins/infinispan-defaults-maven-plugin/src/main/java/org/infinispan/plugins/maven/defaults/DefaultsExtractorMojo.java
+++ b/plugins/infinispan-defaults-maven-plugin/src/main/java/org/infinispan/plugins/maven/defaults/DefaultsExtractorMojo.java
@@ -197,7 +197,8 @@ public class DefaultsExtractorMojo extends AbstractMojo {
             getLog().error(String.format("Unable to process jar '%s'", jarName), e);
          }
       } else {
-         throw new IllegalArgumentException("Jar '" + jarName + "' not on the classpath");
+         // We just warn here, as jars are required for `mvn install`, but not for `mvn test`
+         getLog().info("Skipping Jar '" + jarName + "' as it cannot be found on the classpath");
       }
    }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7371

When running `mvn install` we need to get classes from the jar, but when running `mvn test` the jar is not present, instead the classes are already on the classpath. Therefore, we log a missing jar instead of throwing an exception as we know the classes will be retrieved from the classpath.  