### PR TITLE
removed fix for the java 6 bug (id 6427854) fixed in java 7

### DIFF
--- a/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
+++ b/client/hotrod-client/src/main/java/org/infinispan/client/hotrod/RemoteCacheManager.java
@@ -173,9 +173,6 @@ public class RemoteCacheManager implements RemoteCacheContainer {
 
    @Override
    public void start() {
-      // Workaround for JDK6 NPE: http://bugs.sun.com/view_bug.do?bug_id=6427854
-      SecurityActions.setProperty("sun.nio.ch.bugLevel", "\"\"");
-
       transportFactory = Util.getInstance(configuration.transportFactory());
 
       if (marshaller == null) {


### PR DESCRIPTION
I removed the fix for the Java 6 bug (id 6427854, http://bugs.java.com/view_bug.do?bug_id=6427854).
It was fixed in 2011 (with Java7 b08).
Infinispan is baselined on Java 8.
 