### PR TITLE
ISPN-7391 & ISPN-7392 Hot Rod authentication improvements for both client and server

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/impl/ConfigurationProperties.java
@@ -51,6 +51,9 @@ public class ConfigurationProperties {
    public static final String SASL_MECHANISM = "infinispan.client.hotrod.sasl_mechanism";
    public static final String AUTH_CALLBACK_HANDLER = "infinispan.client.hotrod.auth_callback_handler";
    public static final String AUTH_SERVER_NAME = "infinispan.client.hotrod.auth_server_name";
+   public static final String AUTH_USERNAME = "infinispan.client.hotrod.auth_username";
+   public static final String AUTH_PASSWORD = "infinispan.client.hotrod.auth_password";
+   public static final String AUTH_REALM = "infinispan.client.hotrod.auth_realm";
    public static final String AUTH_CLIENT_SUBJECT = "infinispan.client.hotrod.auth_client_subject";
    public static final String SASL_PROPERTIES_PREFIX = "infinispan.client.hotrod.sasl_properties";
    public static final Pattern SASL_PROPERTIES_PREFIX_REGEX =

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/logging/Log.java
@@ -249,4 +249,7 @@ public interface Log extends BasicLogger {
    @LogMessage(level = WARN)
    @Message(value = "Unable to convert property [%s] to an enum! Using default value of %d", id = 4066)
    void unableToConvertStringPropertyToEnum(String value, String defaultValue);
+
+   @Message(value = "Cannot specify both a callback handler and a username for authentication", id = 4067)
+   CacheConfigurationException callbackHandlerAndUsernameMutuallyExclusive();
 }

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/security/BasicCallbackHandler.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/security/BasicCallbackHandler.java
@@ -1,0 +1,57 @@
+package org.infinispan.client.hotrod.security;
+
+import java.io.IOException;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthorizeCallback;
+import javax.security.sasl.RealmCallback;
+
+/**
+ * A basic {@link CallbackHandler}. This can be used for PLAIN and CRAM-MD mechanisms
+ *
+ * @author Tristan Tarrant
+ * @since 9.0
+ */
+public class BasicCallbackHandler implements CallbackHandler {
+    private final String username;
+    private final String realm;
+    private final char[] password;
+
+    public BasicCallbackHandler(String username, char[] password) {
+        this(username, null, password);
+    }
+
+    public BasicCallbackHandler(String username, String realm, char[] password) {
+        this.username = username;
+        this.password = password;
+        this.realm = realm;
+    }
+
+    @Override
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        for (Callback callback : callbacks) {
+            if (callback instanceof NameCallback) {
+                NameCallback nameCallback = (NameCallback) callback;
+                nameCallback.setName(username);
+            } else if (callback instanceof PasswordCallback) {
+                PasswordCallback passwordCallback = (PasswordCallback) callback;
+                passwordCallback.setPassword(password);
+            } else if (callback instanceof AuthorizeCallback) {
+                AuthorizeCallback authorizeCallback = (AuthorizeCallback) callback;
+                authorizeCallback.setAuthorized(authorizeCallback.getAuthenticationID().equals(
+                      authorizeCallback.getAuthorizationID()));
+            } else if (callback instanceof RealmCallback) {
+                if (realm == null)
+                    throw new UnsupportedCallbackException(callback, "The mech requests a realm, but none has been supplied");
+                RealmCallback realmCallback = (RealmCallback) callback;
+                realmCallback.setText(realm);
+            } else {
+                throw new UnsupportedCallbackException(callback);
+            }
+        }
+    }
+}

