### PR TITLE
ISPN-7447 fix for DefaultExecutorService without keys specified.

### DIFF
--- a/core/src/test/java/org/infinispan/distexec/BasicDistributedExecutorTest.java
+++ b/core/src/test/java/org/infinispan/distexec/BasicDistributedExecutorTest.java
@@ -557,7 +557,7 @@ public class BasicDistributedExecutorTest extends AbstractCacheTest {
 
 
    static class SimpleDistributedCallable implements DistributedCallable<String, String, Boolean>,
-            Serializable {
+            Serializable, ExternalPojo {
 
       /** The serialVersionUID */
       private static final long serialVersionUID = 623845442163221832L;
@@ -599,7 +599,7 @@ public class BasicDistributedExecutorTest extends AbstractCacheTest {
       }
    }
 
-   static class FailOnlyOnceCallable implements Callable<Integer>, Serializable {
+   static class FailOnlyOnceCallable implements Callable<Integer>, Serializable, ExternalPojo {
 
       /** The serialVersionUID */
       private static final long serialVersionUID = 3961940091247573385L;

--- a/core/src/test/java/org/infinispan/distexec/DistributedExecutorFailoverTest.java
+++ b/core/src/test/java/org/infinispan/distexec/DistributedExecutorFailoverTest.java
@@ -3,6 +3,7 @@ package org.infinispan.distexec;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Random;
+import java.util.Scanner;
 import java.util.concurrent.*;
 
 import org.infinispan.Cache;
@@ -65,11 +66,11 @@ public class DistributedExecutorFailoverTest extends MultipleCacheManagersTest {
          future.whenComplete((aVoid,throwable) -> {
             Executors.newSingleThreadExecutor().submit((Callable<Void>)() -> {
                 future.get();
-
-                AssertJUnit.assertEquals(sameNodeTaskFailoverPolicy.failoverCount, 2);
                 return null;
             });
          });
+         Thread.sleep(1000);
+         AssertJUnit.assertEquals(sameNodeTaskFailoverPolicy.failoverCount, 2);
       } catch (Exception ex) {
          AssertJUnit.fail("Task did not failover properly " + ex);
       } finally {

--- a/core/src/test/java/org/infinispan/distexec/DistributedExecutorFailoverTest.java
+++ b/core/src/test/java/org/infinispan/distexec/DistributedExecutorFailoverTest.java
@@ -63,12 +63,7 @@ public class DistributedExecutorFailoverTest extends MultipleCacheManagersTest {
                  .timeout(taskTimeout, TimeUnit.MILLISECONDS);
 
          CompletableFuture<Void> future = des.submit(builder.build());
-         future.whenComplete((aVoid,throwable) -> {
-            Executors.newSingleThreadExecutor().submit((Callable<Void>)() -> {
-                future.get();
-                return null;
-            });
-         });
+         try {future.get(10, TimeUnit.SECONDS);} catch(Exception e) {}
          eventuallyEquals(3, () -> sameNodeTaskFailoverPolicy.failoverCount);
       } catch (Exception ex) {
          AssertJUnit.fail("Task did not failover properly " + ex);

--- a/core/src/test/java/org/infinispan/distexec/DistributedExecutorFailoverTest.java
+++ b/core/src/test/java/org/infinispan/distexec/DistributedExecutorFailoverTest.java
@@ -48,10 +48,6 @@ public class DistributedExecutorFailoverTest extends MultipleCacheManagersTest {
    public void testBasicLocalDistributedCallable() throws Exception {
       long taskTimeout = TimeUnit.SECONDS.toMillis(15);
       EmbeddedCacheManager cacheManager1 = manager(0);
-      final EmbeddedCacheManager cacheManager2 = manager(1);
-      final EmbeddedCacheManager cacheManager3 = manager(2);
-      TestingUtil.killCacheManagers(cacheManager2);
-      TestingUtil.killCacheManagers(cacheManager3);
       Cache<Object, Object> cache1 = cacheManager1.getCache();
       DistributedExecutorService des = null;
 

--- a/core/src/test/java/org/infinispan/distexec/DistributedExecutorFailoverTest.java
+++ b/core/src/test/java/org/infinispan/distexec/DistributedExecutorFailoverTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.CacheMode;
@@ -63,7 +64,7 @@ public class DistributedExecutorFailoverTest extends MultipleCacheManagersTest {
 
          CompletableFuture<Void> future = des.submit(builder.build());
          TriggerFailover(future);
-         eventuallyEquals(3, () -> sameNodeTaskFailoverPolicy.failoverCount);
+         eventuallyEquals(3, () -> sameNodeTaskFailoverPolicy.failoverCount.get());
       } catch (Exception ex) {
          AssertJUnit.fail("Task did not failover properly " + ex);
       } finally {
@@ -169,7 +170,7 @@ public class DistributedExecutorFailoverTest extends MultipleCacheManagersTest {
 
    static class SameNodeTaskFailoverPolicy implements DistributedTaskFailoverPolicy {
       private final int maxFailoverCount;
-      private volatile int failoverCount = 0;
+      private volatile AtomicInteger failoverCount = new AtomicInteger();
 
       public SameNodeTaskFailoverPolicy(int maxFailoverCount) {
          super();
@@ -178,7 +179,7 @@ public class DistributedExecutorFailoverTest extends MultipleCacheManagersTest {
 
       @Override
       public Address failover(FailoverContext fc) {
-         failoverCount++;
+         failoverCount.incrementAndGet();
          return fc.executionFailureLocation();
       }
 

--- a/core/src/test/java/org/infinispan/distexec/DistributedExecutorFailoverTest.java
+++ b/core/src/test/java/org/infinispan/distexec/DistributedExecutorFailoverTest.java
@@ -56,7 +56,7 @@ public class DistributedExecutorFailoverTest extends MultipleCacheManagersTest {
          // initiate task from cache1 and execute on same node
          des = new DefaultExecutorService(cache1);
 
-         SameNodeTaskFailoverPolicy sameNodeTaskFailoverPolicy = new SameNodeTaskFailoverPolicy(2);
+         SameNodeTaskFailoverPolicy sameNodeTaskFailoverPolicy = new SameNodeTaskFailoverPolicy(3);
          DistributedTaskBuilder<Void> builder = des
                  .createDistributedTaskBuilder(new TestCallable())
                  .failoverPolicy(sameNodeTaskFailoverPolicy)
@@ -69,8 +69,7 @@ public class DistributedExecutorFailoverTest extends MultipleCacheManagersTest {
                 return null;
             });
          });
-         Thread.sleep(1000);
-         AssertJUnit.assertEquals(sameNodeTaskFailoverPolicy.failoverCount, 2);
+         eventuallyEquals(3, () -> sameNodeTaskFailoverPolicy.failoverCount);
       } catch (Exception ex) {
          AssertJUnit.fail("Task did not failover properly " + ex);
       } finally {


### PR DESCRIPTION
ISPN-7447 fix for DefaultExecutorService without keys specified.
And also make the with keys specified work like others. Clone the task.getCallable for target equals me.

I don't know what is the clone for. But the Callable is cloned in other submit DistributedTask<T> methods. So I added it as well. Maybe anyone can tell whether the clone is required? I just added it like other submit DistributedTask<T> methods.
For no keys specified, it's submitted to local. And it's reuse the submit(Address, DistributedTask<T>). So the features like failover in DistributedTask will work.