### PR TITLE
ISPN-7454 Always set trimStacktrace to false

### DIFF
--- a/cdi/embedded/pom.xml
+++ b/cdi/embedded/pom.xml
@@ -116,6 +116,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
                     <reuseForks>true</reuseForks>
                     <forkCount>1</forkCount>
                     <parallel>none</parallel>

--- a/cdi/remote/pom.xml
+++ b/cdi/remote/pom.xml
@@ -144,6 +144,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
                     <reuseForks>true</reuseForks>
                     <forkCount>1</forkCount>
                     <parallel>none</parallel>

--- a/cli/cli-client/pom.xml
+++ b/cli/cli-client/pom.xml
@@ -75,6 +75,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+                <trimStackTrace>false</trimStackTrace>
                 <reuseForks>false</reuseForks>
                 <forkCount>1</forkCount>
                 <parallel>none</parallel>

--- a/integrationtests/all-embedded-it/pom.xml
+++ b/integrationtests/all-embedded-it/pom.xml
@@ -79,7 +79,8 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.18.1</version>
                         <configuration>
-                            <systemPropertyVariables>
+                           <trimStackTrace>false</trimStackTrace>
+                           <systemPropertyVariables>
                                 <connection.url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</connection.url>
                                 <driver.class>org.h2.Driver</driver.class>
                                 <jgroups.bind_addr>127.0.0.1</jgroups.bind_addr>

--- a/integrationtests/all-remote-it/pom.xml
+++ b/integrationtests/all-remote-it/pom.xml
@@ -117,6 +117,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <trimStackTrace>false</trimStackTrace>
                <parallel>none</parallel>
                <systemPropertyVariables>
                   <infinispan.jcache.mgmt.lookup.skip>true</infinispan.jcache.mgmt.lookup.skip>

--- a/integrationtests/cdi-jcache-it/pom.xml
+++ b/integrationtests/cdi-jcache-it/pom.xml
@@ -80,6 +80,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <trimStackTrace>false</trimStackTrace>
                <reuseForks>true</reuseForks>
                <forkCount>1</forkCount>
                <parallel>none</parallel>

--- a/integrationtests/osgi/pom.xml
+++ b/integrationtests/osgi/pom.xml
@@ -244,6 +244,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <trimStackTrace>false</trimStackTrace>
                <threadCount>1</threadCount>
                <parallel>classes</parallel>
                <systemPropertyVariables>

--- a/integrationtests/security-manager-it/pom.xml
+++ b/integrationtests/security-manager-it/pom.xml
@@ -80,6 +80,9 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                     <trimStackTrace>false</trimStackTrace>
+                  </configuration>
                   <executions>
                      <execution>
                         <id>default-test</id>

--- a/integrationtests/spring-boot-it/pom.xml
+++ b/integrationtests/spring-boot-it/pom.xml
@@ -101,6 +101,9 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <trimStackTrace>false</trimStackTrace>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>default-test</id>

--- a/jcache/embedded/pom.xml
+++ b/jcache/embedded/pom.xml
@@ -115,6 +115,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <trimStackTrace>false</trimStackTrace>
                <parallel>none</parallel>
                <groups>${defaultTestGroup}</groups>
             </configuration>

--- a/jcache/remote/pom.xml
+++ b/jcache/remote/pom.xml
@@ -102,6 +102,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <trimStackTrace>false</trimStackTrace>
                <parallel>none</parallel>
                <systemPropertyVariables>
                   <infinispan.jcache.mgmt.lookup.skip>true</infinispan.jcache.mgmt.lookup.skip>

--- a/jcache/tck-runner/pom.xml
+++ b/jcache/tck-runner/pom.xml
@@ -194,6 +194,9 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <trimStackTrace>false</trimStackTrace>
+            </configuration>
             <executions>
                <execution>
                   <id>default-test</id>
@@ -348,6 +351,9 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                     <trimStackTrace>false</trimStackTrace>
+                  </configuration>
                   <executions>
                      <execution>
                         <id>default-test</id>

--- a/persistence/cli/pom.xml
+++ b/persistence/cli/pom.xml
@@ -94,6 +94,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <trimStackTrace>false</trimStackTrace>
                <argLine>
                   -Dcom.sun.management.jmxremote=true
                   -Djava.rmi.server.hostname=localhost