--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/security/VoidCallbackHandler.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/security/VoidCallbackHandler.java
@@ -5,7 +5,7 @@ import javax.security.auth.callback.CallbackHandler;
 
 /**
  *
- * No-op {@link javax.security.auth.callback.CallbackHandler}. Convenient CollbackHandler which comes handy when
+ * No-op {@link javax.security.auth.callback.CallbackHandler}. Convenient CallbackHandler which comes handy when
  * no auth. callback is needed. This applies namely to SASL EXTERNAL auth. mechanism when auth. information is obtained
  * from external channel, like TLS certificate.
  *

--- a/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AbstractAuthenticationTest.java
+++ b/client/hotrod-client/src/test/java/org/infinispan/client/hotrod/AbstractAuthenticationTest.java
@@ -1,5 +1,8 @@
 package org.infinispan.client.hotrod;
 
+import java.util.Collections;
+import java.util.Map;
+
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.test.HotRodClientTestingUtil;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -28,6 +31,10 @@ public abstract class AbstractAuthenticationTest extends SingleCacheManagerTest 
    protected abstract SimpleServerAuthenticationProvider createAuthenticationProvider();
 
    protected ConfigurationBuilder initServerAndClient() {
+      return initServerAndClient(Collections.emptyMap());
+   }
+
+   protected ConfigurationBuilder initServerAndClient(Map<String, String> mechProperties) {
       hotrodServer = new HotRodServer();
       HotRodServerConfigurationBuilder serverBuilder = HotRodTestingUtil.getDefaultHotRodConfiguration();
       serverBuilder.authentication()
@@ -35,6 +42,7 @@ public abstract class AbstractAuthenticationTest extends SingleCacheManagerTest 
          .serverName("localhost")
          .addAllowedMech("CRAM-MD5")
          .serverAuthenticationProvider(createAuthenticationProvider());
+      serverBuilder.authentication().mechProperties(mechProperties);
       hotrodServer.start(serverBuilder.build(), cacheManager);
       log.info("Started server on port: " + hotrodServer.getPort());
 
@@ -51,7 +59,8 @@ public abstract class AbstractAuthenticationTest extends SingleCacheManagerTest 
          .enable()
          .saslMechanism("CRAM-MD5")
          .connectionPool()
-         .timeBetweenEvictionRuns(2000);
+            .maxActive(1)
+            .timeBetweenEvictionRuns(2000);
       return clientBuilder;
    }
 

--- a/documentation/src/main/asciidoc/server_guide/security.adoc
+++ b/documentation/src/main/asciidoc/server_guide/security.adoc
@@ -52,27 +52,33 @@ Security Realms are used by the server to provide authentication and authorizati
 </server>
 ----
 
-Infinispan Server comes with an add-user.sh script (add-user.bat for Windows) to ease the process of adding new user/role mappings to the above property files. An example invocation for adding a user to the ApplicationRealm with an initial set of roles:
+Infinispan Server comes with an add-user.sh script (add-user.bat for Windows) to ease the process of adding new user/role mappings to the above property files.
+An example invocation for adding a user to the ApplicationRealm with an initial set of roles:
 
 +./bin/add-user.sh -a -u myuser -p "qwer1234!" -ro supervisor,reader,writer+
 
-It is also possible to authenticate/authorize against alternative sources, such as LDAP, JAAS, etc. Refer to the link:{wildflydocroot}/Security%20Realms[WildFly security realms guide] on how to configure the Security Realms. Bear in mind that the choice of authentication mechanism you select for the protocols limits the type of authentication sources, since the credentials must be in a format supported by the algorithm itself (e.g. pre-digested passwords for the digest algorithm)
+It is also possible to authenticate/authorize against alternative sources, such as LDAP, JAAS, etc.
+Refer to the link:{wildflydocroot}/Security%20Realms[WildFly security realms guide] on how to configure the Security Realms.
+Bear in mind that the choice of authentication mechanism you select for the protocols limits the type of authentication sources, since the credentials must be in a format supported by the algorithm itself (e.g. pre-digested passwords for the digest algorithm)
 
 === Security Audit
 
-The Infinispan subsystem security audit by default sends audit logs to the audit manager configured at the server level. Refer to the link:{wildflydocroot}/Security%20subsystem%20configuration[WildFly security subsystem guide] on how to configure the server audit manager. Alternatively you can also set your custom audit logger by using the same configuration as for embedded mode.
+The Infinispan subsystem security audit by default sends audit logs to the audit manager configured at the server level.
+Refer to the link:{wildflydocroot}/Security%20subsystem%20configuration[WildFly security subsystem guide] on how to configure the server audit manager.
+Alternatively you can also set your custom audit logger by using the same configuration as for embedded mode.
 Refer to the The link:../user_guide/user_guide.html#Security_chapter[Security] chapter in the user guide for details.
 
 === Hot Rod authentication
 
-The Hot Rod protocol supports authentication since version 2.0 (Infinispan 7.0) by leveraging the SASL mechanisms. The supported SASL mechanisms (usually shortened as mechs) are:
+The Hot Rod protocol supports authentication since version 2.0 (Infinispan 7.0) by leveraging the SASL mechanisms.
+The supported SASL mechanisms (usually shortened as mechs) are:
 
-* PLAIN - This is the most insecure mech, since credentials are sent over the wire in plain-text format, however it is the simplest to get to work. In combination with encryption (i.e. SSL) it can be used safely
+* PLAIN - This is the most insecure mech, since credentials are sent over the wire in plain-text format, however it is the simplest to get to work. In combination with encryption (i.e. TLS) it can be used safely
 * DIGEST-MD5 - This mech hashes the credentials before sending them over the wire, so it is more secure than PLAIN
 * GSSAPI - This mech uses Kerberos tickets, and therefore requires the presence of a properly configured Kerberos Domain Controller (such as Microsoft Active Directory)
 * EXTERNAL - This mech obtains credentials from the underlying transport (i.e. from a X.509 client certificate) and therefore requires encryption using client-certificates to be enabled.
 
-The following configuration enables authentication against ApplicationRealm, using the DIGEST-MD5 SASL mechanism:
+The following configuration enables authentication against ApplicationRealm, using the DIGEST-MD5 SASL mechanism and only enables the *auth* QOP:
 
 .Hot Rod connector configuration
 [source,xml]
@@ -84,10 +90,93 @@ The following configuration enables authentication against ApplicationRealm, usi
 </hotrod-connector>
 ----
 Notice the server-name attribute: it is the name that the server declares to incoming clients and therefore the client configuration must match.
+It is particularly important when using GSSAPI as it is equivalent to the Kerberos service name.
+You can specify multiple mechanisms and they will be attempted in order.
 
-Once you have configured a secured Hot Rod connector, you can connect to it using the Hot Rod client:
+==== SASL Quality of Protection
 
-.Hot Rod client configuration
+While the main purpose of SASL is to provide authentication, some mechanisms also support integrity and privacy protection, also known as Quality of Protection (or qop).
+During authentication negotiation, ciphers are exchanged between client and server, and they can be used to add checksums and encryption to all subsequent traffic.
+You can tune the required level of qop as follows:
+
+[%header%autowidth]
+|===
+| QOP | Description
+| auth | Authentication only
+| auth-int | Authentication with integrity protection
+| auth-conf | Authentication with integrity and privacy protection
+|===
+
+==== SASL Policies
+
+You can further refine the way a mechanism is chosen by tuning the SASL policies.
+This will effectively include / exclude mechanisms based on whether they match the desired policies.
+
+[%header%autowidth]
+|===
+| Policy | Description
+| forward-secrecy | Specifies that the selected SASL mechanism must support forward secrecy between sessions. This means that breaking into one session will not automatically provide information for breaking into future sessions.
+| pass-credentials | Specifies that the selected SASL mechanism must require client credentials.
+| no-plain-text | Specifies that the selected SASL mechanism must not be susceptible to simple plain passive attacks.
+| no-active | Specifies that the selected SASL mechanism must not be susceptible to active (non-dictionary) attacks. The mechanism might require mutual authentication as a way to prevent active attacks.
+| no-dictionary | Specifies that the selected SASL mechanism must not be susceptible to passive dictionary attacks.
+| no-anonymous | Specifies that the selected SASL mechanism must not accept anonymous logins.
+|===
+
+Each policy's value is either "true" or "false".
+If a policy is absent, then the chosen mechanism need not have that characteristic (equivalent to setting the policy to "false").
+One notable exception is the *no-anonymous* policy which, if absent, defaults to true, thus preventing anonymous connections.
+
+NOTE: It is possible to have mixed anonymous and authenticated connections to the endpoint, delegating actual access logic to cache
+authorization configuration. To do so, set the *no-anonymous* policy to false and turn on cache authorization.
+
+The following configuration selects all available mechanisms, but effectively only enables GSSAPI, since it is the only one that respects all chosen policies:
+
+.Hot Rod connector policies
+[source,xml]
+----
+<hotrod-connector socket-binding="hotrod" cache-container="default">
+   <authentication security-realm="ApplicationRealm">
+      <sasl server-name="myhotrodserver" mechanisms="PLAIN DIGEST-MD5 GSSAPI EXTERNAL" qop="auth">
+         <policy>
+            <no-active value="true" />
+            <no-anonymous value="true" />
+            <no-plain-text value="true" />
+         </policy<>
+      </sasl>
+   </authentication>
+</hotrod-connector>
+----
+
+
+==== Configuring the Hot Rod client for authentication
+
+Once you have configured a secured Hot Rod connector, you can connect to it using the Hot Rod client. If you are using PLAIN and DIGEST-MD5 mechs
+you can pass your credentials directly to the ConfigurationBuilder:
+
+.Hot Rod client configuration with simple authentication
+[source,java]
+----
+ConfigurationBuilder clientBuilder = new ConfigurationBuilder();
+clientBuilder
+    .addServer()
+        .host("127.0.0.1")
+        .port(11222)
+    .security()
+        .authentication()
+            .enable()
+            .serverName("myhotrodserver")
+            .saslMechanism("DIGEST-MD5")
+            .username("myuser")
+            .realm("ApplicationRealm")
+            .password("qwer1234!");
+remoteCacheManager = new RemoteCacheManager(clientBuilder.build());
+RemoteCache<String, String> cache = remoteCacheManager.getCache("secured");
+----
+
+If instead you want to use your own callback handler:
+
+.Hot Rod client configuration with authentication via callback
 [source,java]
 ----
 public class MyCallbackHandler implements CallbackHandler {
@@ -95,7 +184,7 @@ public class MyCallbackHandler implements CallbackHandler {
    final private char[] password;
    final private String realm;
 
-   public MyCallbackHandler (String username, String realm, char[] password) {
+   public MyCallbackHandler(String username, String realm, char[] password) {
       this.username = username;
       this.password = password;
       this.realm = realm;

--- a/documentation/src/main/asciidoc/upgrading/upgrading.asciidoc
+++ b/documentation/src/main/asciidoc/upgrading/upgrading.asciidoc
@@ -74,7 +74,7 @@ Here is an example:
 
 Additionally there is no Logger implementation specified (since this may vary depending on use case).
 
-=== Total order executor is not removed
+=== Total order executor is now removed
 The total order protocol now uses the `remote-command-executor`. The attribute `total-order-executor` in `<container>` tag is removed.
 
 === HikariCP is now the default implementation for JDBC PooledConnectionFactory
@@ -106,6 +106,9 @@ explicitly defined and validated against the provided store configuration.  Exis
 annotation and the store's configuration class should also declare the `@ConfigurationFor` annotation.  If neither of these
 annotations are present on the store or configuration class, then a your store will continue to function as before, albeit
 with a warning that additional store validation cannot be completed.
+
+=== Server authentication changes
+The no-anonymous policy is now automatically enabled for Hot Rod authentication unless explicitly specified. 
 
 
 == Upgrading from 8.1 to 8.2

--- a/server/hotrod/src/main/java/org/infinispan/server/hotrod/AuthenticationHandler.java
+++ b/server/hotrod/src/main/java/org/infinispan/server/hotrod/AuthenticationHandler.java
@@ -56,8 +56,8 @@ public class AuthenticationHandler extends ChannelInboundHandlerAdapter {
 
       serverConfig = server.getConfiguration();
       authenticationConfig = server.getConfiguration().authentication();
-      requireAuthentication = authenticationConfig.mechProperties().containsKey(Sasl.POLICY_NOANONYMOUS)
-            && authenticationConfig.mechProperties().get(Sasl.POLICY_NOANONYMOUS).equals("true");
+         requireAuthentication = !authenticationConfig.mechProperties().containsKey(Sasl.POLICY_NOANONYMOUS)
+            || authenticationConfig.mechProperties().get(Sasl.POLICY_NOANONYMOUS).equals("true");
    }
 
    @Override

--- a/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/HotRodSubsystemAdd.java
+++ b/server/integration/endpoint/src/main/java/org/infinispan/server/endpoint/subsystem/HotRodSubsystemAdd.java
@@ -119,6 +119,31 @@ class HotRodSubsystemAdd extends ProtocolServiceSubsystemAdd {
             if (strength != null) {
                authenticationBuilder.addMechProperty(Sasl.STRENGTH, strength);
             }
+            if (sasl.hasDefined(ModelKeys.SASL_POLICY) && sasl.get(ModelKeys.SASL_POLICY, ModelKeys.SASL_POLICY_NAME).isDefined()) {
+               for(Property property : sasl.get(ModelKeys.SASL_POLICY, ModelKeys.SASL_POLICY_NAME).asPropertyList()) {
+                  String value = property.getValue().asString();
+                  switch (property.getName()) {
+                     case ModelKeys.FORWARD_SECRECY:
+                        authenticationBuilder.addMechProperty(Sasl.POLICY_FORWARD_SECRECY, value);
+                        break;
+                     case ModelKeys.NO_ACTIVE:
+                        authenticationBuilder.addMechProperty(Sasl.POLICY_NOACTIVE, value);
+                        break;
+                     case ModelKeys.NO_ANONYMOUS:
+                        authenticationBuilder.addMechProperty(Sasl.POLICY_NOANONYMOUS, value);
+                        break;
+                     case ModelKeys.NO_DICTIONARY:
+                        authenticationBuilder.addMechProperty(Sasl.POLICY_NODICTIONARY, value);
+                        break;
+                     case ModelKeys.NO_PLAIN_TEXT:
+                        authenticationBuilder.addMechProperty(Sasl.POLICY_NOPLAINTEXT, value);
+                        break;
+                     case ModelKeys.PASS_CREDENTIALS:
+                        authenticationBuilder.addMechProperty(Sasl.POLICY_PASS_CREDENTIALS, value);
+                        break;
+                  }
+               }
+            }
             if (sasl.hasDefined(ModelKeys.PROPERTY)) {
                for(Property property : sasl.get(ModelKeys.PROPERTY).asPropertyList()) {
                   authenticationBuilder.addMechProperty(property.getName(), property.getValue().asProperty().getValue().asString());


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7391
https://issues.jboss.org/browse/ISPN-7392 

- Add simple authentication configuration to the Hot Rod clients
- Ensure the server applies SASL policies correctly
- ship a more secure example authentication configuration
- enhance the server docs with more details about securing a Hot Rod server

