### PR TITLE
ISPN-7116 Test methods that use a TestNg dataProvider are duplicated in

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -114,6 +114,7 @@
                      <value>true</value>
                   </property>
                </properties>
+               <disableXmlReport>false</disableXmlReport>
             </configuration>
             <dependencies>
                <dependency>

--- a/integrationtests/all-remote-it/pom.xml
+++ b/integrationtests/all-remote-it/pom.xml
@@ -123,6 +123,7 @@
                </systemPropertyVariables>
                <groups combine.self="override"/>
                <excludedGroups combine.self="override"/>
+               <disableXmlReport>false</disableXmlReport>
                <properties>
                   <property>
                      <name>usedefaultlisteners</name>

--- a/integrationtests/osgi/pom.xml
+++ b/integrationtests/osgi/pom.xml
@@ -252,10 +252,11 @@
                <runOrder>alphabetical</runOrder>
                <skipTests>${skipOSGiTests}</skipTests>
                <testNGArtifactName>none:none</testNGArtifactName>
+               <disableXmlReport>false</disableXmlReport>
                <properties>
                   <property>
                      <name>listener</name>
-                     <value>org.junit.runner.notification.RunListener</value>
+                     <value>${junitListener}</value>
                   </property>
                </properties>
             </configuration>

--- a/integrationtests/wildfly-modules/pom.xml
+++ b/integrationtests/wildfly-modules/pom.xml
@@ -200,6 +200,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
                <testNGArtifactName>none:none</testNGArtifactName>
+               <disableXmlReport>false</disableXmlReport>
                <properties>
                   <property>
                      <name>listener</name>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1407,6 +1407,8 @@
                <reuseForks>true</reuseForks>
                <groups>${defaultTestGroup}</groups>
                <excludedGroups>${defaultExcludedTestGroup}</excludedGroups>
+               <disableXmlReport>true</disableXmlReport>
+               <useFile>false</useFile>
                <systemPropertyVariables>
                   <infinispan.test.jgroups.protocol>${infinispan.test.jgroups.protocol}</infinispan.test.jgroups.protocol>
                   <jgroups.bind_addr>127.0.0.1</jgroups.bind_addr>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -205,6 +205,7 @@
                <systemPropertyVariables>
                   <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>
                </systemPropertyVariables>
+               <disableXmlReport>false</disableXmlReport>
             </configuration>
          </plugin>
          <plugin>


### PR DESCRIPTION
JUnit reports

https://issues.jboss.org/browse/ISPN-7116

* Disabled the XML report in the parent POM
* Changed the XML file prefix in PolarionJUnitXMLReporter from
"POLARION-" to "TEST-"