--- a/persistence/jdbc/pom.xml
+++ b/persistence/jdbc/pom.xml
@@ -164,6 +164,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
 
             <configuration>
+               <trimStackTrace>false</trimStackTrace>
                <threadCount>1</threadCount>
             </configuration>
          </plugin>

--- a/persistence/jpa/pom.xml
+++ b/persistence/jpa/pom.xml
@@ -101,7 +101,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-
+               <trimStackTrace>false</trimStackTrace>
                <threadCount>1</threadCount>
             </configuration>
          </plugin>
@@ -181,6 +181,7 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
                   <configuration>
+                     <trimStackTrace>false</trimStackTrace>
                      <systemPropertyVariables>
                         <connection.url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</connection.url>
                         <driver.class>org.h2.Driver</driver.class>
@@ -205,6 +206,7 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
                   <configuration>
+                     <trimStackTrace>false</trimStackTrace>
                      <systemPropertyVariables>
                         <connection.url>jdbc:mysql://localhost:3306/ispn_jpa_test</connection.url>
                         <driver.class>com.mysql.jdbc.Driver</driver.class>
@@ -230,6 +232,7 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
                   <configuration>
+                     <trimStackTrace>false</trimStackTrace>
                      <systemPropertyVariables>
                         <connection.url>jdbc:postgresql://localhost:5432/ispn_jpa_test</connection.url>
                         <driver.class>org.postgresql.Driver</driver.class>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -201,6 +201,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <trimStackTrace>false</trimStackTrace>
                <argLine>-javaagent:${project.build.directory}/agents/byteman.jar=port:9091,boot:${project.build.directory}/agents/byteman.jar</argLine>
                <systemPropertyVariables>
                   <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>

--- a/server/integration/cli/pom.xml
+++ b/server/integration/cli/pom.xml
@@ -19,6 +19,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
                     <includes>
                         <include>**/*TestCase.java</include>
                     </includes>

--- a/server/integration/commons/pom.xml
+++ b/server/integration/commons/pom.xml
@@ -84,6 +84,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
                     <parallel>none</parallel>

--- a/server/integration/event-logger/pom.xml
+++ b/server/integration/event-logger/pom.xml
@@ -73,6 +73,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
                     <parallel>none</parallel>
@@ -91,6 +92,9 @@
                 <plugin>
                    <groupId>org.apache.maven.plugins</groupId>
                    <artifactId>maven-surefire-plugin</artifactId>
+                   <configuration>
+                      <trimStackTrace>false</trimStackTrace>
+                   </configuration>
                    <executions>
                       <execution>
                          <id>default-test</id>

--- a/server/integration/infinispan/pom.xml
+++ b/server/integration/infinispan/pom.xml
@@ -240,6 +240,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
                     <parallel>none</parallel>
@@ -257,6 +258,9 @@
                 <plugin>
                    <groupId>org.apache.maven.plugins</groupId>
                    <artifactId>maven-surefire-plugin</artifactId>
+                   <configuration>
+                      <trimStackTrace>false</trimStackTrace>
+                   </configuration>
                    <executions>
                       <execution>
                          <id>default-test</id>

--- a/server/integration/jgroups/pom.xml
+++ b/server/integration/jgroups/pom.xml
@@ -103,6 +103,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
                     <parallel>none</parallel>

--- a/server/router/pom.xml
+++ b/server/router/pom.xml
@@ -81,6 +81,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration combine.self="override">
+                    <trimStackTrace>false</trimStackTrace>
                     <parallel>suitesAndClasses</parallel>
                     <threadCount>${infinispan.test.parallel.threads}</threadCount>
                     <excludedGroups>${suite.exclude.groups}</excludedGroups>

--- a/spring/spring4/spring4-common/pom.xml
+++ b/spring/spring4/spring4-common/pom.xml
@@ -51,6 +51,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
                     <skipTests>true</skipTests>
                 </configuration>
             </plugin>

--- a/tasks-api/pom.xml
+++ b/tasks-api/pom.xml
@@ -24,6 +24,7 @@
          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+               <trimStackTrace>false</trimStackTrace>
                <skipTests>true</skipTests>
             </configuration>
          </plugin>


### PR DESCRIPTION
https://issues.jboss.org/browse/ISPN-7454

* Without this specific setting, exception causes for test failures are
  hidden from the report.